### PR TITLE
Upgrade to 1.5.0 of did_you_mean

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,8 @@ addons:
     packages:
     - google-chrome-stable
 sudo: required
+before_install:
+  RUBYOPT='--disable-did_you_mean' bundle install
 before_script:
 - cp config/database.travis.yml config/database.yml
 script:

--- a/Gemfile
+++ b/Gemfile
@@ -94,10 +94,6 @@ gem 'MailchimpMarketing'
 # Eventbrite for training page
 gem 'eventbrite_sdk'
 
-# Upgrading to 1.5.0 resolves an issue with infinite loops caused by
-# attempting to log NoMethodError exceptions (either puts or logger)
-gem 'did_you_mean'
-
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platform: :mri
@@ -132,6 +128,10 @@ group :development do
   gem 'fasterer'
   gem 'bundler-audit'
   gem 'brakeman'
+
+  # Upgrading to 1.5.0 resolves an issue with infinite loops caused by
+  # attempting to log NoMethodError exceptions (either puts or logger)
+  gem 'did_you_mean'
 end
 
 group :test do

--- a/Gemfile
+++ b/Gemfile
@@ -94,6 +94,10 @@ gem 'MailchimpMarketing'
 # Eventbrite for training page
 gem 'eventbrite_sdk'
 
+# Upgrading to 1.5.0 resolves an issue with infinite loops caused by
+# attempting to log NoMethodError exceptions (either puts or logger)
+gem 'did_you_mean'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platform: :mri

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -206,6 +206,7 @@ GEM
       railties (>= 4.1.0)
       responders
       warden (~> 1.2.3)
+    did_you_mean (1.5.0)
     diff-lcs (1.4.4)
     dirty-memoize (0.0.4)
     distribution (0.8.0)
@@ -640,6 +641,7 @@ DEPENDENCIES
   closed_struct
   database_cleaner
   devise
+  did_you_mean
   dotenv-rails (~> 2.7.4)
   energy-sparks_analytics!
   eventbrite_sdk


### PR DESCRIPTION
This fixes a long standing bug where attempting to log a NoMethodError triggers the script or server process to hang because its in an infinite loop. Any attempt to log a NoMethodError when calling an object method in my development server triggered the issue. Previously this has been observed on the test server.

Debugging with gdb shows that `did_you_mean` was the cause. Upgrading resolves the issue.

There's also a change to the Travis config to try and [work around this issue](https://github.com/ruby/did_you_mean/issues/117). Explicitly running bundle install with did you mean disabled ensures the right versions of the gems are used for later scripts.

This should all be resolved in Ruby 2.7 later which has Did You Mean 1.5.0 by default I believe.