### PR TITLE
Add extra exception handling to amr importer

### DIFF
--- a/lib/amr/importer.rb
+++ b/lib/amr/importer.rb
@@ -9,9 +9,15 @@ module Amr
     def import_all
       Rails.logger.info "Download all from S3 key pattern: #{@config.identifier}"
       get_array_of_files_in_bucket_with_prefix.each do |file_name|
-        get_file_from_s3(file_name)
-        import_file(file_name)
-        archive_file(file_name)
+        begin
+          get_file_from_s3(file_name)
+          import_file(file_name)
+          archive_file(file_name)
+        rescue => e
+          Rails.logger.error "Exception: running import_all for #{@config.description}"
+          Rails.logger.error e.backtrace.join("\n")
+          Rollbar.error(e, job: :import_all, config: @config.identifier, file_name: file_name)
+        end
       end
       Rails.logger.info "Downloaded all"
     end

--- a/spec/lib/amr/importer_spec.rb
+++ b/spec/lib/amr/importer_spec.rb
@@ -31,4 +31,11 @@ describe Amr::Importer do
     subject.send(:get_file_from_s3, thing_name)
     expect(File.read("#{config.local_bucket_path}/#{thing_name}")).to eq 'meter-readings!'
   end
+
+  it 'logs error to Rollbar' do
+    e = StandardError.new
+    expect_any_instance_of(Amr::CsvParserAndUpserter).to receive(:perform).and_raise(e)
+    expect(Rollbar).to receive(:error).with(e, job: :import_all, config: thing_prefix, file_name: thing_name)
+    subject.import_all
+  end
 end


### PR DESCRIPTION
An error processing one file can still cause an entire amr config to fail. This change adds an exception handler so we process all the files we can in each run, rather than failing at the first error.

This avoids a single incorrect file breaking the loads, as has happened recently.