### PR TITLE
First implementation of user help videos

### DIFF
--- a/app/controllers/admin/videos_controller.rb
+++ b/app/controllers/admin/videos_controller.rb
@@ -1,0 +1,45 @@
+module Admin
+  class VideosController < AdminController
+    load_and_authorize_resource
+
+    def index
+      @videos = Video.order(:title)
+    end
+
+    def show
+    end
+
+    def new
+    end
+
+    def edit
+    end
+
+    def create
+      if @video.save
+        redirect_to admin_videos_path, notice: 'Video was successfully created.'
+      else
+        render :new
+      end
+    end
+
+    def update
+      if @video.update(video_params)
+        redirect_to admin_videos_path, notice: 'Video was successfully updated.'
+      else
+        render :edit
+      end
+    end
+
+    def destroy
+      @video.destroy
+      redirect_to admin_videos_path, notice: 'Video was successfully deleted.'
+    end
+
+    private
+
+    def video_params
+      params.require(:video).permit(:youtube_id, :title, :description, :position, :featured)
+    end
+  end
+end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,4 +1,6 @@
 class HomeController < ApplicationController
+  include VideoHelper
+
   # **** ALL ACTIONS IN THIS CONTROLLER ARE PUBLIC! ****
   skip_before_action :authenticate_user!
   before_action :redirect_if_logged_in, only: :index
@@ -42,6 +44,10 @@ class HomeController < ApplicationController
   end
 
   def attribution
+  end
+
+  def user_guide_videos
+    @videos = Video.order(:position)
   end
 
   def school_statistics

--- a/app/helpers/video_helper.rb
+++ b/app/helpers/video_helper.rb
@@ -1,0 +1,10 @@
+module VideoHelper
+  def featured_videos(number = 1)
+    featured = Video.featured.sample(number)
+    #provide a default based on video previously embedded into home page
+    if featured.empty?
+      featured << Video.new(youtube_id: "PqoKZjwgmoY", title: "", position: 1)
+    end
+    featured
+  end
+end

--- a/app/models/meter.rb
+++ b/app/models/meter.rb
@@ -3,7 +3,10 @@
 # Table name: meters
 #
 #  active                         :boolean          default(TRUE)
+#  consent_granted                :boolean          default(FALSE)
 #  created_at                     :datetime         not null
+#  dcc_meter                      :boolean          default(FALSE)
+#  earliest_available_data        :date
 #  id                             :bigint(8)        not null, primary key
 #  low_carbon_hub_installation_id :bigint(8)
 #  meter_serial_number            :text

--- a/app/models/video.rb
+++ b/app/models/video.rb
@@ -1,0 +1,23 @@
+# == Schema Information
+#
+# Table name: videos
+#
+#  created_at  :datetime         not null
+#  description :text
+#  featured    :boolean          default(FALSE), not null
+#  id          :bigint(8)        not null, primary key
+#  position    :integer          default(0), not null
+#  title       :text             not null
+#  updated_at  :datetime         not null
+#  youtube_id  :text             not null
+#
+class Video < ApplicationRecord
+  validates_presence_of :youtube_id, :title, :position
+  validates_uniqueness_of :youtube_id
+
+  scope :featured, -> { where(featured: true) }
+
+  def embed_url
+    "https://www.youtube.com/embed/#{youtube_id}"
+  end
+end

--- a/app/views/admin/index.html.erb
+++ b/app/views/admin/index.html.erb
@@ -48,6 +48,7 @@
   <li><%= link_to "Case studies", admin_case_studies_path %></li>
   <li><%= link_to "Newsletters", admin_newsletters_path %></li>
   <li><%= link_to "Resources", admin_resource_files_path %></li>
+  <li><%= link_to "Videos", admin_videos_path %></li>
   <li><%= link_to "Partners", admin_partners_path %></li>
   <li><%= link_to "Team members", admin_team_members_path %></li>
   <li><%= link_to "Site Settings", admin_settings_path %></li>

--- a/app/views/admin/videos/_form.html.erb
+++ b/app/views/admin/videos/_form.html.erb
@@ -1,0 +1,8 @@
+<%= simple_form_for([:admin, video]) do |f| %>
+  <%= f.input :youtube_id %>
+  <%= f.input :title %>
+  <%= f.input :description %>
+  <%= f.input :position %>
+  <%= f.input :featured, label: "Featured?", as: :boolean %>
+  <%= f.button :submit %>
+<% end %>

--- a/app/views/admin/videos/edit.html.erb
+++ b/app/views/admin/videos/edit.html.erb
@@ -1,0 +1,4 @@
+<h1>Editing Video</h1>
+<p><%= link_to 'All videos', admin_videos_path %></p>
+
+<%= render 'form', video: @video %>

--- a/app/views/admin/videos/index.html.erb
+++ b/app/views/admin/videos/index.html.erb
@@ -1,0 +1,42 @@
+<h1>Videos</h1>
+
+<% if @videos %>
+
+<table class="table mt-2">
+  <thead>
+    <tr>
+      <th>Id</th>
+      <th>Title</th>
+      <th>Description</th>
+      <th>Position</th>
+      <th>Featured?</th>
+      <th>Actions</th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% @videos.each do |video| %>
+      <tr>
+        <td>
+          <%= link_to video.youtube_id, "https://www.youtube.com/watch?v=#{video.youtube_id}" %>
+        </td>
+        <td><%= video.title %></td>
+        <td><%= video.description %></td>
+        <td><%= video.position %></td>
+        <td><%= video.featured %></td>
+        <td>
+          <div class="btn-group">
+            <%= link_to 'Edit', edit_admin_video_path(video), class: 'btn' %>
+            <%= link_to 'Delete', admin_video_path(video), method: :delete, data: { confirm: 'Are you sure?' }, class: 'btn' %>
+          </div>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<% else %>
+  <p>There are no videos</p>
+<% end %>
+
+<p><%= link_to 'New Video', new_admin_video_path, class: 'btn'%></p>

--- a/app/views/admin/videos/new.html.erb
+++ b/app/views/admin/videos/new.html.erb
@@ -1,0 +1,4 @@
+<h1>New Video</h1>
+<p><%= link_to 'All videos', admin_videos_path %></p>
+
+<%= render 'form', video: @video %>

--- a/app/views/home/_videos.html.erb
+++ b/app/views/home/_videos.html.erb
@@ -1,11 +1,18 @@
 <div class="mt-3">
-  <div class="application container">
-    <div class="card-deck mt-5">
-      <div class="card text-center">
-        <div class="card-body">
-          <iframe width="100%" height="630" src="https://www.youtube.com/embed/PqoKZjwgmoY" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+  <div id="featured-videos" class="application container">
+    <% featured_videos(1).each_slice(1) do |videos| %>
+      <div class="card-deck">
+        <% videos.each do |video| %>
+        <div class="card border-light">
+          <div class="card-body">
+            <div class="embed-responsive embed-responsive-16by9">
+              <iframe class="embed-responsive-item" src="<%= video.embed_url %>" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+            </div>
+          </div>
         </div>
+        <% end %>
       </div>
-      </div>
+    <% end %>
+
   </div>
 </div>

--- a/app/views/home/for_management.html.erb
+++ b/app/views/home/for_management.html.erb
@@ -65,6 +65,7 @@
 
   <div class="row padded-row justify-content-center m-4 pb-3">
     <%= link_to 'Enrol your school', enrol_path, class: 'btn bg-positive' %>
+    <%= link_to 'User guide videos', user_guide_videos_path, class: 'btn' %>
   </div>
 
   <%= render 'testimonial',

--- a/app/views/home/for_pupils.html.erb
+++ b/app/views/home/for_pupils.html.erb
@@ -69,6 +69,7 @@
 
   <div class="row padded-row justify-content-center m-4 pb-3">
     <%= link_to 'Enrol your school', enrol_path, class: 'btn bg-positive' %>
+    <%= link_to 'User guide videos', user_guide_videos_path, class: 'btn' %>
   </div>
 
   <%= render 'testimonial',

--- a/app/views/home/for_teachers.html.erb
+++ b/app/views/home/for_teachers.html.erb
@@ -74,6 +74,7 @@
 
   <div class="row padded-row justify-content-center m-4 pb-3">
     <%= link_to 'Enrol your school', enrol_path, class: 'btn bg-positive' %>
+    <%= link_to 'User guide videos', user_guide_videos_path, class: 'btn' %>
   </div>
 
   <%= render 'testimonial', quote: @testimonial[:quote], by: @testimonial[:by], title: @testimonial[:title], location: @testimonial[:location] %>

--- a/app/views/home/user_guide_videos.html.erb
+++ b/app/views/home/user_guide_videos.html.erb
@@ -1,0 +1,25 @@
+<% content_for :page_title, 'User guide videos' %>
+<div class="application container">
+  <div class="row padded-row">
+    <div class="col">
+      <h1 id="intro">User guide videos</h1>
+
+      <% @videos.each_slice(2) do |videos| %>
+        <div class="card-deck">
+          <% videos.each do |video| %>
+          <div class="card border-light">
+            <div class="card-body">
+              <h5 class="card-title"><strong><%= video.title %></strong></h5>
+
+              <div class="embed-responsive embed-responsive-16by9">
+                <iframe class="embed-responsive-item" src="<%= video.embed_url %>" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+              </div>
+              <p class="card-text"><%= video.description %></p>
+            </div>
+          </div>
+          <% end %>
+        </div>
+      <% end %>
+    </div>
+
+</div>

--- a/app/views/shared/_about_menu.html.erb
+++ b/app/views/shared/_about_menu.html.erb
@@ -8,6 +8,7 @@
     <%= link_to "Scoreboards", scoreboards_path, class: 'dropdown-item' %>
     <%= link_to "Case Studies", case_studies_path, class: 'dropdown-item' %>
     <%= link_to "Newsletters", newsletters_path, class: 'dropdown-item' %>
+    <%= link_to 'User Guide Videos', user_guide_videos_path, class: 'dropdown-item' %>
     <%= link_to 'Resources', resources_path, class: 'dropdown-item' %>
     <%= link_to 'School statistics', school_statistics_path, class: 'dropdown-item' %>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,7 @@ Rails.application.routes.draw do
   get 'enrol', to: 'home#enrol'
   get 'datasets', to: 'home#datasets'
   get 'attribution', to: 'home#attribution'
+  get 'user-guide-videos', to: 'home#user_guide_videos'
   get 'team', to: 'home#team'
   get 'privacy_and_cookie_policy', to: 'home#privacy_and_cookie_policy', as: :privacy_and_cookie_policy
 
@@ -169,6 +170,7 @@ Rails.application.routes.draw do
     resources :newsletters
     resources :resource_file_types
     resources :resource_files
+    resources :videos
     resources :school_groups do
       scope module: :school_groups do
         resources :meter_attributes

--- a/db/migrate/20210208102622_create_videos.rb
+++ b/db/migrate/20210208102622_create_videos.rb
@@ -1,0 +1,12 @@
+class CreateVideos < ActiveRecord::Migration[6.0]
+  def change
+    create_table :videos do |t|
+      t.text :youtube_id, null: false
+      t.text :title, null: false
+      t.text :description
+      t.boolean :featured, null: false, default: true
+      t.integer :position, null: false, default: 1
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_28_151747) do
+ActiveRecord::Schema.define(version: 2021_02_08_102622) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
@@ -765,6 +765,9 @@ ActiveRecord::Schema.define(version: 2021_01_28_151747) do
     t.bigint "low_carbon_hub_installation_id"
     t.boolean "pseudo", default: false
     t.bigint "solar_edge_installation_id"
+    t.boolean "dcc_meter", default: false
+    t.boolean "consent_granted", default: false
+    t.date "earliest_available_data"
     t.index ["low_carbon_hub_installation_id"], name: "index_meters_on_low_carbon_hub_installation_id"
     t.index ["meter_type"], name: "index_meters_on_meter_type"
     t.index ["mpan_mprn"], name: "index_meters_on_mpan_mprn", unique: true
@@ -1164,6 +1167,16 @@ ActiveRecord::Schema.define(version: 2021_01_28_151747) do
     t.index ["school_id", "pupil_password"], name: "index_users_on_school_id_and_pupil_password", unique: true
     t.index ["school_id"], name: "index_users_on_school_id"
     t.index ["staff_role_id"], name: "index_users_on_staff_role_id"
+  end
+
+  create_table "videos", force: :cascade do |t|
+    t.text "youtube_id", null: false
+    t.text "title", null: false
+    t.text "description"
+    t.boolean "featured", default: true, null: false
+    t.integer "position", default: 1, null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "weather_observations", force: :cascade do |t|

--- a/spec/factories/videos.rb
+++ b/spec/factories/videos.rb
@@ -1,0 +1,4 @@
+FactoryBot.define do
+  factory :video do
+  end
+end

--- a/spec/helpers/video_helper_spec.rb
+++ b/spec/helpers/video_helper_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+describe VideoHelper do
+  describe '.featured_videos' do
+    it "returns an default video when there are none in the database" do
+      expect(helper.featured_videos.length).to be 1
+    end
+
+    it "returns the expected video" do
+      create(:video, youtube_id: "dQw4w9WgXcQ", title: "That video")
+      expect(helper.featured_videos.length).to be 1
+      expect(helper.featured_videos.first.title).to eql("That video")
+    end
+
+    it "only returns featured videos" do
+      create(:video, youtube_id: "dQw4w9WgXcQ", title: "That video")
+      create(:video, youtube_id: "djV11Xbc914", title: "Other video", featured: false)
+      expect(helper.featured_videos(2).length).to be 1
+      expect(helper.featured_videos(2).first.title).to eql("That video")
+    end
+  end
+end

--- a/spec/models/video_spec.rb
+++ b/spec/models/video_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+RSpec.describe Video, type: :model do
+  it "created correct embed url" do
+    video = Video.new(youtube_id: 12345, title: "test")
+
+    expect( video.embed_url ).to eql "https://www.youtube.com/embed/12345"
+  end
+
+end

--- a/spec/system/admin/videos_spec.rb
+++ b/spec/system/admin/videos_spec.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+
+describe 'Videos', type: :system do
+
+  let!(:admin)  { create(:admin) }
+
+  describe 'managing videos' do
+
+    before do
+      sign_in(admin)
+      visit root_path
+      click_on 'Admin'
+      within '.application' do
+        click_on 'Videos'
+      end
+    end
+
+    it 'allows the user to create, edit and delete a video' do
+#      create(:video, youtube_id: "abcdef", title: 'My video')
+
+      title = 'My title'
+      new_title = 'The edited title'
+
+      click_on 'New Video'
+      fill_in 'Title', with: title
+      click_on 'Create Video'
+      expect(page).to have_content('blank')
+      fill_in 'Youtube', with: "12345"
+
+      click_on 'Create Video'
+      expect(page).to have_content title
+
+      click_on 'Edit'
+      fill_in 'Title', with: new_title
+      click_on 'Update Video'
+
+      expect(page).to have_content new_title
+
+      click_on 'Delete'
+      expect(page).to have_content('Video was successfully deleted.')
+      expect(Video.count).to eq(0)
+    end
+
+  end
+end

--- a/spec/system/videos_spec.rb
+++ b/spec/system/videos_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+RSpec.describe "videos", type: :system do
+
+  let!(:video)          { create(:video, youtube_id: "PqoKZjwgmoY", title: "Test video", description: "video description") }
+
+  it 'shows a default video on the home page' do
+    visit root_path
+    expect( page.has_css? "#featured-videos/div.card-deck").to be true
+  end
+
+  it 'displays user video page' do
+    visit user_guide_videos_path
+    expect(page.has_content? "User guide videos").to be true
+    expect(page.has_content? video.title).to be true
+    expect(page.has_content? video.description).to be true
+  end
+
+  it 'displays all videos' do
+    create(:video, youtube_id: "dQw4w9WgXcQ", title: "That video")
+    create(:video, youtube_id: "djV11Xbc914", title: "Other video", featured: false)
+    create(:video, youtube_id: "nm6DO_7px1I", title: "Final video")
+
+    visit user_guide_videos_path
+    expect(page.has_content? "That video").to be true
+    expect(page.has_content? "Other video").to be true
+    expect(page.has_content? "Final video").to be true
+  end
+end


### PR DESCRIPTION
* Admin functionality to create, edit, delete videos, specifying their order and also whether they are to be featured
* New "user guide videos" link in navbar to show videos
* Home page now displays any of the featured videos in the system
* If no featured videos are available, as the moment it defaults to the current video on the homepage (only)
