### PR TITLE
2057 allow any school to set a target

### DIFF
--- a/app/services/targets/progress_service.rb
+++ b/app/services/targets/progress_service.rb
@@ -5,8 +5,14 @@ module Targets
     end
 
     def display_progress_for_fuel_type?(fuel_type)
-      has_fuel_type_and_target?(fuel_type) &&
-        @school.configuration.enough_data_to_set_target_for_fuel_type?(fuel_type)
+      #for v2 we will allow them to see a progress report, even if there's not enough data
+      #so just check there is a fuel type and target
+      if EnergySparks::FeatureFlags.active?(:school_targets_v2)
+        has_fuel_type_and_target?(fuel_type)
+      else
+        has_fuel_type_and_target?(fuel_type) &&
+          @school.configuration.enough_data_to_set_target_for_fuel_type?(fuel_type)
+      end
     end
 
     def progress_summary

--- a/app/services/targets/school_target_service.rb
+++ b/app/services/targets/school_target_service.rb
@@ -9,7 +9,7 @@ module Targets
     end
 
     def self.targets_enabled?(school)
-      EnergySparks::FeatureFlags.active?(:school_targets) && school.enable_targets_feature?
+      school.enable_targets_feature?
     end
 
     def build_target
@@ -43,22 +43,30 @@ module Targets
     end
 
     def enough_data?
+      return true if v2_feature_active?
       @school.configuration.enough_data_to_set_target?
     end
 
     def enough_data_for_electricity?
+      return @school.has_electricity? if v2_feature_active?
       @school.configuration.enough_data_to_set_target_for_fuel_type?(:electricity)
     end
 
     def enough_data_for_gas?
+      return @school.has_gas? if v2_feature_active?
       @school.configuration.enough_data_to_set_target_for_fuel_type?(:gas)
     end
 
     def enough_data_for_storage_heater?
+      return @school.has_storage_heaters? if v2_feature_active?
       @school.configuration.enough_data_to_set_target_for_fuel_type?(:storage_heater)
     end
 
     private
+
+    def v2_feature_active?
+      EnergySparks::FeatureFlags.active?(:school_targets_v2)
+    end
 
     def target_end_date
       target_start_date.next_year

--- a/app/services/targets/target_mailer_service.rb
+++ b/app/services/targets/target_mailer_service.rb
@@ -16,7 +16,6 @@ module Targets
     end
 
     def invite_schools_to_set_first_target
-      return unless EnergySparks::FeatureFlags.active?(:school_targets)
       list_schools.each do |school|
         to = to(school)
         if to.any?
@@ -27,7 +26,6 @@ module Targets
     end
 
     def remind_schools_to_set_first_target
-      return unless EnergySparks::FeatureFlags.active?(:school_targets)
       list_schools_requiring_reminder.each do |school|
         to = to(school)
         if to.any?
@@ -38,7 +36,6 @@ module Targets
     end
 
     def invite_schools_to_review_target
-      return unless EnergySparks::FeatureFlags.active?(:school_targets)
       list_schools_requiring_review.each do |school|
         to = to(school)
         if to.any?

--- a/spec/services/activation_email_sender_spec.rb
+++ b/spec/services/activation_email_sender_spec.rb
@@ -45,22 +45,14 @@ describe ActivationEmailSender, :schools, type: :service do
           expect(email.to).to eql [onboarding_user.email]
         end
 
-        it 'records target invite if feature is active and enough data' do
+        it 'records target invite if enough data' do
           allow_any_instance_of(::Targets::SchoolTargetService).to receive(:enough_data?).and_return(true)
-          allow(EnergySparks::FeatureFlags).to receive(:active?).and_return(true)
           service.send
           expect(school.has_school_target_event?(:first_target_sent)).to be true
         end
 
-        it 'does not records target invite if feature is in active' do
-          allow(EnergySparks::FeatureFlags).to receive(:active?).and_return(false)
-          service.send
-          expect(school.has_school_target_event?(:first_target_sent)).to be false
-        end
-
-        it 'does not records target invite if not enough data is in active' do
+        it 'does not records target invite if not enough data' do
           allow_any_instance_of(::Targets::SchoolTargetService).to receive(:enough_data?).and_return(false)
-          allow(EnergySparks::FeatureFlags).to receive(:active?).and_return(true)
           service.send
           expect(school.has_school_target_event?(:first_target_sent)).to be false
         end
@@ -126,25 +118,15 @@ describe ActivationEmailSender, :schools, type: :service do
 
           context 'request to set targets' do
             let(:enough_data) { true }
-            it 'when feature is active and enough data' do
+            it 'when enough data' do
               allow_any_instance_of(::Targets::SchoolTargetService).to receive(:enough_data?).and_return(true)
-              allow(EnergySparks::FeatureFlags).to receive(:active?).and_return(true)
               service.send
               expect(email_body).to include("Set your first targets")
               expect(matcher).to have_link("Set your first target")
             end
 
-            it 'not when feature is inactive' do
-              allow_any_instance_of(::Targets::SchoolTargetService).to receive(:enough_data?).and_return(true)
-              allow(EnergySparks::FeatureFlags).to receive(:active?).and_return(false)
-              service.send
-              expect(email_body).to_not include("Set your first targets")
-              expect(matcher).to_not have_link("Set your first target")
-            end
-
             it 'but not when not enough data' do
               allow_any_instance_of(::Targets::SchoolTargetService).to receive(:enough_data?).and_return(false)
-              allow(EnergySparks::FeatureFlags).to receive(:active?).and_return(true)
               service.send
               expect(email_body).to_not include("Set your first targets")
               expect(matcher).to_not have_link("Set your first target")

--- a/spec/services/targets/generate_progress_service_spec.rb
+++ b/spec/services/targets/generate_progress_service_spec.rb
@@ -96,54 +96,47 @@ describe Targets::GenerateProgressService do
   end
 
   context '#generate!' do
-    context 'and school targets are active' do
+    it 'does nothing if school has no target' do
+      SchoolTarget.all.destroy_all
+      expect( service.generate! ).to be nil
+    end
+
+    context 'with only electricity fuel type' do
+
       before(:each) do
-        allow(EnergySparks::FeatureFlags).to receive(:active?).and_return(true)
+        allow_any_instance_of(TargetsService).to receive(:enough_data_to_set_target?).and_return(true)
+        allow_any_instance_of(TargetsService).to receive(:progress).and_return(progress)
+        allow_any_instance_of(TargetsService).to receive(:recent_data?).and_return(true)
       end
 
-      it 'does nothing if school has no target' do
-        SchoolTarget.all.destroy_all
-        expect( service.generate! ).to be nil
+      let(:target) { service.generate! }
+
+      it 'updates the target' do
+        expect( target ).to eql school_target
       end
 
-      context 'with only electricity fuel type' do
-
-        before(:each) do
-          allow_any_instance_of(TargetsService).to receive(:enough_data_to_set_target?).and_return(true)
-          allow_any_instance_of(TargetsService).to receive(:progress).and_return(progress)
-          allow_any_instance_of(TargetsService).to receive(:recent_data?).and_return(true)
-        end
-
-        let(:target) { service.generate! }
-
-        it 'updates the target' do
-          expect( target ).to eql school_target
-        end
-
-        it 'records when last run' do
-          expect( target.report_last_generated ).to_not be_nil
-        end
-
-        it 'includes only that fuel type' do
-          expect( target.gas_progress ).to eq({})
-          expect( target.storage_heaters_progress ).to eq({})
-          expect( target.electricity_progress ).to_not eq({})
-        end
-
-        it 'reports the fuel progress' do
-          expect( target.electricity_progress["progress"] ).to eql 0.99
-          expect( target.electricity_progress["usage"] ).to eql 15
-          expect( target.electricity_progress["target"] ).to eql 20
-        end
+      it 'records when last run' do
+        expect( target.report_last_generated ).to_not be_nil
       end
 
-      context 'and not enough data' do
-        let(:school_target_fuel_types)  { [] }
+      it 'includes only that fuel type' do
+        expect( target.gas_progress ).to eq({})
+        expect( target.storage_heaters_progress ).to eq({})
+        expect( target.electricity_progress ).to_not eq({})
+      end
 
-        it 'does nothing' do
-          expect( service.generate! ).to eq school_target
-        end
+      it 'reports the fuel progress' do
+        expect( target.electricity_progress["progress"] ).to eql 0.99
+        expect( target.electricity_progress["usage"] ).to eql 15
+        expect( target.electricity_progress["target"] ).to eql 20
+      end
+    end
 
+    context 'and not enough data' do
+      let(:school_target_fuel_types)  { [] }
+
+      it 'does nothing' do
+        expect( service.generate! ).to eq school_target
       end
 
     end

--- a/spec/services/targets/generate_progress_service_spec.rb
+++ b/spec/services/targets/generate_progress_service_spec.rb
@@ -135,13 +135,6 @@ describe Targets::GenerateProgressService do
           expect( target.electricity_progress["usage"] ).to eql 15
           expect( target.electricity_progress["target"] ).to eql 20
         end
-
-        it 'does nothing if feature disabled' do
-          allow(EnergySparks::FeatureFlags).to receive(:active?).and_return(false)
-          expect( service.generate! ).to be nil
-          school.update!(enable_targets_feature: false)
-          expect( service.generate! ).to be nil
-        end
       end
 
       context 'and not enough data' do

--- a/spec/services/targets/progress_service_spec.rb
+++ b/spec/services/targets/progress_service_spec.rb
@@ -42,13 +42,6 @@ RSpec.describe Targets::ProgressService do
           expect( progress_summary.electricity_progress.usage ).to eql 15
           expect( progress_summary.electricity_progress.target ).to eql 20
         end
-
-        it 'returns nil if feature disabled' do
-          allow(EnergySparks::FeatureFlags).to receive(:active?).and_return(false)
-          expect( service.progress_summary ).to be nil
-          school.update!(enable_targets_feature: false)
-          expect( service.progress_summary ).to be nil
-        end
       end
     end
   end

--- a/spec/services/targets/school_target_service_spec.rb
+++ b/spec/services/targets/school_target_service_spec.rb
@@ -92,6 +92,38 @@ RSpec.describe Targets::SchoolTargetService do
 
   describe '#enough_data?' do
 
+    context 'v2' do
+      before(:each) do
+        expect(EnergySparks::FeatureFlags).to receive(:active?).at_least(:once).with(:school_targets_v2).and_return(true)
+      end
+
+      context 'and there isnt enough data' do
+        it 'returns true' do
+          expect(service.enough_data?).to be true
+        end
+      end
+
+      context 'and there is enough data' do
+        before(:each) do
+          school.configuration.update!(school_target_fuel_types: ["electricity", "gas", "storage_heater"])
+        end
+        it 'returns true' do
+          expect(service.enough_data?).to be true
+        end
+        it 'checks for presence of fuel types' do
+          expect(service.enough_data_for_electricity?).to be true
+          expect(service.enough_data_for_gas?).to be true
+          expect(service.enough_data_for_storage_heater?).to be true
+
+          school.configuration.update(fuel_configuration: Schools::FuelConfiguration.new(
+            has_solar_pv: false, has_storage_heaters: false, fuel_types_for_analysis: :electric, has_gas: false, has_electricity: true))
+          expect(service.enough_data_for_electricity?).to be true
+          expect(service.enough_data_for_gas?).to be false
+          expect(service.enough_data_for_storage_heater?).to be false
+        end
+      end
+    end
+
     context 'and there isnt enough data' do
       it 'returns false' do
         expect(service.enough_data?).to be false

--- a/spec/services/targets/target_mailer_service_spec.rb
+++ b/spec/services/targets/target_mailer_service_spec.rb
@@ -8,7 +8,6 @@ RSpec.describe Targets::TargetMailerService do
   let!(:service)            { Targets::TargetMailerService.new }
 
   before(:each) do
-    allow(EnergySparks::FeatureFlags).to receive(:active?).and_return(true)
     allow_any_instance_of(Targets::SchoolTargetService).to receive(:enough_data?).and_return(enough_data)
   end
 

--- a/spec/system/schools/school_targets_spec.rb
+++ b/spec/system/schools/school_targets_spec.rb
@@ -12,8 +12,6 @@ RSpec.describe 'school targets', type: :system do
   let(:school_target_fuel_types) { ["gas", "electricity", "storage_heater"] }
 
   before(:each) do
-    allow(EnergySparks::FeatureFlags).to receive(:active?).and_return(true)
-
     allow_any_instance_of(TargetsService).to receive(:enough_data_to_set_target?).and_return(true)
     allow_any_instance_of(TargetsService).to receive(:annual_kwh_estimate_required?).and_return(false)
     allow_any_instance_of(TargetsService).to receive(:recent_data?).and_return(true)


### PR DESCRIPTION
For the v2 of the targets feature we will allow any school to set a target, even if they don't have enough data.

This changes the logic in the school targets service based on a feature flag. If v2 is active, we only need to check if they have the right fuel type.

The background tasks to actually check what data they have has been left in place, as this allows us to enable/disable the feature cleanly. 