### PR TITLE
Analytics 1.26.4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,9 +22,9 @@ gem 'auto_strip_attributes', '~> 2.5'
 gem 'closed_struct'
 
 # Dashboard analytics
-gem 'energy-sparks_analytics', git: 'https://github.com/Energy-Sparks/energy-sparks_analytics.git', tag: '1.26.3'
+#gem 'energy-sparks_analytics', git: 'https://github.com/Energy-Sparks/energy-sparks_analytics.git', tag: '1.26.3'
 # gem 'energy-sparks_analytics', git: 'https://github.com/Energy-Sparks/energy-sparks_analytics.git', branch: '1590-create-application-page-to-display-targets'
-#gem 'energy-sparks_analytics', path: '../energy-sparks_analytics'
+gem 'energy-sparks_analytics', path: '../energy-sparks_analytics'
 
 # Using master due to it having a patch which doesn't override Enumerable#sum if it's already defined
 # Last proper release does that, causing all kinds of weird behaviour (+ not defined etc)

--- a/Gemfile
+++ b/Gemfile
@@ -22,9 +22,9 @@ gem 'auto_strip_attributes', '~> 2.5'
 gem 'closed_struct'
 
 # Dashboard analytics
-#gem 'energy-sparks_analytics', git: 'https://github.com/Energy-Sparks/energy-sparks_analytics.git', tag: '1.26.3'
+gem 'energy-sparks_analytics', git: 'https://github.com/Energy-Sparks/energy-sparks_analytics.git', tag: '1.26.4'
 # gem 'energy-sparks_analytics', git: 'https://github.com/Energy-Sparks/energy-sparks_analytics.git', branch: '1590-create-application-page-to-display-targets'
-gem 'energy-sparks_analytics', path: '../energy-sparks_analytics'
+#gem 'energy-sparks_analytics', path: '../energy-sparks_analytics'
 
 # Using master due to it having a patch which doesn't override Enumerable#sum if it's already defined
 # Last proper release does that, causing all kinds of weird behaviour (+ not defined etc)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,23 +1,7 @@
 GIT
-  remote: https://github.com/Energy-Sparks/statsample
-  revision: e3de8a332546ca0506938f49f8a9f92762aee737
-  branch: update-gems-and-awesome-print
-  tag: 2.1.1-energy-sparks
-  specs:
-    statsample (2.1.0)
-      amazing_print (~> 1.2.1)
-      daru (~> 0.2.2)
-      dirty-memoize (~> 0.0.4)
-      distribution (~> 0.7)
-      extendmatrix (~> 0.4)
-      minimization (~> 0.2)
-      reportbuilder (~> 1.4)
-      rserve-client (~> 0.3)
-      rubyvis (~> 0.6.1)
-      spreadsheet (~> 1.1)
-
-PATH
-  remote: ../energy-sparks_analytics
+  remote: https://github.com/Energy-Sparks/energy-sparks_analytics.git
+  revision: 0af51e2e75df5e986e2a0a0c9e1ffa5778ca23b7
+  tag: 1.26.4
   specs:
     energy-sparks_analytics (1.2.1)
       activesupport (~> 6.0.0)
@@ -41,6 +25,24 @@ PATH
       statsample (~> 2.1.0)
       structured_warnings (~> 0.3.0)
       write_xlsx (~> 0.85.5)
+
+GIT
+  remote: https://github.com/Energy-Sparks/statsample
+  revision: e3de8a332546ca0506938f49f8a9f92762aee737
+  branch: update-gems-and-awesome-print
+  tag: 2.1.1-energy-sparks
+  specs:
+    statsample (2.1.0)
+      amazing_print (~> 1.2.1)
+      daru (~> 0.2.2)
+      dirty-memoize (~> 0.0.4)
+      distribution (~> 0.7)
+      extendmatrix (~> 0.4)
+      minimization (~> 0.2)
+      reportbuilder (~> 1.4)
+      rserve-client (~> 0.3)
+      rubyvis (~> 0.6.1)
+      spreadsheet (~> 1.1)
 
 GEM
   remote: https://rubygems.org/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,23 @@
 GIT
-  remote: https://github.com/Energy-Sparks/energy-sparks_analytics.git
-  revision: 3a0c9242dfbbc1e5fce7841ab627fdcc65e29601
-  tag: 1.26.3
+  remote: https://github.com/Energy-Sparks/statsample
+  revision: e3de8a332546ca0506938f49f8a9f92762aee737
+  branch: update-gems-and-awesome-print
+  tag: 2.1.1-energy-sparks
+  specs:
+    statsample (2.1.0)
+      amazing_print (~> 1.2.1)
+      daru (~> 0.2.2)
+      dirty-memoize (~> 0.0.4)
+      distribution (~> 0.7)
+      extendmatrix (~> 0.4)
+      minimization (~> 0.2)
+      reportbuilder (~> 1.4)
+      rserve-client (~> 0.3)
+      rubyvis (~> 0.6.1)
+      spreadsheet (~> 1.1)
+
+PATH
+  remote: ../energy-sparks_analytics
   specs:
     energy-sparks_analytics (1.2.1)
       activesupport (~> 6.0.0)
@@ -25,24 +41,6 @@ GIT
       statsample (~> 2.1.0)
       structured_warnings (~> 0.3.0)
       write_xlsx (~> 0.85.5)
-
-GIT
-  remote: https://github.com/Energy-Sparks/statsample
-  revision: e3de8a332546ca0506938f49f8a9f92762aee737
-  branch: update-gems-and-awesome-print
-  tag: 2.1.1-energy-sparks
-  specs:
-    statsample (2.1.0)
-      amazing_print (~> 1.2.1)
-      daru (~> 0.2.2)
-      dirty-memoize (~> 0.0.4)
-      distribution (~> 0.7)
-      extendmatrix (~> 0.4)
-      minimization (~> 0.2)
-      reportbuilder (~> 1.4)
-      rserve-client (~> 0.3)
-      rubyvis (~> 0.6.1)
-      spreadsheet (~> 1.1)
 
 GEM
   remote: https://rubygems.org/

--- a/app/controllers/concerns/school_progress.rb
+++ b/app/controllers/concerns/school_progress.rb
@@ -8,7 +8,7 @@ private
   end
 
   def prompt_to_review_target?
-    EnergySparks::FeatureFlags.active?(:school_targets) && @school.has_target? && @school.most_recent_target.suggest_revision?
+    EnergySparks::FeatureFlags.active?(:school_targets) && target_service.prompt_to_review_target?
   end
 
   def fuel_types_changed

--- a/app/controllers/schools/progress_controller.rb
+++ b/app/controllers/schools/progress_controller.rb
@@ -13,15 +13,15 @@ module Schools
     end
 
     def electricity
-      @school.has_electricity? ? index_for(:electricity) : missing(:electricity)
+      progress_service.display_progress_for_fuel_type?(:electricity) ? index_for(:electricity) : missing(:electricity)
     end
 
     def gas
-      @school.has_gas? ? index_for(:gas) : missing(:gas)
+      progress_service.display_progress_for_fuel_type?(:gas) ? index_for(:gas) : missing(:gas)
     end
 
     def storage_heater
-      @school.has_storage_heaters? ? index_for(:storage_heater) : missing(:storage_heater)
+      progress_service.display_progress_for_fuel_type?(:storage_heaters) ? index_for(:storage_heater) : missing(:storage_heater)
     end
 
     private
@@ -49,6 +49,10 @@ module Schools
 
     def show_storage_heater_notes(school, fuel_type)
       fuel_type == :electricity && school.has_storage_heaters?
+    end
+
+    def progress_service
+      Targets::ProgressService.new(@school, aggregate_school)
     end
   end
 end

--- a/app/controllers/schools/school_targets_controller.rb
+++ b/app/controllers/schools/school_targets_controller.rb
@@ -20,7 +20,7 @@ module Schools
 
     def show
       setup_activity_suggestions
-      @target_service = target_service
+      @progress_service = progress_service
       @prompt_to_review_target = prompt_to_review_target?
       @fuel_types_changed = fuel_types_changed
     end

--- a/app/controllers/schools/school_targets_controller.rb
+++ b/app/controllers/schools/school_targets_controller.rb
@@ -20,6 +20,7 @@ module Schools
 
     def show
       setup_activity_suggestions
+      @target_service = target_service
       @prompt_to_review_target = prompt_to_review_target?
       @fuel_types_changed = fuel_types_changed
     end
@@ -30,10 +31,10 @@ module Schools
         redirect_to school_school_target_path(@school, @school.current_target)
       elsif @school.has_target?
         @previous_school_target = @school.most_recent_target
-        @school_target = Targets::SchoolTargetService.new(@school).build_target
+        @school_target = target_service.build_target
         render :new
       else
-        @school_target = Targets::SchoolTargetService.new(@school).build_target
+        @school_target = target_service.build_target
         render :first
       end
     end
@@ -59,6 +60,7 @@ module Schools
         AggregateSchoolService.new(@school).invalidate_cache
         redirect_to school_school_target_path(@school, @school_target), notice: 'Target successfully updated'
       else
+        target_service
         render :edit
       end
     end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -223,7 +223,7 @@ module ApplicationHelper
   end
 
   def up_downify(text)
-    return if text.nil?
+    return if text.nil? || text == "-"
     icon = if text.match?(/^\+/)
              fa_icon('arrow-circle-up')
            elsif text.match?(/increased/)

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -342,7 +342,7 @@ class School < ApplicationRecord
     #based on start date. So if target as expired, then progress pages still work
     if has_current_target?
       current_target.meter_attributes_by_meter_type
-    elsif has_target?
+    elsif most_recent_target.present?
       most_recent_target.meter_attributes_by_meter_type
     else
       {}

--- a/app/services/targets/fuel_type_event_listener.rb
+++ b/app/services/targets/fuel_type_event_listener.rb
@@ -5,7 +5,7 @@ module Targets
       target = school_target(attribute.meter)
       return unless target.present?
       if storage_heater_attribute?(attribute) && first_storage_heater_attribute?(attribute)
-        add_fuel_type(target, "storage heater")
+        add_fuel_type(target, "storage_heater")
       end
     end
 
@@ -13,7 +13,7 @@ module Targets
       target = school_target(attribute.meter)
       return unless target.present?
       if storage_heater_attribute?(attribute) && last_storage_heater_attribute?(attribute)
-        remove_fuel_type(target, "storage heater")
+        remove_fuel_type(target, "storage_heater")
       end
     end
 

--- a/app/services/targets/progress_service.rb
+++ b/app/services/targets/progress_service.rb
@@ -18,7 +18,7 @@ module Targets
 
     def current_monthly_usage(fuel_type)
       target_progress = target_progress(fuel_type)
-      target_progress.present? ? target_progress.cumulative_usage_kwh[this_month] : nil
+      target_progress.present? ? target_progress.current_cumulative_usage_kwh : nil
     end
 
     #TEMPORARY

--- a/app/services/targets/school_target_service.rb
+++ b/app/services/targets/school_target_service.rb
@@ -18,6 +18,14 @@ module Targets
       )
     end
 
+    def prompt_to_review_target?
+      if @school.has_target? && @school.most_recent_target.suggest_revision?
+        @school.most_recent_target.revised_fuel_types.each do |fuel_type|
+          return true if enough_data_for_fuel_type?(fuel_type.to_sym)
+        end
+      end
+    end
+
     def refresh_target(target)
       if target.revised_fuel_types.include?("storage heater") && target.storage_heaters.nil?
         target.storage_heaters = DEFAULT_STORAGE_HEATER_TARGET

--- a/app/views/schools/school_targets/_form.html.erb
+++ b/app/views/schools/school_targets/_form.html.erb
@@ -6,7 +6,7 @@
 
   <%= render 'shared/errors', subject: school_target, subject_name: 'School target' %>
 
-  <% if school_target.school.has_electricity? %>
+  <% if target_service.enough_data_for_electricity? %>
     <div class="input-group col-12">
       <div class="col-sm-6">
         <%= f.label :electricity, "Reducing electricity usage by", class: "form-label" %>
@@ -20,7 +20,7 @@
     </div>
   <% end %>
 
-  <% if school_target.school.has_gas? %>
+  <% if target_service.enough_data_for_gas? %>
     <div class="input-group col-12">
       <div class="col-sm-6">
         <%= f.label :gas, "Reducing gas usage by", class: "form-label" %>
@@ -34,7 +34,7 @@
     </div>
   <% end %>
 
-  <% if school_target.school.indicated_has_storage_heaters? %>
+  <% if target_service.enough_data_for_storage_heater? %>
     <div class="input-group col-12">
       <div class="col-sm-6">
         <%= f.label :storage_heaters, "Reducing storage heater usage by", class: "form-label" %>

--- a/app/views/schools/school_targets/edit.html.erb
+++ b/app/views/schools/school_targets/edit.html.erb
@@ -40,6 +40,6 @@
   <div class="col-md-8">
     <h3>Your current target</h3>
 
-    <%= render "form", school_target: @school_target %>
+    <%= render "form", target_service: @target_service, school_target: @school_target %>
   </div>
 </div>

--- a/app/views/schools/school_targets/first.html.erb
+++ b/app/views/schools/school_targets/first.html.erb
@@ -47,7 +47,7 @@
       Based on our work with schools across the UK, we recommend setting the following targets for your school this year.
     </p>
 
-    <%= render "form", school_target: @school_target%>
+    <%= render "form", target_service: @target_service, school_target: @school_target%>
 
   </div>
 </div>

--- a/app/views/schools/school_targets/new.html.erb
+++ b/app/views/schools/school_targets/new.html.erb
@@ -35,7 +35,7 @@
       By default we've carried forward your targets from last year. You can amend them below.
     </p>
 
-    <%= render "form", school_target: @school_target %>
+    <%= render "form", target_service: @target_service, school_target: @school_target %>
 
   </div>
 </div>

--- a/app/views/schools/school_targets/show.html.erb
+++ b/app/views/schools/school_targets/show.html.erb
@@ -19,15 +19,15 @@
     </div>
   </div>
 <% else %>
-  <% if @school.has_electricity? %>
+  <% if @school_target.electricity.present? %>
     <%= render "bullet_chart", school_target: @school_target, fuel_type: :electricity, target: @school_target.electricity, progress: @electricity_progress,
     progress_path: electricity_school_progress_index_path(@school)  %>
   <% end %>
-  <% if @school.has_gas? %>
+  <% if @school_target.gas.present? %>
     <%= render "bullet_chart", school_target: @school_target, fuel_type: :gas, target: @school_target.gas, progress: @gas_progress,
     progress_path: gas_school_progress_index_path(@school)  %>
   <% end %>
-  <% if @school.has_storage_heaters? %>
+  <% if @school_target.storage_heaters.present? %>
     <%= render "bullet_chart", school_target: @school_target, fuel_type: :storage_heaters, target: @school_target.storage_heaters, progress: @storage_heater_progress, progress_path: storage_heaters_school_progress_index_path(@school)  %>
   <% end %>
 

--- a/app/views/schools/school_targets/show.html.erb
+++ b/app/views/schools/school_targets/show.html.erb
@@ -19,15 +19,15 @@
     </div>
   </div>
 <% else %>
-  <% if @school_target.electricity.present? %>
+  <% if @progress_service.display_progress_for_fuel_type?(:electricity) %>
     <%= render "bullet_chart", school_target: @school_target, fuel_type: :electricity, target: @school_target.electricity, progress: @electricity_progress,
     progress_path: electricity_school_progress_index_path(@school)  %>
   <% end %>
-  <% if @school_target.gas.present? %>
+  <% if @progress_service.display_progress_for_fuel_type?(:gas) %>
     <%= render "bullet_chart", school_target: @school_target, fuel_type: :gas, target: @school_target.gas, progress: @gas_progress,
     progress_path: gas_school_progress_index_path(@school)  %>
   <% end %>
-  <% if @school_target.storage_heaters.present? %>
+  <% if @progress_service.display_progress_for_fuel_type?(:storage_heaters) %>
     <%= render "bullet_chart", school_target: @school_target, fuel_type: :storage_heaters, target: @school_target.storage_heaters, progress: @storage_heater_progress, progress_path: storage_heaters_school_progress_index_path(@school)  %>
   <% end %>
 

--- a/spec/services/targets/fuel_type_event_listener_spec.rb
+++ b/spec/services/targets/fuel_type_event_listener_spec.rb
@@ -31,7 +31,7 @@ describe Targets::FuelTypeEventListener, type: :system do
           listener.meter_attribute_created(meter_attribute)
           school_target.reload
           expect(school_target.suggest_revision?).to be true
-          expect(school_target.revised_fuel_types).to match_array ["storage heater"]
+          expect(school_target.revised_fuel_types).to match_array ["storage_heater"]
         end
 
         it 'flags fuel types only once' do
@@ -39,11 +39,11 @@ describe Targets::FuelTypeEventListener, type: :system do
           listener.meter_attribute_created(create(:storage_heaters_attribute, meter: meter))
           school_target.reload
           expect(school_target.suggest_revision?).to be true
-          expect(school_target.revised_fuel_types).to match_array ["storage heater"]
+          expect(school_target.revised_fuel_types).to match_array ["storage_heater"]
         end
 
         it 'removes flag if the list is empty' do
-          school_target.update!(revised_fuel_types: ["storage heater"])
+          school_target.update!(revised_fuel_types: ["storage_heater"])
           meter_attribute.update!(deleted_by: create(:admin))
           listener.meter_attribute_deleted(meter_attribute)
           school_target.reload

--- a/spec/services/targets/progress_service_spec.rb
+++ b/spec/services/targets/progress_service_spec.rb
@@ -124,6 +124,7 @@ RSpec.describe Targets::ProgressService do
       context 'but the feature is on' do
         before(:each) do
           allow(EnergySparks::FeatureFlags).to receive(:active?).and_return(true)
+          allow_any_instance_of(TargetsService).to receive(:enough_data_to_set_target?).and_return(true)
           allow_any_instance_of(TargetsService).to receive(:progress).and_return(progress)
         end
 

--- a/spec/system/schools/progress_spec.rb
+++ b/spec/system/schools/progress_spec.rb
@@ -5,7 +5,7 @@ describe 'targets', type: :system do
   let(:admin)                     { create(:admin) }
   let(:school)                    { create_active_school(name: "Big School")}
   let!(:fuel_electricity)         { Schools::FuelConfiguration.new(has_electricity: true) }
-  let(:target)                    { create(:school_target, school: school) }
+  let!(:target)                    { create(:school_target, school: school) }
   let(:months)                    { ['jan', 'feb'] }
   let(:fuel_type)                 { :electricity }
   let(:monthly_targets_kwh)       { [1,2] }
@@ -45,6 +45,7 @@ describe 'targets', type: :system do
 
       before(:each) do
         sign_in(admin)
+        allow_any_instance_of(TargetsService).to receive(:enough_data_to_set_target?).and_return(true)
         allow_any_instance_of(TargetsService).to receive(:progress).and_return(progress)
         allow_any_instance_of(TargetsService).to receive(:recent_data?).and_return(true)
       end
@@ -103,6 +104,7 @@ describe 'targets', type: :system do
     context 'with out of date data' do
       before(:each) do
         sign_in(admin)
+        allow_any_instance_of(TargetsService).to receive(:enough_data_to_set_target?).and_return(true)
         allow_any_instance_of(TargetsService).to receive(:progress).and_return(progress)
         allow_any_instance_of(TargetsService).to receive(:recent_data?).and_return(false)
       end
@@ -115,6 +117,7 @@ describe 'targets', type: :system do
 
       before(:each) do
         sign_in(admin)
+        allow_any_instance_of(TargetsService).to receive(:enough_data_to_set_target?).and_return(true)
         allow_any_instance_of(TargetsService).to receive(:progress).and_raise(StandardError.new('test requested'))
       end
 


### PR DESCRIPTION
* Update to Analytics 1.26.4 with revised target interface
* Ensure we're checking whether there's targets set and enough data to generate reports when prompting to add or review targets
* Add guards around displaying progress to ensure targets are set and enough data is available.