### PR TITLE
First version of integrating tariffs with analytics

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,8 +22,9 @@ gem 'auto_strip_attributes', '~> 2.5'
 gem 'closed_struct'
 
 # Dashboard analytics
-gem 'energy-sparks_analytics', git: 'https://github.com/Energy-Sparks/energy-sparks_analytics.git', tag: '1.17.0'
+#gem 'energy-sparks_analytics', git: 'https://github.com/Energy-Sparks/energy-sparks_analytics.git', tag: '1.17.0'
 # gem 'energy-sparks_analytics', git: 'https://github.com/Energy-Sparks/energy-sparks_analytics.git', branch: '1346-add-findmpan-call-to-api'
+gem 'energy-sparks_analytics', git: 'https://github.com/Energy-Sparks/energy-sparks_analytics.git', ref: '51bb9'
 # gem 'energy-sparks_analytics', path: '../energy-sparks_analytics'
 
 # Using master due to it having a patch which doesn't override Enumerable#sum if it's already defined

--- a/Gemfile
+++ b/Gemfile
@@ -22,9 +22,8 @@ gem 'auto_strip_attributes', '~> 2.5'
 gem 'closed_struct'
 
 # Dashboard analytics
-#gem 'energy-sparks_analytics', git: 'https://github.com/Energy-Sparks/energy-sparks_analytics.git', tag: '1.17.0'
+gem 'energy-sparks_analytics', git: 'https://github.com/Energy-Sparks/energy-sparks_analytics.git', tag: '1.18.0'
 # gem 'energy-sparks_analytics', git: 'https://github.com/Energy-Sparks/energy-sparks_analytics.git', branch: '1346-add-findmpan-call-to-api'
-gem 'energy-sparks_analytics', git: 'https://github.com/Energy-Sparks/energy-sparks_analytics.git', ref: '51bb9'
 # gem 'energy-sparks_analytics', path: '../energy-sparks_analytics'
 
 # Using master due to it having a patch which doesn't override Enumerable#sum if it's already defined

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/Energy-Sparks/energy-sparks_analytics.git
-  revision: 1900387a90d7c4d3bb9a8b081ba7aa432569b3e3
-  tag: 1.17.0
+  revision: 51bb98e571375ee3e244d36447db790a11ff16b4
+  ref: 51bb9
   specs:
     energy-sparks_analytics (1.2.1)
       activesupport (~> 6.0.0)
@@ -189,7 +189,7 @@ GEM
     coderay (1.1.3)
     colorize (0.8.1)
     concurrent-ruby (1.1.8)
-    connection_pool (2.2.3)
+    connection_pool (2.2.5)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     crass (1.0.6)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/Energy-Sparks/energy-sparks_analytics.git
-  revision: 51bb98e571375ee3e244d36447db790a11ff16b4
-  ref: 51bb9
+  revision: ce682eea71706e7e2d7c9e3ed2024e8b75c60797
+  tag: 1.18.0
   specs:
     energy-sparks_analytics (1.2.1)
       activesupport (~> 6.0.0)

--- a/app/models/tariff_import_log.rb
+++ b/app/models/tariff_import_log.rb
@@ -1,3 +1,21 @@
+# == Schema Information
+#
+# Table name: tariff_import_logs
+#
+#  created_at                :datetime         not null
+#  description               :text
+#  end_date                  :date
+#  error_messages            :text
+#  id                        :bigint(8)        not null, primary key
+#  import_time               :datetime
+#  prices_imported           :integer          default(0), not null
+#  prices_updated            :integer          default(0), not null
+#  source                    :text             not null
+#  standing_charges_imported :integer          default(0), not null
+#  standing_charges_updated  :integer          default(0), not null
+#  start_date                :date
+#  updated_at                :datetime         not null
+#
 class TariffImportLog < ApplicationRecord
   has_many :tariff_prices, inverse_of: :tariff_import_log
   has_many :tariff_standing_charges, inverse_of: :tariff_import_log

--- a/app/models/tariff_price.rb
+++ b/app/models/tariff_price.rb
@@ -1,4 +1,24 @@
+# == Schema Information
+#
+# Table name: tariff_prices
+#
+#  created_at           :datetime         not null
+#  id                   :bigint(8)        not null, primary key
+#  meter_id             :bigint(8)
+#  prices               :json
+#  tariff_date          :date             not null
+#  tariff_import_log_id :bigint(8)
+#  updated_at           :datetime         not null
+#
+# Indexes
+#
+#  index_tariff_prices_on_meter_id                  (meter_id)
+#  index_tariff_prices_on_meter_id_and_tariff_date  (meter_id,tariff_date) UNIQUE
+#  index_tariff_prices_on_tariff_import_log_id      (tariff_import_log_id)
+#
 class TariffPrice < ApplicationRecord
+  scope :by_date, -> { order(tariff_date: :asc) }
+
   belongs_to :meter, inverse_of: :tariff_prices
   belongs_to :tariff_import_log, inverse_of: :tariff_prices
 end

--- a/app/models/tariff_standing_charge.rb
+++ b/app/models/tariff_standing_charge.rb
@@ -1,4 +1,24 @@
+# == Schema Information
+#
+# Table name: tariff_standing_charges
+#
+#  created_at           :datetime         not null
+#  id                   :bigint(8)        not null, primary key
+#  meter_id             :bigint(8)
+#  start_date           :date             not null
+#  tariff_import_log_id :bigint(8)
+#  updated_at           :datetime         not null
+#  value                :decimal(, )      not null
+#
+# Indexes
+#
+#  index_tariff_standing_charges_on_meter_id                 (meter_id)
+#  index_tariff_standing_charges_on_meter_id_and_start_date  (meter_id,start_date) UNIQUE
+#  index_tariff_standing_charges_on_tariff_import_log_id     (tariff_import_log_id)
+#
 class TariffStandingCharge < ApplicationRecord
+  scope :by_date,            -> { order(start_date: :asc) }
+
   belongs_to :meter, inverse_of: :tariff_standing_charges
   belongs_to :tariff_import_log, inverse_of: :tariff_standing_charges
 end

--- a/app/services/amr/analytics_meter_factory.rb
+++ b/app/services/amr/analytics_meter_factory.rb
@@ -14,8 +14,26 @@ module Amr
         name:               @active_record_meter.name,
         external_meter_id:  @active_record_meter.id,
         dcc_meter:          @active_record_meter.dcc_meter,
-        attributes:         @active_record_meter.meter_attributes_to_analytics
+        attributes:         all_attributes
       }
+    end
+
+    private
+
+    def all_attributes
+      attributes = meter_attributes || {}
+      tariff_attributes = build_tariff_attributes
+      attributes.merge!(tariff_attributes) if tariff_attributes.present?
+      return nil if attributes.empty?
+      attributes
+    end
+
+    def meter_attributes
+      @active_record_meter.meter_attributes_to_analytics
+    end
+
+    def build_tariff_attributes
+      Amr::AnalyticsTariffFactory.new(@active_record_meter).build
     end
   end
 end

--- a/app/services/amr/analytics_tariff_factory.rb
+++ b/app/services/amr/analytics_tariff_factory.rb
@@ -1,0 +1,37 @@
+module Amr
+  #Convert tariff prices and standing charges into meter attributes for use by analytics
+  class AnalyticsTariffFactory
+    def initialize(meter)
+      @meter = meter
+    end
+
+    def build
+      return nil unless @meter.dcc_meter?
+      convert_to_meter_attributes(build_tariff_data)
+    end
+
+    private
+
+    def build_tariff_data
+      N3rgyTariffs.new({
+        kwh_tariffs: tariffs,
+        standing_charges: standing_charges
+      }).parameterise
+    end
+
+    def convert_to_meter_attributes(tariff_data)
+      N3rgyToEnergySparksTariffs.new(tariff_data).convert
+    end
+
+    def standing_charges
+      Hash[@meter.tariff_standing_charges.by_date.pluck(:start_date, :value)]
+    end
+
+    def tariffs
+      @meter.tariff_prices.by_date.pluck(:tariff_date, :prices).inject({}) do |result, price|
+        result[price[0]] = JSON.parse(price[1])
+        result
+      end
+    end
+  end
+end

--- a/spec/factories/tariff_prices_factory.rb
+++ b/spec/factories/tariff_prices_factory.rb
@@ -1,0 +1,40 @@
+FactoryBot.define do
+  factory :tariff_price do
+    association :meter, factory: :electricity_meter
+    sequence(:tariff_date) { |n| Date.today - n.days }
+    association :tariff_import_log, factory: :tariff_import_log
+
+    trait :with_flat_rate do
+      transient do
+        flat_rate   { Array.new(48, 0.3) }
+      end
+
+      after(:create) do |tariff_prices, evaluator|
+          tariff_prices.update(prices: evaluator.flat_rate.to_json)
+      end
+    end
+
+    trait :with_tiered_tariff do
+      transient do
+        tiered_rate   { Array.new(10, 0.1) + Array.new(20, 0.2) + Array.new(18, 0.3) }
+      end
+
+      after(:create) do |tariff_prices, evaluator|
+          tariff_prices.update(prices: evaluator.tiered_rate.to_json)
+      end
+
+    end
+
+    trait :with_differential_tiered_tariff do
+      transient do
+        tiered_rate   { [{:tariffs=>{1=>0.45, 2=>0.2}, :thresholds=>{1=>1000}, :type=>:tiered}] + Array.new(47, 0.1) }
+      end
+
+      after(:create) do |tariff_prices, evaluator|
+          tariff_prices.update(prices: evaluator.tiered_rate.to_json)
+      end
+
+    end
+
+  end
+end

--- a/spec/factories/tariff_standing_charges_factory.rb
+++ b/spec/factories/tariff_standing_charges_factory.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :tariff_standing_charge do
+    association :meter, factory: :electricity_meter
+    sequence(:start_date) { |n| Date.today - n.days }
+    association :tariff_import_log, factory: :tariff_import_log
+    value { rand(0.01...0.1) }
+  end
+end

--- a/spec/services/amr/analytics_tariff_factory_spec.rb
+++ b/spec/services/amr/analytics_tariff_factory_spec.rb
@@ -1,0 +1,65 @@
+require 'rails_helper'
+require 'dashboard'
+
+module Amr
+  describe AnalyticsTariffFactory do
+
+    let(:meter)       { create(:electricity_meter, dcc_meter: true) }
+    let(:factory)     { Amr::AnalyticsTariffFactory.new(meter) }
+
+    context 'with no data' do
+
+      it 'returns nil' do
+        expect( factory.build ).to be_nil
+      end
+    end
+
+    context 'with valid data' do
+
+      let(:date)        { Date.yesterday }
+
+      let!(:standing_charge) { create(:tariff_standing_charge, meter: meter, start_date: date) }
+      let!(:prices)          { create(:tariff_price, :with_tiered_tariff, meter: meter, tariff_date: date) }
+
+      it 'builds and returns the meter attributes' do
+        attributes = factory.build
+        expect(attributes).to_not be_nil
+        expect(attributes[:accounting_tariff_generic]).to eql(
+          [{
+            start_date: date,
+            end_date: date,
+            name: 'Tariff from DCC SMETS2 meter',
+            rates: {
+              rate0: {
+                from: ::TimeOfDay30mins.new(0, 0),
+                to: ::TimeOfDay30mins.new(4, 30),
+                per: :kwh,
+                rate: 0.1
+              },
+              rate1: {
+                from: ::TimeOfDay30mins.new(5, 0),
+                to: ::TimeOfDay30mins.new(14, 30),
+                per: :kwh,
+                rate: 0.2
+              },
+              rate2: {
+                from: ::TimeOfDay30mins.new(15, 0),
+                to: ::TimeOfDay30mins.new(23, 30),
+                per: :kwh,
+                rate: 0.3
+              },
+              standing_charge: {
+                per: :day,
+                rate: standing_charge.value
+              }
+            },
+            type: :differential,
+            source: :dcc
+          }]
+        )
+      end
+
+    end
+
+  end
+end

--- a/spec/services/amr/analytics_unvalidated_amr_data_factory_spec.rb
+++ b/spec/services/amr/analytics_unvalidated_amr_data_factory_spec.rb
@@ -67,5 +67,27 @@ module Amr
       expect(amr_data[:electricity_meters].last[:readings].last[:kwh_data_x48][1]).to be 0.0
       expect(amr_data[:electricity_meters].last[:readings].last[:kwh_data_x48][47]).to be 0.0
     end
+
+    context 'with custom_tariffs' do
+      let(:date)        { Date.yesterday }
+
+      let!(:standing_charge) { create(:tariff_standing_charge, meter: g_meter, start_date: date) }
+      let!(:prices)          { create(:tariff_price, :with_tiered_tariff, meter: g_meter, tariff_date: date) }
+
+      let(:amr_data)  { AnalyticsUnvalidatedAmrDataFactory.new(heat_meters: [g_meter], electricity_meters: [e_meter]).build }
+
+      it 'includes meter attributes' do
+        first_electricity_meter = amr_data[:electricity_meters].first
+        expect(first_electricity_meter[:attributes]).to be_nil
+      end
+
+      it 'includes extra meter attributes for dcc_meters' do
+        first_gas_meter = amr_data[:heat_meters].first
+        expect(first_gas_meter[:attributes]).to_not be_nil
+        expect(first_gas_meter[:attributes][:accounting_tariff_generic]).to_not be_nil
+      end
+
+    end
+
   end
 end


### PR DESCRIPTION
This is an initial version of integrating tariffs and prices from n3rgy with existing analytics

* `AnalyticsTariffFactory` -- handles call to the analytics code to convert TariffPrice and TariffStandingCharge into meter attributes
* `AnalyticsMeterFactory` -- revised to add in additional attributes (as `accounting_tariff_generic`) for DCC meters

This provides a complete pass-through of the data we're fetching.

Future optimisations:

* instead of converting to meter attributes on the fly, we can convert and store in an earlier step (e.g. as part of job to actually fetch the tariff data). This code would then simply load these attributes.

Note: this is currently pinned to latest commit in analytics, so need to create a proper branch or release before merging.
