### PR TITLE
Initial version of service to generate report data

### DIFF
--- a/.ebextensions/cronjob.config
+++ b/.ebextensions/cronjob.config
@@ -98,13 +98,6 @@ files:
         content: |
             15 5 * * * root /bin/bash -l -c 'cd /var/app/current && RAILS_ENV=production bin/run_as_webapp bundle exec rake solar:import_rtone_variant_readings >> log/jobs.log 2>&1'
 
-    "/etc/cron.d/import-rtone-variant-data":
-        mode: "000644"
-        owner: root
-        group: root
-        content: |
-            15 5 * * * root /bin/bash -l -c 'cd /var/app/current && RAILS_ENV=production bin/run_as_webapp bundle exec rake solar:import_rtone_variant_readings >> log/jobs.log 2>&1'
-
     #
     # Import Solar Edge data
     #
@@ -220,6 +213,17 @@ files:
         group: root
         content: |
           30 08 * * 1 root /bin/bash -l -c 'cd /var/app/current && RAILS_ENV=production bin/run_as_webapp bundle exec rake targets:send_first_target >> log/jobs.log 2>&1'
+
+
+    #
+    # Send weekly email about target progress to admins
+    #
+    "/etc/cron.d/send-weekly-admin-target-reports":
+        mode: "000644"
+        owner: root
+        group: root
+        content: |
+          30 08 * * 5 root /bin/bash -l -c 'cd /var/app/current && RAILS_ENV=production bin/run_as_webapp bundle exec rake targets:admin_report >> log/jobs.log 2>&1'
 
 # Remove baks else jobs get run twice
 commands:

--- a/app/classes/targets/school_targets_progress.rb
+++ b/app/classes/targets/school_targets_progress.rb
@@ -1,0 +1,20 @@
+module Targets
+  class SchoolTargetsProgress
+    attr_reader :school, :targets_enabled, :enough_data, :progress_summary
+
+    def initialize(school:, targets_enabled:, enough_data: nil, progress_summary: nil)
+      @school = school
+      @targets_enabled = targets_enabled
+      @enough_data = enough_data
+      @progress_summary = progress_summary
+    end
+
+    def school_target
+      progress_summary.present? ? progress_summary.school_target : nil
+    end
+
+    def school_target?
+      school_target.present?
+    end
+  end
+end

--- a/app/mailers/target_mailer.rb
+++ b/app/mailers/target_mailer.rb
@@ -12,4 +12,31 @@ class TargetMailer < ApplicationMailer
     @to = params[:to]
     make_bootstrap_mail(to: @to, subject: "Review your progress and set a new saving target")
   end
+
+  def admin_target_report
+    @to = params[:to]
+    @target_summary = params[:target_summary]
+    @progress_report = params[:progress_report]
+    @target_data_report = params[:target_data_report]
+
+    attach(@progress_report, "progress-report")
+    attach(@target_data_report, "target-data-report")
+
+    make_bootstrap_mail(to: @to, subject: "Target Progress and Data Report")
+  end
+
+  private
+
+  def attach(report, prefix, suffix = "csv", mime_type = "text/csv")
+    if report.present?
+      attachments["#{prefix}-#{timestamp}.#{suffix}"] = {
+        mime_type: mime_type,
+        content: report
+      }
+    end
+  end
+
+  def timestamp
+    Time.zone.today.strftime("%Y-%m-%d")
+  end
 end

--- a/app/services/targets/admin_report_service.rb
+++ b/app/services/targets/admin_report_service.rb
@@ -132,7 +132,7 @@ module Targets
       if fuel_target.present?
         row += [
           fuel_target,
-          fuel_progress.progress.present? ? format_target(fuel_progress.progress) : nil
+          fuel_progress.present? && fuel_progress.progress.present? ? format_target(fuel_progress.progress) : nil
         ]
       else
         row += Array.new(2, nil)

--- a/app/services/targets/admin_report_service.rb
+++ b/app/services/targets/admin_report_service.rb
@@ -1,0 +1,147 @@
+module Targets
+  class AdminReportService
+    def send_email_report(progress: true, target_data: true)
+      progress_report = progress_report_as_csv if progress
+      target_data_report = target_data_report_as_csv if target_data
+      TargetMailer.with(to: to,
+        target_summary: target_summary,
+        progress_report: progress_report,
+        target_data_report: target_data_report).admin_target_report.deliver_now
+    end
+
+    def progress_report_as_csv
+      generate_csv_for_school_groups(progress_report_headers) do |csv, school_group|
+        service = Targets::SchoolGroupProgressReportingService.new(school_group)
+        data = service.report
+        data.each do |school_target_progress|
+          #rows for all schools
+          row = [
+            school_group.name,
+            school_target_progress.school.name,
+            school_target_progress.targets_enabled,
+            school_target_progress.enough_data
+          ]
+          #add 8 more columns: 2x dates, 2x for each fuel type
+          progress_summary = school_target_progress.progress_summary
+          if progress_summary.present?
+            row = add_progress_report_fuel_type_columns(row, progress_summary)
+          else
+            row += Array.new(8, nil)
+          end
+          csv << row
+        end
+      end
+    end
+
+    def target_data_report_as_csv
+      generate_csv_for_school_groups(target_data_report_headers) do |csv, school_group|
+        service = Targets::SchoolGroupTargetDataReportingService.new(school_group)
+        data = service.report
+        data.each do |school, school_result|
+          FUEL_TYPES.each do |fuel_type|
+            if school_result[fuel_type].present?
+              csv << [
+                school_group.name,
+                school.name,
+                school.visible,
+                fuel_type,
+                school_result[fuel_type][:target_set],
+                school_result[fuel_type][:holidays],
+                school_result[fuel_type][:temperature],
+                school_result[fuel_type][:readings],
+                school_result[fuel_type][:estimate_needed],
+                school_result[fuel_type][:estimate_set],
+                school_result[fuel_type][:calculate_synthetic_data]
+              ]
+            end
+          end
+        end
+      end
+    end
+
+    private
+
+    FUEL_TYPES = [:electricity, :gas, :storage_heater].freeze
+
+    def school_groups
+      SchoolGroup.all.by_name
+    end
+
+    def to
+      'services@energysparks.uk'
+    end
+
+    def target_summary
+      OpenStruct.new(
+        currently_active: SchoolTarget.currently_active.count,
+        first_target_sent: SchoolTargetEvent.first_target_sent.count,
+        review_target_sent: SchoolTargetEvent.review_target_sent.count
+      )
+    end
+
+    def generate_csv_for_school_groups(headers)
+      CSV.generate do |csv|
+        csv << headers
+        school_groups.each do |school_group|
+          yield csv, school_group
+        end
+      end
+    end
+
+    def target_data_report_headers
+      ["Group",
+       "School",
+       "Visible?",
+       "Fuel type",
+       "Target set?",
+       "Holidays?",
+       "Temperature?",
+       "Readings?",
+       "Annual estimate needed?",
+       "Annual estimate set?",
+       "Can calculate synthetic data?"]
+    end
+
+    def progress_report_headers
+      ["Group",
+       "School",
+       "Targets Enabled?",
+       "Enough Data?",
+       "Start Date",
+       "Target Date",
+       "Electricity Target",
+       "Electricity Progress",
+       "Gas Target",
+       "Gas Progress",
+       "Storage Heater Target",
+       "Storage Heater Progress"]
+    end
+
+    def add_progress_report_fuel_type_columns(row, progress_summary)
+      school_target = progress_summary.school_target
+      #dates
+      row += [school_target.start_date.strftime("%Y-%m-%d"), school_target.target_date.strftime("%Y-%m-%d")]
+      #add 2 columns for each fuel type
+      row = add_progress_report_fuel_type(row, school_target.electricity, progress_summary.electricity_progress)
+      row = add_progress_report_fuel_type(row, school_target.gas, progress_summary.gas_progress)
+      row = add_progress_report_fuel_type(row, school_target.storage_heaters, progress_summary.storage_heater_progress)
+      row
+    end
+
+    def add_progress_report_fuel_type(row, fuel_target, fuel_progress)
+      if fuel_target.present?
+        row += [
+          fuel_target,
+          fuel_progress.progress.present? ? format_target(fuel_progress.progress) : nil
+        ]
+      else
+        row += Array.new(2, nil)
+      end
+      row
+    end
+
+    def format_target(value)
+      FormatEnergyUnit.format(:relative_percent, value, :html, false, true, :target)
+    end
+  end
+end

--- a/app/services/targets/admin_report_service.rb
+++ b/app/services/targets/admin_report_service.rb
@@ -131,13 +131,18 @@ module Targets
     def add_progress_report_fuel_type(row, fuel_target, fuel_progress)
       if fuel_target.present?
         row += [
-          fuel_target,
+          format_percent_reduction(fuel_target),
           fuel_progress.present? && fuel_progress.progress.present? ? format_target(fuel_progress.progress) : nil
         ]
       else
         row += Array.new(2, nil)
       end
       row
+    end
+
+    def format_percent_reduction(target)
+      return "0%" if target == 0
+      return "-#{target}%"
     end
 
     def format_target(value)

--- a/app/services/targets/school_group_progress_reporting_service.rb
+++ b/app/services/targets/school_group_progress_reporting_service.rb
@@ -1,0 +1,64 @@
+module Targets
+  class SchoolGroupProgressReportingService
+    def initialize(school_group)
+      @school_group = school_group
+    end
+
+    def report
+      school_progress = []
+      schools.each do |school|
+        begin
+          school_progress << school_target_progress(school, aggregate_school(school))
+        rescue => e
+          Rails.logger.error "Unable to generate progress report for #{school.name}: #{e.message}"
+          Rails.logger.error e.backtrace.join("\n")
+          Rollbar.error(e, job: :school_progress_reporting, school_id: school.id, school: school.name)
+        end
+      end
+      school_progress
+    end
+
+    private
+
+    def schools
+      @school_group.schools.process_data.by_name
+    end
+
+    def aggregate_school(school)
+      AggregateSchoolService.new(school).aggregate_school
+    end
+
+    def school_target_progress(school, aggregated_school)
+      targets_enabled = Targets::SchoolTargetService.targets_enabled?(school)
+      if targets_enabled
+        Targets::SchoolTargetsProgress.new(
+          school: school,
+          targets_enabled: targets_enabled,
+          enough_data: enough_data?(school),
+          progress_summary: progress_summary(school, aggregated_school)
+        )
+      else
+        Targets::SchoolTargetsProgress.new(
+          school: school,
+          targets_enabled: targets_enabled
+        )
+      end
+    end
+
+    def enough_data?(school)
+      target_service(school).enough_data?
+    end
+
+    def target_service(school)
+      Targets::SchoolTargetService.new(school)
+    end
+
+    def progress_summary(school, aggregate_school)
+      progress_service(school, aggregate_school).progress_summary
+    end
+
+    def progress_service(school, aggregate_school)
+      Targets::ProgressService.new(school, aggregate_school)
+    end
+  end
+end

--- a/app/services/targets/school_group_target_data_reporting_service.rb
+++ b/app/services/targets/school_group_target_data_reporting_service.rb
@@ -4,7 +4,7 @@ module Targets
       @school_group = school_group
     end
 
-    #returns hash school => result
+    #returns Hash of School => Struct(school:, electricity: , gas:, storage_heater:)
     def report
       report = {}
       schools.each do |school|
@@ -12,7 +12,7 @@ module Targets
           aggregate_school = AggregateSchoolService.new(school).aggregate_school
           report[school] = report_for_school(school, aggregate_school)
         rescue => e
-          report[school] = []
+          report[school] = nil
           Rails.logger.error "Unable to generate report for #{school.name}: #{e.message}"
           Rails.logger.error e.backtrace.join("\n")
           Rollbar.error(e, job: :target_data, school: school)
@@ -31,26 +31,29 @@ module Targets
       ::TargetsService.new(aggregate_school, fuel_type)
     end
 
+    #OpenStruct to group them
     def report_for_school(school, aggregate_school)
-      result = []
-      result << report_for_school_and_fuel_type(school, aggregate_school, :electricity) if school.has_electricity?
-      result << report_for_school_and_fuel_type(school, aggregate_school, :gas) if school.has_gas?
-      result << report_for_school_and_fuel_type(school, aggregate_school, :storage_heater) if school.has_storage_heaters?
+      result = OpenStruct.new(school: school)
+      result.electricity = report_for_school_and_fuel_type(school, aggregate_school, :electricity) if school.has_electricity?
+      result.gas = report_for_school_and_fuel_type(school, aggregate_school, :gas) if school.has_gas?
+      result.storage_heater = report_for_school_and_fuel_type(school, aggregate_school, :storage_heater) if school.has_storage_heaters?
       result
     end
 
+    #OpenStruct, move to target service?
     def report_for_school_and_fuel_type(school, aggregate_school, fuel_type)
       service = target_service(aggregate_school, fuel_type)
-      {
+      OpenStruct.new(
         fuel_type: fuel_type,
         holidays: service.enough_holidays?,
         temperature: service.enough_temperature_data?,
         readings: service.enough_readings_to_calculate_target?,
         estimate_needed: service.annual_kwh_estimate_required?,
         estimate_set: service.annual_kwh_estimate?,
-        target: service.target_set?,
-        current_target: school.has_current_target?
-      }
+        calculate_synthetic_data: service.can_calculate_one_year_of_synthetic_data?,
+        target_set: school.has_current_target?,
+        recent_data: service.recent_data?
+      )
     end
   end
 end

--- a/app/services/targets/school_group_target_data_reporting_service.rb
+++ b/app/services/targets/school_group_target_data_reporting_service.rb
@@ -1,0 +1,56 @@
+module Targets
+  class SchoolGroupTargetDataReportingService
+    def initialize(school_group)
+      @school_group = school_group
+    end
+
+    #returns hash school => result
+    def report
+      report = {}
+      schools.each do |school|
+        begin
+          aggregate_school = AggregateSchoolService.new(school).aggregate_school
+          report[school] = report_for_school(school, aggregate_school)
+        rescue => e
+          report[school] = []
+          Rails.logger.error "Unable to generate report for #{school.name}: #{e.message}"
+          Rails.logger.error e.backtrace.join("\n")
+          Rollbar.error(e, job: :target_data, school: school)
+        end
+      end
+      report
+    end
+
+    private
+
+    def schools
+      @school_group.schools.process_data.by_name
+    end
+
+    def target_service(aggregate_school, fuel_type)
+      ::TargetsService.new(aggregate_school, fuel_type)
+    end
+
+    def report_for_school(school, aggregate_school)
+      result = []
+      result << report_for_school_and_fuel_type(school, aggregate_school, :electricity) if school.has_electricity?
+      result << report_for_school_and_fuel_type(school, aggregate_school, :gas) if school.has_gas?
+      result << report_for_school_and_fuel_type(school, aggregate_school, :storage_heater) if school.has_storage_heaters?
+      result
+    end
+
+    def report_for_school_and_fuel_type(school, aggregate_school, fuel_type)
+      service = target_service(aggregate_school, fuel_type)
+      {
+        fuel_type: fuel_type,
+        holidays: service.enough_holidays?,
+        temperature: service.enough_temperature_data?,
+        readings: service.enough_readings_to_calculate_target?,
+        estimate_needed: service.annual_kwh_estimate_required?,
+        estimate_set: service.annual_kwh_estimate?,
+        target: service.target_set?,
+        current_target: school.has_current_target?
+      }
+    end
+  end
+end

--- a/app/services/targets/school_group_targets_testing_service.rb
+++ b/app/services/targets/school_group_targets_testing_service.rb
@@ -1,28 +1,13 @@
 module Targets
-  class SchoolGroupTargetDataReportService
+  # This service is used as part of bulk testing the targets and tracking feature
+  # It should NOT be run on the production service
+  class SchoolGroupTargetsTestingService
     def initialize(school_group)
       @school_group = school_group
     end
 
-    #returns hash school => result
-    def report
-      report = {}
-      schools.each do |school|
-        begin
-          aggregate_school = AggregateSchoolService.new(school).aggregate_school
-          report[school] = report_for_school(school, aggregate_school)
-        rescue => e
-          report[school] = []
-          Rails.logger.error "Unable to generate report for #{school.name}: #{e.message}"
-          Rails.logger.error e.backtrace.join("\n")
-          Rollbar.error(e, job: :target_data, school: school)
-        end
-      end
-      report
-    end
-
     #returns hash school => hash(fuel_type => results)
-    def test_targets
+    def report
       report = {}
       fuel_type_report = {
         enough_data: false,
@@ -94,32 +79,6 @@ module Targets
 
     def schools
       @school_group.schools.process_data.by_name
-    end
-
-    def target_service(aggregate_school, fuel_type)
-      ::TargetsService.new(aggregate_school, fuel_type)
-    end
-
-    def report_for_school(school, aggregate_school)
-      result = []
-      result << report_for_school_and_fuel_type(school, aggregate_school, :electricity) if school.has_electricity?
-      result << report_for_school_and_fuel_type(school, aggregate_school, :gas) if school.has_gas?
-      result << report_for_school_and_fuel_type(school, aggregate_school, :storage_heater) if school.has_storage_heaters?
-      result
-    end
-
-    def report_for_school_and_fuel_type(school, aggregate_school, fuel_type)
-      service = target_service(aggregate_school, fuel_type)
-      {
-        fuel_type: fuel_type,
-        holidays: service.enough_holidays?,
-        temperature: service.enough_temperature_data?,
-        readings: service.enough_readings_to_calculate_target?,
-        estimate_needed: service.annual_kwh_estimate_required?,
-        estimate_set: service.annual_kwh_estimate?,
-        target: service.target_set?,
-        current_target: school.has_current_target?
-      }
     end
   end
 end

--- a/app/views/target_mailer/admin_target_report.html.erb
+++ b/app/views/target_mailer/admin_target_report.html.erb
@@ -1,0 +1,70 @@
+<h1 class="mb-3">Targets & Tracking Weekly Summary</h1>
+
+<h2>Overview</h2>
+<p>
+There are <%= @target_summary.currently_active %> currently active school targets.
+</p>
+<div class="s-3"></div>
+<p>
+<%= @target_summary.first_target_sent %> schools have been invited to set a target.
+</p>
+<div class="s-3"></div>
+<p>
+<%= @target_summary.review_target_sent %> schools have been emailed to ask them to review
+their target after the target date was reached.
+</p>
+<div class="s-3"></div>
+
+<% if @progress_report.present? %>
+<h2>Progress Report</h2>
+<div class="s-3"></div>
+<p>
+  The attached progress report summarises the current progress for all schools that
+  have set a target. There is a single row for each school.
+</p>
+<div class="s-3"></div>
+<p>
+  The report columns are:
+  <ul>
+    <li><code>Group</code> - school group</li>
+    <li><code>School</code> - the name of the school</li>
+    <li><code>Targets Enabled?</code> - is the school configured to use the feature?</li>
+    <li><code>Enough Data?</code> - does the school have enough data/estimates to use the feature?</li>
+    <li><code>Start Date</code> - the start date for the target, if set</li>
+    <li><code>Target Date</code> - the target date for the target, if set</li>
+    <li><code>Electricity Target</code> - target for electricity, as set by user</li>
+    <li><code>Electricity Progress</code> - current cumulative progress towards target</li>
+    <li><code>Gas Target</code> - target for gas, as set by user</li>
+    <li><code>Gas Progress</code> - current cumulative progress towards target</li>
+    <li><code>Storage Heater Target</code> - target for storage heaters, as set by user</li>
+    <li><code>Storage Heater Progress</code> - current cumulative progress towards target</li>
+  </ul>
+</p>
+<div class="s-3"></div>
+<% end %>
+
+<% if @target_data_report.present? %>
+<h2>Target Data Report</h2>
+<div class="s-3"></div>
+<p>
+  The attached target data report summarises the data that impacts the
+  availability of the targets and tracking feature for all schools. There is a single row for each school and fuel type.
+</p>
+<p>
+  The report columns are:
+  <ul>
+    <li><code>Group</code> - school group</li>
+    <li><code>School</code> - the name of the school</li>
+    <li><code>Visible?</code> - is the school visible on the system?</li>
+    <li><code>Fuel Type</code> - the fuel type</li>
+    <li><code>Target set?</code> - has the school already set a target?</li>
+    <li><code>Holidays?</code> - is there enough holiday data to set a target?</li>
+    <li><code>Temperature?</code> - is there enough temperature data to set a target?</li>
+    <li><code>Readings?</code> - is there enough historical readings to set a target?</li>
+    <li><code>Annual estimate needed?</code> - is an annual estimate needed? (for schools with less than a years worth of data)</li>
+    <li><code>Annual estimate set?</code> - has an annual estimate been configured?</li>
+    <li><code>Can calculate synthetic data?</code> - given an estimate, can we actually calcualte a years worth of data to generate targets?</li>
+  </ul>
+</p>
+<div class="s-3"></div>
+<% end %>

--- a/app/views/target_mailer/admin_target_report.html.erb
+++ b/app/views/target_mailer/admin_target_report.html.erb
@@ -63,7 +63,7 @@ their target after the target date was reached.
     <li><code>Readings?</code> - is there enough historical readings to set a target?</li>
     <li><code>Annual estimate needed?</code> - is an annual estimate needed? (for schools with less than a years worth of data)</li>
     <li><code>Annual estimate set?</code> - has an annual estimate been configured?</li>
-    <li><code>Can calculate synthetic data?</code> - given an estimate, can we actually calcualte a years worth of data to generate targets?</li>
+    <li><code>Can calculate synthetic data?</code> - given an estimate, can we actually calculate a years worth of data to generate targets?</li>
   </ul>
 </p>
 <div class="s-3"></div>

--- a/lib/tasks/amr_importer/notifier.rake
+++ b/lib/tasks/amr_importer/notifier.rake
@@ -2,7 +2,11 @@ namespace :amr_importer do
   desc "Send daily notification email of imports"
   task send_daily_notification_email: :environment do
     puts "#{DateTime.now.utc} Import notifier start"
-    ImportNotifier.new(description: 'daily imports').notify(from: 24.hours.ago, to: Time.zone.now)
+    if ENV['ENVIRONMENT_IDENTIFIER'] == "production"
+      ImportNotifier.new(description: 'daily imports').notify(from: 24.hours.ago, to: Time.zone.now)
+    else
+      puts "#{Time.zone.now} Only sending import reports on the production server"
+    end
     puts "#{DateTime.now.utc} Import notifier end"
   end
 end

--- a/lib/tasks/targets/admin_report.rake
+++ b/lib/tasks/targets/admin_report.rake
@@ -1,0 +1,12 @@
+namespace :targets do
+  desc 'Send email to set first target'
+  task admin_report: [:environment] do
+    puts "#{Time.zone.now} Sending weekly target report to admins"
+    if ENV['ENVIRONMENT_IDENTIFIER'] == "production"
+      Targets::AdminReportService.new.send_email_report
+    else
+      puts "#{Time.zone.now} Only sending report on the production server"
+    end
+    puts "#{Time.zone.now} Finished sending weekly target report to admins"
+  end
+end

--- a/lib/tasks/targets/enough_data_report.rake
+++ b/lib/tasks/targets/enough_data_report.rake
@@ -3,25 +3,37 @@ namespace :targets do
   task enough_data_report: [:environment] do
     puts "#{Time.zone.now} Generating enough-data report"
     CSV.open("/tmp/enough-data-report.csv", "w") do |csv|
-      csv << ["Group", "School", "Visible?", "Fuel Type", "Holidays?", "Temperature?", "Readings?", "Estimate needed?", "Estimate set?", "Target?", "Current target?"]
+      csv << ["Group",
+              "School",
+              "Visible?",
+              "Fuel type",
+              "Target set?",
+              "Holidays?",
+              "Temperature?",
+              "Readings?",
+              "Annual estimate needed?",
+              "Annual estimate set?",
+              "Can calculate synthetic data?"]
       SchoolGroup.all.each do |school_group|
         service = Targets::SchoolGroupTargetDataReportingService.new(school_group)
         data = service.report
-        data.each do |school, result_data|
-          result_data.each do |fuel_result_data|
-            csv << [
-              school_group.name,
-              school.name,
-              school.visible,
-              fuel_result_data[:fuel_type],
-              fuel_result_data[:holidays],
-              fuel_result_data[:temperature],
-              fuel_result_data[:readings],
-              fuel_result_data[:estimate_needed],
-              fuel_result_data[:estimate_set],
-              fuel_result_data[:target],
-              fuel_result_data[:current_target]
-            ]
+        data.each do |school, school_result|
+          [:electricity, :gas, :storage_heater].each do |fuel_type|
+            if school_result[fuel_type].present?
+              csv << [
+                school_group.name,
+                school_result.school.name,
+                school_result.school.visible,
+                fuel_type,
+                school_result[fuel_type][:target_set],
+                school_result[fuel_type][:holidays],
+                school_result[fuel_type][:temperature],
+                school_result[fuel_type][:readings],
+                school_result[fuel_type][:estimate_needed],
+                school_result[fuel_type][:estimate_set],
+                school_result[fuel_type][:calculate_synthetic_data]
+              ]
+            end
           end
         end
       end

--- a/lib/tasks/targets/enough_data_report.rake
+++ b/lib/tasks/targets/enough_data_report.rake
@@ -5,7 +5,7 @@ namespace :targets do
     CSV.open("/tmp/enough-data-report.csv", "w") do |csv|
       csv << ["Group", "School", "Visible?", "Fuel Type", "Holidays?", "Temperature?", "Readings?", "Estimate needed?", "Estimate set?", "Target?", "Current target?"]
       SchoolGroup.all.each do |school_group|
-        service = Targets::SchoolGroupTargetDataReportService.new(school_group)
+        service = Targets::SchoolGroupTargetDataReportingService.new(school_group)
         data = service.report
         data.each do |school, result_data|
           result_data.each do |fuel_result_data|

--- a/lib/tasks/targets/send_review_target.rake
+++ b/lib/tasks/targets/send_review_target.rake
@@ -2,7 +2,11 @@ namespace :targets do
   desc 'Send email to set new target'
   task send_review_target: [:environment] do
     puts "#{Time.zone.now} Sending set new target emails"
-    Targets::TargetMailerService.new.invite_schools_to_review_target
+    if ENV['SEND_AUTOMATED_EMAILS']
+      Targets::TargetMailerService.new.invite_schools_to_review_target
+    else
+      puts "#{Time.zone.now} Automated emails disabled, not sending reminders"
+    end
     puts "#{Time.zone.now} Finished sending set new target emails"
   end
 end

--- a/lib/tasks/targets/test_targets.rake
+++ b/lib/tasks/targets/test_targets.rake
@@ -2,23 +2,27 @@ namespace :targets do
   desc 'Run report to targets feature'
   task test_targets: [:environment] do
     puts "#{Time.zone.now} Generating test-target report"
-    CSV.open("/tmp/test-targets-report.csv", "w") do |csv|
-      csv << ["Group", "School", "Fuel Type", "Enough data", "Recent data", "Success", "Progress", "Error"]
-      SchoolGroup.all.each do |school_group|
-        service = Targets::SchoolGroupTargetsTestingService.new(school_group)
-        test_result = service.report
-        test_result.each do |school, report|
-          report.each do |fuel_type, results|
-            csv << [
-              school_group.name,
-              school.name,
-              fuel_type,
-              results[:enough_data],
-              results[:recent_data],
-              results[:success],
-              results[:progress],
-              results[:error],
-            ]
+    if ENV['ENVIRONMENT_IDENTIFIER'] == "production"
+      puts "Cannot run this report in this environment!"
+    else
+      CSV.open("/tmp/test-targets-report.csv", "w") do |csv|
+        csv << ["Group", "School", "Fuel Type", "Enough data", "Recent data", "Success", "Progress", "Error"]
+        SchoolGroup.all.each do |school_group|
+          service = Targets::SchoolGroupTargetsTestingService.new(school_group)
+          test_result = service.report
+          test_result.each do |school, report|
+            report.each do |fuel_type, results|
+              csv << [
+                school_group.name,
+                school.name,
+                fuel_type,
+                results[:enough_data],
+                results[:recent_data],
+                results[:success],
+                results[:progress],
+                results[:error],
+              ]
+            end
           end
         end
       end

--- a/lib/tasks/targets/test_targets.rake
+++ b/lib/tasks/targets/test_targets.rake
@@ -5,8 +5,8 @@ namespace :targets do
     CSV.open("/tmp/test-targets-report.csv", "w") do |csv|
       csv << ["Group", "School", "Fuel Type", "Enough data", "Recent data", "Success", "Progress", "Error"]
       SchoolGroup.all.each do |school_group|
-        service = Targets::SchoolGroupTargetDataReportService.new(school_group)
-        test_result = service.test_targets
+        service = Targets::SchoolGroupTargetsTestingService.new(school_group)
+        test_result = service.report
         test_result.each do |school, report|
           report.each do |fuel_type, results|
             csv << [

--- a/spec/services/targets/admin_report_service_spec.rb
+++ b/spec/services/targets/admin_report_service_spec.rb
@@ -1,0 +1,116 @@
+require 'rails_helper'
+
+describe Targets::AdminReportService, type: :service do
+
+  let(:school_group)         { create(:school_group) }
+  let!(:school)              { create(:school, school_group: school_group) }
+  let!(:school_target)       { create(:school_target, school: school) }
+  let(:progress_summary)     { build(:progress_summary, school_target: school_target) }
+
+  let(:service) { Targets::AdminReportService.new }
+
+  before(:each) do
+    allow(EnergySparks::FeatureFlags).to receive(:active?).and_return(true)
+    allow_any_instance_of(Targets::SchoolTargetService).to receive(:enough_data?).and_return(true)
+    allow_any_instance_of(Targets::ProgressService).to receive(:progress_summary).and_return(progress_summary)
+  end
+
+  context '#progress_report_as_csv' do
+    let(:report)  { service.progress_report_as_csv }
+
+    it 'should not be empty' do
+      expect(report).to_not be_nil
+      expect(CSV.parse(report).size).to eq 2
+    end
+
+    it 'should have expected data' do
+      array = CSV.parse(report)[1]
+      expect(array).to match_array([
+        school_group.name,
+        school.name,
+        "true",
+        "true",
+        "#{school_target.start_date.strftime("%Y-%m-%d")}",
+        "#{school_target.target_date.strftime("%Y-%m-%d")}",
+        "#{school_target.electricity}",
+        "#{FormatEnergyUnit.format(:relative_percent, progress_summary.electricity_progress.progress, :html, false, true, :target)}",
+        "#{school_target.gas}",
+        "#{FormatEnergyUnit.format(:relative_percent, progress_summary.gas_progress.progress, :html, false, true, :target)}",
+        "#{school_target.storage_heaters}",
+        "#{FormatEnergyUnit.format(:relative_percent, progress_summary.storage_heater_progress.progress, :html, false, true, :target)}"
+        ])
+    end
+  end
+
+  context '#target_data_report_as_csv' do
+    let(:report)  { service.target_data_report_as_csv }
+
+    before(:each) do
+      allow_any_instance_of(School).to receive(:has_electricity?).and_return(true)
+      allow_any_instance_of(School).to receive(:has_gas?).and_return(false)
+      allow_any_instance_of(School).to receive(:has_storage_heaters?).and_return(false)
+      allow_any_instance_of(TargetsService).to receive(:enough_holidays?).and_return(true)
+      allow_any_instance_of(TargetsService).to receive(:enough_temperature_data?).and_return(true)
+      allow_any_instance_of(TargetsService).to receive(:enough_readings_to_calculate_target?).and_return(true)
+      allow_any_instance_of(TargetsService).to receive(:annual_kwh_estimate_required?).and_return(false)
+      allow_any_instance_of(TargetsService).to receive(:annual_kwh_estimate?).and_return(false)
+      allow_any_instance_of(TargetsService).to receive(:can_calculate_one_year_of_synthetic_data?).and_return(true)
+      allow_any_instance_of(TargetsService).to receive(:recent_data?).and_return(true)
+    end
+
+    it 'should not be empty' do
+      expect(report).to_not be_nil
+      expect(CSV.parse(report).size).to eq 2
+    end
+
+    it 'should have expected data' do
+      array = CSV.parse(report)[1]
+      expect(array).to match_array([
+        school_group.name,
+        school.name,
+        "true",
+        "electricity",
+        "true",
+        "true",
+        "true",
+        "true",
+        "false",
+        "false",
+        "true"
+        ])
+    end
+  end
+
+  context '#send_email_report' do
+    before(:each) do
+      service.send_email_report
+    end
+
+    let(:email)       { ActionMailer::Base.deliveries.last }
+    let(:email_body)  { email.html_part.body.to_s }
+    let(:today)       { Time.zone.now.strftime("%Y-%m-%d") }
+    it 'should send an email' do
+      expect(ActionMailer::Base.deliveries.count).to eql 1
+    end
+
+    it 'should have right recipient' do
+      expect(email.to).to contain_exactly("services@energysparks.uk")
+    end
+
+    it 'should have the right subject' do
+      expect(email.subject).to eql "Target Progress and Data Report"
+    end
+
+    it 'should include summary' do
+      expect(email_body).to include("There are 1 currently active school targets")
+    end
+
+    it 'should have the expected 2 attachments' do
+      expect(email.attachments.first.mime_type).to eql "text/csv"
+      expect(email.attachments.first.filename).to eql "progress-report-#{today}.csv"
+      expect(email.attachments.last.mime_type).to eql "text/csv"
+      expect(email.attachments.last.filename).to eql "target-data-report-#{today}.csv"
+    end
+  end
+
+end

--- a/spec/services/targets/admin_report_service_spec.rb
+++ b/spec/services/targets/admin_report_service_spec.rb
@@ -25,18 +25,18 @@ describe Targets::AdminReportService, type: :service do
 
     it 'should have expected data' do
       array = CSV.parse(report)[1]
-      expect(array).to match_array([
+      expect(array).to eq([
         school_group.name,
         school.name,
         "true",
         "true",
         "#{school_target.start_date.strftime("%Y-%m-%d")}",
         "#{school_target.target_date.strftime("%Y-%m-%d")}",
-        "#{school_target.electricity}",
+        "-#{school_target.electricity}%",
         "#{FormatEnergyUnit.format(:relative_percent, progress_summary.electricity_progress.progress, :html, false, true, :target)}",
-        "#{school_target.gas}",
+        "-#{school_target.gas}%",
         "#{FormatEnergyUnit.format(:relative_percent, progress_summary.gas_progress.progress, :html, false, true, :target)}",
-        "#{school_target.storage_heaters}",
+        "-#{school_target.storage_heaters}%",
         "#{FormatEnergyUnit.format(:relative_percent, progress_summary.storage_heater_progress.progress, :html, false, true, :target)}"
         ])
     end
@@ -65,7 +65,7 @@ describe Targets::AdminReportService, type: :service do
 
     it 'should have expected data' do
       array = CSV.parse(report)[1]
-      expect(array).to match_array([
+      expect(array).to eq([
         school_group.name,
         school.name,
         "true",

--- a/spec/services/targets/school_group_progress_reporting_service_spec.rb
+++ b/spec/services/targets/school_group_progress_reporting_service_spec.rb
@@ -1,0 +1,80 @@
+require 'rails_helper'
+
+describe Targets::SchoolGroupProgressReportingService, type: :service do
+
+  let(:enable_targets)      { false }
+  let(:enough_data)         { true }
+  let(:school_target)       { nil }
+  let(:progress_summary)    { nil }
+
+  let(:school_group)        { create(:school_group) }
+  let!(:school)              { create(:school, school_group: school_group, enable_targets_feature: enable_targets) }
+
+  let(:service) { Targets::SchoolGroupProgressReportingService.new(school_group) }
+
+  before(:each) do
+    allow(EnergySparks::FeatureFlags).to receive(:active?).and_return(true)
+  end
+
+  describe '#report' do
+
+    before(:each) do
+      allow_any_instance_of(Targets::SchoolTargetService).to receive(:enough_data?).and_return(enough_data)
+    end
+
+    let(:report) { service.report }
+
+    context 'schools with target disabled' do
+      it 'includes the school' do
+        expect(report.size).to eql 1
+        expect(report.first.school).to eq school
+        expect(report.first.targets_enabled).to eq false
+        expect(report.first.enough_data).to be_nil
+        expect(report.first.progress_summary).to be_nil
+      end
+    end
+
+    context 'schools without enough data' do
+      let(:enable_targets)      { true }
+      let(:enough_data)         { false }
+
+      it 'includes the school' do
+        expect(report.size).to eql 1
+        expect(report.first.school).to eq school
+        expect(report.first.targets_enabled).to eq true
+        expect(report.first.enough_data).to eq false
+      end
+    end
+
+    context 'schools with enough data but no target' do
+      let(:enable_targets)      { true }
+      let(:enough_data)         { true }
+
+      it 'includes the school' do
+        expect(report.size).to eql 1
+        expect(report.first.school).to eq school
+        expect(report.first.targets_enabled).to eq true
+        expect(report.first.enough_data).to eq true
+      end
+    end
+
+    context 'schools with enough data and a target' do
+      let(:enable_targets)      { true }
+      let(:enough_data)         { true }
+      let(:school_target)       { create(:school_target, school: school) }
+      let(:progress_summary)    { build(:progress_summary, school_target: school_target) }
+
+      before(:each) do
+        allow_any_instance_of(Targets::ProgressService).to receive(:progress_summary).and_return(progress_summary)
+      end
+      it 'includes the school' do
+        expect(report.size).to eql 1
+        expect(report.first.school).to eq school
+        expect(report.first.targets_enabled).to eq true
+        expect(report.first.enough_data).to eq true
+        expect(report.first.school_target).to eql school_target
+        expect(report.first.progress_summary).to eql progress_summary
+      end
+    end
+  end
+end


### PR DESCRIPTION
* Adds new services to generate reports on target progress and available data for school groups
* Extract the code used to test the targets and tracking feature into a new service
* Ensures that tasks used to send reminders, import notifications and admin targets only execute in production / environment where email sending is enabled
* Adds a service, mailer and template to send a weekly report to admins with 2 attachments, one reporting on target related data another on progress
* Add crontab entry to run the weekly report at 8.30 on a Friday morning