### PR TITLE
1320 complete a review for a dcc meter

### DIFF
--- a/app/controllers/admin/meter_reviews_controller.rb
+++ b/app/controllers/admin/meter_reviews_controller.rb
@@ -1,9 +1,7 @@
 module Admin
   class MeterReviewsController < AdminController
     def index
-      #find all schools/meters that are DCC meters, but which don't have a consent_granted flag.
-      #this might need to be revised to check both that status and whether its covered by a "review" model
-      @schools = School.joins(:meters).where("meters.dcc_meter=? AND consent_granted=?", true, false).order(:name).uniq
+      @schools = MeterReviewService.find_schools_needing_review
     end
   end
 end

--- a/app/controllers/admin/schools/meter_reviews_controller.rb
+++ b/app/controllers/admin/schools/meter_reviews_controller.rb
@@ -7,7 +7,7 @@ module Admin
       def new
         @meter_review = MeterReview.new
         @consent_grant = @school.consent_grants.by_date.first
-        @pending_meters = @school.meters.where(dcc_meter: true, consent_granted: false, meter_review: nil).order(:mpan_mprn)
+        @pending_meters = @school.meters.unreviewed_dcc_meter.order(:mpan_mprn)
       end
 
       def create

--- a/app/controllers/admin/schools/meter_reviews_controller.rb
+++ b/app/controllers/admin/schools/meter_reviews_controller.rb
@@ -1,0 +1,38 @@
+module Admin
+  module Schools
+    class MeterReviewsController < AdminController
+      load_and_authorize_resource :school
+      load_and_authorize_resource
+
+      def new
+        @meter_review = MeterReview.new
+        @consent_grant = @school.consent_grants.by_date.first
+        @pending_meters = @school.meters.where(dcc_meter: true, consent_granted: false, meter_review: nil).order(:mpan_mprn)
+      end
+
+      def create
+        meters = @school.meters.where(id: params[:meter_review]["meter_ids"])
+        if meters.any?
+          consent_documents = @school.consent_documents.where(id: params[:meter_review]["consent_document_ids"])
+
+          service = MeterReviewService.new(@school, current_user)
+          review = service.complete_review!(meters, consent_documents)
+
+          redirect_to admin_school_meter_review_path(@school, review), notice: "Review was successfully recorded. Meters will shortly be activated."
+
+        else
+          redirect_to new_admin_school_meter_review_path(@school), alert: "You must select at least one meter."
+        end
+      end
+
+      def show
+      end
+
+      private
+
+      def meter_review_params
+        params.require(:meter_review).permit(:meter_ids, :consent_document_ids, :school_id)
+      end
+    end
+  end
+end

--- a/app/models/consent_document.rb
+++ b/app/models/consent_document.rb
@@ -16,6 +16,10 @@ class ConsentDocument < ApplicationRecord
   belongs_to :school
   has_one_attached :file
   has_rich_text :description
-  validates_presence_of :school, :title, :file, presence: true
+
+  has_and_belongs_to_many :meter_reviews
+
   scope :by_created_date, -> { order(created_at: :asc) }
+
+  validates_presence_of :school, :title, :file, presence: true
 end

--- a/app/models/meter.rb
+++ b/app/models/meter.rb
@@ -55,6 +55,8 @@ class Meter < ApplicationRecord
   scope :sub_meter, -> { where(pseudo: true, meter_type: SUB_METER_TYPES) }
   scope :no_amr_validated_readings, -> { left_outer_joins(:amr_validated_readings).where(amr_validated_readings: { meter_id: nil }) }
 
+  scope :unreviewed_dcc_meter, -> { where(dcc_meter: true, consent_granted: false, meter_review: nil) }
+
   # If adding a new one, add to the amr_validated_reading case statement for downloading data
   enum meter_type: [:electricity, :gas, :solar_pv, :exported_solar_pv]
 

--- a/app/models/meter.rb
+++ b/app/models/meter.rb
@@ -43,6 +43,8 @@ class Meter < ApplicationRecord
 
   has_many :meter_attributes
 
+  belongs_to :meter_review, optional: true
+
   CREATABLE_METER_TYPES = [:electricity, :gas, :solar_pv, :exported_solar_pv].freeze
   SUB_METER_TYPES = [:solar_pv, :exported_solar_pv].freeze
 

--- a/app/models/meter_review.rb
+++ b/app/models/meter_review.rb
@@ -1,0 +1,10 @@
+class MeterReview < ApplicationRecord
+  belongs_to :school
+  belongs_to :user
+  belongs_to :consent_grant
+
+  has_many :meters
+  has_and_belongs_to_many :consent_documents
+
+  validates_presence_of :school, :user, :consent_grant
+end

--- a/app/models/meter_review.rb
+++ b/app/models/meter_review.rb
@@ -7,4 +7,9 @@ class MeterReview < ApplicationRecord
   has_and_belongs_to_many :consent_documents
 
   validates_presence_of :school, :user, :consent_grant
+
+  before_destroy do |review|
+    review.meters.clear
+    review.consent_documents.clear
+  end
 end

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -78,6 +78,7 @@ class School < ApplicationRecord
   has_many :consent_documents,    inverse_of: :school
   has_many :meter_attributes,     inverse_of: :school, class_name: 'SchoolMeterAttribute'
   has_many :consent_grants,       inverse_of: :school
+  has_many :meter_reviews,        inverse_of: :school
 
   has_many :programmes,               inverse_of: :school
   has_many :programme_activity_types, through: :programmes, source: :activity_types

--- a/app/services/meter_review_service.rb
+++ b/app/services/meter_review_service.rb
@@ -10,18 +10,16 @@ class MeterReviewService
     Meter.unreviewed_dcc_meter.map(&:school).sort_by(&:name).uniq
   end
 
-  def complete_review!(meters, consent_documents = nil)
+  def complete_review!(meters, consent_documents = [])
     return nil unless meters.present? && meters.any?
-    @school.transaction do
-      review = MeterReview.create!(
-        school: @school,
-        user: @user,
-        consent_grant: current_consent
-      )
-      review.meters << meters
-      review.consent_documents << consent_documents if consent_documents.present?
-      return review
-    end
+    review = MeterReview.create!(
+      school: @school,
+      user: @user,
+      consent_grant: current_consent,
+      meters: meters,
+      consent_documents: consent_documents
+    )
+    review
   end
 
   private

--- a/app/services/meter_review_service.rb
+++ b/app/services/meter_review_service.rb
@@ -7,9 +7,7 @@ class MeterReviewService
   end
 
   def self.find_schools_needing_review
-    #find all schools/meters that are DCC meters, but which don't have a consent_granted flag.
-    School.joins(:meters).where("meters.dcc_meter=? AND consent_granted=? AND meter_review_id is null", true, false).order(:name).uniq
-    #this might need to be revised to check both that status and whether there is a completed review
+    Meter.unreviewed_dcc_meter.map(&:school).sort_by(&:name).uniq
   end
 
   def complete_review!(meters, consent_documents = nil)

--- a/app/services/meter_review_service.rb
+++ b/app/services/meter_review_service.rb
@@ -1,0 +1,34 @@
+class MeterReviewService
+  attr_reader :school
+
+  def initialize(school, reviewer)
+    @school = school
+    @user = reviewer
+  end
+
+  def self.find_schools_needing_review
+    #find all schools/meters that are DCC meters, but which don't have a consent_granted flag.
+    School.joins(:meters).where("meters.dcc_meter=? AND consent_granted=?", true, false).order(:name).uniq
+    #this might need to be revised to check both that status and whether there is a completed review
+  end
+
+  def complete_review!(meters, consent_documents = nil)
+    return nil unless meters.present? && meters.any?
+    @school.transaction do
+      review = MeterReview.create!(
+        school: @school,
+        user: @user,
+        consent_grant: current_consent
+      )
+      review.meters << meters
+      review.consent_documents << consent_documents if consent_documents.present?
+      return review
+    end
+  end
+
+  private
+
+  def current_consent
+    @school.consent_grants.by_date.first
+  end
+end

--- a/app/services/meter_review_service.rb
+++ b/app/services/meter_review_service.rb
@@ -8,7 +8,7 @@ class MeterReviewService
 
   def self.find_schools_needing_review
     #find all schools/meters that are DCC meters, but which don't have a consent_granted flag.
-    School.joins(:meters).where("meters.dcc_meter=? AND consent_granted=?", true, false).order(:name).uniq
+    School.joins(:meters).where("meters.dcc_meter=? AND consent_granted=? AND meter_review_id is null", true, false).order(:name).uniq
     #this might need to be revised to check both that status and whether there is a completed review
   end
 

--- a/app/views/admin/meter_reviews/index.html.erb
+++ b/app/views/admin/meter_reviews/index.html.erb
@@ -39,7 +39,7 @@ latest grant of consent and a form to complete the review.
           <% end %>
           <a href="#" class="btn btn-default">Request bill</a>
           <% if school.consent_up_to_date? %>
-            <a href="#" class="btn btn-default">Complete review</a>
+            <%= link_to "Complete review", new_admin_school_meter_review_path(school), class: 'btn btn-default' %>
           <% end %>
         </td>
       </tr>

--- a/app/views/admin/meter_reviews/index.html.erb
+++ b/app/views/admin/meter_reviews/index.html.erb
@@ -20,7 +20,7 @@ latest grant of consent and a form to complete the review.
     <% @schools.each do |school| %>
       <tr>
         <td><%= link_to school.name, school_path(school) %></td>
-        <td><%= link_to school.meters.where(dcc_meter: true, consent_granted: false).count, school_meters_path(school) %></td>
+        <td><%= link_to school.meters.unreviewed_dcc_meter.count, school_meters_path(school) %></td>
         <td class="consent">
           <%= fa_icon( school.consent_up_to_date? ? 'check-circle text-success' : 'times-circle text-danger') %>
           <%= link_to school_consent_grants_path(school) do %>
@@ -39,7 +39,7 @@ latest grant of consent and a form to complete the review.
           <% end %>
           <a href="#" class="btn btn-default">Request bill</a>
           <% if school.consent_up_to_date? %>
-            <%= link_to "Complete review", new_admin_school_meter_review_path(school), class: 'btn btn-default' %>
+            <%= link_to "Perform review", new_admin_school_meter_review_path(school), class: 'btn btn-default' %>
           <% end %>
         </td>
       </tr>

--- a/app/views/admin/schools/meter_reviews/new.html.erb
+++ b/app/views/admin/schools/meter_reviews/new.html.erb
@@ -37,7 +37,6 @@
     <h4>Review form</h4>
     <%= simple_form_for @meter_review, url: admin_school_meter_reviews_path(@school) do |f| %>
 
-
       <div class="card-group">
           <div class="card bg-light">
             <div class="card-body">

--- a/app/views/admin/schools/meter_reviews/new.html.erb
+++ b/app/views/admin/schools/meter_reviews/new.html.erb
@@ -1,0 +1,77 @@
+<% content_for :page_title, "Complete Meter Review for #{@school.name}" %>
+
+<h1>Complete meter review for <%= @school.name %></h1>
+
+<div class="row">
+ <div class="col">
+   <p>
+     To enable the following meters for access via the N3RGY API, we must review
+     whether the school has given us appropriate consent and have provided sufficient
+     proof of access to the meters.
+   </p>
+   <p>
+     Only complete the review if you are confident that these meters belong to the
+     school.
+   </p>
+ </div>
+
+</div>
+
+<div class="row mb-2">
+ <div class="col">
+   <%= fa_icon( @school.consent_up_to_date? ? 'check-circle text-success' : 'times-circle text-danger') %>
+   <% if @school.consent_up_to_date? %>
+    This school has <%= link_to "granted consent", school_consent_grants_path(@school) %> using the latest consent statement
+   <% else %>
+    This school has not <%= link_to "granted consent", school_consent_grants_path(@school) %> using the latest consent statement
+    <div class="alert alert-danger">
+      We do not have up to date consent for <%= @school.name %> so meters cannot be
+      activated. The form is disabled.
+    </div>
+   <% end %>
+ </div>
+</div>
+
+<div class="row">
+ <div class="col">
+    <h4>Review form</h4>
+    <%= simple_form_for @meter_review, url: admin_school_meter_reviews_path(@school) do |f| %>
+
+
+      <div class="card-group">
+          <div class="card bg-light">
+            <div class="card-body">
+              <%= f.association :meters, label: "Which meters can be activated?", as: :check_boxes, collection: @pending_meters, value_method: :id, label_method: :mpan_mprn %>
+            </div>
+            <div class="card-footer">
+              <%= link_to "View meters", school_meters_path(@school), class: "btn btn-sm btn-default", target: "_new" %>
+            </div>
+          </div>
+
+          <div class="card bg-light">
+            <div class="card-body">
+              <%= f.association :consent_documents, label: "Which documents were checked?", as: :check_boxes, collection: @school.consent_documents, value_method: :id, label_method: :title %>
+            </div>
+            <div class="card-footer">
+              <%= link_to "View documents", school_consent_documents_path(@school), class: "btn btn-sm btn-default", target: "_new" %>
+            </div>
+          </div>
+
+      </div>
+
+      <div class="row mt-1 mb-1">
+       <div class="col">
+         <div class="mt-4">
+           <%= f.button :submit, "Complete review", "data-confirm": 'Are you sure?', disabled: !@school.consent_up_to_date? %>
+         </div>
+         <hr>
+         <div class="btn-group">
+           <%= link_to "See all pending reviews", admin_meter_reviews_path, class: "btn btn-default" %>
+         </div>
+       </div>
+      </div>
+
+    </div>
+
+    <% end %>
+</div>

--- a/app/views/admin/schools/meter_reviews/show.html.erb
+++ b/app/views/admin/schools/meter_reviews/show.html.erb
@@ -1,0 +1,62 @@
+<% content_for :page_title, "Completed Meter Review for #{@school.name}" %>
+
+<h1>Completed Meter review for <%= @school.name %></h1>
+
+<div class="row mb-2">
+ <div class="col">
+  <p>
+  This review was completed on <%= nice_date_times(@meter_review.created_at) %> by <%= @meter_review.user.name %>
+  </p>
+
+  <p>
+  At that time, <%= @school.name %> had <%= link_to "given consent", admin_consent_grant_path(@meter_review.consent_grant) %>.
+  </p>
+ </div>
+</div>
+
+<div class="row">
+ <div class="col">
+    <h4>Review summary</h4>
+
+    <div class="card-group">
+        <div class="card bg-light">
+          <div class="card-body">
+            The following meters were reviewed:
+            <ul class="unstyled-list">
+              <% @meter_review.meters.each do |meter| %>
+                <li><%= link_to meter.mpan_mprn, school_meter_path(@school, meter) %></li>
+              <% end %>
+            </ul>
+          </div>
+          <div class="card-footer">
+            <%= link_to "View all meters", school_meters_path(@school), class: "btn btn-sm btn-default", target: "_new" %>
+          </div>
+        </div>
+
+        <div class="card bg-light">
+          <div class="card-body">
+            The following documents confirmed access:
+            <ul class="unstyled-list">
+              <% @meter_review.consent_documents.each do |bill| %>
+                <li><%= link_to bill.title, school_consent_document_path(@school, bill) %></li>
+              <% end %>
+            </ul>
+          </div>
+          <div class="card-footer">
+            <%= link_to "View all documents", school_consent_documents_path(@school), class: "btn btn-sm btn-default", target: "_new" %>
+          </div>
+        </div>
+
+    </div>
+
+    <div class="row mt-1 mb-1">
+     <div class="col">
+       <hr>
+       <div class="btn-group">
+         <%= link_to "View pending reviews", admin_meter_reviews_path, class: "btn btn-default" %>
+       </div>
+     </div>
+    </div>
+
+ </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -204,7 +204,7 @@ Rails.application.routes.draw do
     end
 
     resources :meter_attributes, only: :index
-    resources :meter_reviews
+    resources :meter_reviews, only: :index
 
     resources :programme_types do
       scope module: :programme_types do
@@ -272,6 +272,7 @@ Rails.application.routes.draw do
         resources :meter_attributes
         resources :school_attributes
         resource :partners, only: [:show, :update]
+        resources :meter_reviews
       end
     end
 

--- a/db/migrate/20210318120341_create_meter_reviews.rb
+++ b/db/migrate/20210318120341_create_meter_reviews.rb
@@ -1,0 +1,11 @@
+class CreateMeterReviews < ActiveRecord::Migration[6.0]
+  def change
+    create_table :meter_reviews do |t|
+      t.references :school, null: false, foreign_key: true
+      t.references :user, null: false, foreign_key: true
+      t.references :consent_grant, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20210318120534_add_meter_review_to_meter.rb
+++ b/db/migrate/20210318120534_add_meter_review_to_meter.rb
@@ -1,0 +1,5 @@
+class AddMeterReviewToMeter < ActiveRecord::Migration[6.0]
+  def change
+    add_reference :meters, :meter_review, null: true, foreign_key: true
+  end
+end

--- a/db/migrate/20210318144544_associate_consent_documents_and_meter_reviews.rb
+++ b/db/migrate/20210318144544_associate_consent_documents_and_meter_reviews.rb
@@ -1,0 +1,8 @@
+class AssociateConsentDocumentsAndMeterReviews < ActiveRecord::Migration[6.0]
+  def change
+    create_table :consent_documents_meter_reviews, id: false do |t|
+      t.belongs_to :consent_document
+      t.belongs_to :meter_review
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_09_132149) do
+ActiveRecord::Schema.define(version: 2021_03_18_144544) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
@@ -556,6 +556,13 @@ ActiveRecord::Schema.define(version: 2021_03_09_132149) do
     t.index ["school_id"], name: "index_consent_documents_on_school_id"
   end
 
+  create_table "consent_documents_meter_reviews", id: false, force: :cascade do |t|
+    t.bigint "consent_document_id"
+    t.bigint "meter_review_id"
+    t.index ["consent_document_id"], name: "index_consent_documents_meter_reviews_on_consent_document_id"
+    t.index ["meter_review_id"], name: "index_consent_documents_meter_reviews_on_meter_review_id"
+  end
+
   create_table "consent_grants", force: :cascade do |t|
     t.bigint "consent_statement_id", null: false
     t.bigint "user_id", null: false
@@ -784,6 +791,17 @@ ActiveRecord::Schema.define(version: 2021_03_09_132149) do
     t.index ["meter_id"], name: "index_meter_attributes_on_meter_id"
   end
 
+  create_table "meter_reviews", force: :cascade do |t|
+    t.bigint "school_id", null: false
+    t.bigint "user_id", null: false
+    t.bigint "consent_grant_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["consent_grant_id"], name: "index_meter_reviews_on_consent_grant_id"
+    t.index ["school_id"], name: "index_meter_reviews_on_school_id"
+    t.index ["user_id"], name: "index_meter_reviews_on_user_id"
+  end
+
   create_table "meters", force: :cascade do |t|
     t.bigint "school_id", null: false
     t.integer "meter_type"
@@ -800,7 +818,9 @@ ActiveRecord::Schema.define(version: 2021_03_09_132149) do
     t.boolean "consent_granted", default: false
     t.date "earliest_available_data"
     t.boolean "sandbox", default: false
+    t.bigint "meter_review_id"
     t.index ["low_carbon_hub_installation_id"], name: "index_meters_on_low_carbon_hub_installation_id"
+    t.index ["meter_review_id"], name: "index_meters_on_meter_review_id"
     t.index ["meter_type"], name: "index_meters_on_meter_type"
     t.index ["mpan_mprn"], name: "index_meters_on_mpan_mprn", unique: true
     t.index ["school_id"], name: "index_meters_on_school_id"
@@ -1349,7 +1369,11 @@ ActiveRecord::Schema.define(version: 2021_03_09_132149) do
   add_foreign_key "meter_attributes", "meters", on_delete: :cascade
   add_foreign_key "meter_attributes", "users", column: "created_by_id", on_delete: :nullify
   add_foreign_key "meter_attributes", "users", column: "deleted_by_id", on_delete: :nullify
+  add_foreign_key "meter_reviews", "consent_grants"
+  add_foreign_key "meter_reviews", "schools"
+  add_foreign_key "meter_reviews", "users"
   add_foreign_key "meters", "low_carbon_hub_installations", on_delete: :cascade
+  add_foreign_key "meters", "meter_reviews"
   add_foreign_key "meters", "schools", on_delete: :cascade
   add_foreign_key "meters", "solar_edge_installations", on_delete: :cascade
   add_foreign_key "observations", "activities", on_delete: :nullify

--- a/spec/factories/meter_reviews.rb
+++ b/spec/factories/meter_reviews.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :meter_review do
+    school factory: :school
+    user factory: :admin
+    consent_grant factory: :consent_grant
+  end
+end

--- a/spec/factories/users_factory.rb
+++ b/spec/factories/users_factory.rb
@@ -29,6 +29,7 @@ FactoryBot.define do
     end
 
     factory :admin do
+      name { "Admin"}
       role { :admin }
     end
 

--- a/spec/services/meter_review_service_spec.rb
+++ b/spec/services/meter_review_service_spec.rb
@@ -1,0 +1,68 @@
+require 'rails_helper'
+
+RSpec.describe MeterReviewService do
+
+  let!(:consent_statement)      {   create(:consent_statement, current: true) }
+
+  let!(:school)                { create(:school) }
+  let!(:dcc_meter)             { create(:electricity_meter, school: school, dcc_meter: true, consent_granted: false) }
+  let!(:dcc_meter_ignored)     { create(:electricity_meter, school: school, dcc_meter: true, consent_granted: true) }
+
+  let!(:admin)                 { create(:admin) }
+
+  let!(:service)               { MeterReviewService.new(school, admin) }
+
+  context 'when completing a review' do
+
+    context 'and school has consent' do
+      let!(:consent_grant)     { create(:consent_grant, consent_statement: consent_statement, school: school) }
+
+      it 'should record the review' do
+        expect {
+          service.complete_review!([dcc_meter])
+        }.to change{MeterReview.count}.from(0).to(1)
+      end
+
+      it 'should capture current context' do
+        review = service.complete_review!([dcc_meter])
+        expect(review.user).to eql(admin)
+        expect(review.school).to eql(school)
+        expect(review.consent_grant).to eql(consent_grant)
+      end
+
+      it 'should associate the meters' do
+        review = service.complete_review!([dcc_meter])
+        expect(review.meters).to match([dcc_meter])
+      end
+
+      it 'should require meters' do
+        expect {
+          service.complete_review!([])
+        }.to_not change{MeterReview.count}
+        expect {
+          service.complete_review!(nil)
+        }.to_not change{MeterReview.count}
+      end
+
+      context 'and documents are checked' do
+        let!(:consent_document)       { create(:consent_document, school: school) }
+
+        it 'should record which documents are checked' do
+          review = service.complete_review!([dcc_meter], [consent_document])
+          expect(review.consent_documents).to match([consent_document])
+        end
+      end
+
+    end
+
+    context 'and school has no current consent' do
+      it 'should not allow review to be completed' do
+        expect {
+          service.complete_review!([ dcc_meter ])
+        }.to raise_error(ActiveRecord::RecordInvalid)
+      end
+    end
+
+  end
+
+end

--- a/spec/system/admin/meter_reviews/meter_reviews_spec.rb
+++ b/spec/system/admin/meter_reviews/meter_reviews_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe 'meter_reviews', type: :system do
   let!(:other_school)          { create(:school) }
   let!(:dcc_meter)             { create(:electricity_meter, school: school, dcc_meter: true, consent_granted: false) }
   let!(:dcc_meter_granted)     { create(:electricity_meter, school: reviewed_school, dcc_meter: true, consent_granted: true) }
-  let!(:electricity_meter)     { create(:electricity_meter, school: other_school, ) }
+  let!(:electricity_meter)     { create(:electricity_meter, school: other_school) }
 
   let!(:admin)                 { create(:admin) }
 
@@ -83,6 +83,7 @@ RSpec.describe 'meter_reviews', type: :system do
       before(:each) do
         click_on 'Meter Reviews'
       end
+
       it 'displays a tick' do
         expect(page).to have_css('td.bills i.fa-check-circle')
       end
@@ -101,4 +102,55 @@ RSpec.describe 'meter_reviews', type: :system do
 
   end
 
+  context 'when performing a review' do
+
+    before(:each) do
+      login_as(admin)
+      visit root_path
+      click_on 'Admin'
+    end
+
+    context 'and consent is not current' do
+      it 'should not allow completion' do
+        click_on 'Meter Reviews'
+        expect(page).to_not have_link("Complete review")
+      end
+    end
+
+    context 'when consent is current' do
+      let!(:consent_statement)      {   create(:consent_statement, current: true) }
+      let!(:consent_grant)          {   create(:consent_grant, consent_statement: consent_statement, school: school) }
+
+      before(:each) do
+        click_on 'Meter Reviews'
+      end
+
+      it 'should list the meters' do
+        click_on 'Complete review'
+        expect(page.has_unchecked_field?(dcc_meter.mpan_mprn)).to be true
+      end
+
+      it 'should link to the consent grant'
+      it 'should require meters to be added'
+      it 'should allow the review to be completed'
+      it 'completes the review'
+
+      it 'should not list previously reviewed meters'
+
+      context 'and documents are available' do
+        it 'should provide list of documents'
+        it 'should allow multiple documents to be added'
+      end
+
+    end
+  end
+
+  context 'when showing a review' do
+    it 'should link to consent grant'
+    it 'should display user'
+    it 'should list the meters'
+    it 'should link to consent documents'
+    it 'should list which user completed the review'
+    it 'should say when review was completed'
+  end
 end


### PR DESCRIPTION
Still work in progress but:

- displays list of DCC meters that need an admin review
- provides a form for admin to view relevant consent docs, meter setup and bills
- allows admin to complete review
- displays previous reviews

Need to complete the rspecs and tidy the code. Also consider where best to show previous meter reviews.

![Screenshot from 2021-03-19 12-33-55](https://user-images.githubusercontent.com/109082/111780517-6d56ee00-88af-11eb-89a1-b81066bb564e.png)
