### PR TITLE
Remove card-deck in favour of columns

### DIFF
--- a/app/controllers/activity_categories_controller.rb
+++ b/app/controllers/activity_categories_controller.rb
@@ -9,7 +9,7 @@ class ActivityCategoriesController < ApplicationController
       @suggested_activities = load_suggested_activities(current_user_school)
     end
     @pupil_categories = ActivityCategory.pupil.by_name
-    @activity_categories = ActivityCategory.featured.by_name.select { |activity_category| activity_category.activity_types.active.count > 4 }
+    @activity_categories = ActivityCategory.featured.by_name.select { |activity_category| activity_category.activity_types.active.count >= 4 }
     @activity_count = ActivityType.active_and_not_custom.count
     @programme_types = ProgrammeType.featured
   end

--- a/app/views/activity_categories/_cards.html.erb
+++ b/app/views/activity_categories/_cards.html.erb
@@ -1,22 +1,24 @@
-<div class="card-deck pb-4 activities-deck <%= card_deck_css %>">
+<div class="row pb-4 activities-deck <%= card_deck_css %>">
   <% activity_types.each do |activity_type| %>
-    <div class="card">
-      <%= link_to activity_type_path(activity_type) do %>
-        <%= render 'activity_types/image', activity_type: activity_type, css_class: "activity-card-img" %>
-      <% end %>
-      <div class="card-body">
-        <p class="card-text">
-          <%= link_to activity_type.name, activity_type_path(activity_type) %>
-        </p>
-      </div>
-      <div class="card-footer" style="border-top: none; background-color: white;">
-        <% if activity_type.subjects.any? %>
-          <%= render 'activity_types/activity_type_subjects', activity_type: activity_type %>
+    <div class="col-sm-3">
+      <div class="card pr-1 h-100">
+        <%= link_to activity_type_path(activity_type) do %>
+          <%= render 'activity_types/image', activity_type: activity_type, css_class: "activity-card-img" %>
         <% end %>
-        <% if activity_type.key_stages.any? %>
-          <%= "<br>".html_safe if activity_type.subjects.any? %>
-          <%= render 'activity_types/activity_type_key_stages', activity_type: activity_type %>
-        <% end %>
+        <div class="card-body">
+          <p class="card-text">
+            <%= link_to activity_type.name, activity_type_path(activity_type) %>
+          </p>
+        </div>
+        <div class="card-footer" style="border-top: none; background-color: white;">
+          <% if activity_type.subjects.any? %>
+            <%= render 'activity_types/activity_type_subjects', activity_type: activity_type %>
+          <% end %>
+          <% if activity_type.key_stages.any? %>
+            <%= "<br>".html_safe if activity_type.subjects.any? %>
+            <%= render 'activity_types/activity_type_key_stages', activity_type: activity_type %>
+          <% end %>
+        </div>
       </div>
     </div>
   <% end %>

--- a/app/views/activity_categories/_programme_types.html.erb
+++ b/app/views/activity_categories/_programme_types.html.erb
@@ -1,6 +1,6 @@
 <div class="card-deck justify-content-center bg-light pb-4 activities-deck" id="programme-types">
   <% programme_types.each do |programme_type| %>
-    <div class="card col-3">
+    <div class="card col-sm-3">
       <%= link_to programme_type_path(programme_type) do %>
         <%= render 'programme_types/image', programme_type: programme_type, css_class: "" %>
       <% end %>

--- a/app/views/activity_categories/_pupil_categories.html.erb
+++ b/app/views/activity_categories/_pupil_categories.html.erb
@@ -1,24 +1,16 @@
-<div class="card-deck bg-light pb-4 activities-deck">
+<div class="row bg-light pb-4 activities-deck">
   <% activity_categories.each do |activity_category| %>
-    <div class="card">
-      <%= link_to activity_category_path(activity_category) do %>
-        <%= render 'image', activity_category: activity_category, css_class: "activity-card-img" %>
-      <% end %>
-      <div class="card-body">
-        <p class="card-text">
-          <%= link_to activity_category.name, activity_category_path(activity_category) %>
-        </p>
+    <div class="col-sm-3">
+      <div class="card pr-1 h-100">
+        <%= link_to activity_category_path(activity_category) do %>
+          <%= render 'image', activity_category: activity_category, css_class: "activity-card-img" %>
+        <% end %>
+        <div class="card-body">
+          <p class="card-text">
+            <%= link_to activity_category.name, activity_category_path(activity_category) %>
+          </p>
+        </div>
       </div>
     </div>
   <% end %>
-  <div class="card">
-    <div class="card-body">
-      <p class="card-text">
-        Groups of activities themed around specific learning pathways.
-      </p>
-      <p class="card-text">
-        Individual activities are linked to a variety of subjects and key stages.
-      </p>
-    </div>
-  </div>
 </div>

--- a/app/views/activity_categories/index.html.erb
+++ b/app/views/activity_categories/index.html.erb
@@ -9,11 +9,11 @@
 </div>
 
 <div class="row">
-  <div class="col">
+  <div class="col-sm-6">
     <p>Energy Sparks provides extensive support to <%= link_to 'teachers', for_teachers_path %> and <%= link_to 'pupils', for_pupils_path %> in learning about energy and climate change within the context of your own school.</p>
     <p>Use the links below to explore <strong><%= @activity_count %></strong> freely available activities.
   </div>
-  <div class="col">
+  <div class="col-sm-6">
     <ul class="fa-ul">
       <li class="pb-3"><i class="fa-li fas fa-2x fa-check"></i>Eco-team and curriculum linked energy saving activities.</li>
       <li class="pb-3"><i class="fa-li fas fa-2x fa-check"></i>Energy related lesson plans and downloadable resources.</li>
@@ -34,7 +34,7 @@
       <p>Our suggestions based on your school programmes and analysis of your energy data</p>
     </div>
   </div>
-  <%= render "cards", activity_types: @suggested_activities.first(5), card_deck_css: "bg-light" %>
+  <%= render "cards", activity_types: @suggested_activities.first(4), card_deck_css: "bg-light" %>
 <% end %>
 
 <% if !@pupil_categories.blank? %>
@@ -43,6 +43,8 @@
       <div class="d-flex justify-content-between align-items-center">
         <h4><strong>Pupil activities</strong></h4>
       </div>
+      <p>Groups of activities themed around specific learning pathways. Individual activities are linked to a variety of subjects and key stages.</p>
+
     </div>
   </div>
   <%= render "pupil_categories", activity_categories: @pupil_categories.first(4) %>
@@ -60,7 +62,7 @@
       <p>Short programmes of related activities that pupils can work through step-by-step to achieve greater impact</p>
     </div>
   </div>
-  <%= render "programme_types", programme_types: @programme_types.first(5) %>
+  <%= render "programme_types", programme_types: @programme_types.first(4) %>
 <% end %>
 
 <% @activity_categories.each do |activity_category| %>
@@ -74,5 +76,5 @@
       </div>
     </div>
   </div>
-  <%= render "cards", activity_types: activity_category.activity_types.active_and_not_custom.sample(5), card_deck_css: "" %>
+  <%= render "cards", activity_types: activity_category.activity_types.active_and_not_custom.sample(4), card_deck_css: "" %>
 <% end %>

--- a/app/views/intervention_type_groups/_cards.html.erb
+++ b/app/views/intervention_type_groups/_cards.html.erb
@@ -1,13 +1,15 @@
-<div class="card-deck pb-4 activities-deck <%= card_deck_css %>">
+<div class="row pb-4 justify-content-center activities-deck <%= card_deck_css %>">
   <% intervention_types.each do |intervention_type| %>
-    <div class="card">
-      <%= link_to intervention_type_path(intervention_type) do %>
-        <%= render 'intervention_types/image', intervention_type: intervention_type, css_class: "activity-card-img" %>
-      <% end %>
-      <div class="card-body">
-        <p class="card-text">
-          <%= link_to intervention_type.title, intervention_type_path(intervention_type) %>
-        </p>
+    <div class="col-sm-3">
+      <div class="card pr-1 h-100">
+        <%= link_to intervention_type_path(intervention_type) do %>
+          <%= render 'intervention_types/image', intervention_type: intervention_type, css_class: "activity-card-img" %>
+        <% end %>
+        <div class="card-body">
+          <p class="card-text">
+            <%= link_to intervention_type.title, intervention_type_path(intervention_type) %>
+          </p>
+        </div>
       </div>
     </div>
   <% end %>

--- a/app/views/intervention_type_groups/index.html.erb
+++ b/app/views/intervention_type_groups/index.html.erb
@@ -25,5 +25,5 @@
       </div>
     </div>
   </div>
-  <%= render "cards", intervention_types: intervention_type_group.intervention_types.active_and_not_other.sample(5), card_deck_css: "" %>
+  <%= render "cards", intervention_types: intervention_type_group.intervention_types.active_and_not_other.sample(4), card_deck_css: "" %>
 <% end %>

--- a/spec/system/activity_category_spec.rb
+++ b/spec/system/activity_category_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "activity type", type: :system do
   let!(:activity_type_1_2) { create(:activity_type, activity_category: activity_category_1, key_stages: [ks3])}
   let!(:activity_type_1_3) { create(:activity_type, activity_category: activity_category_1, key_stages: [ks3])}
   let!(:activity_type_1_4) { create(:activity_type, activity_category: activity_category_1, key_stages: [ks3])}
-  let!(:activity_type_1_5) { create(:activity_type, activity_category: activity_category_1, key_stages: [ks3])}
+#  let!(:activity_type_1_5) { create(:activity_type, activity_category: activity_category_1, key_stages: [ks3])}
 
   let!(:activity_category_2) { create(:activity_category, name: 'cat2')}
   let!(:activity_type_2_1) { create(:activity_type, activity_category: activity_category_2, key_stages: [ks3])}
@@ -22,7 +22,7 @@ RSpec.describe "activity type", type: :system do
   let!(:activity_type_3_2) { create(:activity_type, activity_category: activity_category_3, key_stages: [ks3])}
   let!(:activity_type_3_3) { create(:activity_type, activity_category: activity_category_3, key_stages: [ks3])}
   let!(:activity_type_3_4) { create(:activity_type, activity_category: activity_category_3, key_stages: [ks3])}
-  let!(:activity_type_3_5) { create(:activity_type, activity_category: activity_category_3, key_stages: [ks3])}
+#  let!(:activity_type_3_5) { create(:activity_type, activity_category: activity_category_3, key_stages: [ks3])}
 
   let!(:activity_category_4) { create(:activity_category, name: 'cat4', pupil: true)}
   let!(:activity_type_4_1) { create(:activity_type, activity_category: activity_category_4)}
@@ -35,7 +35,7 @@ RSpec.describe "activity type", type: :system do
         visit activity_categories_path
       end
 
-      it 'shows featured activity categories with at least 5 activities, plus Pupil activities and Programmes, but not Recommended section' do
+      it 'shows featured activity categories with at least 4 activities, plus Pupil activities and Programmes, but not Recommended section' do
         expect(page).to have_content(activity_category_1.name)
         expect(page).not_to have_content(activity_category_2.name)
         expect(page).not_to have_content(activity_category_3.name)
@@ -48,19 +48,18 @@ RSpec.describe "activity type", type: :system do
         expect(page).to have_content(programme_type.title)
       end
 
-      it 'shows 5 activities' do
+      it 'shows 4 activities' do
         expect(page).to have_content(activity_type_1_1.name)
         expect(page).to have_content(activity_type_1_2.name)
         expect(page).to have_content(activity_type_1_3.name)
         expect(page).to have_content(activity_type_1_4.name)
-        expect(page).to have_content(activity_type_1_5.name)
 
         expect(page).not_to have_content(activity_type_2_1.name)
         expect(page).not_to have_content(activity_type_3_1.name)
       end
 
       it 'links to category page, activity page and back' do
-        click_link 'View all 5 activities'
+        click_link 'View all 4 activities'
         expect(page).to have_content(activity_category_1.name)
         expect(page).to have_content(activity_category_1.description)
 

--- a/spec/system/activity_category_spec.rb
+++ b/spec/system/activity_category_spec.rb
@@ -10,7 +10,6 @@ RSpec.describe "activity type", type: :system do
   let!(:activity_type_1_2) { create(:activity_type, activity_category: activity_category_1, key_stages: [ks3])}
   let!(:activity_type_1_3) { create(:activity_type, activity_category: activity_category_1, key_stages: [ks3])}
   let!(:activity_type_1_4) { create(:activity_type, activity_category: activity_category_1, key_stages: [ks3])}
-#  let!(:activity_type_1_5) { create(:activity_type, activity_category: activity_category_1, key_stages: [ks3])}
 
   let!(:activity_category_2) { create(:activity_category, name: 'cat2')}
   let!(:activity_type_2_1) { create(:activity_type, activity_category: activity_category_2, key_stages: [ks3])}
@@ -22,7 +21,6 @@ RSpec.describe "activity type", type: :system do
   let!(:activity_type_3_2) { create(:activity_type, activity_category: activity_category_3, key_stages: [ks3])}
   let!(:activity_type_3_3) { create(:activity_type, activity_category: activity_category_3, key_stages: [ks3])}
   let!(:activity_type_3_4) { create(:activity_type, activity_category: activity_category_3, key_stages: [ks3])}
-#  let!(:activity_type_3_5) { create(:activity_type, activity_category: activity_category_3, key_stages: [ks3])}
 
   let!(:activity_category_4) { create(:activity_category, name: 'cat4', pupil: true)}
   let!(:activity_type_4_1) { create(:activity_type, activity_category: activity_category_4)}

--- a/spec/system/schools/activity_category_spec.rb
+++ b/spec/system/schools/activity_category_spec.rb
@@ -13,7 +13,6 @@ RSpec.describe "activity type", type: :system do
   let!(:activity_type_1_2) { create(:activity_type, activity_category: activity_category_1, key_stages: [ks3])}
   let!(:activity_type_1_3) { create(:activity_type, activity_category: activity_category_1, key_stages: [ks3])}
   let!(:activity_type_1_4) { create(:activity_type, activity_category: activity_category_1, key_stages: [ks3])}
-  let!(:activity_type_1_5) { create(:activity_type, activity_category: activity_category_1, key_stages: [ks3])}
 
   let!(:activity_category_2) { create(:activity_category, name: 'cat2', featured: true)}
   let!(:activity_type_2_1) { create(:activity_type, activity_category: activity_category_2, key_stages: [ks3])}
@@ -27,7 +26,7 @@ RSpec.describe "activity type", type: :system do
         sign_in(admin)
       end
 
-      it 'shows categories with 5 activity types, plus Recommended section' do
+      it 'shows categories with 4 activity types, plus Recommended section' do
         expect_any_instance_of(NextActivitySuggesterWithFilter).to receive(:suggest_for_school_targets).and_return([activity_type_3_1])
         visit activity_categories_path
 
@@ -46,7 +45,7 @@ RSpec.describe "activity type", type: :system do
         allow_any_instance_of(NextActivitySuggesterWithFilter).to receive(:suggest_for_school_targets).and_return([])
         visit activity_categories_path
 
-        click_link 'View all 5 activities'
+        click_link 'View all 4 activities'
         expect(page).to have_content(activity_category_1.name)
         expect(page).to have_content(activity_category_1.description)
 


### PR DESCRIPTION
Turns out that `card-deck` in bootstrap isn't responsive. While on small screen sizes the cards do wrap, at larger sizes (e.g. with ipad) you end up with very narrow columns.

Easiest fix was to remove use of `card-deck` in favour of switching to use a 4 card row, with explicit column widths (`col-sm-4`) and use of `pr-1` and `h-100` to force cards to be same height.

This works better across all screen sizes. Made changes to both the activity category and intervention pages.

 