### PR TITLE
Manually created schools should not be visible

### DIFF
--- a/app/controllers/schools_controller.rb
+++ b/app/controllers/schools_controller.rb
@@ -70,6 +70,8 @@ class SchoolsController < ApplicationController
   # POST /schools.json
   def create
     respond_to do |format|
+      #ensure schools are created as not visible initially
+      @school.visible = false
       if @school.save
         SchoolCreator.new(@school).process_new_school!
         format.html { redirect_to new_school_school_group_path(@school), notice: 'School was successfully created.' }
@@ -151,6 +153,7 @@ private
       :cooks_dinners_for_other_schools,
       :cooks_dinners_for_other_schools_count,
       :enable_targets_feature,
+      :public,
       key_stage_ids: []
     )
   end

--- a/app/views/schools/_details_form.html.erb
+++ b/app/views/schools/_details_form.html.erb
@@ -11,6 +11,7 @@
     <strong>Admin options</strong>
     <%= f.input :activation_date, as: :tempus_dominus_date, default_date: nil, label: 'Activation date', hint: 'This is the date when the school becomes active on Energy Sparks' %>
     <%= f.input :enable_targets_feature %>
+    <%= f.input :public %>
   </div>
 <% end %>
 

--- a/spec/system/admin/school_creation_spec.rb
+++ b/spec/system/admin/school_creation_spec.rb
@@ -45,6 +45,7 @@ RSpec.describe "school creation", :schools, type: :system do
 
     choose 'Primary'
     check 'KS1'
+    uncheck 'Public'
 
     click_on 'Next'
 
@@ -69,5 +70,9 @@ RSpec.describe "school creation", :schools, type: :system do
     expect(school.solar_pv_tuos_area).to eq(solar_pv_area)
     expect(school.dark_sky_area).to eq(dark_sky_area)
     expect(school.scoreboard).to eq(scoreboard)
+
+    expect(school.visible).to be false
+    expect(school.public).to be false
   end
+
 end


### PR DESCRIPTION
* Schools created manually are set to not visible to allow admin to complete other parts of the setup process
* Allow admin to configure whether a school is public or not when editing, so it can be configuring during manual creation