### PR TITLE
1446 subscribe user to newsletter during rather than at the end of onboarding

### DIFF
--- a/app/assets/javascripts/checkboxes.js
+++ b/app/assets/javascripts/checkboxes.js
@@ -14,4 +14,12 @@ $(document).ready(function() {
     $("form .must-check").closest('form').find(':submit').prop('disabled', true);
   }
 
+  $(document).on('click','.disable-attributes',function(){
+    $(this).closest('.form-group').find(':checkbox').prop('checked',this.checked);
+    $(this).closest('.form-group').find('select').prop('disabled', this.checked);
+    $(this).closest('.form-group').find('input').prop('disabled', this.checked);
+    $(this).prop('disabled', false);
+    $(this).next('.disabled-label').toggle();
+  });
+
 });

--- a/app/controllers/onboarding/account_controller.rb
+++ b/app/controllers/onboarding/account_controller.rb
@@ -11,13 +11,13 @@ module Onboarding
     end
 
     def create
-      @user = User.new_school_onboarding(user_params.except(:subscribe_to_newsletter))
+      @user = User.new_school_onboarding(user_params)
       if @user.save
         @school_onboarding.update!(created_user: @user)
         @school_onboarding.events.create!(event: :onboarding_user_created)
         @school_onboarding.events.create!(event: :privacy_policy_agreed)
         sign_in(@user, scope: :user)
-        @school_onboarding.update!(subscribe_to_newsletter: user_params[:subscribe_to_newsletter] == 'on')
+        @school_onboarding.update!(subscribe_to_newsletter: newsletter_params[:subscribe_to_newsletter])
         redirect_to new_onboarding_school_details_path(@school_onboarding)
       else
         render :new
@@ -30,7 +30,7 @@ module Onboarding
     def update
       if current_user.update(user_params.reject {|key, value| key =~ /password/ && value.blank?}.except(:subscribe_to_newsletter))
         @school_onboarding.events.create!(event: :onboarding_user_updated)
-        @school_onboarding.update!(subscribe_to_newsletter: user_params[:subscribe_to_newsletter] == 'on')
+        @school_onboarding.update!(subscribe_to_newsletter: newsletter_params[:subscribe_to_newsletter])
         bypass_sign_in(current_user)
         redirect_to new_onboarding_completion_path(@school_onboarding)
       else
@@ -47,7 +47,11 @@ module Onboarding
     end
 
     def user_params
-      params.require(:user).permit(:name, :email, :password, :password_confirmation, :staff_role_id, :subscribe_to_newsletter)
+      params.require(:user).permit(:name, :email, :password, :password_confirmation, :staff_role_id)
+    end
+
+    def newsletter_params
+      params.require(:newsletter).permit(:subscribe_to_newsletter)
     end
   end
 end

--- a/app/controllers/schools/user_tariff_charges_controller.rb
+++ b/app/controllers/schools/user_tariff_charges_controller.rb
@@ -1,0 +1,46 @@
+module Schools
+  class UserTariffChargesController < ApplicationController
+    load_and_authorize_resource :school
+    load_and_authorize_resource :user_tariff
+
+    def index
+    end
+
+    def new
+      @user_tariff_charge = @user_tariff.user_tariff_charges.build
+    end
+
+    def create
+      @user_tariff_charge = @user_tariff.user_tariff_charges.build(user_tariff_charge_params)
+      if @user_tariff_charge.save
+        redirect_to school_user_tariff_user_tariff_charges_path(@school, @user_tariff)
+      else
+        render :new
+      end
+    end
+
+    def edit
+      @user_tariff_charge = @user_tariff.user_tariff_charges.find(params[:id])
+    end
+
+    def update
+      @user_tariff_charge = @user_tariff.user_tariff_charges.find(params[:id])
+      if @user_tariff_charge.update(user_tariff_charge_params)
+        redirect_to school_user_tariff_user_tariff_charges_path(@school, @user_tariff)
+      else
+        render :edit
+      end
+    end
+
+    def destroy
+      @user_tariff.user_tariff_charges.find(params[:id]).destroy
+      redirect_to school_user_tariff_user_tariff_charges_path(@school, @user_tariff)
+    end
+
+    private
+
+    def user_tariff_charge_params
+      params.require(:user_tariff_charge).permit(:charge_type, :value, :units)
+    end
+  end
+end

--- a/app/controllers/schools/user_tariff_prices_controller.rb
+++ b/app/controllers/schools/user_tariff_prices_controller.rb
@@ -1,0 +1,46 @@
+module Schools
+  class UserTariffPricesController < ApplicationController
+    load_and_authorize_resource :school
+    load_and_authorize_resource :user_tariff
+
+    def index
+    end
+
+    def new
+      @user_tariff_price = @user_tariff.user_tariff_prices.build
+    end
+
+    def create
+      @user_tariff_price = @user_tariff.user_tariff_prices.build(user_tariff_price_params.merge(units: 'kwh'))
+      if @user_tariff_price.save
+        redirect_to school_user_tariff_user_tariff_prices_path(@school, @user_tariff)
+      else
+        render :new
+      end
+    end
+
+    def edit
+      @user_tariff_price = @user_tariff.user_tariff_prices.find(params[:id])
+    end
+
+    def update
+      @user_tariff_price = @user_tariff.user_tariff_prices.find(params[:id])
+      if @user_tariff_price.update(user_tariff_price_params)
+        redirect_to school_user_tariff_user_tariff_prices_path(@school, @user_tariff)
+      else
+        render :edit
+      end
+    end
+
+    def destroy
+      @user_tariff.user_tariff_prices.find(params[:id]).destroy
+      redirect_to school_user_tariff_user_tariff_prices_path(@school, @user_tariff)
+    end
+
+    private
+
+    def user_tariff_price_params
+      params.require(:user_tariff_price).permit(:start_time, :end_time, :value)
+    end
+  end
+end

--- a/app/controllers/schools/user_tariffs_controller.rb
+++ b/app/controllers/schools/user_tariffs_controller.rb
@@ -1,0 +1,51 @@
+module Schools
+  class UserTariffsController < ApplicationController
+    load_and_authorize_resource :school
+    load_and_authorize_resource :user_tariff
+
+    def index
+      @user_tariffs = @school.user_tariffs.by_name
+    end
+
+    def new
+      @user_tariff = @school.user_tariffs.build(user_tariff_params.merge(start_date: Date.parse('2021-04-01'), end_date: Date.parse('2022-03-31')))
+    end
+
+    def create
+      @user_tariff = @school.user_tariffs.build(user_tariff_params)
+      if @user_tariff.save
+        redirect_to choose_type_school_user_tariff_path(@school, @user_tariff)
+      else
+        render :new
+      end
+    end
+
+    def choose_meters
+    end
+
+    def choose_type
+    end
+
+    def update
+      if @user_tariff.update(user_tariff_params)
+        redirect_to school_user_tariff_user_tariff_prices_path(@school, @user_tariff)
+      else
+        render :edit
+      end
+    end
+
+    def show
+    end
+
+    def destroy
+      @user_tariff.destroy
+      redirect_to school_user_tariffs_path(@school)
+    end
+
+    private
+
+    def user_tariff_params
+      params.require(:user_tariff).permit(:fuel_type, :name, :start_date, :end_date, :flat_rate, meter_ids: [])
+    end
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -262,4 +262,8 @@ module ApplicationHelper
   def tariff_anchor(meter)
     "#{meter.mpan_mprn}-tariff"
   end
+
+  def can_ignore_children?(field)
+    !field.required? && field.structure.any? { |_k, v| v.required? }
+  end
 end

--- a/app/helpers/tariffs_helper.rb
+++ b/app/helpers/tariffs_helper.rb
@@ -1,0 +1,9 @@
+module TariffsHelper
+  def charge_type_humanized(charge_type)
+    UserTariffCharge::CHARGE_TYPES[charge_type.to_sym]
+  end
+
+  def charge_type_units_humanized(charge_type_units)
+    UserTariffCharge::CHARGE_TYPE_UNITS[charge_type_units.to_sym]
+  end
+end

--- a/app/models/low_carbon_hub_installation.rb
+++ b/app/models/low_carbon_hub_installation.rb
@@ -6,9 +6,11 @@
 #  created_at              :datetime         not null
 #  id                      :bigint(8)        not null, primary key
 #  information             :json
+#  password                :string
 #  rbee_meter_id           :text
 #  school_id               :bigint(8)        not null
 #  updated_at              :datetime         not null
+#  username                :string
 #
 # Indexes
 #

--- a/app/models/meter.rb
+++ b/app/models/meter.rb
@@ -52,6 +52,7 @@ class Meter < ApplicationRecord
   has_many :meter_attributes
 
   belongs_to :meter_review, optional: true
+  has_and_belongs_to_many :user_tariffs, inverse_of: :meters
 
   CREATABLE_METER_TYPES = [:electricity, :gas, :solar_pv, :exported_solar_pv].freeze
   MAIN_METER_TYPES = [:electricity, :gas].freeze

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -3,6 +3,7 @@
 # Table name: schools
 #
 #  activation_date                       :date
+#  active                                :boolean          default(TRUE)
 #  address                               :text
 #  calendar_id                           :bigint(8)
 #  cooks_dinners_for_other_schools       :boolean          default(FALSE), not null
@@ -25,6 +26,7 @@
 #  postcode                              :string
 #  process_data                          :boolean          default(FALSE)
 #  public                                :boolean          default(TRUE)
+#  removal_date                          :date
 #  school_group_id                       :bigint(8)
 #  school_type                           :integer
 #  scoreboard_id                         :bigint(8)
@@ -80,6 +82,7 @@ class School < ApplicationRecord
   has_many :meter_attributes,     inverse_of: :school, class_name: 'SchoolMeterAttribute'
   has_many :consent_grants,       inverse_of: :school
   has_many :meter_reviews,        inverse_of: :school
+  has_many :user_tariffs,         inverse_of: :school
 
   has_many :programmes,               inverse_of: :school
   has_many :programme_activity_types, through: :programmes, source: :activity_types

--- a/app/models/school_onboarding.rb
+++ b/app/models/school_onboarding.rb
@@ -2,22 +2,23 @@
 #
 # Table name: school_onboardings
 #
-#  contact_email         :string           not null
-#  created_at            :datetime         not null
-#  created_by_id         :bigint(8)
-#  created_user_id       :bigint(8)
-#  dark_sky_area_id      :bigint(8)
-#  id                    :bigint(8)        not null, primary key
-#  notes                 :text
-#  school_group_id       :bigint(8)
-#  school_id             :bigint(8)
-#  school_name           :string           not null
-#  scoreboard_id         :bigint(8)
-#  solar_pv_tuos_area_id :bigint(8)
-#  template_calendar_id  :bigint(8)
-#  updated_at            :datetime         not null
-#  uuid                  :string           not null
-#  weather_station_id    :bigint(8)
+#  contact_email           :string           not null
+#  created_at              :datetime         not null
+#  created_by_id           :bigint(8)
+#  created_user_id         :bigint(8)
+#  dark_sky_area_id        :bigint(8)
+#  id                      :bigint(8)        not null, primary key
+#  notes                   :text
+#  school_group_id         :bigint(8)
+#  school_id               :bigint(8)
+#  school_name             :string           not null
+#  scoreboard_id           :bigint(8)
+#  solar_pv_tuos_area_id   :bigint(8)
+#  subscribe_to_newsletter :boolean          default(TRUE)
+#  template_calendar_id    :bigint(8)
+#  updated_at              :datetime         not null
+#  uuid                    :string           not null
+#  weather_station_id      :bigint(8)
 #
 # Indexes
 #

--- a/app/models/tariff_price.rb
+++ b/app/models/tariff_price.rb
@@ -5,7 +5,7 @@
 #  created_at           :datetime         not null
 #  id                   :bigint(8)        not null, primary key
 #  meter_id             :bigint(8)
-#  prices               :json
+#  prices               :text
 #  tariff_date          :date             not null
 #  tariff_import_log_id :bigint(8)
 #  updated_at           :datetime         not null

--- a/app/models/user_tariff.rb
+++ b/app/models/user_tariff.rb
@@ -1,0 +1,36 @@
+# == Schema Information
+#
+# Table name: user_tariffs
+#
+#  created_at :datetime         not null
+#  end_date   :date             not null
+#  flat_rate  :boolean          default(TRUE)
+#  fuel_type  :text             not null
+#  id         :bigint(8)        not null, primary key
+#  name       :text             not null
+#  school_id  :bigint(8)        not null
+#  start_date :date             not null
+#  updated_at :datetime         not null
+#
+# Indexes
+#
+#  index_user_tariffs_on_school_id  (school_id)
+#
+class UserTariff < ApplicationRecord
+  belongs_to :school, inverse_of: :user_tariffs
+  has_many :user_tariff_prices, inverse_of: :user_tariff
+  has_many :user_tariff_charges, inverse_of: :user_tariff
+  has_and_belongs_to_many :meters, inverse_of: :user_tariffs
+
+  validates :name, :start_date, :end_date, presence: true
+
+  scope :by_name, -> { order(name: :asc) }
+
+  def electricity?
+    fuel_type.to_sym == :electricity
+  end
+
+  def gas?
+    fuel_type.to_sym == :gas
+  end
+end

--- a/app/models/user_tariff_charge.rb
+++ b/app/models/user_tariff_charge.rb
@@ -1,0 +1,49 @@
+# == Schema Information
+#
+# Table name: user_tariff_charges
+#
+#  charge_type    :text             not null
+#  created_at     :datetime         not null
+#  id             :bigint(8)        not null, primary key
+#  units          :text             not null
+#  updated_at     :datetime         not null
+#  user_tariff_id :bigint(8)        not null
+#  value          :decimal(, )      not null
+#
+# Indexes
+#
+#  index_user_tariff_charges_on_user_tariff_id  (user_tariff_id)
+#
+class UserTariffCharge < ApplicationRecord
+  belongs_to :user_tariff, inverse_of: :user_tariff_charges
+
+  validates :charge_type, :value, :units, presence: true
+
+  CHARGE_TYPES = {
+    duos_red: 'Duos red',
+    duos_amber: 'Duos amber',
+    duos_green: 'Duos green',
+    fixed_charge: 'Fixed charge',
+    agreed_availability_charge: 'Agreed availability charge',
+    reactive_power_charge: 'Reactive power charge',
+    settlement_agency_fee: 'Settlement agency fee',
+    half_hourly_data_charge: 'Half hourly data charge',
+    site_fee: 'Site fee',
+  }.freeze
+
+  CHARGE_TYPE_UNITS = {
+    kwh: 'kWh',
+    kva: 'kVA',
+    day: 'day',
+    month: 'month',
+    quarter: 'quarter',
+  }.freeze
+
+  def self.charge_types
+    CHARGE_TYPES.map {|k, v| [v, k]}
+  end
+
+  def self.charge_type_units
+    CHARGE_TYPE_UNITS.map {|k, v| [v, k]}
+  end
+end

--- a/app/models/user_tariff_price.rb
+++ b/app/models/user_tariff_price.rb
@@ -1,0 +1,22 @@
+# == Schema Information
+#
+# Table name: user_tariff_prices
+#
+#  created_at     :datetime         not null
+#  end_time       :text             not null
+#  id             :bigint(8)        not null, primary key
+#  start_time     :text             not null
+#  units          :text             not null
+#  updated_at     :datetime         not null
+#  user_tariff_id :bigint(8)        not null
+#  value          :decimal(, )      not null
+#
+# Indexes
+#
+#  index_user_tariff_prices_on_user_tariff_id  (user_tariff_id)
+#
+class UserTariffPrice < ApplicationRecord
+  belongs_to :user_tariff, inverse_of: :user_tariff_prices
+
+  validates :start_time, :end_time, :value, :units, presence: true
+end

--- a/app/views/mailchimp_signups/new.html.erb
+++ b/app/views/mailchimp_signups/new.html.erb
@@ -1,13 +1,6 @@
 <div class="row justify-content-md-center">
   <div class="col col-md-10 col-lg-8">
 
-    <% if @onboarding_complete %>
-      <h1>Thanks!</h1>
-      <p>
-        We'll have a look at school details you've sent us and let you know when your school goes live.
-      </p>
-    <% end %>
-
     <% if @list %>
       <h1>Sign up to the Energy Sparks newsletter</h1>
       <%= render 'mailchimp_form', list: @list, config: @config %>

--- a/app/views/onboarding/account/edit.html.erb
+++ b/app/views/onboarding/account/edit.html.erb
@@ -8,6 +8,13 @@
       <%= f.input :password %>
       <%= f.input :password_confirmation %>
       <%= f.input :staff_role_id, label: 'Role', required: :true, collection: StaffRole.order(:title), label_method: :title, hint: 'What is your primary role in relation to Energy Sparks?'%>
+
+      <div class="custom-control custom-checkbox pb-3">
+        <input type="checkbox" class="custom-control-input" id="user_auto_subscribe_newsletter" name="user[subscribe_to_newsletter]"
+        <%= @school_onboarding.subscribe_to_newsletter ? 'checked' : 'unchecked' %> >
+        <label class="custom-control-label" for="user_auto_subscribe_newsletter">Subscribe to newsletters</label>
+      </div>
+
       <%= f.button :submit, 'Update my account' %>
       <%= link_to 'Back', new_onboarding_completion_path(@school_onboarding, anchor: 'your-account', show: 'account'), class: 'btn' %>
     <% end %>

--- a/app/views/onboarding/account/edit.html.erb
+++ b/app/views/onboarding/account/edit.html.erb
@@ -9,11 +9,9 @@
       <%= f.input :password_confirmation %>
       <%= f.input :staff_role_id, label: 'Role', required: :true, collection: StaffRole.order(:title), label_method: :title, hint: 'What is your primary role in relation to Energy Sparks?'%>
 
-      <div class="custom-control custom-checkbox pb-3">
-        <input type="checkbox" class="custom-control-input" id="user_auto_subscribe_newsletter" name="user[subscribe_to_newsletter]"
-        <%= @school_onboarding.subscribe_to_newsletter ? 'checked' : 'unchecked' %> >
-        <label class="custom-control-label" for="user_auto_subscribe_newsletter">Subscribe to newsletters</label>
-      </div>
+      <%= simple_fields_for :newsletter do |n| %>
+        <%= n.input :subscribe_to_newsletter, label: "Subscribe to newsletters", class: "custom-control-input", as: :boolean, input_html: { checked: @school_onboarding.subscribe_to_newsletter} %>
+      <% end %>
 
       <%= f.button :submit, 'Update my account' %>
       <%= link_to 'Back', new_onboarding_completion_path(@school_onboarding, anchor: 'your-account', show: 'account'), class: 'btn' %>

--- a/app/views/onboarding/account/edit.html.erb
+++ b/app/views/onboarding/account/edit.html.erb
@@ -1,9 +1,6 @@
 <div class="row justify-content-md-center">
   <div class="col col-md-10 col-lg-8">
-    <h1>Your account details</h1>
-
-    <p><%= @school_onboarding.school_name %> will have an administrator login to manage your school on Energy Sparks.</p>
-    <p>Enter the Name, email and password you want to use for this account below:</p>
+    <h1>Update your school adminstrator account details</h1>
 
     <%= simple_form_for(current_user, url: onboarding_account_path(@school_onboarding)) do |f| %>
       <%= f.input :name, label: 'Your name'%>
@@ -12,7 +9,7 @@
       <%= f.input :password_confirmation %>
       <%= f.input :staff_role_id, label: 'Role', required: :true, collection: StaffRole.order(:title), label_method: :title, hint: 'What is your primary role in relation to Energy Sparks?'%>
       <%= f.button :submit, 'Update my account' %>
-      <%= link_to 'Back', new_onboarding_completion_path(@school_onboarding, anchor: 'your-account'), class: 'btn' %>
+      <%= link_to 'Back', new_onboarding_completion_path(@school_onboarding, anchor: 'your-account', show: 'account'), class: 'btn' %>
     <% end %>
   </div>
 </div>

--- a/app/views/onboarding/account/new.html.erb
+++ b/app/views/onboarding/account/new.html.erb
@@ -19,8 +19,13 @@
       <%= f.input :password_confirmation, required: true %>
       <%= f.input :staff_role_id, label: 'Role', required: :true, collection: StaffRole.order(:title), label_method: :title, hint: 'What is your primary role in relation to Energy Sparks?'%>
 
-      <%= render 'shared/agree_terms_checkbox' %>
+      <div class="custom-control custom-checkbox pb-3">
+        <input type="checkbox" class="custom-control-input" id="user_auto_subscribe_newsletter" name="user[subscribe_to_newsletter]"
+        <%= @school_onboarding.subscribe_to_newsletter ? 'checked' : 'unchecked' %>" >
+        <label class="custom-control-label" for="user_auto_subscribe_newsletter">Subscribe to newsletters</label>
+      </div>
 
+      <%= render 'shared/agree_terms_checkbox' %>
       <%= f.button :submit, 'Create my account' %>
     <% end %>
   </div>

--- a/app/views/onboarding/account/new.html.erb
+++ b/app/views/onboarding/account/new.html.erb
@@ -1,8 +1,8 @@
 <div class="row justify-content-md-center">
   <div class="col col-md-10 col-lg-8">
-    <h1>Your account details</h1>
+    <h1>Step 1: Create your school administrator account</h1>
 
-    <p><%= @school_onboarding.school_name %> will have an administrator login to manage your school on Energy Sparks.</p>
+    <p>Your administrator login will allow you to manage your school on Energy Sparks.</p>
 
     <p>You can use an existing administrator account if you have one:</p>
 
@@ -10,7 +10,7 @@
       <%= link_to "Use an existing account", new_onboarding_sessions_path(@school_onboarding), class: :btn %>
     </p>
 
-    <p>Or, to set up a new account, enter the name, email and password you want to use below:</p>
+    <p>Use the form below to create a new account:</p>
 
     <%= simple_form_for(@user, url: onboarding_account_path(@school_onboarding)) do |f| %>
       <%= f.input :name, label: 'Your name'%>

--- a/app/views/onboarding/account/new.html.erb
+++ b/app/views/onboarding/account/new.html.erb
@@ -19,11 +19,13 @@
       <%= f.input :password_confirmation, required: true %>
       <%= f.input :staff_role_id, label: 'Role', required: :true, collection: StaffRole.order(:title), label_method: :title, hint: 'What is your primary role in relation to Energy Sparks?'%>
 
-      <div class="custom-control custom-checkbox pb-3">
-        <input type="checkbox" class="custom-control-input" id="user_auto_subscribe_newsletter" name="user[subscribe_to_newsletter]"
-        <%= @school_onboarding.subscribe_to_newsletter ? 'checked' : 'unchecked' %>" >
-        <label class="custom-control-label" for="user_auto_subscribe_newsletter">Subscribe to newsletters</label>
-      </div>
+      <p>
+      Our newsletters share best practice at participating schools, provide pupil activity prompts, invitations to join free training, volunteer support opportunities and free energy audits and educational workshops.
+      </p>
+
+      <%= simple_fields_for :newsletter do |n| %>
+        <%= n.input :subscribe_to_newsletter, label: "Subscribe to newsletters", class: "custom-control-input", as: :boolean, input_html: { checked: @school_onboarding.subscribe_to_newsletter} %>
+      <% end %>
 
       <%= render 'shared/agree_terms_checkbox' %>
       <%= f.button :submit, 'Create my account' %>

--- a/app/views/onboarding/clustering/new.html.erb
+++ b/app/views/onboarding/clustering/new.html.erb
@@ -1,10 +1,9 @@
 <div class="row justify-content-md-center">
   <div class="col col-md-10 col-lg-8">
-    <h1>Your account details</h1>
+    <h1>Step 1: Confirm your administrator account</h1>
 
-    <p><%= @school_onboarding.school_name %> will have an administrator login to manage your school on Energy Sparks.</p>
     <p>You are currently logged in as <strong><%= current_user.email %></strong></p>
-    <p>Do you want to use this user to manage the new school?</p>
+    <p>Do you want to use this user as your administrator account for <%= @school_onboarding.school_name %>?</p>
 
     <%= simple_form_for(current_user, url: onboarding_clustering_path(@school_onboarding), method: :post) do |f| %>
       <%= f.button :submit, 'Yes, use this account' %>

--- a/app/views/onboarding/completion/new.html.erb
+++ b/app/views/onboarding/completion/new.html.erb
@@ -30,8 +30,16 @@
                   <td><%=current_user.email%></td>
                 </tr>
                 <tr>
+                  <th>Role:</th>
+                  <td><%=current_user.staff_role.title%></td>
+                </tr>
+                <tr>
                   <th>Password:</th>
                   <td>***********</td>
+                </tr>
+                <tr>
+                  <th>Subscribe to newsletter?</th>
+                  <td><%= @school_onboarding.subscribe_to_newsletter ? 'Yes' : 'No' %></td>
                 </tr>
               </tbody>
             </table>

--- a/app/views/onboarding/completion/new.html.erb
+++ b/app/views/onboarding/completion/new.html.erb
@@ -1,241 +1,392 @@
 <div class="row justify-content-md-center">
   <div class="col col-md-10 col-lg-8">
-    <h1>You're almost there!</h1>
+    <h1>Final step: review your answers</h1>
 
-    <p>You've completed all the required sections.</p>
+    <p>
+    Review and update your answers before completing setup.
+    </p>
 
-    <div class="card mb-3" id="school-details">
-      <div class="card-header">
-        <h4>Your school details</h4>
-      </div>
-      <div class="card-body">
-        <dl>
-          <dt>School name:</dt>
-          <dd><%=@school.name%></dd>
-          <dt>URN:</dt>
-          <dd><%=@school.urn%></dd>
-          <dt>School type:</dt>
-          <dd><%=@school.school_type.try(:humanize) %></dd>
-          <dt>Key stages:</dt>
-          <dd><%=@school.key_stages.map(&:name).to_sentence %></dd>
-          <dt>Number of pupils:</dt>
-          <dd><%=@school.number_of_pupils %></dd>
-          <dt>Floor area:</dt>
-          <dd><%=@school.floor_area %></dd>
-          <dt>School address:</dt>
-          <dd><%=@school.address %></dd>
-          <dt>Postcode:</dt>
-          <dd><%=@school.postcode %></dd>
-          <dt>Website:</dt>
-          <dd><%=@school.website %></dd>
-          <dt>Has solar panels?</dt>
-          <dd><%= @school.indicated_has_solar_panels ? 'Yes' : 'No' %></dd>
-          <dt>Has night storage heaters?</dt>
-          <dd><%= @school.indicated_has_storage_heaters ? 'Yes' : 'No' %></dd>
-          <dt>Has swimming pool?</dt>
-          <dd><%= @school.has_swimming_pool ? 'Yes' : 'No' %></dd>
-          <dt>Serves school dinners?</dt>
-          <dd><%= @school.serves_dinners ? 'Yes' : 'No' %></dd>
-          <% if @school.serves_dinners %>
-            <dt>Cooks dinners on site</dt>
-            <dd><%= @school.cooks_dinners_onsite ? 'Yes' : 'No' %></dd>
-            <% if @school.cooks_dinners_onsite %>
-              <dt>Cook dinners for other schools:</dt>
-              <dd><%= @school.cooks_dinners_for_other_schools ? 'Yes' : 'No' %></dd>
-              <% if @school.cooks_dinners_for_other_schools %>
-                <dt>Number of schools:</dt>
-                <dd><%= @school.cooks_dinners_for_other_schools_count %></dd>
-              <% end %>
-            <% end %>
-          <% end %>
-        </dl>
-        <%= link_to 'Edit school details', edit_onboarding_school_details_path(@school_onboarding), class: 'btn btn-primary' %>
-      </div>
-    </div>
-
-    <div class="card mb-3" id="your-account">
-      <div class="card-header">
-        <h4>Your account</h4>
-      </div>
-      <div class="card-body">
-        <dl>
-          <dt>Name:</dt>
-          <dd><%=current_user.name%></dd>
-          <dt>Email:</dt>
-          <dd><%=current_user.email%></dd>
-          <dt>Password:</dt>
-          <dd>***********</dd>
-        </dl>
-        <%= link_to 'Edit your account', edit_onboarding_account_path(@school_onboarding), class: 'btn btn-primary' %>
-      </div>
-    </div>
-
-    <% if @pupil %>
-      <div class="card mb-3" id="pupil-password">
+    <div id="accordion">
+      <div class="card mb-3" id="your-account">
         <div class="card-header">
-          <h4>Pupil account</h4>
+          <h4>
+            1.
+              Your school administrator account
+            <span class="float-right"><button class="btn" data-toggle="collapse" data-target="#collapse-account"
+              aria-expanded="<%= params[:show]=='account' ? 'true' : 'false' %>" aria-controls="collapse-account">View</button></span>
+          </h4>
+
         </div>
-        <div class="card-body">
-          <dl>
-            <dt>Name:</dt>
-            <dd><%=@pupil.name%></dd>
-            <dt>Password:</dt>
-            <dd><%= @pupil.pupil_password %></dd>
-          </dl>
-          <%= link_to 'Edit pupil account', edit_onboarding_pupil_account_path(@school_onboarding), class: 'btn btn-primary' %>
+        <div id="collapse-account" class="collapse <%= 'show' if params[:show]=='account' %>">
+          <div class="card-body">
+            <table class="table table-borderless">
+              <tbody>
+                <tr>
+                  <th>Name:</th>
+                  <td><%=current_user.name%></td>
+                </tr>
+                <tr>
+                  <th>Email:</th>
+                  <td><%=current_user.email%></td>
+                </tr>
+                <tr>
+                  <th>Password:</th>
+                  <td>***********</td>
+                </tr>
+              </tbody>
+            </table>
+            <%= link_to 'Edit your account', edit_onboarding_account_path(@school_onboarding), class: 'btn btn-primary' %>
+          </div>
         </div>
       </div>
-    <% end %>
 
-    <h2>Other things you might want to look at:</h2>
+      <div class="card mb-3" id="school-details">
+        <div class="card-header">
+          <h4>2.
+              Your school details
+            <span class="float-right"><button class="btn" data-toggle="collapse" data-target="#collapse-school-details"
+              aria-expanded="<%= params[:show]=='school-details' ? 'true' : 'false' %>" aria-controls="collapse-school-details">View</button></span>
+          </h4>
+        </div>
+        <div id="collapse-school-details" class="collapse <%= 'show' if params[:show]=='school-details' %>">
+          <div class="card-body">
+            <table class="table table-borderless">
+              <tbody>
+                <tr>
+                  <th>School name:</th>
+                  <td><%=@school.name%></td>
+                </tr>
+                <tr>
+                  <th>URN:</th>
+                  <td><%=@school.urn%></td>
+                </tr>
+                <tr>
+                  <th>School address:</th>
+                  <td><%=@school.address %></td>
+                </tr>
+                <tr>
+                  <th>Postcode:</th>
+                  <td><%=@school.postcode %></td>
+                </tr>
+                <tr>
+                  <th>Website:</th>
+                  <td><%=@school.website %></td>
+                </tr>
+                <tr>
+                  <th>Stage of education:</th>
+                  <td>
+                    <% if @school.school_type.present? %>
+                      <%= @school.school_type.try(:humanize) %>
+                    <% else %>
+                      <%= link_to 'Edit', edit_onboarding_school_details_path(@school_onboarding, anchor: 'basic-details') %>
+                    <% end %>
+                  </td>
+                </tr>
+                <tr>
+                  <th>Key stages:</th>
+                  <td>
+                    <% if @school.key_stages.present? %>
+                      <%= @school.key_stages.map(&:name).to_sentence %>
+                    <% else %>
+                      <%= link_to 'Edit', edit_onboarding_school_details_path(@school_onboarding, anchor: 'basic-details') %>
+                    <% end %>
+                  </td>
+                </tr>
+                <tr>
+                  <th>Number of pupils:</th>
+                  <td>
+                    <% if @school.number_of_pupils.present? %>
+                      <%=@school.number_of_pupils %>
+                    <% else %>
+                      <%= link_to 'Edit', edit_onboarding_school_details_path(@school_onboarding, anchor: 'basic-details') %>
+                    <% end %>
+                  </td>
+                </tr>
+                <tr>
+                  <th>Percentage of free school meals:</th>
+                  <td>
+                    <% if @school.percentage_free_school_meals.present? %>
+                      <%=@school.percentage_free_school_meals %>
+                    <% else %>
+                      <%= link_to 'Edit', edit_onboarding_school_details_path(@school_onboarding, anchor: 'basic-details') %>
+                    <% end %>
+                  </td>
+                </tr>
+                <tr>
+                  <th>Floor area:</th>
+                  <td>
+                    <% if @school.floor_area.present? %>
+                      <%=@school.floor_area %>
+                    <% else %>
+                      <%= link_to 'Edit', edit_onboarding_school_details_path(@school_onboarding, anchor: 'school-features') %>
+                    <% end %>
+                  </td>
+                </tr>
+                <tr>
+                  <th>School has solar PV panels?</th>
+                  <td><%= @school.indicated_has_solar_panels ? 'Yes' : 'No' %></td>
+                </tr>
+                <tr>
+                  <th>School has night storage heaters?</th>
+                  <td><%= @school.indicated_has_storage_heaters ? 'Yes' : 'No' %></td>
+                </tr>
+                <tr>
+                  <th>School has its own swimming pool?</th>
+                  <td><%= @school.has_swimming_pool ? 'Yes' : 'No' %></td>
+                </tr>
+                <tr>
+                  <th>School serves school dinners on site?</th>
+                  <td><%= @school.serves_dinners ? 'Yes' : 'No' %></td>
+                </tr>
+                <% if @school.serves_dinners %>
+                  <tr>
+                    <th>Dinners are cooked on site?</th>
+                    <td><%= @school.cooks_dinners_onsite ? 'Yes' : 'No' %></td>
+                  </tr>
+                  <% if @school.cooks_dinners_onsite %>
+                    <tr>
+                      <th>Kitchen cooks dinners for other schools?</th>
+                      <td><%= @school.cooks_dinners_for_other_schools ? 'Yes' : 'No' %></td>
+                    </tr>
+                    <% if @school.cooks_dinners_for_other_schools %>
+                      <tr>
+                        <th>Number of schools:</th>
+                        <td><%= @school.cooks_dinners_for_other_schools_count %></td>
+                      </tr>
+                    <% end %>
+                  <% end %>
+                <% end %>
+              </tbody>
+            </table>
+
+            <%= link_to 'Edit school details', edit_onboarding_school_details_path(@school_onboarding), class: 'btn btn-primary' %>
+          </div>
+        </div>
+      </div>
+
+      <div class="card mb-3" id="consent">
+        <div class="card-header">
+          <h4>3.
+            Consent
+            <span class="float-right"><button class="btn" data-toggle="collapse" data-target="#collapse-consent"
+              aria-expanded="false" aria-controls="collapse-consent">View</button></span>
+          </h4>
+        </div>
+        <div id="collapse-consent" class="collapse">
+          <div class="card-body">
+            <% if @school.consent_up_to_date? %>
+            You have given us consent to collect, store, analyse and publish your school's energy data
+            <% end %>
+          </div>
+        </div>
+      </div>
+
+      <% if @pupil %>
+        <div class="card mb-3" id="pupil-password">
+          <div class="card-header">
+            <h4>4.
+              Pupil account
+            <span class="float-right"><button class="btn" data-toggle="collapse" data-target="#collapse-pupil-password"
+              aria-expanded="<%= params[:show]=='pupil-password' ? 'true' : 'false' %>" aria-controls="collapse-pupil-password">View</button></span>
+            </h4>
+          </div>
+          <div id="collapse-pupil-password" class="collapse <%= 'show' if params[:show]=='pupil-password' %>">
+            <div class="card-body">
+              <table class="table table-borderless">
+                <tbody>
+                  <tr>
+                    <th>Pupil account name:</th>
+                    <td><%=@pupil.name%></td>
+                  </tr>
+                  <tr>
+                    <th>Pupil password:</th>
+                    <td><%= @pupil.pupil_password %></td>
+                  </tr>
+                </tbody>
+              </table>
+              <%= link_to 'Edit pupil account', edit_onboarding_pupil_account_path(@school_onboarding), class: 'btn btn-primary' %>
+            </div>
+          </div>
+        </div>
+      <% end %>
+    </div>
+
+    <%= button_to "Complete setup", onboarding_completion_path(@school_onboarding), method: :post, class: 'btn btn-primary btn-success' %>
+
+    <hr>
+
+    <h2>Optional steps</h2>
+
     <p>
     It's not necessary for you to fill in the following sections to complete the sign-up process,
     but the more information you provide the quicker your school can start using Energy Sparks
-    and our our energy calculations will be more accurate.
+    and our energy calculations will become more accurate.
     <p>
 
-    <div class="card mb-3" id="meters">
-      <div class="card-header">
-        <h4>Meters: <%=@school.meters.count%></h4>
-      </div>
-      <div class="card-body">
-        <% if @school.meters.empty? %>
-          <p>If you have the details of your energy meters to hand then you can input them here. If not, we can get your meter details from your Local Authority, Multi-academy Trust or school group.</p>
-        <% else %>
-          <table class="table mb-3">
-            <thead>
-              <tr>
-                <th>Type</th>
-                <th>MPAN/MPRN</th>
-                <th>Name</th>
-                <th>Actions</th>
-              </tr>
-            </thead>
-            <% @school.meters.each do |meter|%>
-              <tr>
-                <td><%= meter.meter_type.humanize %></td>
-                <td><%= meter.mpan_mprn %></td>
-                <td><%= meter.name %></td>
-                <td>
-                  <%= link_to 'Edit', edit_onboarding_meter_path(@school_onboarding, meter), class: 'btn btn-sm btn-warning' %>
-                </td>
-              </tr>
+    <div id="accordion-optional-steps">
+      <div class="card mb-3" id="meters">
+        <div class="card-header">
+          <h4>
+            Configure energy meters
+            <span class="float-right"><button class="btn" data-toggle="collapse" data-target="#collapse-meters"
+              aria-expanded="<%= params[:show]=='meters' ? 'true' : 'false' %>" aria-controls="collapse-meters">View</button></span>
+          </h4>
+        </div>
+        <div id="collapse-meters" class="collapse <%= 'show' if params[:show]=='meters' %>">
+          <div class="card-body">
+            <% if @school.meters.empty? %>
+              <p>If you have the details of your energy meters to hand then you can input them here. If not, we can get your meter details from your Local Authority, Multi-academy Trust or school group.</p>
+            <% else %>
+              <table class="table table-borderless mb-3">
+                <thead>
+                  <tr>
+                    <th>Type</th>
+                    <th>MPAN/MPRN</th>
+                    <th>Name</th>
+                    <th>Actions</th>
+                  </tr>
+                </thead>
+                <% @school.meters.each do |meter|%>
+                  <tr>
+                    <td><%= meter.meter_type.humanize %></td>
+                    <td><%= meter.mpan_mprn %></td>
+                    <td><%= meter.name %></td>
+                    <td>
+                      <%= link_to 'Edit', edit_onboarding_meter_path(@school_onboarding, meter), class: 'btn btn-sm btn-warning' %>
+                    </td>
+                  </tr>
+                <% end %>
+                <tbody>
+                </tbody>
+              </table>
             <% end %>
-            <tbody>
-            </tbody>
-          </table>
-        <% end %>
-        <%= link_to 'Add a meter', new_onboarding_meter_path(@school_onboarding), class: 'btn btn-primary' %>
+            <%= link_to 'Add a meter', new_onboarding_meter_path(@school_onboarding), class: 'btn btn-primary' %>
+          </div>
+        </div>
       </div>
+
     </div>
 
     <div class="card mb-3" id="opening-times">
       <div class="card-header">
-        <h4>School opening times</h4>
+        <h4>
+          Set your school opening times
+          <span class="float-right"><button class="btn" data-toggle="collapse" data-target="#collapse-opening-times"
+            aria-expanded="<%= params[:show]=='opening-times' ? 'true' : 'false' %>" aria-controls="collapse-opening-times">View</button></span>
+        </h4>
       </div>
-      <div class="card-body">
-        <p>We've set some default school opening times. If your school has different opening times then you can update them here:</p>
-        <table class="table mb-3">
-          <thead>
-            <tr>
-              <th>Day</th>
-              <th>Opening times</th>
-            </tr>
-          </thead>
-          <tbody>
-            <% @school_times.each do |school_time| %>
+      <div id="collapse-opening-times" class="collapse <%= 'show' if params[:show]=='opening-times' %>">
+        <div class="card-body">
+          <p>We've set some default school opening times. If your school has different opening times then you can update them here:</p>
+          <table class="table table-borderless mb-3">
+            <thead>
               <tr>
-                <td><%= school_time.day.humanize %></td>
-                <td>
-                  <%= format_school_time(school_time.opening_time) %> - <%= format_school_time(school_time.closing_time) %>
-                </td>
+                <th>Day</th>
+                <th>Opening times</th>
               </tr>
-            <% end %>
-          </tbody>
-        </table>
-
-        <%= link_to 'Set school times', edit_onboarding_school_times_path(@school_onboarding), class: 'btn btn-primary' %>
+            </thead>
+            <tbody>
+              <% @school_times.each do |school_time| %>
+                <tr>
+                  <td><%= school_time.day.humanize %></td>
+                  <td>
+                    <%= format_school_time(school_time.opening_time) %> - <%= format_school_time(school_time.closing_time) %>
+                  </td>
+                </tr>
+              <% end %>
+            </tbody>
+          </table>
+          <%= link_to 'Set opening times', edit_onboarding_school_times_path(@school_onboarding), class: 'btn btn-primary' %>
+        </div>
       </div>
     </div>
 
     <% if @inset_days %>
       <div class="card mb-3" id="inset-days">
         <div class="card-header">
-          <h4>Inset days: <%= @inset_days.count %></h4>
+          <h4>Configure inset days
+          <span class="float-right"><button class="btn" data-toggle="collapse" data-target="#collapse-inset-days"
+            aria-expanded="<%= params[:show]=='inset-days' ? 'true' : 'false' %>" aria-controls="collapse-inset-days">View</button></span>
+          </h4>
         </div>
-        <div class="card-body">
-          <p>We've created a calendar for your school based on your school area's term times and national bank holidays.</p>
-          <p>Adding your school's inset days helps us make our energy calculations more accurate for days where the school may be closed.</p>
-          <p>Once your account is activated, you will be able to add any other dates where your school terms differ from your Local Authority recommended dates.</p>
-          <table class="table mb-3">
-            <thead>
-              <tr>
-                <th>Date</th>
-                <th>Type</th>
-                <th>Description</th>
-                <th>Actions</th>
-              </tr>
-            </thead>
-            <tbody>
-              <% @inset_days.each do |inset_day| %>
+        <div id="collapse-inset-days" class="collapse <%= 'show' if params[:show]=='inset-days' %>">
+          <div class="card-body">
+            <p>We've created a calendar for your school based on your school area's term times and national bank holidays.</p>
+            <p>Adding your school's inset days helps us make our energy calculations more accurate for days where the school may be closed.</p>
+            <p>Once your account is activated, you will be able to add any other dates where your school terms differ from your Local Authority recommended dates.</p>
+            <table class="table table-borderless mb-3">
+              <thead>
                 <tr>
-                  <td><%= inset_day.start_date %></td>
-                  <td><%= inset_day.calendar_event_type.title %></td>
-                  <td><%= inset_day.title %></td>
-                  <td>
-                    <div class="btn-group">
-                      <%= link_to 'Edit', edit_onboarding_inset_day_path(@school_onboarding, inset_day), class: 'btn btn-sm btn-warning' %>
-                      <%= link_to 'Delete', onboarding_inset_day_path(@school_onboarding, inset_day), method: :delete, class: 'btn btn-sm btn-danger' %>
-                    </div>
-                  </td>
+                  <th>Date</th>
+                  <th>Type</th>
+                  <th>Description</th>
+                  <th>Actions</th>
                 </tr>
-              <% end %>
-            </tbody>
-          </table>
-          <%= link_to 'Add an inset day', new_onboarding_inset_day_path(@school_onboarding), class: 'btn btn-primary' %>
+              </thead>
+              <tbody>
+                <% @inset_days.each do |inset_day| %>
+                  <tr>
+                    <td><%= inset_day.start_date %></td>
+                    <td><%= inset_day.calendar_event_type.title %></td>
+                    <td><%= inset_day.title %></td>
+                    <td>
+                      <div class="btn-group">
+                        <%= link_to 'Edit', edit_onboarding_inset_day_path(@school_onboarding, inset_day), class: 'btn btn-sm btn-warning' %>
+                        <%= link_to 'Delete', onboarding_inset_day_path(@school_onboarding, inset_day), method: :delete, class: 'btn btn-sm btn-danger' %>
+                      </div>
+                    </td>
+                  </tr>
+                <% end %>
+              </tbody>
+            </table>
+            <%= link_to 'Add an inset day', new_onboarding_inset_day_path(@school_onboarding), class: 'btn btn-primary' %>
+          </div>
         </div>
       </div>
     <% end %>
 
     <div class="card mb-3" id="alert-contacts">
       <div class="card-header">
-        <h4>Sign-up for Energy Sparks alerts</h4>
+        <h4>
+          Sign-up for Energy Sparks alerts
+          <span class="float-right"><button class="btn" data-toggle="collapse" data-target="#collapse-alerts"
+            aria-expanded="<%= params[:show]=='alert-contacts' ? 'true' : 'false' %>" aria-controls="collapse-alerts">View</button></span>
+        </h4>
       </div>
-      <div class="card-body">
-        <%= render 'shared/contact_explainer' %>
-        <p>The alerts can be sent by email or text message to a mobile phone.</p>
-        <table class="table mb-3">
-          <thead>
-            <tr>
-              <th>Name</th>
-              <th>Description</th>
-              <th>Mobile phone number</th>
-              <th>Email Address</th>
-              <th>Actions</th>
-            </tr>
-          </thead>
-          <% @school.contacts.each do |contact|%>
-            <tr>
-              <td><%= contact.name %></td>
-              <td><%= contact.description %></td>
-              <td><%= contact.mobile_phone_number %></td>
-              <td><%= contact.email_address %></td>
-              <td>
-                <%= link_to 'Edit', edit_onboarding_contact_path(@school_onboarding, contact), class: 'btn btn-sm btn-warning' %>
-                <%= link_to 'Delete', onboarding_contact_path(@school_onboarding, contact), method: :delete, class: 'btn btn-sm btn-danger' %>
-              </td>
-            </tr>
-          <% end %>
-          <tbody>
-          </tbody>
-        </table>
-        <%= link_to 'Add an alert contact', new_onboarding_contact_path(@school_onboarding), class: 'btn btn-primary' %>
+      <div id="collapse-alerts" class="collapse  <%= 'show' if params[:show]=='alert-contacts' %>">
+        <div class="card-body">
+          <%= render 'shared/contact_explainer' %>
+          <p>The alerts can be sent by email or text message to a mobile phone.</p>
+          <table class="table table-borderless mb-3">
+            <thead>
+              <tr>
+                <th>Name</th>
+                <th>Description</th>
+                <th>Mobile phone number</th>
+                <th>Email Address</th>
+                <th>Actions</th>
+              </tr>
+            </thead>
+            <% @school.contacts.each do |contact|%>
+              <tr>
+                <td><%= contact.name %></td>
+                <td><%= contact.description %></td>
+                <td><%= contact.mobile_phone_number %></td>
+                <td><%= contact.email_address %></td>
+                <td>
+                  <%= link_to 'Edit', edit_onboarding_contact_path(@school_onboarding, contact), class: 'btn btn-sm btn-warning' %>
+                  <%= link_to 'Delete', onboarding_contact_path(@school_onboarding, contact), method: :delete, class: 'btn btn-sm btn-danger' %>
+                </td>
+              </tr>
+            <% end %>
+            <tbody>
+            </tbody>
+          </table>
+          <%= link_to 'Add an alert contact', new_onboarding_contact_path(@school_onboarding), class: 'btn btn-primary' %>
+        </div>
       </div>
     </div>
 
-
-    <p>If you're ready to finish....</p>
-
-    <%= button_to "I've finished!", onboarding_completion_path(@school_onboarding), method: :post, class: 'btn btn-primary btn-success' %>
+    <%= button_to "Complete setup", onboarding_completion_path(@school_onboarding), method: :post, class: 'btn btn-primary btn-success' %>
   </div>
 </div>

--- a/app/views/onboarding/completion/show.html.erb
+++ b/app/views/onboarding/completion/show.html.erb
@@ -1,0 +1,42 @@
+<div class="row justify-content-md-center">
+  <div class="col col-md-10 col-lg-8">
+
+    <h1>Setup completed</h1>
+
+    <p>
+      <%= @school_onboarding.school.name %> has been successfully set up on Energy Sparks. Thank you.
+    </p>
+
+    <h3>What happens next?</h3>
+
+    <p>
+      Before your school goes live on Energy Sparks we will review the information you've provided, and
+      ensure we have access to your energy data.
+    </p>
+
+    <p>
+      This normally takes about 24 hours. We will email you when we've completed our final checks.
+    </p>
+
+    <h3>Eager to get started?</h3>
+
+    <p>
+      In the meantime you can:
+    </p>
+
+    <ul>
+      <li>Review our <a href="https://energysparks.uk/resources/12/download">user guide</a> or
+      watch our <%= link_to 'training_videos', user_guide_videos_path %></li>
+      <li>Sign up to one of our <%= link_to 'live webinar training sessions', training_path %></li>
+      <li>
+        Or look at how
+        <% if @school_onboarding.school.school_group.present? %>
+          <%= link_to 'schools in your area', school_group_path(@school_onboarding.school.school_group) %> are using Energy Sparks
+        <% else %>
+        <%= link_to 'other schools', school_group_path(@school_onboarding.school.school_group) %> are using Energy Sparks
+        <% end %>
+      </li>
+    </ul>
+
+  </div>
+</div>

--- a/app/views/onboarding/completion/show.html.erb
+++ b/app/views/onboarding/completion/show.html.erb
@@ -10,7 +10,7 @@
     <h3>What happens next?</h3>
 
     <p>
-      Before your school goes live on Energy Sparks we will review the information you've provided, and
+      Before your school goes live on Energy Sparks we will review the information you've provided and
       ensure we have access to your energy data.
     </p>
 
@@ -33,7 +33,7 @@
         <% if @school_onboarding.school.school_group.present? %>
           <%= link_to 'schools in your area', school_group_path(@school_onboarding.school.school_group) %> are using Energy Sparks
         <% else %>
-        <%= link_to 'other schools', school_group_path(@school_onboarding.school.school_group) %> are using Energy Sparks
+        <%= link_to 'other schools', schools_path %> are using Energy Sparks
         <% end %>
       </li>
     </ul>

--- a/app/views/onboarding/consent/_form.html.erb
+++ b/app/views/onboarding/consent/_form.html.erb
@@ -10,5 +10,5 @@
     <%= link_to 'terms and conditions', terms_and_conditions_path, target: "_blank" %>
   </div>
 
-  <%= f.button :submit, 'Submit', class: 'btn btn-primary' %>
+  <%= f.button :submit, 'Grant consent', class: 'btn btn-primary' %>
 <% end %>

--- a/app/views/onboarding/consent/show.html.erb
+++ b/app/views/onboarding/consent/show.html.erb
@@ -1,6 +1,6 @@
 <div class="row justify-content-md-center">
   <div class="col col-md-10 col-lg-8">
-    <h1>Consent to access and use data</h1>
+    <h1>Step 3: Grant consent to access and use data</h1>
 
     <%= render 'statement' %>
 

--- a/app/views/onboarding/contacts/edit.html.erb
+++ b/app/views/onboarding/contacts/edit.html.erb
@@ -1,11 +1,11 @@
 <div class="row justify-content-md-center">
   <div class="col col-md-10 col-lg-8">
-    <h1>Edit alert contact</h1>
+    <h1>Update alert contact</h1>
     <%= simple_form_for(@contact, url: onboarding_contact_path(@school_onboarding, @contact)) do |f| %>
       <%= render 'schools/contacts/form', f: f, submit: 'Save' %>
     <% end %>
     <div class="other-actions">
-      <%= link_to 'Back', new_onboarding_completion_path(@school_onboarding, anchor: 'alert-contacts'), class: 'btn btn-secondary' %>
+      <%= link_to 'Back', new_onboarding_completion_path(@school_onboarding, anchor: 'alert-contacts', show: 'alert-contacts'), class: 'btn btn-secondary' %>
     </div>
   </div>
 </div>

--- a/app/views/onboarding/contacts/new.html.erb
+++ b/app/views/onboarding/contacts/new.html.erb
@@ -1,11 +1,12 @@
 <div class="row justify-content-md-center">
   <div class="col col-md-10 col-lg-8">
-    <h1>New alert contact</h1>
+    <h1>Add a new alert contact</h1>
+
     <%= simple_form_for(@contact, url: onboarding_contacts_path(@school_onboarding)) do |f| %>
       <%= render 'schools/contacts/form', f: f, submit: 'Save' %>
     <% end %>
     <div class="other-actions">
-      <%= link_to 'Back', new_onboarding_completion_path(@school_onboarding, anchor: 'alert-contacts'), class: 'btn btn-secondary' %>
+      <%= link_to 'Back', new_onboarding_completion_path(@school_onboarding, anchor: 'alert-contacts', show: 'alert-contacts'), class: 'btn btn-secondary' %>
     </div>
   </div>
 </div>

--- a/app/views/onboarding/inset_days/edit.html.erb
+++ b/app/views/onboarding/inset_days/edit.html.erb
@@ -5,7 +5,7 @@
     <%= simple_form_for(@calendar_event, url: onboarding_inset_day_path(@school_onboarding, @calendar_event)) do |f| %>
       <%= render 'form', form: f, calendar_event_types: @calendar_event_types %>
       <%= f.button :submit, 'Update inset day' %>
-      <%= link_to 'Back', new_onboarding_completion_path(@school_onboarding, anchor: 'inset-days'), class: 'btn' %>
+      <%= link_to 'Back', new_onboarding_completion_path(@school_onboarding, anchor: 'inset-days', show: 'inset-days'), class: 'btn' %>
     <% end %>
   </div>
 </div>

--- a/app/views/onboarding/inset_days/new.html.erb
+++ b/app/views/onboarding/inset_days/new.html.erb
@@ -5,7 +5,7 @@
     <%= simple_form_for(@calendar_event, url: onboarding_inset_days_path(@school_onboarding)) do |f| %>
       <%= render 'form', form: f, calendar_event_types: @calendar_event_types %>
       <%= f.button :submit, 'Add inset day' %>
-      <%= link_to 'Back', new_onboarding_completion_path(@school_onboarding, anchor: 'inset-days'), class: 'btn' %>
+      <%= link_to 'Back', new_onboarding_completion_path(@school_onboarding, anchor: 'inset-days', show: 'inset-days'), class: 'btn' %>
     <% end %>
   </div>
 </div>

--- a/app/views/onboarding/meters/_form.html.erb
+++ b/app/views/onboarding/meters/_form.html.erb
@@ -1,19 +1,10 @@
-<div class="row justify-content-md-center">
-  <div class="col col-md-10 col-lg-8">
-    <h1>New meter</h1>
-    <p>The Meter Point Number is also known as the MPAN (for electricity meters) and the MPRN (for gas meters).</p>
-    <p>Your MPAN should be printed on your electricity bill. It is a 13 digit number, and can be referred to as a ‘Supply Number’. An example number is: 20 0001 5001 165. Do not confuse your MPAN with your electricity supplier account number or the meter serial number printed on your electricity meter.</p>
+<%= simple_form_for meter, url: url do |form| %>
 
-    <p>Your MPRN should be printed on your gas bill. The format of a MPRN is standard. It is between 6-10 numerical digits long. Do not confuse your MPRN with your gas supplier account number or the meter serial number printed on your gas meter.</p>
-    <%= simple_form_for meter, url: url do |form| %>
+  <%= form.input :meter_type, as: :radio_buttons, collection: Meter::CREATABLE_METER_TYPES.map(&:to_s), label_method: :humanize %>
 
-      <%= form.input :meter_type, as: :radio_buttons, collection: Meter::CREATABLE_METER_TYPES.map(&:to_s), label_method: :humanize %>
-
-      <%= form.input :mpan_mprn, as: :string, label: 'Meter Point Number' %>
-      <%= form.input :name, label: 'Meter Name', hint: 'You can give your meter a name to describe the area of the school is supplies with energy, for example, Kitchen gas. This will help pupils and staff interpret the energy data in Energy Sparks. If you only have one meter this is not necessary.' %>
-      <%= form.input :meter_serial_number, labeL: 'Serial number', as: :string %>
-      <%= form.button :submit %>
-      <%= link_to 'Back', new_onboarding_completion_path(school_onboarding, anchor: 'meters'), class: 'btn' %>
-    <% end %>
-  </div>
-</div>
+  <%= form.input :mpan_mprn, as: :string, label: 'Meter Point Number' %>
+  <%= form.input :name, label: 'Meter Name', hint: 'You can give your meter a name to describe the area of the school is supplies with energy, for example, Kitchen gas. This will help pupils and staff interpret the energy data in Energy Sparks. If you only have one meter this is not necessary.' %>
+  <%= form.input :meter_serial_number, labeL: 'Serial number', as: :string %>
+  <%= form.button :submit %>
+  <%= link_to 'Back', new_onboarding_completion_path(school_onboarding, anchor: 'meters', show: 'meters'), class: 'btn' %>
+<% end %>

--- a/app/views/onboarding/meters/edit.html.erb
+++ b/app/views/onboarding/meters/edit.html.erb
@@ -1,1 +1,14 @@
-<%= render 'form', meter: @meter, school_onboarding: @school_onboarding , url: onboarding_meter_path(@school_onboarding, @meter)%>
+<div class="row justify-content-md-center">
+  <div class="col col-md-10 col-lg-8">
+    <h1>Update meter</h1>
+
+    <p>The Meter Point Number is also known as the MPAN (for electricity meters) and the MPRN (for gas meters).</p>
+    <p>Your MPAN should be printed on your electricity bill. It is a 13 digit number, and can be referred to as a ‘Supply Number’. An example number is: 20 0001 5001 165. Do not confuse your MPAN with your electricity supplier account number or the meter serial number printed on your electricity meter.</p>
+
+    <p>Your MPRN should be printed on your gas bill. The format of a MPRN is standard. It is between 6-10 numerical digits long. Do not confuse your MPRN with your gas supplier account number or the meter serial number printed on your gas meter.</p>
+
+    <%= render 'form', meter: @meter, school_onboarding: @school_onboarding , url: onboarding_meter_path(@school_onboarding, @meter)%>
+
+
+  </div>
+</div>

--- a/app/views/onboarding/meters/new.html.erb
+++ b/app/views/onboarding/meters/new.html.erb
@@ -1,1 +1,13 @@
-<%= render 'form', meter: @meter, school_onboarding: @school_onboarding, url: onboarding_meters_path(@school_onboarding) %>
+<div class="row justify-content-md-center">
+  <div class="col col-md-10 col-lg-8">
+    <h1>Add new meter</h1>
+
+    <p>The Meter Point Number is also known as the MPAN (for electricity meters) and the MPRN (for gas meters).</p>
+    <p>Your MPAN should be printed on your electricity bill. It is a 13 digit number, and can be referred to as a ‘Supply Number’. An example number is: 20 0001 5001 165. Do not confuse your MPAN with your electricity supplier account number or the meter serial number printed on your electricity meter.</p>
+
+    <p>Your MPRN should be printed on your gas bill. The format of a MPRN is standard. It is between 6-10 numerical digits long. Do not confuse your MPRN with your gas supplier account number or the meter serial number printed on your gas meter.</p>
+
+    <%= render 'form', meter: @meter, school_onboarding: @school_onboarding, url: onboarding_meters_path(@school_onboarding) %>
+
+  </div>
+</div>

--- a/app/views/onboarding/pupil_account/_form.html.erb
+++ b/app/views/onboarding/pupil_account/_form.html.erb
@@ -1,8 +1,9 @@
 <p>
-  Pupil accounts allow your school's pupils to log into Energy Sparks using only a password, no email address is required.
-  These accounts can be created to be used in classrooms or with eco-teams, one account per classroom or team and the passwords can then be shared with the pupils.
+  Pupil accounts allow your pupils to log into Energy Sparks using only a password. No email address is required.
 </p>
-
+<p>
+  The accounts can be created to be used in classrooms or with eco-teams, one account per classroom or team and the passwords can then be shared with the pupils.
+</p>
 <p>
   You can create more pupil accounts once your school is activated.
 </p>

--- a/app/views/onboarding/pupil_account/edit.html.erb
+++ b/app/views/onboarding/pupil_account/edit.html.erb
@@ -1,10 +1,11 @@
 <div class="row justify-content-md-center">
   <div class="col col-md-10 col-lg-8">
-    <h1>Edit pupil account</h1>
+    <h1>Update your pupil account</h1>
 
     <%= simple_form_for @pupil, url: onboarding_pupil_account_path(@school_onboarding) do |f| %>
       <%= render 'form', f: f, school: @school_onboarding.school %>
       <%= f.submit 'Update pupil account', class: 'btn btn-rounded'%>
+      <%= link_to 'Back', new_onboarding_completion_path(@school_onboarding, anchor: 'pupil-password', show: 'pupil-password'), class: 'btn' %>
     <% end %>
   </div>
 </div>

--- a/app/views/onboarding/pupil_account/new.html.erb
+++ b/app/views/onboarding/pupil_account/new.html.erb
@@ -1,6 +1,6 @@
 <div class="row justify-content-md-center">
   <div class="col col-md-10 col-lg-8">
-    <h1>New pupil account</h1>
+    <h1>Step 4: Create your pupil account</h1>
 
     <%= simple_form_for @pupil, url: onboarding_pupil_account_path(@school_onboarding) do |f| %>
       <%= render 'form', f: f, school: @school_onboarding.school %>

--- a/app/views/onboarding/school_details/_form.html.erb
+++ b/app/views/onboarding/school_details/_form.html.erb
@@ -1,6 +1,4 @@
-<h1>Your school details</h1>
-
 <%= simple_form_for(school, url: onboarding_school_details_path(school_onboarding)) do |f| %>
   <%= render 'schools/details_form', f: f, key_stages: @key_stages, school: school %>
-  <%= f.button :submit, 'Update school details' %>
+  <%= f.button :submit, school.persisted? ? 'Update school details' : 'Save school details' %>
 <% end %>

--- a/app/views/onboarding/school_details/edit.html.erb
+++ b/app/views/onboarding/school_details/edit.html.erb
@@ -1,8 +1,10 @@
 <div class="row justify-content-md-center">
   <div class="col col-md-10 col-lg-8">
+    <h1>Update your school information</h1>
+
     <%= simple_form_for(@school, url: onboarding_school_details_path(@school_onboarding)) do |f| %>
       <%= render 'form', school: @school, school_onboarding: @school_onboarding, key_stages: @key_stages %>
-      <%= link_to 'Back', new_onboarding_completion_path(@school_onboarding, anchor: 'school-details'), class: 'btn' %>
+      <%= link_to 'Back', new_onboarding_completion_path(@school_onboarding, anchor: 'school-details', show: 'school-details'), class: 'btn' %>
     <% end %>
   </div>
 </div>

--- a/app/views/onboarding/school_details/new.html.erb
+++ b/app/views/onboarding/school_details/new.html.erb
@@ -1,5 +1,13 @@
 <div class="row justify-content-md-center">
   <div class="col col-md-10 col-lg-8">
+    <h1>Step 2: Tell us about <%= @school_onboarding.school_name %></h1>
+
+    <p>
+    Tell us about your school so that we can tailor the activities and insights
+    we provide to you and user pupils, so that you can get the best from our
+    service.
+    </p>
+
     <%= simple_form_for(@school, url: onboarding_school_details_path(@school_onboarding)) do |f| %>
       <%= render 'form', school: @school, school_onboarding: @school_onboarding, key_stages: @key_stages %>
     <% end %>

--- a/app/views/onboarding/school_details/new.html.erb
+++ b/app/views/onboarding/school_details/new.html.erb
@@ -1,10 +1,10 @@
 <div class="row justify-content-md-center">
   <div class="col col-md-10 col-lg-8">
-    <h1>Step 2: Tell us about <%= @school_onboarding.school_name %></h1>
+    <h1>Step 2: Tell us about your school</h1>
 
     <p>
     Tell us about your school so that we can tailor the activities and insights
-    we provide to you and user pupils, so that you can get the best from our
+    we provide to you and your pupils, so that you can get the best from our
     service.
     </p>
 

--- a/app/views/onboarding/school_times/edit.html.erb
+++ b/app/views/onboarding/school_times/edit.html.erb
@@ -1,9 +1,10 @@
 <div class="row justify-content-md-center">
   <div class="col col-md-10 col-lg-8">
+    <h1>Update opening times</h1>
     <%= form_for(@school, url: onboarding_school_times_path(@school_onboarding)) do |f| %>
       <%= render 'schools/times/form', f: f %>
       <%= f.submit 'Update school times', class: 'btn' %>
-      <%= link_to 'Back', new_onboarding_completion_path(@school_onboarding, anchor: 'opening-times'), class: 'btn' %>
+      <%= link_to 'Back', new_onboarding_completion_path(@school_onboarding, anchor: 'opening-times', show: 'opening-times'), class: 'btn' %>
     <% end %>
   </div>
 </div>

--- a/app/views/onboarding/show.html.erb
+++ b/app/views/onboarding/show.html.erb
@@ -1,22 +1,27 @@
 <div class="row justify-content-md-center">
   <div class="col col-md-10 col-lg-8">
-    <h1>Welcome to Energy Sparks</h1>
+    <h1>Set up your school on Energy Sparks</h1>
 
     <p>
-      Thank you for enrolling <%= @school_onboarding.school_name %> onto the Energy Sparks programme (www.energysparks.uk).
+      Thank you for enrolling <strong><%= @school_onboarding.school_name %></strong> with Energy Sparks!
+    </p>
+    <p>
       We are excited to be introducing Energy Sparks to your school, and look forward to working with you to save energy.
     </p>
 
-    <h5>Before we can activate your school we need to:</h5>
+    <h5>To get started, we need to complete the following steps:</h5>
 
     <ol>
-      <li>Set up your Energy Sparks school administrator account and pupil account</li>
-      <li>Gather some more information about your school</li>
+      <li>Create your school administrator account</li>
+      <li>Gather some information about your school</li>
       <li>Get your permission to collect, store, analyse and publish your school's energy data</li>
+      <li>Create a pupil account</li>
     </ol>
 
-    <p>Once you've completed this process we will review your school and activate your account on Energy Sparks.</p>
+    <p>
+      The setup process should take less than 10 minutes.
+    </p>
 
-    <%= link_to 'Next', new_onboarding_account_path(@school_onboarding), class: 'btn btn-primary' %>
+    <%= link_to 'Start', new_onboarding_account_path(@school_onboarding), class: 'btn btn-primary' %>
   </div>
 </div>

--- a/app/views/schools/_details_form.html.erb
+++ b/app/views/schools/_details_form.html.erb
@@ -1,61 +1,21 @@
-<p><%= school.name %> was created on <%= nice_dates(school.created_at) %></p>
+<% if school.persisted? && current_user.admin? %>
+  <p><%= school.name %> was created on <%= nice_dates(school.created_at) %></p>
+<% end %>
 
 <%= f.input :name, label: 'School name'%>
 <%= f.input :urn, label: 'Unique Reference Number', hint: 'This is your URN in England, SEED in Scotland' %>
 
-<%= f.input :activation_date, as: :tempus_dominus_date, default_date: nil, label: 'Activation date', hint: 'This is the date when the school becomes active on Energy Sparks' %>
-
-<h2>School Type</h2>
-<div class="form-group">
-  <% School.school_types.keys.each do |school_type| %>
-    <div class="form-check form-check-inline">
-      <%= f.radio_button :school_type, school_type, class: "form-check-input" %>
-      <%= f.label "school_type_#{school_type.to_sym}", t("school_types.#{school_type}", default: school_type.humanize),  class: "form-check-label" %>
-    </div>
-  <% end %>
-</div>
-
-<hr/>
-
-<p>Currently Energy Sparks supports Key Stages for filtering relevant activities. If you are in Scotland, KS1 covers P2 and P3, KS2 covers P4 to P7, KS3 covers S1 to S3, KS4 covers S4 and S5, KS5 is S6.</p>
-<p>Please select which Key Stages this school teaches.</p>
-
-<%= f.collection_check_boxes(:key_stage_ids, key_stages, :id, :name) do |b| %>
-  <div class="custom-control custom-checkbox custom-control-inline">
-    <%= b.check_box(class: "custom-control-input") %>
-    <%= b.label(class: "custom-control-label") do %>
-      <%= b.object.name %>
-    <% end %>
-  </div>
+<% if current_user.admin? %>
+  <%= f.input :activation_date, as: :tempus_dominus_date, default_date: nil, label: 'Activation date', hint: 'This is the date when the school becomes active on Energy Sparks' %>
 <% end %>
 
-<hr/>
-
-<div class="form-row">
-  <%= f.input :floor_area, label: 'Floor area in square metres', hint: "If you don't know this please leave it blank and we will try to obtain this information from your Local Authority or MAT", wrapper_html: {class: 'col-md-6'}%>
-  <%= f.input :number_of_pupils, wrapper_html: {class: 'col-md-6'}%>
-</div>
-
-<div class="form-row">
-  <%= f.input :percentage_free_school_meals, label: 'Percentage of pupils eligible for free school meals at any time during the past 6 years', hint: "If you don't know, plese leave this field blank." %>
-</div>
-
-
-<%= f.input :indicated_has_solar_panels, label: 'Our school has solar PV panels' %>
-<%= f.input :indicated_has_storage_heaters, label: 'Our school has night storage heaters' %>
-<%= f.input :has_swimming_pool, label: 'Our school has its own swimming pool' %>
-<%= f.input :serves_dinners, label: 'Our school serves school dinners on site', input_html: {data: {reveals: '.school_cooks_dinners_onsite'}}%>
-<%= f.input :cooks_dinners_onsite, label: 'Dinners are cooked on site', input_html: {data: {reveals: '.school_cooks_dinners_for_other_schools'}}, wrapper_html: {data: {revealed_by: '.school_serves_dinners'}} %>
-<%= f.input :cooks_dinners_for_other_schools, label: 'The kitchen cooks dinners for other schools', input_html: {data: {reveals: '.school_cooks_dinners_for_other_schools_count'}}, wrapper_html: {data: {revealed_by: '.school_cooks_dinners_on_site'}} %>
-<%= f.input :cooks_dinners_for_other_schools_count, label: 'How many schools does your school cook dinners for?', wrapper_html: {data: {revealed_by: '.school_cooks_dinners_for_other_schools'}}%>
-
-<h2>Address</h2>
+<h2 id="address">Address</h2>
 <%= f.input :address %>
 <%= f.input :postcode %>
 <%= f.input :website %>
 
 <% if can?(:manage, :geocoding) %>
-  <h2>Geographic location</h2>
+  <h2>Location</h2>
   <p>Leave these blank to have them set from the postcode</p>
   <%= f.input :latitude %>
   <%= f.input :longitude %>
@@ -67,3 +27,51 @@
   <% end %>
 <% end %>
 
+<h2 id="basic-details">Basic details</h2>
+<div class="form-group">
+  <p>Stage of education</p>
+
+  <% School.school_types.keys.each do |school_type| %>
+    <div class="form-check form-check-inline">
+      <%= f.radio_button :school_type, school_type, class: "form-check-input" %>
+      <%= f.label "school_type_#{school_type.to_sym}", t("school_types.#{school_type}", default: school_type.humanize),  class: "form-check-label" %>
+    </div>
+  <% end %>
+</div>
+
+<div class="form-group pt-2">
+  <p>Key stages</p>
+
+  <%= f.collection_check_boxes(:key_stage_ids, key_stages, :id, :name) do |b| %>
+    <div class="custom-control custom-checkbox custom-control-inline">
+      <%= b.check_box(class: "custom-control-input") %>
+      <%= b.label(class: "custom-control-label") do %>
+        <%= b.object.name %>
+      <% end %>
+    </div>
+  <% end %>
+
+  <small class="form-text text-muted">If you are in Scotland, KS1 covers P2 and P3, KS2 covers P4 to P7, KS3 covers S1 to S3, KS4 covers S4 and S5, KS5 is S6.</small>
+</div>
+
+<div class="form-group pt-2">
+  <%= f.input :number_of_pupils %>
+</div>
+
+<div class="form-group">
+  <%= f.input :percentage_free_school_meals, label: 'Percentage of pupils eligible for free school meals at any time during the past 6 years', hint: "If you don't know, please leave this field blank." %>
+</div>
+
+<h2 id="school-features">School features</h2>
+
+<div class="form-group">
+  <%= f.input :floor_area, label: 'Floor area in square metres', hint: "If you don't know this please leave it blank and we will try to obtain this information from your Local Authority or MAT" %>
+</div>
+
+<%= f.input :indicated_has_solar_panels, label: 'Our school has solar PV panels' %>
+<%= f.input :indicated_has_storage_heaters, label: 'Our school has night storage heaters' %>
+<%= f.input :has_swimming_pool, label: 'Our school has its own swimming pool' %>
+<%= f.input :serves_dinners, label: 'Our school serves school dinners on site', input_html: {data: {reveals: '.school_cooks_dinners_onsite'}}%>
+<%= f.input :cooks_dinners_onsite, label: 'Dinners are cooked on site', input_html: {data: {reveals: '.school_cooks_dinners_for_other_schools'}}, wrapper_html: {data: {revealed_by: '.school_serves_dinners'}} %>
+<%= f.input :cooks_dinners_for_other_schools, label: 'The kitchen cooks dinners for other schools', input_html: {data: {reveals: '.school_cooks_dinners_for_other_schools_count'}}, wrapper_html: {data: {revealed_by: '.school_cooks_dinners_on_site'}} %>
+<%= f.input :cooks_dinners_for_other_schools_count, label: 'How many schools does your school cook dinners for?', wrapper_html: {data: {revealed_by: '.school_cooks_dinners_for_other_schools'}}%>

--- a/app/views/schools/inactive/show.html.erb
+++ b/app/views/schools/inactive/show.html.erb
@@ -1,5 +1,13 @@
 <div class="jumbotron">
   <h1 class="display-4"><%= @school.name %></h1>
   <p class="lead">Your school is currently inactive while we are setting up your energy data. You will get an email notification when your school's account is activated on Energy Sparks.</p>
-  <p><%= link_to 'Take a look at other participating, active schools', schools_path %></p>
+
+  <p>
+    Take a look at how
+    <% if @school.school_group.present? %>
+      <%= link_to 'schools in your area', school_group_path(@school.school_group) %> are using Energy Sparks
+    <% else %>
+      <%= link_to 'other schools', schools_path %> are using Energy Sparks
+    <% end %>
+  </p>
 </div>

--- a/app/views/schools/user_tariff_charges/_form.html.erb
+++ b/app/views/schools/user_tariff_charges/_form.html.erb
@@ -1,0 +1,15 @@
+<div class="form-group">
+  <%= f.label :charge_type %>
+  <%= f.select :charge_type, options_for_select(UserTariffCharge.charge_types, f.object ? f.object.charge_type : ''), {include_blank: true}, { class: 'form-control' } %>
+</div>
+<div class="form-group">
+  <%= f.input :value %>
+</div>
+<div class="form-group">
+  <%= f.label :units %>
+  <%= f.select :units, options_for_select(UserTariffCharge.charge_type_units, f.object ? f.object.units : ''), {include_blank: true}, { class: 'form-control' } %>
+</div>
+<p></p>
+<%= link_to "Cancel", school_user_tariff_user_tariff_charges_path(school, user_tariff), class: 'btn' %>
+<%= f.submit 'Save', class: 'btn btn-primary' %>
+

--- a/app/views/schools/user_tariff_charges/_title.html.erb
+++ b/app/views/schools/user_tariff_charges/_title.html.erb
@@ -1,0 +1,1 @@
+<h2><%= user_tariff.name %> <%= user_tariff.fuel_type %> for <%= user_tariff.start_date %> to <%= user_tariff.end_date %> </h2>

--- a/app/views/schools/user_tariff_charges/edit.html.erb
+++ b/app/views/schools/user_tariff_charges/edit.html.erb
@@ -1,0 +1,7 @@
+<h1>Edit tariff standing charge</h1>
+
+<%= simple_form_for @user_tariff_charge, url: school_user_tariff_user_tariff_charge_path(@school, @user_tariff, @user_tariff_charge), method: :put do |f| %>
+
+  <%= render 'form', school: @school, user_tariff: @user_tariff, user_tariff_price: @user_tariff_price, f: f %>
+
+<% end %>

--- a/app/views/schools/user_tariff_charges/index.html.erb
+++ b/app/views/schools/user_tariff_charges/index.html.erb
@@ -1,0 +1,11 @@
+<h1>Tariff standing charges</h1>
+
+<h2><%= render 'title', user_tariff: @user_tariff %> </h2>
+
+<h4>Standing charges
+  <%= link_to "Add standing charge", new_school_user_tariff_user_tariff_charge_path(@school, @user_tariff), class: 'btn' %>
+</h4>
+
+<%= render 'schools/user_tariffs/charges_table', school: @school, user_tariff: @user_tariff, allow_edits: true %>
+
+<%= link_to "Next", school_user_tariff_path(@school, @user_tariff), class: 'btn' %>

--- a/app/views/schools/user_tariff_charges/new.html.erb
+++ b/app/views/schools/user_tariff_charges/new.html.erb
@@ -1,0 +1,7 @@
+<h1>Add tariff standing charge</h1>
+
+<%= simple_form_for @user_tariff_charge, url: school_user_tariff_user_tariff_charges_path(@school, @user_tariff) do |f| %>
+
+  <%= render 'form', school: @school, user_tariff: @user_tariff, user_tariff_price: @user_tariff_price, f: f %>
+
+<% end %>

--- a/app/views/schools/user_tariff_prices/_form.html.erb
+++ b/app/views/schools/user_tariff_prices/_form.html.erb
@@ -1,0 +1,6 @@
+<%= f.input :start_time, as: :string %>
+<%= f.input :end_time, as: :string %>
+<%= f.input :value, label: 'Value in £/kWh' %>
+<%= link_to "Cancel", school_user_tariff_user_tariff_prices_path(school, user_tariff), class: 'btn' %>
+<%= f.submit 'Save', class: 'btn btn-primary' %>
+

--- a/app/views/schools/user_tariff_prices/_title.html.erb
+++ b/app/views/schools/user_tariff_prices/_title.html.erb
@@ -1,0 +1,1 @@
+<h2><%= user_tariff.name %> <%= user_tariff.fuel_type %> for <%= user_tariff.start_date %> to <%= user_tariff.end_date %> </h2>

--- a/app/views/schools/user_tariff_prices/edit.html.erb
+++ b/app/views/schools/user_tariff_prices/edit.html.erb
@@ -1,0 +1,7 @@
+<h1>Edit tariff rate</h1>
+
+<%= simple_form_for @user_tariff_price, url: school_user_tariff_user_tariff_price_path(@school, @user_tariff, @user_tariff_price), method: :put do |f| %>
+
+  <%= render 'form', school: @school, user_tariff: @user_tariff, user_tariff_price: @user_tariff_price, f: f %>
+
+<% end %>

--- a/app/views/schools/user_tariff_prices/index.html.erb
+++ b/app/views/schools/user_tariff_prices/index.html.erb
@@ -1,0 +1,11 @@
+<h1>Tariff rates</h1>
+
+<h2><%= render 'title', user_tariff: @user_tariff %> </h2>
+
+<h4>Rates
+  <%= link_to "Add rate", new_school_user_tariff_user_tariff_price_path(@school, @user_tariff), class: 'btn' %>
+</h4>
+
+<%= render 'schools/user_tariffs/rates_table', school: @school, user_tariff: @user_tariff, allow_edits: true %>
+
+<%= link_to "Next", school_user_tariff_user_tariff_charges_path(@school, @user_tariff), class: 'btn' %>

--- a/app/views/schools/user_tariff_prices/new.html.erb
+++ b/app/views/schools/user_tariff_prices/new.html.erb
@@ -1,0 +1,7 @@
+<h1>Add tariff rate</h1>
+
+<%= simple_form_for @user_tariff_price, url: school_user_tariff_user_tariff_prices_path(@school, @user_tariff) do |f| %>
+
+  <%= render 'form', school: @school, user_tariff: @user_tariff, user_tariff_price: @user_tariff_price, f: f %>
+
+<% end %>

--- a/app/views/schools/user_tariffs/_charges_table.html.erb
+++ b/app/views/schools/user_tariffs/_charges_table.html.erb
@@ -1,0 +1,25 @@
+<table class="table table-striped table-sm">
+  <thead>
+  <tr>
+    <th style="width: 50%">Standing charge type</th>
+    <th>Amount</th>
+    <% if allow_edits %>
+      <th style="width: 10%"></th>
+    <% end %>
+  </tr>
+  </thead>
+  <tbody>
+  <% user_tariff.user_tariff_charges.each do |user_tariff_charge| %>
+    <tr class="rate-row">
+      <td><%= charge_type_humanized(user_tariff_charge.charge_type) %></td>
+      <td><%= user_tariff_charge.value %> per <%= charge_type_units_humanized(user_tariff_charge.units) %></td>
+      <% if allow_edits %>
+        <td>
+          <%= link_to "Edit", edit_school_user_tariff_user_tariff_charge_path(school, user_tariff, user_tariff_charge), class: 'btn' %>
+          <%= link_to "Delete", school_user_tariff_user_tariff_charge_path(school, user_tariff, user_tariff_charge), method: :delete, data: {confirm: 'Are you sure?'}, class: 'btn btn-danger' %>
+        </td>
+      <% end %>
+    </tr>
+  <% end %>
+  </tbody>
+</table>

--- a/app/views/schools/user_tariffs/_form.html.erb
+++ b/app/views/schools/user_tariffs/_form.html.erb
@@ -1,0 +1,17 @@
+<%= f.input :fuel_type, as: :hidden %>
+<div class="form-row">
+  <div class="form-group col-md-6">
+    <%= f.input :name, as: :string %>
+  </div>
+</div>
+<div class="form-row">
+  <div class="form-group col-md-6">
+    <%= f.input :start_date %>
+  </div>
+</div>
+<div class="form-row">
+  <div class="form-group col-md-6">
+    <%= f.input :end_date %>
+  </div>
+</div>
+<%= f.submit 'Next', class: 'btn'%>

--- a/app/views/schools/user_tariffs/_rates_table.html.erb
+++ b/app/views/schools/user_tariffs/_rates_table.html.erb
@@ -1,0 +1,27 @@
+<table class="table table-striped table-sm">
+
+  <thead>
+  <tr>
+    <th style="width: 50%">Type</th>
+    <th>Rate</th>
+    <% if allow_edits %>
+      <th style="width: 10%"></th>
+    <% end %>
+  </tr>
+  </thead>
+  <tbody>
+  <% user_tariff.user_tariff_prices.each do |user_tariff_price| %>
+    <tr class="rate-row">
+      <td><%= user_tariff_price.start_time %> to <%= user_tariff_price.end_time %></td>
+      <td><%= user_tariff_price.value %> £/kWh</td>
+      <% if allow_edits %>
+        <td>
+          <%= link_to "Edit", edit_school_user_tariff_user_tariff_price_path(school, user_tariff, user_tariff_price), class: 'btn' %>
+          <%= link_to "Delete", school_user_tariff_user_tariff_price_path(school, user_tariff, user_tariff_price), method: :delete, data: {confirm: 'Are you sure?'}, class: 'btn btn-danger' %>
+        </td>
+      <% end %>
+    </tr>
+  <% end %>
+  </tbody>
+
+</table>

--- a/app/views/schools/user_tariffs/_title.html.erb
+++ b/app/views/schools/user_tariffs/_title.html.erb
@@ -1,0 +1,1 @@
+<%= user_tariff.name %> <%= user_tariff.fuel_type %> for <%= user_tariff.start_date %> to <%= user_tariff.end_date %>

--- a/app/views/schools/user_tariffs/choose_meters.html.erb
+++ b/app/views/schools/user_tariffs/choose_meters.html.erb
@@ -1,0 +1,11 @@
+<h1>Select meters for tariff</h1>
+
+<p>Which meters will this tariff apply to?</p>
+
+<%= simple_form_for :user_tariff, url: new_school_user_tariff_path(@school), method: :get do |f| %>
+  <br/>
+  <%= f.hidden_field :fuel_type, value: params[:fuel_type] %>
+  <%= f.input :meter_ids, as: :check_boxes, collection: @school.meters.map{|meter| [meter.mpan_mprn, meter.id]} %>
+  <br/>
+  <%= submit_tag "Next", class: 'btn btn-info' %>
+<% end %>

--- a/app/views/schools/user_tariffs/choose_type.html.erb
+++ b/app/views/schools/user_tariffs/choose_type.html.erb
@@ -1,0 +1,20 @@
+<h1>Edit <%= @user_tariff.fuel_type %> tariff</h1>
+
+<h2><%= render 'title', user_tariff: @user_tariff %> </h2>
+
+<p>Is this a simple flat rate?</p>
+
+<%= simple_form_for [@school, @user_tariff] do |f| %>
+  <%= f.hidden_field :flat_rate, value: true %>
+  <%= submit_tag "Simple", class: 'btn btn-info' %>
+<% end %>
+
+<br/>
+<br/>
+
+<p>Or a rate which varies by time of day (e.g. Economy7, day/night rates)</p>
+
+<%= simple_form_for [@school, @user_tariff] do |f| %>
+  <%= f.hidden_field :flat_rate, value: false %>
+  <%= submit_tag "Economy 7", class: 'btn btn-info' %>
+<% end %>

--- a/app/views/schools/user_tariffs/edit.html.erb
+++ b/app/views/schools/user_tariffs/edit.html.erb
@@ -1,0 +1,7 @@
+<h1>Edit <%= @user_tariff.fuel_type %> tariff</h1>
+
+<%= simple_form_for [@school, @user_tariff] do |f| %>
+
+  <%= render 'form', school: @school, user_tariff: @user_tariff, f: f %>
+
+<% end %>

--- a/app/views/schools/user_tariffs/index.html.erb
+++ b/app/views/schools/user_tariffs/index.html.erb
@@ -1,0 +1,48 @@
+<h1>All tariffs</h1>
+
+<h2>Electricity</h2>
+
+<div>
+  <%= link_to 'Add electricity tariff', choose_meters_school_user_tariffs_path(@school, fuel_type: :electricity), class: 'btn btn-success' %>
+</div>
+
+<br/>
+<br/>
+
+<% @user_tariffs.select{|tariff| tariff.electricity?}.each_with_index do |user_tariff, idx| %>
+  <div id="accordion<%= idx %>" class="accordion-block">
+    <div class="card">
+      <div class="card-header" id="heading<%= idx %>">
+        <h5 class="mb-0">
+          <a class="nav-link collapsed" data-toggle="collapse" data-target="#collapse<%= idx %>" href="#collapse<%= idx %>" role="button" aria-expanded="false" aria-controls="multiCollapseExample1">
+            <%= render 'title', user_tariff: user_tariff %>
+          </a>
+        </h5>
+      </div>
+      <div id="collapse<%= idx %>" class="collapse" aria-labelledby="heading<%= idx %>" data-parent="#accordion<%= idx %>">
+        <div class="card-body">
+          <div class="padded-row">
+            <%= render 'schools/user_tariffs/rates_table', school: @school, user_tariff: user_tariff, allow_edits: false %>
+            <br/>
+            <%= render 'schools/user_tariffs/charges_table', school: @school, user_tariff: user_tariff, allow_edits: false %>
+          </div>
+          <%# if user_tariff.meters.present? %>
+            <div class="padded-row">
+              <p>The following meters are associated with this tariff:</p>
+              <ul>
+                <% user_tariff.meters.each do |meter| %>
+                  <li><%= meter.mpan_mprn %></li>
+                <% end %>
+              </ul>
+            </div>
+          <%# end %>
+          <div class="padded-row">
+            <%= link_to "Edit", edit_school_user_tariff_path(@school, user_tariff), class: 'btn' %>
+            <%= link_to "Delete", school_user_tariff_path(@school, user_tariff), method: :delete, data: {confirm: 'Are you sure?'}, class: 'btn btn-danger' %>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+<% end %>
+

--- a/app/views/schools/user_tariffs/new.html.erb
+++ b/app/views/schools/user_tariffs/new.html.erb
@@ -1,0 +1,13 @@
+<h1>Add <%= @user_tariff.fuel_type %> tariff</h1>
+
+<%= simple_form_for [@school, @user_tariff] do |f| %>
+
+  <%= f.hidden_field :fuel_type, value: @user_tariff.fuel_type %>
+
+  <% @user_tariff.meters.each do |meter| %>
+    <%= f.hidden_field :meter_ids, value: meter.id, multiple: true %>
+  <% end %>
+
+  <%= render 'form', school: @school, user_tariff: @user_tariff, f: f %>
+
+<% end %>

--- a/app/views/schools/user_tariffs/show.html.erb
+++ b/app/views/schools/user_tariffs/show.html.erb
@@ -1,0 +1,19 @@
+<h1>Review tariff</h1>
+
+<h2><%= render 'title', user_tariff: @user_tariff %> </h2>
+
+<h4>
+  Rates
+  <%= link_to "Edit", school_user_tariff_user_tariff_prices_path(@school, @user_tariff), class: 'btn' %>
+</h4>
+
+<%= render 'schools/user_tariffs/rates_table', school: @school, user_tariff: @user_tariff, allow_edits: false %>
+
+<h4>
+  Standing charges
+  <%= link_to "Edit", school_user_tariff_user_tariff_charges_path(@school, @user_tariff), class: 'btn' %>
+</h4>
+
+<%= render 'schools/user_tariffs/charges_table', school: @school, user_tariff: @user_tariff, allow_edits: false %>
+
+<%= link_to "Finished", school_user_tariffs_path(@school), class: 'btn' %>

--- a/app/views/shared/_manage_school.html.erb
+++ b/app/views/shared/_manage_school.html.erb
@@ -16,6 +16,7 @@
     <%= link_to 'Energy saving actions', school_interventions_path(school), class: 'dropdown-item' if can? :index, Observation %>
     <%= link_to 'Expert analysis', admin_school_analysis_path(school), class: 'dropdown-item' if can? :expert_analyse, school %>
     <%= link_to 'Meter attributes', admin_school_meter_attributes_path(school), class: 'dropdown-item' if can? :manage, SchoolMeterAttribute %>
+    <%= link_to 'Manage tariffs', school_user_tariffs_path(school), class: 'dropdown-item' if can? :manage, UserTariff %>
     <%= link_to 'Remove school', removal_admin_school_path(school), class: 'dropdown-item' if can? :remove_school, school %>
   </div>
 </li>

--- a/app/views/shared/meter_attributes/_edit_form.html.erb
+++ b/app/views/shared/meter_attributes/_edit_form.html.erb
@@ -1,4 +1,8 @@
 <%= render "shared/meter_attributes/#{meter_attribute_type.attribute_structure.type}", value: input_data, field: meter_attribute_type.attribute_structure, field_name: 'root', form: form, label: '' %>
 <hr />
-<%= form.input :reason, input_html: {value: meter_attribute.reason}, required: false %>
+
+<fieldset class='form-group'>
+  <%= form.input :reason, input_html: {value: meter_attribute.reason}, required: false %>
+</fieldset>
+
 <%= form.submit 'Update', class: 'btn btn-rounded'%>

--- a/app/views/shared/meter_attributes/_hash.html.erb
+++ b/app/views/shared/meter_attributes/_hash.html.erb
@@ -1,9 +1,16 @@
 <fieldset class='form-group'>
   <%= form.label field_name, label: label.to_s.humanize, required: field.required?, class: 'col-form-label-lg', hint: field.hint unless label.blank? %>
   <%= form.hint field.hint %>
+
+  <% if field_name != 'root' && can_ignore_children?(field) %>
+    <%= check_box_tag "disable", false, false, { title: "Disable section" , class: 'disable-attributes' } %>
+    <%= label_tag 'disabled-label', '(disabled)', class: 'hidden disabled-label' %>
+  <% end %>
+
   <div class="<%= 'ml-5' unless field_name == 'root' %>">
     <% field.structure.each do |key, structure| %>
       <%= render "shared/meter_attributes/#{structure.type.to_s}", value: value ? value[key.to_s] : nil, field: structure, field_name: field_name + "[#{key}]", form: form, label: key %>
     <% end %>
   </div>
+
 </fieldset>

--- a/app/views/shared/meter_attributes/_time_of_day_30.html.erb
+++ b/app/views/shared/meter_attributes/_time_of_day_30.html.erb
@@ -7,6 +7,6 @@
     <%= form.input field_name + '[hour]', as: :integer, input_html: {value: value ? value['hour'] : ''}, required: field.required?, min: 0, max: 23, label: 'hour'%>
   </div>
   <div class="col-6">
-    <%= form.input field_name + '[minutes]', as: :integer, input_html: {value: value ? value['minutes'] : ''},  required: field.required?, min: 0, max: 59, label: 'minutes' %>
+    <%= form.input field_name + '[minutes]', as: :integer, input_html: {value: value ? value['minutes'] : ''}, required: field.required?, min: 0, max: 59, label: 'minutes' %>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -158,6 +158,17 @@ Rails.application.routes.draw do
       resources :batch_runs, only: [:index, :create, :show]
 
       resource :consents, only: [:show, :create]
+      resources :user_tariffs do
+        resources :user_tariff_prices
+        resources :user_tariff_charges
+        collection do
+          get :choose_meters, to: 'user_tariffs#choose_meters'
+        end
+        member do
+          get :choose_type, to: 'user_tariffs#choose_type'
+        end
+      end
+
     end
 
     # Maintain old scoreboard URL

--- a/db/migrate/20210614100949_create_user_tariffs.rb
+++ b/db/migrate/20210614100949_create_user_tariffs.rb
@@ -1,0 +1,28 @@
+class CreateUserTariffs < ActiveRecord::Migration[6.0]
+  def change
+    create_table :user_tariffs do |t|
+      t.references    :school, null: false
+      t.text          :name, null: false
+      t.text          :fuel_type, null: false
+      t.boolean       :flat_rate, default: true
+      t.date          :start_date, null: false
+      t.date          :end_date, null: false
+      t.timestamps
+    end
+    create_table :user_tariff_prices do |t|
+      t.references    :user_tariff, null: false
+      t.text          :start_time, null: false
+      t.text          :end_time, null: false
+      t.decimal       :value, null: false
+      t.text          :units, null: false
+      t.timestamps
+    end
+    create_table :user_tariff_charges do |t|
+      t.references    :user_tariff, null: false
+      t.text          :charge_type, null: false
+      t.decimal       :value, null: false
+      t.text          :units, null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20210615143142_associate_meters_and_user_tariffs.rb
+++ b/db/migrate/20210615143142_associate_meters_and_user_tariffs.rb
@@ -1,0 +1,8 @@
+class AssociateMetersAndUserTariffs < ActiveRecord::Migration[6.0]
+  def change
+    create_table :meters_user_tariffs, id: false do |t|
+      t.belongs_to :meter
+      t.belongs_to :user_tariff
+    end
+  end
+end

--- a/db/migrate/20210616141804_add_newsletter_preference_to_onboarding.rb
+++ b/db/migrate/20210616141804_add_newsletter_preference_to_onboarding.rb
@@ -1,0 +1,5 @@
+class AddNewsletterPreferenceToOnboarding < ActiveRecord::Migration[6.0]
+  def change
+    add_column :school_onboardings,       :subscribe_to_newsletter, :boolean, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_09_102549) do
+ActiveRecord::Schema.define(version: 2021_06_15_143142) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
@@ -830,6 +830,13 @@ ActiveRecord::Schema.define(version: 2021_06_09_102549) do
     t.index ["solar_edge_installation_id"], name: "index_meters_on_solar_edge_installation_id"
   end
 
+  create_table "meters_user_tariffs", id: false, force: :cascade do |t|
+    t.bigint "meter_id"
+    t.bigint "user_tariff_id"
+    t.index ["meter_id"], name: "index_meters_user_tariffs_on_meter_id"
+    t.index ["user_tariff_id"], name: "index_meters_user_tariffs_on_user_tariff_id"
+  end
+
   create_table "newsletters", force: :cascade do |t|
     t.text "title", null: false
     t.text "url", null: false
@@ -1253,6 +1260,39 @@ ActiveRecord::Schema.define(version: 2021_06_09_102549) do
     t.string "name", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "user_tariff_charges", force: :cascade do |t|
+    t.bigint "user_tariff_id", null: false
+    t.text "charge_type", null: false
+    t.decimal "value", null: false
+    t.text "units", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["user_tariff_id"], name: "index_user_tariff_charges_on_user_tariff_id"
+  end
+
+  create_table "user_tariff_prices", force: :cascade do |t|
+    t.bigint "user_tariff_id", null: false
+    t.text "start_time", null: false
+    t.text "end_time", null: false
+    t.decimal "value", null: false
+    t.text "units", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["user_tariff_id"], name: "index_user_tariff_prices_on_user_tariff_id"
+  end
+
+  create_table "user_tariffs", force: :cascade do |t|
+    t.bigint "school_id", null: false
+    t.text "name", null: false
+    t.text "fuel_type", null: false
+    t.boolean "flat_rate", default: true
+    t.date "start_date", null: false
+    t.date "end_date", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["school_id"], name: "index_user_tariffs_on_school_id"
   end
 
   create_table "users", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1029,6 +1029,7 @@ ActiveRecord::Schema.define(version: 2021_06_15_143142) do
     t.bigint "template_calendar_id"
     t.bigint "scoreboard_id"
     t.bigint "weather_station_id"
+    t.boolean "subscribe_to_newsletter", default: true
     t.index ["created_by_id"], name: "index_school_onboardings_on_created_by_id"
     t.index ["created_user_id"], name: "index_school_onboardings_on_created_user_id"
     t.index ["school_group_id"], name: "index_school_onboardings_on_school_group_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_15_143142) do
+ActiveRecord::Schema.define(version: 2021_06_16_141804) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"

--- a/spec/controllers/onboarding/completion_controller_spec.rb
+++ b/spec/controllers/onboarding/completion_controller_spec.rb
@@ -14,17 +14,10 @@ RSpec.describe Onboarding::CompletionController, type: :controller do
   end
 
   describe '#show' do
-    it 'redirects to mailchimp signup if the school is not visible' do
+    it 'displays confirmation if the school is not visible' do
       school.update!(visible: false)
       get :show, params: {onboarding_id: onboarding.to_param}
-      signup_details = {
-        onboarding_complete: true,
-        user_name: user.name,
-        school_name: school.name,
-        email_address: user.email,
-        tags: ''
-      }
-      expect(response).to redirect_to(new_mailchimp_signup_path(signup_details))
+      expect(response).to render_template("show")
     end
     it 'redirects to the school if it is active' do
       get :show, params: {onboarding_id: onboarding.to_param}

--- a/spec/system/admin/meter_reviews/consent_requests_spec.rb
+++ b/spec/system/admin/meter_reviews/consent_requests_spec.rb
@@ -111,7 +111,7 @@ RSpec.describe 'consent_requests', type: :system do
         end
 
         it 'should record consent' do
-          click_on 'Submit'
+          click_on 'Grant consent'
 
           school.reload
           consent_grant = school.consent_grants.last
@@ -123,7 +123,7 @@ RSpec.describe 'consent_requests', type: :system do
         end
 
         it 'should send an email' do
-          click_on 'Submit'
+          click_on 'Grant consent'
 
           expect(ActionMailer::Base.deliveries.count).to be 1
           @email = ActionMailer::Base.deliveries.last

--- a/spec/system/school_onboarding_spec.rb
+++ b/spec/system/school_onboarding_spec.rb
@@ -172,7 +172,7 @@ RSpec.describe "onboarding", :schools, type: :system do
       #Add specific tests for each stage, rather than lots of assertions here
       it 'it walks through the expected sequence' do
         #Welcome
-        click_on 'Next'
+        click_on 'Start'
 
         #Account
         fill_in 'Your name', with: 'A Teacher'
@@ -187,13 +187,13 @@ RSpec.describe "onboarding", :schools, type: :system do
         fill_in 'Address', with: '1 Station Road'
         fill_in 'Postcode', with: 'A1 2BC'
         fill_in 'Website', with: 'http://oldfield.sch.uk'
-        click_on 'Update school details'
+        click_on 'Save school details'
 
         #Consent
         fill_in 'Name', with: 'Boss user'
         fill_in 'Job title', with: 'Boss'
         fill_in 'School name', with: 'Boss school'
-        click_on 'Submit'
+        click_on 'Grant consent'
 
         #Pupils
         fill_in 'Name', with: 'The energy savers'
@@ -201,16 +201,16 @@ RSpec.describe "onboarding", :schools, type: :system do
         click_on 'Create pupil account'
 
         #Completion
-        click_on "I've finished"
+        click_on "Complete setup", match: :first
         expect(page).to have_content("We'll have a look at school details you've sent us and let you know when your school goes live.")
       end
 
       it 'starts at the welcome page' do
-        expect(page).to have_content('Welcome to Energy Sparks')
+        expect(page).to have_content('Set up your school on Energy Sparks')
       end
 
       it 'allows a new account to be created' do
-        click_on 'Next'
+        click_on 'Start'
         expect(page).to have_field('Email', with: onboarding.contact_email)
         expect(page).to have_content('I confirm agreement with the Energy Sparks')
         fill_in 'Your name', with: 'A Teacher'
@@ -241,7 +241,7 @@ RSpec.describe "onboarding", :schools, type: :system do
         end
 
         it 'prompts for school details' do
-          expect(page).to have_content("Your school details")
+          expect(page).to have_content("Tell us about #{school_name}")
           fill_in 'Unique Reference Number', with: '4444244'
           fill_in 'Number of pupils', with: 300
           fill_in 'Floor area in square metres', with: 400
@@ -261,7 +261,7 @@ RSpec.describe "onboarding", :schools, type: :system do
           choose 'Primary'
           check 'KS1'
 
-          click_on 'Update school details'
+          click_on 'Save school details'
 
           onboarding.reload
           expect(onboarding).to have_event(:school_details_created)
@@ -295,7 +295,7 @@ RSpec.describe "onboarding", :schools, type: :system do
           fill_in 'Job title', with: 'Boss'
           fill_in 'School name', with: 'Boss school'
 
-          click_on 'Submit'
+          click_on 'Grant consent'
 
           onboarding.reload
           expect(onboarding).to have_event(:permission_given)
@@ -357,14 +357,14 @@ RSpec.describe "onboarding", :schools, type: :system do
         end
 
         it 'the process can be completed' do
-          expect(page).to have_content("You're almost there!")
-          click_on "I've finished"
+          expect(page).to have_content("Final step: review your answers")
+          click_on "Complete setup", match: :first
           expect(onboarding).to have_event(:onboarding_complete)
           expect(page).to have_content("We'll have a look at school details you've sent us and let you know when your school goes live.")
         end
 
         it 'sends an email after completion' do
-          click_on "I've finished"
+          click_on "Complete setup", match: :first
           email = ActionMailer::Base.deliveries.last
           expect(email.subject).to include('Oldfield Park Infants has completed the onboarding process')
           expect(email.to).to include(admin.email)
@@ -397,20 +397,20 @@ RSpec.describe "onboarding", :schools, type: :system do
 
       it 'meters can be added' do
         visit new_onboarding_completion_path(onboarding)
-        expect(page).to have_content('Meters: 0')
+        expect(page).to have_content('Configure energy meters')
         click_on 'Add a meter'
         fill_in 'Meter Point Number', with: '123543'
         fill_in 'Meter Name', with: 'Gas'
         choose 'Gas'
         click_on 'Create Meter'
-        expect(page).to have_content('Meters: 1')
+        expect(page).to have_content('123543')
       end
 
       it 'opening times can be added' do
         visit new_onboarding_completion_path(onboarding)
-
+        expect(page).to have_content('Set your school opening times')
         expect(page).to have_content('Monday 08:50 - 15:20')
-        click_on 'Set school times'
+        click_on 'Set opening times'
         fill_in 'monday-opening_time', with: '900'
         click_on 'Update school times'
         expect(page).to have_content('Monday 09:00 - 15:20')
@@ -422,7 +422,7 @@ RSpec.describe "onboarding", :schools, type: :system do
         visit new_onboarding_completion_path(onboarding)
 
         # Inset days
-        expect(page).to have_content('Inset days: 0')
+        expect(page).to have_content('Configure inset days')
         click_on 'Add an inset day'
         fill_in 'Description', with: 'Teacher training'
         select 'Teacher training', from: 'Type'
@@ -431,7 +431,7 @@ RSpec.describe "onboarding", :schools, type: :system do
         expect(page).to have_field('Date', with: '2019-01-09')
 
         expect { click_on 'Add inset day' }.to change { CalendarEvent.count }.by(1)
-        expect(page).to have_content('Inset days: 1')
+        expect(page).to have_content('2019-01-09')
       end
 
       it 'account details can be edited' do

--- a/spec/system/school_onboarding_spec.rb
+++ b/spec/system/school_onboarding_spec.rb
@@ -1,7 +1,8 @@
 require 'rails_helper'
 
-RSpec.describe "school onboarding", :schools, type: :system do
+RSpec.describe "onboarding", :schools, type: :system do
 
+  let(:admin) { create(:admin) }
   let(:school_name)               { 'Oldfield Park Infants'}
 
   # This calendar is there to allow for the calendar area selection
@@ -9,7 +10,6 @@ RSpec.describe "school onboarding", :schools, type: :system do
   let(:solar_pv_area)             { create(:solar_pv_tuos_area, title: 'BANES solar') }
   let(:dark_sky_weather_area)     { create(:dark_sky_area, title: 'BANES dark sky weather') }
   let(:scoreboard)                { create(:scoreboard, name: 'BANES scoreboard') }
-  let!(:other_template_calendar)  { create(:regional_calendar, :with_terms, title: 'Oxford calendar') }
   let!(:weather_station)          { create(:weather_station, title: 'BANES weather') }
 
   let!(:school_group) do
@@ -24,13 +24,10 @@ RSpec.describe "school onboarding", :schools, type: :system do
     )
   end
 
-  let(:admin) { create(:admin)}
-
-  let!(:headteacher_role) { create(:staff_role, :management, title: 'Headteacher') }
   let!(:consent_statement) { ConsentStatement.create!(title: 'Some consent statement', content: 'Some consent text', current: true) }
 
   context 'as an admin' do
-
+    let!(:other_template_calendar)  { create(:regional_calendar, :with_terms, title: 'Oxford calendar') }
 
     before(:each) do
       sign_in(admin)
@@ -39,7 +36,7 @@ RSpec.describe "school onboarding", :schools, type: :system do
       click_on 'Admin'
     end
 
-    it 'records basic details and sends an email to the school' do
+    it 'allows a new onboarding to be setup and sends an email to the school' do
       click_on 'Automatic School Setup'
       click_on 'New Automatic School Setup'
 
@@ -79,7 +76,7 @@ RSpec.describe "school onboarding", :schools, type: :system do
       expect(email.html_part.body.to_s).to include(onboarding_path(onboarding))
     end
 
-    it 'allows editing' do
+    it 'allows editing of an onboarding setup' do
       onboarding = create :school_onboarding, :with_events
       click_on 'Automatic School Setup'
       click_on 'Edit'
@@ -94,10 +91,8 @@ RSpec.describe "school onboarding", :schools, type: :system do
       expect(onboarding.template_calendar).to eq(other_template_calendar)
     end
 
-    it 'completes onboardings with schools' do
-
+    it 'allows an onboarding to be completed for a school' do
       school_onboarding = create :school_onboarding, :with_school
-
       expect(school_onboarding).to be_incomplete
 
       click_on 'Automatic School Setup'
@@ -105,7 +100,6 @@ RSpec.describe "school onboarding", :schools, type: :system do
 
       school_onboarding.reload
       expect(school_onboarding).to be_complete
-
     end
 
     it 'I can download a CSV of onboarding schools' do
@@ -153,9 +147,9 @@ RSpec.describe "school onboarding", :schools, type: :system do
     end
   end
 
-  context 'as school user signing up' do
-
+  context 'as a user' do
     let!(:ks1) { KeyStage.create(name: 'KS1') }
+    let!(:headteacher_role) { create(:staff_role, :management, title: 'Headteacher') }
 
     let!(:onboarding) do
       create(
@@ -167,207 +161,326 @@ RSpec.describe "school onboarding", :schools, type: :system do
       )
     end
 
-    before(:each) do
-      visit onboarding_path(onboarding)
-    end
-
-    it 'walks the user through the steps required' do
-      expect(page).to have_content('Welcome to Energy Sparks')
-      click_on 'Next'
-
-      expect(page).to have_field('Email', with: onboarding.contact_email)
-      expect(page).to have_content('I confirm agreement with the Energy Sparks')
-      fill_in 'Your name', with: 'A Teacher'
-      select 'Headteacher', from: 'Role'
-      fill_in 'Password', with: 'testtest1', match: :prefer_exact
-      fill_in 'Password confirmation', with: 'testtest1'
-      check :privacy
-      click_on 'Create my account'
-
-      onboarding.reload
-      expect(onboarding).to have_event(:onboarding_user_created)
-      expect(onboarding).to have_event(:privacy_policy_agreed)
-      expect(onboarding.created_user.name).to eq('A Teacher')
-      expect(onboarding.created_user.role).to eq('school_onboarding')
-
-      fill_in 'Unique Reference Number', with: '4444244'
-      fill_in 'Number of pupils', with: 300
-      fill_in 'Floor area in square metres', with: 400
-      fill_in 'Percentage of pupils eligible for free school meals at any time during the past 6 years', with: 16
-      fill_in 'Address', with: '1 Station Road'
-      fill_in 'Postcode', with: 'A1 2BC'
-      fill_in 'Website', with: 'http://oldfield.sch.uk'
-
-      check 'Our school has solar PV panels'
-      check 'Our school has night storage heaters'
-      uncheck 'Our school has its own swimming pool'
-      check 'Our school serves school dinners on site'
-      check 'Dinners are cooked on site'
-      check 'The kitchen cooks dinners for other schools'
-      fill_in 'How many schools does your school cook dinners for?', with: '5'
-
-      choose 'Primary'
-      check 'KS1'
-
-      click_on 'Update school details'
-
-      expect(page).to have_content(consent_statement.content.to_plain_text)
-      expect(page).to have_content('I give permission and confirm full agreement with')
-
-      fill_in 'Name', with: 'Boss user'
-      fill_in 'Job title', with: 'Boss'
-      fill_in 'School name', with: 'Boss school'
-
-      click_on 'Submit'
-
-      onboarding.reload
-      expect(onboarding).to have_event(:permission_given)
-
-      consent_grant = onboarding.school.consent_grants.last
-      expect(consent_grant.name).to eq('Boss user')
-      expect(consent_grant.job_title).to eq('Boss')
-      expect(consent_grant.school_name).to eq('Boss school')
-      expect(consent_grant.user).to eq(onboarding.created_user)
-      expect(consent_grant.school).to eq(onboarding.school)
-
-      fill_in 'Name', with: 'The energy savers'
-      fill_in 'Pupil password', with: ''
-      click_on 'Create pupil account'
-      expect(page).to have_content("can't be blank")
-
-      fill_in 'Pupil password', with: 'theenergysavers'
-      click_on 'Create pupil account'
-
-      onboarding.reload
-      pupil = onboarding.school.users.pupil.first
-      expect(pupil.email).to_not be_nil
-      expect(pupil.pupil_password).to eq('theenergysavers')
-
-      click_on "I've finished"
-      expect(onboarding).to have_event(:onboarding_complete)
-      onboarding.reload
-
-      expect(onboarding.school.indicated_has_solar_panels?).to eq(true)
-      expect(onboarding.school.indicated_has_storage_heaters?).to eq(true)
-      expect(onboarding.school.has_swimming_pool?).to eq(false)
-      expect(onboarding.school.cooks_dinners_for_other_schools_count).to eq(5)
-      expect(onboarding.school.percentage_free_school_meals).to eq(16)
-
-      expect(page).to have_content("We'll have a look at school details you've sent us and let you know when your school goes live.")
-
-      email = ActionMailer::Base.deliveries.last
-      expect(email.subject).to include('Oldfield Park Infants has completed the onboarding process')
-      expect(email.to).to include(admin.email)
-    end
-
-    it 'lets the user edit inset days, meters, pupils and opening times but does not require them' do
-      create :calendar_event_type, title: 'Teacher training', inset_day: true
-      academic_year = create :academic_year, start_date: Date.new(2018, 9,1), end_date: Date.new(2019, 8, 31), calendar: template_calendar
-      user = create(:onboarding_user)
-      onboarding.update!(created_user: user)
-      school = build(:school)
-      SchoolCreator.new(school).onboard_school!(onboarding)
-      pupil = create(:pupil, school: school)
-
-      sign_in(user)
-      visit new_onboarding_completion_path(onboarding)
-
-      click_on 'Edit pupil account'
-      fill_in 'Pupil password', with: 'testtest2'
-      click_on 'Update pupil account'
-      pupil.reload
-      expect(pupil.pupil_password).to eq('testtest2')
-
-      # Meters
-      expect(page).to have_content('Meters: 0')
-      click_on 'Add a meter'
-      fill_in 'Meter Point Number', with: '123543'
-      fill_in 'Meter Name', with: 'Gas'
-      choose 'Gas'
-      click_on 'Create Meter'
-      expect(page).to have_content('Meters: 1')
-
-      # Opening times
-      expect(page).to have_content('Monday 08:50 - 15:20')
-      click_on 'Set school times'
-      fill_in 'monday-opening_time', with: '900'
-      click_on 'Update school times'
-      expect(page).to have_content('Monday 09:00 - 15:20')
-
-      # Inset days
-      expect(page).to have_content('Inset days: 0')
-      click_on 'Add an inset day'
-      fill_in 'Description', with: 'Teacher training'
-      select 'Teacher training', from: 'Type'
-      # Grr, actual input hidden for JS datepicker
-      fill_in 'Date', with: '2019-01-09'
-
-      expect(page).to have_field('Date', with: '2019-01-09')
-
-      expect { click_on 'Add inset day' }.to change { CalendarEvent.count }.by(1)
-      expect(page).to have_content('Inset days: 1')
-
-    end
-
-    it 'adds the onboarding user as an alert contact and allows management' do
-      user = create(:onboarding_user)
-      onboarding.update!(created_user: user)
-      school = build(:school)
-      SchoolCreator.new(school).onboard_school!(onboarding)
-
-      sign_in(user)
-
-      visit new_onboarding_completion_path(onboarding)
-
-      click_on 'Edit your account'
-
-      fill_in 'Your name', with: 'Better name'
-      click_on 'Update my account'
-      user.reload
-      expect(user.name).to eq('Better name')
-
-      click_on 'Edit school details'
-      fill_in 'School name', with: 'Correct school'
-      click_on 'Update school details'
-      school.reload
-      expect(school.name).to eq('Correct school')
-
-    end
-
-    it 'lets the user edit and add contacts' do
-      user = create(:onboarding_user)
-      onboarding.update!(created_user: user)
-      school = build(:school)
-      SchoolCreator.new(school).onboard_school!(onboarding)
-
-      sign_in(user)
-
-      visit new_onboarding_completion_path(onboarding)
-
-      within '#alert-contacts' do
-        expect(page).to have_content(user.name)
-        click_on 'Edit'
+    context 'completing onboarding' do
+      before(:each) do
+        visit onboarding_path(onboarding)
       end
 
-      fill_in 'Mobile phone number', with: '07123 4567890'
-      click_on 'Save'
-      expect(school.contacts.first.mobile_phone_number).to eq('07123 4567890')
+      #Note: this is just to test the sequencing of the multi-stage form
+      #this test just fills in the required fields at each stage
+      #then checks it completes as expected.
+      #Add specific tests for each stage, rather than lots of assertions here
+      it 'it walks through the expected sequence' do
+        #Welcome
+        click_on 'Next'
 
-      within '#alert-contacts' do
-        click_on 'Delete'
+        #Account
+        fill_in 'Your name', with: 'A Teacher'
+        select 'Headteacher', from: 'Role'
+        fill_in 'Password', with: 'testtest1', match: :prefer_exact
+        fill_in 'Password confirmation', with: 'testtest1'
+        check :privacy
+        click_on 'Create my account'
+
+        #School details
+        fill_in 'Unique Reference Number', with: '4444244'
+        fill_in 'Address', with: '1 Station Road'
+        fill_in 'Postcode', with: 'A1 2BC'
+        fill_in 'Website', with: 'http://oldfield.sch.uk'
+        click_on 'Update school details'
+
+        #Consent
+        fill_in 'Name', with: 'Boss user'
+        fill_in 'Job title', with: 'Boss'
+        fill_in 'School name', with: 'Boss school'
+        click_on 'Submit'
+
+        #Pupils
+        fill_in 'Name', with: 'The energy savers'
+        fill_in 'Pupil password', with: 'theenergysavers'
+        click_on 'Create pupil account'
+
+        #Completion
+        click_on "I've finished"
+        expect(page).to have_content("We'll have a look at school details you've sent us and let you know when your school goes live.")
       end
 
-      expect(school.contacts.size).to eq(0)
+      it 'starts at the welcome page' do
+        expect(page).to have_content('Welcome to Energy Sparks')
+      end
 
-      click_on 'Add an alert contact'
+      it 'allows a new account to be created' do
+        click_on 'Next'
+        expect(page).to have_field('Email', with: onboarding.contact_email)
+        expect(page).to have_content('I confirm agreement with the Energy Sparks')
+        fill_in 'Your name', with: 'A Teacher'
+        select 'Headteacher', from: 'Role'
+        fill_in 'Password', with: 'testtest1', match: :prefer_exact
+        fill_in 'Password confirmation', with: 'testtest1'
+        check :privacy
+        click_on 'Create my account'
 
-      fill_in 'Name', with: 'Joe Bloggs'
-      fill_in 'Email', with: 'test@example.com'
-      click_on 'Save'
+        onboarding.reload
+        expect(onboarding).to have_event(:onboarding_user_created)
+        expect(onboarding).to have_event(:privacy_policy_agreed)
+        expect(onboarding.created_user.name).to eq('A Teacher')
+        expect(onboarding.created_user.role).to eq('school_onboarding')
+      end
 
-      expect(school.contacts.size).to eq(1)
+      it 'stores newsletter preference'
 
+      it 'allows an existing user to sign in'
+
+      context 'having created an account' do
+        let(:user) { create(:onboarding_user) }
+
+        before(:each) do
+          onboarding.update!(created_user: user)
+          sign_in(user)
+          visit new_onboarding_school_details_path(onboarding)
+        end
+
+        it 'prompts for school details' do
+          expect(page).to have_content("Your school details")
+          fill_in 'Unique Reference Number', with: '4444244'
+          fill_in 'Number of pupils', with: 300
+          fill_in 'Floor area in square metres', with: 400
+          fill_in 'Percentage of pupils eligible for free school meals at any time during the past 6 years', with: 16
+          fill_in 'Address', with: '1 Station Road'
+          fill_in 'Postcode', with: 'A1 2BC'
+          fill_in 'Website', with: 'http://oldfield.sch.uk'
+
+          check 'Our school has solar PV panels'
+          check 'Our school has night storage heaters'
+          uncheck 'Our school has its own swimming pool'
+          check 'Our school serves school dinners on site'
+          check 'Dinners are cooked on site'
+          check 'The kitchen cooks dinners for other schools'
+          fill_in 'How many schools does your school cook dinners for?', with: '5'
+
+          choose 'Primary'
+          check 'KS1'
+
+          click_on 'Update school details'
+
+          onboarding.reload
+          expect(onboarding).to have_event(:school_details_created)
+          expect(onboarding.school.indicated_has_solar_panels?).to eq(true)
+          expect(onboarding.school.indicated_has_storage_heaters?).to eq(true)
+          expect(onboarding.school.has_swimming_pool?).to eq(false)
+          expect(onboarding.school.cooks_dinners_for_other_schools_count).to eq(5)
+          expect(onboarding.school.percentage_free_school_meals).to eq(16)
+        end
+
+        it 'signs user up to newsletter after school is created'
+
+      end
+
+      context 'having provided school details' do
+        let(:user) { create(:onboarding_user) }
+        let(:school) { build(:school) }
+
+        before(:each) do
+          onboarding.update!(created_user: user)
+          SchoolCreator.new(school).onboard_school!(onboarding)
+          sign_in(user)
+          visit onboarding_consent_path(onboarding)
+        end
+
+        it 'prompts for consent' do
+          expect(page).to have_content(consent_statement.content.to_plain_text)
+          expect(page).to have_content('I give permission and confirm full agreement with')
+
+          fill_in 'Name', with: 'Boss user'
+          fill_in 'Job title', with: 'Boss'
+          fill_in 'School name', with: 'Boss school'
+
+          click_on 'Submit'
+
+          onboarding.reload
+          expect(onboarding).to have_event(:permission_given)
+
+          consent_grant = onboarding.school.consent_grants.last
+          expect(consent_grant.name).to eq('Boss user')
+          expect(consent_grant.job_title).to eq('Boss')
+          expect(consent_grant.school_name).to eq('Boss school')
+          expect(consent_grant.user).to eq(onboarding.created_user)
+          expect(consent_grant.school).to eq(onboarding.school)
+        end
+
+        it 'sends a confirmation email'
+
+      end
+
+      context 'having given consent' do
+        let(:user) { create(:onboarding_user) }
+        let(:school) { build(:school) }
+
+        before(:each) do
+          onboarding.update!(created_user: user)
+          SchoolCreator.new(school).onboard_school!(onboarding)
+          sign_in(user)
+          visit new_onboarding_pupil_account_path(onboarding)
+        end
+
+        it 'should do something with consent here???'
+
+        it 'prompts for a pupil login' do
+          fill_in 'Name', with: 'The energy savers'
+          fill_in 'Pupil password', with: 'theenergysavers'
+          click_on 'Create pupil account'
+
+          onboarding.reload
+          expect(onboarding).to have_event(:pupil_account_created)
+          pupil = onboarding.school.users.pupil.first
+          expect(pupil.email).to_not be_nil
+          expect(pupil.pupil_password).to eq('theenergysavers')
+        end
+
+        it 'validates form' do
+          fill_in 'Name', with: 'The energy savers'
+          fill_in 'Pupil password', with: ''
+          click_on 'Create pupil account'
+          expect(page).to have_content("can't be blank")
+        end
+      end
+
+      context 'having finished the initial steps' do
+        let(:user) { create(:onboarding_user) }
+        let(:school) { build(:school, visible: false) }
+
+        before(:each) do
+          onboarding.update!(created_user: user)
+          SchoolCreator.new(school).onboard_school!(onboarding)
+          sign_in(user)
+          visit new_onboarding_completion_path(onboarding)
+        end
+
+        it 'the process can be completed' do
+          expect(page).to have_content("You're almost there!")
+          click_on "I've finished"
+          expect(onboarding).to have_event(:onboarding_complete)
+          expect(page).to have_content("We'll have a look at school details you've sent us and let you know when your school goes live.")
+        end
+
+        it 'sends an email after completion' do
+          click_on "I've finished"
+          email = ActionMailer::Base.deliveries.last
+          expect(email.subject).to include('Oldfield Park Infants has completed the onboarding process')
+          expect(email.to).to include(admin.email)
+        end
+      end
     end
 
+    context 'at the final stage' do
+      let(:user) { create(:onboarding_user) }
+      let(:school) { build(:school) }
+
+      before(:each) do
+        onboarding.update!(created_user: user)
+        SchoolCreator.new(school).onboard_school!(onboarding)
+        sign_in(user)
+      end
+
+      it 'redirects me if I revisit the start'
+
+      it 'pupil details can be edited' do
+        pupil = create(:pupil, school: school)
+        visit new_onboarding_completion_path(onboarding)
+
+        click_on 'Edit pupil account'
+        fill_in 'Pupil password', with: 'testtest2'
+        click_on 'Update pupil account'
+        pupil.reload
+        expect(pupil.pupil_password).to eq('testtest2')
+      end
+
+      it 'meters can be added' do
+        visit new_onboarding_completion_path(onboarding)
+        expect(page).to have_content('Meters: 0')
+        click_on 'Add a meter'
+        fill_in 'Meter Point Number', with: '123543'
+        fill_in 'Meter Name', with: 'Gas'
+        choose 'Gas'
+        click_on 'Create Meter'
+        expect(page).to have_content('Meters: 1')
+      end
+
+      it 'opening times can be added' do
+        visit new_onboarding_completion_path(onboarding)
+
+        expect(page).to have_content('Monday 08:50 - 15:20')
+        click_on 'Set school times'
+        fill_in 'monday-opening_time', with: '900'
+        click_on 'Update school times'
+        expect(page).to have_content('Monday 09:00 - 15:20')
+      end
+
+      it 'inset days can be added' do
+        create :calendar_event_type, title: 'Teacher training', inset_day: true
+        academic_year = create :academic_year, start_date: Date.new(2018, 9,1), end_date: Date.new(2019, 8, 31), calendar: template_calendar
+        visit new_onboarding_completion_path(onboarding)
+
+        # Inset days
+        expect(page).to have_content('Inset days: 0')
+        click_on 'Add an inset day'
+        fill_in 'Description', with: 'Teacher training'
+        select 'Teacher training', from: 'Type'
+        # Grr, actual input hidden for JS datepicker
+        fill_in 'Date', with: '2019-01-09'
+        expect(page).to have_field('Date', with: '2019-01-09')
+
+        expect { click_on 'Add inset day' }.to change { CalendarEvent.count }.by(1)
+        expect(page).to have_content('Inset days: 1')
+      end
+
+      it 'account details can be edited' do
+        visit new_onboarding_completion_path(onboarding)
+        click_on 'Edit your account'
+
+        fill_in 'Your name', with: 'Better name'
+        click_on 'Update my account'
+        user.reload
+        expect(user.name).to eq('Better name')
+      end
+
+      it 'school details can be edited' do
+        visit new_onboarding_completion_path(onboarding)
+
+        click_on 'Edit school details'
+        fill_in 'School name', with: 'Correct school'
+        click_on 'Update school details'
+        school.reload
+        expect(school.name).to eq('Correct school')
+      end
+
+      it 'the user is listed as a default contact, and contacts can be managed' do
+        visit new_onboarding_completion_path(onboarding)
+        within '#alert-contacts' do
+          expect(page).to have_content(user.name)
+          click_on 'Edit'
+        end
+
+        fill_in 'Mobile phone number', with: '07123 4567890'
+        click_on 'Save'
+        expect(school.contacts.first.mobile_phone_number).to eq('07123 4567890')
+
+        within '#alert-contacts' do
+          click_on 'Delete'
+        end
+
+        expect(school.contacts.size).to eq(0)
+
+        click_on 'Add an alert contact'
+
+        fill_in 'Name', with: 'Joe Bloggs'
+        fill_in 'Email', with: 'test@example.com'
+        click_on 'Save'
+
+        expect(school.contacts.size).to eq(1)
+      end
+
+    end
   end
+
 end

--- a/spec/system/school_onboarding_spec.rb
+++ b/spec/system/school_onboarding_spec.rb
@@ -218,6 +218,8 @@ RSpec.describe "onboarding", :schools, type: :system do
         select 'Headteacher', from: 'Role'
         fill_in 'Password', with: 'testtest1', match: :prefer_exact
         fill_in 'Password confirmation', with: 'testtest1'
+        expect(page).to have_checked_field('newsletter_subscribe_to_newsletter')
+
         check :privacy
         click_on 'Create my account'
 
@@ -241,7 +243,7 @@ RSpec.describe "onboarding", :schools, type: :system do
         end
 
         it 'prompts for school details' do
-          expect(page).to have_content("Tell us about #{school_name}")
+          expect(page).to have_content("Tell us about your school")
           fill_in 'Unique Reference Number', with: '4444244'
           fill_in 'Number of pupils', with: 300
           fill_in 'Floor area in square metres', with: 400
@@ -468,6 +470,11 @@ RSpec.describe "onboarding", :schools, type: :system do
         click_on 'Update my account'
         onboarding.reload
         expect(onboarding.subscribe_to_newsletter).to eql false
+        click_on 'Edit your account'
+        check 'Subscribe to newsletters'
+        click_on 'Update my account'
+        onboarding.reload
+        expect(onboarding.subscribe_to_newsletter).to eql true
       end
 
       it 'school details can be edited' do

--- a/spec/system/school_onboarding_spec.rb
+++ b/spec/system/school_onboarding_spec.rb
@@ -306,8 +306,6 @@ RSpec.describe "onboarding", :schools, type: :system do
           expect(consent_grant.school).to eq(onboarding.school)
         end
 
-        it 'sends a confirmation email'
-
       end
 
       context 'having given consent' do

--- a/spec/system/schools/user_tariffs_spec.rb
+++ b/spec/system/schools/user_tariffs_spec.rb
@@ -1,0 +1,99 @@
+require 'rails_helper'
+
+describe 'user tariffs', type: :system do
+
+  let!(:school)                   { create_active_school(name: "Big School")}
+  let!(:admin)                    { create(:admin) }
+  let!(:electricity_meter)        { create(:electricity_meter, school: school, mpan_mprn: '12345678901234') }
+
+  context 'as a school admin' do
+    let!(:school_admin)                    { create(:school_admin, school: school) }
+
+    before(:each) do
+      sign_in(school_admin)
+    end
+
+    it 'menu item is not there' do
+      visit school_path(school)
+      expect(page).not_to have_link('Manage tariffs')
+    end
+
+    it 'access is denied' do
+      visit school_user_tariffs_path(school)
+      expect(page).to have_content('not authorized')
+      expect(page).to have_content('Management Dashboard')
+    end
+  end
+
+  context 'as an admin' do
+
+    before(:each) do
+      sign_in(admin)
+    end
+
+    context 'creating electricity tariffs' do
+
+      it 'can create a tariff and add prices and charges' do
+        visit school_path(school)
+        click_link('Manage tariffs')
+
+        expect(page).to have_content('All tariffs')
+
+        click_link('Add electricity tariff')
+
+        expect(page).to have_content('Select meters for tariff')
+        check('12345678901234')
+        click_button('Next')
+
+        expect(page).to have_content('Add electricity tariff')
+
+        fill_in 'Name', with: 'My First Tariff'
+        click_button('Next')
+
+        expect(page).to have_content('Edit electricity tariff')
+        click_button('Economy 7')
+
+        expect(page).to have_content('Tariff rates')
+        expect(page).to have_content('My First Tariff electricity for 2021-04-01 to 2022-03-31')
+
+        click_link('Add rate')
+        expect(page).to have_content('Add tariff rate')
+        fill_in 'Start time', with: '00:00'
+        fill_in 'End time', with: '07:00'
+        fill_in 'Value in £/kWh', with: '1.23'
+        click_button('Save')
+
+        expect(page).to have_content('Tariff rates')
+        expect(page).to have_content('00:00')
+        expect(page).to have_content('07:00')
+        expect(page).to have_content('1.23 £/kWh')
+
+        click_link('Next')
+
+        expect(page).to have_content('Tariff standing charges')
+        expect(page).to have_content('My First Tariff electricity for 2021-04-01 to 2022-03-31')
+
+        click_link('Add standing charge')
+        expect(page).to have_content('Add tariff standing charge')
+        select 'Fixed charge', from: 'Charge type'
+        fill_in 'Value', with: '4.56'
+        select 'kVA', from: 'Units'
+        click_button('Save')
+
+        click_link('Next')
+        expect(page).to have_content('Review tariff')
+        expect(page).to have_content('1.23 £/kWh')
+        expect(page).to have_content('4.56 per kVA')
+        expect(page).not_to have_link('Delete')
+
+        click_link('Finished')
+        expect(page).to have_content('All tariffs')
+        expect(page).to have_content('12345678901234')
+
+        expect(UserTariff.last.meters).to match_array([electricity_meter])
+      end
+
+    end
+
+  end
+end

--- a/yarn.lock
+++ b/yarn.lock
@@ -7566,9 +7566,9 @@ wrappy@1:
   integrity sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=
 
 ws@^6.2.1:
-  version "6.2.1"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-6.2.1.tgz#442fdf0a47ed64f59b6a5d8ff130f4748ed524fb"
-  integrity sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==
+  version "6.2.2"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-6.2.2.tgz#dd5cdbd57a9979916097652d78f1cc5faea0c32e"
+  integrity sha512-zmhltoSR8u1cnDsD43TX59mzoMZsLKqUweyYBAIvTngR3shc0W6aOZylZmq/7hqyVxPdi+5Ud2QInblgyE72fw==
   dependencies:
     async-limiter "~1.0.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5850,9 +5850,9 @@ postcss-values-parser@^2.0.0, postcss-values-parser@^2.0.1:
     uniq "^1.0.1"
 
 postcss@^7.0.0, postcss@^7.0.1, postcss@^7.0.14, postcss@^7.0.17, postcss@^7.0.2, postcss@^7.0.26, postcss@^7.0.27, postcss@^7.0.32, postcss@^7.0.5, postcss@^7.0.6:
-  version "7.0.34"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.34.tgz#f2baf57c36010df7de4009940f21532c16d65c20"
-  integrity sha512-H/7V2VeNScX9KE83GDrDZNiGT1m2H+UTnlinIzhjlLX9hfMUn1mHNnGeX81a1c8JSBdBvqk7c2ZOG6ZPn5itGw==
+  version "7.0.36"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.36.tgz#056f8cffa939662a8f5905950c07d5285644dfcb"
+  integrity sha512-BebJSIUMwJHRH0HAQoxN4u1CN86glsrwsW0q7T+/m44eXOUAxSNdHRkNZPYz5vVUbg17hFgOQDE7fZk7li3pZw==
   dependencies:
     chalk "^2.4.2"
     source-map "^0.6.1"


### PR DESCRIPTION
Quite a big change, but most of it is templates.

Quick summary:

* reworked the onboarding spec to make it easier to test for different variant flows and make it more manageable
* updated all of the views throughout onboarding to improve labelling, layout, etc
* removed some admin only fields that had appeared on the school details page but were being presented to users in onboarding
* added in some missing fields that weren't displayed on the final summary page
* changed the summary page to use collapsable sections to make it more manageable
* added extra button to prompt users to complete, which they're not doing currently
* improved the final form to indicate what happens next
* allowed user to indicate whether they want to sign up to newsletter. This is stored on the onboarding model as we don't have a school at the point they create their account. We do the mailchimp registration at the end, which also allows them to revise their decision
* removed the original redirect to the mailchimp form and created a dedicated confirmation page at the end of onboarding