### PR TITLE
User display name when creating onboarding contact

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -92,7 +92,7 @@ class User < ApplicationRecord
   end
 
   def display_name
-    name || email
+    name.present? ? name : email
   end
 
   def staff_role_as_symbol

--- a/app/services/school_creator.rb
+++ b/app/services/school_creator.rb
@@ -81,7 +81,7 @@ private
     record_events(onboarding, :alert_contact_created) do
       @school.contacts.create!(
         user: onboarding.created_user,
-        name: onboarding.created_user.name,
+        name: onboarding.created_user.display_name,
         email_address: onboarding.created_user.email,
         description: 'School Energy Sparks contact'
       )

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -3,6 +3,18 @@ require "cancan/matchers"
 
 describe User do
 
+  it 'generates display name' do
+    user = create(:user, name:"Name")
+    expect(user.display_name).to eql user.name
+
+    user = create(:user, name: nil)
+    expect(user.display_name).to eql user.email
+
+    user = create(:user, name: "")
+    expect(user.display_name).to eql user.email
+
+  end
+
   describe 'pupil validation' do
     let(:school){ create(:school) }
     let!(:existing_pupil){ create(:pupil, pupil_password: 'testtest', school: school) }

--- a/spec/services/school_creator_spec.rb
+++ b/spec/services/school_creator_spec.rb
@@ -82,6 +82,16 @@ describe SchoolCreator, :schools, type: :service do
       expect(contact.name).to eq(onboarding_user.name)
     end
 
+    it 'defaults contact name when not set on administrator user' do
+      onboarding_user.update!( {name: ""} )
+      service = SchoolCreator.new(school)
+      service.onboard_school!(school_onboarding)
+      contact = school.contacts.first
+      expect(contact.email_address).to eq(onboarding_user.email)
+      expect(contact.user).to eq(onboarding_user)
+      expect(contact.name).to eq(onboarding_user.email)
+    end
+
     it 'creates onboarding events' do
       service = SchoolCreator.new(school)
       service.onboard_school!(school_onboarding)


### PR DESCRIPTION
Users don't have to have named, but Contacts to.

During onboarding we create Contacts from Users. So it can fail if a name isn't set (or is empty)

So use `display_name` instead.

Also ensure `display_name` returns a useful value if name is empty.