### PR TITLE
1565 redirect loops with invisible public schools

### DIFF
--- a/app/controllers/concerns/non_public_schools.rb
+++ b/app/controllers/concerns/non_public_schools.rb
@@ -4,6 +4,7 @@ module NonPublicSchools
 private
 
   def redirect_unless_permitted(permission)
+    return if @school.public
     redirect_to school_private_path(@school) unless can?(permission, @school)
   end
 end

--- a/app/controllers/schools/aggregated_meter_collections_controller.rb
+++ b/app/controllers/schools/aggregated_meter_collections_controller.rb
@@ -1,6 +1,6 @@
 module Schools
   class AggregatedMeterCollectionsController < ApplicationController
-    load_and_authorize_resource :school
+    load_resource :school
     skip_before_action :authenticate_user!
 
     def post

--- a/app/controllers/schools/aggregated_meter_collections_controller.rb
+++ b/app/controllers/schools/aggregated_meter_collections_controller.rb
@@ -15,7 +15,7 @@ module Schools
     rescue => e
       Rollbar.error(e)
       respond_to do |format|
-        format.json { render json: { status: 'error', message: e.message }, status: :internal_server_error}
+        format.json { render json: { status: 'error', message: e.message }, status: :unauthorized}
       end
     end
   end

--- a/app/controllers/schools/aggregated_meter_collections_controller.rb
+++ b/app/controllers/schools/aggregated_meter_collections_controller.rb
@@ -4,6 +4,7 @@ module Schools
     skip_before_action :authenticate_user!
 
     def post
+      authorize! :show, @school
       # JSON request to load cache
       service = AggregateSchoolService.new(@school)
       service.aggregate_school unless service.in_cache?

--- a/spec/controllers/schools/aggregated_meter_collections_controller_spec.rb
+++ b/spec/controllers/schools/aggregated_meter_collections_controller_spec.rb
@@ -1,0 +1,56 @@
+require 'rails_helper'
+
+RSpec.describe Schools::AggregatedMeterCollectionsController, type: :controller do
+
+  let(:admin)   { create(:admin) }
+
+  let(:school)             { create(:school, visible: visible, public: public)}
+
+  context "as an admin" do
+    before(:each) do
+      sign_in(:admin)
+    end
+
+    describe 'with visible school' do
+      let(:visible) { true }
+
+      context "that is public" do
+        let(:public)  { true }
+        it "can trigger a load" do
+          post :post, format: :json, params: { school_id: school.id }
+          expect(response).to have_http_status(200)
+        end
+      end
+
+      context "that is private" do
+        let(:public)  { false }
+        it "can trigger a load" do
+          post :post, format: :json, params: { school_id: school.id }
+          expect(response).to have_http_status(200)
+        end
+      end
+    end
+
+    describe 'with invisible school' do
+      let(:visible) { false }
+
+      context "that is public" do
+        let(:public)  { true }
+        it "can trigger a load" do
+          post :post, format: :json, params: { school_id: school.id }
+          expect(response).to have_http_status(200)
+        end
+      end
+      context "that is private" do
+        let(:public)  { false }
+
+        it "can trigger a load" do
+          post :post, format: :json, params: { school_id: school.id }
+          expect(response).to have_http_status(200)
+        end
+      end
+
+    end
+
+  end
+end

--- a/spec/controllers/schools/aggregated_meter_collections_controller_spec.rb
+++ b/spec/controllers/schools/aggregated_meter_collections_controller_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe Schools::AggregatedMeterCollectionsController, type: :controller 
         let(:public)  { true }
         it "can request a load" do
           post :post, format: :json, params: { school_id: school.id }
-          expect(response).to have_http_status(500)
+          expect(response).to have_http_status(401)
         end
       end
       context "that is private" do
@@ -81,7 +81,7 @@ RSpec.describe Schools::AggregatedMeterCollectionsController, type: :controller 
 
         it "can request a load" do
           post :post, format: :json, params: { school_id: school.id }
-          expect(response).to have_http_status(500)
+          expect(response).to have_http_status(401)
         end
       end
     end

--- a/spec/controllers/schools/aggregated_meter_collections_controller_spec.rb
+++ b/spec/controllers/schools/aggregated_meter_collections_controller_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Schools::AggregatedMeterCollectionsController, type: :controller 
     let(:admin)   { create(:admin) }
 
     before(:each) do
-      sign_in(:admin)
+      sign_in(admin)
     end
 
     describe 'with visible school' do
@@ -64,7 +64,26 @@ RSpec.describe Schools::AggregatedMeterCollectionsController, type: :controller 
           expect(response).to have_http_status(200)
         end
       end
+    end
 
+    describe 'with invisible school' do
+      let(:visible) { false }
+
+      context "that is public" do
+        let(:public)  { true }
+        it "can request a load" do
+          post :post, format: :json, params: { school_id: school.id }
+          expect(response).to have_http_status(500)
+        end
+      end
+      context "that is private" do
+        let(:public)  { false }
+
+        it "can request a load" do
+          post :post, format: :json, params: { school_id: school.id }
+          expect(response).to have_http_status(500)
+        end
+      end
     end
   end
 
@@ -72,7 +91,7 @@ RSpec.describe Schools::AggregatedMeterCollectionsController, type: :controller 
     let(:teacher)               { create(:school_admin, school: school)}
 
     before(:each) do
-      sign_in(:teacher)
+      sign_in(teacher)
     end
 
     describe 'with visible school' do

--- a/spec/controllers/schools/aggregated_meter_collections_controller_spec.rb
+++ b/spec/controllers/schools/aggregated_meter_collections_controller_spec.rb
@@ -2,11 +2,11 @@ require 'rails_helper'
 
 RSpec.describe Schools::AggregatedMeterCollectionsController, type: :controller do
 
-  let(:admin)   { create(:admin) }
-
   let(:school)             { create(:school, visible: visible, public: public)}
 
   context "as an admin" do
+    let(:admin)   { create(:admin) }
+
     before(:each) do
       sign_in(:admin)
     end
@@ -49,8 +49,50 @@ RSpec.describe Schools::AggregatedMeterCollectionsController, type: :controller 
           expect(response).to have_http_status(200)
         end
       end
-
     end
 
+  end
+
+  context "as a guest" do
+    describe 'with visible school' do
+      let(:visible) { true }
+
+      context "that is public" do
+        let(:public)  { true }
+        it "can trigger a load" do
+          post :post, format: :json, params: { school_id: school.id }
+          expect(response).to have_http_status(200)
+        end
+      end
+
+    end
+  end
+
+  context "as a teacher" do
+    let(:teacher)               { create(:school_admin, school: school)}
+
+    before(:each) do
+      sign_in(:teacher)
+    end
+
+    describe 'with visible school' do
+      let(:visible) { true }
+
+      context "that is public" do
+        let(:public)  { true }
+        it "can trigger a load" do
+          post :post, format: :json, params: { school_id: school.id }
+          expect(response).to have_http_status(200)
+        end
+      end
+
+      context "that is private" do
+        let(:public)  { false }
+        it "can trigger a load" do
+          post :post, format: :json, params: { school_id: school.id }
+          expect(response).to have_http_status(200)
+        end
+      end
+    end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -36,6 +36,12 @@ describe User do
       %w(Activity ActivityType ActivityCategory Calendar CalendarEvent School User).each do |thing|
         it { is_expected.to be_able_to(:manage, thing.constantize.new) }
       end
+
+      it { is_expected.to be_able_to(:show, create(:school, visible: false, public: true)) }
+      it { is_expected.to be_able_to(:show, create(:school, visible: true, public: true)) }
+      it { is_expected.to be_able_to(:show, create(:school, visible: false, public: true)) }
+      it { is_expected.to be_able_to(:show, create(:school, visible: false, public: false)) }
+
     end
 
     context "as a school admin" do

--- a/spec/system/school_spec.rb
+++ b/spec/system/school_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe "school", type: :system do
 
       it 'prompts user to login when viewing' do
         visit school_path(school_invisible)
-        expect(page.has_content? 'Your school is currently inactive while we are setting up your energy data.').to be true
+        expect(page.has_content? 'You are not authorized to access this page').to be true
       end
 
     end

--- a/spec/system/school_spec.rb
+++ b/spec/system/school_spec.rb
@@ -66,12 +66,20 @@ RSpec.describe "school", type: :system do
   context 'with invisible school' do
     let!(:school_invisible)       { create(:school, name: 'Invisible School', visible: false, school_group: school_group)}
 
-    it 'does not show invisible school or the group' do
-      visit root_path
-      click_on('Schools')
-      expect(page.has_content? school_name).to be true
-      expect(page.has_content? 'Invisible School').to_not be true
-      expect(page.has_content? 'School Group').to_not be true
+    context "as guest user" do
+      it 'does not show invisible school or the group' do
+        visit root_path
+        click_on('Schools')
+        expect(page.has_content? school_name).to be true
+        expect(page.has_content? 'Invisible School').to_not be true
+        expect(page.has_content? 'School Group').to_not be true
+      end
+
+      it 'prompts user to login when viewing' do
+        visit school_path(school_invisible)
+        expect(page.has_content? 'Your school is currently inactive while we are setting up your energy data.').to be true
+      end
+
     end
 
     context 'as admin' do
@@ -86,6 +94,12 @@ RSpec.describe "school", type: :system do
         expect(page.has_content? 'Not visible schools').to be true
         expect(page.has_content? 'Invisible School').to be true
         expect(page.has_content? 'School Group').to_not be true
+      end
+
+      it 'shows school' do
+        visit school_path(school_invisible)
+        expect(page.has_link? "Pupil dashboard").to be true
+        expect(page.has_content? school_invisible.name).to be true
       end
 
     end


### PR DESCRIPTION
Two fixes:

* for the non-public school check, test if the school is public before issuing a redirect based solely on permissions. As this triggers a redirect from non-visible schools too.
* for the aggregate meter post, do the authorize check in the controller method so authorisation failures are caught and handled. 