### PR TITLE
Transport surveys - allow up to 6 passengers per journey (rather than 4)

### DIFF
--- a/app/models/transport_survey_response.rb
+++ b/app/models/transport_survey_response.rb
@@ -45,7 +45,7 @@ class TransportSurveyResponse < ApplicationRecord
   end
 
   def self.passengers_options
-    [1, 2, 3, 4]
+    [1, 2, 3, 4, 5, 6]
   end
 
   def weather_symbol


### PR DESCRIPTION
Smallest pull request ever...

Provide the option to select up to 6 passengers per journey rather than 4.