### PR TITLE
Intervention pages should display description and links

### DIFF
--- a/app/views/activity_categories/index.html.erb
+++ b/app/views/activity_categories/index.html.erb
@@ -28,7 +28,7 @@
       <div class="d-flex justify-content-between align-items-center">
         <h4><strong>Recommended for your school</strong></h4>
         <div>
-          <%= link_to 'View all suggestions', recommended_activity_categories_path, class: "btn btn-secondary" %>
+          <%= link_to 'View all suggestions', recommended_activity_categories_path, class: "btn btn-outline-dark rounded-pill font-weight-bold" %>
         </div>
       </div>
       <p>Our suggestions based on your school programmes and analysis of your energy data</p>
@@ -56,7 +56,7 @@
       <div class="d-flex justify-content-between align-items-center">
         <h4><strong>Our Programmes</strong></h4>
         <div>
-          <%= link_to 'View all programmes', programme_types_path, class: "btn btn-secondary" %>
+          <%= link_to 'View all programmes', programme_types_path, class: "btn btn-outline-dark rounded-pill font-weight-bold" %>
         </div>
       </div>
       <p>Short programmes of related activities that pupils can work through step-by-step to achieve greater impact</p>
@@ -71,7 +71,7 @@
       <div class="d-flex justify-content-between align-items-center">
         <h4><strong><%= activity_category.name %></strong></h4>
         <div>
-          <%= link_to "View all #{activity_category.activity_types.active.count} activities", activity_category_path(activity_category), class: "btn btn-secondary" %>
+          <%= link_to "View all #{activity_category.activity_types.active.count} activities", activity_category_path(activity_category), class: "btn btn-outline-dark rounded-pill font-weight-bold" %>
         </div>
       </div>
     </div>

--- a/app/views/activity_categories/show.html.erb
+++ b/app/views/activity_categories/show.html.erb
@@ -3,7 +3,7 @@
     <div class="d-flex justify-content-between align-items-center">
       <h1><%= @activity_category.name %></h1>
       <div>
-        <%= link_to 'All activities', activity_categories_path, class: 'btn btn-secondary'  %>
+        <%= link_to 'All activities', activity_categories_path, class: 'btn btn-outline-dark rounded-pill font-weight-bold'  %>
       </div>
     </div>
   </div>

--- a/app/views/activity_types/show.html.erb
+++ b/app/views/activity_types/show.html.erb
@@ -16,7 +16,7 @@
     </div>
   </div>
   <div class="col-md-3">
-    <%= link_to "All #{@activity_type.activity_category.name} activities", activity_category_path(@activity_type.activity_category), class: 'btn btn-secondary float-right' %>
+    <%= link_to "View #{@activity_type.activity_category.activity_types.count} related activities", activity_category_path(@activity_type.activity_category), class: 'btn btn-outline-dark rounded-pill font-weight-bold' %>
   </div>
 </div>
 

--- a/app/views/intervention_type_groups/index.html.erb
+++ b/app/views/intervention_type_groups/index.html.erb
@@ -20,7 +20,7 @@
       <div class="d-flex justify-content-between align-items-center">
         <h4><strong><%= intervention_type_group.title %></strong></h4>
         <div>
-          <%= link_to "View all #{intervention_type_group.intervention_types.active.count} action types", intervention_type_group_path(intervention_type_group), class: "btn btn-secondary" %>
+          <%= link_to "View all #{intervention_type_group.intervention_types.active.count} actions", intervention_type_group_path(intervention_type_group), class: "btn btn-outline-dark rounded-pill font-weight-bold" %>
         </div>
       </div>
     </div>

--- a/app/views/intervention_type_groups/show.html.erb
+++ b/app/views/intervention_type_groups/show.html.erb
@@ -3,7 +3,7 @@
     <div class="d-flex justify-content-between align-items-center">
       <h1><%= @intervention_type_group.title %></h1>
       <div>
-        <%= link_to 'All action type groups', intervention_type_groups_path, class: 'btn btn-secondary'  %>
+        <%= link_to 'All actions', intervention_type_groups_path, class: 'btn btn-outline-dark rounded-pill font-weight-bold'  %>
       </div>
     </div>
   </div>
@@ -16,7 +16,7 @@
       <% end %>
     </p>
     <p>
-      A collection of <strong><%= @intervention_type_group.intervention_types.active.count %></strong> actions types relevant to a range of subjects and key stages.
+      A collection of <strong><%= @intervention_type_group.intervention_types.active.count %></strong> actions that can be carried out around the school to help improve your save energy.
     </p>
   </div>
 </div>

--- a/app/views/intervention_types/show.html.erb
+++ b/app/views/intervention_types/show.html.erb
@@ -4,14 +4,14 @@
 
 <div class="row padded-row">
   <div class="col-md-3">
-    <%= render 'activity_types/image', activity_type: @intervention_type, css_class: "" %>
+    <%= render 'image', intervention_type: @intervention_type, css_class: "" %>
   </div>
   <div class="col-md-6">
     <h2><%= @intervention_type.title %></h2>
     <p><%= @intervention_type.summary %></p>
   </div>
   <div class="col-md-3">
-    <%= link_to "All #{@intervention_type.intervention_type_group.title} actions", intervention_type_group_path(@intervention_type.intervention_type_group), class: 'btn btn-secondary float-right' %>
+    <%= link_to "View #{@intervention_type.intervention_type_group.intervention_types.count} related actions", intervention_type_group_path(@intervention_type.intervention_type_group), class: 'btn btn-outline-dark rounded-pill font-weight-bold float-right' %>
   </div>
 </div>
 
@@ -22,3 +22,18 @@
 <% if current_user_school %>
   <%= render 'intervention_types/prompt', intervention_type: @intervention_type, school: current_user_school %>
 <% end %>
+
+<div class="row padded-row">
+  <div class="col-md-9">
+    <h3>Overview</h3>
+    <%= @intervention_type.description %>
+  </div>
+  <div class="col-md-3 text-center">
+    <% if @intervention_type.download_links.present? %>
+      <h4 style="padding-top: 0px;">Download resources</h4>
+      <div class="activity_type">
+        <%= @intervention_type.download_links %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/spec/system/activity_category_spec.rb
+++ b/spec/system/activity_category_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe "activity type", type: :system do
         expect(page).to have_content(activity_type_1_1.name)
         expect(page).to have_content('public descriptive text here')
 
-        click_link "All #{activity_category_1.name} activities"
+        click_link "View #{activity_category_1.activity_types.count} related activities"
         expect(page).to have_content(activity_category_1.name)
 
         click_link 'All activities'

--- a/spec/system/interventions_spec.rb
+++ b/spec/system/interventions_spec.rb
@@ -6,7 +6,7 @@ describe 'adding interventions' do
   let!(:school)     { create(:school, :with_calendar, solar_pv_tuos_area: create(:solar_pv_tuos_area)) }
   let!(:user)       { create(:school_admin, school: school)}
 
-  let!(:boiler_intervention){ create :intervention_type, title: 'Changed boiler', summary: 'Old boiler bad, new boiler good' }
+  let!(:boiler_intervention){ create :intervention_type, title: 'Changed boiler', summary: 'Old boiler bad, new boiler good', description: 'How to change your boiler' }
 
   context 'using the management pages' do
 
@@ -122,8 +122,9 @@ describe 'adding interventions' do
 
       click_on 'Changed boiler'
       expect(page).to have_content('Old boiler bad, new boiler good')
+      expect(page).to have_content('How to change your boiler')
 
-      click_on "All #{boiler_intervention.intervention_type_group.title} actions"
+      click_on "View #{boiler_intervention.intervention_type_group.intervention_types.count} related actions"
       expect(page).to have_content(boiler_intervention.intervention_type_group.title)
     end
   end

--- a/spec/system/schools/activity_category_spec.rb
+++ b/spec/system/schools/activity_category_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe "activity type", type: :system do
         expect(page).to have_content(activity_type_1_1.name)
         expect(page).to have_content('school specific descriptive text here')
 
-        click_link "All #{activity_category_1.name} activities"
+        click_link "View #{activity_category_1.activity_types.count} related activities"
         expect(page).to have_content(activity_category_1.name)
 
         click_link 'All activities'


### PR DESCRIPTION
Intervention page templates didn't have code to display description and download links

Changed button styling, to match elsewhere on the site we have links in the top right

Tweaked button labels to reduce amount of text.