### PR TITLE
2038 initial improvements to calendar editing

### DIFF
--- a/app/assets/javascripts/calendar_year_view.js
+++ b/app/assets/javascripts/calendar_year_view.js
@@ -16,7 +16,6 @@ $(document).ready(function() {
       $('#event-modal input[name="_method"]').val('patch');
 
       $("#calendar_event_calendar_event_type_id").val(lastEvent.calendarEventTypeId);
-      $('#event-modal input[name="calendar_event[title]"]').val(lastEvent.title);
 
       $('#event-modal input[name="calendar_event[start_date]"]').val(startDate.toLocaleDateString("en-GB"));
       $('#event-modal input[name="calendar_event[end_date]"]').val(endDate.toLocaleDateString("en-GB"));
@@ -41,7 +40,6 @@ $(document).ready(function() {
       $('#event-modal input[name="_method"]').val('post');
 
       $("#calendar_event_calendar_event_type_id").val('');
-      $('#event-modal input[name="calendar_event[title]"]').val('');
 
       $('#event-modal input[name="calendar_event[start_date]"]').val(event.date.toLocaleDateString("en-GB"));
       $('#event-modal input[name="calendar_event[end_date]"]').val(event.date.toLocaleDateString("en-GB"));
@@ -115,7 +113,6 @@ $(document).ready(function() {
             startDate: new Date(returnedData[i].startDate),
             endDate: new Date(returnedData[i].endDate),
             color: returnedData[i].color,
-            title: returnedData[i].title
           });
         }
         $('#calendar').data('calendar').setDataSource(data);
@@ -187,8 +184,7 @@ $(document).ready(function() {
             name: returnedData[i].name,
             startDate: new Date(returnedData[i].startDate),
             endDate: new Date(returnedData[i].endDate),
-            color: returnedData[i].color,
-            title: returnedData[i].title
+            color: returnedData[i].color
           });
         }
         $('#data-calendar').data('calendar').setDataSource(data);

--- a/app/assets/stylesheets/calendars.scss
+++ b/app/assets/stylesheets/calendars.scss
@@ -3,7 +3,7 @@ div#ui-datepicker-div {
 }
 
 div.calendar-legend {
-    padding-bottom: 50px;
+    padding-top: 10px;
     align-content: center;
 
     .legend-scale ul {
@@ -18,7 +18,7 @@ div.calendar-legend {
         width: 175px;
         margin-bottom: 6px;
         text-align: center;
-        font-size: 120%;
+        font-size: 100%;
         list-style: none;
     }
     .legend-scale.vertical ul li {

--- a/app/controllers/calendars/calendar_events_controller.rb
+++ b/app/controllers/calendars/calendar_events_controller.rb
@@ -46,6 +46,6 @@ class Calendars::CalendarEventsController < ApplicationController
 private
 
   def calendar_event_params
-    params.require(:calendar_event).permit(:title, :calendar_event_type_id, :start_date, :end_date, :school_id)
+    params.require(:calendar_event).permit(:calendar_event_type_id, :start_date, :end_date, :school_id)
   end
 end

--- a/app/controllers/calendars/calendar_events_controller.rb
+++ b/app/controllers/calendars/calendar_events_controller.rb
@@ -22,7 +22,7 @@ class Calendars::CalendarEventsController < ApplicationController
   def create
     if @calendar_event.save
       broadcast(:calendar_edited, @calendar)
-      redirect_to @calendar, notice: 'Calendar Event was successfully created.'
+      redirect_to calendar_path(@calendar, anchor: "calendar_event_#{@calendar_event.id}"), notice: 'Calendar Event was successfully created.'
     else
       render :new
     end
@@ -31,7 +31,7 @@ class Calendars::CalendarEventsController < ApplicationController
   def update
     if HolidayFactory.new(@calendar).with_neighbour_updates(@calendar_event, calendar_event_params)
       broadcast(:calendar_edited, @calendar)
-      redirect_to calendar_path(@calendar), notice: 'Event was successfully updated.'
+      redirect_to calendar_path(@calendar, anchor: "calendar_event_#{@calendar_event.id}"), notice: 'Event was successfully updated.'
     else
       render :edit
     end

--- a/app/controllers/calendars_controller.rb
+++ b/app/controllers/calendars_controller.rb
@@ -5,8 +5,24 @@ class CalendarsController < ApplicationController
 
   # GET /calendars/1
   def show
+    @academic_year = academic_year
+    @current_events = list_current_events(@academic_year)
     if @calendar.schools.count == 1
       @school = @calendar.schools.first
     end
+  end
+
+  private
+
+  def academic_year
+    academic_year_ids = @calendar.calendar_events.pluck(:academic_year_id).uniq.sort_by(&:to_i).reject(&:nil?)
+    AcademicYear.find(academic_year_ids).select(&:current?).first
+  end
+
+  def list_current_events(academic_year)
+    return [] unless academic_year
+    next_academic_year = academic_year.next_year
+    academic_year_filter = next_academic_year.present? ? [academic_year, next_academic_year] : academic_year
+    @calendar.calendar_events.where(academic_year: academic_year_filter).order(:start_date)
   end
 end

--- a/app/controllers/calendars_controller.rb
+++ b/app/controllers/calendars_controller.rb
@@ -12,6 +12,18 @@ class CalendarsController < ApplicationController
     end
   end
 
+  def destroy
+    if @calendar.school? || @calendar.national?
+      redirect_to admin_calendars_path, notice: 'Cannot delete national or school calendars' if @calendar.school?
+    end
+    if @calendar.regional? && @calendar.calendars.count > 0
+      redirect_to admin_calendars_path, notice: 'Cannot delete regional calendar with children'
+    else
+      @calendar.destroy
+      redirect_to admin_calendars_path, notice: 'Calendar was successfully deleted.'
+    end
+  end
+
   private
 
   def academic_year

--- a/app/controllers/onboarding/inset_days_controller.rb
+++ b/app/controllers/onboarding/inset_days_controller.rb
@@ -51,7 +51,7 @@ module Onboarding
     end
 
     def calendar_event_params
-      params.require(:calendar_event).permit(:title, :calendar_event_type_id, :start_date)
+      params.require(:calendar_event).permit(:calendar_event_type_id, :start_date)
     end
   end
 end

--- a/app/models/academic_year.rb
+++ b/app/models/academic_year.rb
@@ -22,6 +22,10 @@ class AcademicYear < ApplicationRecord
     (start_date <= today) && (end_date >= today)
   end
 
+  def next_year
+    AcademicYear.for_date(self.end_date + 1).where(calendar: self.calendar).reject(&:current?).first
+  end
+
   def title
     "#{start_date.year} - #{end_date.year}"
   end

--- a/app/services/alerts/system/upcoming_holiday.rb
+++ b/app/services/alerts/system/upcoming_holiday.rb
@@ -52,7 +52,7 @@ module Alerts
             template_data: {
               holiday_start_date: next_holiday.start_date.strftime("%d/%m/%Y"),
               holiday_end_date: next_holiday.end_date.strftime("%d/%m/%Y"),
-              holiday_title: next_holiday.title
+              holiday_title: nil
             },
             priority_data: {
               time_of_year_relevance: 10.0

--- a/app/services/calendar_term_factory.rb
+++ b/app/services/calendar_term_factory.rb
@@ -9,7 +9,7 @@ class CalendarTermFactory
       event_type = CalendarEventType.select { |cet| event[:term].include? cet.title }.first
       raise ArgumentError if event_type.nil?
 
-      @calendar.calendar_events.where(title: event[:term], start_date: event[:start_date], end_date: event[:end_date], calendar_event_type: event_type).first_or_create!
+      @calendar.calendar_events.where(start_date: event[:start_date], end_date: event[:end_date], calendar_event_type: event_type).first_or_create!
     end
 
     create_holidays_between_terms

--- a/app/services/schedule_data_manager_service.rb
+++ b/app/services/schedule_data_manager_service.rb
@@ -25,7 +25,7 @@ class ScheduleDataManagerService
 
         analytics_holiday = Holiday.new(
           holiday.calendar_event_type.analytics_event_type.to_sym,
-          holiday.title || 'No title',
+          nil,
           holiday.start_date,
           holiday.end_date,
           academic_year

--- a/app/views/admin/calendars/_regional_calendars.html.erb
+++ b/app/views/admin/calendars/_regional_calendars.html.erb
@@ -17,7 +17,7 @@
         <td>
           <div class='btn-group'>
           <%= link_to 'Show', calendar, class: 'btn btn-info' if can?(:read, calendar) %>
-          <%= link_to 'Delete', calendar, method: :delete, data: { confirm: 'Are you sure?' }, class: 'btn btn-danger' if can?(:destroy, calendar) %>
+          <%= link_to 'Delete', calendar, method: :delete, data: { confirm: 'Are you sure?' }, class: 'btn btn-danger' if calendar.calendars.count == 0 && can?(:destroy, calendar) %>
           </div>
         </td>
       </tr>

--- a/app/views/admin/calendars/_school_calendars.html.erb
+++ b/app/views/admin/calendars/_school_calendars.html.erb
@@ -18,7 +18,6 @@
         <td>
           <div class="btn-group">
             <%= link_to 'Show', calendar, class: 'btn btn-info' if can?(:read, calendar) %>
-            <%= link_to 'Delete', calendar, method: :delete, data: { confirm: 'Are you sure?' }, class: 'btn btn-danger' if can?(:destroy, calendar) %>
           </div>
         </td>
       </tr>

--- a/app/views/calendars/_admin_calendar_info.html.erb
+++ b/app/views/calendars/_admin_calendar_info.html.erb
@@ -1,0 +1,25 @@
+<div class="mb-2 alert alert-secondary">
+  <% if @calendar.regional? %>
+    <p>This calendar is a regional calendar, it currently has <%= School.joins(:calendar).where('calendars.based_on_id = ?', @calendar.id).count %> dependent schools and <%= @calendar.calendars.count %> calendars which are dependent.</p>
+  <% end %>
+
+  <% if @calendar.national? %>
+    <p>This calendar is a national calendar, it currently has <%= @calendar.calendars.count %> calendars which are directly dependent.</p>
+  <% end %>
+
+  <% if @calendar.schools.any? %>
+    <p>This calendar is allocated to the following schools:</p>
+    <ul>
+      <% @calendar.schools.each do |school| %>
+        <li><%= link_to school.name, school_path(school) %></li>
+      <% end %>
+    </ul>
+  <% end %>
+  <% unless @calendar.based_on.nil? %>
+    <% if can?(:manage, :parent_calendars) %>
+      <p>This calendar is based on the <%= link_to "#{@calendar.based_on.title} #{@calendar.based_on.calendar_type} calendar", calendar_path(@calendar.based_on) %></p>
+    <% else %>
+      <p>This calendar is based on the <%= @calendar.based_on.title %> <%= @calendar.based_on.calendar_type %> calendar which is maintained by Energy Sparks.</p>
+    <% end %>
+  <% end %>
+</div>

--- a/app/views/calendars/_calendar.json.jbuilder
+++ b/app/views/calendars/_calendar.json.jbuilder
@@ -4,8 +4,7 @@
 json.calendar_events @calendar.calendar_events.order(calendar_event_type_id: :asc) do |event|
   json.id event.id
   json.calendarEventTypeId event.calendar_event_type.id
-  json.name "#{event.calendar_event_type.description} - #{event.title}"
-  json.title event.title
+  json.name "#{event.calendar_event_type.description}"
   json.color event.calendar_event_type.colour
   json.startDate event.start_date
   json.endDate event.end_date

--- a/app/views/calendars/_event_modal.html.erb
+++ b/app/views/calendars/_event_modal.html.erb
@@ -12,11 +12,6 @@
       <div class="modal-body">
         <input name="event-index" type="hidden">
         <div class="form-group">
-          <%= f.label :title %>
-          <%= f.text_field :title, class: 'form-control' %>
-
-        </div>
-        <div class="form-group">
           <label for="inputAddress">Event Type</label>
           <%= f.select :calendar_event_type_id, options_from_collection_for_select(CalendarEventType.all, 'id', 'display_title',nil) ,{}, { class: 'form-control' } %>
         </div>

--- a/app/views/calendars/_legend.html
+++ b/app/views/calendars/_legend.html
@@ -1,12 +1,14 @@
-<h3>Calendar Legend</h3>
-<div class='calendar-legend'>
+<h3>Legend</h3>
+<div class="row">
+<div class='calendar-legend col'>
   <div class='legend-scale'>
     <ul class='legend-labels'>
-      <li><span style='background:rgb(59,192,240);'></span>Bank Holiday</li>
-      <li><span style='background:rgb(255,172,33);'></span>Term Time</li>
-      <li><span style='background:rgb(92,184,92);'></span>Holiday</li>
-      <li><span style='background:rgb(255,69,0);'></span>Inset Day (in school)</li>
-      <li><span style='background:rgb(181,108,226);'></span>Inset Day (out school)</li>
+      <li><span style='background:rgb(59,192,240);'></span><div class="description">Bank Holiday</div></li>
+      <li><span style='background:rgb(255,172,33);'></span><div class="description">Term Time</div></li>
+      <li><span style='background:rgb(92,184,92);'></span><div class="description">Holiday</div></li>
+      <li><span style='background:rgb(255,69,0);'></span><div class="description">Inset Day<br>(in school)</div></li>
+      <li><span style='background:rgb(181,108,226);'></span><div class="description">Inset Day<br>(out school)</div></li>
     </ul>
   </div>
+</div>
 </div>

--- a/app/views/calendars/calendar_events/_form.html.erb
+++ b/app/views/calendars/calendar_events/_form.html.erb
@@ -1,11 +1,6 @@
 <%= simple_form_for([calendar, calendar_event], html: { class: 'calendar_event_form'}) do |f| %>
   <%= render 'shared/errors', subject: calendar_event, subject_name: 'event' %>
   <div class="form-group">
-    <%= f.label :title %>
-    <%= f.text_field :title, class: 'form-control' %>
-  </div>
-
-  <div class="form-group">
     <%= f.label :calendar_event_type_id, 'Event Type' %>
     <%= f.select :calendar_event_type_id, options_from_collection_for_select(CalendarEventType.all, 'id', 'display_title',  calendar_event.calendar_event_type.nil? ? 1 : calendar_event.calendar_event_type.id),{}, { class: 'form-control' } %>
   </div>

--- a/app/views/calendars/calendar_events/index.html.erb
+++ b/app/views/calendars/calendar_events/index.html.erb
@@ -19,8 +19,7 @@
       <table class="table table-striped">
         <thead>
           <tr>
-            <th>Title</th>
-            <th>Type of Event</th>
+            <th>Type</th>
             <th>Start Date</th>
             <th>End Date</th>
             <th>Actions</th>
@@ -29,7 +28,6 @@
         <tbody>
           <% @calendar_events.where(academic_year: academic_year).each do |calendar_event| %>
             <tr scope="row">
-              <td><%= calendar_event.title %></td>
               <td><%= calendar_event.calendar_event_type.title %></td>
               <td><%= nice_dates(calendar_event.start_date) %></td>
               <td><%= nice_dates(calendar_event.end_date) %></td>

--- a/app/views/calendars/calendar_events/index.html.erb
+++ b/app/views/calendars/calendar_events/index.html.erb
@@ -1,6 +1,6 @@
 <h1><%= @calendar.title %></h1>
 <p><%= link_to 'Calendar view', calendar_path(@calendar), class: 'btn btn-success' %></p>
-<p><%= link_to 'Add Event to calendar', new_calendar_calendar_event_path(@calendar), class: 'btn btn-primary' %></p>
+<p><%= link_to 'Add new event', new_calendar_calendar_event_path(@calendar), class: 'btn btn-primary' %></p>
 <p>This shows the calendar events in a list - click on the title to edit the event</p>
 <nav>
   <div class="nav nav-tabs" id="nav-tab" role="tablist">

--- a/app/views/calendars/show.html.erb
+++ b/app/views/calendars/show.html.erb
@@ -58,7 +58,7 @@
               <th colspan="4"><%= calendar_event.academic_year.title %></th>
             </tr>
           <% end %>
-          <tr scope="row">
+          <tr scope="row" id='calendar_event_<%= calendar_event.id %>'>
             <td><%= calendar_event.calendar_event_type.title %></td>
             <td><%= nice_dates(calendar_event.start_date) %></td>
             <td><%= nice_dates(calendar_event.end_date) %></td>
@@ -67,6 +67,8 @@
         <% end %>
       </tbody>
     </table>
+
+    <%= link_to 'Add new event', new_calendar_calendar_event_path(@calendar), class: 'btn btn-primary' %>
 
     <p class="pt-4">
       <% if @calendar.school? || @calendar.regional? %>

--- a/app/views/calendars/show.html.erb
+++ b/app/views/calendars/show.html.erb
@@ -1,31 +1,42 @@
-<h1>Calendar: <%= @calendar.title %></h1>
-<p><%= link_to 'All calendars', admin_calendars_path if can? :index, Calendar %></p>
+<% content_for :page_title, "#{@calendar.title} Calendar" %>
 
-<% if @calendar.regional? %>
-  <p>This calendar is a regional calendar, it currently has <%= School.joins(:calendar).where('calendars.based_on_id = ?', @calendar.id).count %> dependent schools and <%= @calendar.calendars.count %> calendars which are dependent.</p>
-<% end %>
-
-<% if @calendar.national? %>
-  <p>This calendar is a national calendar, it currently has <%= @calendar.calendars.count %> calendars which are directly dependent.</p>
-<% end %>
-
-<% if @calendar.schools.any? %>
-  <h3>This calendar is allocated to the following schools:</h3>
-  <ul>
-    <% @calendar.schools.each do |school| %>
-      <li><%= link_to school.name, school_path(school) %></li>
+<div class="d-flex justify-content-between align-items-center">
+  <h1><%= @calendar.title %> Calendar </h1>
+  <div>
+    <% if can?(:index, Calendar) %>
+      <%= link_to "All calendars", admin_calendars_path, class: "btn btn-outline-dark rounded-pill font-weight-bold" %>
     <% end %>
-  </ul>
-<% end %>
-<% unless @calendar.based_on.nil? %>
-  <% if can?(:manage, :parent_calendars) %>
-    <p>And is based on: <%= link_to "#{@calendar.based_on.title} calendar", calendar_path(@calendar.based_on) %></p>
-  <% else %>
-    <p>And is based on: <%= @calendar.based_on.title %>, which the Energy Sparks administrator can edit.</p>
+  </div>
+</div>
+
+<% if current_user.admin? %>
+<div class="mb-2 alert alert-secondary">
+  <% if @calendar.regional? %>
+    <p>This calendar is a regional calendar, it currently has <%= School.joins(:calendar).where('calendars.based_on_id = ?', @calendar.id).count %> dependent schools and <%= @calendar.calendars.count %> calendars which are dependent.</p>
   <% end %>
+
+  <% if @calendar.national? %>
+    <p>This calendar is a national calendar, it currently has <%= @calendar.calendars.count %> calendars which are directly dependent.</p>
+  <% end %>
+
+  <% if @calendar.schools.any? %>
+    <p>This calendar is allocated to the following schools:</p>
+    <ul>
+      <% @calendar.schools.each do |school| %>
+        <li><%= link_to school.name, school_path(school) %></li>
+      <% end %>
+    </ul>
+  <% end %>
+  <% unless @calendar.based_on.nil? %>
+    <% if can?(:manage, :parent_calendars) %>
+      <p>This calendar is based on the <%= link_to "#{@calendar.based_on.title} #{@calendar.based_on.calendar_type} calendar", calendar_path(@calendar.based_on) %></p>
+    <% else %>
+      <p>This calendar is based on the <%= @calendar.based_on.title %> <%= @calendar.based_on.calendar_type %> calendar which is maintained by Energy Sparks.</p>
+    <% end %>
+  <% end %>
+</div>
 <% end %>
 
-<h3>This calendar is editable</h3>
 <p>You can amend the events, like the term times by clicking on them, updating the dates and saving the changes. You can also add a new event, like an inset day for example by clicking on the 'Add Event to calendar' button</p>
 
 <p><%= link_to 'Add Event to calendar', new_calendar_calendar_event_path(@calendar), class: 'btn btn-primary' %></p>
@@ -33,18 +44,20 @@
 <p>You can switch to a list view, which also allows you to delete events here</p>
 <p><%= link_to 'List view', calendar_calendar_events_path(@calendar), class: 'btn btn-success' %></p>
 
-<%= render 'legend' %>
-
 <div id="calendar" class="calendar"></div>
+
+<%= render 'legend' %>
 
 <%= render 'event_modal' %>
 
-<% if School.joins(:calendar).where('calendars.based_on_id = ?', @calendar.id).any? %>
-  <h3>Dependent Schools</h3>
-  <p>These schools all have their own calendar, based on this one.</p>
-  <ul>
-    <% School.joins(:calendar).where('calendars.based_on_id = ?', @calendar.id).each do | school| %>
-      <li><%= link_to school.name, calendar_path(school.calendar) %></li>
-    <% end %>
-  </ul>
+<% if current_user.admin? %>
+  <% if School.joins(:calendar).where('calendars.based_on_id = ?', @calendar.id).any? %>
+    <h3>Dependent Schools</h3>
+    <p>These schools all have their own calendar, based on this one.</p>
+    <ul>
+      <% School.joins(:calendar).where('calendars.based_on_id = ?', @calendar.id).each do | school| %>
+        <li><%= link_to school.name, calendar_path(school.calendar) %></li>
+      <% end %>
+    </ul>
+  <% end %>
 <% end %>

--- a/app/views/calendars/show.html.erb
+++ b/app/views/calendars/show.html.erb
@@ -10,48 +10,89 @@
 </div>
 
 <% if current_user.admin? %>
-<div class="mb-2 alert alert-secondary">
-  <% if @calendar.regional? %>
-    <p>This calendar is a regional calendar, it currently has <%= School.joins(:calendar).where('calendars.based_on_id = ?', @calendar.id).count %> dependent schools and <%= @calendar.calendars.count %> calendars which are dependent.</p>
-  <% end %>
-
-  <% if @calendar.national? %>
-    <p>This calendar is a national calendar, it currently has <%= @calendar.calendars.count %> calendars which are directly dependent.</p>
-  <% end %>
-
-  <% if @calendar.schools.any? %>
-    <p>This calendar is allocated to the following schools:</p>
-    <ul>
-      <% @calendar.schools.each do |school| %>
-        <li><%= link_to school.name, school_path(school) %></li>
-      <% end %>
-    </ul>
-  <% end %>
-  <% unless @calendar.based_on.nil? %>
-    <% if can?(:manage, :parent_calendars) %>
-      <p>This calendar is based on the <%= link_to "#{@calendar.based_on.title} #{@calendar.based_on.calendar_type} calendar", calendar_path(@calendar.based_on) %></p>
-    <% else %>
-      <p>This calendar is based on the <%= @calendar.based_on.title %> <%= @calendar.based_on.calendar_type %> calendar which is maintained by Energy Sparks.</p>
-    <% end %>
-  <% end %>
-</div>
+  <%= render 'admin_calendar_info' %>
 <% end %>
 
-<p>You can amend the events, like the term times by clicking on them, updating the dates and saving the changes. You can also add a new event, like an inset day for example by clicking on the 'Add Event to calendar' button</p>
+<p>You can amend existing events, like the term times by clicking on them, updating the dates and saving the changes.</p>
 
-<p><%= link_to 'Add Event to calendar', new_calendar_calendar_event_path(@calendar), class: 'btn btn-primary' %></p>
 
-<p>You can switch to a list view, which also allows you to delete events here</p>
-<p><%= link_to 'List view', calendar_calendar_events_path(@calendar), class: 'btn btn-success' %></p>
+<%= link_to 'Add new event', new_calendar_calendar_event_path(@calendar), class: 'btn btn-primary' %>
 
-<div id="calendar" class="calendar"></div>
+<nav class="mt-2">
+  <div class="nav nav-tabs" id="nav-tab" role="tablist">
+      <a class="nav-item nav-link active" id="nav-list-view-tab" data-toggle="tab" href="#list-view-tab" role="tab" aria-controls="list-view-tab" aria-selected="yes">
+        Current events
+      </a>
+      <a class="nav-item nav-link" id="nav-calendar-view-tab" data-toggle="tab" href="#calendar-view-tab" role="tab" aria-controls="calendar-view-tab" aria-selected="yes">
+        Calendar view
+      </a>
+  </div>
+</nav>
+<div class="tab-content" id="nav-tabContent">
+  <div class="tab-pane active" id="list-view-tab" role="tabpanel" aria-labelledby="nav-list-view-tab">
 
-<%= render 'legend' %>
+    <p class="pt-4">
+      <% if @calendar.school? || @calendar.regional? %>
+        <%= link_to 'View all older events and bank holidays', calendar_calendar_events_path(@calendar) %>
+      <% else %>
+        <%= link_to 'View all older events', calendar_calendar_events_path(@calendar) %>
+      <% end %>
+    </p>
+
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>Type</th>
+          <th>Start Date</th>
+          <th>End Date</th>
+          <th>Actions</th>
+        </tr>
+      </thead>
+      <tbody>
+        <% previous_year = nil %>
+        <% @current_events.each do |calendar_event| %>
+          <%= next if (@calendar.school? || @calendar.regional?) && calendar_event.calendar_event_type.bank_holiday? %>
+          <% if calendar_event.academic_year != previous_year %>
+            <% previous_year = calendar_event.academic_year %>
+            <tr scope="row">
+              <th colspan="4"><%= calendar_event.academic_year.title %></th>
+            </tr>
+          <% end %>
+          <tr scope="row">
+            <td><%= calendar_event.calendar_event_type.title %></td>
+            <td><%= nice_dates(calendar_event.start_date) %></td>
+            <td><%= nice_dates(calendar_event.end_date) %></td>
+            <td><div class="btn-group"><%= link_to 'Edit', edit_calendar_calendar_event_path(calendar_event.calendar, calendar_event), class: 'btn btn-warning' %><%= link_to 'Delete', calendar_calendar_event_path(@calendar, calendar_event), method: :delete, data: { confirm: 'Are you sure?' }, class: 'btn btn-danger' %></div></td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+
+    <p class="pt-4">
+      <% if @calendar.school? || @calendar.regional? %>
+        <%= link_to 'View all older events and bank holidays', calendar_calendar_events_path(@calendar) %>
+      <% else %>
+        <%= link_to 'View all older events', calendar_calendar_events_path(@calendar) %>
+      <% end %>
+    </p>
+
+
+  </div>
+  <div class="tab-pane" id="calendar-view-tab" role="tabpanel" aria-labelledby="nav-calendar-view-tab">
+
+    <div id="calendar" class="calendar"></div>
+
+    <%= render 'legend' %>
+
+  </div>
+</div>
 
 <%= render 'event_modal' %>
 
 <% if current_user.admin? %>
   <% if School.joins(:calendar).where('calendars.based_on_id = ?', @calendar.id).any? %>
+  <div class="mb-2 alert alert-secondary">
+
     <h3>Dependent Schools</h3>
     <p>These schools all have their own calendar, based on this one.</p>
     <ul>
@@ -59,5 +100,6 @@
         <li><%= link_to school.name, calendar_path(school.calendar) %></li>
       <% end %>
     </ul>
+  </div>
   <% end %>
 <% end %>

--- a/app/views/onboarding/completion/new.html.erb
+++ b/app/views/onboarding/completion/new.html.erb
@@ -369,7 +369,6 @@
                 <tr>
                   <th>Date</th>
                   <th>Type</th>
-                  <th>Description</th>
                   <th>Actions</th>
                 </tr>
               </thead>
@@ -378,7 +377,6 @@
                   <tr>
                     <td><%= inset_day.start_date %></td>
                     <td><%= inset_day.calendar_event_type.title %></td>
-                    <td><%= inset_day.title %></td>
                     <td>
                       <div class="btn-group">
                         <%= link_to 'Edit', edit_onboarding_inset_day_path(@school_onboarding, inset_day), class: 'btn btn-sm btn-warning' %>

--- a/app/views/onboarding/inset_days/_form.html.erb
+++ b/app/views/onboarding/inset_days/_form.html.erb
@@ -1,4 +1,2 @@
 <%= form.input :start_date, as: :tempus_dominus_date, label: 'Date'%>
 <%= form.input :calendar_event_type_id, collection: calendar_event_types, label_method: :display_title, label: 'Type', include_blank: false %>
-<%= form.input :title, label: 'Description', as: :string %>
-

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -65,7 +65,7 @@ Rails.application.routes.draw do
   end
   resources :interventions, only: [:new, :create, :edit, :update, :destroy]
 
-  resources :calendars, only: [:show] do
+  resources :calendars, only: [:show, :destroy] do
     scope module: :calendars do
       resources :calendar_events
     end

--- a/db/migrate/20220310143919_remove_calendar_event_title.rb
+++ b/db/migrate/20220310143919_remove_calendar_event_title.rb
@@ -1,0 +1,5 @@
+class RemoveCalendarEventTitle < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :calendar_events, :title
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_03_08_152432) do
+ActiveRecord::Schema.define(version: 2022_03_10_143919) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
@@ -548,7 +548,6 @@ ActiveRecord::Schema.define(version: 2022_03_08_152432) do
     t.bigint "academic_year_id", null: false
     t.bigint "calendar_id", null: false
     t.bigint "calendar_event_type_id", null: false
-    t.text "title"
     t.text "description"
     t.date "start_date", null: false
     t.date "end_date", null: false

--- a/lib/loader/bank_holidays.rb
+++ b/lib/loader/bank_holidays.rb
@@ -17,7 +17,6 @@ module Loader
           CalendarEvent.where(
             calendar: calendar,
             calendar_event_type: bank_holiday_type,
-            title: bank_holiday["title"],
             start_date: bank_holiday["date"],
             end_date: bank_holiday["date"],
             description: bank_holiday["notes"]

--- a/lib/tasks/deployment/20220310135856_fix_term_six_description.rake
+++ b/lib/tasks/deployment/20220310135856_fix_term_six_description.rake
@@ -1,0 +1,17 @@
+namespace :after_party do
+  desc 'Deployment task: Fix Term 6 description'
+  task fix_term_six_description: :environment do
+    puts "Running deploy task 'fix_term_six_description'"
+
+    # Put your task implementation HERE.
+    cet = CalendarEventType.where(title: "Term 6", description: "Autumn Half Term 2").first
+    if cet.present?
+      cet.update!(description: "Summer Half Term 2")
+    end
+
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord
+      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+  end
+end

--- a/spec/controllers/calendars/calendar_events_controller_spec.rb
+++ b/spec/controllers/calendars/calendar_events_controller_spec.rb
@@ -15,7 +15,6 @@ RSpec.describe Calendars::CalendarEventsController, type: :controller do
   let!(:valid_attributes) {
     {
       calendar_event_type_id: CalendarEventType.first.id,
-      title: "My New Event",
       start_date: "2022-01-01",
       end_date: "2022-01-31"
     }
@@ -39,8 +38,7 @@ RSpec.describe Calendars::CalendarEventsController, type: :controller do
   describe "PUT #update" do
     let!(:new_attributes) {
       {
-        title: "My Updated Event",
-        start_date: "2022-01-01",
+        start_date: "2022-01-02",
         end_date: "2022-01-31"
       }
     }
@@ -48,14 +46,14 @@ RSpec.describe Calendars::CalendarEventsController, type: :controller do
     it 'updates event' do
       put :update, params: {calendar_id: event.calendar.id, id: event.to_param, calendar_event: new_attributes}
       event.reload
-      expect(event.title).to eql(new_attributes[:title])
+      expect(event.start_date.iso8601).to eql(new_attributes[:start_date])
     end
 
     xit 'broadcasts calendar changed' do
       expect_any_instance_of(CalendarEventListener).to receive(:calendar_edited).with(event.calendar)
       put :update, params: {calendar_id: event.calendar.id, id: event.to_param, calendar_event: new_attributes}
       event.reload
-      expect(event.title).to eql(new_attributes[:title])
+      expect(event.start_date.iso8601).to eql(new_attributes[:start_date])
     end
   end
 

--- a/spec/controllers/calendars/calendar_events_controller_spec.rb
+++ b/spec/controllers/calendars/calendar_events_controller_spec.rb
@@ -27,7 +27,8 @@ RSpec.describe Calendars::CalendarEventsController, type: :controller do
   describe "POST #create" do
     it 'creates event' do
       post :create, params: { calendar_id: calendar.id, calendar_event: valid_attributes }
-      expect(response).to redirect_to(calendar_path(calendar))
+      event = CalendarEvent.where(calendar: calendar, start_date: Date.parse("2022-01-01")).last
+      expect(response).to redirect_to(calendar_path(calendar, anchor: "calendar_event_#{event.id}"))
     end
     xit 'broadcasts calendar changed' do
       expect_any_instance_of(CalendarEventListener).to receive(:calendar_edited).with(calendar)

--- a/spec/factories/calendar_events_factory.rb
+++ b/spec/factories/calendar_events_factory.rb
@@ -2,7 +2,6 @@ FactoryBot.define do
   factory :calendar_event do
     start_date  { 1.week.from_now }
     end_date    { 8.weeks.from_now }
-    title       { 'new event' }
     description { 'this is a new event' }
 
     after(:build) do |object|
@@ -15,17 +14,14 @@ FactoryBot.define do
     end
 
     factory :term do
-      title       { 'new term' }
       description { 'this is a new term' }
       association :calendar_event_type, term_time: true, holiday: false
     end
     factory :holiday do
-      title       { 'new holiday' }
       description { 'this is a new holiday' }
       association :calendar_event_type, term_time: false, holiday: true, analytics_event_type: :school_holiday
     end
     factory :bank_holiday  do
-      title       { 'new holiday' }
       description { 'this is a new bank holiday event' }
       association :calendar
       association :calendar_event_type, term_time: false, holiday: false, bank_holiday: true, analytics_event_type: :bank_holiday, title: 'Woof'

--- a/spec/support/calendar_data.rb
+++ b/spec/support/calendar_data.rb
@@ -23,7 +23,7 @@ RSpec.shared_context "calendar data", shared_context: :metadata do
   let!(:academic_year) { create(:academic_year, calendar: parent_template_calendar, start_date: '2016-09-01', end_date: '2017-08-30')}
   let!(:academic_year_2) { create(:academic_year, calendar: parent_template_calendar, start_date: '2017-09-01', end_date: '2018-08-30')}
 
-  let!(:bank_holiday) { create :bank_holiday, calendar: parent_template_calendar, title: 'Good Friday', start_date: "2012-04-06", end_date: "2012-04-06" }
+  let!(:bank_holiday) { create :bank_holiday, calendar: parent_template_calendar, start_date: "2012-04-06", end_date: "2012-04-06" }
   let!(:calendar) do
     cal = CalendarFactory.new(existing_calendar: parent_template_calendar, title: 'calendar title').create
     CalendarTermFactory.new(cal, autumn_terms).create_terms
@@ -36,14 +36,12 @@ RSpec.shared_context "calendar data", shared_context: :metadata do
 
   let!(:random_before_holiday) {
     CalendarEvent.create!(
-      title: 'random holiday',
       calendar: calendar,
       calendar_event_type: CalendarEventType.holiday.first,
       start_date: random_before_holiday_start_date,
       end_date: '01/02/2017')}
   let!(:random_after_holiday) {
     CalendarEvent.create!(
-      title: 'random holiday 2',
       calendar: calendar,
       calendar_event_type: CalendarEventType.holiday.first,
       start_date: '16/12/2017',

--- a/spec/system/admin/calendars_spec.rb
+++ b/spec/system/admin/calendars_spec.rb
@@ -44,6 +44,10 @@ RSpec.describe 'calendars', :calendar, type: :system do
       expect(calendar.terms.count).to eq(1)
 
       expect(calendar.based_on).to eq(england_and_wales_calendar)
+
+      click_on 'Delete'
+      expect(page).to have_content('Calendar was successfully deleted.')
+      expect(Calendar.regional.count).to eq 0
     end
   end
 end

--- a/spec/system/admin/calendars_spec.rb
+++ b/spec/system/admin/calendars_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'calendars', :calendar, type: :system do
   end
 
   let!(:england_and_wales_calendar) { create :national_calendar, title: 'England and Wales'  }
-  let!(:bank_holiday)               { create :bank_holiday, calendar: england_and_wales_calendar, title: 'Good Friday', start_date: "2012-04-06", end_date: "2012-04-06" }
+  let!(:bank_holiday)               { create :bank_holiday, calendar: england_and_wales_calendar, start_date: "2012-04-06", end_date: "2012-04-06" }
 
   before do
     create_all_calendar_events

--- a/spec/system/calendar_spec.rb
+++ b/spec/system/calendar_spec.rb
@@ -20,7 +20,6 @@ RSpec.describe "calendar view", type: :system do
       expect(page).to have_content('New Calendar Event')
 
       select 'Holiday - Holiday', from: 'calendar_event_calendar_event_type_id'
-      fill_in(:calendar_event_title, with: 'Exciting day off')
 
       expect { click_on('Save') }.to change { calendar.calendar_events.count }.by(1)
 
@@ -29,16 +28,12 @@ RSpec.describe "calendar view", type: :system do
 
       fifteenth_jan.click
       expect(page).to have_content('Edit Calendar Event')
-      expect(page).to have_field('Title', with: 'Exciting day off')
-
-      fill_in(:calendar_event_title, with: 'Boring day off')
       click_on('Save')
 
       # Wait until ajax call is back
       assert_selector('td[style*="background-color"]')
 
       fifteenth_jan.click
-      expect(page).to have_field('Title', with: 'Boring day off')
       expect(page).to have_content('Delete')
 
       expect { click_on('Delete') }.to change { calendar.calendar_events.count }.by(-1)
@@ -63,7 +58,6 @@ RSpec.describe "calendar view", type: :system do
 
       click_on('School calendar')
       click_on('Add new event')
-      fill_in 'Title', with: 'Calendar event'
       first('input#calendar_event_start_date', visible: false).set('16/08/2018')
       first('input#calendar_event_end_date', visible: false).set('17/08/2018')
 

--- a/spec/system/calendar_spec.rb
+++ b/spec/system/calendar_spec.rb
@@ -12,10 +12,6 @@ RSpec.describe "calendar view", type: :system do
       visit calendar_path(calendar)
     end
 
-    describe 'using the table view' do
-      it 'allows an event to be added, edited and deleted'
-    end
-
     describe 'using the calendar view', js: true do
       it 'shows the calendar, allows an event to be added and deleted - flickering' do
         click_on('Calendar view')
@@ -62,7 +58,7 @@ RSpec.describe "calendar view", type: :system do
 
   end
 
-  describe 'a school admin can only do things with their calendar' do
+  describe 'a school admin can' do
 
     let!(:school)           { create_active_school }
     let!(:school_admin)     { create(:school_admin, school: school) }
@@ -72,7 +68,7 @@ RSpec.describe "calendar view", type: :system do
       cal
     end
 
-    it 'allows them to add an event to their calendar' do
+    it 'add an event to their calendar' do
       calendar_event_count = CalendarEvent.count
 
       sign_in(school_admin)

--- a/spec/system/calendar_spec.rb
+++ b/spec/system/calendar_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe "calendar view", type: :system do
       visit school_path(school)
 
       click_on('School calendar')
-      click_on('Add Event to calendar')
+      click_on('Add new event')
       fill_in 'Title', with: 'Calendar event'
       first('input#calendar_event_start_date', visible: false).set('16/08/2018')
       first('input#calendar_event_end_date', visible: false).set('17/08/2018')

--- a/spec/system/calendar_spec.rb
+++ b/spec/system/calendar_spec.rb
@@ -3,41 +3,63 @@ require 'rails_helper'
 RSpec.describe "calendar view", type: :system do
   include_context 'calendar data'
 
-  describe 'does lots of good calendar work', js: true do
+  context 'as an admin' do
     let!(:admin)  { create(:admin) }
 
-    xit 'shows the calendar, allows an event to be added and deleted - flickering' do
+    before(:each) do
       create(:academic_year, calendar: calendar, start_date: Date.parse("01/01/#{Date.today.year}"))
-
       sign_in(admin)
       visit calendar_path(calendar)
-      expect(page.has_content?(calendar.title)).to be true
-      expect(page.has_content?('January')).to be true
-
-      fifteenth_jan = find(".calendar .day", text: '15', match: :first)
-
-      fifteenth_jan.click
-      expect(page).to have_content('New Calendar Event')
-
-      select 'Holiday - Holiday', from: 'calendar_event_calendar_event_type_id'
-
-      expect { click_on('Save') }.to change { calendar.calendar_events.count }.by(1)
-
-      # Wait until ajax call is back
-      assert_selector('td[style*="background-color"]')
-
-      fifteenth_jan.click
-      expect(page).to have_content('Edit Calendar Event')
-      click_on('Save')
-
-      # Wait until ajax call is back
-      assert_selector('td[style*="background-color"]')
-
-      fifteenth_jan.click
-      expect(page).to have_content('Delete')
-
-      expect { click_on('Delete') }.to change { calendar.calendar_events.count }.by(-1)
     end
+
+    describe 'using the table view' do
+      it 'allows an event to be added, edited and deleted'
+    end
+
+    describe 'using the calendar view', js: true do
+      it 'shows the calendar, allows an event to be added and deleted - flickering' do
+        click_on('Calendar view')
+        #wait for view to display
+        expect(page).to have_css('.calendar-legend')
+
+        #check title, etc
+        expect(page.has_content?(calendar.title)).to be true
+        expect(page.has_content?('January')).to be true
+
+        #add an event on this day
+        fifteenth_jan = find(".calendar .day", text: '15', match: :first)
+        fifteenth_jan.click
+
+        expect(page).to have_content('New Calendar Event')
+
+        select 'Holiday - Holiday', from: 'calendar_event_calendar_event_type_id'
+
+        #potential race condition here
+        expect { click_on('Save') }.to change { calendar.calendar_events.count }.by(1)
+
+        #switch tab
+        click_on('Calendar view')
+
+        # Wait until ajax call is back
+        assert_selector('td[style*="background-color"]')
+
+        fifteenth_jan.click
+        expect(page).to have_content('Edit Calendar Event')
+        click_on('Save')
+
+        #switch tab
+        click_on('Calendar view')
+
+        # Wait until ajax call is back
+        assert_selector('td[style*="background-color"]')
+
+        fifteenth_jan.click
+        expect(page).to have_content('Delete')
+
+        expect { click_on('Delete') }.to change { calendar.calendar_events.count }.by(-1)
+      end
+    end
+
   end
 
   describe 'a school admin can only do things with their calendar' do
@@ -57,7 +79,7 @@ RSpec.describe "calendar view", type: :system do
       visit school_path(school)
 
       click_on('School calendar')
-      click_on('Add new event')
+      click_on('Add new event', match: :first)
       first('input#calendar_event_start_date', visible: false).set('16/08/2018')
       first('input#calendar_event_end_date', visible: false).set('17/08/2018')
 

--- a/spec/system/school_onboarding_spec.rb
+++ b/spec/system/school_onboarding_spec.rb
@@ -442,7 +442,6 @@ RSpec.describe "onboarding", :schools, type: :system do
         # Inset days
         expect(page).to have_content('Configure inset days')
         click_on 'Add an inset day'
-        fill_in 'Description', with: 'Teacher training'
         select 'Teacher training', from: 'Type'
         # Grr, actual input hidden for JS datepicker
         fill_in 'Date', with: '2019-01-09'


### PR DESCRIPTION
* Tidied calendar view page layout, removing unnecessary text
* Move admin content into separate blocks
* Made default view a list of events for current and next academic year, retained calendar view in separate panel
* Removed the Calendar Event Title, this wasn't really being used and was sometimes inconsistently set
* Changed how page updates following adding or editing an event to drop user back into a more helpful place
* Allow calendars to be deleted
* Fix labelling of one of the existing Calender Event Types