### PR TITLE
Meteostat Integration

### DIFF
--- a/.ebextensions/cronjob.config
+++ b/.ebextensions/cronjob.config
@@ -23,6 +23,13 @@ files:
         content: |
             45 3 * * * root /bin/bash -l -c 'cd /var/app/current && RAILS_ENV=production bin/run_as_webapp bundle exec rake data_feeds:dark_sky_temperature_loader >> log/jobs.log 2>&1'
 
+    "/etc/cron.d/load-meteostat-data":
+        mode: "000644"
+        owner: root
+        group: root
+        content: |
+            45 3 * * * root /bin/bash -l -c 'cd /var/app/current && RAILS_ENV=production bin/run_as_webapp bundle exec rake data_feeds:meteostat_loader >> log/jobs.log 2>&1'
+
     "/etc/cron.d/back-fill-any-dark-sky-temperatures":
         mode: "000644"
         owner: root

--- a/app/controllers/admin/school_groups_controller.rb
+++ b/app/controllers/admin/school_groups_controller.rb
@@ -43,7 +43,8 @@ module Admin
         :name, :description, :default_scoreboard_id,
         :default_template_calendar_id,
         :default_dark_sky_area_id,
-        :default_solar_pv_tuos_area_id
+        :default_solar_pv_tuos_area_id,
+        :default_weather_station_id
       )
     end
   end

--- a/app/controllers/admin/school_onboardings/configuration_controller.rb
+++ b/app/controllers/admin/school_onboardings/configuration_controller.rb
@@ -8,6 +8,7 @@ module Admin
           @school_onboarding.template_calendar = @school_onboarding.school_group.default_template_calendar
           @school_onboarding.solar_pv_tuos_area = @school_onboarding.school_group.default_solar_pv_tuos_area
           @school_onboarding.dark_sky_area = @school_onboarding.school_group.default_dark_sky_area
+          @school_onboarding.weather_station = @school_onboarding.school_group.default_weather_station
           @school_onboarding.scoreboard = @school_onboarding.school_group.default_scoreboard
         end
       end
@@ -28,7 +29,8 @@ module Admin
           :template_calendar_id,
           :solar_pv_tuos_area_id,
           :dark_sky_area_id,
-          :scoreboard_id
+          :scoreboard_id,
+          :weather_station_id
         )
       end
     end

--- a/app/controllers/admin/weather_stations_controller.rb
+++ b/app/controllers/admin/weather_stations_controller.rb
@@ -31,7 +31,7 @@ module Admin
     private
 
     def weather_station_params
-      params.require(:weather_station).permit(:title, :description, :type, :latitude, :longitude, :active, :provider)
+      params.require(:weather_station).permit(:title, :description, :type, :latitude, :longitude, :active, :provider, :back_fill_years)
     end
   end
 end

--- a/app/controllers/admin/weather_stations_controller.rb
+++ b/app/controllers/admin/weather_stations_controller.rb
@@ -1,0 +1,37 @@
+module Admin
+  class WeatherStationsController < AdminController
+    load_and_authorize_resource
+
+    def index
+    end
+
+    def new
+    end
+
+    def create
+      if @weather_station.save
+        redirect_to admin_weather_stations_path, notice: 'New Weather Station created.'
+      else
+        render :new
+      end
+    end
+
+    def edit
+    end
+
+    #TODO decide how to handle lat/lng updates, if at all
+    def update
+      if @weather_station.update(weather_station_params)
+        redirect_to admin_weather_stations_path, notice: 'Weather Station was updated.'
+      else
+        render :edit
+      end
+    end
+
+    private
+
+    def weather_station_params
+      params.require(:weather_station).permit(:title, :description, :type, :latitude, :longitude, :active, :provider)
+    end
+  end
+end

--- a/app/controllers/data_feeds/generic_controller.rb
+++ b/app/controllers/data_feeds/generic_controller.rb
@@ -24,6 +24,7 @@ module DataFeeds
   private
 
     def get_missing_array(first_reading, reading_summary)
+      return [] if first_reading.nil?
       missing_array = (first_reading.reading_date.to_date..Time.zone.today).collect do |day|
         if ! reading_summary.key?(day)
           [day, 'No readings']

--- a/app/controllers/data_feeds/weather_observations_controller.rb
+++ b/app/controllers/data_feeds/weather_observations_controller.rb
@@ -1,0 +1,31 @@
+module DataFeeds
+  class WeatherObservationsController < GenericController
+    include CsvDownloader
+
+    load_and_authorize_resource
+
+    CSV_HEADER = "Area Title,Reading Date,00:30,01:00,01:30,02:00,02:30,03:00,03:30,04:00,04:30,05:00,05:30,06:00,06:30,07:00,07:30,08:00,08:30,09:00,09:30,10:00,10:30,11:00,11:30,12:00,12:30,13:00,13:30,14:00,14:30,15:00,15:30,16:00,16:30,17:00,17:30,18:00,18:30,19:00,19:30,20:00,20:30,21:00,21:30,22:00,22:30,23:00,23:30,00:00".freeze
+
+    def show
+      weather_station_id = params[:weather_station_id]
+      ordered_readings = @data_class.where(weather_station_id: weather_station_id).order(reading_date: :asc)
+
+      @first_read = ordered_readings.first
+      @reading_summary = ordered_readings.group(:reading_date, @data_class_column_name).pluck(Arel.sql("reading_date, array_length(#{@data_class_column_name}, 1)")).to_h
+      @missing_array = get_missing_array(@first_read, @reading_summary)
+
+      respond_to do |format|
+        format.html { render 'data_feeds/generic/show' }
+        format.json { render 'data_feeds/generic/show' }
+        format.csv  { send_data readings_to_csv(@data_class.download_for_area_id(weather_station_id), @csv_header), filename: "#{weather_station_id}-#{@title}.csv" }
+      end
+    end
+
+    def set_up_data_feed
+      @title = "Weather station readings".freeze
+      @data_class = WeatherObservation
+      @data_class_column_name = :temperature_celsius_x48
+      @csv_header = CSV_HEADER
+    end
+  end
+end

--- a/app/controllers/schools/configuration_controller.rb
+++ b/app/controllers/schools/configuration_controller.rb
@@ -7,6 +7,7 @@ module Schools
         @school.template_calendar = @school.school_group.default_template_calendar
         @school.solar_pv_tuos_area = @school.school_group.default_solar_pv_tuos_area
         @school.dark_sky_area = @school.school_group.default_dark_sky_area
+        @school.weather_station = @school.school_group.default_weather_station
         @school.scoreboard = @school.school_group.default_scoreboard
       end
     end
@@ -38,7 +39,8 @@ module Schools
         :solar_pv_tuos_area_id,
         :dark_sky_area_id,
         :scoreboard_id,
-        :school_group_id
+        :school_group_id,
+        :weather_station_id
       )
     end
 

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -19,9 +19,9 @@
 #
 # Foreign Keys
 #
-#  fk_rails_...  (activity_category_id => activity_categories.id)
-#  fk_rails_...  (activity_type_id => activity_types.id)
-#  fk_rails_...  (school_id => schools.id)
+#  fk_rails_...  (activity_category_id => activity_categories.id) ON DELETE => restrict
+#  fk_rails_...  (activity_type_id => activity_types.id) ON DELETE => restrict
+#  fk_rails_...  (school_id => schools.id) ON DELETE => cascade
 #
 
 class Activity < ApplicationRecord

--- a/app/models/activity_type_suggestion.rb
+++ b/app/models/activity_type_suggestion.rb
@@ -15,7 +15,7 @@
 #
 # Foreign Keys
 #
-#  fk_rails_...  (activity_type_id => activity_types.id)
+#  fk_rails_...  (activity_type_id => activity_types.id) ON DELETE => cascade
 #
 
 class ActivityTypeSuggestion < ApplicationRecord

--- a/app/models/alert.rb
+++ b/app/models/alert.rb
@@ -29,7 +29,7 @@
 #
 # Foreign Keys
 #
-#  fk_rails_...  (alert_generation_run_id => alert_generation_runs.id)
+#  fk_rails_...  (alert_generation_run_id => alert_generation_runs.id) ON DELETE => cascade
 #  fk_rails_...  (alert_type_id => alert_types.id) ON DELETE => cascade
 #  fk_rails_...  (school_id => schools.id) ON DELETE => cascade
 #

--- a/app/models/alert_subscription_event.rb
+++ b/app/models/alert_subscription_event.rb
@@ -28,11 +28,10 @@
 #
 # Foreign Keys
 #
-#  fk_rails_...  (alert_id => alerts.id)
+#  fk_rails_...  (alert_id => alerts.id) ON DELETE => cascade
 #  fk_rails_...  (alert_type_rating_content_version_id => alert_type_rating_content_versions.id) ON DELETE => cascade
-#  fk_rails_...  (contact_id => contacts.id)
-#  fk_rails_...  (content_generation_run_id => content_generation_runs.id) ON DELETE => cascade
-#  fk_rails_...  (email_id => emails.id)
+#  fk_rails_...  (contact_id => contacts.id) ON DELETE => cascade
+#  fk_rails_...  (email_id => emails.id) ON DELETE => nullify
 #  fk_rails_...  (find_out_more_id => find_out_mores.id) ON DELETE => nullify
 #  fk_rails_...  (subscription_generation_run_id => subscription_generation_runs.id) ON DELETE => cascade
 #

--- a/app/models/alert_type_rating.rb
+++ b/app/models/alert_type_rating.rb
@@ -26,7 +26,7 @@
 #
 # Foreign Keys
 #
-#  fk_rails_...  (alert_type_id => alert_types.id) ON DELETE => restrict
+#  fk_rails_...  (alert_type_id => alert_types.id) ON DELETE => cascade
 #
 
 class AlertTypeRating < ApplicationRecord

--- a/app/models/amr_data_feed_config.rb
+++ b/app/models/amr_data_feed_config.rb
@@ -13,6 +13,7 @@
 #  identifier              :text             not null
 #  import_warning_days     :integer          default(7)
 #  meter_description_field :text
+#  missing_readings_limit  :integer
 #  mpan_mprn_field         :text             not null
 #  msn_field               :text
 #  number_of_header_rows   :integer          default(0), not null

--- a/app/models/amr_data_feed_reading.rb
+++ b/app/models/amr_data_feed_reading.rb
@@ -29,7 +29,9 @@
 #
 # Foreign Keys
 #
+#  fk_rails_...  (amr_data_feed_config_id => amr_data_feed_configs.id) ON DELETE => cascade
 #  fk_rails_...  (amr_data_feed_import_log_id => amr_data_feed_import_logs.id) ON DELETE => cascade
+#  fk_rails_...  (meter_id => meters.id) ON DELETE => nullify
 #
 
 class AmrDataFeedReading < ApplicationRecord

--- a/app/models/amr_validated_reading.rb
+++ b/app/models/amr_validated_reading.rb
@@ -19,7 +19,7 @@
 #
 # Foreign Keys
 #
-#  fk_rails_...  (meter_id => meters.id)
+#  fk_rails_...  (meter_id => meters.id) ON DELETE => cascade
 #
 
 class AmrValidatedReading < ApplicationRecord

--- a/app/models/analysis_page.rb
+++ b/app/models/analysis_page.rb
@@ -19,7 +19,7 @@
 #
 # Foreign Keys
 #
-#  fk_rails_...  (alert_id => alerts.id) ON DELETE => restrict
+#  fk_rails_...  (alert_id => alerts.id) ON DELETE => cascade
 #  fk_rails_...  (alert_type_rating_content_version_id => alert_type_rating_content_versions.id) ON DELETE => restrict
 #  fk_rails_...  (content_generation_run_id => content_generation_runs.id) ON DELETE => cascade
 #

--- a/app/models/area.rb
+++ b/app/models/area.rb
@@ -2,12 +2,13 @@
 #
 # Table name: areas
 #
-#  description :text
-#  id          :bigint(8)        not null, primary key
-#  latitude    :decimal(10, 6)
-#  longitude   :decimal(10, 6)
-#  title       :text
-#  type        :text             not null
+#  back_fill_years :integer          default(4)
+#  description     :text
+#  id              :bigint(8)        not null, primary key
+#  latitude        :decimal(10, 6)
+#  longitude       :decimal(10, 6)
+#  title           :text
+#  type            :text             not null
 #
 
 class Area < ApplicationRecord

--- a/app/models/calendar_event.rb
+++ b/app/models/calendar_event.rb
@@ -19,9 +19,9 @@
 #
 # Foreign Keys
 #
-#  fk_rails_...  (academic_year_id => academic_years.id)
-#  fk_rails_...  (calendar_event_type_id => calendar_event_types.id)
-#  fk_rails_...  (calendar_id => calendars.id)
+#  fk_rails_...  (academic_year_id => academic_years.id) ON DELETE => restrict
+#  fk_rails_...  (calendar_event_type_id => calendar_event_types.id) ON DELETE => restrict
+#  fk_rails_...  (calendar_id => calendars.id) ON DELETE => cascade
 #
 
 class CalendarEvent < ApplicationRecord

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -19,7 +19,7 @@
 #
 # Foreign Keys
 #
-#  fk_rails_...  (school_id => schools.id)
+#  fk_rails_...  (school_id => schools.id) ON DELETE => cascade
 #  fk_rails_...  (staff_role_id => staff_roles.id) ON DELETE => restrict
 #  fk_rails_...  (user_id => users.id) ON DELETE => cascade
 #

--- a/app/models/dark_sky_area.rb
+++ b/app/models/dark_sky_area.rb
@@ -2,12 +2,13 @@
 #
 # Table name: areas
 #
-#  description :text
-#  id          :bigint(8)        not null, primary key
-#  latitude    :decimal(10, 6)
-#  longitude   :decimal(10, 6)
-#  title       :text
-#  type        :text             not null
+#  back_fill_years :integer          default(4)
+#  description     :text
+#  id              :bigint(8)        not null, primary key
+#  latitude        :decimal(10, 6)
+#  longitude       :decimal(10, 6)
+#  title           :text
+#  type            :text             not null
 #
 class DarkSkyArea < Area
   has_many :dark_sky_temperature_readings, class_name: 'DataFeeds::DarkSkyTemperatureReading', foreign_key: :area_id, dependent: :destroy

--- a/app/models/data_feeds/dark_sky_temperature_reading.rb
+++ b/app/models/data_feeds/dark_sky_temperature_reading.rb
@@ -2,7 +2,7 @@
 #
 # Table name: dark_sky_temperature_readings
 #
-#  area_id                 :bigint(8)
+#  area_id                 :bigint(8)        not null
 #  created_at              :datetime         not null
 #  id                      :bigint(8)        not null, primary key
 #  reading_date            :date             not null

--- a/app/models/meter.rb
+++ b/app/models/meter.rb
@@ -12,6 +12,7 @@
 #  name                           :string
 #  pseudo                         :boolean          default(FALSE)
 #  school_id                      :bigint(8)        not null
+#  solar_edge_installation_id     :bigint(8)
 #  updated_at                     :datetime         not null
 #
 # Indexes
@@ -20,11 +21,13 @@
 #  index_meters_on_meter_type                      (meter_type)
 #  index_meters_on_mpan_mprn                       (mpan_mprn) UNIQUE
 #  index_meters_on_school_id                       (school_id)
+#  index_meters_on_solar_edge_installation_id      (solar_edge_installation_id)
 #
 # Foreign Keys
 #
 #  fk_rails_...  (low_carbon_hub_installation_id => low_carbon_hub_installations.id) ON DELETE => cascade
-#  fk_rails_...  (school_id => schools.id)
+#  fk_rails_...  (school_id => schools.id) ON DELETE => cascade
+#  fk_rails_...  (solar_edge_installation_id => solar_edge_installations.id) ON DELETE => cascade
 #
 
 class Meter < ApplicationRecord

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -15,7 +15,9 @@
 #  id                                    :bigint(8)        not null, primary key
 #  indicated_has_solar_panels            :boolean          default(FALSE), not null
 #  indicated_has_storage_heaters         :boolean          default(FALSE)
+#  latitude                              :decimal(10, 6)
 #  level                                 :integer          default(0)
+#  longitude                             :decimal(10, 6)
 #  met_office_area_id                    :bigint(8)
 #  name                                  :string
 #  number_of_pupils                      :integer
@@ -39,10 +41,11 @@
 #
 # Indexes
 #
-#  index_schools_on_calendar_id      (calendar_id)
-#  index_schools_on_school_group_id  (school_group_id)
-#  index_schools_on_scoreboard_id    (scoreboard_id)
-#  index_schools_on_urn              (urn) UNIQUE
+#  index_schools_on_calendar_id             (calendar_id)
+#  index_schools_on_latitude_and_longitude  (latitude,longitude)
+#  index_schools_on_school_group_id         (school_group_id)
+#  index_schools_on_scoreboard_id           (scoreboard_id)
+#  index_schools_on_urn                     (urn) UNIQUE
 #
 # Foreign Keys
 #

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -37,6 +37,7 @@
 #  urn                                   :integer          not null
 #  validation_cache_key                  :string           default("initial")
 #  visible                               :boolean          default(FALSE)
+#  weather_station_id                    :bigint(8)
 #  website                               :string
 #
 # Indexes
@@ -107,6 +108,7 @@ class School < ApplicationRecord
 
   belongs_to :solar_pv_tuos_area, optional: true
   belongs_to :dark_sky_area, optional: true
+  belongs_to :weather_station, optional: true
   belongs_to :school_group, optional: true
   belongs_to :scoreboard, optional: true
 

--- a/app/models/school_batch_run.rb
+++ b/app/models/school_batch_run.rb
@@ -1,3 +1,21 @@
+# == Schema Information
+#
+# Table name: school_batch_runs
+#
+#  created_at :datetime         not null
+#  id         :bigint(8)        not null, primary key
+#  school_id  :bigint(8)
+#  status     :integer          default("pending"), not null
+#  updated_at :datetime         not null
+#
+# Indexes
+#
+#  index_school_batch_runs_on_school_id  (school_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (school_id => schools.id) ON DELETE => cascade
+#
 class SchoolBatchRun < ApplicationRecord
   belongs_to :school
   has_many :school_batch_run_log_entries

--- a/app/models/school_batch_run_log_entry.rb
+++ b/app/models/school_batch_run_log_entry.rb
@@ -1,3 +1,21 @@
+# == Schema Information
+#
+# Table name: school_batch_run_log_entries
+#
+#  created_at          :datetime         not null
+#  id                  :bigint(8)        not null, primary key
+#  message             :string
+#  school_batch_run_id :bigint(8)
+#  updated_at          :datetime         not null
+#
+# Indexes
+#
+#  index_school_batch_run_log_entries_on_school_batch_run_id  (school_batch_run_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (school_batch_run_id => school_batch_runs.id) ON DELETE => cascade
+#
 class SchoolBatchRunLogEntry < ApplicationRecord
   belongs_to :school_batch_run
   scope :by_date, -> { order(created_at: :asc) }

--- a/app/models/school_group.rb
+++ b/app/models/school_group.rb
@@ -7,6 +7,7 @@
 #  default_scoreboard_id         :bigint(8)
 #  default_solar_pv_tuos_area_id :bigint(8)
 #  default_template_calendar_id  :bigint(8)
+#  default_weather_station_id    :bigint(8)
 #  description                   :string
 #  id                            :bigint(8)        not null, primary key
 #  name                          :string           not null
@@ -40,6 +41,7 @@ class SchoolGroup < ApplicationRecord
   belongs_to :default_template_calendar, class_name: 'Calendar', optional: true
   belongs_to :default_solar_pv_tuos_area, class_name: 'SolarPvTuosArea', optional: true
   belongs_to :default_dark_sky_area, class_name: 'DarkSkyArea', optional: true
+  belongs_to :default_weather_station, class_name: 'WeatherStation', foreign_key: 'default_weather_station_id', optional: true
   belongs_to :default_scoreboard, class_name: 'Scoreboard', optional: true
 
   has_many :meter_attributes, inverse_of: :school_group, class_name: 'SchoolGroupMeterAttribute'

--- a/app/models/school_onboarding.rb
+++ b/app/models/school_onboarding.rb
@@ -17,6 +17,7 @@
 #  template_calendar_id  :bigint(8)
 #  updated_at            :datetime         not null
 #  uuid                  :string           not null
+#  weather_station_id    :bigint(8)
 #
 # Indexes
 #
@@ -48,6 +49,7 @@ class SchoolOnboarding < ApplicationRecord
   belongs_to :template_calendar, optional: true, class_name: 'Calendar'
   belongs_to :solar_pv_tuos_area, optional: true
   belongs_to :dark_sky_area, class_name: 'DarkSkyArea', optional: true
+  belongs_to :weather_station, optional: true
   belongs_to :scoreboard, optional: true
   belongs_to :created_user, class_name: 'User', optional: true
   belongs_to :created_by, class_name: 'User', optional: true

--- a/app/models/schools/configuration.rb
+++ b/app/models/schools/configuration.rb
@@ -4,6 +4,7 @@
 #
 #  analysis_charts                     :json             not null
 #  created_at                          :datetime         not null
+#  electricity_dashboard_chart_type    :integer          default("no_electricity_chart"), not null
 #  fuel_configuration                  :json
 #  gas_dashboard_chart_type            :integer          default("no_gas_chart"), not null
 #  id                                  :bigint(8)        not null, primary key

--- a/app/models/simulation.rb
+++ b/app/models/simulation.rb
@@ -19,8 +19,8 @@
 #
 # Foreign Keys
 #
-#  fk_rails_...  (school_id => schools.id)
-#  fk_rails_...  (user_id => users.id)
+#  fk_rails_...  (school_id => schools.id) ON DELETE => cascade
+#  fk_rails_...  (user_id => users.id) ON DELETE => nullify
 #
 
 class Simulation < ApplicationRecord

--- a/app/models/solar_edge_installation.rb
+++ b/app/models/solar_edge_installation.rb
@@ -1,3 +1,27 @@
+# == Schema Information
+#
+# Table name: solar_edge_installations
+#
+#  amr_data_feed_config_id :bigint(8)        not null
+#  api_key                 :text
+#  created_at              :datetime         not null
+#  id                      :bigint(8)        not null, primary key
+#  information             :json
+#  mpan                    :text
+#  school_id               :bigint(8)        not null
+#  site_id                 :text
+#  updated_at              :datetime         not null
+#
+# Indexes
+#
+#  index_solar_edge_installations_on_amr_data_feed_config_id  (amr_data_feed_config_id)
+#  index_solar_edge_installations_on_school_id                (school_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (amr_data_feed_config_id => amr_data_feed_configs.id) ON DELETE => cascade
+#  fk_rails_...  (school_id => schools.id) ON DELETE => cascade
+#
 class SolarEdgeInstallation < ApplicationRecord
   belongs_to :school, inverse_of: :solar_edge_installations
   belongs_to :amr_data_feed_config

--- a/app/models/solar_pv_tuos_area.rb
+++ b/app/models/solar_pv_tuos_area.rb
@@ -2,12 +2,13 @@
 #
 # Table name: areas
 #
-#  description :text
-#  id          :bigint(8)        not null, primary key
-#  latitude    :decimal(10, 6)
-#  longitude   :decimal(10, 6)
-#  title       :text
-#  type        :text             not null
+#  back_fill_years :integer          default(4)
+#  description     :text
+#  id              :bigint(8)        not null, primary key
+#  latitude        :decimal(10, 6)
+#  longitude       :decimal(10, 6)
+#  title           :text
+#  type            :text             not null
 #
 
 # TUOS is The University of Sheffield

--- a/app/models/weather_observation.rb
+++ b/app/models/weather_observation.rb
@@ -11,13 +11,12 @@
 #
 # Indexes
 #
-#  index_weather_obs_on_weather_station_id                   (weather_station_id)
 #  index_weather_obs_on_weather_station_id_and_reading_date  (weather_station_id,reading_date) UNIQUE
 #  index_weather_observations_on_weather_station_id          (weather_station_id)
 #
 # Foreign Keys
 #
-#  fk_rails_...  (weather_station_id => weather_stations.id)
+#  fk_rails_...  (weather_station_id => weather_stations.id) ON DELETE => cascade
 #
 class WeatherObservation < ApplicationRecord
   belongs_to :weather_station

--- a/app/models/weather_observation.rb
+++ b/app/models/weather_observation.rb
@@ -23,4 +23,23 @@ class WeatherObservation < ApplicationRecord
   belongs_to :weather_station
   scope :by_date, -> { order(:reading_date) }
   scope :since, ->(date) { where('reading_date >= ?', date) }
+
+  def self.download_all_data
+    <<~QUERY
+      SELECT station.title, obs.reading_date, obs.temperature_celsius_x48
+      FROM  weather_observations obs, weather_stations station
+      WHERE obs.weather_station_id = station.id
+      ORDER BY station.id, obs.reading_date ASC
+    QUERY
+  end
+
+  def self.download_for_area_id(id)
+    <<~QUERY
+      SELECT station.title, obs.reading_date, obs.temperature_celsius_x48
+      FROM  weather_observations obs, weather_stations station
+      WHERE obs.weather_station_id = station.id
+      AND   obs.weather_station_id = #{id}
+      ORDER BY station.id, obs.reading_date ASC
+    QUERY
+  end
 end

--- a/app/models/weather_observation.rb
+++ b/app/models/weather_observation.rb
@@ -1,0 +1,26 @@
+# == Schema Information
+#
+# Table name: weather_observations
+#
+#  created_at              :datetime         not null
+#  id                      :bigint(8)        not null, primary key
+#  reading_date            :date             not null
+#  temperature_celsius_x48 :decimal(, )      not null, is an Array
+#  updated_at              :datetime         not null
+#  weather_station_id      :bigint(8)        not null
+#
+# Indexes
+#
+#  index_weather_obs_on_weather_station_id                   (weather_station_id)
+#  index_weather_obs_on_weather_station_id_and_reading_date  (weather_station_id,reading_date) UNIQUE
+#  index_weather_observations_on_weather_station_id          (weather_station_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (weather_station_id => weather_stations.id)
+#
+class WeatherObservation < ApplicationRecord
+  belongs_to :weather_station
+  scope :by_date, -> { order(:reading_date) }
+  scope :since, ->(date) { where('reading_date >= ?', date) }
+end

--- a/app/models/weather_station.rb
+++ b/app/models/weather_station.rb
@@ -20,4 +20,20 @@ class WeatherStation < ApplicationRecord
   scope :by_title, -> { order(title: :asc) }
   scope :active_by_provider, ->(provider) { where(active: true, provider: provider) }
   scope :by_provider, ->(provider) { where(provider: provider) }
+
+  def observation_count
+    weather_observations.count
+  end
+
+  def first_observation_date
+    if observation_count > 0
+      weather_observations.by_date.first.reading_date.strftime('%d %b %Y')
+    end
+  end
+
+  def last_observation_date
+    if observation_count > 0
+      weather_observations.by_date.last.reading_date.strftime('%d %b %Y')
+    end
+  end
 end

--- a/app/models/weather_station.rb
+++ b/app/models/weather_station.rb
@@ -9,12 +9,14 @@
 #  latitude    :decimal(10, 6)
 #  longitude   :decimal(10, 6)
 #  title       :text
-#  type        :string           not null
+#  provider    :string           not null
 #  updated_at  :datetime         not null
 #
 class WeatherStation < ApplicationRecord
   has_many :weather_observations, dependent: :destroy
-  validates_presence_of :latitude, :longitude, :title, :type
-  validates :type, inclusion: { in: ["meteostat"] }
+  validates_presence_of :latitude, :longitude, :title, :provider
+  validates :provider, inclusion: { in: ["meteostat"] }
   scope :by_title, -> { order(title: :asc) }
+  scope :active_by_provider, ->(provider) { where(active: true, provider: provider) }
+  scope :by_provider, ->(provider) { where(provider: provider) }
 end

--- a/app/models/weather_station.rb
+++ b/app/models/weather_station.rb
@@ -13,9 +13,10 @@
 #  updated_at  :datetime         not null
 #
 class WeatherStation < ApplicationRecord
+  METEOSTAT = "meteostat".freeze
   has_many :weather_observations, dependent: :destroy
   validates_presence_of :latitude, :longitude, :title, :provider
-  validates :provider, inclusion: { in: ["meteostat"] }
+  validates :provider, inclusion: { in: [METEOSTAT] }
   scope :by_title, -> { order(title: :asc) }
   scope :active_by_provider, ->(provider) { where(active: true, provider: provider) }
   scope :by_provider, ->(provider) { where(provider: provider) }

--- a/app/models/weather_station.rb
+++ b/app/models/weather_station.rb
@@ -1,0 +1,21 @@
+# == Schema Information
+#
+# Table name: weather_stations
+#
+#  active      :boolean          default(TRUE)
+#  created_at  :datetime         not null
+#  description :text
+#  id          :bigint(8)        not null, primary key
+#  latitude    :decimal(10, 6)
+#  longitude   :decimal(10, 6)
+#  title       :text
+#  type        :string           not null
+#  updated_at  :datetime         not null
+#
+class WeatherStation < ApplicationRecord
+  has_many :weather_observations, dependent: :destroy
+
+  validates_presence_of :latitude, :longitude, :title, :type
+
+  scope :by_title, -> { order(title: :asc) }
+end

--- a/app/models/weather_station.rb
+++ b/app/models/weather_station.rb
@@ -2,20 +2,21 @@
 #
 # Table name: weather_stations
 #
-#  active      :boolean          default(TRUE)
-#  created_at  :datetime         not null
-#  description :text
-#  id          :bigint(8)        not null, primary key
-#  latitude    :decimal(10, 6)
-#  longitude   :decimal(10, 6)
-#  title       :text
-#  provider    :string           not null
-#  updated_at  :datetime         not null
+#  active          :boolean          default(TRUE)
+#  back_fill_years :integer          default(4)
+#  created_at      :datetime         not null
+#  description     :text
+#  id              :bigint(8)        not null, primary key
+#  latitude        :decimal(10, 6)
+#  longitude       :decimal(10, 6)
+#  provider        :string           not null
+#  title           :text
+#  updated_at      :datetime         not null
 #
 class WeatherStation < ApplicationRecord
   METEOSTAT = "meteostat".freeze
   has_many :weather_observations, dependent: :destroy
-  validates_presence_of :latitude, :longitude, :title, :provider
+  validates_presence_of :latitude, :longitude, :title, :provider, :back_fill_years
   validates :provider, inclusion: { in: [METEOSTAT] }
   scope :by_title, -> { order(title: :asc) }
   scope :active_by_provider, ->(provider) { where(active: true, provider: provider) }

--- a/app/models/weather_station.rb
+++ b/app/models/weather_station.rb
@@ -14,8 +14,7 @@
 #
 class WeatherStation < ApplicationRecord
   has_many :weather_observations, dependent: :destroy
-
   validates_presence_of :latitude, :longitude, :title, :type
-
+  validates :type, inclusion: { in: ["meteostat"] }
   scope :by_title, -> { order(title: :asc) }
 end

--- a/app/models/weather_station.rb
+++ b/app/models/weather_station.rb
@@ -37,4 +37,8 @@ class WeatherStation < ApplicationRecord
       weather_observations.by_date.last.reading_date.strftime('%d %b %Y')
     end
   end
+
+  def has_sufficient_readings?(latest_date, minimum_readings_per_year)
+    weather_observations.since(latest_date - back_fill_years.years).count >= minimum_readings_per_year * back_fill_years
+  end
 end

--- a/app/views/admin/index.html.erb
+++ b/app/views/admin/index.html.erb
@@ -40,6 +40,7 @@
   <li><%= link_to "AMR Data feed configuration", admin_amr_data_feed_configs_path %></li>
   <li><%= link_to "Dark Sky Areas", admin_dark_sky_areas_path %></li>
   <li><%= link_to "Solar PV Areas", admin_solar_pv_tuos_areas_path %></li>
+  <li><%= link_to "Weather Stations", admin_weather_stations_path %></li>
 </ul>
 
 <h2>Other</h2>

--- a/app/views/admin/reports/index.html.erb
+++ b/app/views/admin/reports/index.html.erb
@@ -50,5 +50,8 @@
   <% SolarPvTuosArea.all.each do |area| %>
     <li><%= link_to "Solar Pv 2 tuos CSV for #{area.title}", data_feeds_solar_pv_tuos_readings_path(area.id, format: "csv") %></li>
   <% end %>
+  <% WeatherStation.all.each do |area| %>
+    <li><%= link_to "#{area.provider.capitalize} Weather Station CSV for #{area.title}", data_feeds_weather_observations_path(area.id, format: "csv") %></li>
+  <% end %>
   <li><%= link_to 'Carbon intensity data CSV', data_feeds_carbon_intensity_readings_path(format: "csv") %></li>
 </ul>

--- a/app/views/admin/reports/index.html.erb
+++ b/app/views/admin/reports/index.html.erb
@@ -39,6 +39,14 @@
   <% end %>
 </ul>
 
+<h2>Weather Stations</h2>
+<ul>
+  <% WeatherStation.by_title.each do |area| %>
+    <li><%= link_to "#{area.title}", data_feeds_weather_observations_path(area.id) %></li>
+  <% end %>
+</ul>
+
+
 <h1>Downloads</h1>
 
 <ul>

--- a/app/views/admin/school_groups/_form.html.erb
+++ b/app/views/admin/school_groups/_form.html.erb
@@ -35,6 +35,11 @@
       </div>
 
       <div class="form-group">
+        <%= f.label :default_weather_station_id, 'Default Weather Station' %>
+        <%= f.select :default_weather_station_id, options_from_collection_for_select(WeatherStation.order(:title), 'id', 'title', @school_group.default_weather_station_id), {include_blank: true}, { class: 'form-control' } %>
+      </div>
+
+      <div class="form-group">
         <%= f.label :default_scoreboard_id, 'Default scoreboard' %>
         <%= f.select :default_scoreboard_id, options_from_collection_for_select(Scoreboard.order(:name), 'id', 'name', (@school_group.default_scoreboard_id)), {include_blank: true}, { class: 'form-control' } %>
       </div>

--- a/app/views/admin/school_onboardings/configuration/edit.html.erb
+++ b/app/views/admin/school_onboardings/configuration/edit.html.erb
@@ -19,6 +19,10 @@
       <%= f.select :dark_sky_area_id, options_from_collection_for_select(DarkSkyArea.all, 'id', 'title', (@school_onboarding.dark_sky_area.id if @school_onboarding.dark_sky_area)),{}, { class: 'form-control' }%>
     </div>
   </div>
+  <div class="form-group">
+    <%= f.label :weather_station_id, 'Weather Station' %>
+    <%= f.select :weather_station_id, options_from_collection_for_select(WeatherStation.order(:title), 'id', 'title', @school_onboarding.weather_station_id), {include_blank: true}, { class: 'form-control' } %>
+  </div>
   <div class="form-row">
     <div class="form-group col-md-6">
       <%= f.label :scoreboard_id, 'Scoreboard' %>

--- a/app/views/admin/weather_stations/_form.html.erb
+++ b/app/views/admin/weather_stations/_form.html.erb
@@ -5,6 +5,6 @@
   <%= f.input :longitude, readonly: (f.object.persisted? && f.object.observation_count > 0) %>
   <%= f.input :back_fill_years %>
   <%= f.input :provider, collection: [["Meteostat", "meteostat"]], selected: "meteostat" %>
-  <%= f.input :active, as: :boolean %>
+  <%= f.input :active, label: "Load data?", as: :boolean %>
   <%= f.submit class: 'btn btn-primary' %>
 <% end %>

--- a/app/views/admin/weather_stations/_form.html.erb
+++ b/app/views/admin/weather_stations/_form.html.erb
@@ -1,0 +1,9 @@
+<%= simple_form_for([:admin, weather_station]) do |f| %>
+  <%= f.input :title, as: :string %>
+  <%= f.input :description, as: :string %>
+  <%= f.input :latitude, readonly: f.object.persisted? %>
+  <%= f.input :longitude, readonly: f.object.persisted? %>
+  <%= f.input :provider, collection: [["Meteostat", "meteostat"]], selected: "meteostat" %>
+  <%= f.input :active, as: :boolean %>
+  <%= f.submit class: 'btn btn-primary' %>
+<% end %>

--- a/app/views/admin/weather_stations/_form.html.erb
+++ b/app/views/admin/weather_stations/_form.html.erb
@@ -1,8 +1,8 @@
 <%= simple_form_for([:admin, weather_station]) do |f| %>
   <%= f.input :title, as: :string %>
   <%= f.input :description, as: :string %>
-  <%= f.input :latitude, readonly: f.object.persisted? %>
-  <%= f.input :longitude, readonly: f.object.persisted? %>
+  <%= f.input :latitude, readonly: (f.object.persisted? && f.object.observation_count > 0) %>
+  <%= f.input :longitude, readonly: (f.object.persisted? && f.object.observation_count > 0) %>
   <%= f.input :back_fill_years %>
   <%= f.input :provider, collection: [["Meteostat", "meteostat"]], selected: "meteostat" %>
   <%= f.input :active, as: :boolean %>

--- a/app/views/admin/weather_stations/_form.html.erb
+++ b/app/views/admin/weather_stations/_form.html.erb
@@ -3,6 +3,7 @@
   <%= f.input :description, as: :string %>
   <%= f.input :latitude, readonly: f.object.persisted? %>
   <%= f.input :longitude, readonly: f.object.persisted? %>
+  <%= f.input :back_fill_years %>
   <%= f.input :provider, collection: [["Meteostat", "meteostat"]], selected: "meteostat" %>
   <%= f.input :active, as: :boolean %>
   <%= f.submit class: 'btn btn-primary' %>

--- a/app/views/admin/weather_stations/edit.html.erb
+++ b/app/views/admin/weather_stations/edit.html.erb
@@ -1,0 +1,7 @@
+<h1>Edit Weather Station</h1>
+
+<%= render 'form', weather_station: @weather_station %>
+
+<div class="other-actions">
+  <%= link_to 'Back', admin_weather_stations_path, class: 'btn' %>
+</div>

--- a/app/views/admin/weather_stations/index.html.erb
+++ b/app/views/admin/weather_stations/index.html.erb
@@ -6,11 +6,11 @@
     <tr>
       <th>Title</th>
       <th>Description</th>
-      <th>Latitude</th>
-      <th>Longitude</th>
+      <th>Location</th>
       <th>Readings</th>
       <th>Earliest date</th>
       <th>Latest date</th>
+      <th>Backfill Years</th>
       <th>Active?</th>
       <th>Actions</th>
     </tr>
@@ -20,11 +20,11 @@
       <tr>
         <td><%= station.title %></td>
         <td><%= station.description %></td>
-        <td><%= station.latitude %></td>
-        <td><%= station.longitude %></td>
+        <td><%= station.latitude %>, <%= station.longitude %></td>
         <td><%= station.observation_count %></td>
         <td><%= station.first_observation_date %></td>
         <td><%= station.last_observation_date %></td>
+        <td><%= station.back_fill_years %></td>
         <td><%= station.active? %></td>
         <td>
           <div class='btn-group'>

--- a/app/views/admin/weather_stations/index.html.erb
+++ b/app/views/admin/weather_stations/index.html.erb
@@ -1,0 +1,42 @@
+<h1>Weather Stations</h1>
+
+<% if @weather_stations.any? %>
+<table class="table table-sorted">
+  <thead>
+    <tr>
+      <th>Title</th>
+      <th>Description</th>
+      <th>Latitude</th>
+      <th>Longitude</th>
+      <th>Readings</th>
+      <th>Earliest date</th>
+      <th>Latest date</th>
+      <th>Active?</th>
+      <th>Actions</th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @weather_stations.each do |station| %>
+      <tr>
+        <td><%= station.title %></td>
+        <td><%= station.description %></td>
+        <td><%= station.latitude %></td>
+        <td><%= station.longitude %></td>
+        <td><%= station.observation_count %></td>
+        <td><%= station.first_observation_date %></td>
+        <td><%= station.last_observation_date %></td>
+        <td><%= station.active? %></td>
+        <td>
+          <div class='btn-group'>
+            <%= link_to 'Edit', edit_admin_weather_station_path(station), class: 'btn' %>
+          </div>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+<% else %>
+  <p>There are no Weather Stations</p>
+<% end %>
+
+<%= link_to 'New Weather Station', new_admin_weather_station_path, class: 'btn' %>

--- a/app/views/admin/weather_stations/index.html.erb
+++ b/app/views/admin/weather_stations/index.html.erb
@@ -10,8 +10,8 @@
       <th>Readings</th>
       <th>Earliest date</th>
       <th>Latest date</th>
-      <th>Backfill Years</th>
-      <th>Active?</th>
+      <th title="Number of years of historical data to backfill">Backfill Years</th>
+      <th title="Is data for this station being loaded?">Loading?</th>
       <th>Actions</th>
     </tr>
   </thead>

--- a/app/views/admin/weather_stations/index.html.erb
+++ b/app/views/admin/weather_stations/index.html.erb
@@ -18,9 +18,10 @@
   <tbody>
     <% @weather_stations.each do |station| %>
       <tr>
-        <td><%= station.title %></td>
+        <td><%= link_to "#{station.title}", data_feeds_weather_observations_path(station.id) %></td>
         <td><%= station.description %></td>
-        <td><%= station.latitude %>, <%= station.longitude %></td>
+        <td>
+          <%= link_to "#{station.latitude}, #{station.longitude}", "https://www.openstreetmap.org/?mlat=#{station.latitude}&mlon=#{station.longitude}", target: '_blank' %>
         <td><%= station.observation_count %></td>
         <td><%= station.first_observation_date %></td>
         <td><%= station.last_observation_date %></td>

--- a/app/views/admin/weather_stations/new.html.erb
+++ b/app/views/admin/weather_stations/new.html.erb
@@ -1,0 +1,7 @@
+<h1>New Weather Station</h1>
+
+<%= render 'form', weather_station: @weather_station %>
+
+<div class="other-actions">
+  <%= link_to 'Back', admin_weather_stations_path, class: 'btn' %>
+</div>

--- a/app/views/data_feeds/generic/show.html.erb
+++ b/app/views/data_feeds/generic/show.html.erb
@@ -3,7 +3,12 @@
 <p><%= link_to 'All reports', admin_reports_path, class: 'btn btn-success' %></p>
 
 <h2>Missing days summary</h2>
-<p>Dates start at date of first recorded reading, <%= nice_dates @first_read.reading_date %>, up until the present day.</p>
+
+<% if @first_read.nil? %>
+  <strong>There are currently no readings for this location</strong>
+<% else %>
+  <p>Dates start at date of first recorded reading, <%= nice_dates @first_read.reading_date %>, up until the present day.</p>
+<% end %>
 
 <div id="calendar" class="calendar"></div>
 

--- a/app/views/schools/configuration/_form.html.erb
+++ b/app/views/schools/configuration/_form.html.erb
@@ -27,6 +27,12 @@
   </div>
   <div class="form-row">
     <div class="form-group col-md-6">
+      <%= f.label :weather_station_id, 'Weather Station' %>
+      <%= f.select :weather_station_id, options_from_collection_for_select(WeatherStation.all, 'id', 'title', (@school.weather_station_id if @school.weather_station)),{:include_blank => true }, { class: 'form-control' }%>
+    </div>
+  </div>
+  <div class="form-row">
+    <div class="form-group col-md-6">
       <%= f.label :scoreboard_id, 'Scoreboard' %>
       <%= f.select :scoreboard_id, options_from_collection_for_select(@scoreboards, 'id', 'name', (@school.scoreboard.id if @school.scoreboard)),{}, { class: 'form-control' }%>
     </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,6 +25,7 @@ Rails.application.routes.draw do
   get 'data_feeds/dark_sky_temperature_readings/:area_id', to: 'data_feeds/dark_sky_temperature_readings#show', as: :data_feeds_dark_sky_temperature_readings
   get 'data_feeds/solar_pv_tuos_readings/:area_id',  to: 'data_feeds/solar_pv_tuos_readings#show', as: :data_feeds_solar_pv_tuos_readings
   get 'data_feeds/carbon_intensity_readings',  to: 'data_feeds/carbon_intensity_readings#show', as: :data_feeds_carbon_intensity_readings
+  get 'data_feeds/weather_observations/:weather_station_id', to: 'data_feeds/weather_observations#show', as: :data_feeds_weather_observations
   get 'data_feeds/:id/:feed_type', to: 'data_feeds#show', as: :data_feed
 
   get 'benchmarks', to: 'benchmarks#index'
@@ -178,6 +179,7 @@ Rails.application.routes.draw do
     resource :activity_type_preview, only: :create
 
     resources :dark_sky_areas, except: [:destroy, :show]
+    resources :weather_stations, except: [:destroy, :show]
     resources :solar_pv_tuos_areas, except: [:destroy, :show]
 
     resources :schools, only: [] do

--- a/db/migrate/20210127100405_create_weather_stations.rb
+++ b/db/migrate/20210127100405_create_weather_stations.rb
@@ -1,0 +1,14 @@
+class CreateWeatherStations < ActiveRecord::Migration[6.0]
+  def change
+    create_table :weather_stations do |t|
+      t.text :title
+      t.text :description
+      t.string :type, null: false
+      t.boolean :active, default: true
+      t.decimal :latitude, precision: 10, scale: 6
+      t.decimal :longitude, precision: 10, scale: 6
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20210127100405_create_weather_stations.rb
+++ b/db/migrate/20210127100405_create_weather_stations.rb
@@ -3,7 +3,7 @@ class CreateWeatherStations < ActiveRecord::Migration[6.0]
     create_table :weather_stations do |t|
       t.text :title
       t.text :description
-      t.string :type, null: false
+      t.string :provider, null: false
       t.boolean :active, default: true
       t.decimal :latitude, precision: 10, scale: 6
       t.decimal :longitude, precision: 10, scale: 6

--- a/db/migrate/20210127101121_create_weather_observations.rb
+++ b/db/migrate/20210127101121_create_weather_observations.rb
@@ -1,0 +1,12 @@
+class CreateWeatherObservations < ActiveRecord::Migration[6.0]
+  def change
+    create_table :weather_observations do |t|
+      t.references :weather_station, null: false, foreign_key: {on_delete: :cascade}
+      t.date :reading_date, null: false
+      t.decimal "temperature_celsius_x48", null: false, array: true
+      t.timestamps
+
+      t.index ["weather_station_id", "reading_date"], name: "index_weather_obs_on_weather_station_id_and_reading_date", unique: true
+    end
+  end
+end

--- a/db/migrate/20210128120519_add_back_fill_years_to_weather_station.rb
+++ b/db/migrate/20210128120519_add_back_fill_years_to_weather_station.rb
@@ -1,0 +1,5 @@
+class AddBackFillYearsToWeatherStation < ActiveRecord::Migration[6.0]
+  def change
+    add_column :weather_stations, :back_fill_years, :integer, default: 4
+  end
+end

--- a/db/migrate/20210128151747_add_weather_station_to_school.rb
+++ b/db/migrate/20210128151747_add_weather_station_to_school.rb
@@ -1,0 +1,7 @@
+class AddWeatherStationToSchool < ActiveRecord::Migration[6.0]
+  def change
+    add_column :schools, :weather_station_id, :bigint, index: true
+    add_column :school_onboardings, :weather_station_id, :bigint, index: true
+    add_column :school_groups, :default_weather_station_id, :bigint, index: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1176,7 +1176,7 @@ ActiveRecord::Schema.define(version: 2021_01_27_101121) do
   create_table "weather_stations", force: :cascade do |t|
     t.text "title"
     t.text "description"
-    t.string "type", null: false
+    t.string "provider", null: false
     t.boolean "active", default: true
     t.decimal "latitude", precision: 10, scale: 6
     t.decimal "longitude", precision: 10, scale: 6

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_28_120519) do
+ActiveRecord::Schema.define(version: 2021_01_28_151747) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
@@ -901,6 +901,7 @@ ActiveRecord::Schema.define(version: 2021_01_28_120519) do
     t.bigint "default_solar_pv_tuos_area_id"
     t.bigint "default_dark_sky_area_id"
     t.bigint "default_template_calendar_id"
+    t.bigint "default_weather_station_id"
     t.index ["default_scoreboard_id"], name: "index_school_groups_on_default_scoreboard_id"
     t.index ["default_solar_pv_tuos_area_id"], name: "index_school_groups_on_default_solar_pv_tuos_area_id"
     t.index ["default_template_calendar_id"], name: "index_school_groups_on_default_template_calendar_id"
@@ -950,6 +951,7 @@ ActiveRecord::Schema.define(version: 2021_01_28_120519) do
     t.bigint "dark_sky_area_id"
     t.bigint "template_calendar_id"
     t.bigint "scoreboard_id"
+    t.bigint "weather_station_id"
     t.index ["created_by_id"], name: "index_school_onboardings_on_created_by_id"
     t.index ["created_user_id"], name: "index_school_onboardings_on_created_user_id"
     t.index ["school_group_id"], name: "index_school_onboardings_on_school_group_id"
@@ -1004,6 +1006,7 @@ ActiveRecord::Schema.define(version: 2021_01_28_120519) do
     t.date "activation_date"
     t.decimal "latitude", precision: 10, scale: 6
     t.decimal "longitude", precision: 10, scale: 6
+    t.bigint "weather_station_id"
     t.index ["calendar_id"], name: "index_schools_on_calendar_id"
     t.index ["latitude", "longitude"], name: "index_schools_on_latitude_and_longitude"
     t.index ["school_group_id"], name: "index_schools_on_school_group_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_27_101121) do
+ActiveRecord::Schema.define(version: 2021_01_28_120519) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
@@ -1182,6 +1182,7 @@ ActiveRecord::Schema.define(version: 2021_01_27_101121) do
     t.decimal "longitude", precision: 10, scale: 6
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.integer "back_fill_years", default: 4
   end
 
   add_foreign_key "academic_years", "calendars", on_delete: :restrict

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_12_142347) do
+ActiveRecord::Schema.define(version: 2021_01_27_101121) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
@@ -1163,6 +1163,27 @@ ActiveRecord::Schema.define(version: 2021_01_12_142347) do
     t.index ["staff_role_id"], name: "index_users_on_staff_role_id"
   end
 
+  create_table "weather_observations", force: :cascade do |t|
+    t.bigint "weather_station_id", null: false
+    t.date "reading_date", null: false
+    t.decimal "temperature_celsius_x48", null: false, array: true
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["weather_station_id", "reading_date"], name: "index_weather_obs_on_weather_station_id_and_reading_date", unique: true
+    t.index ["weather_station_id"], name: "index_weather_observations_on_weather_station_id"
+  end
+
+  create_table "weather_stations", force: :cascade do |t|
+    t.text "title"
+    t.text "description"
+    t.string "type", null: false
+    t.boolean "active", default: true
+    t.decimal "latitude", precision: 10, scale: 6
+    t.decimal "longitude", precision: 10, scale: 6
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
   add_foreign_key "academic_years", "calendars", on_delete: :restrict
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "activities", "activity_categories", on_delete: :restrict
@@ -1306,4 +1327,5 @@ ActiveRecord::Schema.define(version: 2021_01_12_142347) do
   add_foreign_key "users", "school_groups", on_delete: :restrict
   add_foreign_key "users", "schools", on_delete: :cascade
   add_foreign_key "users", "staff_roles", on_delete: :restrict
+  add_foreign_key "weather_observations", "weather_stations", on_delete: :cascade
 end

--- a/lib/data_feeds/meteostat_loader.rb
+++ b/lib/data_feeds/meteostat_loader.rb
@@ -1,0 +1,58 @@
+require 'dashboard'
+
+module DataFeeds
+  class MeteostatLoader
+    attr_reader :insert_count, :update_count, :stations_processed
+
+    def initialize(start_date = Date.yesterday - 10.days, end_date = Date.yesterday, meteostat_interface = MeteoStat.new)
+      @start_date = start_date
+      @end_date = end_date
+      @meteostat_interface = meteostat_interface
+      @insert_count = 0
+      @update_count = 0
+      @stations_processed = 0
+    end
+
+    def import
+      WeatherStation.active_by_provider(WeatherStation::METEOSTAT).each do |station|
+        import_station(station)
+      end
+    end
+
+    def import_station(station)
+      process_station(station)
+      @stations_processed = @stations_processed + 1
+    end
+
+    private
+
+    def process_station(station)
+      begin
+        results = @meteostat_interface.historic_temperatures(station.latitude, station.longitude, @start_date, @end_date)
+        results[:temperatures].each do |reading_date, temperature_celsius_x48|
+          next if temperature_celsius_x48.size != 48
+          process_day(reading_date, temperature_celsius_x48, station)
+        end
+      rescue => e
+        Rails.logger.error "Exception: running station import for #{station.title} from #{@start_date} to #{@end_date} : #{e.class} #{e.message}"
+        Rails.logger.error e.backtrace.join("\n")
+        Rollbar.error(e)
+      end
+    end
+
+    def process_day(reading_date, temperature_celsius_x48, station)
+      record = WeatherObservation.find_by(reading_date: reading_date, weather_station: station)
+      if record
+        record.update(temperature_celsius_x48: temperature_celsius_x48)
+        @update_count = @update_count + 1
+      else
+        WeatherObservation.create(
+          weather_station: station,
+          reading_date: reading_date,
+          temperature_celsius_x48: temperature_celsius_x48
+        )
+        @insert_count = @insert_count + 1
+      end
+    end
+  end
+end

--- a/lib/data_feeds/meteostat_loader.rb
+++ b/lib/data_feeds/meteostat_loader.rb
@@ -4,7 +4,7 @@ module DataFeeds
   class MeteostatLoader
     attr_reader :insert_count, :update_count, :stations_processed
 
-    def initialize(start_date = Date.yesterday - 10.days, end_date = Date.yesterday, meteostat_interface = MeteoStat.new)
+    def initialize(start_date = Date.yesterday - 8.days, end_date = Date.yesterday, meteostat_interface = MeteoStat.new)
       @start_date = start_date
       @end_date = end_date
       @meteostat_interface = meteostat_interface

--- a/lib/tasks/data_feeds/meteostat_back_fill.rake
+++ b/lib/tasks/data_feeds/meteostat_back_fill.rake
@@ -1,0 +1,30 @@
+namespace :data_feeds do
+  desc 'Backfill meteostat data'
+  task meteostat_back_fill: :environment do
+
+    MINIMUM_READINGS_PER_YEAR = 365
+
+    WeatherStation.active_by_provider(WeatherStation::METEOSTAT).each do |station|
+
+      unless station.has_sufficient_readings?(Date.yesterday, MINIMUM_READINGS_PER_YEAR)
+
+        station.back_fill_years.times.each do |year_number|
+          # End date
+          # Year 0 - Date Today
+          # Year 1 - Date Today - 1 year
+          # Year 2 - Date Today - 2 year
+          # Year 3 - Date Today - 3 year
+          end_date = Date.yesterday - (year_number * MINIMUM_READINGS_PER_YEAR)
+          start_date = end_date - MINIMUM_READINGS_PER_YEAR.days
+
+          p "Running #{station.title} for #{start_date} - #{end_date}"
+
+          DataFeeds::MeteostatLoader.new(start_date, end_date).import_station(station)
+
+          break if station.has_sufficient_readings?(Date.yesterday, MINIMUM_READINGS_PER_YEAR)
+
+        end
+      end
+    end
+  end
+end

--- a/lib/tasks/data_feeds/meteostat_loader.rake
+++ b/lib/tasks/data_feeds/meteostat_loader.rake
@@ -6,6 +6,6 @@ namespace :data_feeds do
 
     loader = DataFeeds::MeteostatLoader.new(start_date, end_date)
     loader.import
-    p "Imported #{loader.insert_count} records, Updated #{loader.update_count} records from #{loader.stations} stations"
+    p "Imported #{loader.insert_count} records, Updated #{loader.update_count} records from #{loader.stations_processed} stations"
   end
 end

--- a/lib/tasks/data_feeds/meteostat_loader.rake
+++ b/lib/tasks/data_feeds/meteostat_loader.rake
@@ -1,7 +1,7 @@
 namespace :data_feeds do
   desc 'Load dark meteostat data'
   task :meteostat_loader, [:start_date, :end_date] => :environment do |_t, args|
-    start_date = args[:start_date].present? ? Date.parse(args[:start_date]) : Date.yesterday - 1
+    start_date = args[:start_date].present? ? Date.parse(args[:start_date]) : Date.yesterday - 8
     end_date = args[:end_date].present? ? Date.parse(args[:end_date]) : Date.yesterday
 
     loader = DataFeeds::MeteostatLoader.new(start_date, end_date)

--- a/lib/tasks/data_feeds/meteostat_loader.rake
+++ b/lib/tasks/data_feeds/meteostat_loader.rake
@@ -1,0 +1,11 @@
+namespace :data_feeds do
+  desc 'Load dark meteostat data'
+  task :meteostat_loader, [:start_date, :end_date] => :environment do |_t, args|
+    start_date = args[:start_date].present? ? Date.parse(args[:start_date]) : Date.yesterday - 1
+    end_date = args[:end_date].present? ? Date.parse(args[:end_date]) : Date.yesterday
+
+    loader = DataFeeds::MeteostatLoader.new(start_date, end_date)
+    loader.import
+    p "Imported #{loader.insert_count} records, Updated #{loader.update_count} records from #{loader.stations} stations"
+  end
+end

--- a/spec/factories/schools_factory.rb
+++ b/spec/factories/schools_factory.rb
@@ -34,7 +34,7 @@ FactoryBot.define do
 
     trait :with_feed_areas do
       after(:create) do |school, evaluator|
-        school.update(dark_sky_area: create(:dark_sky_area), solar_pv_tuos_area: create(:solar_pv_tuos_area))
+        school.update(dark_sky_area: create(:dark_sky_area), solar_pv_tuos_area: create(:solar_pv_tuos_area), weather_station: create(:weather_station))
       end
     end
 

--- a/spec/factories/weather_observations.rb
+++ b/spec/factories/weather_observations.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :weather_observation do
+    weather_station { nil }
+    reading_date { "2021-01-27" }
+    temperature_celsius_x48 { "9.99" }
+  end
+end

--- a/spec/factories/weather_observations.rb
+++ b/spec/factories/weather_observations.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :weather_observation do
-    weather_station { nil }
-    reading_date { "2021-01-27" }
-    temperature_celsius_x48 { "9.99" }
+    weather_station
+    reading_date            { 1.month.ago }
+    temperature_celsius_x48 { Array.new(48, rand.to_f) }
   end
 end

--- a/spec/factories/weather_stations.rb
+++ b/spec/factories/weather_stations.rb
@@ -1,9 +1,9 @@
 FactoryBot.define do
   factory :weather_station do
-    title { "MyText" }
-    description { "MyText" }
-    type { "" }
-    latitude { "9.99" }
-    longitude { "9.99" }
+    sequence(:title) {|n| "Weather Station #{n}"}
+    description { "A weather station" }
+    type { "meteostat" }
+    latitude { 51.4667 }
+    longitude { -2.6000 }
   end
 end

--- a/spec/factories/weather_stations.rb
+++ b/spec/factories/weather_stations.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  factory :weather_station do
+    title { "MyText" }
+    description { "MyText" }
+    type { "" }
+    latitude { "9.99" }
+    longitude { "9.99" }
+  end
+end

--- a/spec/factories/weather_stations.rb
+++ b/spec/factories/weather_stations.rb
@@ -2,7 +2,8 @@ FactoryBot.define do
   factory :weather_station do
     sequence(:title) {|n| "Weather Station #{n}"}
     description { "A weather station" }
-    type { "meteostat" }
+    provider { "meteostat" }
+    active { true }
     latitude { 51.4667 }
     longitude { -2.6000 }
   end

--- a/spec/lib/data_feeds/meteostat_loader_spec.rb
+++ b/spec/lib/data_feeds/meteostat_loader_spec.rb
@@ -1,0 +1,91 @@
+require 'rails_helper'
+
+module DataFeeds
+  describe MeteostatLoader do
+    let(:interface) { double("meteostat_interface")}
+    let!(:weather_station)                  { create(:weather_station) }
+    let!(:inactive_station)                 { create(:weather_station, active: false) }
+    let(:start_date)                        { Date.parse('2021-01-01') }
+    let(:bad_temperature_readings)          { [10.0] }
+    let(:good_temperature_readings)         { Array.new(48, 10.0) }
+    let(:good_warmer_temperature_readings)  { Array.new(48, 15.0) }
+    let(:weather_observation)               { create(:weather_observation, weather_station: weather_station, reading_date: start_date, temperature_celsius_x48: good_temperature_readings)}
+
+    context "when running an import" do
+      it "only processes active meteostat stations" do
+        allow(interface).to receive(:historic_temperatures) do
+          { temperatures: { start_date => good_temperature_readings }, missing: nil }
+        end
+        loader = MeteostatLoader.new(start_date, start_date + 1.day, interface)
+        expect { loader.import }.to change { WeatherObservation.count}.from(0).to(1)
+      end
+
+      it "counts number of stations processed" do
+        allow(interface).to receive(:historic_temperatures) do
+          { temperatures: { start_date => good_temperature_readings }, missing: nil }
+        end
+        loader = MeteostatLoader.new(start_date, start_date + 1.day, interface)
+        expect { loader.import }.to change { WeatherObservation.count }.from(0).to(1)
+        expect(loader.stations_processed).to eql 1
+      end
+    end
+    context "with good data" do
+      it "inserts a record per day" do
+        allow(interface).to receive(:historic_temperatures) do
+          { temperatures: { start_date => good_temperature_readings }, missing: nil }
+        end
+        loader = MeteostatLoader.new(start_date, start_date + 1.day, interface)
+        expect { loader.import_station(weather_station) }.to change { WeatherObservation.count}.from(0).to(1)
+        expect(WeatherObservation.first.weather_station).to eq weather_station
+        expect(WeatherObservation.first.temperature_celsius_x48).to eq good_temperature_readings
+        expect(loader.insert_count).to eql 1
+        expect(loader.update_count).to eql 0
+        expect(loader.stations_processed).to eql 1
+      end
+
+      it "updates existing records" do
+        weather_observation
+        allow(interface).to receive(:historic_temperatures) do
+          { temperatures: { start_date => good_warmer_temperature_readings }, missing: nil }
+        end
+        loader = MeteostatLoader.new(start_date, start_date + 1.day, interface)
+        expect { loader.import_station(weather_station) }.to_not change { WeatherObservation.count}
+        expect(WeatherObservation.first.temperature_celsius_x48).to eq good_warmer_temperature_readings
+        expect(loader.insert_count).to eql 0
+        expect(loader.update_count).to eql 1
+      end
+    end
+
+    context "with bad data" do
+      it "does not insert readings" do
+        allow(interface).to receive(:historic_temperatures) do
+          { temperatures: { start_date: bad_temperature_readings }, missing: nil }
+        end
+
+        loader = MeteostatLoader.new(start_date, start_date + 1.day, interface)
+        expect { loader.import_station(weather_station) }.to_not change { WeatherObservation.count }
+      end
+    end
+
+    context "working with the API" do
+      it "passes the right parameters" do
+        allow(interface).to receive(:historic_temperatures) do
+          { temperatures: { start_date => good_temperature_readings }, missing: nil }
+        end
+        expect(interface).to receive(:historic_temperatures).with(
+          weather_station.latitude, weather_station.longitude, start_date, start_date + 1.day)
+        loader = MeteostatLoader.new(start_date, start_date + 1.day, interface)
+        loader.import_station(weather_station)
+      end
+
+      it "does not fail on error" do
+        allow(interface).to receive(:historic_temperatures).and_raise("an error") do
+          raise NoMethodError, "raised a test error"
+        end
+
+        loader = MeteostatLoader.new(start_date, start_date + 1.day, interface)
+        expect { loader.import_station(weather_station) }.to_not raise_error
+      end
+    end
+  end
+end

--- a/spec/models/weather_observation_spec.rb
+++ b/spec/models/weather_observation_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+RSpec.describe WeatherObservation, type: :model do
+
+  let!(:station) { create(:weather_station) }
+  let!(:reading_1) { create(:weather_observation, weather_station: station, reading_date: '2020-01-01') }
+  let!(:reading_2) { create(:weather_observation, weather_station: station, reading_date: '2021-01-01') }
+
+  it 'applies date scope' do
+    expect(station.weather_observations.since(Date.new(2019,01,01))).to eq([reading_1, reading_2])
+    expect(station.weather_observations.since(Date.new(2020,02,01))).to eq([reading_2])
+    expect(station.weather_observations.since(Date.new(2021,02,01))).to eq([])
+  end
+
+
+end

--- a/spec/models/weather_observation_spec.rb
+++ b/spec/models/weather_observation_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe WeatherObservation, type: :model do
   let!(:reading_2) { create(:weather_observation, weather_station: station, reading_date: '2021-01-01') }
 
   it 'applies date scope' do
-    expect(station.weather_observations.since(Date.new(2019,01,01))).to eq([reading_1, reading_2])
+    expect(station.weather_observations.by_date).to eq([reading_1, reading_2])
     expect(station.weather_observations.since(Date.new(2020,02,01))).to eq([reading_2])
     expect(station.weather_observations.since(Date.new(2021,02,01))).to eq([])
   end

--- a/spec/models/weather_station_spec.rb
+++ b/spec/models/weather_station_spec.rb
@@ -1,4 +1,13 @@
 require 'rails_helper'
 
 RSpec.describe WeatherStation, type: :model do
+
+  let!(:station) { create(:weather_station) }
+  let!(:station_inactive) { create(:weather_station, active: false)}
+
+  it 'applies active by type scope' do
+    expect(WeatherStation.count).to eql 2
+    expect( WeatherStation.by_provider("meteostat").to_a ).to eql([station, station_inactive])
+    expect( WeatherStation.active_by_provider("meteostat").to_a).to eql([station])
+  end
 end

--- a/spec/models/weather_station_spec.rb
+++ b/spec/models/weather_station_spec.rb
@@ -1,0 +1,4 @@
+require 'rails_helper'
+
+RSpec.describe WeatherStation, type: :model do
+end

--- a/spec/models/weather_station_spec.rb
+++ b/spec/models/weather_station_spec.rb
@@ -10,4 +10,27 @@ RSpec.describe WeatherStation, type: :model do
     expect( WeatherStation.by_provider("meteostat").to_a ).to eql([station, station_inactive])
     expect( WeatherStation.active_by_provider("meteostat").to_a).to eql([station])
   end
+
+  context "with observations" do
+
+    it "counts correctly" do
+      expect( station.observation_count ).to eql 0
+      create(:weather_observation, weather_station: station)
+      expect(WeatherObservation.count).to eql 1
+      expect( station.observation_count ).to eql 1
+    end
+
+    it "formats earliest" do
+      create(:weather_observation, weather_station: station, reading_date: Date.yesterday)
+      create(:weather_observation, weather_station: station, reading_date: Date.today)
+      expect( station.first_observation_date ).to eql(Date.yesterday.strftime('%d %b %Y'))
+    end
+
+    it "formats latest" do
+      create(:weather_observation, weather_station: station, reading_date: Date.yesterday)
+      create(:weather_observation, weather_station: station, reading_date: Date.today)
+      expect( station.last_observation_date ).to eql(Date.today.strftime('%d %b %Y'))
+    end
+
+  end
 end

--- a/spec/services/schedule_data_manager_service_spec.rb
+++ b/spec/services/schedule_data_manager_service_spec.rb
@@ -14,4 +14,70 @@ describe ScheduleDataManagerService do
       expect(school_date_period.type).to_not be_nil
     end
   end
+
+  describe '#temperatures' do
+    let!(:area)             { create(:dark_sky_area) }
+    let!(:station)          { create(:weather_station) }
+    let!(:school)           { create(:school, dark_sky_area: area, weather_station: station) }
+
+    let!(:service)          { ScheduleDataManagerService.new(school) }
+
+    it 'loads dark_sky data' do
+      reading_1 = create(:dark_sky_temperature_reading, dark_sky_area: area, reading_date: '2019-01-01')
+      reading_2 = create(:dark_sky_temperature_reading, dark_sky_area: area, reading_date: '2019-02-01')
+      temperatures = service.temperatures
+      expect( temperatures.start_date ).to eql reading_1.reading_date
+      expect( temperatures.end_date ).to eql reading_2.reading_date
+    end
+
+    it 'loads dark sky data, with feature flag set off' do
+      reading_1 = create(:dark_sky_temperature_reading, dark_sky_area: area, reading_date: '2019-01-01')
+      reading_2 = create(:dark_sky_temperature_reading, dark_sky_area: area, reading_date: '2019-02-01')
+      ClimateControl.modify FEATURE_FLAG_USE_METEOSTAT: 'false' do
+        temperatures = service.temperatures
+        expect( temperatures.start_date ).to eql reading_1.reading_date
+        expect( temperatures.end_date ).to eql reading_2.reading_date
+      end
+    end
+
+    it 'loads meteostat data, with feature flag set on' do
+      obs_1 = create(:weather_observation, weather_station: station, reading_date: '2020-01-01')
+      obs_2 = create(:weather_observation, weather_station: station, reading_date: '2020-02-01')
+      ClimateControl.modify FEATURE_FLAG_USE_METEOSTAT: 'true' do
+        temperatures = service.temperatures
+        expect( temperatures.start_date ).to eql obs_1.reading_date
+        expect( temperatures.end_date ).to eql obs_2.reading_date
+      end
+    end
+
+    it 'merges across sources where available' do
+      reading_1 = create(:dark_sky_temperature_reading, dark_sky_area: area, reading_date: '2019-01-01')
+      reading_2 = create(:dark_sky_temperature_reading, dark_sky_area: area, reading_date: '2019-02-01')
+      obs_1 = create(:weather_observation, weather_station: station, reading_date: '2020-01-01')
+      obs_2 = create(:weather_observation, weather_station: station, reading_date: '2020-02-01')
+      ClimateControl.modify FEATURE_FLAG_USE_METEOSTAT: 'true' do
+        temperatures = service.temperatures
+        #all 4 dates with expected start/end
+        expect( temperatures.date_exists?(reading_1.reading_date) ).to eql true
+        expect( temperatures.date_exists?(reading_2.reading_date) ).to eql true
+        expect( temperatures.date_exists?(obs_1.reading_date) ).to eql true
+        expect( temperatures.date_exists?(obs_2.reading_date) ).to eql true
+        expect( temperatures.start_date ).to eql reading_1.reading_date
+        expect( temperatures.end_date ).to eql obs_2.reading_date
+      end
+    end
+
+    it 'returns dark sky if no meteostat data' do
+      reading_1 = create(:dark_sky_temperature_reading, dark_sky_area: area, reading_date: '2019-01-01')
+      reading_2 = create(:dark_sky_temperature_reading, dark_sky_area: area, reading_date: '2019-02-01')
+      ClimateControl.modify FEATURE_FLAG_USE_METEOSTAT: 'true' do
+        temperatures = service.temperatures
+        expect( temperatures.date_exists?(reading_1.reading_date) ).to eql true
+        expect( temperatures.date_exists?(reading_2.reading_date) ).to eql true
+        expect( temperatures.start_date ).to eql reading_1.reading_date
+        expect( temperatures.end_date ).to eql reading_2.reading_date
+      end
+    end
+
+  end
 end

--- a/spec/system/admin/school_creation_spec.rb
+++ b/spec/system/admin/school_creation_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe "school creation", :schools, type: :system do
   let!(:solar_pv_area)  { create(:solar_pv_tuos_area, title: 'BANES solar') }
   let!(:dark_sky_area)  { create(:dark_sky_area, title: 'BANES dark sky weather') }
   let!(:scoreboard)     { create(:scoreboard, name: 'BANES scoreboard') }
+  let!(:weather_station) { create(:weather_station, title: 'BANES weather')}
 
   let!(:school_group) do
     create(
@@ -20,6 +21,7 @@ RSpec.describe "school creation", :schools, type: :system do
       default_template_calendar: calendar,
       default_solar_pv_tuos_area: solar_pv_area,
       default_dark_sky_area: dark_sky_area,
+      default_weather_station: weather_station,
       default_scoreboard: scoreboard
     )
   end
@@ -51,6 +53,7 @@ RSpec.describe "school creation", :schools, type: :system do
 
     expect(page).to have_select('Template calendar', selected: 'BANES calendar')
     expect(page).to have_select('Dark Sky Data Feed Area', selected: 'BANES dark sky weather')
+    expect(page).to have_select('Weather Station', selected: 'BANES weather')
     expect(page).to have_select('Solar PV from The University of Sheffield Data Feed Area', selected: 'BANES solar')
     expect(page).to have_select('Scoreboard', selected: 'BANES scoreboard')
 

--- a/spec/system/admin/weather_stations_spec.rb
+++ b/spec/system/admin/weather_stations_spec.rb
@@ -80,15 +80,15 @@ RSpec.describe 'Weather stations', type: :system do
         expect(WeatherStation.count).to be 1
         click_on 'Edit'
 
-        #new_latitude = 111.111
-        #new_longitude = 999.999
+        new_latitude = 111.111
+        new_longitude = 999.999
         new_title = "New title"
         new_description = "New description"
 
         fill_in 'Title', with: new_title
         fill_in 'Description', with: new_description
-        #fill_in 'Latitude', with: new_latitude
-        #fill_in 'Longitude', with: new_longitude
+        fill_in 'Latitude', with: new_latitude
+        fill_in 'Longitude', with: new_longitude
 
         click_on 'Update'
 
@@ -97,8 +97,8 @@ RSpec.describe 'Weather stations', type: :system do
         expect(page).to have_content('Weather Stations')
         expect(page).to have_content new_title
         expect(page).to have_content new_description
-        #expect(page).to have_content new_latitude
-        #expect(page).to have_content new_longitude
+        expect(page).to have_content new_latitude
+        expect(page).to have_content new_longitude
       end
 
       it 'checks for valid fields on update' do

--- a/spec/system/admin/weather_stations_spec.rb
+++ b/spec/system/admin/weather_stations_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe 'Weather stations', type: :system do
       fill_in 'Latitude', with: latitude
       fill_in 'Longitude', with: longitude
       select 'Meteostat', from: 'Provider'
-      check 'Active'
+      check 'Load data?'
 
       expect { click_on 'Create' }.to change { WeatherStation.count }.by(1)
 
@@ -51,7 +51,7 @@ RSpec.describe 'Weather stations', type: :system do
 
       fill_in 'Longitude', with: longitude
       select 'Meteostat', from: 'Provider'
-      check 'Active'
+      check 'Load data?'
       expect { click_on 'Create' }.to change { WeatherStation.count }.by(1)
 
       expect(page).to have_content('Weather Stations')
@@ -107,7 +107,7 @@ RSpec.describe 'Weather stations', type: :system do
         new_title = "New title"
 
         fill_in 'Title', with: ''
-        check('Active')
+        check('Load data?')
 
         click_on 'Update'
 

--- a/spec/system/admin/weather_stations_spec.rb
+++ b/spec/system/admin/weather_stations_spec.rb
@@ -1,0 +1,127 @@
+require 'rails_helper'
+
+RSpec.describe 'Weather stations', type: :system do
+  let!(:admin)                  { create(:admin) }
+  let(:title)                   { 'Weather station zebra' }
+  let(:description)             { 'The description'}
+  let(:latitude)                { 123.456 }
+  let(:longitude)               { -789.012 }
+  let(:provider)                { "Meteostat"}
+
+  describe 'when logged in' do
+    before(:each) do
+      sign_in(admin)
+      visit root_path
+      click_on 'Manage'
+      click_on 'Admin'
+      click_on 'Weather Stations'
+    end
+
+    it 'can create a new weather station' do
+      expect(page).to have_content("There are no Weather Stations")
+
+      click_on 'New Weather Station'
+
+      fill_in 'Title', with: title
+      fill_in 'Description', with: description
+      fill_in 'Latitude', with: latitude
+      fill_in 'Longitude', with: longitude
+      select 'Meteostat', from: 'Provider'
+      check 'Active'
+
+      expect { click_on 'Create' }.to change { WeatherStation.count }.by(1)
+
+      expect(page).to have_content("New Weather Station created")
+      expect(page).to have_content('Weather Stations')
+      expect(page).to have_content title
+      expect(page).to have_content description
+      expect(page).to have_content latitude
+      expect(page).to have_content longitude
+    end
+
+    it 'checks for valid fields when creating a station' do
+      click_on 'New Weather Station'
+
+      fill_in 'Title', with: title
+      fill_in 'Latitude', with: latitude
+
+      expect { click_on 'Create' }.to change { WeatherStation.count }.by(0)
+
+      expect(page).to have_content("can't be blank")
+
+      fill_in 'Longitude', with: longitude
+      select 'Meteostat', from: 'Provider'
+      check 'Active'
+      expect { click_on 'Create' }.to change { WeatherStation.count }.by(1)
+
+      expect(page).to have_content('Weather Stations')
+      expect(page).to have_content title
+      expect(page).to have_content latitude
+      expect(page).to have_content longitude
+    end
+
+    context 'with an existing weather station' do
+
+      let!(:station) { WeatherStation.create!(title: title, latitude: latitude, longitude: longitude, provider: "meteostat") }
+
+      before(:each) do
+        click_on 'Manage'
+        click_on 'Admin'
+        click_on 'Weather Stations'
+
+        expect(WeatherStation.count).to be 1
+        expect(page).to have_content('Weather Stations')
+        expect(page).to have_content title
+        expect(page).to have_content latitude
+        expect(page).to have_content longitude
+      end
+
+      it 'can be edited' do
+        expect(WeatherStation.count).to be 1
+        click_on 'Edit'
+
+        #new_latitude = 111.111
+        #new_longitude = 999.999
+        new_title = "New title"
+        new_description = "New description"
+
+        fill_in 'Title', with: new_title
+        fill_in 'Description', with: new_description
+        #fill_in 'Latitude', with: new_latitude
+        #fill_in 'Longitude', with: new_longitude
+
+        click_on 'Update'
+
+        expect(page).to have_content("Weather Station was updated")
+
+        expect(page).to have_content('Weather Stations')
+        expect(page).to have_content new_title
+        expect(page).to have_content new_description
+        #expect(page).to have_content new_latitude
+        #expect(page).to have_content new_longitude
+      end
+
+      it 'checks for valid fields on update' do
+        click_on 'Edit'
+
+        new_title = "New title"
+
+        fill_in 'Title', with: ''
+        check('Active')
+
+        click_on 'Update'
+
+        expect(page).to have_content("can't be blank")
+
+        fill_in 'Title', with: new_title
+
+        click_on 'Update'
+        expect(page).to have_content("Weather Station was updated")
+
+        expect(page).to have_content('Weather Stations')
+        expect(page).to have_content new_title
+      end
+
+    end
+  end
+end

--- a/spec/system/school_onboarding_spec.rb
+++ b/spec/system/school_onboarding_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe "school onboarding", :schools, type: :system do
   let(:dark_sky_weather_area)     { create(:dark_sky_area, title: 'BANES dark sky weather') }
   let(:scoreboard)                { create(:scoreboard, name: 'BANES scoreboard') }
   let!(:other_template_calendar)  { create(:regional_calendar, :with_terms, title: 'Oxford calendar') }
+  let!(:weather_station)          { create(:weather_station, title: 'BANES weather') }
 
   let!(:school_group) do
     create(
@@ -18,6 +19,7 @@ RSpec.describe "school onboarding", :schools, type: :system do
       default_template_calendar: template_calendar,
       default_solar_pv_tuos_area: solar_pv_area,
       default_dark_sky_area: dark_sky_weather_area,
+      default_weather_station: weather_station,
       default_scoreboard: scoreboard
     )
   end
@@ -49,6 +51,7 @@ RSpec.describe "school onboarding", :schools, type: :system do
       expect(page).to have_select('Template calendar', selected: 'BANES calendar')
       expect(page).to have_select('Solar PV from The University of Sheffield Data Feed Area', selected: 'BANES solar')
       expect(page).to have_select('Dark Sky Data Feed Area', selected: 'BANES dark sky weather')
+      expect(page).to have_select('Weather Station', selected: 'BANES weather')
       expect(page).to have_select('Scoreboard', selected: 'BANES scoreboard')
 
       click_on 'Next'
@@ -354,4 +357,3 @@ RSpec.describe "school onboarding", :schools, type: :system do
 
   end
 end
-


### PR DESCRIPTION
Initial branch for adding support for Meteostat.

Currently includes:

* [x] new models for `WeatherStation` and `WeatherObservation` (ultimately to replace the dark sky stuff)
* [x] new data loader, using the `MeteoStat` interface in the analytics package
* [x] admin interface to create and manage weather stations
* [x] ability for admin to download CSV files of data for each weather station

Still to do around this bit of the code:

* [x] associate weather stations with schools
* [x] association of weather stations with school groups and onboarding?
* [x] decide when to automatically add stations and associate them with schools
* [x] whether to allow lat/long to be changed, or prefer switching to new station
* [x] switching between Dark Sky and MeteoStat if a schools is associate with an active Weather Station, so right readings are passed to analytics
* [x] decide how to handle/generalise current `Area` stuff (replace in favour of stations?)
* [x] updates to EB config to add new cron job for Meteostat loading, as well as env variables to drive it

Separately need to decide how to handle Dark Sky migration, historical loading, and any improvements to the `MeteoStat` API client. 