### PR TITLE
Transport surveys UI - change passenger labels

### DIFF
--- a/app/views/schools/transport_surveys/edit.html.erb
+++ b/app/views/schools/transport_surveys/edit.html.erb
@@ -78,7 +78,7 @@
               <div class="container">
                 <div class="row">
                   <% TransportSurveyResponse.passengers_options.each do |passengers| %>
-                    <%= render 'option', { label: "Just me" + ((passengers > 1) ? " + #{passengers - 1} more" : ""), content: TransportSurveyResponse.passenger_symbol * passengers, identifier: passengers, action: "confirm" } %>
+                    <%= render 'option', { label: ((passengers > 1) ? "Me + #{passengers - 1} more" : "Just me"), content: TransportSurveyResponse.passenger_symbol * passengers, identifier: passengers, action: "confirm" } %>
                   <% end %>
                 </div>
               </div>


### PR DESCRIPTION
Another small pull request - this time to update the passenger labels in the transport surveys app.

Change passenger label to "Me + 1 more" etc here, rather than "Just Me + 1 more."

The build is currently failing on a test that looks like is from elsewhere. 