### PR TITLE
1381 allow analysis pages to serve meter specific charts - WIP

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ gem 'closed_struct'
 
 # Dashboard analytics
 #gem 'energy-sparks_analytics', git: 'https://github.com/Energy-Sparks/energy-sparks_analytics.git', tag: '1.18.1'
-gem 'energy-sparks_analytics', git: 'https://github.com/Energy-Sparks/energy-sparks_analytics.git', branch: 'refactor-financial-advice-to-native'
+gem 'energy-sparks_analytics', git: 'https://github.com/Energy-Sparks/energy-sparks_analytics.git', branch: 'reintroduce-default-accounting-tariff'
 #gem 'energy-sparks_analytics', path: '../energy-sparks_analytics'
 
 # Using master due to it having a patch which doesn't override Enumerable#sum if it's already defined

--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ gem 'closed_struct'
 # Dashboard analytics
 #gem 'energy-sparks_analytics', git: 'https://github.com/Energy-Sparks/energy-sparks_analytics.git', tag: '1.18.1'
 gem 'energy-sparks_analytics', git: 'https://github.com/Energy-Sparks/energy-sparks_analytics.git', branch: 'refactor-financial-advice-to-native'
-# gem 'energy-sparks_analytics', path: '../energy-sparks_analytics'
+#gem 'energy-sparks_analytics', path: '../energy-sparks_analytics'
 
 # Using master due to it having a patch which doesn't override Enumerable#sum if it's already defined
 # Last proper release does that, causing all kinds of weird behaviour (+ not defined etc)

--- a/Gemfile
+++ b/Gemfile
@@ -22,8 +22,8 @@ gem 'auto_strip_attributes', '~> 2.5'
 gem 'closed_struct'
 
 # Dashboard analytics
-gem 'energy-sparks_analytics', git: 'https://github.com/Energy-Sparks/energy-sparks_analytics.git', tag: '1.18.2'
-# gem 'energy-sparks_analytics', git: 'https://github.com/Energy-Sparks/energy-sparks_analytics.git', branch: '1346-add-findmpan-call-to-api'
+#gem 'energy-sparks_analytics', git: 'https://github.com/Energy-Sparks/energy-sparks_analytics.git', tag: '1.18.1'
+gem 'energy-sparks_analytics', git: 'https://github.com/Energy-Sparks/energy-sparks_analytics.git', branch: 'refactor-financial-advice-to-native'
 # gem 'energy-sparks_analytics', path: '../energy-sparks_analytics'
 
 # Using master due to it having a patch which doesn't override Enumerable#sum if it's already defined

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/Energy-Sparks/energy-sparks_analytics.git
-  revision: e6e825c85d5a97171e81f4b83088e6062d3a7904
-  tag: 1.18.2
+  revision: ed69510674c0926e406a68e58a18c0d8a2db2e76
+  branch: refactor-financial-advice-to-native
   specs:
     energy-sparks_analytics (1.2.1)
       activesupport (~> 6.0.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/Energy-Sparks/energy-sparks_analytics.git
-  revision: 7a203308097682366228974e410629573ff5e25a
+  revision: 536333a2cddcc685dd4d447459a7b3215f1eb001
   branch: reintroduce-default-accounting-tariff
   specs:
     energy-sparks_analytics (1.2.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/Energy-Sparks/energy-sparks_analytics.git
-  revision: ed69510674c0926e406a68e58a18c0d8a2db2e76
+  revision: c729654a5a1053e842bc2e0227c0daaca01f1ab4
   branch: refactor-financial-advice-to-native
   specs:
     energy-sparks_analytics (1.2.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/Energy-Sparks/energy-sparks_analytics.git
-  revision: 6b3617f452797fae6ef3f4a02c68c111f99d6629
+  revision: fe861a7340e4ff42a0759b4ae6f3bec0e34e7790
   branch: reintroduce-default-accounting-tariff
   specs:
     energy-sparks_analytics (1.2.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/Energy-Sparks/energy-sparks_analytics.git
-  revision: add0b1019f4f7701cad53639ff74b00332b312f6
+  revision: df24f01bc5f98310bdf52cfa065a57a3f3cd367e
   branch: reintroduce-default-accounting-tariff
   specs:
     energy-sparks_analytics (1.2.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/Energy-Sparks/energy-sparks_analytics.git
-  revision: c729654a5a1053e842bc2e0227c0daaca01f1ab4
+  revision: d157cbe7111b622c0afe2f21bdbb51ec2f803895
   branch: refactor-financial-advice-to-native
   specs:
     energy-sparks_analytics (1.2.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/Energy-Sparks/energy-sparks_analytics.git
-  revision: d157cbe7111b622c0afe2f21bdbb51ec2f803895
-  branch: refactor-financial-advice-to-native
+  revision: add0b1019f4f7701cad53639ff74b00332b312f6
+  branch: reintroduce-default-accounting-tariff
   specs:
     energy-sparks_analytics (1.2.1)
       activesupport (~> 6.0.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/Energy-Sparks/energy-sparks_analytics.git
-  revision: cbdda36213296922fabf48c551badb6339eada0e
+  revision: 7a203308097682366228974e410629573ff5e25a
   branch: reintroduce-default-accounting-tariff
   specs:
     energy-sparks_analytics (1.2.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/Energy-Sparks/energy-sparks_analytics.git
-  revision: df24f01bc5f98310bdf52cfa065a57a3f3cd367e
+  revision: cbdda36213296922fabf48c551badb6339eada0e
   branch: reintroduce-default-accounting-tariff
   specs:
     energy-sparks_analytics (1.2.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/Energy-Sparks/energy-sparks_analytics.git
-  revision: 536333a2cddcc685dd4d447459a7b3215f1eb001
+  revision: 6b3617f452797fae6ef3f4a02c68c111f99d6629
   branch: reintroduce-default-accounting-tariff
   specs:
     energy-sparks_analytics (1.2.1)

--- a/app/helpers/chart_helper.rb
+++ b/app/helpers/chart_helper.rb
@@ -5,7 +5,7 @@ module ChartHelper
     chart_container = content_tag(
       :div,
       '',
-      id: "chart_#{chart_type}",
+      id: chart_config[:mpan_mprn].present? ? "chart_#{chart_type}_#{chart_config[:mpan_mprn]}" : "chart_#{chart_type}",
       class: html_class,
       data: {
         chart_config: chart_config.merge(

--- a/app/views/schools/analysis/_chart_name.html.erb
+++ b/app/views/schools/analysis/_chart_name.html.erb
@@ -1,5 +1,6 @@
 <div id="chart_wrapper_<%= content %>" class="pt-3 chart-wrapper">
   <%= render 'shared/analysis_controls' %>
   <h5 class="text-center"></h5>
-  <%= chart_tag(school, content, show_advice: false, no_zoom: true, wrap: false) %>
+  <% chart_config = mpan_mprn.present? ? { mpan_mprn: mpan_mprn } : {} %>
+  <%= chart_tag(school, content, show_advice: false, no_zoom: true, wrap: false, chart_config: chart_config) %>
 </div>

--- a/app/views/schools/analysis/show.html.erb
+++ b/app/views/schools/analysis/show.html.erb
@@ -6,11 +6,9 @@
     <% @structured_content.each_with_index do |part_content, index| %>
       <div class="card">
         <div class="card-header" id="heading<%= index %>">
-          <h2 class="mb-0">
-            <button class="btn btn-link" type="button" data-toggle="collapse" data-target="#collapse<%= index %>" aria-expanded="true" aria-controls="collapse<%= index %>">
-              <%= part_content[:title].html_safe %>
-            </button>
-          </h2>
+          <a class="nav-link" type="button" data-toggle="collapse" data-target="#collapse<%= index %>" aria-expanded="true" aria-controls="collapse<%= index %>">
+            <%= part_content[:title].html_safe %>
+          </a>
         </div>
 
         <div id="collapse<%= index %>" class="collapse <%= 'show' if index.zero? %>" aria-labelledby="heading<%= index %>" data-parent="#accordion-structured-content">

--- a/app/views/schools/analysis/show.html.erb
+++ b/app/views/schools/analysis/show.html.erb
@@ -8,7 +8,7 @@
         <div class="card-header" id="heading<%= index %>">
           <h2 class="mb-0">
             <button class="btn btn-link" type="button" data-toggle="collapse" data-target="#collapse<%= index %>" aria-expanded="true" aria-controls="collapse<%= index %>">
-              <%= part_content[:title] %>
+              <%= part_content[:title].html_safe %>
             </button>
           </h2>
         </div>
@@ -16,7 +16,7 @@
         <div id="collapse<%= index %>" class="collapse <%= 'show' if index.zero? %>" aria-labelledby="heading<%= index %>" data-parent="#accordion-structured-content">
           <div class="card-body">
             <% part_content[:content].each do |content| %>
-              <%= render content[:type].to_s, content: content[:content], school: @school unless content[:type] == :chart %>
+              <%= render content[:type].to_s, content: content[:content], school: @school, mpan_mprn: content[:mpan_mprn] unless content[:type] == :chart %>
             <% end %>
           </div>
         </div>
@@ -24,6 +24,6 @@
   </div>
 <% elsif @content %>
   <% @content.each do |content| %>
-    <%= render content[:type].to_s, content: content[:content], school: @school %>
+    <%= render content[:type].to_s, content: content[:content], school: @school, mpan_mprn: content[:mpan_mprn] %>
   <% end %>
 <% end %>

--- a/spec/system/schools/analysis_pages_spec.rb
+++ b/spec/system/schools/analysis_pages_spec.rb
@@ -44,7 +44,8 @@ RSpec.describe "analysis page", type: :system do
         [
           {type: :enhanced_title, content: { title: 'Heating advice', rating: 10.0 }},
           {type: :html, content: '<h2>Turn your heating down</h2>'},
-          {type: :chart_name, content: :benchmark}
+          {type: :chart_name, content: :benchmark},
+          {type: :chart_name, content: :meter_chart, mpan_mprn: 1234567890}
         ]
       )
     end
@@ -141,6 +142,14 @@ RSpec.describe "analysis page", type: :system do
         within 'h2' do
           expect(page).to have_content('Turn your heating down')
         end
+        expect(page.find('#chart_benchmark')).to_not be_nil
+      end
+
+      it 'produces right chart elements' do
+        click_on alert_type_rating_content_version.analysis_title
+        expect(page.find('#chart_benchmark')).to_not be_nil
+        expect(page.find('#chart_meter_chart_1234567890')).to_not be_nil
+
       end
     end
 


### PR DESCRIPTION
Because of dependencies on analytics branch, this now includes several related changes:

* Adjusting the analysis page to display per-meter charts, adding an mpan_mprn parameter when requesting data
* Uses the latest analytics code which includes the revised charts (and other changes, including bug fix for content batch issues)
* Tweaks to titles of accordions on analysis page so they're no longer buttons
* As the analytics is also now adding a span with `float-right` around its total prices, this will also pick up that change

Pending nice to have would be to add a down-arrow icon + toggle for the accordion opening. Bootstrap 5 seems to do that automatically but Bootstrap 4 needs some more CSS.