### PR TITLE
Correctly assign weather and solar observations when stations not set

### DIFF
--- a/app/controllers/concerns/school_aggregation.rb
+++ b/app/controllers/concerns/school_aggregation.rb
@@ -14,8 +14,8 @@ private
   def setup_loading_stats
     @number_of_meter_readings = @school.amr_validated_readings.count * 48
     @number_of_meters = @school.meters.count
-    @number_of_weather_readings = DataFeeds::DarkSkyTemperatureReading.where(area_id: @school.dark_sky_area.id).count * 48
-    @number_of_solar_pv_readings = DataFeeds::SolarPvTuosReading.where(area_id: @school.solar_pv_tuos_area.id).count * 48
+    @number_of_weather_readings = number_of_weather_readings
+    @number_of_solar_pv_readings = number_of_solar_readings
   end
 
   def aggregate_school_service
@@ -24,5 +24,22 @@ private
 
   def aggregate_school
     aggregate_school_service.aggregate_school
+  end
+
+  def number_of_solar_readings
+    if @school.solar_pv_tuos_area.present?
+      DataFeeds::SolarPvTuosReading.where(area_id: @school.solar_pv_tuos_area.id).count * 48
+    end
+    0
+  end
+
+  def number_of_weather_readings
+    if @school.weather_station.present?
+      WeatherObservation.where(weather_station_id: @school.weather_station.id).count * 48
+    elsif @school.dark_sky_area.present?
+      DataFeeds::DarkSkyTemperatureReading.where(area_id: @school.dark_sky_area.id).count * 48
+    else
+      0
+    end
   end
 end

--- a/spec/controllers/teachers/school_controller_spec.rb
+++ b/spec/controllers/teachers/school_controller_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+RSpec.describe Teachers::SchoolsController, type: :controller do
+
+  let(:school)          { create(:school) }
+
+  describe "GET #show" do
+
+    context "school not in cache" do
+        before(:each) do
+          allow(AggregateSchoolService).to receive(:caching_off?).and_return(false, true)
+          allow_any_instance_of(AggregateSchoolService).to receive(:aggregate_school).and_return(school)
+          sign_in_user(:school_admin, school.id)
+        end
+
+        it "shows error page" do
+          get :show, params: {id: school.to_param}
+          expect(assigns(:school)).to eq(school)
+          expect(assigns(:number_of_weather_readings)).to eql(0)
+          expect(assigns(:number_of_solar_pv_readings)).to eql(0)
+          expect(response).to_not redirect_to(teachers_school_path(school))
+          expect(response).to render_template("schools/aggregated_meter_collections/show")
+        end
+
+        it "shows weather count" do
+          station = create(:weather_station)
+          create(:weather_observation, weather_station: station, reading_date: '2020-01-01')
+          school.update!(weather_station: station)
+
+          get :show, params: {id: school.to_param}
+          expect(assigns(:number_of_weather_readings)).to eql(48)
+          expect(assigns(:number_of_solar_pv_readings)).to eql(0)
+          expect(response).to_not redirect_to(teachers_school_path(school))
+          expect(response).to render_template("schools/aggregated_meter_collections/show")
+        end
+
+    end
+  end
+end

--- a/spec/system/teachers/school_spec.rb
+++ b/spec/system/teachers/school_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe "teachers school view", type: :system do
         visit teachers_school_path(school)
 
         expect(page).to have_content('Gas')
-        # if redirect fails it will stille be processing
+        # if redirect fails it will still be processing
         expect(page).to_not have_content('processing')
         expect(page).to_not have_content("we're having trouble processing your energy data today")
       end
@@ -81,7 +81,6 @@ RSpec.describe "teachers school view", type: :system do
 
       it 'shows an error message', errors_expected: true do
         visit teachers_school_path(school)
-
         expect(page).to have_content("we're having trouble processing your energy data today")
       end
     end
@@ -96,4 +95,3 @@ RSpec.describe "teachers school view", type: :system do
     end
   end
 end
-


### PR DESCRIPTION
Test for presence of MeteoStat and Dark Sky stations.

Also handle missing solar pv area.

Add test for the single page(?) that displays these values if school is not in cache.