### PR TITLE
Add check to see if onboarding user is nil

### DIFF
--- a/app/services/school_creator.rb
+++ b/app/services/school_creator.rb
@@ -51,7 +51,8 @@ class SchoolCreator
 private
 
   def activation_email_list(school)
-    users = [school.school_onboarding.created_user]
+    users = []
+    users << school.school_onboarding.created_user unless school.school_onboarding.created_user.nil?
     #also email admin, staff and group users
     users += (school.school_admin.to_a + school.cluster_users.to_a + school.users.staff.to_a)
     users.uniq.map(&:email)

--- a/spec/services/school_creator_spec.rb
+++ b/spec/services/school_creator_spec.rb
@@ -144,6 +144,20 @@ describe SchoolCreator, :schools, type: :service do
         service.make_visible!
         expect(ActionMailer::Base.deliveries.size).to eq(0)
       end
+
+      it 'sends email if onboarding doesnt have a created user' do
+        school_admin = create(:school_admin, school: school)
+        staff = create(:staff, school: school)
+        school_onboarding.update(created_user: nil)
+
+        service = SchoolCreator.new(school)
+        service.make_visible!
+        email = ActionMailer::Base.deliveries.last
+        expect(email.subject).to include('is live on Energy Sparks')
+        expect(email.to).to match [school_admin.email, staff.email]
+        expect(school_onboarding).to have_event(:activation_email_sent)
+      end
+
     end
   end
 


### PR DESCRIPTION
If a school is setup manually, it won't have an "created user" associated with the onboarding. But may have other users.

This fixes up error when sending the activation email by checking if the user is nil.