### PR TITLE
1431 allow admin to configure password for rtone solar api

### DIFF
--- a/app/controllers/schools/low_carbon_hub_installations_controller.rb
+++ b/app/controllers/schools/low_carbon_hub_installations_controller.rb
@@ -24,7 +24,7 @@ module Schools
         render :new
       end
     rescue EnergySparksUnexpectedStateException
-      redirect_to school_low_carbon_hub_installations_path(@school), notice: 'Low carbon hub API is not available at the moment'
+      redirect_to school_low_carbon_hub_installations_path(@school), notice: 'Rtone API is not available at the moment'
     end
 
     def destroy

--- a/app/controllers/schools/low_carbon_hub_installations_controller.rb
+++ b/app/controllers/schools/low_carbon_hub_installations_controller.rb
@@ -25,6 +25,9 @@ module Schools
       end
     rescue EnergySparksUnexpectedStateException
       redirect_to school_low_carbon_hub_installations_path(@school), notice: 'Rtone API is not available at the moment'
+    rescue => e
+      flash[:error] = e.message
+      render :new
     end
 
     def destroy

--- a/app/controllers/schools/low_carbon_hub_installations_controller.rb
+++ b/app/controllers/schools/low_carbon_hub_installations_controller.rb
@@ -32,6 +32,17 @@ module Schools
       render :new
     end
 
+    def edit
+    end
+
+    def update
+      if @low_carbon_hub_installation.update(low_carbon_hub_installation_params)
+        redirect_to school_low_carbon_hub_installations_path(@school), notice: 'Installation was updated'
+      else
+        render :edit
+      end
+    end
+
     def destroy
       @low_carbon_hub_installation.meters.each do |meter|
         MeterManagement.new(meter).delete_meter!

--- a/app/controllers/schools/low_carbon_hub_installations_controller.rb
+++ b/app/controllers/schools/low_carbon_hub_installations_controller.rb
@@ -15,6 +15,8 @@ module Schools
       @low_carbon_hub_installation = Amr::LowCarbonHubInstallationFactory.new(
         school: @school,
         rbee_meter_id: low_carbon_hub_installation_params[:rbee_meter_id],
+        username: low_carbon_hub_installation_params[:username],
+        password: low_carbon_hub_installation_params[:password],
         amr_data_feed_config: AmrDataFeedConfig.find(low_carbon_hub_installation_params[:amr_data_feed_config_id]),
       ).perform
 
@@ -43,7 +45,7 @@ module Schools
 
     def low_carbon_hub_installation_params
       params.require(:low_carbon_hub_installation).permit(
-        :rbee_meter_id, :amr_data_feed_config_id
+        :rbee_meter_id, :amr_data_feed_config_id, :username, :password
       )
     end
 

--- a/app/services/amr/low_carbon_hub_download_and_upsert.rb
+++ b/app/services/amr/low_carbon_hub_download_and_upsert.rb
@@ -3,18 +3,30 @@ module Amr
     def initialize(
         low_carbon_hub_installation:,
         start_date:,
-        end_date:,
-        low_carbon_hub_api: LowCarbonHubMeterReadings.new
+        end_date:
       )
       @low_carbon_hub_installation = low_carbon_hub_installation
-      @low_carbon_hub_api = low_carbon_hub_api
       @start_date = start_date
       @end_date = end_date
     end
 
     def perform
-      readings = LowCarbonHubDownloader.new(low_carbon_hub_installation: @low_carbon_hub_installation, start_date: @start_date, end_date: @end_date, low_carbon_hub_api: @low_carbon_hub_api).readings
+      readings = LowCarbonHubDownloader.new(low_carbon_hub_installation: @low_carbon_hub_installation, start_date: @start_date, end_date: @end_date, low_carbon_hub_api: low_carbon_hub_api).readings
       LowCarbonHubUpserter.new(low_carbon_hub_installation: @low_carbon_hub_installation, readings: readings).perform
+    end
+
+    private
+
+    def low_carbon_hub_api
+      @low_carbon_hub_api ||= LowCarbonHubMeterReadings.new(username: username, password: password)
+    end
+
+    def username
+      @low_carbon_hub_installation.username || ENV['ENERGYSPARKSRBEEUSERNAME']
+    end
+
+    def password
+      @low_carbon_hub_installation.password || ENV['ENERGYSPARKSRBEEPASSWORD']
     end
   end
 end

--- a/app/services/amr/low_carbon_hub_downloader.rb
+++ b/app/services/amr/low_carbon_hub_downloader.rb
@@ -6,7 +6,7 @@ module Amr
         low_carbon_hub_installation:,
         start_date:,
         end_date:,
-        low_carbon_hub_api: LowCarbonHubMeterReadings.new
+        low_carbon_hub_api:
       )
       @low_carbon_hub_installation = low_carbon_hub_installation
       @low_carbon_hub_api = low_carbon_hub_api

--- a/app/services/amr/low_carbon_hub_installation_factory.rb
+++ b/app/services/amr/low_carbon_hub_installation_factory.rb
@@ -6,25 +6,27 @@ module Amr
         school:,
         rbee_meter_id:,
         amr_data_feed_config:,
-        low_carbon_hub_api: LowCarbonHubMeterReadings.new
+        username:,
+        password:
       )
-      @low_carbon_hub_api = low_carbon_hub_api
       @school = school
       @rbee_meter_id = rbee_meter_id
       @amr_data_feed_config = amr_data_feed_config
+      @username = username
+      @password = password
       raise ArgumentError, 'Amr Data Feed Config is not set for the Low carbon hub API' unless amr_data_feed_config.low_carbon_hub_api?
     end
 
     def perform
       installation = LowCarbonHubInstallation.where(school_id: @school.id, rbee_meter_id: @rbee_meter_id, amr_data_feed_config: @amr_data_feed_config).first_or_create!
-      installation.update(information: information)
+      installation.update(information: information, username: username, password: password)
 
       # Retrieve two days worth of data, just to get the meters set up and ensure some data comes back
       LowCarbonHubDownloadAndUpsert.new(
         low_carbon_hub_installation: installation,
         start_date: first_reading_date,
         end_date: first_reading_date + 1.day,
-        low_carbon_hub_api: @low_carbon_hub_api
+        low_carbon_hub_api: low_carbon_hub_api
       ).perform
 
       installation
@@ -32,12 +34,24 @@ module Amr
 
     private
 
+    def low_carbon_hub_api
+      @low_carbon_hub_api ||= LowCarbonHubMeterReadings.new(username: username, password: password)
+    end
+
     def information
-      @low_carbon_hub_api.full_installation_information(@rbee_meter_id)
+      low_carbon_hub_api.full_installation_information(@rbee_meter_id)
     end
 
     def first_reading_date
-      @first_reading_date ||= @low_carbon_hub_api.first_meter_reading_date(@rbee_meter_id)
+      @first_reading_date ||= low_carbon_hub_api.first_meter_reading_date(@rbee_meter_id)
+    end
+
+    def username
+      @username || ENV['ENERGYSPARKSRBEEUSERNAME']
+    end
+
+    def password
+      @password || ENV['ENERGYSPARKSRBEEPASSWORD']
     end
   end
 end

--- a/app/services/amr/low_carbon_hub_installation_factory.rb
+++ b/app/services/amr/low_carbon_hub_installation_factory.rb
@@ -25,8 +25,7 @@ module Amr
       LowCarbonHubDownloadAndUpsert.new(
         low_carbon_hub_installation: installation,
         start_date: first_reading_date,
-        end_date: first_reading_date + 1.day,
-        low_carbon_hub_api: low_carbon_hub_api
+        end_date: first_reading_date + 1.day
       ).perform
 
       installation

--- a/app/views/schools/low_carbon_hub_installations/_form.html.erb
+++ b/app/views/schools/low_carbon_hub_installations/_form.html.erb
@@ -1,0 +1,13 @@
+<%= simple_form_for [school, low_carbon_hub_installation] do |form| %>
+  <%= render 'shared/errors', subject: low_carbon_hub_installation, subject_name: 'rtone installation' %>
+
+  <%= form.input :amr_data_feed_config_id, collection: AmrDataFeedConfig.low_carbon_hub_api.pluck(:description, :id), label_method: :first, value_method: :second, include_blank: false %>
+  <%= form.input :rbee_meter_id, as: :string, label: "Rbee id", disabled: low_carbon_hub_installation.persisted? %>
+  <%= form.input :username, as: :string %>
+  <%= form.input :password, as: :string %>
+
+  <div class="actions">
+    <%= form.submit "Submit", class: 'btn btn-primary'%>
+  </div>
+
+<% end %>

--- a/app/views/schools/low_carbon_hub_installations/edit.html.erb
+++ b/app/views/schools/low_carbon_hub_installations/edit.html.erb
@@ -1,4 +1,4 @@
-<h1>Create a new Rtone installation</h1>
+<h1>Update Rtone installation</h1>
 <h2><%= @school.name %></h2>
 
 <%= render 'form', school: @school, low_carbon_hub_installation: @low_carbon_hub_installation %>

--- a/app/views/schools/low_carbon_hub_installations/index.html.erb
+++ b/app/views/schools/low_carbon_hub_installations/index.html.erb
@@ -1,19 +1,18 @@
-<h1>Low carbon hub installations for <%= link_to @school.name, school_path(@school) %></h1>
+<h1>Rtone installations for <%= link_to @school.name, school_path(@school) %></h1>
 
 <p><%= link_to 'All school meters',  school_meters_path(@school) %></p>
 
-<p class="alert alert-warning">Please note, you cannot create a new, or download data for, a Low carbon hub installation between <%= @start_time %> and <%= @end_time %></p>
-<p><%= link_to 'New Low carbon hub installation', new_school_low_carbon_hub_installation_path, class: 'btn' %></p>
+<p class="alert alert-warning">Please note, you cannot create a new installation, or download data between <%= @start_time %> and <%= @end_time %></p>
+<p><%= link_to 'New installation', new_school_low_carbon_hub_installation_path, class: 'btn' %></p>
 
 <% if @school.low_carbon_hub_installations.any? %>
   <% @school.low_carbon_hub_installations.each do |installation| %>
     <h2>Rbee id: <%= installation.rbee_meter_id %></h2>
-
     <p>
       <%= link_to 'Details', school_low_carbon_hub_installation_path(@school, installation), class: 'btn' %>
       <%= link_to 'Delete', school_low_carbon_hub_installation_path(@school, installation), method: :delete, data: { confirm: 'Are you sure?' }, class: 'btn' %>
     </p>
   <% end %>
 <% else %>
-  <p>There are no Low carbon hub installations at the moment for this school</p>
+  <p>There are no Rtone installations at the moment for this school</p>
 <% end %>

--- a/app/views/schools/low_carbon_hub_installations/index.html.erb
+++ b/app/views/schools/low_carbon_hub_installations/index.html.erb
@@ -10,6 +10,7 @@
     <h2>Rbee id: <%= installation.rbee_meter_id %></h2>
     <p>
       <%= link_to 'Details', school_low_carbon_hub_installation_path(@school, installation), class: 'btn' %>
+      <%= link_to 'Edit', edit_school_low_carbon_hub_installation_path(@school, installation), class: 'btn' %>
       <%= link_to 'Delete', school_low_carbon_hub_installation_path(@school, installation), method: :delete, data: { confirm: 'Are you sure?' }, class: 'btn' %>
     </p>
   <% end %>

--- a/app/views/schools/low_carbon_hub_installations/new.html.erb
+++ b/app/views/schools/low_carbon_hub_installations/new.html.erb
@@ -1,16 +1,16 @@
-<h1>Create a new Low Carbon Hub installation</h1>
+<h1>Create a new Rtone installation</h1>
 <h2><%= @school.name %></h2>
 
 
 <%= simple_form_for [@school, @low_carbon_hub_installation] do |form| %>
-  <%= render 'shared/errors', subject: @low_carbon_hub_installation, subject_name: 'low carbon hub installation' %>
+  <%= render 'shared/errors', subject: @low_carbon_hub_installation, subject_name: 'rtone installation' %>
 
   <%= form.input :amr_data_feed_config_id, collection: AmrDataFeedConfig.low_carbon_hub_api.pluck(:description, :id), label_method: :first, value_method: :second, include_blank: false %>
-  <%= form.input :rbee_meter_id, as: :string %>
-
+  <%= form.input :rbee_meter_id, as: :string, label: "Rbee id" %>
 
   <div class="actions">
-    <%= form.submit class: 'btn btn-primary'%>
+    <%= form.submit "Create installation", class: 'btn btn-primary'%>
+    <%= link_to 'Cancel', school_low_carbon_hub_installations_path(@school), class: 'btn' %>
   </div>
 
 <% end %>

--- a/app/views/schools/low_carbon_hub_installations/new.html.erb
+++ b/app/views/schools/low_carbon_hub_installations/new.html.erb
@@ -7,6 +7,8 @@
 
   <%= form.input :amr_data_feed_config_id, collection: AmrDataFeedConfig.low_carbon_hub_api.pluck(:description, :id), label_method: :first, value_method: :second, include_blank: false %>
   <%= form.input :rbee_meter_id, as: :string, label: "Rbee id" %>
+  <%= form.input :username, as: :string %>
+  <%= form.input :password, as: :string %>
 
   <div class="actions">
     <%= form.submit "Create installation", class: 'btn btn-primary'%>

--- a/app/views/schools/low_carbon_hub_installations/show.html.erb
+++ b/app/views/schools/low_carbon_hub_installations/show.html.erb
@@ -1,7 +1,7 @@
-<h1>Low carbon hub installation <%= @low_carbon_hub_installation.rbee_meter_id %></h1>
+<h1>Rtone installation data for <%= @low_carbon_hub_installation.rbee_meter_id %></h1>
 <h2><%= @school.name %></h2>
 
-<p><%= link_to "All low carbon hub installations for #{@school.name}",  school_low_carbon_hub_installations_path(@school) %>
+<p><%= link_to "All Rtone installations for #{@school.name}",  school_low_carbon_hub_installations_path(@school) %>
 <% @low_carbon_hub_installation.information.each do |key, value| %>
   <dl>
     <dt><%= key %></dt>
@@ -10,4 +10,3 @@
 <% end %>
 
 <p><%= link_to 'Delete', school_low_carbon_hub_installation_path(@school, @low_carbon_hub_installation), method: :delete, data: { confirm: 'Are you sure?' }, class: 'btn' %>
-

--- a/app/views/shared/_manage_school.html.erb
+++ b/app/views/shared/_manage_school.html.erb
@@ -5,7 +5,7 @@
     <%= link_to 'Calendar', calendar_path(school.calendar), class: 'dropdown-item' if school.calendar && can?(:show, school.calendar) %>
     <%= link_to 'School configuration', edit_school_configuration_path(school), class: 'dropdown-item' if can? :configure, school %>
     <%= link_to 'Manage meters', school_meters_path(school), class: 'dropdown-item' if can? :index, Meter %>
-    <%= link_to 'Manage Low carbon hub installations', school_low_carbon_hub_installations_path(school), class: 'dropdown-item' if can? :manage, LowCarbonHubInstallation %>
+    <%= link_to 'Manage Rtone installations', school_low_carbon_hub_installations_path(school), class: 'dropdown-item' if can? :manage, LowCarbonHubInstallation %>
     <%= link_to 'Manage school times', edit_school_times_path(school), class: 'dropdown-item' if can? :manage_school_times, school%>
     <%= link_to 'Manage alert contacts', school_contacts_path(school), class: 'dropdown-item' if can? :manage, Contact %>
     <%= link_to 'Manage users', school_users_path(school), class: 'dropdown-item' if can? :manage_users, school %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -110,7 +110,7 @@ Rails.application.routes.draw do
           put :deactivate
         end
       end
-      resources :low_carbon_hub_installations, only: [:show, :index, :create, :new, :destroy]
+      resources :low_carbon_hub_installations
 
       resource :meter_readings_validation, only: [:create]
 

--- a/db/migrate/20210609102549_add_credentials_to_low_carbon_hub.rb
+++ b/db/migrate/20210609102549_add_credentials_to_low_carbon_hub.rb
@@ -1,0 +1,6 @@
+class AddCredentialsToLowCarbonHub < ActiveRecord::Migration[6.0]
+  def change
+    add_column :low_carbon_hub_installations, :username, :string, default: nil
+    add_column :low_carbon_hub_installations, :password, :string, default: nil
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_20_134717) do
+ActiveRecord::Schema.define(version: 2021_06_09_102549) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
@@ -749,6 +749,8 @@ ActiveRecord::Schema.define(version: 2021_05_20_134717) do
     t.json "information", default: {}
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "username"
+    t.string "password"
     t.index ["amr_data_feed_config_id"], name: "index_low_carbon_hub_installations_on_amr_data_feed_config_id"
     t.index ["school_id"], name: "index_low_carbon_hub_installations_on_school_id"
   end

--- a/spec/services/amr/low_carbon_hub_installation_factory_spec.rb
+++ b/spec/services/amr/low_carbon_hub_installation_factory_spec.rb
@@ -6,9 +6,12 @@ module Amr
     include_context "low carbon hub data"
 
     it 'creates the meters and initial readings' do
+      allow(LowCarbonHubMeterReadings).to receive(:new).and_return(low_carbon_hub_api)
+
       expect(amr_data_feed_config).to_not be nil
 
-      factory = LowCarbonHubInstallationFactory.new(school: school, rbee_meter_id: rbee_meter_id, low_carbon_hub_api: low_carbon_hub_api, amr_data_feed_config: amr_data_feed_config)
+      factory = LowCarbonHubInstallationFactory.new(school: school, rbee_meter_id: rbee_meter_id, amr_data_feed_config: amr_data_feed_config,
+        username: username, password: password)
       expect { factory.perform }.to change { Meter.count }.by(3)
       expect(school.meters.solar_pv.count).to be 1
       expect(school.meters.electricity.count).to be 1

--- a/spec/support/low_carbon_hub_data.rb
+++ b/spec/support/low_carbon_hub_data.rb
@@ -3,6 +3,8 @@ RSpec.shared_context  "low carbon hub data", shared_context: :metadata do
   let!(:school)               { create(:school) }
   let(:low_carbon_hub_api)    { double("low_carbon_hub_api") }
   let(:rbee_meter_id)         { "216057958" }
+  let(:username)              { "rtone-user" }
+  let(:password)              { "rtone-pass" }
   let!(:amr_data_feed_config) { create(:amr_data_feed_config, process_type: :low_carbon_hub_api) }
   let(:info_text)             { 'Some info' }
   let(:information)           { { info: info_text } }

--- a/spec/system/low_carbon_hub_installation_spec.rb
+++ b/spec/system/low_carbon_hub_installation_spec.rb
@@ -20,11 +20,16 @@ RSpec.describe "Low carbon hub management", :low_carbon_hub_installations, type:
       allow(LowCarbonHubMeterReadings).to receive(:new).and_return(low_carbon_hub_api)
 
       fill_in(:low_carbon_hub_installation_rbee_meter_id, with: rbee_meter_id)
+      fill_in(:low_carbon_hub_installation_username, with: username)
+      fill_in(:low_carbon_hub_installation_password, with: password)
+
       expect { click_on 'Create' }.to change { Meter.count }.by(3).and change { LowCarbonHubInstallation.count }.by(1).and change { AmrDataFeedReading.count }.by(6)
 
       expect(page).to_not have_content("There are no Rtone installations at the moment for this school")
       expect(page).to have_content(rbee_meter_id)
       expect(school.low_carbon_hub_installations.count).to be 1
+      expect(school.low_carbon_hub_installations.first.username).to eql username
+      expect(school.low_carbon_hub_installations.first.password).to eql password
       expect(school.meters.count).to be 3
 
       expect(page).to have_content(info_text)
@@ -39,9 +44,9 @@ RSpec.describe "Low carbon hub management", :low_carbon_hub_installations, type:
     end
 
     it 'handles being run out of hours properly' do
-      expect(LowCarbonHubMeterReadings).to receive(:new).and_raise(EnergySparksUnexpectedStateException)
+      expect(Amr::LowCarbonHubInstallationFactory).to receive(:new).and_raise(EnergySparksUnexpectedStateException)
 
-      click_on 'Create'
+      click_on 'Create installation'
       expect(page).to have_content("There are no Rtone installations at the moment for this school")
       expect(page).to have_content("Rtone API is not available at the moment")
     end
@@ -57,9 +62,6 @@ RSpec.describe "Low carbon hub management", :low_carbon_hub_installations, type:
       click_on 'Manage Rtone installations'
       expect(page).to have_content low_carbon_hub_installation.rbee_meter_id
       expect { click_on 'Delete' }.to change { Meter.count }.by(-3).and change { LowCarbonHubInstallation.count }.by(-1).and change { AmrValidatedReading.count }.by(-3)
-
-
-
     end
   end
 end

--- a/spec/system/low_carbon_hub_installation_spec.rb
+++ b/spec/system/low_carbon_hub_installation_spec.rb
@@ -11,9 +11,9 @@ RSpec.describe "Low carbon hub management", :low_carbon_hub_installations, type:
       sign_in(admin)
       visit school_path(school)
 
-      click_on 'Manage Low carbon hub installations'
-      expect(page).to have_content("There are no Low carbon hub installations at the moment for this school")
-      click_on 'New Low carbon hub installation'
+      click_on 'Manage Rtone installations'
+      expect(page).to have_content("There are no Rtone installations at the moment for this school")
+      click_on 'New installation'
     end
 
     it 'I can add a low carbon hub installation' do
@@ -22,28 +22,28 @@ RSpec.describe "Low carbon hub management", :low_carbon_hub_installations, type:
       fill_in(:low_carbon_hub_installation_rbee_meter_id, with: rbee_meter_id)
       expect { click_on 'Create' }.to change { Meter.count }.by(3).and change { LowCarbonHubInstallation.count }.by(1).and change { AmrDataFeedReading.count }.by(6)
 
-      expect(page).to_not have_content("There are no Low carbon hub installations at the moment for this school")
+      expect(page).to_not have_content("There are no Rtone installations at the moment for this school")
       expect(page).to have_content(rbee_meter_id)
       expect(school.low_carbon_hub_installations.count).to be 1
       expect(school.meters.count).to be 3
 
       expect(page).to have_content(info_text)
-      click_on "All low carbon hub installations for #{school.name}"
+      click_on "All Rtone installations for #{school.name}"
       click_on 'Details'
       expect(page).to have_content(info_text)
-      click_on "All low carbon hub installations for #{school.name}"
+      click_on "All Rtone installations for #{school.name}"
       expect(page).to have_content("Delete")
       expect { click_on 'Delete' }.to change { Meter.count }.by(-3).and change { LowCarbonHubInstallation.count }.by(-1)
 
-      expect(page).to have_content("There are no Low carbon hub installations at the moment for this school")
+      expect(page).to have_content("There are no Rtone installations at the moment for this school")
     end
 
     it 'handles being run out of hours properly' do
       expect(LowCarbonHubMeterReadings).to receive(:new).and_raise(EnergySparksUnexpectedStateException)
 
       click_on 'Create'
-      expect(page).to have_content("There are no Low carbon hub installations at the moment for this school")
-      expect(page).to have_content("Low carbon hub API is not available at the moment")
+      expect(page).to have_content("There are no Rtone installations at the moment for this school")
+      expect(page).to have_content("Rtone API is not available at the moment")
     end
 
     it 'I delete a low carbon hub installation and meter readngs get removed' do
@@ -54,7 +54,7 @@ RSpec.describe "Low carbon hub management", :low_carbon_hub_installations, type:
 
       low_carbon_hub_installation = LowCarbonHubInstallation.first
 
-      click_on 'Manage Low carbon hub installations'
+      click_on 'Manage Rtone installations'
       expect(page).to have_content low_carbon_hub_installation.rbee_meter_id
       expect { click_on 'Delete' }.to change { Meter.count }.by(-3).and change { LowCarbonHubInstallation.count }.by(-1).and change { AmrValidatedReading.count }.by(-3)
 

--- a/spec/system/low_carbon_hub_installation_spec.rb
+++ b/spec/system/low_carbon_hub_installation_spec.rb
@@ -10,7 +10,6 @@ RSpec.describe "Low carbon hub management", :low_carbon_hub_installations, type:
     before(:each) do
       sign_in(admin)
       visit school_path(school)
-
       click_on 'Manage Rtone installations'
       expect(page).to have_content("There are no Rtone installations at the moment for this school")
       click_on 'New installation'
@@ -23,7 +22,7 @@ RSpec.describe "Low carbon hub management", :low_carbon_hub_installations, type:
       fill_in(:low_carbon_hub_installation_username, with: username)
       fill_in(:low_carbon_hub_installation_password, with: password)
 
-      expect { click_on 'Create installation' }.to change { Meter.count }.by(3).and change { LowCarbonHubInstallation.count }.by(1).and change { AmrDataFeedReading.count }.by(6)
+      expect { click_on 'Submit' }.to change { Meter.count }.by(3).and change { LowCarbonHubInstallation.count }.by(1).and change { AmrDataFeedReading.count }.by(6)
 
       expect(page).to_not have_content("There are no Rtone installations at the moment for this school")
       expect(page).to have_content(rbee_meter_id)
@@ -43,15 +42,44 @@ RSpec.describe "Low carbon hub management", :low_carbon_hub_installations, type:
       expect(page).to have_content("There are no Rtone installations at the moment for this school")
     end
 
+    it 'allows an installation to be edited' do
+      allow(LowCarbonHubMeterReadings).to receive(:new).and_return(low_carbon_hub_api)
+
+      fill_in(:low_carbon_hub_installation_rbee_meter_id, with: rbee_meter_id)
+      fill_in(:low_carbon_hub_installation_username, with: username)
+      fill_in(:low_carbon_hub_installation_password, with: password)
+
+      expect { click_on 'Submit' }.to change { Meter.count }.by(3).and change { LowCarbonHubInstallation.count }.by(1).and change { AmrDataFeedReading.count }.by(6)
+
+      click_on "All Rtone installations for #{school.name}"
+
+      expect(page).to have_content(rbee_meter_id)
+      click_on 'Edit'
+      expect(page).to have_content("Update Rtone installation")
+
+      expect(find_field(:low_carbon_hub_installation_username).value).to eql username
+      expect(find_field(:low_carbon_hub_installation_password).value).to eql password
+
+      fill_in(:low_carbon_hub_installation_username, with: "changed-user")
+      fill_in(:low_carbon_hub_installation_password, with: "changed-pass")
+
+      click_on 'Submit'
+      expect(page).to have_content("Installation was updated")
+
+      click_on 'Edit'
+      expect(find_field(:low_carbon_hub_installation_username).value).to eql "changed-user"
+      expect(find_field(:low_carbon_hub_installation_password).value).to eql "changed-pass"
+    end
+
     it 'handles being run out of hours properly' do
       expect(Amr::LowCarbonHubInstallationFactory).to receive(:new).and_raise(EnergySparksUnexpectedStateException)
 
-      click_on 'Create installation'
+      click_on 'Submit'
       expect(page).to have_content("There are no Rtone installations at the moment for this school")
       expect(page).to have_content("Rtone API is not available at the moment")
     end
 
-    it 'I delete a low carbon hub installation and meter readngs get removed' do
+    it 'I delete a low carbon hub installation and meter readings get removed' do
 
       expect { create(:low_carbon_hub_installation_with_meters_and_validated_readings, school: school) }.to change { Meter.count }.by(3).and change { AmrValidatedReading.count }.by(3)
 

--- a/spec/system/low_carbon_hub_installation_spec.rb
+++ b/spec/system/low_carbon_hub_installation_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe "Low carbon hub management", :low_carbon_hub_installations, type:
       fill_in(:low_carbon_hub_installation_username, with: username)
       fill_in(:low_carbon_hub_installation_password, with: password)
 
-      expect { click_on 'Create' }.to change { Meter.count }.by(3).and change { LowCarbonHubInstallation.count }.by(1).and change { AmrDataFeedReading.count }.by(6)
+      expect { click_on 'Create installation' }.to change { Meter.count }.by(3).and change { LowCarbonHubInstallation.count }.by(1).and change { AmrDataFeedReading.count }.by(6)
 
       expect(page).to_not have_content("There are no Rtone installations at the moment for this school")
       expect(page).to have_content(rbee_meter_id)


### PR DESCRIPTION
* Relabel navigation and forms to refer to "Rtone" and not low carbon hub
* Allow username and password to be configured
* Use username and password if configured, defaulting to environment variable (for now)
* Allow editing of username and password

I've kept the existing environment variable for now, until we've updated the data for the Oxford schools, then we can remove.
