### PR TITLE
Fix bug with passing credentials, & ensure errors are caught and logged

### DIFF
--- a/app/controllers/schools/low_carbon_hub_installations_controller.rb
+++ b/app/controllers/schools/low_carbon_hub_installations_controller.rb
@@ -23,6 +23,7 @@ module Schools
     rescue EnergySparksUnexpectedStateException
       redirect_to school_solar_feeds_configuration_index_path(@school), notice: 'Rtone API is not available at the moment'
     rescue => e
+      Rollbar.error(e)
       flash[:error] = e.message
       render :new
     end

--- a/app/services/amr/low_carbon_hub_download_and_upsert.rb
+++ b/app/services/amr/low_carbon_hub_download_and_upsert.rb
@@ -18,7 +18,7 @@ module Amr
     private
 
     def low_carbon_hub_api
-      @low_carbon_hub_api ||= LowCarbonHubMeterReadings.new(username: username, password: password)
+      @low_carbon_hub_api ||= LowCarbonHubMeterReadings.new(username, password)
     end
 
     def username

--- a/app/services/amr/low_carbon_hub_installation_factory.rb
+++ b/app/services/amr/low_carbon_hub_installation_factory.rb
@@ -19,7 +19,9 @@ module Amr
 
     def perform
       installation = LowCarbonHubInstallation.where(school_id: @school.id, rbee_meter_id: @rbee_meter_id, amr_data_feed_config: @amr_data_feed_config).first_or_create!
-      installation.update(information: information, username: username, password: password)
+      #save credentials to avoid api error meaning they're not saved
+      installation.update(username: username, password: password)
+      installation.update(information: information)
 
       # Retrieve two days worth of data, just to get the meters set up and ensure some data comes back
       LowCarbonHubDownloadAndUpsert.new(
@@ -34,7 +36,7 @@ module Amr
     private
 
     def low_carbon_hub_api
-      @low_carbon_hub_api ||= LowCarbonHubMeterReadings.new(username: username, password: password)
+      @low_carbon_hub_api ||= LowCarbonHubMeterReadings.new(username, password)
     end
 
     def information

--- a/spec/system/low_carbon_hub_installation_spec.rb
+++ b/spec/system/low_carbon_hub_installation_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe "Low carbon hub management", :low_carbon_hub_installations, type:
       expect(page).to have_content("This school has no Rtone API feeds")
       click_on 'New Rtone API feed'
 
-      allow(LowCarbonHubMeterReadings).to receive(:new).and_return(low_carbon_hub_api)
+      allow(LowCarbonHubMeterReadings).to receive(:new).with(username, password).and_return(low_carbon_hub_api)
 
       fill_in(:low_carbon_hub_installation_rbee_meter_id, with: rbee_meter_id)
       fill_in(:low_carbon_hub_installation_username, with: username)
@@ -46,7 +46,7 @@ RSpec.describe "Low carbon hub management", :low_carbon_hub_installations, type:
       expect(page).to have_content("This school has no Rtone API feeds")
       click_on 'New Rtone API feed'
 
-      allow(LowCarbonHubMeterReadings).to receive(:new).and_return(low_carbon_hub_api)
+      allow(LowCarbonHubMeterReadings).to receive(:new).with(username, password).and_return(low_carbon_hub_api)
 
       fill_in(:low_carbon_hub_installation_rbee_meter_id, with: rbee_meter_id)
       fill_in(:low_carbon_hub_installation_username, with: username)


### PR DESCRIPTION
Incorrectly calling the constructor, so api lookups were broken. Fixed this, ensure errors are logged in rollbar and separate out saving model from API calls.