### PR TITLE
Only show estimate prompt for specific fuel type

### DIFF
--- a/app/views/schools/progress/index.html.erb
+++ b/app/views/schools/progress/index.html.erb
@@ -6,8 +6,8 @@
   </div>
 </div>
 
-<% if @suggest_estimates.present? && @suggest_estimates.any? %>
-  <%= render 'schools/school_targets/prompt_to_add_estimate' %>
+<% if @suggest_estimates.present? && @suggest_estimates.any? && @suggest_estimates.include?(@fuel_type.to_s) %>
+  <%= render 'schools/school_targets/prompt_to_add_estimate', school: @school, suggest_estimates: [@fuel_type.to_s] %>
 <% end %>
 
 <% if !@recent_data %>

--- a/app/views/schools/school_targets/_prompt_to_add_estimate.html.erb
+++ b/app/views/schools/school_targets/_prompt_to_add_estimate.html.erb
@@ -1,8 +1,8 @@
 <div class="row alert text-dark bg-neutral">
   <div class="col-md-2">
-    <%= link_to "Add an estimate", school_estimated_annual_consumptions_path(@school), class: "btn btn-light rounded-pill" %>
+    <%= link_to "Add an estimate", school_estimated_annual_consumptions_path(school), class: "btn btn-light rounded-pill" %>
   </div>
   <div class="col">
-    <span class="align-middle">If you can supply an estimate of your annual consumption then we can generate a more detailed progress report for your <%= @suggest_estimates.map{|s| s.humanize(capitalize: false)}.to_sentence %> <%= "target".pluralize(@suggest_estimates.size) %>.</span>
+    <span class="align-middle">If you can supply an estimate of your annual consumption then we can generate a more detailed progress report for your <%= suggest_estimates.map{|s| s.humanize(capitalize: false)}.to_sentence %> <%= "target".pluralize(suggest_estimates.size) %>.</span>
   </div>
 </div>

--- a/app/views/schools/school_targets/show.html.erb
+++ b/app/views/schools/school_targets/show.html.erb
@@ -46,7 +46,7 @@
 <% end %>
 
 <% if @suggest_estimates.present? && @suggest_estimates.any? %>
-  <%= render 'prompt_to_add_estimate' %>
+  <%= render 'prompt_to_add_estimate', school: @school, suggest_estimates: @suggest_estimates %>
 <% end %>
 
 <div class="row">

--- a/spec/system/schools/progress_spec.rb
+++ b/spec/system/schools/progress_spec.rb
@@ -194,6 +194,13 @@ describe 'targets', type: :system do
           visit electricity_school_progress_index_path(school)
           expect(page).to have_content("If you can supply an estimate of your annual consumption then we can generate a more detailed progress report")
         end
+
+        it 'doesnt show prompt if different fuel type' do
+          school.configuration.update!(suggest_estimates_fuel_types: ["gas"])
+          visit electricity_school_progress_index_path(school)
+          expect(page).to_not have_content("If you can supply an estimate of your annual consumption then we can generate a more detailed progress report")
+        end
+
       end
 
       context 'and there is missing target consumption and performance' do

--- a/spec/system/schools/school_targets_spec.rb
+++ b/spec/system/schools/school_targets_spec.rb
@@ -239,7 +239,7 @@ RSpec.describe 'school targets', type: :system do
         end
 
         it 'shows prompt to add estimate' do
-          expect(page).to have_content("If you can supply an estimate of your annual consumption then we can generate a more detailed progress report")
+          expect(page).to have_content("If you can supply an estimate of your annual consumption then we can generate a more detailed progress report for your electricity")
         end
 
         context 'and some recent data' do


### PR DESCRIPTION
On the progress report, only prompt for an estimate if we need one for the specific fuel type.

On the target summary page, prompt for all estimates as before.