### PR TITLE
Give pupils access to mgt dashboard

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -109,6 +109,11 @@ class Ability
       can :read, Scoreboard, public: false, id: user.default_scoreboard.try(:id)
       can :read, [:my_school_menu, :school_downloads]
       can :read, Meter
+      #pupils can view management dashboard for their school and others in group
+      if user.pupil?
+        can :show_management_dash, School, id: user.school_id, visible: true
+        can :show_management_dash, School, { school_group_id: user.school.school_group_id, visible: true }
+      end
       #pupils and volunteers can only read real cost data if their school is public
       if user.volunteer? || user.pupil?
         can :read_restricted_analysis, School, { id: user.school_id, visible: true, public: true }

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -406,7 +406,7 @@ describe School do
         it 'allows access' do
           expect(ability).to be_able_to(:show, school)
           expect(ability).to be_able_to(:show_pupils_dash, school)
-          expect(ability).to_not be_able_to(:show_management_dash, school)
+          expect(ability).to be_able_to(:show_management_dash, school)
           expect(ability).to_not be_able_to(:read_restricted_analysis, school)
         end
       end
@@ -439,7 +439,7 @@ describe School do
         it 'allows access' do
           expect(ability).to be_able_to(:show, school)
           expect(ability).to be_able_to(:show_pupils_dash, school)
-          expect(ability).to_not be_able_to(:show_management_dash, school)
+          expect(ability).to be_able_to(:show_management_dash, school)
           expect(ability).to_not be_able_to(:read_restricted_analysis, school)
         end
 

--- a/spec/system/management/dashboard_spec.rb
+++ b/spec/system/management/dashboard_spec.rb
@@ -19,6 +19,21 @@ describe 'Adult dashboard' do
     end
   end
 
+  context 'when logged in as pupil' do
+    let(:pupil) { create(:pupil, school: school)}
+    before(:each) do
+      sign_in(pupil)
+    end
+    it 'allows login and access to dashboard' do
+      visit root_path
+      expect(page).to have_content("#{school.name}")
+      expect(page).to have_link("Adult dashboard", href: management_school_path(school))
+      click_on 'Adult dashboard'
+      expect(page).to have_content("#{school.name}")
+      expect(page).to have_link("Compare schools")
+    end
+  end
+
   context 'when logged in as staff' do
     before(:each) do
       sign_in(staff)


### PR DESCRIPTION
Allow pupils to access the management dashboard now that we've replaced the teacher dashboard.