### PR TITLE
Implement private scoreboards

### DIFF
--- a/app/controllers/benchmarks_controller.rb
+++ b/app/controllers/benchmarks_controller.rb
@@ -84,7 +84,7 @@ private
 
   def filter_lists
     @school_groups = SchoolGroup.order(:name)
-    @scoreboards = Scoreboard.order(:name)
+    @scoreboards = ComparisonService.new(current_user).list_scoreboards
   end
 
   def benchmark_results

--- a/app/controllers/scoreboards_controller.rb
+++ b/app/controllers/scoreboards_controller.rb
@@ -1,13 +1,14 @@
 class ScoreboardsController < ApplicationController
-  load_and_authorize_resource
+  load_resource
   skip_before_action :authenticate_user!
 
   # GET /scoreboards
   def index
-    @scoreboards = @scoreboards.order(:name)
+    @scoreboards = ComparisonService.new(current_user).list_scoreboards
   end
 
   def show
+    authorize! :read, @scoreboard
     @academic_year = if params[:academic_year]
                        @scoreboard.academic_year_calendar.academic_years.find(params[:academic_year])
                      else

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -16,7 +16,8 @@ class Ability
     can :show_pupils_dash, School, visible: true, public: true
     can :show_teachers_dash, School, visible: true, public: true
     can :suggest_activity, School, visible: true, public: true
-    can :read, Scoreboard
+    can :read, Scoreboard, public: true
+
     can :read, FindOutMore
     can :read, Observation
     can :read, ProgrammeType
@@ -68,6 +69,7 @@ class Ability
       ], School, school_scope
       can :manage, Activity, related_school_scope
       can :manage, Contact, related_school_scope
+      can :read, Scoreboard, public: false, id: user.default_scoreboard
       can [:index, :create, :read, :update], ConsentDocument, related_school_scope
       can [:index, :read], ConsentGrant, related_school_scope
       can [:index, :create, :read, :update], Meter, related_school_scope
@@ -86,6 +88,7 @@ class Ability
     elsif user.staff? || user.volunteer? || user.pupil?
       can :manage, Activity, school: { id: user.school_id, visible: true }
       can :manage, Observation, school: { id: user.school_id, visible: true }
+      can :read, Scoreboard, public: false, id: user.default_scoreboard.try(:id)
       can :read_restricted_analysis, School, school_scope
       can :read, [:my_school_menu, :school_downloads]
       can :read, Meter

--- a/app/models/scoreboard.rb
+++ b/app/models/scoreboard.rb
@@ -23,6 +23,8 @@
 class Scoreboard < ApplicationRecord
   extend FriendlyId
 
+  scope :is_public, -> { where(public: true) }
+
   FIRST_YEAR = 2018
 
   friendly_id :name, use: [:finders, :slugged, :history]

--- a/app/services/comparison_service.rb
+++ b/app/services/comparison_service.rb
@@ -1,0 +1,20 @@
+class ComparisonService
+  def initialize(user)
+    @user = user
+  end
+
+  def list_scoreboards
+    if @user.present? && @user.admin?
+      return Scoreboard.order(:name).to_a
+    end
+    scoreboards = Scoreboard.is_public.order(:name).to_a
+    if @user.present? && @user.school.present? && @user.school.scoreboard.present?
+        scoreboards << @user.school.scoreboard
+    end
+    scoreboards.uniq
+  end
+
+  def list_school_groups
+    SchoolGroup.order(:name)
+  end
+end

--- a/config/sitemap.rb
+++ b/config/sitemap.rb
@@ -26,7 +26,7 @@ if ENV.key?('GENERATE_SITEMAP')
 
     add scoreboards_path
 
-    Scoreboard.find_each do |scoreboard|
+    Scoreboard.is_public.find_each do |scoreboard|
       add scoreboard_path(scoreboard)
     end
 

--- a/spec/models/scoreboard_spec.rb
+++ b/spec/models/scoreboard_spec.rb
@@ -6,6 +6,37 @@ describe Scoreboard, :scoreboards, type: :model do
 
   subject { scoreboard }
 
+  describe 'abilities' do
+    let(:ability) { Ability.new(user) }
+    let(:user) { nil }
+
+    context 'public scoreboard' do
+      context 'guests' do
+        it { expect(ability).to be_able_to(:read, scoreboard) }
+      end
+      context 'admin' do
+        let(:user) { create(:admin) }
+        it { expect(ability).to be_able_to(:read, scoreboard) }
+      end
+
+    end
+    context 'private scoreboard' do
+      let!(:scoreboard) { create :scoreboard, public: false }
+      context 'guests' do
+        it { expect(ability).to_not be_able_to(:read, scoreboard) }
+      end
+      context 'admin' do
+        let(:user) { create(:admin) }
+        it { expect(ability).to be_able_to(:read, scoreboard) }
+      end
+      context 'staff' do
+        let!(:school)       { create(:school, :with_school_group, scoreboard: scoreboard) }
+        let!(:user)         { create(:staff, school: school)}
+        it { expect(ability).to be_able_to(:read, scoreboard) }
+      end
+    end
+  end
+
   describe '#safe_destroy' do
 
     it 'does not let you delete if there is an associated school' do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -14,6 +14,7 @@ require 'pry'
 require 'capybara/rspec'
 require 'webdrivers'
 require 'capybara/email/rspec'
+require 'cancan/matchers'
 
 # Add additional requires below this line. Rails is not loaded until this point!
 

--- a/spec/system/scoreboard_spec.rb
+++ b/spec/system/scoreboard_spec.rb
@@ -4,19 +4,52 @@ RSpec.describe 'scoreboards', :scoreboards, type: :system do
 
   let!(:scoreboard)   { create(:scoreboard, name: 'Super scoreboard')}
   let!(:school)       { create(:school, :with_school_group, scoreboard: scoreboard) }
-  let!(:user)         { create(:staff, school: school)}
 
-  describe 'when logged in' do
-    before(:each) do
-      sign_in(user)
-    end
+  describe 'with public scoreboards' do
+      it 'allows anyone to see the scoreboard' do
+        visit schools_path
+        click_on 'Scoreboards'
+        click_on 'Super scoreboard'
+        expect(page).to have_content('Super scoreboard')
+        expect(page).to have_content(school.name)
+      end
+  end
 
-    it 'can add a new scoreboard with validation' do
+  describe 'with private scoreboards' do
+    let!(:private_scoreboard)   { create(:scoreboard, name: 'Private scoreboard', public: false)}
+    let!(:other_school)       { create(:school, :with_school_group, scoreboard: private_scoreboard) }
+
+    it 'doesnt list the scoreboard' do
       visit schools_path
       click_on 'Scoreboards'
-      click_on 'Super scoreboard'
       expect(page).to have_content('Super scoreboard')
-      expect(page).to have_content(school.name)
+      expect(page).to_not have_content('Private scoreboard')
     end
+
+    it 'doesnt allow access to the private scoreboard' do
+      visit scoreboard_path(private_scoreboard)
+      expect(page).to have_content('You are not authorized to access this page')
+    end
+
+    describe 'when logged in as user from school linked to scoreboard' do
+      let!(:user)         { create(:staff, school: other_school)}
+
+      before(:each) do
+        sign_in(user)
+      end
+
+      it 'can view the public and private boards' do
+        visit schools_path
+        click_on 'Scoreboards'
+        expect(page).to have_content('Super scoreboard')
+        expect(page).to have_content('Private scoreboard')
+        click_on 'Private scoreboard'
+        expect(page).to have_content('Private scoreboard')
+        expect(page).to have_content(other_school.name)
+      end
+
+    end
+
   end
+
 end


### PR DESCRIPTION
* Users can only see public scoreboards, plus those associated with their school. Admins see all.
* Add access control to scoreboard page
* Restrict list of scoreboards listed on benchmark page, to match public list
* Remove private scoreboards from sitemap