### PR TITLE
Add elements check

### DIFF
--- a/app/controllers/schools/meters_controller.rb
+++ b/app/controllers/schools/meters_controller.rb
@@ -16,6 +16,7 @@ module Schools
 
     def show
       @n3rgy_status = MeterManagement.new(@meter).check_n3rgy_status
+      @elements = MeterManagement.new(@meter).elements
       respond_to do |format|
         format.html
         format.csv { send_data readings_to_csv(AmrValidatedReading.download_query_for_meter(@meter), AmrValidatedReading::CSV_HEADER_FOR_METER), filename: "meter-amr-readings-#{@meter.mpan_mprn}.csv" }

--- a/app/services/meter_management.rb
+++ b/app/services/meter_management.rb
@@ -25,6 +25,16 @@ class MeterManagement
     return :api_error
   end
 
+  def elements
+    return nil unless @meter.dcc_meter?
+    @n3rgy_api_factory.data_api(@meter).elements(@meter.mpan_mprn, @meter.meter_type)
+  rescue => e
+    Rails.logger.error "Exception: checking elements of meter #{@meter.mpan_mprn} : #{e.class} #{e.message}"
+    Rails.logger.error e.backtrace.join("\n")
+    Rollbar.error(e)
+    return :api_error
+  end
+
   def process_creation!
     assign_amr_data_feed_readings
   end

--- a/app/views/schools/meters/show.html.erb
+++ b/app/views/schools/meters/show.html.erb
@@ -28,5 +28,7 @@
   <dt class="col-sm-3">Earliest Available Data</dt>
   <dd class="col-sm-9"><%= @meter.earliest_available_data %></dd>
   <dt class="col-sm-3">N3RGY API Status</dt>
-  <dd class="col-sm-9"><%= @n3rgy_status %></dt>
+  <dd class="col-sm-9"><%= @n3rgy_status %></dd>
+  <dt class="col-sm-3">Meter Elements</dt>
+  <dd class="col-sm-9"><%= @elements %></dd>
 </dl>

--- a/lib/tasks/utility.rake
+++ b/lib/tasks/utility.rake
@@ -76,4 +76,13 @@ namespace :utility do
     RollbarNotifierService.new.perform
   end
 
+  desc 'Check elements of DCC meters'
+  task check_elements: :environment do
+    api_factory = Amr::N3rgyApiFactory.new
+    Meter.where(dcc_meter: true).order(:mpan_mprn).each do |meter|
+      api = api_factory.data_api(meter)
+      elements = api.elements(meter.mpan_mprn, meter.meter_type)
+      puts "#{meter.mpan_mprn}, #{meter.school.name}, #{elements.size}"
+    end
+  end
 end


### PR DESCRIPTION
We're assuming DCC meters always have a single element. But this might not always be the case.

To give us a way to check/confirm this when testing, have added:

* a lookup on the meter details page, which displays number of elements
* a `utility:check_elements` rake raks that dumps a simple CSV export of school, mpan, element count
