### PR TITLE
Streaming resources via stable URL

### DIFF
--- a/app/controllers/case_studies_controller.rb
+++ b/app/controllers/case_studies_controller.rb
@@ -3,4 +3,13 @@ class CaseStudiesController < ApplicationController
   def index
     @case_studies = CaseStudy.order(position: :asc)
   end
+
+  def download
+    resource = CaseStudy.find_by(id: params[:id])
+    if resource.present?
+      serve_from_storage(resource.file, params[:serve])
+    else
+      render file: Rails.public_path.join('404.html'), status: :not_found, layout: false
+    end
+  end
 end

--- a/app/controllers/case_studies_controller.rb
+++ b/app/controllers/case_studies_controller.rb
@@ -1,4 +1,5 @@
 class CaseStudiesController < ApplicationController
+  include StorageHelper
   skip_before_action :authenticate_user!
   def index
     @case_studies = CaseStudy.order(position: :asc)

--- a/app/controllers/resource_files_controller.rb
+++ b/app/controllers/resource_files_controller.rb
@@ -6,11 +6,16 @@ class ResourceFilesController < ApplicationController
   end
 
   def download
-    resource = ResourceFile.find(params[:id])
-    response.headers["Content-Disposition"] = "#{params[:serve]}; filename=\"#{resource.file.filename}\""
-    response.headers["Content-Type"] = resource.file.content_type
-    resource.file.download do |chunk|
-      response.stream.write(chunk)
+    resource = ResourceFile.find_by(id: params[:id])
+    if resource.present?
+      serve = params[:serve] == "attachment" ? "attachment" : "inline"
+      response.headers["Content-Disposition"] = "#{serve}; filename=\"#{resource.file.filename}\""
+      response.headers["Content-Type"] = resource.file.content_type
+      resource.file.download do |chunk|
+        response.stream.write(chunk)
+      end
+    else
+      render file: Rails.public_path.join('404.html'), status: :not_found, layout: false
     end
   end
 end

--- a/app/controllers/resource_files_controller.rb
+++ b/app/controllers/resource_files_controller.rb
@@ -4,4 +4,13 @@ class ResourceFilesController < ApplicationController
     @resource_file_types = ResourceFileType.order(:position)
     @other_resource_files = ResourceFile.where(resource_file_type_id: nil).order(:title)
   end
+
+  def download
+    resource = ResourceFile.find(params[:id])
+    response.headers["Content-Disposition"] = "#{params[:serve]}; filename=\"#{resource.file.filename}\""
+    response.headers["Content-Type"] = resource.file.content_type
+    resource.file.download do |chunk|
+      response.stream.write(chunk)
+    end
+  end
 end

--- a/app/controllers/resource_files_controller.rb
+++ b/app/controllers/resource_files_controller.rb
@@ -8,12 +8,7 @@ class ResourceFilesController < ApplicationController
   def download
     resource = ResourceFile.find_by(id: params[:id])
     if resource.present?
-      serve = params[:serve] == "attachment" ? "attachment" : "inline"
-      response.headers["Content-Disposition"] = "#{serve}; filename=\"#{resource.file.filename}\""
-      response.headers["Content-Type"] = resource.file.content_type
-      resource.file.download do |chunk|
-        response.stream.write(chunk)
-      end
+      serve_from_storage(resource.file, params[:serve])
     else
       render file: Rails.public_path.join('404.html'), status: :not_found, layout: false
     end

--- a/app/controllers/resource_files_controller.rb
+++ b/app/controllers/resource_files_controller.rb
@@ -1,4 +1,5 @@
 class ResourceFilesController < ApplicationController
+  include StorageHelper
   skip_before_action :authenticate_user!
   def index
     @resource_file_types = ResourceFileType.order(:position)

--- a/app/helpers/storage_helper.rb
+++ b/app/helpers/storage_helper.rb
@@ -1,6 +1,6 @@
 module StorageHelper
   def serve_from_storage(attachment, disposition = "inline")
-    serve = disposition == "attachment" ? "attachment" : "inline"
+    serve = disposition == "download" ? "attachment" : "inline"
     response.headers["Content-Disposition"] = "#{serve}; filename=\"#{attachment.filename}\""
     response.headers["Content-Type"] = attachment.content_type
     attachment.download do |chunk|

--- a/app/helpers/storage_helper.rb
+++ b/app/helpers/storage_helper.rb
@@ -1,0 +1,10 @@
+module StorageHelper
+  def serve_from_storage(attachment, disposition = "inline")
+    serve = disposition == "attachment" ? "attachment" : "inline"
+    response.headers["Content-Disposition"] = "#{serve}; filename=\"#{attachment.filename}\""
+    response.headers["Content-Type"] = attachment.content_type
+    attachment.download do |chunk|
+      response.stream.write(chunk)
+    end
+  end
+end

--- a/app/views/home/_case_studies.html.erb
+++ b/app/views/home/_case_studies.html.erb
@@ -23,9 +23,9 @@
                 </div>
               </div>
               <div class="card-footer">
-                <%= link_to url_for(case_study.file), class: 'btn btn-primary' do %>
+                <%= link_to url_for( controller: :case_studies, action: :download, serve: :download, id: case_study.id ), class: 'btn' do %>
                   Download <i class="fas fa-file-download"></i>
-                <% end%>
+                <% end %>
               </div>
             </div>
           <% end %>

--- a/app/views/resource_files/index.html.erb
+++ b/app/views/resource_files/index.html.erb
@@ -18,7 +18,7 @@
         </th>
         <td><%= resource_file.description %></td>
         <td>
-          <%= link_to url_for( controller: :resource_files, action: :download, serve: :attachment, id: resource_file.id ), class: 'btn' do %>
+          <%= link_to url_for( controller: :resource_files, action: :download, serve: :download, id: resource_file.id ), class: 'btn' do %>
             Download <i class="fas fa-file-download"></i>
           <% end %>
         </td>
@@ -39,7 +39,7 @@
       </th>
       <td><%= resource_file.description %></td>
       <td>
-        <%= link_to url_for( controller: :resource_files, action: :download, serve: :attachment, id: resource_file.id ), class: 'btn' do %>
+        <%= link_to url_for( controller: :resource_files, action: :download, serve: :download, id: resource_file.id ), class: 'btn' do %>
           Download <i class="fas fa-file-download"></i>
         <% end %>
 

--- a/app/views/resource_files/index.html.erb
+++ b/app/views/resource_files/index.html.erb
@@ -13,12 +13,14 @@
     <% end %>
     <% type.resource_files.order(:title).each do |resource_file| %>
       <tr>
-        <th scope="row"><%= link_to resource_file.title, url_for(resource_file.file)%></th>
+        <th scope="row">
+          <%= link_to resource_file.title, controller: :resource_files, action: :download, serve: :inline, id: resource_file.id %>
+        </th>
         <td><%= resource_file.description %></td>
         <td>
-          <%= link_to url_for(resource_file.file), class: 'btn' do %>
+          <%= link_to url_for( controller: :resource_files, action: :download, serve: :attachment, id: resource_file.id ), class: 'btn' do %>
             Download <i class="fas fa-file-download"></i>
-          <% end%>
+          <% end %>
         </td>
       </tr>
     <% end %>
@@ -32,12 +34,15 @@
   <% end %>
   <% @other_resource_files.order(:title).each do |resource_file| %>
     <tr>
-      <th scope="row"><%= link_to resource_file.title, url_for(resource_file.file)%></th>
+      <th scope="row">
+        <%= link_to resource_file.title, controller: :resource_files, action: :download, serve: :inline, id: resource_file.id %>
+      </th>
       <td><%= resource_file.description %></td>
       <td>
-        <%= link_to url_for(resource_file.file), class: 'btn' do %>
+        <%= link_to url_for( controller: :resource_files, action: :download, serve: :attachment, id: resource_file.id ), class: 'btn' do %>
           Download <i class="fas fa-file-download"></i>
-        <% end%>
+        <% end %>
+
       </td>
     </tr>
   <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
   get 'for-pupils', to: 'home#for_pupils'
   get 'for-management', to: 'home#for_management'
   get 'case-studies', to: 'case_studies#index', as: :case_studies
+  get 'case_studies/:id/:serve', to: 'case_studies#download'
   get 'newsletters', to: 'newsletters#index', as: :newsletters
   get 'resources', to: 'resource_files#index', as: :resources
   get 'resources/:id/:serve', to: 'resource_files#download'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,7 @@ Rails.application.routes.draw do
   get 'case-studies', to: 'case_studies#index', as: :case_studies
   get 'newsletters', to: 'newsletters#index', as: :newsletters
   get 'resources', to: 'resource_files#index', as: :resources
-  get 'resources/:serve/:id', to: 'resource_files#download'
+  get 'resources/:id/:serve', to: 'resource_files#download'
   get 'home-page', to: 'home#show'
   get 'school_statistics', to: 'home#school_statistics'
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,7 @@ Rails.application.routes.draw do
   get 'case-studies', to: 'case_studies#index', as: :case_studies
   get 'newsletters', to: 'newsletters#index', as: :newsletters
   get 'resources', to: 'resource_files#index', as: :resources
+  get 'resources/:serve/:id', to: 'resource_files#download'
   get 'home-page', to: 'home#show'
   get 'school_statistics', to: 'home#school_statistics'
 

--- a/spec/system/case_studies_spec.rb
+++ b/spec/system/case_studies_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+RSpec.describe "case_studies", type: :system do
+
+  let!(:case_study) { CaseStudy.create!( title: "First Case Study", position: 1,
+    file: fixture_file_upload(Rails.root + "spec/fixtures/images/newsletter-placeholder.png"))}
+
+  it 'shows me the resources page' do
+    visit case_studies_path
+    expect(page.has_content? "Case Studies").to be true
+    expect(page.has_content? "First Case Study").to be true
+  end
+
+  it 'uses an internal download link' do
+    visit case_studies_path
+    expect(page.has_link? "", href: "/case_studies/#{case_study.id}/download").to be true
+  end
+end

--- a/spec/system/case_studies_spec.rb
+++ b/spec/system/case_studies_spec.rb
@@ -11,8 +11,14 @@ RSpec.describe "case_studies", type: :system do
     expect(page.has_content? "First Case Study").to be true
   end
 
-  it 'uses an internal download link' do
+  it 'shows the expexted link' do
     visit case_studies_path
     expect(page.has_link? "", href: "/case_studies/#{case_study.id}/download").to be true
+  end
+
+  it 'serves the file' do
+    visit case_studies_path
+    find("a[href='/case_studies/#{case_study.id}/download']").click
+    expect(page.status_code).to eql 200
   end
 end

--- a/spec/system/resources_spec.rb
+++ b/spec/system/resources_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+RSpec.describe "resources", type: :system do
+
+  before(:all) do
+    @resource_type = ResourceFileType.create!(title: "Resource Collection", position: 1)
+    @resource = ResourceFile.create!( title: "A resource", resource_file_type: @resource_type,
+      file: fixture_file_upload(Rails.root + "spec/fixtures/images/newsletter-placeholder.png") )
+    @other_resource = ResourceFile.create!( title: "Other resource",
+     file: fixture_file_upload(Rails.root + "spec/fixtures/images/banes.png") )
+  end
+
+  it 'shows me the resources page' do
+    visit resources_path
+    expect(page.has_content? "Resources").to be true
+    expect(page.has_content? "Resource Collection").to be true
+    expect(page.has_link? "A resource", href: "/resources/#{@resource.id}/inline").to be true
+    expect(page.has_link? "", href: "/resources/1/download").to be true
+    expect(page.has_link? "Other resource", href: "/resources/#{@other_resource.id}/inline").to be true
+  end
+
+end

--- a/spec/system/resources_spec.rb
+++ b/spec/system/resources_spec.rb
@@ -14,9 +14,18 @@ RSpec.describe "resources", type: :system do
     visit resources_path
     expect(page.has_content? "Resources").to be true
     expect(page.has_content? "Resource Collection").to be true
+  end
+
+  it 'shows expected download links' do
+    visit resources_path
     expect(page.has_link? "A resource", href: "/resources/#{@resource.id}/inline").to be true
     expect(page.has_link? "", href: "/resources/#{@resource.id}/download").to be true
     expect(page.has_link? "Other resource", href: "/resources/#{@other_resource.id}/inline").to be true
   end
 
+  it 'serves the file' do
+    visit resources_path
+    find("a[href='/resources/#{@resource.id}/download']").click
+    expect(page.status_code).to eql 200
+  end
 end

--- a/spec/system/resources_spec.rb
+++ b/spec/system/resources_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe "resources", type: :system do
     expect(page.has_content? "Resources").to be true
     expect(page.has_content? "Resource Collection").to be true
     expect(page.has_link? "A resource", href: "/resources/#{@resource.id}/inline").to be true
-    expect(page.has_link? "", href: "/resources/1/download").to be true
+    expect(page.has_link? "", href: "/resources/#{@resource.id}/download").to be true
     expect(page.has_link? "Other resource", href: "/resources/#{@other_resource.id}/inline").to be true
   end
 


### PR DESCRIPTION
Spiked implementation of streaming resources via the app. This is still a WIP for discussion.

* Adds new route `/resources/:serve/:id` to stream resource files from active storage. Use `/resources/inline/:id` for inline display, `/resources/attachment/:id` to force a download
* URLs use id of the resource file which will be stable over time, even if the attached files are changed or updated
* Uploaded file names are preserved as now and these are used for downloads, so you'll get whatever name is provided by the ES admin

Produces urls like: `test.energysparks/resources/attachment/18`

Files should get caught by the CDN I think (although I haven't check the config) and cached.

@jhigman do you think this is a sensible option? It preserves all uploaded content so quick to implement and apply.

I can add a simple route for case studies too.

