### PR TITLE
Ensure progress summaries are tolerant of limited data

### DIFF
--- a/app/assets/stylesheets/targets.scss
+++ b/app/assets/stylesheets/targets.scss
@@ -27,3 +27,12 @@
 pre.debug {
     white-space: pre-wrap;
 }
+
+.work_week {
+  .fa-arrow-circle-down {
+    color: $green;
+  }
+  .fa-arrow-circle-up {
+    color: $new-red;
+  }
+}

--- a/app/classes/tables/summary_table_data.rb
+++ b/app/classes/tables/summary_table_data.rb
@@ -24,6 +24,14 @@ module Tables
       format_date(fetch(fuel_type, :end_date))
     end
 
+    def work_week(fuel_type)
+      summary_data_for(fuel_type, :workweek)
+    end
+
+    def year(fuel_type)
+      summary_data_for(fuel_type, :year)
+    end
+
     private
 
     def fuel_types

--- a/app/controllers/schools/school_targets_controller.rb
+++ b/app/controllers/schools/school_targets_controller.rb
@@ -29,6 +29,7 @@ module Schools
         @progress_summary = progress_service.progress_summary
         @prompt_to_review_target = prompt_to_review_target?
         @fuel_types_changed = fuel_types_changed
+        @overview_data = Schools::ManagementTableService.new(@school).management_data
       end
     end
 

--- a/app/helpers/targets_helper.rb
+++ b/app/helpers/targets_helper.rb
@@ -1,0 +1,5 @@
+module TargetsHelper
+  def show_limited_data?(school_target, fuel_type)
+    EnergySparks::FeatureFlags.active?(:school_targets_v2) && school_target[fuel_type].present?
+  end
+end

--- a/app/views/schools/school_targets/_generating_report.html.erb
+++ b/app/views/schools/school_targets/_generating_report.html.erb
@@ -1,0 +1,8 @@
+<div class="row alert text-dark alert-secondary">
+  <div class="col">
+    <p class="align-middle">
+      We need to process your data to create a more detailed progress report that will show progress against your targets. Check back tomorrow to see the results.
+    </p>
+    <p class="align-middle">Get started with the activities below to start working towards your goal</p>
+  </div>
+</div>

--- a/app/views/schools/school_targets/_limited_data.html.erb
+++ b/app/views/schools/school_targets/_limited_data.html.erb
@@ -1,4 +1,4 @@
-<div class="row">
+<div class="row limited_data">
   <div class="col-md-4 justify-content-center align-self-center">
     <h4 class="card-title"><%= fuel_type.to_s.humanize %></h4>
   </div>
@@ -8,7 +8,7 @@
     </h4>
   </div>
   <div class="col-md-3 justify-content-center align-self-center work_week">
-    <% if overview_data.work_week(fuel_type).has_data %>
+    <% if overview_data.present? && overview_data.work_week(fuel_type).has_data %>
     <h4>
       Last week: <%= up_downify(overview_data.work_week(fuel_type).change) %>
     </h4>

--- a/app/views/schools/school_targets/_limited_data.html.erb
+++ b/app/views/schools/school_targets/_limited_data.html.erb
@@ -1,0 +1,24 @@
+<div class="row">
+  <div class="col-md-4 justify-content-center align-self-center">
+    <h4 class="card-title"><%= fuel_type.to_s.humanize %></h4>
+  </div>
+  <div class="col-md-2 justify-content-center align-self-center">
+    <h4>
+      Goal: <%= target %>% <span style="color: green;"<%= fa_icon('arrow-circle-down') %>
+    </h4>
+  </div>
+  <div class="col-md-3 justify-content-center align-self-center work_week">
+    <% if overview_data.work_week(fuel_type).has_data %>
+    <h4>
+      Last week: <%= up_downify(overview_data.work_week(fuel_type).change) %>
+    </h4>
+    <% end %>
+  </div>
+  <div class="col-md-1 justify-content-center align-self-center">
+  </div>
+  <div class="col-md-2 justify-content-center align-self-center">
+    <span class="text-center">
+      <%= link_to "View progress", progress_path, class: "btn btn-outline-dark rounded-pill font-weight-bold" %>
+    </span>
+  </div>
+</div>

--- a/app/views/schools/school_targets/_prompt_to_review_target.html.erb
+++ b/app/views/schools/school_targets/_prompt_to_review_target.html.erb
@@ -1,0 +1,8 @@
+<div class="row alert text-dark bg-neutral">
+  <div class="col-md-2">
+    <%= link_to "Review your target", edit_school_school_target_path(@school, @school_target), class: "btn btn-light rounded-pill" %>
+  </div>
+  <div class="col">
+    <span class="align-middle">Your <%= @fuel_types_changed.map(&:humanize).to_sentence %> configuration has changed, which means you may need to revisit your targets for this year.</span>
+  </div>
+</div>

--- a/app/views/schools/school_targets/_warn_recent_data.html.erb
+++ b/app/views/schools/school_targets/_warn_recent_data.html.erb
@@ -1,0 +1,5 @@
+<div class="row alert info-bar text-light bg-negative">
+  <div class="col">
+    <span class="align-middle">We have not received data for your <%= @progress_summary.out_of_date_fuel_types_as_sentence %> usage for over thirty days. As a result your progress <%= "report".pluralize(@progress_summary.out_of_date_fuel_types.count) %> will be out of date.</span>
+  </div>
+</div>

--- a/app/views/schools/school_targets/show.html.erb
+++ b/app/views/schools/school_targets/show.html.erb
@@ -2,7 +2,7 @@
 
 <div class="d-flex justify-content-between align-items-center">
   <% if @school_target.report_last_generated.nil? %>
-    <h1>We are calculating your targets</h1>
+    <h1>We are calculating your progress</h1>
   <% else %>
     <h1>Your energy saving target</h1>
   <% end %>
@@ -15,41 +15,32 @@
 </div>
 
 <% if @school_target.report_last_generated.nil? %>
-  <div class="row alert text-dark alert-secondary">
-    <div class="col">
-      <p class="align-middle">
-        We need to process your data to create a progress report that will show your monthly targets. Check back tomorrow to see the results.
-      </p>
-      <p class="align-middle">Get started with the activities below to start working towards your goal</p>
-    </div>
-  </div>
+  <%= render 'generating_report' %>
 <% else %>
   <% if @progress_summary.electricity_progress.present? %>
     <%= render "bullet_chart", fuel_progress: @progress_summary.electricity_progress, school_target: @school_target, progress_path: electricity_school_progress_index_path(@school)  %>
+  <% elsif @school_target.electricity.present? %>
+    <%= render "limited_data", fuel_type: :electricity, overview_data: @overview_data, target: @school_target.electricity, school_target: @school_target, progress_path: electricity_school_progress_index_path(@school)  %>
   <% end %>
+
   <% if @progress_summary.gas_progress.present? %>
     <%= render "bullet_chart", fuel_progress: @progress_summary.gas_progress, school_target: @school_target, progress_path: gas_school_progress_index_path(@school)  %>
+  <% elsif @school_target.gas.present? %>
+    <%= render "limited_data", fuel_type: :gas, overview_data: @overview_data, target: @school_target.gas, school_target: @school_target, progress_path: gas_school_progress_index_path(@school)  %>
   <% end %>
+
   <% if @progress_summary.storage_heater_progress.present? %>
     <%= render "bullet_chart", fuel_progress: @progress_summary.storage_heater_progress, school_target: @school_target, progress_path: storage_heater_school_progress_index_path(@school)  %>
+  <% elsif @school_target.storage_heaters.present? %>
+    <%= render "limited_data", fuel_type: :storage_heaters, overview_data: @overview_data, target: @school_target.storage_heaters, school_target: @school_target, progress_path: storage_heater_school_progress_index_path(@school)  %>
   <% end %>
 
   <% if @prompt_to_review_target %>
-    <div class="row alert text-dark bg-neutral">
-      <div class="col-md-2">
-        <%= link_to "Review your target", edit_school_school_target_path(@school, @school_target), class: "btn btn-light rounded-pill" %>
-      </div>
-      <div class="col">
-        <span class="align-middle">Your <%= @fuel_types_changed.map(&:humanize).to_sentence %> configuration has changed, which means you may need to revisit your targets for this year.</span>
-      </div>
-    </div>
+    <%= render 'prompt_to_review_target' %>
   <% end %>
+
   <% if @progress_summary.any_out_of_date_fuel_types? %>
-  <div class="row alert info-bar text-light bg-negative">
-    <div class="col">
-      <span class="align-middle">We have not received data for your <%= @progress_summary.out_of_date_fuel_types_as_sentence %> usage for over thirty days. As a result your progress <%= "report".pluralize(@progress_summary.out_of_date_fuel_types.count) %> will be out of date.</span>
-    </div>
-  </div>
+    <%= render 'warn_recent_data' %>
   <% end %>
 <% end %>
 

--- a/app/views/schools/school_targets/show.html.erb
+++ b/app/views/schools/school_targets/show.html.erb
@@ -19,19 +19,19 @@
 <% else %>
   <% if @progress_summary.electricity_progress.present? %>
     <%= render "bullet_chart", fuel_progress: @progress_summary.electricity_progress, school_target: @school_target, progress_path: electricity_school_progress_index_path(@school)  %>
-  <% elsif @school_target.electricity.present? %>
+  <% elsif show_limited_data?(@school_target, :electricity) %>
     <%= render "limited_data", fuel_type: :electricity, overview_data: @overview_data, target: @school_target.electricity, school_target: @school_target, progress_path: electricity_school_progress_index_path(@school)  %>
   <% end %>
 
   <% if @progress_summary.gas_progress.present? %>
     <%= render "bullet_chart", fuel_progress: @progress_summary.gas_progress, school_target: @school_target, progress_path: gas_school_progress_index_path(@school)  %>
-  <% elsif @school_target.gas.present? %>
+  <% elsif show_limited_data?(@school_target, :gas) %>
     <%= render "limited_data", fuel_type: :gas, overview_data: @overview_data, target: @school_target.gas, school_target: @school_target, progress_path: gas_school_progress_index_path(@school)  %>
   <% end %>
 
   <% if @progress_summary.storage_heater_progress.present? %>
     <%= render "bullet_chart", fuel_progress: @progress_summary.storage_heater_progress, school_target: @school_target, progress_path: storage_heater_school_progress_index_path(@school)  %>
-  <% elsif @school_target.storage_heaters.present? %>
+  <% elsif show_limited_data?(@school_target, :storage_heaters) %>
     <%= render "limited_data", fuel_type: :storage_heaters, overview_data: @overview_data, target: @school_target.storage_heaters, school_target: @school_target, progress_path: storage_heater_school_progress_index_path(@school)  %>
   <% end %>
 

--- a/spec/system/schools/school_targets_spec.rb
+++ b/spec/system/schools/school_targets_spec.rb
@@ -16,6 +16,9 @@ RSpec.describe 'school targets', type: :system do
     allow_any_instance_of(TargetsService).to receive(:annual_kwh_estimate_required?).and_return(false)
     allow_any_instance_of(TargetsService).to receive(:recent_data?).and_return(true)
 
+    allow(EnergySparks::FeatureFlags).to receive(:active?).and_return(true)
+    allow(EnergySparks::FeatureFlags).to receive(:active?).with(:school_targets_v2).and_return(false)
+
     #Update the configuration rather than creating one, as the school factory builds one
     #and so if we call create(:configuration, school: school) we end up with 2 records for a has_one
     #relationship
@@ -44,6 +47,14 @@ RSpec.describe 'school targets', type: :system do
         refresh
         expect(page).to_not have_link("Review targets", href: school_school_targets_path(school))
       end
+
+      it 'does have a link if v2 of targets is active' do
+        school.configuration.update!(school_target_fuel_types: [])
+        allow(EnergySparks::FeatureFlags).to receive(:active?).with(:school_targets_v2).and_return(true)
+        refresh
+        expect(page).to have_link("Review targets", href: school_school_targets_path(school))
+      end
+
     end
 
     context 'with targets disabled' do
@@ -61,7 +72,6 @@ RSpec.describe 'school targets', type: :system do
         visit school_school_targets_path(school)
         expect(page).to have_current_path(management_school_path(school))
       end
-
     end
 
     context "with no target" do
@@ -93,7 +103,7 @@ RSpec.describe 'school targets', type: :system do
             click_on 'Set this target'
 
             expect(page).to have_content('Target successfully created')
-            expect(page).to have_content("We are calculating your targets")
+            expect(page).to have_content("We are calculating your progress")
             expect(school.has_current_target?).to eql(true)
             expect(school.current_target.electricity).to eql 15.0
             expect(school.current_target.gas).to eql 15.0
@@ -120,7 +130,7 @@ RSpec.describe 'school targets', type: :system do
           click_on 'Set this target'
 
           expect(page).to have_content('Target successfully created')
-          expect(page).to have_content("We are calculating your targets")
+          expect(page).to have_content("We are calculating your progress")
           expect(school.has_current_target?).to eql(true)
           expect(school.current_target.electricity).to eql 15.0
           expect(school.current_target.gas).to eql nil
@@ -143,7 +153,7 @@ RSpec.describe 'school targets', type: :system do
           click_on 'Set this target'
 
           expect(page).to have_content('Target successfully created')
-          expect(page).to have_content("We are calculating your targets")
+          expect(page).to have_content("We are calculating your progress")
           expect(school.has_current_target?).to eql(true)
           expect(school.current_target.electricity).to eql 15.0
           expect(school.current_target.gas).to eql nil
@@ -160,7 +170,7 @@ RSpec.describe 'school targets', type: :system do
       end
 
       it "displays message to come back tomorrow" do
-        expect(page).to have_content("We are calculating your targets")
+        expect(page).to have_content("We are calculating your progress")
         expect(page).to have_content("Check back tomorrow to see the results.")
         expect(page).to_not have_link("View progress", href: electricity_school_progress_index_path(school))
       end
@@ -191,6 +201,47 @@ RSpec.describe 'school targets', type: :system do
         expect(School.first.has_electricity?).to be true
 
         expect(page).to have_link("View progress", href: electricity_school_progress_index_path(school))
+      end
+
+      it 'shows the bullet charts' do
+        expect(page).to have_css('#bullet-chart-electricity')
+        expect(page).to have_css('#bullet-chart-gas')
+        expect(page).to_not have_css('#bullet-chart-storage_heater')
+      end
+
+      it 'does not show limited data' do
+        expect(page).to_not have_content("Goal")
+        expect(page).to_not have_content("Last week")
+      end
+
+      context "and v2 is active and limited data is available" do
+        before(:each) do
+          allow(EnergySparks::FeatureFlags).to receive(:active?).with(:school_targets_v2).and_return(true)
+          target.update!(electricity_progress: {})
+          refresh
+        end
+        it 'doesnt show the electricity bullet chart' do
+          expect(page).to_not have_css('#bullet-chart-electricity')
+          expect(page).to have_css('#bullet-chart-gas')
+        end
+
+        it 'shows limited data' do
+          expect(page).to have_content("Goal")
+          expect(page).to_not have_content("Last week")
+        end
+
+        context 'and some recent data' do
+          let(:management_data) {
+            Tables::SummaryTableData.new({ electricity: { year: { :percent_change => 0.11050 }, workweek: { :kwh => 100, :percent_change => -0.0923132131 } } })
+          }
+          before(:each) do
+            allow_any_instance_of(Schools::ManagementTableService).to receive(:management_data).and_return(management_data)
+            refresh
+          end
+          it 'shows the same data as the management dashboard' do
+            expect(page).to have_content("Last week")
+          end
+        end
       end
 
       it 'links to help page if there is one' do
@@ -271,7 +322,6 @@ RSpec.describe 'school targets', type: :system do
 
         context "and theres enough data" do
           before(:each) do
-
             target.update!(revised_fuel_types: ["storage_heater"])
           end
 
@@ -451,7 +501,7 @@ RSpec.describe 'school targets', type: :system do
             click_on 'Set this target'
 
             expect(page).to have_content('Target successfully created')
-            expect(page).to have_content("We are calculating your targets")
+            expect(page).to have_content("We are calculating your progress")
             expect(school.has_current_target?).to eql(true)
             expect(school.current_target.electricity).to eql 15.0
             expect(school.current_target.gas).to eql 15.0


### PR DESCRIPTION
When we have limited data, display an alternate view of the school targets progress overview.