### PR TITLE
Add meter notes to record and track issues and changes with meters

### DIFF
--- a/app/controllers/schools/meters_controller.rb
+++ b/app/controllers/schools/meters_controller.rb
@@ -100,7 +100,7 @@ module Schools
     end
 
     def meter_params
-      params.require(:meter).permit(:mpan_mprn, :meter_type, :name, :meter_serial_number, :dcc_meter, :sandbox, :earliest_available_data)
+      params.require(:meter).permit(:mpan_mprn, :meter_type, :name, :meter_serial_number, :dcc_meter, :sandbox, :earliest_available_data, :notes)
     end
   end
 end

--- a/app/models/meter.rb
+++ b/app/models/meter.rb
@@ -55,6 +55,8 @@ class Meter < ApplicationRecord
   belongs_to :meter_review, optional: true
   has_and_belongs_to_many :user_tariffs, inverse_of: :meters
 
+  has_rich_text :notes
+
   CREATABLE_METER_TYPES = [:electricity, :gas, :solar_pv, :exported_solar_pv].freeze
   MAIN_METER_TYPES = [:electricity, :gas].freeze
   SUB_METER_TYPES = [:solar_pv, :exported_solar_pv].freeze

--- a/app/views/schools/meters/_active_meters.html.erb
+++ b/app/views/schools/meters/_active_meters.html.erb
@@ -25,6 +25,9 @@
             <i class="fas fa-file-download"></i>
           <% end %>
         <% end %>
+        <% if current_user.admin? && meter.notes.present? %>
+          <%= render 'meter_notes', meter: meter %>
+        <% end %>
       </div>
     </td>
     <td>

--- a/app/views/schools/meters/_form.html.erb
+++ b/app/views/schools/meters/_form.html.erb
@@ -26,9 +26,9 @@
 
   <div class="form-group">
 
-    <p class="alert alert-warning">Experimental features for n3rgy integration</p>
-
     <% if show_dcc_fields %>
+
+      <p class="alert alert-warning">Admin only experimental features for n3rgy integration</p>
 
       <% if meter_is_dcc %>
         <p class="alert alert-success">This meter is available via n3rgy</p>
@@ -41,17 +41,17 @@
         <%= form.label :dcc_meter, 'DCC Smart Meter', class: "custom-control-label"  %>
       </div>
 
+      <div class="custom-control custom-checkbox">
+        <%= form.check_box :sandbox, class: 'custom-control-input' %>
+        <%= form.label :sandbox, class: "custom-control-label" %>
+      </div>
+
+      <div class="form-group">
+        <%= form.label :earliest_available_data %>
+        <%= date_field(:meter, :earliest_available_data, max: Time.zone.today, min: Date.parse("2012-01-01")) %>
+      </div>
+
     <% end %>
-
-    <div class="custom-control custom-checkbox">
-      <%= form.check_box :sandbox, class: 'custom-control-input' %>
-      <%= form.label :sandbox, class: "custom-control-label" %>
-    </div>
-
-    <div class="form-group">
-      <%= form.label :earliest_available_data %>
-      <%= date_field(:meter, :earliest_available_data, max: Time.zone.today, min: Date.parse("2012-01-01")) %>
-    </div>
 
   </div>
 

--- a/app/views/schools/meters/_form.html.erb
+++ b/app/views/schools/meters/_form.html.erb
@@ -23,6 +23,14 @@
       </div>
     <% end %>
   </div>
+  <% if current_user.admin? %>
+    <div class="form-group">
+      <%= form.label :notes, 'Admin notes' %>
+      <div class="trix-wrapper">
+        <%= form.rich_text_area :notes %>
+      </div>
+    </div>
+  <% end %>
 
   <div class="form-group">
 

--- a/app/views/schools/meters/_meter_notes.html.erb
+++ b/app/views/schools/meters/_meter_notes.html.erb
@@ -1,0 +1,23 @@
+<div>
+  <button type="button" class="btn btn-sm" data-toggle="modal" data-target="#meter-notes-<%= meter.id %>">
+    <i class="far fa-sticky-note"></i>
+  </button>
+  <div class="modal fade" id="meter-notes-<%= meter.id %>" tabindex="-1" role="dialog" aria-labelledby="#meter-notes-<%= meter.id %>-title" aria-hidden="true">
+    <div class="modal-dialog" role="document">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title" id="meter-notes-<%= meter.id %>-title">Meter Notes (<%= meter.mpan_mprn %>)</h5>
+          <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+            <span aria-hidden="true">&times;</span>
+          </button>
+        </div>
+        <div class="modal-body">
+          <%= meter.notes %>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/schools/meters/edit.html.erb
+++ b/app/views/schools/meters/edit.html.erb
@@ -1,3 +1,3 @@
 <h1>Edit meter: <%= @school.name %> : <%= @meter.name %></h1>
 
-<%= render 'form', school: @school, meter: @meter, show_dcc_fields: true, meter_is_dcc: @meter_is_dcc %>
+<%= render 'form', school: @school, meter: @meter, show_dcc_fields: current_user.admin?, meter_is_dcc: @meter_is_dcc %>

--- a/app/views/schools/meters/index.html.erb
+++ b/app/views/schools/meters/index.html.erb
@@ -137,6 +137,9 @@
                   <i class="fas fa-file-download"></i>
                 <% end %>
               <% end %>
+              <% if current_user.admin? && meter.notes.present? %>
+                <%= render 'meter_notes', meter: meter %>
+              <% end %>
             </div>
           </td>
           <td>

--- a/app/views/schools/meters/index.html.erb
+++ b/app/views/schools/meters/index.html.erb
@@ -160,7 +160,7 @@
   <div class="card bg-light mb-3">
     <div class="card-header"><h4>Add meter</h4></div>
     <div class="card-body">
-      <%= render 'form', school: @school, meter: @meter, show_dcc_fields: false, meter_is_dcc: false %>
+      <%= render 'form', school: @school, meter: @meter, show_dcc_fields: current_user.admin?, meter_is_dcc: false %>
     </div>
   </div>
 <% end %>

--- a/app/views/schools/meters/show.html.erb
+++ b/app/views/schools/meters/show.html.erb
@@ -1,61 +1,92 @@
-<h1>Meter: <%= @meter.mpan_mprn %></h1>
-<h2><%= @meter.name %></h2>
-<p><%= link_to 'School meter management', school_meters_path(@school) %></p>
-<p>
-  <%= link_to "Download CSV of Validated Readings", school_meter_path(@school, @meter, format: "csv"), class: 'btn btn-info btn-sm' if @meter.amr_validated_readings.any? %>
-  <%= link_to 'Edit', edit_school_meter_path(@school, @meter), class: 'btn btn-sm btn-warning' %>
-  <% if can?(:report_on, @meter) && @meter.amr_validated_readings.any? %>
-    <%= link_to 'Report', admin_reports_amr_validated_reading_path(@meter), class: 'btn btn-info btn-sm' %>
-  <% end %>
-  <% if can?(:view_meter_attributes, @meter) %>
-    <%= link_to 'Attributes', admin_school_single_meter_attribute_path(@school, @meter), class: 'btn btn-sm' %>
-  <% end %>
-  <% if @meter.active? %>
-    <%= link_to 'Deactivate', deactivate_school_meter_path(@school, @meter), method: :put, class: 'btn btn-sm btn-secondary' %>
-  <% else %>
-    <%= link_to 'Activate', activate_school_meter_path(@school, @meter), method: :put, class: 'btn btn-sm btn-secondary' %>
-  <% end %>
-  <% if @meter.dcc_meter? %>
-    <% if @meter.can_withdraw_consent? && can?(:withdraw_consent, @meter) %>
-      <%= link_to 'Withdraw consent', admin_withdraw_dcc_consent_path(mpxn: @meter.mpan_mprn), method: :post, class: 'btn btn-info btn-sm' %>
-    <% end %>
-    <% if @meter.can_grant_consent? && can?(:grant_consent, @meter) %>
-      <%= link_to 'Grant consent', admin_grant_dcc_consent_path(mpxn: @meter.mpan_mprn), method: :post, class: 'btn btn-info btn-sm' %>
-    <% end %>
-    <% if can?(:view_inventory, @meter) %>
-      <%= link_to 'Inventory', inventory_school_meter_path(@school, @meter), class: 'btn btn-info btn-sm' %>
-    <% end %>
-    <% if can?(:view_tariff_reports, @meter)%>
-      <%= link_to 'Tariff Report', admin_reports_tariff_path(@meter), class: 'btn btn-info btn-sm' %>
-    <% end %>
-  <% end %>
-  </p>
+<div class="d-flex justify-content-between align-items-center">
+  <h1><%= @meter.name.present? ? @meter.name : 'Meter' %> (<%= @meter.mpan_mprn %>)</h1>
+  <div class="h5">
+    <%= link_to 'School meter management', school_meters_path(@school), class: 'btn btn-outline-dark round-pill' %>
+  </div>
+</div>
 
-<dl class="row">
-  <dt class="col-sm-3">Type</dt>
-  <dd class="col-sm-9"><%= @meter.meter_type.capitalize %></dd>
-  <dt class="col-sm-3">Serial Number</dt>
-  <dd class="col-sm-9"><%= @meter.meter_serial_number %></dd>
-  <dt class="col-sm-3">Created</dt>
-  <dd class="col-sm-9"><%= nice_date_times @meter.created_at %></dd>
-  <dt class="col-sm-3">Last updated</dt>
-  <dd class="col-sm-9"><%= nice_date_times @meter.updated_at %></dd>
-  <dt class="col-sm-3">Status</dt>
-  <dd class="col-sm-9"><%= @meter.active ? 'Active' : 'Inactive' %></dd>
-  <dt class="col-sm-3">DCC Meter?</dt>
-  <dd class="col-sm-9"><%= @meter.dcc_meter? %></dd>
-  <dt class="col-sm-3">User Consented?</dt>
-  <dd class="col-sm-9"><%= @meter.meter_review.present? %></dd>
-  <dt class="col-sm-3">DCC Consented?</dt>
-  <dd class="col-sm-9"><%= @meter.consent_granted? %></dd>
-  <dt class="col-sm-3">Sandbox?</dt>
-  <dd class="col-sm-9"><%= @meter.sandbox? %></dd>
-  <dt class="col-sm-3">Earliest Available Data</dt>
-  <dd class="col-sm-9"><%= @meter.earliest_available_data %></dd>
-  <dt class="col-sm-3">n3rgy API Status</dt>
-  <dd class="col-sm-9"><%= @n3rgy_status %></dd>
-  <dt class="col-sm-3">DCC last checked</dt>
-  <dd class="col-sm-9"><%= nice_date_times @meter.dcc_checked_at %></dd>
-  <dt class="col-sm-3">Meter Elements</dt>
-  <dd class="col-sm-9"><%= @elements %></dd>
-</dl>
+<div class="mb-2 alert alert-secondary row">
+  <div class="col-md-6">
+    <%= link_to "Download readings", school_meter_path(@school, @meter, format: "csv"), class: 'btn btn-info btn-sm' if @meter.amr_validated_readings.any? %>
+    <%= link_to 'Edit', edit_school_meter_path(@school, @meter), class: 'btn btn-sm btn-warning' %>
+    <% if can?(:report_on, @meter) && @meter.amr_validated_readings.any? %>
+      <%= link_to 'Report', admin_reports_amr_validated_reading_path(@meter), class: 'btn btn-info btn-sm' %>
+    <% end %>
+    <% if can?(:view_meter_attributes, @meter) %>
+      <%= link_to 'Attributes', admin_school_single_meter_attribute_path(@school, @meter), class: 'btn btn-sm' %>
+    <% end %>
+    <% if @meter.active? %>
+      <%= link_to 'Deactivate', deactivate_school_meter_path(@school, @meter), method: :put, class: 'btn btn-sm btn-secondary' %>
+    <% else %>
+      <%= link_to 'Activate', activate_school_meter_path(@school, @meter), method: :put, class: 'btn btn-sm btn-secondary' %>
+    <% end %>
+  </div>
+  <div class="col-md-6">
+    <% if @meter.dcc_meter? %>
+      <% if @meter.can_withdraw_consent? && can?(:withdraw_consent, @meter) %>
+        <%= link_to 'Withdraw consent', admin_withdraw_dcc_consent_path(mpxn: @meter.mpan_mprn), method: :post, class: 'btn btn-info btn-sm' %>
+      <% end %>
+      <% if @meter.can_grant_consent? && can?(:grant_consent, @meter) %>
+        <%= link_to 'Grant consent', admin_grant_dcc_consent_path(mpxn: @meter.mpan_mprn), method: :post, class: 'btn btn-info btn-sm' %>
+      <% end %>
+      <% if can?(:view_inventory, @meter) %>
+        <%= link_to 'Inventory', inventory_school_meter_path(@school, @meter), class: 'btn btn-info btn-sm' %>
+      <% end %>
+      <% if can?(:view_tariff_reports, @meter)%>
+        <%= link_to 'Tariff Report', admin_reports_tariff_path(@meter), class: 'btn btn-info btn-sm' %>
+      <% end %>
+    <% end %>
+  </div>
+</div>
+
+<div class="row">
+  <div class="col-md-6">
+    <h3>Basic information</h3>
+    <dl class="row">
+      <dt class="col-sm-3">MPAN/MPRN</dt>
+      <dd class="col-sm-9"><%= @meter.mpan_mprn %></dd>
+      <dt class="col-sm-3">Serial Number</dt>
+      <dd class="col-sm-9"><%= @meter.meter_serial_number %></dd>
+      <dt class="col-sm-3">Type</dt>
+      <dd class="col-sm-9"><%= @meter.meter_type.capitalize %></dd>
+      <dt class="col-sm-3">Status</dt>
+      <dd class="col-sm-9"><%= @meter.active ? 'Active' : 'Inactive' %></dd>
+      <dt class="col-sm-3">Created</dt>
+      <dd class="col-sm-9"><%= nice_date_times @meter.created_at %></dd>
+      <dt class="col-sm-3">Last updated</dt>
+      <dd class="col-sm-9"><%= nice_date_times @meter.updated_at %></dd>
+    </dl>
+  </div>
+  <div class="col-md-6">
+    <h3>DCC information</h3>
+    <% if @meter.dcc_meter? %>
+      <dl class="row">
+        <dt class="col-sm-3">DCC last checked</dt>
+        <dd class="col-sm-9"><%= nice_date_times @meter.dcc_checked_at %></dd>
+        <dt class="col-sm-3">Sandbox?</dt>
+        <dd class="col-sm-9"><%= @meter.sandbox? %></dd>
+        <dt class="col-sm-3">n3rgy API Status</dt>
+        <dd class="col-sm-9"><%= @n3rgy_status %></dd>
+        <dt class="col-sm-3">User Consented?</dt>
+        <dd class="col-sm-9"><%= @meter.meter_review.present? %></dd>
+        <dt class="col-sm-3">DCC Consented?</dt>
+        <dd class="col-sm-9"><%= @meter.consent_granted? %></dd>
+        <dt class="col-sm-3">Earliest Available Data</dt>
+        <dd class="col-sm-9"><%= @meter.earliest_available_data %></dd>
+        <dt class="col-sm-3">Meter Elements</dt>
+        <dd class="col-sm-9"><%= @elements %></dd>
+      </dl>
+    <% else %>
+      <p>Not a DCC meter</p>
+      <dl class="row">
+        <dt class="col-sm-3">DCC last checked</dt>
+        <dd class="col-sm-9"><%= nice_date_times @meter.dcc_checked_at %></dd>
+      </dl>
+    <% end %>
+  </div>
+</div>
+
+<% if current_user.admin? && @meter.notes.present? %>
+  <h3>Admin notes</h3>
+  <%= @meter.notes %>
+<% end %>

--- a/app/views/shared/meter_attributes/_details_table.html.erb
+++ b/app/views/shared/meter_attributes/_details_table.html.erb
@@ -1,6 +1,7 @@
 <table class="table mt-3">
   <tbody>
     <tr><th scope="row">Type:</th><td><%= safely { meter_attribute.meter_attribute_type.attribute_name } %></td></tr>
+    <tr><th scope="row"><%= meter_attribute.replaces ? 'Updated' : 'Created' %></th><td><%= nice_date_times(meter_attribute.created_at) %></td></tr>
     <% unless meter_attribute.reason.blank? %>
       <tr><th scope="row">Reason:</th><td><%= meter_attribute.reason %></td></tr>
     <% end %>

--- a/spec/system/dcc_consent_spec.rb
+++ b/spec/system/dcc_consent_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe "DCC consents", type: :system do
           expect_any_instance_of(MeterReadingsFeeds::N3rgyConsent).to receive(:grant_trusted_consent).with(1234567890123, meter_review.consent_grant.guid).and_return(true)
           click_on('DCC Consents')
           click_on('1234567890123')
-          expect(page).to have_content('Meter: 1234567890123')
+          expect(page).to have_content('1234567890123')
           click_on('Grant consent')
           expect(page).to have_content('Consent granted for 1234567890123')
           expect(meter_1.reload.consent_granted).to be_truthy
@@ -59,7 +59,7 @@ RSpec.describe "DCC consents", type: :system do
           expect_any_instance_of(MeterReadingsFeeds::N3rgyConsent).to receive(:withdraw_trusted_consent).with(987654321).and_return(true)
           click_on('DCC Consents')
           click_on('987654321')
-          expect(page).to have_content('Meter: 987654321')
+          expect(page).to have_content('987654321')
           click_on('Withdraw consent')
           expect(page).to have_content('Consent withdrawn for 987654321')
           expect(meter_1.reload.consent_granted).to be_falsey

--- a/spec/system/meter_management_spec.rb
+++ b/spec/system/meter_management_spec.rb
@@ -128,11 +128,15 @@ RSpec.describe "meter management", :meters, type: :system do
 
         fill_in 'Meter Point Number', with: '123543'
         fill_in 'Name', with: 'Gas'
+        fill_in_trix '#meter_notes', with: "These are my notes"
         choose 'Gas'
         click_on 'Create Meter'
 
         expect(school.meters.count).to eq(1)
         expect(school.meters.first.mpan_mprn).to eq(123543)
+
+        click_on "Details"
+        expect(page).to have_content("These are my notes")
       end
     end
 


### PR DESCRIPTION
* Display created/updated dates for meter attributes
* Only show n3rgy / DCC specific fields to admins, not school admins 
* Add a notes field to individual meters
* Allow admin to add notes from the form to edit meters
* Display notes as a pop-up modal on the meter management page, for admins only
* Display notes on the meter view page, for admins only
* Tidy up the meter page a bit