### PR TITLE
1318 dcc meter review status page

### DIFF
--- a/app/controllers/admin/meter_reviews_controller.rb
+++ b/app/controllers/admin/meter_reviews_controller.rb
@@ -1,0 +1,9 @@
+module Admin
+  class MeterReviewsController < AdminController
+    def index
+      #find all schools/meters that are DCC meters, but which don't have a consent_granted flag.
+      #this might need to be revised to check both that status and whether its covered by a "review" model
+      @schools = School.joins(:meters).where("meters.dcc_meter=? AND consent_granted=?", true, false).order(:name).uniq
+    end
+  end
+end

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -359,6 +359,10 @@ class School < ApplicationRecord
     all_partners
   end
 
+  def consent_up_to_date?
+    consent_grants.any? && consent_grants.by_date.first.consent_statement.current
+  end
+
   private
 
   def add_joining_observation

--- a/app/views/admin/index.html.erb
+++ b/app/views/admin/index.html.erb
@@ -7,6 +7,7 @@
   <li><%= link_to "Manual School Setup", new_school_path %></li>
   <li><%= link_to "Automatic School Setup", admin_school_onboardings_path %></li>
   <li><%= link_to "Calendars", admin_calendars_path %></li>
+  <li><%= link_to "Meter Reviews", admin_meter_reviews_path %></li>
 </ul>
 
 <h2>Schools, Scoreboards and groups</h2>

--- a/app/views/admin/meter_reviews/index.html.erb
+++ b/app/views/admin/meter_reviews/index.html.erb
@@ -1,0 +1,48 @@
+<% content_for :page_title, 'Meter Reviews' %>
+
+<h1>Meter Reviews</h1>
+
+<p>
+The following schools have smart meters for which data is available via N3RGY. A
+review is required before access is enabled. Links are provided to their bills,
+latest grant of consent and a form to complete the review.
+</p>
+
+<table class="table">
+  <thead>
+    <th>School</th>
+    <th>Pending Smart Meters</th>
+    <th>Consent Current?</th>
+    <th>Bills Provided?</th>
+    <th>Actions</th>
+  </thead>
+  <tbody>
+    <% @schools.each do |school| %>
+      <tr>
+        <td><%= link_to school.name, school_path(school) %></td>
+        <td><%= link_to school.meters.where(dcc_meter: true, consent_granted: false).count, school_meters_path(school) %></td>
+        <td class="consent">
+          <%= fa_icon( school.consent_up_to_date? ? 'check-circle text-success' : 'times-circle text-danger') %>
+          <%= link_to school_consent_grants_path(school) do %>
+             View
+          <% end %>
+        </td>
+        <td class="bills">
+          <%= fa_icon( school.consent_documents.any? ? 'check-circle text-success' : 'times-circle text-danger') %>
+          <%= link_to school_consent_documents_path(school) do %>
+             View
+          <% end %>
+        </td>
+        <td>
+          <% if !school.consent_up_to_date? %>
+            <a href="#" class="btn btn-default">Request consent</a>
+          <% end %>
+          <a href="#" class="btn btn-default">Request bill</a>
+          <% if school.consent_up_to_date? %>
+            <a href="#" class="btn btn-default">Complete review</a>
+          <% end %>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -204,6 +204,7 @@ Rails.application.routes.draw do
     end
 
     resources :meter_attributes, only: :index
+    resources :meter_reviews
 
     resources :programme_types do
       scope module: :programme_types do

--- a/spec/factories/consent_grants_factory.rb
+++ b/spec/factories/consent_grants_factory.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :consent_grant do
+    consent_statement
+    school
+    association :user, factory: :school_admin
+  end
+end

--- a/spec/factories/consent_statement_factory.rb
+++ b/spec/factories/consent_statement_factory.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :consent_statement do
+    sequence(:title)        { |n| "Consent Statement #{n}"}
+    sequence(:content)  { |n| "I grant thee consent #{n}"}
+  end
+end

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -269,4 +269,16 @@ describe School do
     end
   end
 
+  context 'with consent' do
+    let!(:consent_statement)    { create(:consent_statement, current: true) }
+
+    it "identifies whether consent is current" do
+      expect(subject.consent_up_to_date?).to be false
+      create(:consent_grant, school: subject)
+      expect(subject.consent_up_to_date?).to be false
+      create(:consent_grant, school: subject, consent_statement: consent_statement)
+      expect(subject.consent_up_to_date?).to be true
+    end
+  end
+
 end

--- a/spec/system/admin/meter_reviews/meter_reviews_spec.rb
+++ b/spec/system/admin/meter_reviews/meter_reviews_spec.rb
@@ -1,0 +1,104 @@
+require 'rails_helper'
+
+RSpec.describe 'meter_reviews', type: :system do
+
+  let!(:school)                { create(:school) }
+  let!(:reviewed_school)       { create(:school) }
+  let!(:other_school)          { create(:school) }
+  let!(:dcc_meter)             { create(:electricity_meter, school: school, dcc_meter: true, consent_granted: false) }
+  let!(:dcc_meter_granted)     { create(:electricity_meter, school: reviewed_school, dcc_meter: true, consent_granted: true) }
+  let!(:electricity_meter)     { create(:electricity_meter, school: other_school, ) }
+
+  let!(:admin)                 { create(:admin) }
+
+  context 'with pending reviews' do
+    before(:each) do
+      login_as(admin)
+      visit root_path
+      click_on 'Admin'
+    end
+
+    it 'lists only meters pending reviews' do
+      click_on 'Meter Reviews'
+      expect(page).to have_title "Meter Reviews"
+      expect(page).to have_content school.name
+      expect(page).to_not have_content reviewed_school.name
+      expect(page).to_not have_content other_school
+    end
+
+    it 'has link to school consent documents' do
+      click_on 'Meter Reviews'
+      expect(page).to have_link("View", href: school_consent_documents_path(school))
+    end
+
+    it 'has link to school consent grants' do
+      click_on 'Meter Reviews'
+      expect(page).to have_link("View", href: school_consent_grants_path(school))
+    end
+
+    context 'with current consent' do
+      let!(:consent_statement)      {   create(:consent_statement, current: true) }
+      let!(:consent_grant)          {   create(:consent_grant, consent_statement: consent_statement, school: school) }
+
+      before(:each) do
+        click_on 'Meter Reviews'
+      end
+
+      it 'displays a tick' do
+        expect(page).to have_css('td.consent i.fa-check-circle')
+      end
+
+      it 'does not offer option to request consent' do
+        expect(page).to_not have_link('Request consent')
+      end
+
+      it 'offers option to complete review' do
+        expect(page).to have_link('Complete review')
+      end
+
+    end
+
+    context 'with no consent' do
+      before(:each) do
+        click_on 'Meter Reviews'
+      end
+
+      it 'displays a cross' do
+        expect(page).to have_css('td.consent i.fa-times-circle')
+      end
+
+      it 'offers to request consent' do
+        expect(page).to have_link('Request consent')
+      end
+
+      it 'does not offer to complete review' do
+        expect(page).to_not have_link('Complete review')
+      end
+
+    end
+
+    context 'with bills' do
+      let!(:consent_document)       { create(:consent_document, school: school) }
+
+      before(:each) do
+        click_on 'Meter Reviews'
+      end
+      it 'displays a tick' do
+        expect(page).to have_css('td.bills i.fa-check-circle')
+      end
+
+    end
+
+    context 'without bills' do
+      before(:each) do
+        click_on 'Meter Reviews'
+      end
+
+      it 'displays a cross' do
+        expect(page).to have_css('td.bills i.fa-times-circle')
+      end
+    end
+
+  end
+
+end


### PR DESCRIPTION
Provides a page listing DCC meters that haven't yet been activated via a trusted consent call on N3RGY API.

Admin can use this to check to see if the school consent is up to date (and view docs). And if they have supplied a bill as proof.

The buttons for requesting consent, emailing to request bills and completing a review a placeholders (covered by different cards in the backlog).

![Screenshot from 2021-03-16 15-28-30](https://user-images.githubusercontent.com/109082/111335832-9cc9e880-866c-11eb-9840-4dac473cb313.png)

