### PR TITLE
Dont make n3rgy api call on edit page

### DIFF
--- a/app/controllers/schools/meters_controller.rb
+++ b/app/controllers/schools/meters_controller.rb
@@ -39,8 +39,6 @@ module Schools
     end
 
     def edit
-      manager = MeterManagement.new(@meter)
-      @meter_is_dcc = manager.check_n3rgy_status
     end
 
     def update

--- a/app/views/schools/meters/_form.html.erb
+++ b/app/views/schools/meters/_form.html.erb
@@ -36,22 +36,20 @@
 
     <% if show_dcc_fields %>
 
-      <p class="alert alert-warning">Admin only experimental features for n3rgy integration</p>
-
-      <% if meter_is_dcc %>
-        <p class="alert alert-success">This meter is available via n3rgy</p>
-      <% else %>
-        <p class="alert alert-warning">This meter is not available via n3rgy</p>
-      <% end %>
+      <p class="alert alert-warning">Admin only features for n3rgy integration</p>
 
       <div class="custom-control custom-checkbox">
         <%= form.check_box :dcc_meter, class: 'custom-control-input'  %>
         <%= form.label :dcc_meter, 'DCC Smart Meter', class: "custom-control-label"  %>
+        <small class="form-text text-muted">
+          Leave this blank for new meters and system will check it is registered with n3rgy
+        </small>
       </div>
 
       <div class="custom-control custom-checkbox">
         <%= form.check_box :sandbox, class: 'custom-control-input' %>
         <%= form.label :sandbox, class: "custom-control-label" %>
+        <small class="form-text text-muted">Only check if you're adding an n3rgy test meter, not used for live schools</small>
       </div>
 
       <div class="form-group">

--- a/app/views/schools/meters/edit.html.erb
+++ b/app/views/schools/meters/edit.html.erb
@@ -1,3 +1,3 @@
 <h1>Edit meter: <%= @school.name %> : <%= @meter.name %></h1>
 
-<%= render 'form', school: @school, meter: @meter, show_dcc_fields: current_user.admin?, meter_is_dcc: @meter_is_dcc %>
+<%= render 'form', school: @school, meter: @meter, show_dcc_fields: current_user.admin? %>

--- a/app/views/schools/meters/index.html.erb
+++ b/app/views/schools/meters/index.html.erb
@@ -163,7 +163,7 @@
   <div class="card bg-light mb-3">
     <div class="card-header"><h4>Add meter</h4></div>
     <div class="card-body">
-      <%= render 'form', school: @school, meter: @meter, show_dcc_fields: current_user.admin?, meter_is_dcc: false %>
+      <%= render 'form', school: @school, meter: @meter, show_dcc_fields: current_user.admin? %>
     </div>
   </div>
 <% end %>

--- a/app/views/schools/meters/show.html.erb
+++ b/app/views/schools/meters/show.html.erb
@@ -77,10 +77,12 @@
         <dd class="col-sm-9"><%= @elements %></dd>
       </dl>
     <% else %>
-      <p>Not a DCC meter</p>
+      <p>Not configured as a DCC meter</p>
       <dl class="row">
         <dt class="col-sm-3">DCC last checked</dt>
         <dd class="col-sm-9"><%= nice_date_times @meter.dcc_checked_at %></dd>
+        <dt class="col-sm-3">n3rgy API Status</dt>
+        <dd class="col-sm-9"><%= @n3rgy_status %></dd>
       </dl>
     <% end %>
   </div>

--- a/spec/system/meter_management_spec.rb
+++ b/spec/system/meter_management_spec.rb
@@ -115,7 +115,11 @@ RSpec.describe "meter management", :meters, type: :system do
         allow_any_instance_of(Amr::N3rgyApiFactory).to receive(:data_api).with(meter).and_return(data_api)
         click_on 'Manage meters'
         click_on 'Edit'
-        expect(page).to have_content('This meter is available via n3rgy')
+        check "DCC Smart Meter"
+        check "Sandbox"
+        click_on 'Update Meter'
+        meter.reload
+        expect(meter.dcc_meter).to be true
       end
     end
 


### PR DESCRIPTION
Edit meters, e.g. to add notes, is currently slow because we're always calling the n3rgy API.

Remove this call and rely on a) system checking this behind the scenes and b) admin being able to check this on the details page for a meter and then update accordingly.

We may decide to recheck DCC status more regularly, but that will be covered by a separate PR.