### PR TITLE
Revert recent analytics change

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,7 @@ gem 'auto_strip_attributes', '~> 2.5'
 gem 'closed_struct'
 
 # Dashboard analytics
-gem 'energy-sparks_analytics', git: 'https://github.com/Energy-Sparks/energy-sparks_analytics.git', tag: '1.24.0'
+gem 'energy-sparks_analytics', git: 'https://github.com/Energy-Sparks/energy-sparks_analytics.git', tag: '1.23.0'
 # gem 'energy-sparks_analytics', git: 'https://github.com/Energy-Sparks/energy-sparks_analytics.git', branch: '1590-create-application-page-to-display-targets'
 #gem 'energy-sparks_analytics', path: '../energy-sparks_analytics'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/Energy-Sparks/energy-sparks_analytics.git
-  revision: 4c87f694d6310d2128c88328e6c168cb0a2cbc66
-  tag: 1.24.0
+  revision: b3cbd860e9d9654ceb4cae2a03af4343ae76a9e1
+  tag: 1.23.0
   specs:
     energy-sparks_analytics (1.2.1)
       activesupport (~> 6.0.0)

--- a/app/controllers/schools/progress_controller.rb
+++ b/app/controllers/schools/progress_controller.rb
@@ -33,7 +33,7 @@ module Schools
       begin
         service = TargetsService.new(aggregate_school, @fuel_type)
         @progress = service.progress
-        @debug_content = service.analytics_debug_info if current_user.analytics?
+        #@debug_content = service.analytics_debug_info if current_user.analytics?
       rescue => e
         Rollbar.error(e)
         flash[:error] = e.message

--- a/app/views/schools/progress/index.html.erb
+++ b/app/views/schools/progress/index.html.erb
@@ -82,7 +82,7 @@
 
   <% if current_user.analytics? %>
     <h2>Debug</h2>
-    <%= @debug_content %>
+
   <% end %>
 
 <% else %>


### PR DESCRIPTION
NOT TO BE MERGED - used to revert changes on test.

Leaving open until we've got a newer, working version.