### PR TITLE
2165 park and stride flag for transport types

### DIFF
--- a/app/controllers/admin/transport_types_controller.rb
+++ b/app/controllers/admin/transport_types_controller.rb
@@ -28,7 +28,7 @@ module Admin
     private
 
     def transport_type_params
-      params.require(:transport_type).permit(:name, :image, :kg_co2e_per_km, :speed_km_per_hour, :can_share, :note)
+      params.require(:transport_type).permit(:name, :image, :kg_co2e_per_km, :speed_km_per_hour, :can_share, :park_and_stride, :note)
     end
   end
 end

--- a/app/controllers/transport_types_controller.rb
+++ b/app/controllers/transport_types_controller.rb
@@ -2,6 +2,6 @@ class TransportTypesController < ApplicationController
   respond_to :json
 
   def index
-    respond_with TransportType.select(:id, :name, :image, :kg_co2e_per_km, :speed_km_per_hour, :can_share).index_by(&:id)
+    respond_with TransportType.select(:id, :name, :image, :kg_co2e_per_km, :speed_km_per_hour, :can_share, :park_and_stride).index_by(&:id)
   end
 end

--- a/app/javascript/packs/transport_surveys/carbon.js
+++ b/app/javascript/packs/transport_surveys/carbon.js
@@ -60,7 +60,7 @@ const parkAndStrideTimeMins = function(timeMins) {
 
 export const carbonCalc = function(transport, timeMins, passengers) {
   if (transport) {
-    timeMins = transport.image === '🚶🚘' ? parkAndStrideTimeMins(timeMins) : timeMins; // need a better way of identifying park and stride!
+    timeMins = transport.park_and_stride == true ? parkAndStrideTimeMins(timeMins) : timeMins;
     return (((transport.speed_km_per_hour * timeMins) / 60) * transport.kg_co2e_per_km) / passengers ;
   } else {
     return 0;

--- a/app/views/admin/transport_types/_form.html.erb
+++ b/app/views/admin/transport_types/_form.html.erb
@@ -5,5 +5,6 @@
   <%= f.input :speed_km_per_hour, label: 'Speed (km/h)' %>
   <%= f.input :kg_co2e_per_km, label: 'Carbon (kg co2e/km)' %>
   <%= f.input :can_share, as: :boolean %>
+  <%= f.input :park_and_stride, as: :boolean %>
   <%= f.submit 'Save', class: 'btn btn-primary' %>
 <% end %>

--- a/app/views/admin/transport_types/index.html.erb
+++ b/app/views/admin/transport_types/index.html.erb
@@ -8,6 +8,7 @@
       <th>Speed (km/h)</th>
       <th>Carbon (kg co2e/km)</th>
       <th>Can share</th>
+      <th>Park and stride</th>
       <th>Note</th>
       <th>Actions</th>
     </tr>
@@ -21,6 +22,7 @@
         <td><%= transport_type.speed_km_per_hour %></td>
         <td><%= transport_type.kg_co2e_per_km %></td>
         <td><span class="badge bg-primary text-light"><%= y_n(transport_type.can_share) %></span></td>
+        <td><span class="badge bg-primary text-light"><%= y_n(transport_type.park_and_stride) %></span></td>
         <td><%= transport_type.note %></td>
         <td>
           <div class="btn-group">

--- a/app/views/admin/transport_types/show.html.erb
+++ b/app/views/admin/transport_types/show.html.erb
@@ -20,6 +20,10 @@
 
   <dt class="col-md-2">Can share</dt>
   <dd class="col-md-10"><span class="badge bg-primary text-light"><%= y_n(@transport_type.can_share) %></span></dd>
+
+  <dt class="col-md-2">Park and stride</dt>
+  <dd class="col-md-10"><span class="badge bg-primary text-light"><%= y_n(@transport_type.park_and_stride) %></span></dd>
+
   <dt class="col-md-2">Created at</dt>
   <dd class="col-md-10"><%= nice_date_times @transport_type.created_at %></dd>
 

--- a/db/migrate/20220513160539_add_park_and_stride_to_transport_types.rb
+++ b/db/migrate/20220513160539_add_park_and_stride_to_transport_types.rb
@@ -1,0 +1,5 @@
+class AddParkAndStrideToTransportTypes < ActiveRecord::Migration[6.0]
+  def change
+    add_column :transport_types, :park_and_stride, :boolean, { default: false, null: false }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_05_10_172051) do
+ActiveRecord::Schema.define(version: 2022_05_13_160539) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
@@ -1471,6 +1471,7 @@ ActiveRecord::Schema.define(version: 2022_05_10_172051) do
     t.boolean "can_share", default: false, null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.boolean "park_and_stride", default: false, null: false
     t.index ["name"], name: "index_transport_types_on_name", unique: true
   end
 

--- a/lib/tasks/deployment/20220516101905_set_park_and_stride.rake
+++ b/lib/tasks/deployment/20220516101905_set_park_and_stride.rake
@@ -1,0 +1,13 @@
+namespace :after_party do
+  desc 'Deployment task: set_park_and_stride'
+  task set_park_and_stride: :environment do
+    puts "Running deploy task 'set_park_and_stride'"
+
+    TransportType.where("image = ? OR name = ?", "🚶🚘", "Park and Stride").update_all(park_and_stride: true)
+
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord
+      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+  end
+end

--- a/spec/factories/transport_types.rb
+++ b/spec/factories/transport_types.rb
@@ -6,5 +6,6 @@ FactoryBot.define do
     speed_km_per_hour { "32" }
     note { "Average car, unknown size or fuel type" }
     can_share { true }
+    park_and_stride { false }
   end
 end

--- a/spec/system/schools/transport_surveys_spec.rb
+++ b/spec/system/schools/transport_surveys_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe 'TransportSurveys', type: :system do
 
   let!(:school)            { create(:school, :with_school_group) }
-  let!(:transport_type)    { create(:transport_type) }
+  let!(:transport_type)    { create(:transport_type, can_share: true) }
 
   describe "Survey app" do
 


### PR DESCRIPTION
Provide a less brittle way of identifying "park and stride".

The javascript to calculate carbon for a journey was taken from the old app, which identified if a transport type was to be treated as "park and stride" by checking if the given transport type had the image "🚶🚘". This image is editable in the transport types admin interface, so would break park and stride functionality if it were to be changed (and also it's not a great way of doing this!).

This change adds a park_and_stride flag to the transport_types table and support for it in the admin interface and javascript frontend.
There's also an after_party task that sets the flag to true for transport types with the name "Park and Stride" or image "🚶🚘" (I expect this only to change the original park and stride transport type).