### PR TITLE
Ensure bill and consent requests go to all school admins

### DIFF
--- a/app/controllers/schools/users_controller.rb
+++ b/app/controllers/schools/users_controller.rb
@@ -8,7 +8,7 @@ module Schools
     def index
       authorize! :manage_users, @school
       @users = @school.users
-      @school_admins = (@school.cluster_users + @users.school_admin).uniq
+      @school_admins = @school.all_school_admins.uniq
       @staff = @users.staff
       @pupils = @users.pupil
     end

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -259,7 +259,19 @@ class School < ApplicationRecord
   end
 
   def school_admin
-    users.where(role: :school_admin)
+    users.school_admin
+  end
+
+  def staff
+    users.staff
+  end
+
+  def all_school_admins
+    school_admin + cluster_users
+  end
+
+  def all_adult_school_users
+    all_school_admins + staff
   end
 
   def latest_content

--- a/app/services/school_creator.rb
+++ b/app/services/school_creator.rb
@@ -63,7 +63,7 @@ private
       users << school.school_onboarding.created_user
     end
     #also email admin, staff and group users
-    users += (school.school_admin.to_a + school.cluster_users.to_a + school.users.staff.to_a)
+    users += school.all_adult_school_users.to_a
     users.uniq.map(&:email)
   end
 

--- a/app/services/schools/bill_request_service.rb
+++ b/app/services/schools/bill_request_service.rb
@@ -5,7 +5,7 @@ module Schools
     end
 
     def users
-      users = @school.users.school_admin + @school.users.staff
+      users = @school.all_adult_school_users
       users.sort_by(&:staff_role)
     end
 

--- a/app/services/schools/consent_request_service.rb
+++ b/app/services/schools/consent_request_service.rb
@@ -5,7 +5,7 @@ module Schools
     end
 
     def users
-      users = @school.users.school_admin + @school.users.staff
+      users = @school.all_adult_school_users
       users.sort_by(&:staff_role)
     end
 

--- a/app/services/targets/target_mailer_service.rb
+++ b/app/services/targets/target_mailer_service.rb
@@ -41,8 +41,7 @@ module Targets
     end
 
     def to(school)
-      #should we include cluster users might be a lot of email at start?
-      users = school.school_admin.to_a + school.cluster_users.to_a + school.users.staff.to_a
+      users = school.all_adult_school_users.to_a
       users.uniq.map(&:email)
     end
   end

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -520,4 +520,34 @@ describe School do
       end
     end
   end
+
+  context 'school users' do
+    let!(:school_admin)     { create(:school_admin, school: subject)}
+    let!(:cluster_admin)    { create(:school_admin, name: "Cluster admin", cluster_schools: [subject]) }
+    let!(:staff)            { create(:staff, school: subject)}
+    let!(:pupil)            { create(:pupil, school: subject)}
+
+    it 'identifies different groups' do
+      expect(subject.school_admin).to match_array([school_admin])
+      expect(subject.cluster_users).to match_array([cluster_admin])
+      expect(subject.staff).to match_array([staff])
+      expect(subject.all_school_admins).to match_array([school_admin, cluster_admin])
+      expect(subject.all_adult_school_users).to match_array([school_admin, cluster_admin, staff])
+    end
+
+    it 'handles empty lists' do
+      school = create(:school)
+      expect(school.school_admin).to be_empty
+      expect(school.cluster_users).to be_empty
+      expect(school.staff).to be_empty
+      expect(school.all_school_admins).to be_empty
+      expect(school.all_adult_school_users).to be_empty
+
+      new_admin = create(:school_admin, school: school)
+      expect(school.all_school_admins).to match_array([new_admin])
+      expect(school.all_adult_school_users).to match_array([new_admin])
+    end
+
+
+  end
 end

--- a/spec/services/schools/bill_request_service_spec.rb
+++ b/spec/services/schools/bill_request_service_spec.rb
@@ -15,12 +15,14 @@ RSpec.describe Schools::BillRequestService do
 
     context 'with users' do
       let!(:school_admin)     { create(:school_admin, school: school)}
+      let!(:cluster_admin)    { create(:school_admin, name: "Cluster admin", cluster_schools: [school]) }
       let!(:staff)            { create(:staff, school: school)}
       let!(:pupil)            { create(:pupil, school: school)}
 
       it 'should return only staff and school admins' do
-        expect(service.users).to match_array([staff, school_admin])
+        expect(service.users).to match_array([staff, cluster_admin, school_admin])
       end
+
     end
 
   end


### PR DESCRIPTION
Fixes specific issue with requests for bills not including cluster admins by adding new helper methods to school for different groups of users: `all_school_admins`, `staff`, `all_adult_users`. Change controllers and services that select individual user types to use these consistently.