### PR TITLE
Add credentials for test db

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -14,6 +14,9 @@ test: &test
   <<: *default
   host: localhost
   database: energy_sparks_test
+  username: <%= ENV['DEV_DB_USERNAME'] %>
+  password: <%= ENV['DEV_DB_PASSWORD'] %>
+
 
 staging:
   <<: *default


### PR DESCRIPTION
Add credentials for test database.

On ubuntu at least, postgres needs to be configured to allow local connections for postgres user and recommended approach is to set a password for that.

So I needed to specify these for my environment to work.

Expect travis may need the default values populating...?