### PR TITLE
Transport surveys UI - present an error if localStorage is not available

### DIFF
--- a/app/javascript/packs/transport_surveys.js
+++ b/app/javascript/packs/transport_surveys.js
@@ -34,7 +34,7 @@ $(document).ready(function() {
     $('.responses-remove').on('click', deleteResponses);
 
   } else {
-    setPageError("localStorage needs to be available in your browser to use this app. Either upgrade your browser, or enable localStorage.");
+    setPageError("Your browser does not support a feature required by our survey tool. Either upgrade your browser, use an alternative or enable 'localStorage'.");
     disableAppButton();
   }
 

--- a/app/javascript/packs/transport_surveys.js
+++ b/app/javascript/packs/transport_surveys.js
@@ -14,26 +14,29 @@ $(document).ready(function() {
     passenger_symbol: $("#passenger_symbol").val()
   }
 
-  storage.init({key: config.storage_key, base_url: config.base_url});
+  if (storage.init({key: config.storage_key, base_url: config.base_url})) {
+    setupSurvey();
 
-  setupSurvey();
+    /* onclick bindings */
+    $('.start').on('click', start);
+    $('.next').on('click', next);
+    $('.sharing').on('click', sharing);
+    $('.previous').on('click', previous);
+    $('.confirm').on('click', confirm);
+    $('.store').on('click', store);
+    $('.next-pupil').on('click', nextSurveyRun);
+    $('#reset').on('click', fullReset);
 
-  /* onclick bindings */
+    $('#save-results').on('click', function(e) { $('#transport_survey').submit(); });
+    $('#transport_survey').on('submit', function(e) { submit(e); });
 
-  $('.start').on('click', start);
-  $('.next').on('click', next);
-  $('.sharing').on('click', sharing);
-  $('.previous').on('click', previous);
-  $('.confirm').on('click', confirm);
-  $('.store').on('click', store);
-  $('.next-pupil').on('click', nextSurveyRun);
-  $('#reset').on('click', fullReset);
+    $('.responses-save').on('click', saveResponses);
+    $('.responses-remove').on('click', deleteResponses);
 
-  $('#save-results').on('click', function(e) { $('#transport_survey').submit(); });
-  $('#transport_survey').on('submit', function(e) { submit(e); });
-
-  $('.responses-save').on('click', saveResponses);
-  $('.responses-remove').on('click', deleteResponses);
+  } else {
+    setPageError("localStorage needs to be available in your browser to use this app. Either upgrade your browser, or enable localStorage.");
+    disableAppButton();
+  }
 
   /* onclick handlers */
 
@@ -118,6 +121,15 @@ $(document).ready(function() {
   }
 
   /* end of onclick handlers */
+
+  function setPageError(error) {
+    $('#page-error').text(error);
+    $('#page-error').show();
+  }
+
+  function disableAppButton() {
+    $('.jsonly').hide();
+  }
 
   function fullSurveyReset() {
     updateResponsesCounts();

--- a/app/javascript/packs/transport_surveys/storage.js
+++ b/app/javascript/packs/transport_surveys/storage.js
@@ -10,6 +10,15 @@ export const storage = ( function() {
   // private methods
   function init(cfg) {
     local = cfg;
+    return checkLocalStorage();
+  }
+
+  function checkLocalStorage() {
+    try {
+      return !!localStorage.getItem;
+    } catch(e) {
+      return false;
+    }
   }
 
   function getAllResponses() {

--- a/app/views/schools/transport_surveys/edit.html.erb
+++ b/app/views/schools/transport_surveys/edit.html.erb
@@ -8,6 +8,7 @@
 
 <%= render partial: 'no_javascript_warning' %>
 
+<div id="page-error" class="alert alert-danger hide" role="alert"></div>
 <div id="unsaved-responses"></div>
 
 <%= render 'intro' %>


### PR DESCRIPTION
Also hides the app button if localStorage is not present.

This has been manually tested in firefox where you can easily disable localStorage. 
(In Chrome, you can't turn off localStorage without turning off cookies)
