### PR TITLE
2081 improve ux of target summary and progress pages page

### DIFF
--- a/app/assets/javascripts/bullet_charts.js
+++ b/app/assets/javascripts/bullet_charts.js
@@ -13,9 +13,9 @@ $(document).ready(function() {
 
     Highcharts.chart(el[0], {
         chart: {
-            marginTop: 40,
+            marginTop: 10,
             inverted: true,
-            marginLeft: 135,
+            marginLeft: 100,
             type: 'bullet'
         },
         plotOptions: {
@@ -32,7 +32,8 @@ $(document).ready(function() {
             enabled: false
         },
         title: {
-            text: title
+            text: null,
+            align: 'left'
         },
         credits: {
             enabled: false

--- a/app/assets/javascripts/bullet_charts.js
+++ b/app/assets/javascripts/bullet_charts.js
@@ -9,6 +9,7 @@ $(document).ready(function() {
     units = $(el).data("units");
     plotBands = $(el).data("bands");
     start_date = $(el).data("start-date");
+    month = $(el).data("month");
 
     Highcharts.chart(el[0], {
         chart: {
@@ -40,7 +41,7 @@ $(document).ready(function() {
             enabled: false
         },
         xAxis: {
-            categories: ['<span class="bullet-chart-title">' + label + '</span> ('+ units + ')']
+            categories: ['<span class="bullet-chart-title">' + label + '</span><br>('+ units + ')']
         },
         yAxis: {
             gridLineWidth: 0,
@@ -52,7 +53,7 @@ $(document).ready(function() {
         }],
         tooltip: {
             headerFormat: ""  ,
-            pointFormat: '<b>{point.y} '+ units + '</b> consumed since <b>' + start_date + '</b>. With a target of <b>{point.target} ' + units + '</b> consumed by the end of this month)'
+            pointFormat: '<b>{point.y} '+ units + '</b> consumed since <b>' + start_date + '</b>. You should use less than <b>{point.target} ' + units + '</b> by the end of ' + month
         }
     });
   }

--- a/app/views/schools/progress/_row.html.erb
+++ b/app/views/schools/progress/_row.html.erb
@@ -3,8 +3,18 @@
     <%= title %>
   </td>
   <% keys.each do |key| %>
-    <td class="text-right <%= target_percent_cell_colour(data[key]) if units == :relative_percent %><%= ' partial-month' if partial_months[key] %><%= ' estimated-target-month' if percentage_synthetic[key].present? && percentage_synthetic[key] > 0.0 %>">
-      <%= format_target(data[key], units) %>
-    </td>
+    <% if units == :relative_percent %>
+      <td class="text-right <%= target_percent_cell_colour(data[key]) if @progress.monthly_targets_kwh[key].present? %><%= ' partial-month' if partial_months[key] %>">
+        <% if @progress.monthly_targets_kwh[key].present? %>
+          <%= format_target(data[key], units) %>
+        <% else %>
+        <% end %>
+      </td>
+    <% else %>
+      <td class="text-right <%= ' partial-month' if partial_months[key] %><%= ' estimated-target-month' if percentage_synthetic[key].present? && percentage_synthetic[key] > 0.0 %>">
+        <%= format_target(data[key], units) %>
+      </td>
+    <% end %>
+
   <% end %>
 </tr>

--- a/app/views/schools/progress/index.html.erb
+++ b/app/views/schools/progress/index.html.erb
@@ -28,7 +28,11 @@
   <% end %>
 
   <% if @progress && @progress.current_cumulative_performance_versus_synthetic_last_year %>
-    <% if @progress.current_cumulative_performance_versus_synthetic_last_year > 0.0 %>
+    <% if @progress.current_cumulative_performance_versus_synthetic_last_year == 0.0 %>
+      <p>
+        Unfortunately you are currently consuming as much data as you did last year.
+      </p>
+    <% elsif @progress.current_cumulative_performance_versus_synthetic_last_year > 0.0 %>
       <p>
         Unfortunately you are currently running
         <%= format_target(@progress.current_cumulative_performance_versus_synthetic_last_year, :relative_percent) %>
@@ -62,9 +66,9 @@
     </tr>
     </thead>
     <tbody>
-    <%= render 'row', title: 'Target Consumption (kWh)', data: @progress.monthly_targets_kwh, keys: @progress.months, partial_months: {}, percentage_synthetic: @progress.percentage_synthetic, units: :kwh, final_row: false %>
-    <%= render 'row', title: 'Actual Consumption (kWh)', data: @progress.monthly_usage_kwh, keys: @progress.months, partial_months: @progress.partial_months, percentage_synthetic: {}, units: :kwh, final_row: false %>
-    <%= render 'row', title: 'Overall change since last year', data: @progress.monthly_performance_versus_synthetic_last_year, keys: @progress.months, partial_months: @progress.partial_months, percentage_synthetic: {}, units: :relative_percent, final_row: true %>
+    <%= render 'row', title: 'Target Consumption (kWh)', progress: @progress, data: @progress.monthly_targets_kwh, keys: @progress.months, partial_months: {}, percentage_synthetic: @progress.percentage_synthetic, units: :kwh, final_row: false %>
+    <%= render 'row', title: 'Actual Consumption (kWh)', progress: @progress, data: @progress.monthly_usage_kwh, keys: @progress.months, partial_months: @progress.partial_months, percentage_synthetic: {}, units: :kwh, final_row: false %>
+    <%= render 'row', title: 'Overall change since last year', progress: @progress, data: @progress.monthly_performance_versus_synthetic_last_year, keys: @progress.months, partial_months: @progress.partial_months, percentage_synthetic: {}, units: :relative_percent, final_row: true %>
     </tbody>
   </table>
 

--- a/app/views/schools/school_targets/_bullet_chart.html.erb
+++ b/app/views/schools/school_targets/_bullet_chart.html.erb
@@ -1,8 +1,8 @@
 <div class="row pt-4">
-  <div class="col-md-2 justify-content-center align-self-center">
+  <div class="col-md-2 align-self-center">
     <h4 class="card-title"><%= fuel_progress.fuel_type.to_s.humanize %></h4>
   </div>
-  <div class="col-md-8">
+  <div class="col-md-8 d-none d-sm-block">
     <% if fuel_progress.can_chart? %>
       <figure class="highcharts-figure">
           <div class="bullet-chart" id="bullet-chart-<%= fuel_progress.fuel_type.to_s %>" data-title="Progress against target reduction of <%=target%>%" data-series='<%= bullet_chart_series(fuel_progress) %>'
@@ -10,9 +10,7 @@
       </figure>
     <% end %>
   </div>
-  <div class="col-md-2 justify-content-center align-self-center">
-    <span class="text-center">
-      <%= link_to "View report", progress_path, class: "btn btn-outline-dark rounded-pill font-weight-bold" %>
-    </span>
+  <div class="col-md-2 align-self-center">
+    <%= link_to "View report", progress_path, class: "btn btn-outline-dark font-weight-bold" %>
   </div>
 </div>

--- a/app/views/schools/school_targets/_bullet_chart.html.erb
+++ b/app/views/schools/school_targets/_bullet_chart.html.erb
@@ -1,11 +1,14 @@
 <div class="row pt-4">
-  <div class="col-md-2 align-self-center">
+  <div class="col-md-2 align-self-center" style="padding-right: 0px">
     <h4 class="card-title"><%= fuel_progress.fuel_type.to_s.humanize %></h4>
   </div>
-  <div class="col-md-8 d-none d-sm-block">
+  <div class="col-md-8 d-none d-sm-block" style="padding-right: 25px">
+      <div class="d-flex justify-content-center">
+        <span style="margin-left: 10px; width: 100%;" class="text-center work_week"><%= up_downify(format_target(fuel_progress.progress, :relative_percent))%> against target of <%=target%>%</span>
+      </div>
     <% if fuel_progress.can_chart? %>
       <figure class="highcharts-figure">
-          <div class="bullet-chart" id="bullet-chart-<%= fuel_progress.fuel_type.to_s %>" data-title="Progress against target reduction of <%=target%>%" data-series='<%= bullet_chart_series(fuel_progress) %>'
+          <div class="bullet-chart" id="bullet-chart-<%= fuel_progress.fuel_type.to_s %>" data-title="" data-series='<%= bullet_chart_series(fuel_progress) %>'
           data-label="Consumption" data-units="kWh" data-start-date="<%=school_target.start_date.strftime("%b %Y")%>" data-bands='<%= bullet_chart_bands(fuel_progress) %>' data-month='<%= Time.now.strftime("%b %Y")%> '></div>
       </figure>
     <% end %>

--- a/app/views/schools/school_targets/_bullet_chart.html.erb
+++ b/app/views/schools/school_targets/_bullet_chart.html.erb
@@ -1,20 +1,18 @@
-<div class="row">
+<div class="row pt-4">
   <div class="col-md-2 justify-content-center align-self-center">
     <h4 class="card-title"><%= fuel_progress.fuel_type.to_s.humanize %></h4>
   </div>
-  <div class="col-md-6">
+  <div class="col-md-8">
     <% if fuel_progress.can_chart? %>
       <figure class="highcharts-figure">
-          <div class="bullet-chart" id="bullet-chart-<%= fuel_progress.fuel_type.to_s %>" data-title="Progress against target consumption" data-series='<%= bullet_chart_series(fuel_progress) %>'
-          data-label="Consumption" data-units="kWh" data-start-date="<%=nice_dates(school_target.start_date)%>" data-bands='<%= bullet_chart_bands(fuel_progress) %>'></div>
+          <div class="bullet-chart" id="bullet-chart-<%= fuel_progress.fuel_type.to_s %>" data-title="Progress against target reduction of <%=target%>%" data-series='<%= bullet_chart_series(fuel_progress) %>'
+          data-label="Consumption" data-units="kWh" data-start-date="<%=school_target.start_date.strftime("%b %Y")%>" data-bands='<%= bullet_chart_bands(fuel_progress) %>' data-month='<%= Time.now.strftime("%b %Y")%> '></div>
       </figure>
     <% end %>
   </div>
-  <div class="col-md-2 justify-content-center align-self-center align-items-center">
-  </div>
   <div class="col-md-2 justify-content-center align-self-center">
     <span class="text-center">
-      <%= link_to "View progress", progress_path, class: "btn btn-outline-dark rounded-pill font-weight-bold" %>
+      <%= link_to "View report", progress_path, class: "btn btn-outline-dark rounded-pill font-weight-bold" %>
     </span>
   </div>
 </div>

--- a/app/views/schools/school_targets/_limited_data.html.erb
+++ b/app/views/schools/school_targets/_limited_data.html.erb
@@ -1,8 +1,8 @@
 <div class="row pt-4 limited_data">
-  <div class="col-md-2 justify-content-center align-self-center">
+  <div class="col-md-2 align-self-center">
     <h4 class="card-title"><%= fuel_type.to_s.humanize %></h4>
   </div>
-  <div class="col-md-8 align-self-center work_week">
+  <div class="col-md-8 align-self-center work_week d-none d-sm-block">
     <div class="d-flex justify-content-center">
         <span class="text-center">
         Progress against target reduction of <%= target %>%
@@ -18,9 +18,7 @@
       </span>
     </div>
   </div>
-  <div class="col-md-2 justify-content-center align-self-center">
-    <span class="text-center">
-      <%= link_to "View report", progress_path, class: "btn btn-outline-dark rounded-pill font-weight-bold" %>
-    </span>
+  <div class="col-md-2 align-self-center">
+    <%= link_to "View report", progress_path, class: "btn btn-outline-dark font-weight-bold" %>
   </div>
 </div>

--- a/app/views/schools/school_targets/_limited_data.html.erb
+++ b/app/views/schools/school_targets/_limited_data.html.erb
@@ -1,24 +1,26 @@
-<div class="row limited_data">
-  <div class="col-md-4 justify-content-center align-self-center">
+<div class="row pt-4 limited_data">
+  <div class="col-md-2 justify-content-center align-self-center">
     <h4 class="card-title"><%= fuel_type.to_s.humanize %></h4>
   </div>
-  <div class="col-md-2 justify-content-center align-self-center work_week">
-    <h4>
-      Goal: <%= up_downify("-#{target}%") %>
-    </h4>
-  </div>
-  <div class="col-md-3 justify-content-center align-self-center work_week">
-    <% if overview_data.present? && overview_data.work_week(fuel_type).has_data %>
-    <h4>
-      Last week: <%= up_downify(overview_data.work_week(fuel_type).change) %>
-    </h4>
-    <% end %>
-  </div>
-  <div class="col-md-1 justify-content-center align-self-center">
+  <div class="col-md-8 align-self-center work_week">
+    <div class="d-flex justify-content-center">
+        <span class="text-center">
+        Progress against target reduction of <%= target %>%
+        </span>
+    </div>
+    <div class="d-flex justify-content-center mt-2">
+      <span class="text-center">
+      <% if overview_data.present? && overview_data.work_week(fuel_type).has_data %>
+        <%= up_downify(overview_data.work_week(fuel_type).change) %> Last week
+      <% else %>
+        N/A
+      <% end %>
+      </span>
+    </div>
   </div>
   <div class="col-md-2 justify-content-center align-self-center">
     <span class="text-center">
-      <%= link_to "View progress", progress_path, class: "btn btn-outline-dark rounded-pill font-weight-bold" %>
+      <%= link_to "View report", progress_path, class: "btn btn-outline-dark rounded-pill font-weight-bold" %>
     </span>
   </div>
 </div>

--- a/app/views/schools/school_targets/_limited_data.html.erb
+++ b/app/views/schools/school_targets/_limited_data.html.erb
@@ -2,19 +2,14 @@
   <div class="col-md-2 align-self-center">
     <h4 class="card-title"><%= fuel_type.to_s.humanize %></h4>
   </div>
-  <div class="col-md-8 align-self-center work_week d-none d-sm-block">
-    <div class="d-flex justify-content-center">
-        <span class="text-center">
-        Progress against target reduction of <%= target %>%
-        </span>
-    </div>
+  <div class="col-md-8 align-self-center work_week d-none d-sm-block" style="padding-right: 25px">
     <div class="d-flex justify-content-center mt-2">
       <span class="text-center">
-      <% if overview_data.present? && overview_data.work_week(fuel_type).has_data %>
-        <%= up_downify(overview_data.work_week(fuel_type).change) %> Last week
-      <% else %>
-        N/A
-      <% end %>
+        <% if overview_data.present? && overview_data.work_week(fuel_type).has_data %>
+              <%= up_downify(overview_data.work_week(fuel_type).change) %> last week against target of <%= target %>%
+        <% else %>
+          Target reduction of <%= target %>%
+        <% end %>
       </span>
     </div>
   </div>

--- a/app/views/schools/school_targets/_prompt_to_add_estimate.html.erb
+++ b/app/views/schools/school_targets/_prompt_to_add_estimate.html.erb
@@ -3,6 +3,6 @@
     <%= link_to "Add an estimate", school_estimated_annual_consumptions_path(@school), class: "btn btn-light rounded-pill" %>
   </div>
   <div class="col">
-    <span class="align-middle">If you can supply an estimate of your annual consumption then we can generate a detailed progress report for your <%= @suggest_estimates.map{|s| s.humanize(capitalize: false)}.to_sentence %> <%= "target".pluralize(@suggest_estimates.size) %>.</span>
+    <span class="align-middle">If you can supply an estimate of your annual consumption then we can generate a more detailed progress report for your <%= @suggest_estimates.map{|s| s.humanize(capitalize: false)}.to_sentence %> <%= "target".pluralize(@suggest_estimates.size) %>.</span>
   </div>
 </div>

--- a/app/views/schools/school_targets/show.html.erb
+++ b/app/views/schools/school_targets/show.html.erb
@@ -4,7 +4,7 @@
   <% if @school_target.report_last_generated.nil? %>
     <h1>We are calculating your progress</h1>
   <% else %>
-    <h1>Progress towards reducing your energy usage</h1>
+    <h1>Reducing your energy usage by <%= @school_target.target_date.strftime("%B %Y") %></h1>
   <% end %>
   <div>
     <% if can?(:manage, @school_target) %>

--- a/app/views/schools/school_targets/show.html.erb
+++ b/app/views/schools/school_targets/show.html.erb
@@ -8,9 +8,9 @@
   <% end %>
   <div>
     <% if can?(:manage, @school_target) %>
-      <%= link_to "Revise your target", edit_school_school_target_path(@school, @school_target), class: "btn btn-outline-dark rounded-pill font-weight-bold" %>
+      <%= link_to "Revise your target", edit_school_school_target_path(@school, @school_target), class: "btn btn-outline-dark font-weight-bold" %>
     <% end %>
-    <%= link_to_help_for_feature :school_targets, css: "btn btn-outline-dark rounded-pill font-weight-bold" %>
+    <%= link_to_help_for_feature :school_targets, css: "btn btn-outline-dark font-weight-bold" %>
   </div>
 </div>
 

--- a/app/views/schools/school_targets/show.html.erb
+++ b/app/views/schools/school_targets/show.html.erb
@@ -4,7 +4,7 @@
   <% if @school_target.report_last_generated.nil? %>
     <h1>We are calculating your progress</h1>
   <% else %>
-    <h1>Your energy saving target</h1>
+    <h1>Progress towards reducing your energy usage</h1>
   <% end %>
   <div>
     <% if can?(:manage, @school_target) %>
@@ -18,22 +18,23 @@
   <%= render 'generating_report' %>
 <% else %>
   <% if @progress_summary.electricity_progress.present? %>
-    <%= render "bullet_chart", fuel_progress: @progress_summary.electricity_progress, school_target: @school_target, progress_path: electricity_school_progress_index_path(@school)  %>
+    <%= render "bullet_chart", fuel_progress: @progress_summary.electricity_progress, school_target: @school_target, target: @school_target.electricity, progress_path: electricity_school_progress_index_path(@school)  %>
   <% elsif show_limited_data?(@school_target, :electricity) %>
     <%= render "limited_data", fuel_type: :electricity, overview_data: @overview_data, target: @school_target.electricity, school_target: @school_target, progress_path: electricity_school_progress_index_path(@school)  %>
   <% end %>
-
   <% if @progress_summary.gas_progress.present? %>
-    <%= render "bullet_chart", fuel_progress: @progress_summary.gas_progress, school_target: @school_target, progress_path: gas_school_progress_index_path(@school)  %>
+    <%= render "bullet_chart", fuel_progress: @progress_summary.gas_progress, school_target: @school_target, target: @school_target.gas, progress_path: gas_school_progress_index_path(@school)  %>
   <% elsif show_limited_data?(@school_target, :gas) %>
     <%= render "limited_data", fuel_type: :gas, overview_data: @overview_data, target: @school_target.gas, school_target: @school_target, progress_path: gas_school_progress_index_path(@school)  %>
   <% end %>
 
   <% if @progress_summary.storage_heater_progress.present? %>
-    <%= render "bullet_chart", fuel_progress: @progress_summary.storage_heater_progress, school_target: @school_target, progress_path: storage_heater_school_progress_index_path(@school)  %>
+    <%= render "bullet_chart", fuel_progress: @progress_summary.storage_heater_progress, school_target: @school_target, target: @school_target.storage_heaters, progress_path: storage_heater_school_progress_index_path(@school)  %>
   <% elsif show_limited_data?(@school_target, :storage_heaters) %>
     <%= render "limited_data", fuel_type: :storage_heaters, overview_data: @overview_data, target: @school_target.storage_heaters, school_target: @school_target, progress_path: storage_heater_school_progress_index_path(@school)  %>
   <% end %>
+
+  <div class="pt-4"></div>
 
   <% if @prompt_to_review_target %>
     <%= render 'prompt_to_review_target' %>

--- a/spec/system/schools/progress_spec.rb
+++ b/spec/system/schools/progress_spec.rb
@@ -192,7 +192,7 @@ describe 'targets', type: :system do
 
         it 'shows prompt to add estimate' do
           visit electricity_school_progress_index_path(school)
-          expect(page).to have_content("If you can supply an estimate of your annual consumption then we can generate a detailed progress report")
+          expect(page).to have_content("If you can supply an estimate of your annual consumption then we can generate a more detailed progress report")
         end
       end
 

--- a/spec/system/schools/school_targets_spec.rb
+++ b/spec/system/schools/school_targets_spec.rb
@@ -210,8 +210,8 @@ RSpec.describe 'school targets', type: :system do
       end
 
       it 'does not show limited data' do
-        expect(page).to_not have_content("Goal")
-        expect(page).to_not have_content("Last week")
+        expect(page).to_not have_content("Progress against target reduction")
+        expect(page).to_not have_content("last week")
       end
 
       context "and v2 is active and limited data is available" do
@@ -227,8 +227,8 @@ RSpec.describe 'school targets', type: :system do
         end
 
         it 'shows limited data' do
-          expect(page).to have_content("Progress against target reduction")
-          expect(page).to_not have_content("Last week")
+          expect(page).to have_content("Target reduction")
+          expect(page).to_not have_content("last week")
         end
 
         it 'shows prompt to add estimate' do
@@ -244,7 +244,7 @@ RSpec.describe 'school targets', type: :system do
             refresh
           end
           it 'shows the same data as the management dashboard' do
-            expect(page).to have_content("Last week")
+            expect(page).to have_content("last week")
           end
         end
       end

--- a/spec/system/schools/school_targets_spec.rb
+++ b/spec/system/schools/school_targets_spec.rb
@@ -192,7 +192,7 @@ RSpec.describe 'school targets', type: :system do
       end
 
       it "displays current target" do
-        expect(page).to have_content("Progress towards reducing your energy usage")
+        expect(page).to have_content("Reducing your energy usage by")
       end
 
       it "links to progress pages" do
@@ -210,7 +210,7 @@ RSpec.describe 'school targets', type: :system do
       end
 
       it 'does not show limited data' do
-        expect(page).to_not have_content("Progress against target reduction")
+        expect(page).to_not have_content("against target reduction")
         expect(page).to_not have_content("last week")
       end
 
@@ -311,7 +311,7 @@ RSpec.describe 'school targets', type: :system do
 
       it "redirects from new target page" do
         visit new_school_school_target_path(school, target)
-        expect(page).to have_content("Progress towards reducing your energy usage")
+        expect(page).to have_content("Reducing your energy usage by")
       end
 
       context "and fuel types are out of date" do
@@ -448,7 +448,7 @@ RSpec.describe 'school targets', type: :system do
       visit school_school_targets_path(school)
     end
     it 'lets me view a target' do
-      expect(page).to have_content("Progress towards reducing your energy usage")
+      expect(page).to have_content("Reducing your energy usage by")
     end
     it 'shows me a link to the report' do
       expect(page).to have_link("View report", href: electricity_school_progress_index_path(school))
@@ -472,7 +472,7 @@ RSpec.describe 'school targets', type: :system do
       visit school_school_targets_path(school)
     end
     it 'lets me view a target' do
-      expect(page).to have_content("Progress towards reducing your energy usage")
+      expect(page).to have_content("Reducing your energy usage by")
     end
     it 'shows me a link to the report' do
       expect(page).to have_link("View report", href: electricity_school_progress_index_path(school))

--- a/spec/system/schools/school_targets_spec.rb
+++ b/spec/system/schools/school_targets_spec.rb
@@ -192,7 +192,7 @@ RSpec.describe 'school targets', type: :system do
       end
 
       it "displays current target" do
-        expect(page).to have_content("Your energy saving target")
+        expect(page).to have_content("Progress towards reducing your energy usage")
       end
 
       it "links to progress pages" do
@@ -200,7 +200,7 @@ RSpec.describe 'school targets', type: :system do
         expect(Schools::Configuration.count).to eql 1
         expect(School.first.has_electricity?).to be true
 
-        expect(page).to have_link("View progress", href: electricity_school_progress_index_path(school))
+        expect(page).to have_link("View report", href: electricity_school_progress_index_path(school))
       end
 
       it 'shows the bullet charts' do
@@ -227,7 +227,7 @@ RSpec.describe 'school targets', type: :system do
         end
 
         it 'shows limited data' do
-          expect(page).to have_content("Goal")
+          expect(page).to have_content("Progress against target reduction")
           expect(page).to_not have_content("Last week")
         end
 
@@ -311,7 +311,7 @@ RSpec.describe 'school targets', type: :system do
 
       it "redirects from new target page" do
         visit new_school_school_target_path(school, target)
-        expect(page).to have_content("Your energy saving target")
+        expect(page).to have_content("Progress towards reducing your energy usage")
       end
 
       context "and fuel types are out of date" do
@@ -448,10 +448,10 @@ RSpec.describe 'school targets', type: :system do
       visit school_school_targets_path(school)
     end
     it 'lets me view a target' do
-      expect(page).to have_content("Your energy saving target")
+      expect(page).to have_content("Progress towards reducing your energy usage")
     end
     it 'shows me a link to the report' do
-      expect(page).to have_link("View progress", href: electricity_school_progress_index_path(school))
+      expect(page).to have_link("View report", href: electricity_school_progress_index_path(school))
     end
     it 'doesnt have a revise link' do
       expect(page).to_not have_link("Revise your target")
@@ -472,10 +472,10 @@ RSpec.describe 'school targets', type: :system do
       visit school_school_targets_path(school)
     end
     it 'lets me view a target' do
-      expect(page).to have_content("Your energy saving target")
+      expect(page).to have_content("Progress towards reducing your energy usage")
     end
     it 'shows me a link to the report' do
-      expect(page).to have_link("View progress", href: electricity_school_progress_index_path(school))
+      expect(page).to have_link("View report", href: electricity_school_progress_index_path(school))
     end
     it 'doesnt have a revise link' do
       expect(page).to_not have_link("Revise your target")

--- a/spec/system/schools/school_targets_spec.rb
+++ b/spec/system/schools/school_targets_spec.rb
@@ -232,7 +232,7 @@ RSpec.describe 'school targets', type: :system do
         end
 
         it 'shows prompt to add estimate' do
-          expect(page).to have_content("If you can supply an estimate of your annual consumption then we can generate a detailed progress report")
+          expect(page).to have_content("If you can supply an estimate of your annual consumption then we can generate a more detailed progress report")
         end
 
         context 'and some recent data' do


### PR DESCRIPTION
* Tweak wording on prompt to add estimates
* Don't show 0% in table if there's no target for that month
* Don't show 0% change as a positive
* Improve layout, altering spacing around charts and elements
* Make limited data view more consistent with richer view with bullet char
* Remove some unneeded CSS classes from prototyping.