### PR TITLE
Handle missing targets in feedback logic

### DIFF
--- a/app/classes/targets/fuel_progress.rb
+++ b/app/classes/targets/fuel_progress.rb
@@ -23,7 +23,7 @@ module Targets
     end
 
     def achieving_target?
-      @progress.present? && @progress <= 0
+      @target.present? && @progress.present? && @progress <= 0
     end
   end
 end

--- a/app/controllers/schools/progress_controller.rb
+++ b/app/controllers/schools/progress_controller.rb
@@ -38,6 +38,7 @@ module Schools
       begin
         @recent_data = service.recent_data?
         @progress = service.progress
+        @this_month_target = @progress.cumulative_targets_kwh[this_month]
         @suggest_estimate_important = suggest_estimate_for_fuel_type?(@fuel_type, check_data: true)
         @debug_content = service.analytics_debug_info if current_user.present? && current_user.analytics?
       rescue => e
@@ -54,6 +55,10 @@ module Schools
         end
       end
       render :index
+    end
+
+    def this_month
+      Time.zone.now.strftime("%b")
     end
 
     def bad_estimate?(type)

--- a/app/views/schools/progress/index.html.erb
+++ b/app/views/schools/progress/index.html.erb
@@ -27,7 +27,7 @@
     </p>
   <% end %>
 
-  <% if @progress && @progress.current_cumulative_performance_versus_synthetic_last_year %>
+  <% if @progress && @current_month_target && @progress.current_cumulative_performance_versus_synthetic_last_year %>
     <% if @progress.current_cumulative_performance_versus_synthetic_last_year == 0.0 %>
       <p>
         Unfortunately you are currently consuming as much data as you did last year.


### PR DESCRIPTION
Check whether there is target consumption in the month before giving user feedback.