### PR TITLE
1528 rework of rbee interface for newport

### DIFF
--- a/.ebextensions/cronjob.config
+++ b/.ebextensions/cronjob.config
@@ -91,6 +91,13 @@ files:
         content: |
             00 5 * * * root /bin/bash -l -c 'cd /var/app/current && RAILS_ENV=production bin/run_as_webapp bundle exec rake amr:import_low_carbon_hub_readings >> log/jobs.log 2>&1'
 
+    "/etc/cron.d/import-rtone-variant-data":
+        mode: "000644"
+        owner: root
+        group: root
+        content: |
+            15 5 * * * root /bin/bash -l -c 'cd /var/app/current && RAILS_ENV=production bin/run_as_webapp bundle exec rake solar:import_rtone_variant_readings >> log/jobs.log 2>&1'
+
     #
     # Import Solar Edge data
     #

--- a/Gemfile
+++ b/Gemfile
@@ -22,8 +22,8 @@ gem 'auto_strip_attributes', '~> 2.5'
 gem 'closed_struct'
 
 # Dashboard analytics
-gem 'energy-sparks_analytics', git: 'https://github.com/Energy-Sparks/energy-sparks_analytics.git', tag: '1.19.9'
-# gem 'energy-sparks_analytics', git: 'https://github.com/Energy-Sparks/energy-sparks_analytics.git', branch: 'reintroduce-default-accounting-tariff'
+#gem 'energy-sparks_analytics', git: 'https://github.com/Energy-Sparks/energy-sparks_analytics.git', tag: '1.19.8'
+gem 'energy-sparks_analytics', git: 'https://github.com/Energy-Sparks/energy-sparks_analytics.git', branch: 'rtone-variant'
 #gem 'energy-sparks_analytics', path: '../energy-sparks_analytics'
 
 # Using master due to it having a patch which doesn't override Enumerable#sum if it's already defined

--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ gem 'closed_struct'
 
 # Dashboard analytics
 #gem 'energy-sparks_analytics', git: 'https://github.com/Energy-Sparks/energy-sparks_analytics.git', tag: '1.19.8'
-gem 'energy-sparks_analytics', git: 'https://github.com/Energy-Sparks/energy-sparks_analytics.git', branch: 'rtone-variant'
+gem 'energy-sparks_analytics', git: 'https://github.com/Energy-Sparks/energy-sparks_analytics.git', branch: 'aws-eb-test'
 #gem 'energy-sparks_analytics', path: '../energy-sparks_analytics'
 
 # Using master due to it having a patch which doesn't override Enumerable#sum if it's already defined

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/Energy-Sparks/energy-sparks_analytics.git
-  revision: b5bed94652bdcbff78c6e2545283eaf078416e93
+  revision: c07740fc3914960ab098ac4bcd8ce5ba159dc1f2
   branch: aws-eb-test
   specs:
     energy-sparks_analytics (1.2.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/Energy-Sparks/energy-sparks_analytics.git
-  revision: cf84ee7428615a44749ba35c25599158d2349a22
-  tag: 1.19.9
+  revision: a2d032840df87600a5abb0ab96335e334fd3b246
+  branch: rtone-variant
   specs:
     energy-sparks_analytics (1.2.1)
       activesupport (~> 6.0.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/Energy-Sparks/energy-sparks_analytics.git
-  revision: a2d032840df87600a5abb0ab96335e334fd3b246
-  branch: rtone-variant
+  revision: b5bed94652bdcbff78c6e2545283eaf078416e93
+  branch: aws-eb-test
   specs:
     energy-sparks_analytics (1.2.1)
       activesupport (~> 6.0.0)

--- a/app/controllers/schools/rtone_variant_installations_controller.rb
+++ b/app/controllers/schools/rtone_variant_installations_controller.rb
@@ -42,7 +42,7 @@ module Schools
 
     def rtone_variant_installation_params
       params.require(:rtone_variant_installation).permit(
-        :amr_data_feed_config_id, :meter_id, :rtone_meter_id, :rtone_meter_type, :username, :password
+        :amr_data_feed_config_id, :meter_id, :rtone_meter_id, :rtone_component_type, :username, :password
       )
     end
   end

--- a/app/controllers/schools/rtone_variant_installations_controller.rb
+++ b/app/controllers/schools/rtone_variant_installations_controller.rb
@@ -1,0 +1,49 @@
+module Schools
+  class RtoneVariantInstallationsController < ApplicationController
+    load_and_authorize_resource :school
+    load_and_authorize_resource through: :school
+
+    before_action :load_non_gas_meters
+
+    def new
+      @rtone_variant_installation = RtoneVariantInstallation.new
+      @rtone_variant_installation.meter = @non_gas_meters.first
+    end
+
+    def create
+      if @rtone_variant_installation.save
+        redirect_to school_solar_feeds_configuration_index_path(@school), notice: 'New Rtone Variant API feed created.'
+      else
+        render :new
+      end
+    end
+
+    def edit
+    end
+
+    def update
+      if @rtone_variant_installation.update(rtone_variant_installation_params)
+        redirect_to school_solar_feeds_configuration_index_path(@school), notice: 'New Rtone Variant API feed updated.'
+      else
+        render :edit
+      end
+    end
+
+    def destroy
+      @rtone_variant_installation.destroy
+      redirect_to school_solar_feeds_configuration_index_path(@school), notice: 'New Rtone Variant API feed deleted.'
+    end
+
+    private
+
+    def load_non_gas_meters
+      @non_gas_meters = @school.meters.where.not(meter_type: :gas)
+    end
+
+    def rtone_variant_installation_params
+      params.require(:rtone_variant_installation).permit(
+        :amr_data_feed_config_id, :meter_id, :rtone_meter_id, :rtone_meter_type, :username, :password
+      )
+    end
+  end
+end

--- a/app/controllers/schools/solar_feeds_configuration_controller.rb
+++ b/app/controllers/schools/solar_feeds_configuration_controller.rb
@@ -6,6 +6,7 @@ module Schools
       @start_time = formatted_localised_utc_time('12pm')
       @end_time = formatted_localised_utc_time('1pm')
       @rtone_installations = @school.low_carbon_hub_installations
+      @rtone_variant_installations = @school.rtone_variant_installations
       @solar_edge_installations = @school.solar_edge_installations
     end
 

--- a/app/models/amr_data_feed_config.rb
+++ b/app/models/amr_data_feed_config.rb
@@ -35,7 +35,7 @@
 #
 
 class AmrDataFeedConfig < ApplicationRecord
-  enum process_type: [:s3_folder, :low_carbon_hub_api, :solar_edge_api, :n3rgy_api]
+  enum process_type: [:s3_folder, :low_carbon_hub_api, :solar_edge_api, :n3rgy_api, :rtone_variant_api]
   enum source_type: [:email, :manual, :api, :sftp]
 
   has_many :amr_data_feed_import_logs

--- a/app/models/meter.rb
+++ b/app/models/meter.rb
@@ -16,6 +16,7 @@
 #  mpan_mprn                      :bigint(8)
 #  name                           :string
 #  pseudo                         :boolean          default(FALSE)
+#  rtone_variant_installation_id  :bigint(8)
 #  sandbox                        :boolean          default(FALSE)
 #  school_id                      :bigint(8)        not null
 #  solar_edge_installation_id     :bigint(8)
@@ -27,6 +28,7 @@
 #  index_meters_on_meter_review_id                 (meter_review_id)
 #  index_meters_on_meter_type                      (meter_type)
 #  index_meters_on_mpan_mprn                       (mpan_mprn) UNIQUE
+#  index_meters_on_rtone_variant_installation_id   (rtone_variant_installation_id)
 #  index_meters_on_school_id                       (school_id)
 #  index_meters_on_solar_edge_installation_id      (solar_edge_installation_id)
 #
@@ -34,6 +36,7 @@
 #
 #  fk_rails_...  (low_carbon_hub_installation_id => low_carbon_hub_installations.id) ON DELETE => cascade
 #  fk_rails_...  (meter_review_id => meter_reviews.id)
+#  fk_rails_...  (rtone_variant_installation_id => rtone_variant_installations.id)
 #  fk_rails_...  (school_id => schools.id) ON DELETE => cascade
 #  fk_rails_...  (solar_edge_installation_id => solar_edge_installations.id) ON DELETE => cascade
 #
@@ -42,6 +45,7 @@ class Meter < ApplicationRecord
   belongs_to :school, inverse_of: :meters
   belongs_to :low_carbon_hub_installation, optional: true
   belongs_to :solar_edge_installation, optional: true
+  has_one :rtone_variant_installation, required: false
 
   has_many :amr_data_feed_readings,     inverse_of: :meter, dependent: :destroy
   has_many :amr_validated_readings,     inverse_of: :meter, dependent: :destroy

--- a/app/models/meter.rb
+++ b/app/models/meter.rb
@@ -16,7 +16,6 @@
 #  mpan_mprn                      :bigint(8)
 #  name                           :string
 #  pseudo                         :boolean          default(FALSE)
-#  rtone_variant_installation_id  :bigint(8)
 #  sandbox                        :boolean          default(FALSE)
 #  school_id                      :bigint(8)        not null
 #  solar_edge_installation_id     :bigint(8)
@@ -28,7 +27,6 @@
 #  index_meters_on_meter_review_id                 (meter_review_id)
 #  index_meters_on_meter_type                      (meter_type)
 #  index_meters_on_mpan_mprn                       (mpan_mprn) UNIQUE
-#  index_meters_on_rtone_variant_installation_id   (rtone_variant_installation_id)
 #  index_meters_on_school_id                       (school_id)
 #  index_meters_on_solar_edge_installation_id      (solar_edge_installation_id)
 #
@@ -36,7 +34,6 @@
 #
 #  fk_rails_...  (low_carbon_hub_installation_id => low_carbon_hub_installations.id) ON DELETE => cascade
 #  fk_rails_...  (meter_review_id => meter_reviews.id)
-#  fk_rails_...  (rtone_variant_installation_id => rtone_variant_installations.id)
 #  fk_rails_...  (school_id => schools.id) ON DELETE => cascade
 #  fk_rails_...  (solar_edge_installation_id => solar_edge_installations.id) ON DELETE => cascade
 #

--- a/app/models/rtone_variant_installation.rb
+++ b/app/models/rtone_variant_installation.rb
@@ -1,0 +1,34 @@
+# == Schema Information
+#
+# Table name: rtone_variant_installations
+#
+#  amr_data_feed_config_id :bigint(8)        not null
+#  created_at              :datetime         not null
+#  id                      :bigint(8)        not null, primary key
+#  password                :string
+#  rtone_meter_id          :string
+#  rtone_meter_type        :integer
+#  school_id               :bigint(8)        not null
+#  updated_at              :datetime         not null
+#  username                :string
+#
+# Indexes
+#
+#  index_rtone_variant_installations_on_amr_data_feed_config_id  (amr_data_feed_config_id)
+#  index_rtone_variant_installations_on_school_id                (school_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (amr_data_feed_config_id => amr_data_feed_configs.id)
+#  fk_rails_...  (school_id => schools.id)
+#
+class RtoneVariantInstallation < ApplicationRecord
+  belongs_to :school
+  belongs_to :amr_data_feed_config
+  belongs_to :meter
+
+  enum rtone_meter_type: [:prod, :in1, :out1]
+
+  validates_presence_of :school, :rtone_meter_id, :rtone_meter_type, :username, :password
+  validates_uniqueness_of :rtone_meter_id, scope: :school
+end

--- a/app/models/rtone_variant_installation.rb
+++ b/app/models/rtone_variant_installation.rb
@@ -7,12 +7,12 @@
 #  created_at              :datetime         not null
 #  id                      :bigint(8)        not null, primary key
 #  meter_id                :bigint(8)        not null
-#  password                :string
-#  rtone_component_type    :integer
-#  rtone_meter_id          :string
+#  password                :string           not null
+#  rtone_component_type    :integer          not null
+#  rtone_meter_id          :string           not null
 #  school_id               :bigint(8)        not null
 #  updated_at              :datetime         not null
-#  username                :string
+#  username                :string           not null
 #
 # Indexes
 #

--- a/app/models/rtone_variant_installation.rb
+++ b/app/models/rtone_variant_installation.rb
@@ -3,11 +3,13 @@
 # Table name: rtone_variant_installations
 #
 #  amr_data_feed_config_id :bigint(8)        not null
+#  configuration           :json
 #  created_at              :datetime         not null
 #  id                      :bigint(8)        not null, primary key
+#  meter_id                :bigint(8)        not null
 #  password                :string
+#  rtone_component_type    :integer
 #  rtone_meter_id          :string
-#  rtone_meter_type        :integer
 #  school_id               :bigint(8)        not null
 #  updated_at              :datetime         not null
 #  username                :string
@@ -15,11 +17,13 @@
 # Indexes
 #
 #  index_rtone_variant_installations_on_amr_data_feed_config_id  (amr_data_feed_config_id)
+#  index_rtone_variant_installations_on_meter_id                 (meter_id)
 #  index_rtone_variant_installations_on_school_id                (school_id)
 #
 # Foreign Keys
 #
 #  fk_rails_...  (amr_data_feed_config_id => amr_data_feed_configs.id)
+#  fk_rails_...  (meter_id => meters.id)
 #  fk_rails_...  (school_id => schools.id)
 #
 class RtoneVariantInstallation < ApplicationRecord
@@ -27,8 +31,14 @@ class RtoneVariantInstallation < ApplicationRecord
   belongs_to :amr_data_feed_config
   belongs_to :meter
 
-  enum rtone_meter_type: [:prod, :in1, :out1]
+  enum rtone_component_type: [:prod, :in1, :out1, :in2]
 
-  validates_presence_of :school, :rtone_meter_id, :rtone_meter_type, :username, :password
+  validates_presence_of :school, :meter, :rtone_meter_id, :rtone_component_type, :username, :password
   validates_uniqueness_of :rtone_meter_id, scope: :school
+
+  def latest_electricity_reading
+    if meter.amr_data_feed_readings.any
+      Date.parse(meter.amr_data_feed_readings.order(reading_date: :desc).first.reading_date)
+    end
+  end
 end

--- a/app/models/rtone_variant_installation.rb
+++ b/app/models/rtone_variant_installation.rb
@@ -37,7 +37,7 @@ class RtoneVariantInstallation < ApplicationRecord
   validates_uniqueness_of :rtone_meter_id, scope: :school
 
   def latest_electricity_reading
-    if meter.amr_data_feed_readings.any
+    if meter.amr_data_feed_readings.any?
       Date.parse(meter.amr_data_feed_readings.order(reading_date: :desc).first.reading_date)
     end
   end

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -96,6 +96,7 @@ class School < ApplicationRecord
 
   has_many :low_carbon_hub_installations, inverse_of: :school
   has_many :solar_edge_installations, inverse_of: :school
+  has_many :rtone_variant_installations, inverse_of: :school
 
   has_many :equivalences
 

--- a/app/models/user_tariff_charge.rb
+++ b/app/models/user_tariff_charge.rb
@@ -5,7 +5,7 @@
 #  charge_type    :text             not null
 #  created_at     :datetime         not null
 #  id             :bigint(8)        not null, primary key
-#  units          :text             not null
+#  units          :text
 #  updated_at     :datetime         not null
 #  user_tariff_id :bigint(8)        not null
 #  value          :decimal(, )      not null

--- a/app/services/solar/rtone_variant_download_and_upsert.rb
+++ b/app/services/solar/rtone_variant_download_and_upsert.rb
@@ -6,16 +6,51 @@ module Solar
         end_date:
       )
       @rtone_variant_installation = rtone_variant_installation
-      @start_date = start_date
-      @end_date = end_date
+      @requested_start_date = start_date
+      @requested_end_date = end_date
+      @import_log = create_import_log
     end
 
     def perform
-      readings = RtoneVariantDownloader.new(rtone_variant_installation: @rtone_variant_installation, start_date: @start_date, end_date: @end_date, low_carbon_hub_api: low_carbon_hub_api).readings
-      RtoneVariantUpserter.new(rtone_variant_installation: @rtone_variant_installation, readings: readings).perform
+      readings = RtoneVariantDownloader.new(rtone_variant_installation: @rtone_variant_installation, start_date: start_date, end_date: end_date, low_carbon_hub_api: low_carbon_hub_api).readings
+
+      RtoneVariantUpserter.new(rtone_variant_installation: @rtone_variant_installation, readings: readings, import_log: @import_log).perform
+    rescue => e
+      @import_log.update!(error_messages: "Error downloading data from #{start_date} to #{end_date} : #{e.message}")
+      Rails.logger.error "Exception: downloading Rtone data for #{meter.mpan_mprn} from #{start_date} to #{end_date} : #{e.class} #{e.message}"
+      Rails.logger.error e.backtrace.join("\n")
+      Rollbar.error(e, job: :rtone_variant_download, school: @rtone_variant_installation.school.name, meter_id: meter.mpan_mprn, start_date: start_date, end_date: end_date)
     end
 
     private
+
+    def start_date
+      default_start_date = Date.yesterday - 5
+      if @requested_start_date
+        @requested_start_date
+      else
+        latest_reading && latest_reading < default_start_date ? latest_reading : default_start_date
+      end
+    end
+
+    def end_date
+      @requested_end_date.present? ? @requested_end_date : Date.yesterday
+    end
+
+    def meter
+      @rtone_variant_installation.meter
+    end
+
+    def latest_reading
+      @rtone_variant_installation.latest_electricity_reading
+    end
+
+    def create_import_log
+      AmrDataFeedImportLog.create(
+        amr_data_feed_config: @rtone_variant_installation.amr_data_feed_config,
+        file_name: "Rtone Variant API import #{DateTime.now.utc}",
+        import_time: DateTime.now.utc)
+    end
 
     def low_carbon_hub_api
       @low_carbon_hub_api ||= LowCarbonHubMeterReadings.new(username, password)

--- a/app/services/solar/rtone_variant_download_and_upsert.rb
+++ b/app/services/solar/rtone_variant_download_and_upsert.rb
@@ -1,0 +1,32 @@
+module Solar
+  class RtoneVariantDownloadAndUpsert
+    def initialize(
+        rtone_variant_installation:,
+        start_date:,
+        end_date:
+      )
+      @rtone_variant_installation = rtone_variant_installation
+      @start_date = start_date
+      @end_date = end_date
+    end
+
+    def perform
+      readings = RtoneVariantDownloader.new(rtone_variant_installation: @rtone_variant_installation, start_date: @start_date, end_date: @end_date, low_carbon_hub_api: low_carbon_hub_api).readings
+      RtoneVariantUpserter.new(rtone_variant_installation: @rtone_variant_installation, readings: readings).perform
+    end
+
+    private
+
+    def low_carbon_hub_api
+      @low_carbon_hub_api ||= LowCarbonHubMeterReadings.new(username, password)
+    end
+
+    def username
+      @rtone_variant_installation.username
+    end
+
+    def password
+      @rtone_variant_installation.password
+    end
+  end
+end

--- a/app/services/solar/rtone_variant_downloader.rb
+++ b/app/services/solar/rtone_variant_downloader.rb
@@ -1,0 +1,27 @@
+require 'dashboard'
+
+module Solar
+  class RtoneVariantDownloader
+    def initialize(
+        rtone_variant_installation:,
+        start_date:,
+        end_date:,
+        low_carbon_hub_api:
+      )
+      @rtone_variant_installation = rtone_variant_installation
+      @low_carbon_hub_api = low_carbon_hub_api
+      @start_date = start_date
+      @end_date = end_date
+    end
+
+    def readings
+      @low_carbon_hub_api.download_by_component(
+        @rtone_variant_installation.rtone_meter_id,
+        @rtone_variant_installation.rtone_component_type,
+        @rtone_variant_installation.meter.mpan_mprn,
+        @start_date,
+        @end_date
+      )
+    end
+  end
+end

--- a/app/services/solar/rtone_variant_upserter.rb
+++ b/app/services/solar/rtone_variant_upserter.rb
@@ -2,35 +2,40 @@ require 'dashboard'
 
 module Solar
   class RtoneVariantUpserter
-    def initialize(rtone_variant_installation:, readings:)
+    def initialize(rtone_variant_installation:, readings:, import_log:)
       @rtone_variant_installation = rtone_variant_installation
       @readings = readings
-      @amr_data_feed_config = @rtone_variant_installation.amr_data_feed_config
-      @amr_data_feed_import_log = AmrDataFeedImportLog.create(amr_data_feed_config_id: @amr_data_feed_config.id, file_name: "Rtone Variant API import #{DateTime.now.utc}", import_time: DateTime.now.utc)
+      @import_log = import_log
     end
 
     def perform
       Rails.logger.info "Upserting #{@readings.count} for #{@rtone_variant_installation.rtone_meter_id} at #{@rtone_variant_installation.school.name}"
 
-      readings_hash = @readings[:readings]
-      meter = @rtone_variant_installation.meter
+      Amr::DataFeedUpserter.new(data_feed_reading_array(@readings[:readings]), @import_log).perform
 
-      Amr::DataFeedUpserter.new(data_feed_reading_array(readings_hash, meter.id, meter.mpan_mprn), @amr_data_feed_import_log).perform
-      Rails.logger.info "Upserted #{@amr_data_feed_import_log.records_updated} inserted #{@amr_data_feed_import_log.records_imported}for #{@rtone_variant_installation.rtone_meter_id} at #{@rtone_variant_installation.school.name}"
+      Rails.logger.info "Upserted #{@import_log.records_updated} inserted #{@import_log.records_imported}for #{@rtone_variant_installation.rtone_meter_id} at #{@rtone_variant_installation.school.name}"
     end
 
     private
 
-    def data_feed_reading_array(readings_hash, meter_id, mpan_mprn)
+    def data_feed_reading_array(readings_hash)
       readings_hash.map do |reading_date, one_day_amr_reading|
         {
-          amr_data_feed_config_id: @amr_data_feed_config.id,
+          amr_data_feed_config_id: @rtone_variant_installation.amr_data_feed_config.id,
           meter_id: meter_id,
           mpan_mprn: mpan_mprn,
           reading_date: reading_date,
           readings: one_day_amr_reading.kwh_data_x48
         }
       end
+    end
+
+    def meter_id
+      @rtone_variant_installation.meter.id
+    end
+
+    def mpan_mprn
+      @rtone_variant_installation.meter.mpan_mprn
     end
   end
 end

--- a/app/services/solar/rtone_variant_upserter.rb
+++ b/app/services/solar/rtone_variant_upserter.rb
@@ -1,0 +1,36 @@
+require 'dashboard'
+
+module Solar
+  class RtoneVariantUpserter
+    def initialize(rtone_variant_installation:, readings:)
+      @rtone_variant_installation = rtone_variant_installation
+      @readings = readings
+      @amr_data_feed_config = @rtone_variant_installation.amr_data_feed_config
+      @amr_data_feed_import_log = AmrDataFeedImportLog.create(amr_data_feed_config_id: @amr_data_feed_config.id, file_name: "Rtone Variant API import #{DateTime.now.utc}", import_time: DateTime.now.utc)
+    end
+
+    def perform
+      Rails.logger.info "Upserting #{@readings.count} for #{@rtone_variant_installation.rtone_meter_id} at #{@rtone_variant_installation.school.name}"
+
+      readings_hash = @readings[:readings]
+      meter = @rtone_variant_installation.meter
+
+      Amr::DataFeedUpserter.new(data_feed_reading_array(readings_hash, meter.id, meter.mpan_mprn), @amr_data_feed_import_log).perform
+      Rails.logger.info "Upserted #{@amr_data_feed_import_log.records_updated} inserted #{@amr_data_feed_import_log.records_imported}for #{@rtone_variant_installation.rtone_meter_id} at #{@rtone_variant_installation.school.name}"
+    end
+
+    private
+
+    def data_feed_reading_array(readings_hash, meter_id, mpan_mprn)
+      readings_hash.map do |reading_date, one_day_amr_reading|
+        {
+          amr_data_feed_config_id: @amr_data_feed_config.id,
+          meter_id: meter_id,
+          mpan_mprn: mpan_mprn,
+          reading_date: reading_date,
+          readings: one_day_amr_reading.kwh_data_x48
+        }
+      end
+    end
+  end
+end

--- a/app/views/schools/rtone_variant_installations/_form.html.erb
+++ b/app/views/schools/rtone_variant_installations/_form.html.erb
@@ -7,7 +7,7 @@
   include_blank: false, label: "Energy Sparks Meter" %>
 
   <%= form.input :rtone_meter_id, as: :string, label: "Rtone Meter Id", disabled: rtone_variant_installation.persisted? %>
-  <%= form.input :rtone_meter_type, collection: RtoneVariantInstallation.rtone_meter_types.keys, include_blank: false, label: "Rtone Meter Type" %>
+  <%= form.input :rtone_component_type, collection: RtoneVariantInstallation.rtone_component_types.keys, include_blank: false, label: "Rtone Meter Type" %>
 
   <%= form.input :username, as: :string %>
   <%= form.input :password, as: :string %>

--- a/app/views/schools/rtone_variant_installations/_form.html.erb
+++ b/app/views/schools/rtone_variant_installations/_form.html.erb
@@ -1,0 +1,19 @@
+<%= simple_form_for [school, rtone_variant_installation] do |form| %>
+  <%= render 'shared/errors', subject: rtone_variant_installation, subject_name: 'rtone variant api feed' %>
+
+  <%= form.input :amr_data_feed_config_id, as: :hidden, input_html: { value: AmrDataFeedConfig.rtone_variant_api.first.id } %>
+
+  <%= form.input :meter_id, collection: non_gas_meters, label_method: :mpan_mprn, value_method: :id,
+  include_blank: false, label: "Energy Sparks Meter" %>
+
+  <%= form.input :rtone_meter_id, as: :string, label: "Rtone Meter Id", disabled: rtone_variant_installation.persisted? %>
+  <%= form.input :rtone_meter_type, collection: RtoneVariantInstallation.rtone_meter_types.keys, include_blank: false, label: "Rtone Meter Type" %>
+
+  <%= form.input :username, as: :string %>
+  <%= form.input :password, as: :string %>
+
+  <div class="actions">
+    <%= form.submit "Submit", class: 'btn btn-primary'%>
+  </div>
+
+<% end %>

--- a/app/views/schools/rtone_variant_installations/edit.html.erb
+++ b/app/views/schools/rtone_variant_installations/edit.html.erb
@@ -1,0 +1,8 @@
+<h1>Update Rtone Variant API feed</h1>
+<h2><%= @school.name %></h2>
+
+<%= render 'form', school: @school, rtone_variant_installation: @rtone_variant_installation, non_gas_meters: @non_gas_meters %>
+
+<div class="other-actions">
+  <%= link_to 'Cancel', school_solar_feeds_configuration_index_path(@school), class: 'btn' %>
+</div>

--- a/app/views/schools/rtone_variant_installations/new.html.erb
+++ b/app/views/schools/rtone_variant_installations/new.html.erb
@@ -1,0 +1,8 @@
+<h1>Create a new Rtone Variant API feed</h1>
+<h2><%= @school.name %></h2>
+
+<%= render 'form', school: @school, rtone_variant_installation: @rtone_variant_installation, non_gas_meters: @non_gas_meters %>
+
+<div class="other-actions">
+  <%= link_to 'Cancel', school_solar_feeds_configuration_index_path(@school), class: 'btn' %>
+</div>

--- a/app/views/schools/solar_feeds_configuration/_rtone_feeds.html.erb
+++ b/app/views/schools/solar_feeds_configuration/_rtone_feeds.html.erb
@@ -1,0 +1,34 @@
+<% if rtone_installations.any? %>
+  <table class="table table-sm">
+    <tbody>
+      <tr>
+        <th class="w-25">RBee Id</th>
+        <th class="w-25">Username</th>
+        <th>Password</th>
+        <th class="w-25">Actions</th>
+      </tr>
+      <% rtone_installations.each do |installation| %>
+        <tr>
+          <td>
+            <%= link_to installation.rbee_meter_id, school_low_carbon_hub_installation_path(school, installation)
+            %>
+          </td>
+          <td><%= installation.username %></td>
+          <td><%= installation.password %></td>
+          <td>
+            <p>
+              <%= link_to 'Edit', edit_school_low_carbon_hub_installation_path(school, installation), class: 'btn' %>
+              <%= link_to 'Delete', school_low_carbon_hub_installation_path(school, installation), method: :delete, data: { confirm: 'Are you sure?' }, class: 'btn' %>
+            </p>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+<% else %>
+  <p>This school has no Rtone API feeds</p>
+<% end %>
+
+<p class="alert alert-warning">You cannot create a new new Rtone installation, or download data from an installation, between <%= start_time %> and <%= end_time %></p>
+
+<p><%= link_to 'New Rtone API feed', new_school_low_carbon_hub_installation_path, class: 'btn' %></p>

--- a/app/views/schools/solar_feeds_configuration/_rtone_variant_feeds.html.erb
+++ b/app/views/schools/solar_feeds_configuration/_rtone_variant_feeds.html.erb
@@ -12,7 +12,7 @@
       <% rtone_variant_installations.each do |installation| %>
         <tr>
           <td><%= installation.rtone_meter_id %></td>
-          <td><%= installation.rtone_meter_type %></td>
+          <td><%= installation.rtone_component_type %></td>
           <td><%= installation.meter.mpan_mprn %></td>
           <td><%= installation.username %></td>
           <td><%= installation.password %></td>

--- a/app/views/schools/solar_feeds_configuration/_rtone_variant_feeds.html.erb
+++ b/app/views/schools/solar_feeds_configuration/_rtone_variant_feeds.html.erb
@@ -1,0 +1,33 @@
+<% if rtone_variant_installations.any? %>
+  <table class="table table-sm">
+    <tbody>
+      <tr>
+        <th>Rtone Id</th>
+        <th>Rtone Meter Type</th>
+        <th>Meter</th>
+        <th>Username</th>
+        <th>Password</th>
+        <th class="w-25">Actions</th>
+      </tr>
+      <% rtone_variant_installations.each do |installation| %>
+        <tr>
+          <td><%= installation.rtone_meter_id %></td>
+          <td><%= installation.rtone_meter_type %></td>
+          <td><%= installation.meter.mpan_mprn %></td>
+          <td><%= installation.username %></td>
+          <td><%= installation.password %></td>
+          <td>
+            <p>
+              <%= link_to 'Edit', edit_school_rtone_variant_installation_path(school, installation), class: 'btn' %>
+              <%= link_to 'Delete', school_rtone_variant_installation_path(school, installation), method: :delete, data: { confirm: 'Are you sure?' }, class: 'btn' %>
+            </p>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+<% else %>
+  <p>This school has no Rtone Variant API feeds</p>
+<% end %>
+
+<p><%= link_to 'New Rtone Variant API feed', new_school_rtone_variant_installation_path, class: 'btn' %></p>

--- a/app/views/schools/solar_feeds_configuration/_solar_edge_feeds.html.erb
+++ b/app/views/schools/solar_feeds_configuration/_solar_edge_feeds.html.erb
@@ -1,0 +1,30 @@
+<% if solar_edge_installations.any? %>
+  <table class="table table-sm">
+    <tbody>
+      <tr>
+        <th class="w-25">Mpan</th>
+        <th class="w-25">Site Id</th>
+        <th>API Key</th>
+        <th class="w-25">Actions</th>
+      </tr>
+      <% solar_edge_installations.each do |installation| %>
+        <tr>
+          <td><%= installation.mpan %></td>
+          <td><%= installation.site_id %></td>
+          <td><%= installation.api_key %></td>
+          <td>
+            <p>
+              <%= link_to 'Edit', edit_school_solar_edge_installation_path(school, installation), class: 'btn' %>
+              <%= link_to 'Delete', school_solar_edge_installation_path(school, installation), method: :delete, data: { confirm: 'Are you sure?' }, class: 'btn btn-danger' %>
+            </p>
+
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+<% else %>
+  <p>This school has no Solar Edge API feeds</p>
+<% end %>
+
+<p><%= link_to 'New Solar Edge API feed', new_school_solar_edge_installation_path, class: 'btn' %></p>

--- a/app/views/schools/solar_feeds_configuration/index.html.erb
+++ b/app/views/schools/solar_feeds_configuration/index.html.erb
@@ -4,71 +4,15 @@
 
 <h3>Solar Edge</h3>
 
-<% if @solar_edge_installations.any? %>
-  <table class="table table-sm">
-    <tbody>
-      <tr>
-        <th class="w-25">Mpan</th>
-        <th class="w-25">Site Id</th>
-        <th>API Key</th>
-        <th class="w-25">Actions</th>
-      </tr>
-      <% @solar_edge_installations.each do |installation| %>
-        <tr>
-          <td><%= installation.mpan %></td>
-          <td><%= installation.site_id %></td>
-          <td><%= installation.api_key %></td>
-          <td>
-            <p>
-              <%= link_to 'Edit', edit_school_solar_edge_installation_path(@school, installation), class: 'btn' %>
-              <%= link_to 'Delete', school_solar_edge_installation_path(@school, installation), method: :delete, data: { confirm: 'Are you sure?' }, class: 'btn btn-danger' %>
-            </p>
-
-          </td>
-        </tr>
-      <% end %>
-    </tbody>
-  </table>
-<% else %>
-  <p>This school has no Solar Edge API feeds</p>
-<% end %>
-
-<p><%= link_to 'New Solar Edge API feed', new_school_solar_edge_installation_path, class: 'btn' %></p>
+<%= render 'solar_edge_feeds', school: @school, solar_edge_installations: @solar_edge_installations %>
 
 
 <h3>Rtone</h3>
 
-<% if @rtone_installations.any? %>
-  <table class="table table-sm">
-    <tbody>
-      <tr>
-        <th class="w-25">RBee Id</th>
-        <th class="w-25">Username</th>
-        <th>Password</th>
-        <th class="w-25">Actions</th>
-      </tr>
-      <% @rtone_installations.each do |installation| %>
-        <tr>
-          <td>
-            <%= link_to installation.rbee_meter_id, school_low_carbon_hub_installation_path(@school, installation)
-            %>
-          </td>
-          <td><%= installation.username %></td>
-          <td><%= installation.password %></td>
-          <td>
-            <p>
-              <%= link_to 'Edit', edit_school_low_carbon_hub_installation_path(@school, installation), class: 'btn' %>
-              <%= link_to 'Delete', school_low_carbon_hub_installation_path(@school, installation), method: :delete, data: { confirm: 'Are you sure?' }, class: 'btn' %>
-            </p>
-          </td>
-        </tr>
-      <% end %>
-    </tbody>
-  </table>
-<% else %>
-  <p>This school has no Rtone API feeds</p>
-<% end %>
+<%= render 'rtone_feeds', school: @school, rtone_installations: @rtone_installations, start_time: @start_time, end_time: @end_time %>
 
-<p class="alert alert-warning">You cannot create a new new Rtone installation, or download data from an installation, between <%= @start_time %> and <%= @end_time %></p>
+<h3>Rtone (Newport Variant)</h3>
 
-<p><%= link_to 'New Rtone API feed', new_school_low_carbon_hub_installation_path, class: 'btn' %></p>
+<p>This configuration is used to setup rtone api feeds that use the alternate setup first seen in some Newport school</p>
+
+<%= render 'rtone_variant_feeds', school: @school, rtone_variant_installations: @rtone_variant_installations %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -115,8 +115,8 @@ Rails.application.routes.draw do
       resources :solar_feeds_configuration, only: [:index]
 
       resources :solar_edge_installations, only: [:new, :create, :edit, :update, :destroy]
-
       resources :low_carbon_hub_installations, only: [:new, :show, :create, :edit, :update, :destroy]
+      resources :rtone_variant_installations, only: [:new, :create, :edit, :update, :destroy]
 
       resource :meter_readings_validation, only: [:create]
 

--- a/db/migrate/20210707085818_create_rtone_variant_installations.rb
+++ b/db/migrate/20210707085818_create_rtone_variant_installations.rb
@@ -1,10 +1,10 @@
 class CreateRtoneVariantInstallations < ActiveRecord::Migration[6.0]
   def change
     create_table :rtone_variant_installations do |t|
-      t.string :username
-      t.string :password
-      t.string :rtone_meter_id
-      t.integer :rtone_component_type
+      t.string :username, null: false
+      t.string :password, null: false
+      t.string :rtone_meter_id, null: false
+      t.integer :rtone_component_type, null: false
       t.json   :configuration
       t.references :school, null: false, foreign_key: true
       t.references :amr_data_feed_config, null: false, foreign_key: true

--- a/db/migrate/20210707085818_create_rtone_variant_installations.rb
+++ b/db/migrate/20210707085818_create_rtone_variant_installations.rb
@@ -4,7 +4,8 @@ class CreateRtoneVariantInstallations < ActiveRecord::Migration[6.0]
       t.string :username
       t.string :password
       t.string :rtone_meter_id
-      t.integer :rtone_meter_type
+      t.integer :rtone_component_type
+      t.json   :configuration
       t.references :school, null: false, foreign_key: true
       t.references :amr_data_feed_config, null: false, foreign_key: true
       t.references :meter, null: false, foreign_key: true

--- a/db/migrate/20210707085818_create_rtone_variant_installations.rb
+++ b/db/migrate/20210707085818_create_rtone_variant_installations.rb
@@ -1,0 +1,14 @@
+class CreateRtoneVariantInstallations < ActiveRecord::Migration[6.0]
+  def change
+    create_table :rtone_variant_installations do |t|
+      t.string :username
+      t.string :password
+      t.string :rtone_meter_id
+      t.integer :rtone_meter_type
+      t.references :school, null: false, foreign_key: true
+      t.references :amr_data_feed_config, null: false, foreign_key: true
+      t.references :meter, null: false, foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_09_091537) do
+ActiveRecord::Schema.define(version: 2021_07_07_085818) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
@@ -918,6 +918,21 @@ ActiveRecord::Schema.define(version: 2021_07_09_091537) do
     t.index ["resource_file_type_id"], name: "index_resource_files_on_resource_file_type_id"
   end
 
+  create_table "rtone_variant_installations", force: :cascade do |t|
+    t.string "username"
+    t.string "password"
+    t.string "rtone_meter_id"
+    t.integer "rtone_meter_type"
+    t.bigint "school_id", null: false
+    t.bigint "amr_data_feed_config_id", null: false
+    t.bigint "meter_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["amr_data_feed_config_id"], name: "index_rtone_variant_installations_on_amr_data_feed_config_id"
+    t.index ["meter_id"], name: "index_rtone_variant_installations_on_meter_id"
+    t.index ["school_id"], name: "index_rtone_variant_installations_on_school_id"
+  end
+
   create_table "school_alert_type_exclusions", force: :cascade do |t|
     t.bigint "alert_type_id"
     t.bigint "school_id"
@@ -1475,6 +1490,9 @@ ActiveRecord::Schema.define(version: 2021_07_09_091537) do
   add_foreign_key "programmes", "programme_types", on_delete: :cascade
   add_foreign_key "programmes", "schools", on_delete: :cascade
   add_foreign_key "resource_files", "resource_file_types", on_delete: :restrict
+  add_foreign_key "rtone_variant_installations", "amr_data_feed_configs"
+  add_foreign_key "rtone_variant_installations", "meters"
+  add_foreign_key "rtone_variant_installations", "schools"
   add_foreign_key "school_alert_type_exclusions", "alert_types", on_delete: :cascade
   add_foreign_key "school_alert_type_exclusions", "schools", on_delete: :cascade
   add_foreign_key "school_batch_run_log_entries", "school_batch_runs", on_delete: :cascade

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -922,7 +922,8 @@ ActiveRecord::Schema.define(version: 2021_07_07_085818) do
     t.string "username"
     t.string "password"
     t.string "rtone_meter_id"
-    t.integer "rtone_meter_type"
+    t.integer "rtone_component_type"
+    t.json "configuration"
     t.bigint "school_id", null: false
     t.bigint "amr_data_feed_config_id", null: false
     t.bigint "meter_id", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_07_085818) do
+ActiveRecord::Schema.define(version: 2021_07_09_091537) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -919,10 +919,10 @@ ActiveRecord::Schema.define(version: 2021_07_07_085818) do
   end
 
   create_table "rtone_variant_installations", force: :cascade do |t|
-    t.string "username"
-    t.string "password"
-    t.string "rtone_meter_id"
-    t.integer "rtone_component_type"
+    t.string "username", null: false
+    t.string "password", null: false
+    t.string "rtone_meter_id", null: false
+    t.integer "rtone_component_type", null: false
     t.json "configuration"
     t.bigint "school_id", null: false
     t.bigint "amr_data_feed_config_id", null: false

--- a/lib/tasks/deployment/20210707093230_rtone_variant_config.rake
+++ b/lib/tasks/deployment/20210707093230_rtone_variant_config.rake
@@ -1,0 +1,28 @@
+namespace :after_party do
+  desc 'Deployment task: rtone_variant_config'
+  task rtone_variant_config: :environment do
+    puts "Running deploy task 'rtone_variant_config'"
+
+    config = {}
+    config['description'] = "Rtone Variant API"
+    config['identifier'] = 'rtone-variant-api'
+    config['date_format'] = "%Y%m%d"
+    config['mpan_mprn_field'] = 'N/A'
+    config['reading_date_field'] = 'N/A'
+    config['reading_fields'] = 'N/A'
+    config['process_type'] = :rtone_variant_api
+    config['source_type'] = :api
+
+    fc = AmrDataFeedConfig.find_by_identifier('rtone-variant-api')
+    if fc.nil?
+      AmrDataFeedConfig.create!(config)
+    else
+      fc.update!(config)
+    end
+
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord
+      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+  end
+end

--- a/lib/tasks/solar_importer/import_rtone_variant_readings.rake
+++ b/lib/tasks/solar_importer/import_rtone_variant_readings.rake
@@ -2,21 +2,14 @@ namespace :solar do
   desc "Import rtone variant api readings"
   task :import_rtone_variant_readings, [:start_date, :end_date] => :environment do |_t, args|
 
-    default_start_date = Date.yesterday - 5
-    requested_start_date =  Date.parse(args[:start_date]) if args[:start_date].present?
+    start_date = args[:start_date].present? ? Date.parse(args[:start_date]) : nil
+    end_date = args[:end_date].present? ? Date.parse(args[:end_date]) : nil
 
-    end_date = args[:end_date].present? ? Date.parse(args[:end_date]) : Date.yesterday
-
+    puts "#{DateTime.now.utc} import_rtone_variant_readings start"
     RtoneVariantInstallation.all.each do |installation|
       puts "Running for #{installation.rtone_meter_id}"
-
-      start_date = if requested_start_date
-                     requested_start_date
-                   else
-                     installation.latest_electricity_reading < default_start_date ? installation.latest_electricity_reading : default_start_date
-                   end
-
       Solar::RtoneVariantDownloadAndUpsert.new(rtone_variant_installation: installation, start_date: start_date, end_date: end_date).perform
     end
+    puts "#{DateTime.now.utc} import_rtone_variant_readings end"
   end
 end

--- a/lib/tasks/solar_importer/import_rtone_variant_readings.rake
+++ b/lib/tasks/solar_importer/import_rtone_variant_readings.rake
@@ -1,0 +1,22 @@
+namespace :solar do
+  desc "Import rtone variant api readings"
+  task :import_rtone_variant_readings, [:start_date, :end_date] => :environment do |_t, args|
+
+    default_start_date = Date.yesterday - 5
+    requested_start_date =  Date.parse(args[:start_date]) if args[:start_date].present?
+
+    end_date = args[:end_date].present? ? Date.parse(args[:end_date]) : Date.yesterday
+
+    RtoneVariantInstallation.all.each do |installation|
+      puts "Running for #{installation.rtone_meter_id}"
+
+      start_date = if requested_start_date
+                     requested_start_date
+                   else
+                     installation.latest_electricity_reading < default_start_date ? installation.latest_electricity_reading : default_start_date
+                   end
+
+      Solar::RtoneVariantDownloadAndUpsert.new(rtone_variant_installation: installation, start_date: start_date, end_date: end_date).perform
+    end
+  end
+end

--- a/spec/factories/rtone_variant_installations.rb
+++ b/spec/factories/rtone_variant_installations.rb
@@ -1,0 +1,13 @@
+FactoryBot.define do
+  factory :rtone_variant_installation do
+    school
+    amr_data_feed_config
+    association :meter, factory: :electricity_meter
+
+    username { |n| "username_#{n}" }
+    password { |n| "password_#{n}" }
+
+    sequence(:rtone_meter_id, (100000..900000).cycle)  { |n| n }
+    rtone_meter_type { 1 }
+  end
+end

--- a/spec/factories/rtone_variant_installations.rb
+++ b/spec/factories/rtone_variant_installations.rb
@@ -8,6 +8,6 @@ FactoryBot.define do
     password { |n| "password_#{n}" }
 
     sequence(:rtone_meter_id, (100000..900000).cycle)  { |n| n }
-    rtone_meter_type { 1 }
+    rtone_component_type { 1 }
   end
 end

--- a/spec/services/solar/rtone_variant_download_and_upsert_spec.rb
+++ b/spec/services/solar/rtone_variant_download_and_upsert_spec.rb
@@ -1,0 +1,95 @@
+require 'rails_helper'
+
+module Solar
+  describe RtoneVariantDownloadAndUpsert do
+
+    let(:meter)         { create(:electricity_meter) }
+    let(:installation)  { create(:rtone_variant_installation, meter: meter)}
+
+    let(:end_date)    { Date.today }
+    let(:start_date)    { Date.today - 1 }
+
+    let(:readings)      {
+      {
+        mpan_mprn:        meter.mpan_mprn,
+        readings:         { start_date: OneDayAMRReading.new(meter.mpan_mprn, start_date, 'ORIG', nil, start_date, Array.new(48, 0.25)) },
+        missing_readings: []
+      }
+    }
+
+    let(:api)       { double("low-carbon-hub-api") }
+
+    let(:requested_start_date) { nil }
+    let(:requested_end_date) { nil }
+
+    let(:upserter)  { Solar::RtoneVariantDownloadAndUpsert.new(rtone_variant_installation: installation, start_date: requested_start_date, end_date: requested_end_date)}
+
+    before(:each) do
+      expect(LowCarbonHubMeterReadings).to receive(:new).with(installation.username, installation.password).and_return(api)
+    end
+
+    it "should handle and log exceptions" do
+      expect(api).to receive(:download_by_component).and_raise(StandardError)
+      upserter.perform
+      expect( AmrDataFeedImportLog.count ).to eql 1
+      expect( AmrDataFeedImportLog.first.error_messages ).to_not be_blank
+    end
+
+    context "when a date window is given" do
+      let(:requested_start_date) { start_date }
+      let(:requested_end_date) { end_date }
+
+      before(:each) do
+        expect(api).to receive(:download_by_component).with(installation.rtone_meter_id, installation.rtone_component_type, installation.meter.mpan_mprn, requested_start_date, requested_end_date).and_return(readings)
+      end
+
+      it "should use that" do
+        upserter.perform
+      end
+
+      it "should insert data" do
+        expect{ upserter.perform }.to change(AmrDataFeedReading, :count).by(1)
+      end
+    end
+
+    context "when there are existing readings" do
+      let!(:reading) {
+        create(:amr_data_feed_reading, reading_date: reading_date,
+        meter: meter)
+      }
+
+      before(:each) do
+        expect(api).to receive(:download_by_component).with(installation.rtone_meter_id, installation.rtone_component_type, installation.meter.mpan_mprn, expected_start, expected_end).and_return(readings)
+      end
+
+      context "and they are old" do
+        let(:reading_date)  { Date.yesterday - 20 }
+        let(:expected_start) { reading_date }
+        let(:expected_end) { Date.yesterday }
+
+        it "should use last reading date as start" do
+          upserter.perform
+        end
+      end
+      context "and they are recent" do
+        let(:reading_date)  { Date.yesterday }
+        let(:expected_start) { Date.yesterday - 5 }
+        let(:expected_end) { Date.yesterday }
+        it "should default to reloading last 6 days" do
+          upserter.perform
+        end
+      end
+    end
+
+    context "when there are no readings" do
+      let(:expected_end) { Date.yesterday }
+      let(:expected_start) { Date.yesterday - 5 }
+
+      it "should default to loading last 6 days" do
+        expect(api).to receive(:download_by_component).with(installation.rtone_meter_id, installation.rtone_component_type, installation.meter.mpan_mprn, expected_start, expected_end).and_return(readings)
+        upserter.perform
+      end
+    end
+
+  end
+end

--- a/spec/services/solar/rtone_variant_upserter_spec.rb
+++ b/spec/services/solar/rtone_variant_upserter_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+module Solar
+  describe RtoneVariantUpserter do
+
+    let(:meter)         { create(:electricity_meter) }
+    let(:installation)  { create(:rtone_variant_installation, meter: meter)}
+    let(:import_log)    { create(:amr_data_feed_import_log) }
+
+    let(:start_date)    { Date.today - 1 }
+
+    let(:readings)      {
+      {
+        mpan_mprn:        meter.mpan_mprn,
+        readings:         { start_date: OneDayAMRReading.new(meter.mpan_mprn, start_date, 'ORIG', nil, start_date, Array.new(48, 0.25)) },
+        missing_readings: []
+      }
+    }
+
+    let(:upserter) { Solar::RtoneVariantUpserter.new(rtone_variant_installation: installation, readings: readings, import_log: import_log) }
+
+    it "inserts new readings" do
+      expect( AmrDataFeedReading.count ).to eql 0
+      upserter.perform
+      expect( AmrDataFeedReading.count ).to eql 1
+    end
+
+  end
+end

--- a/spec/system/rtone_variant_installation_spec.rb
+++ b/spec/system/rtone_variant_installation_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe "Rtone variant installation management", :low_carbon_hub_installa
 
       click_on 'Submit'
 
-      expect(school.rtone_variant_installations.first.rtone_meter_type).to eql "in1"
+      expect(school.rtone_variant_installations.first.rtone_component_type).to eql "in1"
       expect(school.rtone_variant_installations.first.password).to eql "changed-pass"
       expect(school.rtone_variant_installations.first.username).to eql "changed-user"
 

--- a/spec/system/rtone_variant_installation_spec.rb
+++ b/spec/system/rtone_variant_installation_spec.rb
@@ -1,0 +1,59 @@
+require 'rails_helper'
+require 'dashboard'
+
+RSpec.describe "Rtone variant installation management", :low_carbon_hub_installations, type: :system do
+
+  let!(:admin)                { create(:admin) }
+  let!(:school)               { create(:school) }
+  let!(:meter)                { create(:electricity_meter, school: school)}
+  let(:rtone_meter_id)         { "216057958" }
+  let(:username)              { "rtone-user" }
+  let(:password)              { "rtone-pass" }
+  let!(:amr_data_feed_config) { create(:amr_data_feed_config, process_type: :rtone_variant_api) }
+  let(:start_date)            { Date.parse('02/08/2016') }
+  let(:end_date)              { start_date + 1.day }
+
+  context 'as an admin' do
+    before(:each) do
+      sign_in(admin)
+      visit school_meters_path(school)
+      click_on 'Manage Solar API feeds'
+    end
+
+    it 'I can add, edit and delete an rtone variant installation' do
+      expect(page).to have_content("This school has no Rtone Variant API feeds")
+      click_on 'New Rtone Variant API feed'
+
+      fill_in(:rtone_variant_installation_rtone_meter_id, with: rtone_meter_id)
+      fill_in(:rtone_variant_installation_username, with: username)
+      fill_in(:rtone_variant_installation_password, with: password)
+
+      expect { click_on 'Submit' }.to change { RtoneVariantInstallation.count }.by(1)
+
+      expect(page).to_not have_content("This school has no Rtone Variant API feeds")
+      expect(page).to have_content(rtone_meter_id)
+      expect(school.rtone_variant_installations.first.meter).to eql meter
+      expect(school.rtone_variant_installations.first.username).to eql username
+      expect(school.rtone_variant_installations.first.password).to eql password
+
+      click_on 'Edit'
+      expect(page).to have_content("Update Rtone Variant API feed")
+
+      select 'in1', from: 'Rtone Meter Type'
+      fill_in(:rtone_variant_installation_username, with: "changed-user")
+      fill_in(:rtone_variant_installation_password, with: "changed-pass")
+
+      click_on 'Submit'
+
+      expect(school.rtone_variant_installations.first.rtone_meter_type).to eql "in1"
+      expect(school.rtone_variant_installations.first.password).to eql "changed-pass"
+      expect(school.rtone_variant_installations.first.username).to eql "changed-user"
+
+      expect(page).to have_content("Delete")
+      expect { click_on 'Delete' }.to change { RtoneVariantInstallation.count }.by(-1)
+
+      expect(page).to have_content("This school has no Rtone Variant API feeds")
+    end
+
+  end
+end


### PR DESCRIPTION
This:

* add a new model for a variation of Solar feeds, used in Newport which need extra configuration and special handling
* adds new pages to manage those installations for admin users
* adds new loader to load readings from those meters. This uses a different way of accessing the API and relies on meters existing vs the existing approach which creates meters on the fly
* new cron job to load the data 

@jhigman One question is whether we need a new cron job, or do we just add it to the existing low carbon hub load?