### PR TITLE
Allow lat/long to be edited

### DIFF
--- a/app/controllers/admin/weather_stations_controller.rb
+++ b/app/controllers/admin/weather_stations_controller.rb
@@ -19,9 +19,9 @@ module Admin
     def edit
     end
 
-    #TODO decide how to handle lat/lng updates, if at all
     def update
       if @weather_station.update(weather_station_params)
+        @weather_station.weather_observations.delete_all if lat_long_changed?
         redirect_to admin_weather_stations_path, notice: 'Weather Station was updated.'
       else
         render :edit
@@ -29,6 +29,11 @@ module Admin
     end
 
     private
+
+    def lat_long_changed?
+      changes = @weather_station.previous_changes
+      changes.key?(:latitude) || changes.key?(:longitude)
+    end
 
     def weather_station_params
       params.require(:weather_station).permit(:title, :description, :type, :latitude, :longitude, :active, :provider, :back_fill_years)

--- a/app/views/admin/weather_stations/_form.html.erb
+++ b/app/views/admin/weather_stations/_form.html.erb
@@ -1,10 +1,10 @@
 <%= simple_form_for([:admin, weather_station]) do |f| %>
   <%= f.input :title, as: :string %>
   <%= f.input :description, as: :string %>
-  <%= f.input :latitude, readonly: (f.object.persisted? && f.object.observation_count > 0) %>
-  <%= f.input :longitude, readonly: (f.object.persisted? && f.object.observation_count > 0) %>
+  <%= f.input :latitude %>
+  <%= f.input :longitude %>
   <%= f.input :back_fill_years %>
   <%= f.input :provider, collection: [["Meteostat", "meteostat"]], selected: "meteostat" %>
   <%= f.input :active, label: "Load data?", as: :boolean %>
-  <%= f.submit class: 'btn btn-primary' %>
+  <%= f.submit class: 'btn btn-primary', data: {confirm: 'Modifying latitude or longitude will reset data for this station - are you sure?'} %>
 <% end %>

--- a/spec/system/admin/weather_stations_spec.rb
+++ b/spec/system/admin/weather_stations_spec.rb
@@ -122,6 +122,44 @@ RSpec.describe 'Weather stations', type: :system do
         expect(page).to have_content new_title
       end
 
+      it 'deletes old temperature readings if lat/long changed' do
+
+        WeatherObservation.create!(
+          reading_date: '2020-03-25',
+          temperature_celsius_x48: 48.times.map{rand(40.0)},
+          weather_station_id: station.id
+        )
+
+        expect(station.weather_observations.count).to eq(1)
+
+        click_on 'Edit'
+
+        new_title = 'New title for this station'
+        new_latitude = 111.111
+        new_longitude = 999.999
+
+        fill_in 'Title', with: new_title
+
+        click_on 'Update'
+
+        expect(page).to have_content("Weather Station was updated")
+        expect(page).to have_content new_title
+        expect(station.weather_observations.count).to eq(1)
+
+        click_on 'Edit'
+
+        fill_in 'Latitude', with: new_latitude
+        fill_in 'Longitude', with: new_longitude
+
+        click_on 'Update'
+
+        expect(page).to have_content("Weather Station was updated")
+        expect(page).to have_content new_latitude
+        expect(page).to have_content new_longitude
+        expect(station.weather_observations.count).to eq(0)
+
+      end
+
     end
   end
 end


### PR DESCRIPTION
Allow admin to edit lat/long of a weather station. Remove old observations if they do.