### PR TITLE
Ensure that progress report handles missing data

### DIFF
--- a/app/classes/tables/summary_table_data.rb
+++ b/app/classes/tables/summary_table_data.rb
@@ -12,8 +12,16 @@ module Tables
 
     def date_ranges
       fuel_types.map do |fuel_type|
-        "#{fuel_type.to_s.humanize} data: #{format_date(fetch(fuel_type, :start_date))} - #{format_date(fetch(fuel_type, :end_date))}."
+        "#{fuel_type.to_s.humanize} data: #{start_date(fuel_type)} - #{end_date(fuel_type)}."
       end.join(' ')
+    end
+
+    def start_date(fuel_type)
+      format_date(fetch(fuel_type, :start_date))
+    end
+
+    def end_date(fuel_type)
+      format_date(fetch(fuel_type, :end_date))
     end
 
     private

--- a/app/controllers/schools/progress_controller.rb
+++ b/app/controllers/schools/progress_controller.rb
@@ -29,6 +29,12 @@ module Schools
 
     private
 
+    def summary_table
+      if EnergySparks::FeatureFlags.active?(:use_management_data)
+        Schools::ManagementTableService.new(@school).management_data
+      end
+    end
+
     def index_for(fuel_type)
       @fuel_type = fuel_type
       @current_target = @school.current_target
@@ -38,6 +44,9 @@ module Schools
         service = TargetsService.new(aggregate_school, @fuel_type)
         @recent_data = service.recent_data?
         @progress = service.progress
+        @partial_consumption = partial_consumption_data?(@progress)
+        @partial_targets = partial_target_data?(@progress)
+        @overview_data = summary_table
         @debug_content = service.analytics_debug_info if current_user.present? && current_user.analytics?
       rescue => e
         Rollbar.error(e, school_id: @school.id, school: @school.name, fuel_type: @fuel_type)
@@ -53,6 +62,17 @@ module Schools
 
     def show_storage_heater_notes(school, fuel_type)
       fuel_type == :electricity && school.has_storage_heaters?
+    end
+
+    def partial_consumption_data?(progress)
+      #this could be more sophisticated, relies on ordering of months array reflecting
+      #actual starting month of the target reporting period
+      first_month = progress.months.first
+      progress.monthly_usage_kwh[first_month].nil? || progress.partial_months[first_month] == true
+    end
+
+    def partial_target_data?(progress)
+      progress.monthly_targets_kwh.value?(nil)
     end
 
     def progress_service

--- a/app/views/schools/progress/index.html.erb
+++ b/app/views/schools/progress/index.html.erb
@@ -88,6 +88,18 @@
     </tbody>
   </table>
 
+  <% if @partial_consumption %>
+    <% if @overview_data.present? && @overview_data.start_date(@fuel_type).present? %>
+      <p>We only have your actual <%= @fuel_type.to_s.humanize(capitalize: false) %> consumption data from <%= @overview_data.start_date(@fuel_type) %>. So can only show your consumption for a portion of your target period.</p>
+    <% else %>
+      <p>We only have a limited view of your actual <%= @fuel_type.to_s.humanize(capitalize: false) %> consumption data. So can only show your consumption for a portion of your target period.</p>
+    <% end %>
+  <% end %>
+
+  <% if @partial_targets %>
+    <p>We only have limited consumption data for your school, so we cannot currently calculate a full set of monthly targets or progress.</p>
+  <% end %>
+
   <p>
     In the tables above <span class="partial-month">text in red</span> indicates where we have only partial consumption data for a given month. Your usage figures and our estimate of your progress will not be accurate until the end of the month, or until we receive additional data. We also indicate when you have <span class="bg-positive-dark">met your target</span> or <span class="bg-negative-dark">exceeded your target</span> in a given month.
   </p>


### PR DESCRIPTION
Adds tests to ensure that if we have some months of missing data for actual consumption or targets, then the progress report still displays. This might happen if we only start getting enough data within the target period -- this might be the case if a school's gas/electricity periods don't align. And we're also planning to allow them to set targets at any time, which means that reports might be incomplete, e.g. in their first year.

So this is mostly adding tests to ensure that the current functionality won't error. And adding some comments to the page to explain why some months in the tables aren't populated.