### PR TITLE
1228 update wording of user account confirmation email

### DIFF
--- a/app/mailers/onboarding_mailer.rb
+++ b/app/mailers/onboarding_mailer.rb
@@ -21,4 +21,10 @@ class OnboardingMailer < ApplicationMailer
     @school = @school_onboarding.school
     make_bootstrap_mail(to: @school_onboarding.created_user.email, subject: "#{@school.name} is live on Energy Sparks")
   end
+
+  def welcome_email
+    @user = params[:user]
+    @school = @user.school
+    make_bootstrap_mail(to: @user.email, subject: "Welcome to Energy Sparks")
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -151,6 +151,10 @@ class User < ApplicationRecord
     contacts.for_school(school).first
   end
 
+  def after_confirmation
+    OnboardingMailer.with(user: self).welcome_email.deliver_now if self.school.present?
+  end
+
 protected
 
   def password_required?

--- a/app/views/devise/mailer/confirmation_instructions.html.erb
+++ b/app/views/devise/mailer/confirmation_instructions.html.erb
@@ -2,7 +2,11 @@
 
 <p>Welcome <%= @resource.name %></p>
 
-<p>An account has been created for you on Energy Sparks.</p>
+<% if @resource.school.present? %>
+  <p>An account has been created for you on Energy Sparks for <%= @resource.school.name %>.</p>
+<% else %>
+  <p>An account has been created for you on Energy Sparks.</p>
+<% end %>
 
 <p>You can confirm your account email through the link below:</p>
 
@@ -12,4 +16,3 @@
   If you have any questions or concerns then please contact the <%= t('application') %> team by replying to
   this email.
 </p>
-

--- a/app/views/onboarding_mailer/welcome_email.html.erb
+++ b/app/views/onboarding_mailer/welcome_email.html.erb
@@ -1,0 +1,21 @@
+<h1 class="mb-3">Thanks for confirming your Energy Sparks user account.</h1>
+
+<p>
+You can now use Energy Sparks to see how much energy your school is using,
+find out about the greatest energy saving opportunities and explore our
+activities and educational resources designed to teach your pupils about
+energy whilst saving money for their school.
+</p>
+
+<p>
+For help using Energy Sparks please read our <a href="https://energysparks.uk/resources/12/download">User Guide</a>,
+watch our <a href="https://energysparks.uk/user-guide-videos">Training Videos</a> or
+join one of our <a href="https://energysparks.uk/training">live webinar training</a> sessions.
+</p>
+
+<p>
+  We hope Energy Sparks will empower your pupils, school staff,
+  and wider school community to take action to make your school more energy efficient.
+</p>
+
+<%= link_to 'View your school', school_url(@school), class: 'btn btn-primary mt-3 mb-3'%>

--- a/spec/controllers/admin/users_controller_spec.rb
+++ b/spec/controllers/admin/users_controller_spec.rb
@@ -53,6 +53,12 @@ RSpec.describe Admin::UsersController, type: :controller do
           }.to change(User, :count).by(1)
         end
 
+        it "creates uses as already confirmed" do
+          post :create, params: { user: valid_attributes }
+          expect(User.last.confirmed?).to eq true
+          expect(ActionMailer::Base.deliveries.last ).to be_nil
+        end
+
         it "assigns a newly created user as @user" do
           post :create, params: { user: valid_attributes }
           expect(assigns(:user)).to be_a(User)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -73,6 +73,27 @@ describe User do
       expect(staff.staff_role_as_symbol).to be :awkward_tricky_and_space
     end
   end
+
+  describe 'welcome email' do
+    let(:school) { create(:school) }
+    let(:user) { create(:staff, school: school, confirmed_at: nil) }
+
+    it 'sends welcome email after confirmation for school roles' do
+      expect(user.confirmed?).to eql(false)
+      expect(user.confirm ).to eql(true)
+
+      email = ActionMailer::Base.deliveries.last
+      expect(email.subject).to eq('Welcome to Energy Sparks')
+    end
+
+    it 'does not send welcome email for other users' do
+      other_user = create(:user, role: :guest, confirmed_at: nil)
+      expect(other_user.confirmed?).to eql(false)
+      expect(other_user.confirm ).to eql(true)
+
+      email = ActionMailer::Base.deliveries.last
+      expect(email.subject).to eq('Energy Sparks: confirm your account')
+    end
+
+  end
 end
-
-

--- a/spec/system/school_admin/user_management_spec.rb
+++ b/spec/system/school_admin/user_management_spec.rb
@@ -72,6 +72,7 @@ describe 'School admin user management' do
 
         email = ActionMailer::Base.deliveries.last
         expect(email.subject).to eq('Energy Sparks: confirm your account')
+        expect(email.encoded).to match(school.name)
       end
 
       it 'can create staff without generating an alert contact' do
@@ -84,6 +85,7 @@ describe 'School admin user management' do
 
         email = ActionMailer::Base.deliveries.last
         expect(email.subject).to eq('Energy Sparks: confirm your account')
+        expect(email.encoded).to match(school.name)
       end
 
     end
@@ -128,6 +130,7 @@ describe 'School admin user management' do
 
       email = ActionMailer::Base.deliveries.last
       expect(email.subject).to eq('Energy Sparks: confirm your account')
+      expect(email.encoded).to match(school.name)
     end
 
     context 'it can create school admins' do
@@ -149,6 +152,7 @@ describe 'School admin user management' do
 
         email = ActionMailer::Base.deliveries.last
         expect(email.subject).to eq('Energy Sparks: confirm your account')
+        expect(email.encoded).to match(school.name)
       end
 
       it 'without generating an alert contact' do
@@ -160,6 +164,7 @@ describe 'School admin user management' do
 
         email = ActionMailer::Base.deliveries.last
         expect(email.subject).to eq('Energy Sparks: confirm your account')
+        expect(email.encoded).to match(school.name)
       end
     end
 

--- a/spec/system/school_admin/user_management_spec.rb
+++ b/spec/system/school_admin/user_management_spec.rb
@@ -25,6 +25,8 @@ describe 'School admin user management' do
       pupil = school.users.pupil.first
       expect(pupil.email).to_not be_nil
       expect(pupil.pupil_password).to eq('the elektrons')
+
+      expect( ActionMailer::Base.deliveries.last ).to be_nil
     end
 
     it 'can edit and delete pupils' do
@@ -69,6 +71,7 @@ describe 'School admin user management' do
         staff = school.users.staff.first
         expect(staff.email).to eq('mrsjones@test.com')
         expect(staff.staff_role).to eq(teacher_role)
+        expect(staff.confirmed?).to be false
 
         email = ActionMailer::Base.deliveries.last
         expect(email.subject).to eq('Energy Sparks: confirm your account')
@@ -82,6 +85,7 @@ describe 'School admin user management' do
         staff = school.users.staff.first
         expect(staff.email).to eq('mrsjones@test.com')
         expect(staff.staff_role).to eq(teacher_role)
+        expect(staff.confirmed?).to be false
 
         email = ActionMailer::Base.deliveries.last
         expect(email.subject).to eq('Energy Sparks: confirm your account')
@@ -127,6 +131,7 @@ describe 'School admin user management' do
 
       school_admin = school.users.school_admin.last
       expect(school_admin.email).to eq('mrsjones@test.com')
+      expect(school_admin.confirmed?).to be false
 
       email = ActionMailer::Base.deliveries.last
       expect(email.subject).to eq('Energy Sparks: confirm your account')
@@ -149,6 +154,7 @@ describe 'School admin user management' do
 
         school_admin = school.users.school_admin.last
         expect(school_admin.email).to eq('mrsjones@test.com')
+        expect(school_admin.confirmed?).to be false
 
         email = ActionMailer::Base.deliveries.last
         expect(email.subject).to eq('Energy Sparks: confirm your account')
@@ -161,6 +167,7 @@ describe 'School admin user management' do
 
         school_admin = school.users.school_admin.last
         expect(school_admin.email).to eq('mrsjones@test.com')
+        expect(school_admin.confirmed?).to be false
 
         email = ActionMailer::Base.deliveries.last
         expect(email.subject).to eq('Energy Sparks: confirm your account')


### PR DESCRIPTION
Revise confirmation email text.

Send welcome email after account is confirmed.