### PR TITLE
Added start/end log messages with consistent timestamp

### DIFF
--- a/lib/tasks/alerts/create_alerts.rake
+++ b/lib/tasks/alerts/create_alerts.rake
@@ -1,12 +1,12 @@
 namespace :alerts do
   desc 'Run alerts job'
   task create: [:environment] do
-    puts Time.zone.now
+    puts "#{DateTime.now.utc} Generate alerts start"
     schools = School.process_data.with_config
     schools.each do |school|
       puts "Running all alerts for #{school.name}"
       Alerts::GenerateAndSaveAlertsAndBenchmarks.new(school: school).perform
     end
-    puts Time.zone.now
+    puts "#{DateTime.now.utc} Generate alerts end"
   end
 end

--- a/lib/tasks/alerts/generate_content.rake
+++ b/lib/tasks/alerts/generate_content.rake
@@ -1,7 +1,7 @@
 namespace :alerts do
   desc 'Run alert content job'
   task generate_content: [:environment] do
-    puts Time.zone.now
+    puts "#{DateTime.now.utc} Generate content start"
     schools = School.process_data.with_config
 
     schools.each do |school|
@@ -9,6 +9,6 @@ namespace :alerts do
       Alerts::GenerateContent.new(school).perform
     end
 
-    puts Time.zone.now
+    puts "#{DateTime.now.utc} Generate content end"
   end
 end

--- a/lib/tasks/alerts/generate_subscriptions.rake
+++ b/lib/tasks/alerts/generate_subscriptions.rake
@@ -1,7 +1,7 @@
 namespace :alerts do
   desc 'Run alert subscription job'
   task generate_subscriptions: [:environment] do
-    puts Time.zone.now
+    puts "#{DateTime.now.utc} Generate subscriptions start"
     schools = School.process_data.visible.with_config
 
     schools.each do |school|
@@ -14,6 +14,6 @@ namespace :alerts do
       Alerts::GenerateSubscriptions.new(school).perform(subscription_frequency: subscription_frequency)
     end
 
-    puts Time.zone.now
+    puts "#{DateTime.now.utc} Generate subscriptions end"
   end
 end

--- a/lib/tasks/amr_importer/notifier.rake
+++ b/lib/tasks/amr_importer/notifier.rake
@@ -1,6 +1,8 @@
 namespace :amr_importer do
   desc "Send daily notification email of imports"
   task send_daily_notification_email: :environment do
+    puts "#{DateTime.now.utc} Import notifier start"
     ImportNotifier.new(description: 'daily imports').notify(from: 24.hours.ago, to: Time.zone.now)
+    puts "#{DateTime.now.utc} Import notifier end"
   end
 end

--- a/lib/tasks/amr_importer/validate_amr_readings.rake
+++ b/lib/tasks/amr_importer/validate_amr_readings.rake
@@ -1,7 +1,7 @@
 namespace :amr_importer do
   desc "Validate readings"
   task validate_amr_readings: :environment do
-    puts DateTime.now.utc
+    puts "#{DateTime.now.utc} Validate AMR readings start"
     total_amr_readings_before = AmrValidatedReading.count
     puts "Total AMR Readings before: #{total_amr_readings_before}"
 
@@ -22,6 +22,6 @@ namespace :amr_importer do
 
     total_amr_readings_after = AmrValidatedReading.count
     puts "Total AMR Readings after: #{total_amr_readings_after} - inserted: #{total_amr_readings_after - total_amr_readings_before}"
-    puts DateTime.now.utc
+    puts "#{DateTime.now.utc} Validate AMR readings end"
   end
 end

--- a/lib/tasks/content_batch.rake
+++ b/lib/tasks/content_batch.rake
@@ -1,7 +1,9 @@
 namespace :content do
-  desc "Validate readings"
+  desc "Content batch"
   task batch: :environment do
+    puts "#{DateTime.now.utc} Content batch start"
     Rails.cache.clear
     ContentBatch.new(School.process_data.order(:name)).generate
+    puts "#{DateTime.now.utc} Content batch end"
   end
 end

--- a/lib/tasks/equivalences/create_equivalences.rake
+++ b/lib/tasks/equivalences/create_equivalences.rake
@@ -1,7 +1,8 @@
 namespace :equivalences do
   desc 'Run equivalences job'
   task create: [:environment] do
-    puts Time.zone.now
+    puts "#{DateTime.now.utc} Generate equivalences start"
+
     schools = School.process_data.with_config
     schools.each do |school|
       begin
@@ -13,6 +14,6 @@ namespace :equivalences do
       end
 
     end
-    puts Time.zone.now
+    puts "#{DateTime.now.utc} Generate equivalences end"
   end
 end

--- a/lib/tasks/generate_benchmarks.rake
+++ b/lib/tasks/generate_benchmarks.rake
@@ -1,6 +1,8 @@
 namespace :generate do
-  desc "Validate readings"
+  desc "Generate benchmarks"
   task benchmarks: :environment do
+    puts "#{DateTime.now.utc} Generate benchmarks start"
     GenerateBenchmarks.new(School.process_data).generate
+    puts "#{DateTime.now.utc} Generate benchmarks end"
   end
 end


### PR DESCRIPTION
Some of the background tasks weren't using consistent log messages to record start/end times, backing it difficult to identify run times.

This fixes up some of the tasks.