### PR TITLE
Rename alert contact field; remove newsletter from edit

### DIFF
--- a/app/controllers/concerns/alert_contact_creator.rb
+++ b/app/controllers/concerns/alert_contact_creator.rb
@@ -3,11 +3,40 @@ module AlertContactCreator
 
   private
 
+  def existing_alert_contact?(school, user)
+    user.contacts.where(school: school).any?
+  end
+
+  def update_alert_contact(school, user)
+    if auto_create_alert_contact?
+      create_or_update_alert_contact(school, user)
+    elsif existing_alert_contact?(school, user)
+      delete_contact(school, user)
+    end
+  end
+
+  def create_or_update_alert_contact(school, user)
+    if existing_alert_contact?(school, user)
+      contact = user.contacts.where(school: school).first
+      contact.update!(
+        email_address: user.email,
+        name: user.name,
+        staff_role_id: user.staff_role_id
+      )
+    else
+      Contact.create!(email_address: user.email, name: user.name, school: school, user: user, staff_role_id: user.staff_role_id)
+    end
+  end
+
   def create_alert_contact(school, user)
     Contact.create!(email_address: user.email, name: user.name, school: school, user: user, staff_role_id: user.staff_role_id)
   end
 
+  def delete_contact(_school, user)
+    user.contacts.where(school: @school).delete_all
+  end
+
   def auto_create_alert_contact?
-    params[:user] && params[:user].key?(:auto_create_alert_contact)
+    params[:contact] && params[:contact][:auto_create_alert_contact] && ActiveModel::Type::Boolean.new.cast(params[:contact][:auto_create_alert_contact])
   end
 end

--- a/app/controllers/schools/cluster_admins_controller.rb
+++ b/app/controllers/schools/cluster_admins_controller.rb
@@ -13,7 +13,7 @@ module Schools
       if user
         user.add_cluster_school(@school)
         if user.save
-          create_alert_contact(@school, user) if auto_create_alert_contact?
+          create_or_update_alert_contact(@school, user) if auto_create_alert_contact?
         end
         redirect_to school_users_path(@school), notice: "User added as school admin"
       else
@@ -25,7 +25,7 @@ module Schools
     private
 
     def user_params
-      params.require(:user).permit(:email, :auto_create_alert_contact)
+      params.require(:user).permit(:email)
     end
   end
 end

--- a/app/controllers/schools/school_admins_controller.rb
+++ b/app/controllers/schools/school_admins_controller.rb
@@ -32,6 +32,7 @@ module Schools
       @school_admin = @school.find_user_or_cluster_user_by_id(params[:id])
       authorize! :update, @school_admin
       if @school_admin.update(school_admin_params)
+        update_alert_contact(@school, @school_admin)
         redirect_to school_users_path(@school)
       else
         render :edit

--- a/app/controllers/schools/staff_controller.rb
+++ b/app/controllers/schools/staff_controller.rb
@@ -31,6 +31,7 @@ module Schools
       @staff = @school.users.staff.find(params[:id])
       authorize! :update, @staff
       if @staff.update(staff_params)
+        update_alert_contact(@school, @staff)
         redirect_to school_users_path(@school)
       else
         render :edit

--- a/app/views/schools/cluster_admins/new.html.erb
+++ b/app/views/schools/cluster_admins/new.html.erb
@@ -16,8 +16,8 @@
   <%= f.input :email, required: :true %>
 
   <div class="custom-control custom-checkbox pb-3">
-    <input type="checkbox" class="custom-control-input" id="user_auto_create_alert_contact" name="user[auto_create_alert_contact]" checked >
-    <label class="custom-control-label" for="user_auto_create_alert_contact">Subscribe to school alerts</label>
+    <input type="checkbox" class="custom-control-input" id="contact_auto_create_alert_contact" name="contact[auto_create_alert_contact]" checked >
+    <label class="custom-control-label" for="contact_auto_create_alert_contact">Subscribe to school alerts</label>
   </div>
 
   <%= f.submit 'Add user', class: 'btn btn-rounded'%>

--- a/app/views/schools/school_admins/_form.html.erb
+++ b/app/views/schools/school_admins/_form.html.erb
@@ -1,6 +1,3 @@
 <%= f.input :name, required: :true %>
 <%= f.input :email, required: :true %>
 <%= f.input :staff_role_id, label: 'Role', required: :true, collection: StaffRole.order(:title), label_method: :title, hint: 'What is their primary role in relation to Energy Sparks?'%>
-
-<%= render 'schools/users/auto_create_alert_contact' %>
-<%= render 'schools/users/auto_subscribe_newsletter' %>

--- a/app/views/schools/school_admins/edit.html.erb
+++ b/app/views/schools/school_admins/edit.html.erb
@@ -2,6 +2,6 @@
 
 <%= simple_form_for @school_admin, url: school_school_admin_path(@school, @school_admin) do |f| %>
   <%= render 'form', f: f %>
-  <%= render 'schools/users/auto_create_alert_contact' %>
+  <%= render 'schools/users/auto_create_alert_contact', f: f, school: @school, user: @school_admin %>
   <%= f.submit 'Update account', class: 'btn btn-rounded'%>
 <% end %>

--- a/app/views/schools/school_admins/edit.html.erb
+++ b/app/views/schools/school_admins/edit.html.erb
@@ -2,5 +2,6 @@
 
 <%= simple_form_for @school_admin, url: school_school_admin_path(@school, @school_admin) do |f| %>
   <%= render 'form', f: f %>
+  <%= render 'schools/users/auto_create_alert_contact' %>
   <%= f.submit 'Update account', class: 'btn btn-rounded'%>
 <% end %>

--- a/app/views/schools/school_admins/new.html.erb
+++ b/app/views/schools/school_admins/new.html.erb
@@ -4,7 +4,7 @@
 </p>
 <%= simple_form_for @school_admin, url: school_school_admins_path(@school) do |f| %>
   <%= render 'form', f: f %>
-  <%= render 'schools/users/auto_create_alert_contact' %>
+  <%= render 'schools/users/auto_create_alert_contact', f: f, school: @school, user: @school_admin %>
   <%= render 'schools/users/auto_subscribe_newsletter' %>
   <%= f.submit 'Create account', class: 'btn btn-rounded'%>
 <% end %>

--- a/app/views/schools/school_admins/new.html.erb
+++ b/app/views/schools/school_admins/new.html.erb
@@ -4,5 +4,7 @@
 </p>
 <%= simple_form_for @school_admin, url: school_school_admins_path(@school) do |f| %>
   <%= render 'form', f: f %>
+  <%= render 'schools/users/auto_create_alert_contact' %>
+  <%= render 'schools/users/auto_subscribe_newsletter' %>
   <%= f.submit 'Create account', class: 'btn btn-rounded'%>
 <% end %>

--- a/app/views/schools/staff/_form.html.erb
+++ b/app/views/schools/staff/_form.html.erb
@@ -1,6 +1,3 @@
 <%= f.input :name, required: :true %>
 <%= f.input :email, required: :true %>
 <%= f.input :staff_role_id, label: 'Role', required: :true, collection: StaffRole.order(:title), label_method: :title, hint: 'What is their primary role in relation to Energy Sparks?'%>
-
-<%= render 'schools/users/auto_create_alert_contact' %>
-<%= render 'schools/users/auto_subscribe_newsletter' %>

--- a/app/views/schools/staff/edit.html.erb
+++ b/app/views/schools/staff/edit.html.erb
@@ -2,6 +2,6 @@
 
 <%= simple_form_for @staff, url: school_staff_path(@school, @staff) do |f| %>
   <%= render 'form', f: f %>
-  <%= render 'schools/users/auto_create_alert_contact' %>
+  <%= render 'schools/users/auto_create_alert_contact', f: f, school: @school, user: @staff %>
   <%= f.submit 'Update account', class: 'btn btn-rounded'%>
 <% end %>

--- a/app/views/schools/staff/edit.html.erb
+++ b/app/views/schools/staff/edit.html.erb
@@ -2,5 +2,6 @@
 
 <%= simple_form_for @staff, url: school_staff_path(@school, @staff) do |f| %>
   <%= render 'form', f: f %>
+  <%= render 'schools/users/auto_create_alert_contact' %>
   <%= f.submit 'Update account', class: 'btn btn-rounded'%>
 <% end %>

--- a/app/views/schools/staff/new.html.erb
+++ b/app/views/schools/staff/new.html.erb
@@ -4,7 +4,7 @@
 </p>
 <%= simple_form_for @staff, url: school_staff_index_path(@school) do |f| %>
   <%= render 'form', f: f %>
-  <%= render 'schools/users/auto_create_alert_contact' %>
+  <%= render 'schools/users/auto_create_alert_contact', f: f, school: @school, user: @staff %>
   <%= render 'schools/users/auto_subscribe_newsletter' %>
   <%= f.submit 'Create account', class: 'btn btn-rounded'%>
 <% end %>

--- a/app/views/schools/staff/new.html.erb
+++ b/app/views/schools/staff/new.html.erb
@@ -4,5 +4,7 @@
 </p>
 <%= simple_form_for @staff, url: school_staff_index_path(@school) do |f| %>
   <%= render 'form', f: f %>
+  <%= render 'schools/users/auto_create_alert_contact' %>
+  <%= render 'schools/users/auto_subscribe_newsletter' %>
   <%= f.submit 'Create account', class: 'btn btn-rounded'%>
 <% end %>

--- a/app/views/schools/users/_auto_create_alert_contact.html.erb
+++ b/app/views/schools/users/_auto_create_alert_contact.html.erb
@@ -8,7 +8,6 @@
 </ul>
 <p>Short term consumption change alerts are sent weekly. Alerts telling you about your long term energy use are sent termly.</p>
 
-<div class="custom-control custom-checkbox pb-3">
-  <input type="checkbox" class="custom-control-input" id="user_auto_create_alert_contact" name="user[auto_create_alert_contact]" checked >
-  <label class="custom-control-label" for="user_auto_create_alert_contact">Subscribe to alerts</label>
-</div>
+<%= simple_fields_for :contact do |n| %>
+  <%= n.input :auto_create_alert_contact, label: "Subscribe to school alerts", as: :boolean, class: "custom-checkbox pb-3", wrapper_html: { id: "test", class: "custom-checkbox pb-3"}, label_html: {class: "custom-control-label"}, input_html: { class: "custom-control-input", checked: user.persisted? ? user.contacts.where(school: school).any? : true } %>
+<% end %>

--- a/app/views/schools/users/_auto_create_alert_contact.html.erb
+++ b/app/views/schools/users/_auto_create_alert_contact.html.erb
@@ -1,4 +1,4 @@
-<p>Energy Sparks can automatically create an alert contact so you can receive alert notificiations by email or SMS.</p>
+<p>Energy Sparks can automatically create an alert contact so you can receive alert notifications by email or SMS.</p>
 
 <p> Energy Sparks alerts:</p>
 <ul>
@@ -10,5 +10,5 @@
 
 <div class="custom-control custom-checkbox pb-3">
   <input type="checkbox" class="custom-control-input" id="user_auto_create_alert_contact" name="user[auto_create_alert_contact]" checked >
-  <label class="custom-control-label" for="user_auto_create_alert_contact">Auto create alert contact</label>
+  <label class="custom-control-label" for="user_auto_create_alert_contact">Subscribe to alerts</label>
 </div>

--- a/spec/system/school_admin/user_management_spec.rb
+++ b/spec/system/school_admin/user_management_spec.rb
@@ -78,7 +78,7 @@ describe 'School admin user management' do
       end
 
       it 'can create staff without generating an alert contact' do
-        uncheck 'Subscribe to alerts'
+        uncheck 'Subscribe to school alerts'
         expect { click_on 'Create account' }.to change { User.count }.by(1).and change { Contact.count }.by(0)
 
         staff = school.users.staff.first
@@ -112,6 +112,25 @@ describe 'School admin user management' do
       expect(school.users.staff.count).to eq(0)
     end
 
+    it 'can edit alert contact' do
+      staff = create(:staff, school: school)
+      contact = create(:contact, name: staff.name, user: staff, email_address: staff.email, school: school)
+      click_on 'Manage users'
+      within '.staff' do
+        click_on 'Edit'
+      end
+
+      uncheck "Subscribe to school alerts"
+      expect { click_on 'Update account' }.to change { Contact.count }.by(-1)
+
+      within '.staff' do
+        click_on 'Edit'
+      end
+      expect(page).to_not have_checked_field('contact_auto_create_alert_contact')
+      check "Subscribe to school alerts"
+      expect { click_on 'Update account' }.to change { Contact.count }.by(1)
+
+    end
   end
 
   describe 'managing school admins' do
@@ -147,7 +166,7 @@ describe 'School admin user management' do
       end
 
       it 'doesnt create contact when requested' do
-        uncheck 'Subscribe to alerts'
+        uncheck 'Subscribe to school alerts'
         expect { click_on 'Create account' }.to change { User.count }.by(1).and change { Contact.count }.by(0)
       end
 
@@ -178,6 +197,34 @@ describe 'School admin user management' do
         expect(page).to have_content("Ms Jones")
         new_admin.reload
         expect(new_admin.name).to eq('Ms Jones')
+      end
+
+      it 'can edit alert contact' do
+        within '.school_admin' do
+          #this avoids problems with ambiguous matches in find/click_on
+          #find the row for the new admin, using name set above
+          tr = find(:xpath, "//td", text: new_admin.name).ancestor("tr")
+          #click on the edit for that row
+          within tr do
+            click_on 'Edit'
+          end
+        end
+        uncheck "Subscribe to school alerts"
+        expect { click_on 'Update account' }.to change { Contact.count }.by(-1)
+
+        within '.school_admin' do
+          #this avoids problems with ambiguous matches in find/click_on
+          #find the row for the new admin, using name set above
+          tr = find(:xpath, "//td", text: new_admin.name).ancestor("tr")
+          #click on the edit for that row
+          within tr do
+            click_on 'Edit'
+          end
+        end
+        expect(page).to_not have_checked_field('contact_auto_create_alert_contact')
+        check "Subscribe to school alerts"
+        expect { click_on 'Update account' }.to change { Contact.count }.by(1)
+
       end
 
       context 'when deleting' do

--- a/spec/system/school_admin/user_management_spec.rb
+++ b/spec/system/school_admin/user_management_spec.rb
@@ -78,7 +78,7 @@ describe 'School admin user management' do
       end
 
       it 'can create staff without generating an alert contact' do
-        uncheck 'Auto create alert contact'
+        uncheck 'Subscribe to alerts'
         expect { click_on 'Create account' }.to change { User.count }.by(1).and change { Contact.count }.by(0)
 
         staff = school.users.staff.first
@@ -147,7 +147,7 @@ describe 'School admin user management' do
       end
 
       it 'doesnt create contact when requested' do
-        uncheck 'Auto create alert contact'
+        uncheck 'Subscribe to alerts'
         expect { click_on 'Create account' }.to change { User.count }.by(1).and change { Contact.count }.by(0)
       end
 


### PR DESCRIPTION
Some of the school admin and staff form fields didn't actually do anything on edit. This: 

* removes the mailchimp sign-up (pending separate changes) on the edit form
* improves label of checkbox for alert contacts
* makes the checkbox functional a new contact is created, existing one updated, or removed depending on option selected