### PR TITLE
Move controls for edit/delete a bill

### DIFF
--- a/app/views/schools/consent_documents/index.html.erb
+++ b/app/views/schools/consent_documents/index.html.erb
@@ -31,6 +31,10 @@
             <%= link_to url_for(bill.file), class: 'btn btn-primary' do %>
               Download <i class="fas fa-file-download"></i>
             <% end%>
+            <%= link_to "Edit", edit_school_consent_document_path(@school, bill), class: 'btn' %>
+            <% if can?(:delete, bill) %>
+              <%= link_to "Delete", school_consent_document_path(@school, bill), method: :delete, data: {confirm: 'Are you sure?'}, class: 'btn btn-danger'  %>
+            <% end %>
           </td>
         </tr>
       <% end %>

--- a/spec/system/schools/consent_documents_spec.rb
+++ b/spec/system/schools/consent_documents_spec.rb
@@ -34,6 +34,8 @@ describe 'consent documents', type: :system do
         expect(page).to have_content "Uploaded Bills"
         expect(page).to have_content "New bill"
         expect(page).to have_link 'Upload a new bill'
+        expect(page).to have_content "Edit"
+        expect(page).to_not have_content "Delete"
       end
 
       it 'can update a bill' do
@@ -89,13 +91,21 @@ describe 'consent documents', type: :system do
   end
 
   context 'as admin' do
+    let!(:consent_document) { create(:consent_document, school: school, description: "Proof!", title: "Our Energy Bill") }
+
     before(:each) do
       sign_in(admin)
     end
 
-    context 'when managing consent documents' do
-      let!(:consent_document)                 { create(:consent_document, school: school, description: "Proof!", title: "Our Energy Bill") }
+    context 'when viewing documents' do
+      it 'should allow admin to edit and delete' do
+        visit school_consent_documents_path(school)
+        expect(page).to have_link("Delete")
+        expect(page).to have_link("Edit")
+      end
+    end
 
+    context 'when managing consent documents' do
       it 'can delete a bill' do
         visit school_consent_document_path(school, consent_document)
         expect {


### PR DESCRIPTION
Display edit link on list of consent documents.

Allow admins to delete these from the list