### PR TITLE
First iteration of code to generate emails from custom RQL reports

### DIFF
--- a/.ebextensions/cronjob.config
+++ b/.ebextensions/cronjob.config
@@ -158,6 +158,16 @@ files:
             45 8 * * * root /bin/bash -l -c 'cd /var/app/current && RAILS_ENV=production bin/run_as_webapp bundle exec rake amr_importer:send_daily_notification_email >> log/jobs.log 2>&1'
 
     #
+    # EMail summary of Rollbar errors from imports
+    #
+    "/etc/cron.d/notify-amr-imports-daily":
+        mode: "000644"
+        owner: root
+        group: root
+        content: |
+            0 9 * * * root /bin/bash -l -c 'cd /var/app/current && RAILS_ENV=production bin/run_as_webapp bundle exec rake util:custom_rollbar_reports >> log/jobs.log 2>&1'
+
+    #
     # Generate sitemap
     #
     "/etc/cron.d/generate-sitemap-daily":

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -18,6 +18,12 @@ module ApplicationHelper
     "#{date.strftime('%a')} #{date.day.ordinalize} #{date.strftime('%b %Y')} "
   end
 
+  def nice_dates_from_timestamp(timestamp)
+    return "" if timestamp.nil?
+    datetime = DateTime.strptime(timestamp.to_s, '%s')
+    nice_date_times(datetime)
+  end
+
   def active(bool = true)
     bool ? '' : 'bg-warning'
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -21,7 +21,7 @@ module ApplicationHelper
   def nice_dates_from_timestamp(timestamp)
     return "" if timestamp.nil?
     datetime = DateTime.strptime(timestamp.to_s, '%s')
-    nice_date_times(datetime)
+    nice_dates(datetime)
   end
 
   def active(bool = true)

--- a/app/helpers/rollbar_mailer_helper.rb
+++ b/app/helpers/rollbar_mailer_helper.rb
@@ -1,0 +1,11 @@
+module RollbarMailerHelper
+  #generate link to Rollbar
+  def rollbar_item_url(environment, item_counter, occurence_id)
+    return "https://rollbar.com/energysparks/#{environment}/items/#{item_counter}/occurrences/#{occurence_id}"
+  end
+
+  #strip the prefixes that Rollbar adds to custom columns
+  def nice_column_title(col)
+    col.gsub("body.trace.", "").gsub("extra.", "")
+  end
+end

--- a/app/mailers/rollbar_mailer.rb
+++ b/app/mailers/rollbar_mailer.rb
@@ -1,0 +1,10 @@
+class RollbarMailer < ApplicationMailer
+  helper :application
+  def report_errors
+    subject_description = params[:description] || 'Rollbar custom report'
+    environment_identifier = ENV['ENVIRONMENT_IDENTIFIER'] || 'unknown'
+    @rollbar_environment = "EnergySparks#{environment_identifier.capitalize}Environment"
+    @reported_results = params[:reported_results]
+    make_bootstrap_mail(to: 'services@energysparks.uk', subject: "[energy-sparks-#{environment_identifier}] Energy Sparks #{subject_description}: #{Time.zone.today.strftime('%d/%m/%Y')}")
+  end
+end

--- a/app/mailers/rollbar_mailer.rb
+++ b/app/mailers/rollbar_mailer.rb
@@ -1,7 +1,7 @@
 class RollbarMailer < ApplicationMailer
-  helper :application
+  helper :application, :rollbar_mailer
   def report_errors
-    subject_description = params[:description] || 'Rollbar custom report'
+    subject_description = params[:description] || 'Custom Error Reports'
     environment_identifier = ENV['ENVIRONMENT_IDENTIFIER'] || 'unknown'
     @rollbar_environment = "EnergySparks#{environment_identifier.capitalize}Environment"
     @reported_results = params[:reported_results]

--- a/app/services/alerts/generate_alert_type_run_result.rb
+++ b/app/services/alerts/generate_alert_type_run_result.rb
@@ -42,7 +42,7 @@ module Alerts
       error_message = "Exception: #{@alert_type.class_name} for #{@school.name}: #{e.class} #{e.message}"
       Rails.logger.error error_message
       Rails.logger.error e.backtrace.join("\n")
-      Rollbar.error(e, school_id: @school.id, school_name: @school.name, alert_type: @alert_type.class_name)
+      Rollbar.error(e, job: :generate_alert_report, school_id: @school.id, school: @school.name, alert_type: @alert_type.class_name)
 
       error_message = "#{error_message}\n" + e.backtrace.join("\n")
 

--- a/app/services/amr/n3rgy_download_and_upsert.rb
+++ b/app/services/amr/n3rgy_download_and_upsert.rb
@@ -21,7 +21,7 @@ module Amr
     rescue => e
       Rails.logger.error "Exception: downloading N3rgy data for #{@meter.mpan_mprn} from #{@start_date} to #{@end_date} : #{e.class} #{e.message}"
       Rails.logger.error e.backtrace.join("\n")
-      Rollbar.error(e)
+      Rollbar.error(e, job: :n3rgy_download, meter_id: @meter.mpan_mprn, start_date: @start_date, end_date: @end_date)
     end
 
     private

--- a/app/services/content_batch.rb
+++ b/app/services/content_batch.rb
@@ -53,7 +53,7 @@ class ContentBatch
 
     rescue StandardError => e
       @logger.error "There was an error for #{school.name} - #{e.message}"
-      Rollbar.error(e, school_id: school.id, school_name: school.name)
+      Rollbar.error(e, job: :content_batch, school_id: school.id, school: school.name)
     end
   end
 

--- a/app/services/equivalences/generate_equivalences.rb
+++ b/app/services/equivalences/generate_equivalences.rb
@@ -18,7 +18,7 @@ module Equivalences
             Rails.logger.debug("#{e.message} for #{@school.name}")
           rescue => e
             Rails.logger.error("#{e.message} for #{@school.name}")
-            Rollbar.error(e, school_id: @school.id, school_name: @school.name)
+            Rollbar.error(e, job: :generate_equivalances, equivalence_type: equivalence_type, school_id: @school.id, school: @school.name)
           end
         end
       end

--- a/app/services/rollbar_notifier_service.rb
+++ b/app/services/rollbar_notifier_service.rb
@@ -1,7 +1,7 @@
 require 'rollbar_api/rql_jobs'
 
 class RollbarNotifierService
-  def initialize(rql_jobs = RollbarAPI::RQLJobs.new, description = nil)
+  def initialize(rql_jobs = RollbarAPI::RQLJobs.new(ENV['ROLLBAR_READ_ACCESS_TOKEN']), description = nil)
     @rql_jobs = rql_jobs
     @description = description
   end

--- a/app/services/rollbar_notifier_service.rb
+++ b/app/services/rollbar_notifier_service.rb
@@ -9,13 +9,12 @@ class RollbarNotifierService
   REPORTS = {
     validation_errors: {
       title: "Meter validation problems",
-      description: "Meter validation failed for the following schools on the specified day",
+      description: "Validation failed for the following schools in the last 48 hours. Failed caused by the listed meter",
       rql_query: <<-QUERY
-      SELECT timestamp, body.trace.extra.school_id, body.trace.extra.school_name, body.trace.extra.alert_type, body.trace.exception.message
+      SELECT timestamp, body.trace.extra.school_id, body.trace.extra.school_name, body.trace.extra.mpan_mprn, body.trace.exception.message
       from item_occurrence
-      where request.url is null
-      AND body.trace.extra.school_id != NULL
-      AND body.trace.extra.alert_type != NULL
+      where body.trace.extra.job = 'validate_amr_readings'
+      AND timestamp > unix_timestamp() - 60 * 60 * 48
       ORDER by timestamp desc
       QUERY
     }

--- a/app/services/rollbar_notifier_service.rb
+++ b/app/services/rollbar_notifier_service.rb
@@ -8,27 +8,15 @@ class RollbarNotifierService
 
   REPORTS = {
     validation_errors: {
-      title: "Validation, content and related errors",
-      description: "Lists problems encountered with validating readings, generating content batches, equivalences, etc",
+      title: "Meter validation problems",
+      description: "Meter validation failed for the following schools on the specified day",
       rql_query: <<-QUERY
-        SELECT timestamp, body.trace.exception.message, body.trace.extra.alert_type, body.trace.extra.school_id, body.trace.extra.school_name
-        from item_occurrence
-        where request.url is null
-        AND body.trace.extra.school_id != NULL
-        AND body.trace.extra.alert_type = NULL
-        ORDER by timestamp desc
-      QUERY
-    },
-    chart_errors: {
-      title: "Chart errors",
-      description: "Lists errors reported when generating charts",
-      rql_query: <<-QUERY
-        SELECT timestamp, request.url, context, request.params.school_id, body.trace.exception.message, body.trace.extra.school_name,
-        body.trace.extra.chart_config_overrides.y_axis_units, body.trace.extra.original_chart_type, body.trace.extra.transformations
-        from item_occurrence
-        WHERE
-        body.trace.extra.original_chart_type != NULL
-        ORDER by timestamp desc
+      SELECT timestamp, body.trace.extra.school_id, body.trace.extra.school_name, body.trace.extra.alert_type, body.trace.exception.message
+      from item_occurrence
+      where request.url is null
+      AND body.trace.extra.school_id != NULL
+      AND body.trace.extra.alert_type != NULL
+      ORDER by timestamp desc
       QUERY
     }
   }.freeze

--- a/app/services/rollbar_notifier_service.rb
+++ b/app/services/rollbar_notifier_service.rb
@@ -1,0 +1,63 @@
+require 'rollbar_api/rql_jobs'
+
+class RollbarNotifierService
+  def initialize(rql_jobs = RollbarAPI::RQLJobs.new, description = nil)
+    @rql_jobs = rql_jobs
+    @description = description
+  end
+
+  REPORTS = {
+    validation_errors: {
+      title: "Validation, content and related errors",
+      description: "Lists problems encountered with validating readings, generating content batches, equivalences, etc",
+      rql_query: <<-QUERY
+        SELECT timestamp, body.trace.exception.message, body.trace.extra.alert_type, body.trace.extra.school_id, body.trace.extra.school_name
+        from item_occurrence
+        where request.url is null
+        AND body.trace.extra.school_id != NULL
+        AND body.trace.extra.alert_type = NULL
+        ORDER by timestamp desc
+      QUERY
+    },
+    chart_errors: {
+      title: "Chart errors",
+      description: "Lists errors reported when generating charts",
+      rql_query: <<-QUERY
+        SELECT timestamp, request.url, context, request.params.school_id, body.trace.exception.message, body.trace.extra.school_name,
+        body.trace.extra.chart_config_overrides.y_axis_units, body.trace.extra.original_chart_type, body.trace.extra.transformations
+        from item_occurrence
+        WHERE
+        body.trace.extra.original_chart_type != NULL
+        ORDER by timestamp desc
+      QUERY
+    }
+  }.freeze
+
+  def run_queries
+    results = {}
+    REPORTS.each do |key, config|
+      results[key] = config.dup
+      results[key][:results] = run_report(config)
+    end
+    return results
+  end
+
+  def perform
+    RollbarMailer.with(reported_results: run_queries, description: @description).report_errors.deliver_now
+  end
+
+  private
+
+  def run_report(report)
+    query_result = @rql_jobs.run_query(report[:rql_query])
+    return {
+      columns: query_result["result"]["result"]["columns"],
+      rows: query_result["result"]["result"]["rows"]
+    }
+  rescue => e
+    Rails.logger.error "Exception: running RQL report '#{report[:title]}' against rollbar. #{e.class} #{e.message}"
+    Rails.logger.error e.backtrace.join("\n")
+    Rollbar.error(e)
+    return { error: true, rows: [], columns: [] }
+  end
+end

--- a/app/views/rollbar_mailer/_rql_report_table.html.erb
+++ b/app/views/rollbar_mailer/_rql_report_table.html.erb
@@ -1,0 +1,29 @@
+<h2><%= report_result[:title] %></h2>
+
+<% if report_result[:results][:error].present? %>
+ <p>Report failed to run</p>
+<% else %>
+  <table class="table mt-3 mb-5">
+    <thead class="thead-light">
+      <tr>
+        <% report_result[:results][:columns][0..-3].each do |col| %>
+          <th><%= col %></th>
+        <% end %>
+        <th>View</th>
+      </tr>
+
+    </thead>
+    <tbody>
+      <% report_result[:results][:rows].each do |row| %>
+      <tr>
+        <% row[0..-3].each do |val| %>
+          <td><%= val %></td>
+        <% end %>
+        <td>
+          <a href="https://rollbar.com/energysparks/<%= @rollbar_environment %>/items/<%= row[-2] %>/occurrences/<%= row[-1] %>/">View</a>
+        </td>
+      <tr>
+      <% end %>
+    </tbody>
+  </table>
+<% end %>

--- a/app/views/rollbar_mailer/_rql_report_table.html.erb
+++ b/app/views/rollbar_mailer/_rql_report_table.html.erb
@@ -1,5 +1,7 @@
 <h2><%= report_result[:title] %></h2>
 
+<p><%= report_result[:description] %></p>
+
 <% if report_result[:results][:error].present? %>
  <p>Report failed to run</p>
 <% else %>
@@ -7,21 +9,24 @@
     <thead class="thead-light">
       <tr>
         <% report_result[:results][:columns][0..-3].each do |col| %>
-          <th><%= col %></th>
+          <th><%= nice_column_title(col) %></th>
         <% end %>
-        <th>View</th>
       </tr>
-
     </thead>
     <tbody>
       <% report_result[:results][:rows].each do |row| %>
       <tr>
-        <% row[0..-3].each do |val| %>
-          <td><%= val %></td>
+        <% row[0..-3].each_with_index do |val, index| %>
+          <% if index == 0 %>
+            <td>
+              <a href="<%= rollbar_item_url(@rollbar_environment, row[-2], row[-1]) %>">
+                <%= nice_dates_from_timestamp(val) %>
+              </a>
+            </td>
+          <% else %>
+            <td><%= val %></td>
+          <% end %>
         <% end %>
-        <td>
-          <a href="https://rollbar.com/energysparks/<%= @rollbar_environment %>/items/<%= row[-2] %>/occurrences/<%= row[-1] %>/">View</a>
-        </td>
       <tr>
       <% end %>
     </tbody>

--- a/app/views/rollbar_mailer/report_errors.html.erb
+++ b/app/views/rollbar_mailer/report_errors.html.erb
@@ -1,7 +1,10 @@
-<h1>Rollbar Custom Errors</h1>
+<h1>Custom Error Reports</h1>
 
 <p>
 The following reports having been run against the <%= @rollbar_environment %> project.
+</p>
+
+<p>
 </p>
 
 <% @reported_results.each do |key, result| %>

--- a/app/views/rollbar_mailer/report_errors.html.erb
+++ b/app/views/rollbar_mailer/report_errors.html.erb
@@ -1,0 +1,9 @@
+<h1>Rollbar Custom Errors</h1>
+
+<p>
+The following reports having been run against the <%= @rollbar_environment %> project.
+</p>
+
+<% @reported_results.each do |key, result| %>
+  <%= render 'rql_report_table', report_result: result %>
+<% end %>

--- a/lib/data_feeds/dark_sky_temperature_loader.rb
+++ b/lib/data_feeds/dark_sky_temperature_loader.rb
@@ -40,7 +40,7 @@ module DataFeeds
     rescue => e
       Rails.logger.error "Exception: running dark sky area import for #{area.title} from #{@start_date} to #{@end_date} : #{e.class} #{e.message}"
       Rails.logger.error e.backtrace.join("\n")
-      Rollbar.error(e)
+      Rollbar.error(e, job: :dark_sky, area_id: area.id, area: area.title)
     end
 
     def process_day(reading_date, temperature_celsius_x48, area)

--- a/lib/data_feeds/meteostat_loader.rb
+++ b/lib/data_feeds/meteostat_loader.rb
@@ -36,7 +36,7 @@ module DataFeeds
       rescue => e
         Rails.logger.error "Exception: running station import for #{station.title} from #{@start_date} to #{@end_date} : #{e.class} #{e.message}"
         Rails.logger.error e.backtrace.join("\n")
-        Rollbar.error(e)
+        Rollbar.error(e, job: :meteostat_loader, station_id: station.id, station: station.title)
       end
     end
 

--- a/lib/data_feeds/solar_pv_tuos_v2_loader.rb
+++ b/lib/data_feeds/solar_pv_tuos_v2_loader.rb
@@ -45,7 +45,7 @@ module DataFeeds
     rescue => e
       Rails.logger.error "Exception: running solar pv for #{area.title} from #{@start_date} to #{@end_date} : #{e.class} #{e.message}"
       Rails.logger.error e.backtrace.join("\n")
-      Rollbar.error(e)
+      Rollbar.error(e, job: :solar_pv_tuos_area, area_id: area.id, area: area.title)
     end
 
     def process_day(reading_date, generation_mw_x48, area, gsp_area)

--- a/lib/rollbar_api/rql_jobs.rb
+++ b/lib/rollbar_api/rql_jobs.rb
@@ -11,7 +11,7 @@ module RollbarAPI
       @client = if client != nil
         client
                 else
-        Faraday.new(API_BASE)
+        Faraday.new(API_BASE, request: { timeout: 20 })
                 end
       raise "ROLLBAR_READ_ACCESS_TOKEN not configured" unless api_token
       @api_token = api_token

--- a/lib/rollbar_api/rql_jobs.rb
+++ b/lib/rollbar_api/rql_jobs.rb
@@ -1,0 +1,64 @@
+require 'json'
+require 'faraday'
+
+module RollbarAPI
+  API_BASE = "https://api.rollbar.com".freeze
+  FAILED_STATES = %w[failed cancelled timed_out].freeze
+  END_STATES = FAILED_STATES + ["success"]
+
+  class RQLJobs
+    def initialize(api_token = ENV['ROLLBAR_READ_ACCESS_TOKEN'], client = nil)
+      @client = if client != nil
+        client
+                else
+        Faraday.new(API_BASE)
+                end
+      raise "ROLLBAR_READ_ACCESS_TOKEN not configured" unless api_token
+      @api_token = api_token
+    end
+
+    def submit_job(query)
+      body = {
+        query_string: query,
+        access_token: @api_token
+      }
+      resp = @client.post("/api/1/rql/jobs") do |req|
+        req.body = body.to_json
+      end
+      raise "Unable to submit job" unless resp.success?
+      json = JSON.parse(resp.body)
+      return json["result"]["id"]
+    end
+
+    def job_status(job_id)
+      json = get_job(job_id)
+      return json["result"]["status"]
+    end
+
+    def get_job(job_id)
+      resp = @client.get("/api/1/rql/job/#{job_id}", {
+        access_token: @api_token
+      })
+      raise "Unable to get job" unless resp.success?
+      json = JSON.parse(resp.body)
+      return json
+    end
+
+    def get_result(job_id)
+      resp = @client.get("/api/1/rql/job/#{job_id}/result", {
+        access_token: @api_token
+      })
+      raise "Unable to fetch RQL results" unless resp.success?
+      json = JSON.parse(resp.body)
+      return json
+    end
+
+    def run_query(query)
+      job_id = submit_job(query)
+      status = job_status(job_id)
+      status = job_status(job_id) until END_STATES.include?(status)
+      raise "RQL query failed #{status}" if FAILED_STATES.include?(status)
+      return get_result(job_id)
+    end
+  end
+end

--- a/lib/rollbar_api/rql_jobs.rb
+++ b/lib/rollbar_api/rql_jobs.rb
@@ -7,7 +7,7 @@ module RollbarAPI
   END_STATES = FAILED_STATES + ["success"]
 
   class RQLJobs
-    def initialize(api_token = ENV['ROLLBAR_READ_ACCESS_TOKEN'], client = nil)
+    def initialize(api_token, client = nil)
       @client = if client != nil
         client
                 else

--- a/lib/tasks/amr_importer/validate_amr_readings.rake
+++ b/lib/tasks/amr_importer/validate_amr_readings.rake
@@ -16,7 +16,7 @@ namespace :amr_importer do
         puts e.backtrace.join("\n")
         Rails.logger.error "Exception: running validation for #{each_school.name}: #{e.class} #{e.message}"
         Rails.logger.error e.backtrace.join("\n")
-        Rollbar.error(e, school_id: each_school.id, school_name: each_school.name)
+        Rollbar.error(e, job: :validate_amr_readings, school_id: each_school.id, school: each_school.name)
       end
     end
 

--- a/lib/tasks/equivalences/create_equivalences.rake
+++ b/lib/tasks/equivalences/create_equivalences.rake
@@ -9,7 +9,7 @@ namespace :equivalences do
         Equivalences::GenerateEquivalences.new(school: school).perform
       rescue => e
         Rails.logger.error("#{e.message} for #{school.name}")
-        Rollbar.error(e, school_id: school.id, school_name: school.name)
+        Rollbar.error(e, job: :create_equivalences, school_id: school.id, school: school.name)
       end
 
     end

--- a/lib/tasks/utility.rake
+++ b/lib/tasks/utility.rake
@@ -51,7 +51,7 @@ namespace :utility do
       EnergySparks::S3Yaml.save(aggregate_school, school.name, data_type: 'aggregated-meter-collection', bucket: target_bucket)
     rescue StandardError => e
       Rails.logger.error "There was an error for aggregated #{school.name} - #{e.message}"
-      Rollbar.error(e, school_id: school.id, school_name: school.name)
+      Rollbar.error(e, job: :save_aggregate_schools_to_s3, school_id: school.id, school: school.name)
     end
   end
 
@@ -67,7 +67,7 @@ namespace :utility do
       EnergySparks::S3Yaml.save(data, school.name, data_type: 'unvalidated-data', bucket: target_bucket)
     rescue StandardError => e
       Rails.logger.error "There was an error for unvalidated #{school.name} - #{e.message}"
-      Rollbar.error(e, school_id: school.id, school_name: school.name)
+      Rollbar.error(e, job: :save_unvalidated_schools_to_s3, school_id: school.id, school: school.name)
     end
   end
 

--- a/lib/tasks/utility.rake
+++ b/lib/tasks/utility.rake
@@ -71,4 +71,9 @@ namespace :utility do
     end
   end
 
+  desc 'Send custom rollbar reports'
+  task custom_rollbar_reports: :environment do
+    RollbarNotifierService.new.perform
+  end
+
 end

--- a/spec/lib/rollbar_api/rql_jobs_spec.rb
+++ b/spec/lib/rollbar_api/rql_jobs_spec.rb
@@ -1,0 +1,160 @@
+require 'rails_helper'
+require 'rollbar_api/rql_jobs.rb'
+
+module RollbarAPI
+  describe RQLJobs do
+
+    let(:stubs)     { Faraday::Adapter::Test::Stubs.new }
+    let(:client)      { Faraday.new { |b| b.adapter(:test, stubs) } }
+
+    let(:api_token) { "token"}
+    let(:rql_jobs)  { RollbarAPI::RQLJobs.new(api_token, client)}
+
+    let(:query)     { "select * from item_occurence" }
+
+    after(:all) do
+      Faraday.default_connection = nil
+    end
+
+    let(:job) {
+        { 'err': 0,
+          'result': {
+            'status': job_status,
+            'job_hash': 'eea93bcc3cfc304027d70cd77b6326e03605ea66',
+            'date_modified': 1613650640,
+            'query_string': 'query',
+            'date_created': 1613650632,
+            'project_id': 193054,
+            'id': 95683968,
+            'project_group_id': 20954
+          }
+        }
+    }
+
+    let(:job_result) {
+        {
+          'err': 0,
+          'result': {
+            'job_id': 95684744,
+            'result': {
+                'isSimpleSelect': 'True',
+                'errors': [],
+                'warnings': ['No timestamp filter.'],
+                'executionTime': 12.060364961624146,
+                'effectiveTimestamp': 1613657827,
+                'rowcount': 2,
+                'rows': [[1607577513, 'Wimbledon High School', 564, 145051707090], [1607491119, 'Wimbledon High School', 564, 144931196345]],
+                'selectionColumns': ['timestamp', 'body.trace.extra.school_name'],
+                'projectIds': [193054, 193054],
+                'columns': ['timestamp', 'body.trace.extra.school_name', 'item.counter', 'occurrence_id']
+            }
+          }
+        }
+    }
+
+    it 'raises error for missing config' do
+      expect{ RollbarAPI::RQLJobs.new(nil) }.to raise_error(RuntimeError)
+    end
+
+    context 'when submitting a job' do
+      let(:job_status) { "new" }
+
+      it 'call the API' do
+        stubs.post("/api/1/rql/jobs") do |env|
+          expect(env.body).to eql({
+              'query_string': query,
+              'access_token': api_token
+          }.to_json)
+          [
+            200,
+            { 'Content-Type': "application/json"},
+            job.to_json
+          ]
+        end
+
+        expect( rql_jobs.submit_job(query) ).to eql 95683968
+        stubs.verify_stubbed_calls
+      end
+
+      it 'raises errors' do
+        stubs.post("/api/1/rql/jobs") do |env|
+          [400, {}, ""]
+        end
+
+        expect{ rql_jobs.submit_job(query) }.to raise_error(RuntimeError)
+        stubs.verify_stubbed_calls
+      end
+
+    end
+
+    context 'when working with jobs' do
+
+      let(:job_status) { "running" }
+
+      it 'gets a job' do
+        stubs.get("/api/1/rql/job/12345") do |env|
+          expect(env.params).to include("access_token" => api_token)
+          [200, {}, "{}"]
+        end
+        expect(rql_jobs.get_job(12345) ).to eql({})
+        stubs.verify_stubbed_calls
+      end
+
+      it 'checks job status' do
+        stubs.get("/api/1/rql/job/12345") do |env|
+          expect(env.params).to include("access_token" => api_token)
+          [200, {}, job.to_json]
+        end
+        expect(rql_jobs.job_status(12345) ).to eql("running")
+        stubs.verify_stubbed_calls
+      end
+
+      it 'gets job result' do
+        stubs.get("/api/1/rql/job/12345/result") do |env|
+          expect(env.params).to include("access_token" => api_token)
+          [200, {}, job_result.to_json]
+        end
+        result = rql_jobs.get_result(12345)
+        expect( result["result"]["result"]["rowcount"] ).to eql(2)
+        stubs.verify_stubbed_calls
+      end
+
+    end
+
+    context 'when running a query' do
+      let(:job_status) { "success" }
+
+      it 'runs a query' do
+        stubs.post("/api/1/rql/jobs") do |env|
+          [200, {}, { "result": { "id": 4444 }}.to_json
+          ]
+        end
+        stubs.get("/api/1/rql/job/4444") do |env|
+          [200, {}, job.to_json]
+        end
+        stubs.get("/api/1/rql/job/4444/result") do |env|
+          [200, {}, job_result.to_json]
+        end
+        result = rql_jobs.run_query(query)
+        expect( result["result"]["result"]["rowcount"] ).to eql(2)
+        stubs.verify_stubbed_calls
+      end
+
+      context 'with failed queries' do
+        let(:job_status) { "failed" }
+
+        it 'handles cancelled, timeout, failed queries' do
+          stubs.post("/api/1/rql/jobs") do |env|
+            [200, {}, { "result": { "id": 4444 }}.to_json
+            ]
+          end
+          stubs.get("/api/1/rql/job/4444") do |env|
+            [200, {}, job.to_json]
+          end
+          expect{ rql_jobs.run_query(query) }.to raise_error(RuntimeError)
+        end
+
+      end
+    end
+  end
+end

--- a/spec/services/rollbar_notifier_service_spec.rb
+++ b/spec/services/rollbar_notifier_service_spec.rb
@@ -75,9 +75,9 @@ describe RollbarNotifierService do
       results = RollbarNotifierService.new(rql_jobs).perform
 
       email = ActionMailer::Base.deliveries.last
-      expect(email.subject).to include('Rollbar custom report')
+      expect(email.subject).to include('Custom Error Reports')
       email_body = email.html_part.body.to_s
-      expect(email_body).to include("Rollbar Custom Errors")
+      expect(email_body).to include("Custom Error Reports")
     end
 
     it "the email includes all the reports" do
@@ -91,7 +91,20 @@ describe RollbarNotifierService do
       end
     end
 
-    it "formats timestamps correctly"
-    it "builds links to Rollbar"
+    it "formats timestamps correctly" do
+      allow(rql_jobs).to receive(:run_query).and_return(job_result)
+      results = RollbarNotifierService.new(rql_jobs).perform
+      email = ActionMailer::Base.deliveries.last
+      email_body = email.html_part.body.to_s
+      expect(email_body).to include("Thu 10th Dec 2020")
+    end
+
+    it "builds links to Rollbar" do
+      allow(rql_jobs).to receive(:run_query).and_return(job_result)
+      results = RollbarNotifierService.new(rql_jobs).perform
+      email = ActionMailer::Base.deliveries.last
+      email_body = email.html_part.body.to_s
+      expect(email_body).to match(/href="https:\/\/rollbar.com\/energysparks\/EnergySparksTestEnvironment\/items\/564\/occurrences\/145051707090"/)
+    end
   end
 end

--- a/spec/services/rollbar_notifier_service_spec.rb
+++ b/spec/services/rollbar_notifier_service_spec.rb
@@ -1,0 +1,97 @@
+require 'rails_helper'
+
+describe RollbarNotifierService do
+
+  let(:rql_jobs)    { double("RollbarAPI::RQLJobs") }
+
+  #this is a subset of what the Rollbar API returns
+  let(:job_result) {
+      {
+        'err' => 0,
+        'result' => {
+          'job_id' => 95684744,
+          'result' => {
+              'isSimpleSelect' => 'True',
+              'errors' => [],
+              'warnings' => ['No timestamp filter.'],
+              'executionTime' => 12.060364961624146,
+              'effectiveTimestamp' => 1613657827,
+              'rowcount' => 2,
+              'rows' => [[1607577513, 'Wimbledon High School', 564, 145051707090], [1607491119, 'Wimbledon High School', 564, 144931196345]],
+              'selectionColumns' => ['timestamp', 'body.trace.extra.school_name'],
+              'projectIds' => [293054, 293054],
+              'columns' => ['timestamp', 'body.trace.extra.school_name', 'item.counter', 'occurrence_id']
+          }
+        }
+      }
+  }
+
+  describe '#run_queries' do
+
+    it "runs all the queries" do
+      RollbarNotifierService::REPORTS.keys.each do |key|
+        query = RollbarNotifierService::REPORTS[key][:rql_query]
+        expect(rql_jobs).to receive(:run_query).with(query).and_return(job_result)
+      end
+      results = RollbarNotifierService.new(rql_jobs).run_queries
+      expect(results.keys).to eql(RollbarNotifierService::REPORTS.keys)
+    end
+
+    it "includes the report configuration" do
+        allow(rql_jobs).to receive(:run_query).and_return(job_result)
+
+        results = RollbarNotifierService.new(rql_jobs).run_queries
+        results.each do |key, reported_result|
+          expect(reported_result[:title]).to_not be_nil
+          expect(reported_result[:rql_query]).to_not be_nil
+          expect(reported_result[:results]).to_not be_nil
+          expect(reported_result[:results][:rows]).to eql(job_result["result"]["result"]["rows"])
+          expect(reported_result[:results][:columns]).to eql(job_result["result"]["result"]["columns"])
+          expect(reported_result[:results][:error]).to be_nil
+        end
+    end
+
+    it "records an error when report failed" do
+      allow(rql_jobs).to receive(:run_query).and_raise(RuntimeError)
+
+      results = RollbarNotifierService.new(rql_jobs).run_queries
+      results.each do |key, reported_result|
+        expect(reported_result[:title]).to_not be_nil
+        expect(reported_result[:rql_query]).to_not be_nil
+        expect(reported_result[:results]).to_not be_nil
+        expect(reported_result[:results][:rows]).to eql([])
+        expect(reported_result[:results][:columns]).to eql([])
+        expect(reported_result[:results][:error]).to eql(true)
+      end
+
+    end
+
+  end
+
+  describe '#perform' do
+    it "generates an email" do
+      allow(rql_jobs).to receive(:run_query).and_raise(RuntimeError)
+
+      results = RollbarNotifierService.new(rql_jobs).perform
+
+      email = ActionMailer::Base.deliveries.last
+      expect(email.subject).to include('Rollbar custom report')
+      email_body = email.html_part.body.to_s
+      expect(email_body).to include("Rollbar Custom Errors")
+    end
+
+    it "the email includes all the reports" do
+      allow(rql_jobs).to receive(:run_query).and_return(job_result)
+
+      results = RollbarNotifierService.new(rql_jobs).perform
+      email = ActionMailer::Base.deliveries.last
+      email_body = email.html_part.body.to_s
+      RollbarNotifierService::REPORTS.each do |key, report|
+        expect(email_body).to include(report[:title])
+      end
+    end
+
+    it "formats timestamps correctly"
+    it "builds links to Rollbar"
+  end
+end

--- a/spec/services/rollbar_notifier_service_spec.rb
+++ b/spec/services/rollbar_notifier_service_spec.rb
@@ -100,11 +100,13 @@ describe RollbarNotifierService do
     end
 
     it "builds links to Rollbar" do
-      allow(rql_jobs).to receive(:run_query).and_return(job_result)
-      results = RollbarNotifierService.new(rql_jobs).perform
-      email = ActionMailer::Base.deliveries.last
-      email_body = email.html_part.body.to_s
-      expect(email_body).to match(/href="https:\/\/rollbar.com\/energysparks\/EnergySparksTestEnvironment\/items\/564\/occurrences\/145051707090"/)
+      ClimateControl.modify ENVIRONMENT_IDENTIFIER: "Test" do
+        allow(rql_jobs).to receive(:run_query).and_return(job_result)
+        results = RollbarNotifierService.new(rql_jobs).perform
+        email = ActionMailer::Base.deliveries.last
+        email_body = email.html_part.body.to_s
+        expect(email_body).to match(/href="https:\/\/rollbar.com\/energysparks\/EnergySparksTestEnvironment\/items\/564\/occurrences\/145051707090"/)
+      end
     end
   end
 end


### PR DESCRIPTION
We want to produce a more detailed reports about failures to validate API readings, listing individual meters. Doing this will require some changes to how the application generates, captures and log errors around the analytics code.

In order to report on failures we need to keep track of when and where they occur. Rollbar already does this for us. It also allows us to provide additional metadata when we record errors. For example, we currently log school ids, names and other information in a few places. That information can be queried using [the RQL query language](https://docs.rollbar.com/docs/rql).

So, rather than create a new set of tables to manage logging of errors, we can use Rollbar to capture the issues. This will allow us to trap all errors, including unforseen problems, not just those we've anticipated.

This PR has an initial implementation of a daily process that will run a set of pre-configured reports against [the Rollbar API](https://explorer.docs.rollbar.com/#tag/RQL) then generate an email containing the results of each report. 

Each report has a title, description, an RQL query and a set of results (if it was executed successfully). The format of the queries can vary and the template displays all columns and rows. It also introduces links to Rollbar to allow more fine-grained view of errors.

* [x] Implement basic Rollbar client to executing RQL queries
* [x] Integrate the above with a simple service class that runs a set of queries and sends the results as an email
* [x] Tidy up uses of Rollbar across the application to add useful metadata as tags and/or by using [the scope](https://docs.rollbar.com/docs/ruby#the-scope) and [context](https://docs.rollbar.com/docs/ruby#error-contexts) functionality (the latter is already being applied automatically in Rails controllers)
* [x] Add new exception handling into the validation code in the analytics package to log individual meter validation errors, so they can be queried using RQL
* [x] Write initial RQL query to report on meter validation errors 
* [x] Add additional RQL queries to help to surface other problem areas

