### PR TITLE
Add gtag events for downloads

### DIFF
--- a/app/assets/javascripts/activity_types.js
+++ b/app/assets/javascripts/activity_types.js
@@ -16,5 +16,4 @@ $(document).ready(function() {
       reader.readAsDataURL(this.files[0]);
     }
   });
-
 });

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -53,3 +53,4 @@
 //= require mailchimp
 //= require map
 //= require live_data
+//= require gtag

--- a/app/assets/javascripts/gtag.js
+++ b/app/assets/javascripts/gtag.js
@@ -1,0 +1,46 @@
+"use strict"
+
+$(document).ready(function() {
+
+  if (typeof gtag !== 'undefined') {
+    $(".activity-type-download-links a").click(function() {
+      gtag('event', 'download-link', {
+        'event_label': $(this).text(),
+        'event_category': 'activity-type',
+        'value': $(this).parents(".activity-type-download-links").data("event-value")
+      });
+    });
+
+    $(".intervention-type-download-links a").click(function() {
+      gtag('event', 'download-link', {
+        'event_label': $(this).text(),
+        'event_category': 'intervention-type',
+        'value': $(this).parents(".intervention-type-download-links").data("event-value")
+      });
+    });
+
+    $(".programme-type-download-links a").click(function() {
+      gtag('event', 'download-link', {
+        'event_label': 'Download',
+        'event_category': 'programme-type',
+        'value': $(this).parents(".programme-type-download-links").data("event-value")
+      });
+    });
+
+    $(".resource-download-links a").click(function() {
+      gtag('event', 'download-link', {
+        'event_label': $(this).text(),
+        'event_category': 'resource',
+        'value': $(this).parents(".resource-download-links").data("event-value")
+      });
+    });
+
+    $(".case-studies-download-links a").click(function() {
+      gtag('event', 'download-link', {
+        'event_label': 'Download',
+        'event_category': 'case-study',
+        'value': $(this).parents(".case-studies-download-links").data("event-value")
+      });
+    });
+  }
+});

--- a/app/views/activity_types/show.html.erb
+++ b/app/views/activity_types/show.html.erb
@@ -41,7 +41,7 @@
   <div class="col-md-3">
     <% if @activity_type.download_links.present? %>
       <h4 style="padding-top: 0px;">Download resources</h4>
-      <div class="activity_type">
+      <div class="activity_type activity-type-download-links" data-event-value="<%= @activity_type.id %>">
         <%= @activity_type.download_links %>
       </div>
     <% end %>

--- a/app/views/home/_case_studies.html.erb
+++ b/app/views/home/_case_studies.html.erb
@@ -22,7 +22,7 @@
                   <%= case_study.description %>
                 </div>
               </div>
-              <div class="card-footer">
+              <div class="card-footer case-studies-download-links" data-event-value="<%= case_study.id %>">
                 <%= link_to url_for( controller: :case_studies, action: :download, serve: :download, id: case_study.id ), class: 'btn' do %>
                   Download <i class="fas fa-file-download"></i>
                 <% end %>

--- a/app/views/intervention_types/show.html.erb
+++ b/app/views/intervention_types/show.html.erb
@@ -28,7 +28,7 @@
     <h3>Overview</h3>
     <%= @intervention_type.description %>
   </div>
-  <div class="col-md-3 text-center">
+  <div class="col-md-3 text-center intervention-type-download-links" data-event-value="<%= @intervention_type.id %>">
     <% if @intervention_type.download_links.present? %>
       <h4 style="padding-top: 0px;">Download resources</h4>
       <div class="activity_type">

--- a/app/views/programme_types/show.html.erb
+++ b/app/views/programme_types/show.html.erb
@@ -20,7 +20,7 @@
     <h3>Overview</h3>
     <p><%= @programme_type.description %></p>
   </div>
-  <div class="col-md-3 text-center">
+  <div class="col-md-3 text-center programme-type-download-links" data-event-value="<%= @programme_type.id %>">
     <% if @programme_type.document_link.present? %>
       <%= link_to @programme_type.document_link, class: "btn btn-lg", target: '_blank' do %>
         Download <%= fa_icon("download") %>

--- a/app/views/resource_files/index.html.erb
+++ b/app/views/resource_files/index.html.erb
@@ -12,7 +12,7 @@
       </thead>
     <% end %>
     <% type.resource_files.order(:title).each do |resource_file| %>
-      <tr>
+      <tr class="resource-download-links" data-event-value="<%= resource_file.id %>">
         <th scope="row">
           <%= link_to resource_file.title, controller: :resource_files, action: :download, serve: :inline, id: resource_file.id %>
         </th>


### PR DESCRIPTION
Adds jquery click handlers for downloads associated with activity types, intervention types, programme types, resources and case studies

Logs a google analytics event with the link text (or a default) and the id of the model which holds the download links.

Only adds the click handlers if google analytics is defined, so only in production.

For testing in development I:

* used Google Analytics Chrome debugger to log events to console
* configured a test google analytics code
* tweaked `_footer.html.erb` to include analytics
