### PR TITLE
Analytics test release

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,8 +23,8 @@ gem 'closed_struct'
 gem 'pg_search'
 
 # Dashboard analytics
-#gem 'energy-sparks_analytics', git: 'https://github.com/Energy-Sparks/energy-sparks_analytics.git', tag: '1.40.9'
-gem 'energy-sparks_analytics', git: 'https://github.com/Energy-Sparks/energy-sparks_analytics.git', branch: 'aws-eb-test'
+gem 'energy-sparks_analytics', git: 'https://github.com/Energy-Sparks/energy-sparks_analytics.git', tag: '1.50.0'
+#gem 'energy-sparks_analytics', git: 'https://github.com/Energy-Sparks/energy-sparks_analytics.git', branch: 'aws-eb-test'
 #gem 'energy-sparks_analytics', path: '../energy-sparks_analytics'
 
 # Using master due to it having a patch which doesn't override Enumerable#sum if it's already defined

--- a/Gemfile
+++ b/Gemfile
@@ -23,8 +23,8 @@ gem 'closed_struct'
 gem 'pg_search'
 
 # Dashboard analytics
-gem 'energy-sparks_analytics', git: 'https://github.com/Energy-Sparks/energy-sparks_analytics.git', tag: '1.40.8'
-#gem 'energy-sparks_analytics', git: 'https://github.com/Energy-Sparks/energy-sparks_analytics.git', branch: 'aws-eb-test'
+#gem 'energy-sparks_analytics', git: 'https://github.com/Energy-Sparks/energy-sparks_analytics.git', tag: '1.40.8'
+gem 'energy-sparks_analytics', git: 'https://github.com/Energy-Sparks/energy-sparks_analytics.git', branch: 'aws-eb-test'
 #gem 'energy-sparks_analytics', path: '../energy-sparks_analytics'
 
 # Using master due to it having a patch which doesn't override Enumerable#sum if it's already defined

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/Energy-Sparks/energy-sparks_analytics.git
-  revision: 55d45b2ee036d7bb6a807bec48371b47b5331f15
+  revision: 040d39845dc8abdd69d1b5081273e9ce1f07b68e
   branch: aws-eb-test
   specs:
     energy-sparks_analytics (1.2.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/Energy-Sparks/energy-sparks_analytics.git
-  revision: 1e2b2638658237aeaf832c6e05271fd6ba25400d
-  tag: 1.40.8
+  revision: 55d45b2ee036d7bb6a807bec48371b47b5331f15
+  branch: aws-eb-test
   specs:
     energy-sparks_analytics (1.2.1)
       activesupport (~> 6.0.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/Energy-Sparks/energy-sparks_analytics.git
-  revision: fc14ea7d6e85858e4b153ff039719259dcd8a2aa
-  branch: aws-eb-test
+  revision: de5e8ababd8cb183d93e78c6fdc64fef26766982
+  tag: 1.50.0
   specs:
     energy-sparks_analytics (1.2.1)
       activesupport (~> 6.0.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/Energy-Sparks/energy-sparks_analytics.git
-  revision: d8dbbb6111c17eb8e2ebc51aa87627cc125e960c
+  revision: fc14ea7d6e85858e4b153ff039719259dcd8a2aa
   branch: aws-eb-test
   specs:
     energy-sparks_analytics (1.2.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/Energy-Sparks/energy-sparks_analytics.git
-  revision: 040d39845dc8abdd69d1b5081273e9ce1f07b68e
+  revision: d8dbbb6111c17eb8e2ebc51aa87627cc125e960c
   branch: aws-eb-test
   specs:
     energy-sparks_analytics (1.2.1)

--- a/app/controllers/schools/charts_controller.rb
+++ b/app/controllers/schools/charts_controller.rb
@@ -26,7 +26,7 @@ class Schools::ChartsController < ApplicationController
         y_axis_units = params[:chart_y_axis_units]
         chart_config[:y_axis_units] = y_axis_units.to_sym if y_axis_units.present?
 
-        output = ChartData.new(@school, aggregate_school, @chart_type, chart_config, show_benchmark_figures: show_benchmark_figures?, transformations: get_transformations).data
+        output = ChartData.new(@school, aggregate_school, @chart_type, chart_config, transformations: get_transformations).data
         if output
           render json: ChartDataValues.as_chart_json(output)
         else
@@ -37,10 +37,6 @@ class Schools::ChartsController < ApplicationController
   end
 
 private
-
-  def show_benchmark_figures?
-    can?(:read, :show_benchmark_figures)
-  end
 
   def set_school
     @school = School.friendly.find(params[:school_id])

--- a/app/controllers/schools/simulations_controller.rb
+++ b/app/controllers/schools/simulations_controller.rb
@@ -115,7 +115,7 @@ private
 
     simulator = ElectricitySimulator.new(local_school)
     simulator.simulate(@simulation_configuration)
-    chart_manager = ChartManager.new(local_school, false)
+    chart_manager = ChartManager.new(local_school)
 
     @number_of_charts = @charts.size
 

--- a/app/models/chart_data.rb
+++ b/app/models/chart_data.rb
@@ -3,17 +3,16 @@ require 'dashboard'
 class ChartData
   OPERATIONS = %i[move extend contract compare].freeze
 
-  def initialize(school, aggregated_school, original_chart_type, chart_config, transformations: [], show_benchmark_figures: false)
+  def initialize(school, aggregated_school, original_chart_type, chart_config, transformations: [])
     @school = school
     @aggregated_school = aggregated_school
     @original_chart_type = original_chart_type
     @chart_config_overrides = chart_config
     @transformations = transformations
-    @show_benchmark_figures = show_benchmark_figures
   end
 
   def data
-    chart_manager = ChartManager.new(@aggregated_school, @show_benchmark_figures)
+    chart_manager = ChartManager.new(@aggregated_school)
 
     chart_config = customised_chart_config(chart_manager)
 

--- a/lib/tasks/deployment/20220411122056_season_analysis_alerts.rake
+++ b/lib/tasks/deployment/20220411122056_season_analysis_alerts.rake
@@ -30,11 +30,11 @@ namespace :after_party do
       fuel_type: :electricity,
       sub_category: :heating,
       title: "Warn school when it's warm enough to turn their storage radiators off",
-      class_name: 'AlertTurnHeatingOffStorageHeater',
+      class_name: 'AlertTurnHeatingOffStorageHeaters',
       source: :analytics,
       has_ratings: true,
       benchmark: true
-    ) unless AlertType.find_by_class_name('AlertTurnHeatingOffStorageHeater')
+    ) unless AlertType.find_by_class_name('AlertTurnHeatingOffStorageHeaters')
 
     AlertType.create!(
       frequency: :weekly,

--- a/lib/tasks/deployment/20220411122056_season_analysis_alerts.rake
+++ b/lib/tasks/deployment/20220411122056_season_analysis_alerts.rake
@@ -19,11 +19,11 @@ namespace :after_party do
       fuel_type: :gas,
       sub_category: :heating,
       title: "Warn school when it's warm enough to turn their boilers off",
-      class_name: 'AlertHeatingOff',
+      class_name: 'AlertTurnHeatingOff',
       source: :analytics,
       has_ratings: true,
       benchmark: true
-    ) unless AlertType.find_by_class_name('AlertHeatingOff')
+    ) unless AlertType.find_by_class_name('AlertTurnHeatingOff')
 
     AlertType.create!(
       frequency: :weekly,

--- a/lib/tasks/deployment/20220411122056_season_analysis_alerts.rake
+++ b/lib/tasks/deployment/20220411122056_season_analysis_alerts.rake
@@ -1,0 +1,66 @@
+namespace :after_party do
+  desc 'Deployment task: Configure new seasonal analysis alerts'
+  task season_analysis_alerts: :environment do
+    puts "Running deploy task 'season_analysis_alerts'"
+
+    #Remove old alerts
+    ["AlertHeatingOnOff",
+     "AlertHeatingOnSchoolDays",
+     "AlertHeatingOnNonSchoolDays",
+     "AlertHeatingOnSchoolDaysStorageHeaters"
+    ].each do |class_name|
+      alert = AlertType.find_by_class_name(class_name)
+      alert.destroy if alert.present?
+    end
+
+    #Configure the new ones
+    AlertType.create!(
+      frequency: :weekly,
+      fuel_type: :gas,
+      sub_category: :heating,
+      title: "Warn school when it's warm enough to turn their boilers off",
+      class_name: 'AlertHeatingOff',
+      source: :analytics,
+      has_ratings: true,
+      benchmark: true
+    ) unless AlertType.find_by_class_name('AlertHeatingOff')
+
+    AlertType.create!(
+      frequency: :weekly,
+      fuel_type: :electricity,
+      sub_category: :heating,
+      title: "Warn school when it's warm enough to turn their storage radiators off",
+      class_name: 'AlertTurnHeatingOffStorageHeater',
+      source: :analytics,
+      has_ratings: true,
+      benchmark: true
+    ) unless AlertType.find_by_class_name('AlertTurnHeatingOffStorageHeater')
+
+    AlertType.create!(
+      frequency: :weekly,
+      fuel_type: :gas,
+      sub_category: :heating,
+      title: "Gas heating usage in warm weather",
+      class_name: 'AlertSeasonalHeatingSchoolDays',
+      source: :analytics,
+      has_ratings: true,
+      benchmark: true
+    ) unless AlertType.find_by_class_name('AlertSeasonalHeatingSchoolDays')
+
+    AlertType.create!(
+      frequency: :weekly,
+      fuel_type: :electricity,
+      sub_category: :heating,
+      title: "Storage heater usage in warm weather",
+      class_name: 'AlertSeasonalHeatingSchoolDaysStorageHeaters',
+      source: :analytics,
+      has_ratings: true,
+      benchmark: true
+    ) unless AlertType.find_by_class_name('AlertSeasonalHeatingSchoolDaysStorageHeaters')
+
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord
+      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+  end
+end


### PR DESCRIPTION
Switches to `aws-eb-test` branch of analytics to allow testing of:

* energy-sparks/energy-sparks_analytics#241
* energy-sparks/energy-sparks_analytics#240
* energy-sparks/energy-sparks_analytics#242
