### PR TITLE
Allow targets to be disabled for individual schools

### DIFF
--- a/app/controllers/concerns/school_progress.rb
+++ b/app/controllers/concerns/school_progress.rb
@@ -3,12 +3,16 @@ module SchoolProgress
 
 private
 
+  def redirect_if_disabled
+    redirect_to school_path(@school) unless Targets::SchoolTargetService.targets_enabled?(@school)
+  end
+
   def prompt_for_target?
-    EnergySparks::FeatureFlags.active?(:school_targets) && !@school.has_target? && target_service.enough_data?
+    Targets::SchoolTargetService.targets_enabled?(@school) && !@school.has_target? && target_service.enough_data?
   end
 
   def prompt_to_review_target?
-    EnergySparks::FeatureFlags.active?(:school_targets) && target_service.prompt_to_review_target?
+    Targets::SchoolTargetService.targets_enabled?(@school) && target_service.prompt_to_review_target?
   end
 
   def fuel_types_changed

--- a/app/controllers/schools/progress_controller.rb
+++ b/app/controllers/schools/progress_controller.rb
@@ -5,8 +5,10 @@ module Schools
     load_and_authorize_resource :school
 
     include SchoolAggregation
+    include SchoolProgress
 
     before_action :check_aggregated_school_in_cache, only: :index
+    before_action :redirect_if_disabled
 
     def index
       redirect_to electricity_school_progress_index_path

--- a/app/controllers/schools/school_targets_controller.rb
+++ b/app/controllers/schools/school_targets_controller.rb
@@ -8,6 +8,7 @@ module Schools
     include ActivityTypeFilterable
 
     before_action :check_aggregated_school_in_cache, only: :show
+    before_action :redirect_if_disabled
     before_action :calculate_current_progress, only: :show
 
     def index

--- a/app/controllers/schools_controller.rb
+++ b/app/controllers/schools_controller.rb
@@ -143,6 +143,7 @@ private
       :cooks_dinners_onsite,
       :cooks_dinners_for_other_schools,
       :cooks_dinners_for_other_schools_count,
+      :enable_targets_feature,
       key_stage_ids: []
     )
   end

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -11,6 +11,7 @@
 #  cooks_dinners_onsite                  :boolean          default(FALSE), not null
 #  created_at                            :datetime         not null
 #  dark_sky_area_id                      :bigint(8)
+#  enable_targets_feature                :boolean          default(TRUE)
 #  floor_area                            :decimal(, )
 #  has_swimming_pool                     :boolean          default(FALSE), not null
 #  id                                    :bigint(8)        not null, primary key

--- a/app/services/alerts/generate_email_notifications.rb
+++ b/app/services/alerts/generate_email_notifications.rb
@@ -18,7 +18,7 @@ module Alerts
     private
 
     def include_target_prompt_in_email?(school)
-      return EnergySparks::FeatureFlags.active?(:school_targets) && Targets::SchoolTargetService.new(school).enough_data?
+      return Targets::SchoolTargetService.targets_enabled?(school) && Targets::SchoolTargetService.new(school).enough_data?
     end
   end
 end

--- a/app/services/programmes/enroller.rb
+++ b/app/services/programmes/enroller.rb
@@ -5,12 +5,12 @@ module Programmes
     end
 
     def enrol(school)
-      return unless enrol?
+      return unless enrol?(school)
       Programmes::Creator.new(school, @enrol_programme_type).create
     end
 
     def enrol_all
-      return unless enrol?
+      return unless enrol?(school)
       School.visible.each do |school|
         enrol(school)
       end
@@ -22,8 +22,8 @@ module Programmes
       programme_type || ProgrammeType.default.first
     end
 
-    def enrol?
-      @enrol_programme_type.present? && EnergySparks::FeatureFlags.active?(:school_targets)
+    def enrol?(school)
+      @enrol_programme_type.present? && Targets::SchoolTargetService.targets_enabled?(school)
     end
   end
 end

--- a/app/services/school_creator.rb
+++ b/app/services/school_creator.rb
@@ -99,7 +99,7 @@ private
   end
 
   def include_target_prompt_in_email?
-    return EnergySparks::FeatureFlags.active?(:school_targets) && Targets::SchoolTargetService.new(@school).enough_data?
+    return Targets::SchoolTargetService.targets_enabled?(@school) && Targets::SchoolTargetService.new(@school).enough_data?
   end
 
   def enrol_in_default_programme

--- a/app/services/targets/progress_service.rb
+++ b/app/services/targets/progress_service.rb
@@ -29,7 +29,7 @@ module Targets
     def setup_management_table
       dashboard_table = @school.latest_management_dashboard_tables.first
       return nil unless dashboard_table.present?
-      return dashboard_table.table unless @school.has_target? && EnergySparks::FeatureFlags.active?(:school_targets)
+      return dashboard_table.table unless Targets::SchoolTargetService.targets_enabled?(@school) && @school.has_target?
       dashboard_table.table.each do |row|
         row.insert(-2, "Target progress") if row[0] == ""
         row.insert(-2, management_table_entry(:electricity)) if row[0] == "Electricity"

--- a/app/services/targets/school_target_service.rb
+++ b/app/services/targets/school_target_service.rb
@@ -8,6 +8,10 @@ module Targets
       @school = school
     end
 
+    def self.targets_enabled?(school)
+      EnergySparks::FeatureFlags.active?(:school_targets) && school.enable_targets_feature?
+    end
+
     def build_target
       @school.school_targets.build(
         start_date: target_start_date,

--- a/app/services/targets/target_mailer_service.rb
+++ b/app/services/targets/target_mailer_service.rb
@@ -36,7 +36,7 @@ module Targets
 
     def with_enough_data(schools)
       schools.select do |school|
-        Targets::SchoolTargetService.new(school).enough_data?
+        Targets::SchoolTargetService.targets_enabled?(school) && Targets::SchoolTargetService.new(school).enough_data?
       end
     end
 

--- a/app/views/admin/schools/target_data/show.html.erb
+++ b/app/views/admin/schools/target_data/show.html.erb
@@ -12,10 +12,12 @@ Where there is enough calendar and AMR data we should be able to generate both
 their targets and a progress report.
 </p>
 
-<% if @school.has_current_target? %>
-<p>
-This school currently has a target set, you can <%= link_to "view their target and progress", school_school_targets_path(@school) %>
-</p>
+Is the targets feature enabled for this school?: <strong><%= @school.enable_targets_feature? %></strong>
+
+<% if @school.enable_targets_feature? && @school.has_current_target? %>
+  <p>
+    This school currently has a target set, you can <%= link_to "view their target and progress", school_school_targets_path(@school) %>
+  </p>
 <% end %>
 
 <table class="table">

--- a/app/views/schools/_details_form.html.erb
+++ b/app/views/schools/_details_form.html.erb
@@ -6,7 +6,11 @@
 <%= f.input :urn, label: 'Unique Reference Number', hint: 'This is your URN in England, SEED in Scotland' %>
 
 <% if current_user.admin? %>
-  <%= f.input :activation_date, as: :tempus_dominus_date, default_date: nil, label: 'Activation date', hint: 'This is the date when the school becomes active on Energy Sparks' %>
+  <div class="bg-light">
+    <strong>Admin options</strong>
+    <%= f.input :activation_date, as: :tempus_dominus_date, default_date: nil, label: 'Activation date', hint: 'This is the date when the school becomes active on Energy Sparks' %>
+    <%= f.input :enable_targets_feature %>
+  </div>
 <% end %>
 
 <h2 id="address">Address</h2>

--- a/app/views/shared/_manage_school.html.erb
+++ b/app/views/shared/_manage_school.html.erb
@@ -18,7 +18,7 @@
     <%= link_to 'Meter attributes', admin_school_meter_attributes_path(school), class: 'dropdown-item' if can? :manage, SchoolMeterAttribute %>
     <%= link_to 'Manage tariffs', school_user_tariffs_path(school), class: 'dropdown-item' if can? :manage, UserTariff %>
     <%= link_to 'View target data', admin_school_target_data_path(school), class: 'dropdown-item' if can?(:view_target_data, SchoolTarget) %>
-    <%= link_to 'Review targets', school_school_targets_path(school), class: 'dropdown-item' if EnergySparks::FeatureFlags.active?(:school_targets) && can?(:manage, SchoolTarget) %>
+    <%= link_to 'Review targets', school_school_targets_path(school), class: 'dropdown-item' if Targets::SchoolTargetService.targets_enabled?(school) && can?(:manage, SchoolTarget) %>
     <%= link_to 'Remove school', removal_admin_school_path(school), class: 'dropdown-item' if can? :remove_school, school %>
   </div>
 </li>

--- a/db/migrate/20210914121624_add_targets_feature_flag_to_schools.rb
+++ b/db/migrate/20210914121624_add_targets_feature_flag_to_schools.rb
@@ -1,0 +1,5 @@
+class AddTargetsFeatureFlagToSchools < ActiveRecord::Migration[6.0]
+  def change
+    add_column :schools, :enable_targets_feature, :boolean, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_09_07_160618) do
+ActiveRecord::Schema.define(version: 2021_09_14_121624) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
@@ -1146,6 +1146,7 @@ ActiveRecord::Schema.define(version: 2021_09_07_160618) do
     t.boolean "public", default: true
     t.boolean "active", default: true
     t.date "removal_date"
+    t.boolean "enable_targets_feature", default: true
     t.index ["calendar_id"], name: "index_schools_on_calendar_id"
     t.index ["latitude", "longitude"], name: "index_schools_on_latitude_and_longitude"
     t.index ["school_group_id"], name: "index_schools_on_school_group_id"

--- a/spec/services/targets/progress_service_spec.rb
+++ b/spec/services/targets/progress_service_spec.rb
@@ -128,6 +128,15 @@ RSpec.describe Targets::ProgressService do
           allow_any_instance_of(TargetsService).to receive(:progress).and_return(progress)
         end
 
+        context 'but not for our school' do
+          before(:each) do
+            school.update!(enable_targets_feature: false)
+          end
+          it 'does not include the progress' do
+            expect(service.setup_management_table).to eql summary
+          end
+        end
+
         context 'and theres a target' do
           let!(:target)              { create(:school_target, school: school) }
 

--- a/spec/services/targets/target_mailer_service_spec.rb
+++ b/spec/services/targets/target_mailer_service_spec.rb
@@ -35,12 +35,24 @@ RSpec.describe Targets::TargetMailerService do
         expect(list_of_schools).to contain_exactly(other_school)
       end
 
-      context 'when a school cant use feature' do
-        let(:enough_data) { false }
-        it 'should ignore schools that cant use feature' do
-          expect(list_of_schools).to be_empty
+      context 'when a school cant use feature because of data' do
+        context 'because they lack data' do
+          let(:enough_data) { false }
+          it 'should ignore schools that cant use feature' do
+            expect(list_of_schools).to be_empty
+          end
+        end
+        context 'because its disabled for them' do
+          before(:each) do
+            school.update!(enable_targets_feature: false)
+          end
+          it 'should ignore schools that cant use feature' do
+            expect(list_of_schools).to contain_exactly(other_school)
+          end
         end
       end
+
+
   end
 
   describe '#list_schools_requiring_review' do

--- a/spec/system/management/dashboard_spec.rb
+++ b/spec/system/management/dashboard_spec.rb
@@ -110,6 +110,13 @@ describe 'Adult dashboard' do
         expect(page).to_not have_content("Set targets to reduce your school's energy consumption")
       end
 
+      it 'doesnt display prompt if feature disabled' do
+        allow(EnergySparks::FeatureFlags).to receive(:active?).and_return(true)
+        school.update!(enable_targets_feature: false)
+        visit root_path
+        expect(page).to_not have_content("Set targets to reduce your school's energy consumption")
+      end
+
       it 'displays a report version of the page' do
         visit root_path
         click_on 'Print view'

--- a/spec/system/school_spec.rb
+++ b/spec/system/school_spec.rb
@@ -329,6 +329,16 @@ RSpec.describe "school", type: :system do
           expect(school.activation_date).to eq nil
         end
 
+        it 'can change target feature flag' do
+          expect(school.enable_targets_feature?).to be true
+          click_on(school_name)
+          click_on('Edit school details')
+          uncheck 'Enable targets feature'
+          click_on('Update School')
+          school.reload
+          expect(school.enable_targets_feature?).to be false
+        end
+
         context "can update storage heaters" do
           it "and changes are saved" do
             click_on(school_name)

--- a/spec/system/schools/progress_spec.rb
+++ b/spec/system/schools/progress_spec.rb
@@ -55,6 +55,12 @@ describe 'targets', type: :system do
         expect(page).to have_content('Tracking progress')
       end
 
+      it 'redirects to management dashboard if disabled' do
+        school.update!(enable_targets_feature: false)
+        visit school_progress_index_path(school)
+        expect(page).to have_current_path(management_school_path(school))
+      end
+
       it 'shows electricity progress' do
         visit electricity_school_progress_index_path(school)
         expect(page).to have_content('Tracking progress')

--- a/spec/system/schools/progress_spec.rb
+++ b/spec/system/schools/progress_spec.rb
@@ -32,6 +32,10 @@ describe 'targets', type: :system do
     )
   end
 
+  before(:each) do
+    allow(EnergySparks::FeatureFlags).to receive(:active?).and_return(true)
+  end
+
   context 'as an admin' do
 
     let(:fuel_electricity) { Schools::FuelConfiguration.new(has_electricity: true, has_storage_heaters: false) }

--- a/spec/system/schools/school_targets_spec.rb
+++ b/spec/system/schools/school_targets_spec.rb
@@ -25,6 +25,22 @@ RSpec.describe 'school targets', type: :system do
       sign_in(school_admin)
     end
 
+    context 'with targets disabled' do
+      before(:each) do
+          school.update!(enable_targets_feature: false)
+      end
+
+      it 'doesnt have a link to review targets' do
+        expect(page).to_not have_link("Review targets", href: school_school_targets_path(school))
+      end
+
+      it 'doesnt let me navigate there' do
+        visit school_school_targets_path(school)
+        expect(page).to have_current_path(management_school_path(school))
+      end
+
+    end
+
     context "with no target" do
 
       context "with all fuel types" do


### PR DESCRIPTION
Allow an admin to disable targets feature for individual schools.

Refactored checking for feature flag into SchoolTargetsService, revised the logic and updated tests.

Also ensure that any bookmarked links, etc trigger redirects in case we disable this for a school that currently has targets.