### PR TITLE
2080 bug after setting a target and an estimate 2 regenerations are required to get a bullet chart

### DIFF
--- a/app/services/schools/generate_configuration.rb
+++ b/app/services/schools/generate_configuration.rb
@@ -6,7 +6,8 @@ module Schools
     end
 
     def generate
-      configuration = Schools::Configuration.where(school: @school).first_or_create
+      @school.build_configuration unless @school.configuration
+      configuration = @school.configuration
 
       fuel_configuration = GenerateFuelConfiguration.new(@aggregated_meter_collection).generate
       configuration.update!(fuel_configuration: fuel_configuration)


### PR DESCRIPTION
Change how the GenerateConfiguration service loads (or creates) the Configuration for a school. Accessing via the school model avoids us having potentially cached data later in the content batch.