### PR TITLE
Suggest use of estimate

### DIFF
--- a/app/models/schools/configuration.rb
+++ b/app/models/schools/configuration.rb
@@ -12,6 +12,7 @@
 #  school_id                           :bigint(8)        not null
 #  school_target_fuel_types            :string           default([]), not null, is an Array
 #  storage_heater_dashboard_chart_type :integer          default("no_storage_heater_chart"), not null
+#  suggest_estimates_fuel_types        :string           default([]), not null, is an Array
 #  updated_at                          :datetime         not null
 #
 # Indexes

--- a/app/models/schools/configuration.rb
+++ b/app/models/schools/configuration.rb
@@ -76,6 +76,15 @@ module Schools
       end
     end
 
+    def suggest_annual_estimate_for_fuel_type?(fuel_type)
+      case fuel_type.to_s
+      when "storage_heater", "storage_heaters"
+        suggest_estimates_fuel_types.include?("storage_heater")
+      else
+        suggest_estimates_fuel_types.include?(fuel_type.to_s)
+      end
+    end
+
     def analysis_charts_as_symbols(charts_field = :analysis_charts)
       configuration = {}
       self[charts_field].each do |page, config|

--- a/app/services/schools/generate_configuration.rb
+++ b/app/services/schools/generate_configuration.rb
@@ -29,8 +29,11 @@ module Schools
       configuration.update!(pupil_analysis_charts: pupil_analysis_charts)
 
       #should come after fuel_configuration
-      school_target_fuel_types = Targets::GenerateFuelTypes.new(@school, @aggregated_meter_collection).perform
+      school_target_fuel_types = Targets::GenerateFuelTypes.new(@school, @aggregated_meter_collection).fuel_types_with_enough_data
       configuration.update!(school_target_fuel_types: school_target_fuel_types)
+
+      suggest_estimates_fuel_types = Targets::GenerateFuelTypes.new(@school, @aggregated_meter_collection).suggest_estimates_for_fuel_types
+      configuration.update!(suggest_estimates_fuel_types: suggest_estimates_fuel_types)
 
       configuration
     end

--- a/app/services/targets/generate_fuel_types.rb
+++ b/app/services/targets/generate_fuel_types.rb
@@ -5,12 +5,24 @@ module Targets
       @aggregated_meter_collection = aggregated_meter_collection
     end
 
-    def perform
+    def fuel_types_with_enough_data
       fuel_types = []
       begin
         fuel_types << "electricity" if enough_data_for_electricity?
         fuel_types << "gas" if enough_data_for_gas?
         fuel_types << "storage_heater" if enough_data_for_storage_heater?
+      rescue => e
+        Rollbar.error(e, school_id: @school.id, school: @school.name)
+      end
+      fuel_types
+    end
+
+    def suggest_estimates_for_fuel_types
+      fuel_types = []
+      begin
+        fuel_types << "electricity" if suggest_estimate_for_electricity?
+        fuel_types << "gas" if suggest_estimate_for_gas?
+        fuel_types << "storage_heater" if suggest_estimate_for_storage_heater?
       rescue => e
         Rollbar.error(e, school_id: @school.id, school: @school.name)
       end
@@ -29,6 +41,22 @@ module Targets
 
     def enough_data_for_storage_heater?
       @school.has_storage_heaters? && enough_data_for_fuel_type?(:storage_heater)
+    end
+
+    def suggest_estimate_for_electricity?
+      @school.has_electricity? && suggest_use_of_estimate?(:electricity)
+    end
+
+    def suggest_estimate_for_gas?
+      @school.has_gas? && suggest_use_of_estimate?(:gas)
+    end
+
+    def suggest_estimate_for_storage_heater?
+      @school.has_storage_heaters? && suggest_use_of_estimate?(:storage_heater)
+    end
+
+    def suggest_use_of_estimate?(fuel_type)
+      target_service(fuel_type).suggest_use_of_estimate?
     end
 
     def enough_data_for_fuel_type?(fuel_type)

--- a/db/migrate/20220316140302_add_estimates_to_school_configuration.rb
+++ b/db/migrate/20220316140302_add_estimates_to_school_configuration.rb
@@ -1,0 +1,5 @@
+class AddEstimatesToSchoolConfiguration < ActiveRecord::Migration[6.0]
+  def change
+    add_column :configurations, :suggest_estimates_fuel_types, :string, array: true, null: false, default: []
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_03_15_163745) do
+ActiveRecord::Schema.define(version: 2022_03_16_140302) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
@@ -600,6 +600,7 @@ ActiveRecord::Schema.define(version: 2022_03_15_163745) do
     t.integer "storage_heater_dashboard_chart_type", default: 0, null: false
     t.integer "electricity_dashboard_chart_type", default: 0, null: false
     t.string "school_target_fuel_types", default: [], null: false, array: true
+    t.string "suggest_estimates_fuel_types", default: [], null: false, array: true
     t.index ["school_id"], name: "index_configurations_on_school_id"
   end
 

--- a/spec/services/targets/generate_fuel_types_spec.rb
+++ b/spec/services/targets/generate_fuel_types_spec.rb
@@ -11,55 +11,111 @@ describe Targets::GenerateFuelTypes do
     school.configuration.update!(fuel_configuration: fuel_configuration)
   end
 
-  context 'with all fuel types and enough data' do
-    let(:fuel_configuration)   { Schools::FuelConfiguration.new(
-      has_solar_pv: false, has_storage_heaters: true, fuel_types_for_analysis: :electric, has_gas: true, has_electricity: true) }
+  describe '#fuel_types_with_enough_data' do
+    context 'with all fuel types and enough data' do
+      let(:fuel_configuration)   { Schools::FuelConfiguration.new(
+        has_solar_pv: false, has_storage_heaters: true, fuel_types_for_analysis: :electric, has_gas: true, has_electricity: true) }
 
-    before(:each) do
-      allow_any_instance_of(::TargetsService).to receive(:enough_data_to_set_target?).and_return(true)
+      before(:each) do
+        allow_any_instance_of(::TargetsService).to receive(:enough_data_to_set_target?).and_return(true)
+      end
+
+      it 'lists all types' do
+        expect(service.fuel_types_with_enough_data).to match_array(["electricity", "gas", "storage_heater"])
+      end
     end
 
-    it 'lists all types' do
-      expect(service.perform).to match_array(["electricity", "gas", "storage_heater"])
+    context 'with limited fuel types and enough data' do
+      let(:fuel_configuration)   { Schools::FuelConfiguration.new(
+        has_solar_pv: false, has_storage_heaters: false, fuel_types_for_analysis: :electric, has_gas: true, has_electricity: false) }
+
+      before(:each) do
+        allow_any_instance_of(::TargetsService).to receive(:enough_data_to_set_target?).and_return(true)
+      end
+
+      it 'lists just the right types' do
+        expect(service.fuel_types_with_enough_data).to match_array(["gas"])
+      end
+    end
+
+    context 'with all fuel types and no data' do
+      let(:fuel_configuration)   { Schools::FuelConfiguration.new(
+        has_solar_pv: false, has_storage_heaters: true, fuel_types_for_analysis: :electric, has_gas: true, has_electricity: true) }
+
+      before(:each) do
+        allow_any_instance_of(::TargetsService).to receive(:enough_data_to_set_target?).and_return(false)
+      end
+
+      it 'lists nothing' do
+        expect(service.fuel_types_with_enough_data).to match_array([])
+      end
+    end
+
+    context 'with an error' do
+      let(:fuel_configuration)   { Schools::FuelConfiguration.new(
+        has_solar_pv: false, has_storage_heaters: true, fuel_types_for_analysis: :electric, has_gas: true, has_electricity: true) }
+
+      before(:each) do
+        allow_any_instance_of(::TargetsService).to receive(:enough_data_to_set_target?).and_raise("error")
+      end
+
+      it 'returns some result' do
+        expect(service.fuel_types_with_enough_data).to match_array([])
+      end
     end
   end
 
-  context 'with limited fuel types and enough data' do
-    let(:fuel_configuration)   { Schools::FuelConfiguration.new(
-      has_solar_pv: false, has_storage_heaters: false, fuel_types_for_analysis: :electric, has_gas: true, has_electricity: false) }
+  describe '#suggest_estimates_for_fuel_types' do
+    context 'with all fuel types and enough data' do
+      let(:fuel_configuration)   { Schools::FuelConfiguration.new(
+        has_solar_pv: false, has_storage_heaters: true, fuel_types_for_analysis: :electric, has_gas: true, has_electricity: true) }
 
-    before(:each) do
-      allow_any_instance_of(::TargetsService).to receive(:enough_data_to_set_target?).and_return(true)
+      before(:each) do
+        allow_any_instance_of(::TargetsService).to receive(:suggest_use_of_estimate?).and_return(true)
+      end
+
+      it 'lists all types' do
+        expect(service.suggest_estimates_for_fuel_types).to match_array(["electricity", "gas", "storage_heater"])
+      end
     end
 
-    it 'lists just the right types' do
-      expect(service.perform).to match_array(["gas"])
-    end
-  end
+    context 'with limited fuel types and enough data' do
+      let(:fuel_configuration)   { Schools::FuelConfiguration.new(
+        has_solar_pv: false, has_storage_heaters: false, fuel_types_for_analysis: :electric, has_gas: true, has_electricity: false) }
 
-  context 'with all fuel types and no data' do
-    let(:fuel_configuration)   { Schools::FuelConfiguration.new(
-      has_solar_pv: false, has_storage_heaters: true, fuel_types_for_analysis: :electric, has_gas: true, has_electricity: true) }
+      before(:each) do
+        allow_any_instance_of(::TargetsService).to receive(:suggest_use_of_estimate?).and_return(true)
+      end
 
-    before(:each) do
-      allow_any_instance_of(::TargetsService).to receive(:enough_data_to_set_target?).and_return(false)
-    end
-
-    it 'lists nothing' do
-      expect(service.perform).to match_array([])
-    end
-  end
-
-  context 'with an error' do
-    let(:fuel_configuration)   { Schools::FuelConfiguration.new(
-      has_solar_pv: false, has_storage_heaters: true, fuel_types_for_analysis: :electric, has_gas: true, has_electricity: true) }
-
-    before(:each) do
-      allow_any_instance_of(::TargetsService).to receive(:enough_data_to_set_target?).and_raise("error")
+      it 'lists just the right types' do
+        expect(service.suggest_estimates_for_fuel_types).to match_array(["gas"])
+      end
     end
 
-    it 'returns some result' do
-      expect(service.perform).to match_array([])
+    context 'with all fuel types and no data' do
+      let(:fuel_configuration)   { Schools::FuelConfiguration.new(
+        has_solar_pv: false, has_storage_heaters: true, fuel_types_for_analysis: :electric, has_gas: true, has_electricity: true) }
+
+      before(:each) do
+        allow_any_instance_of(::TargetsService).to receive(:suggest_use_of_estimate?).and_return(false)
+      end
+
+      it 'lists nothing' do
+        expect(service.suggest_estimates_for_fuel_types).to match_array([])
+      end
+    end
+
+    context 'with an error' do
+      let(:fuel_configuration)   { Schools::FuelConfiguration.new(
+        has_solar_pv: false, has_storage_heaters: true, fuel_types_for_analysis: :electric, has_gas: true, has_electricity: true) }
+
+      before(:each) do
+        allow_any_instance_of(::TargetsService).to receive(:suggest_use_of_estimate?).and_raise("error")
+      end
+
+      it 'returns some result' do
+        expect(service.suggest_estimates_for_fuel_types).to match_array([])
+      end
     end
   end
 end


### PR DESCRIPTION
Extends overnight run to generate list of fuel types where adding an annual estimate would unlock a more detailed target report.