### PR TITLE
Send email to multiple users

### DIFF
--- a/app/mailers/onboarding_mailer.rb
+++ b/app/mailers/onboarding_mailer.rb
@@ -19,7 +19,8 @@ class OnboardingMailer < ApplicationMailer
   def activation_email
     @school_onboarding = params[:school_onboarding]
     @school = @school_onboarding.school
-    make_bootstrap_mail(to: @school_onboarding.created_user.email, subject: "#{@school.name} is live on Energy Sparks")
+    @to = params[:to]
+    make_bootstrap_mail(to: @to, subject: "#{@school.name} is live on Energy Sparks")
   end
 
   def welcome_email

--- a/app/services/school_creator.rb
+++ b/app/services/school_creator.rb
@@ -33,7 +33,7 @@ class SchoolCreator
     @school.update!(visible: true)
     record_event(@school.school_onboarding, :onboarding_complete) if should_complete_onboarding?
     if should_send_activation_email?
-      OnboardingMailer.with(school_onboarding: @school.school_onboarding).activation_email.deliver_now
+      OnboardingMailer.with(to: activation_email_list(@school), school_onboarding: @school.school_onboarding).activation_email.deliver_now
       record_event(@school.school_onboarding, :activation_email_sent)
     end
   end
@@ -49,6 +49,13 @@ class SchoolCreator
   end
 
 private
+
+  def activation_email_list(school)
+    users = [school.school_onboarding.created_user]
+    #also email admin, staff and group users
+    users += (school.school_admin.to_a + school.cluster_users.to_a + school.users.staff.to_a)
+    users.uniq.map(&:email)
+  end
 
   def add_school(user, school)
     user.add_cluster_school(school)

--- a/spec/services/school_creator_spec.rb
+++ b/spec/services/school_creator_spec.rb
@@ -123,6 +123,18 @@ describe SchoolCreator, :schools, type: :service do
         service.make_visible!
         email = ActionMailer::Base.deliveries.last
         expect(email.subject).to include('is live on Energy Sparks')
+        expect(email.to).to eql [onboarding_user.email]
+        expect(school_onboarding).to have_event(:activation_email_sent)
+      end
+
+      it 'sends an activation email to staff and admins' do
+        school_admin = create(:school_admin, school: school)
+        staff = create(:staff, school: school)
+        service = SchoolCreator.new(school)
+        service.make_visible!
+        email = ActionMailer::Base.deliveries.last
+        expect(email.subject).to include('is live on Energy Sparks')
+        expect(email.to).to match [onboarding_user.email, school_admin.email, staff.email]
         expect(school_onboarding).to have_event(:activation_email_sent)
       end
 


### PR DESCRIPTION
Send the activation email to all school admins, staff and group users.

Sends a single email with everyone in the to: field