### PR TITLE
Change storage model for benchmark data

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -119,7 +119,6 @@ group :development, :test do
   gem 'rubocop-performance', '1.8.0'
   gem 'rubocop-rspec'
   gem 'wisper-rspec', require: false
-  gem 'scout_apm'
 end
 
 group :development do
@@ -135,6 +134,9 @@ group :development do
   gem 'fasterer'
   gem 'bundler-audit'
   gem 'brakeman'
+  gem 'scout_apm'
+#  gem 'rack-mini-profiler'
+#  gem 'memory_profiler'
 end
 
 group :test do

--- a/Gemfile
+++ b/Gemfile
@@ -23,8 +23,8 @@ gem 'closed_struct'
 gem 'pg_search'
 
 # Dashboard analytics
-gem 'energy-sparks_analytics', git: 'https://github.com/Energy-Sparks/energy-sparks_analytics.git', tag: '1.50.3'
-#gem 'energy-sparks_analytics', git: 'https://github.com/Energy-Sparks/energy-sparks_analytics.git', branch: 'aws-eb-test'
+#gem 'energy-sparks_analytics', git: 'https://github.com/Energy-Sparks/energy-sparks_analytics.git', tag: '1.50.3'
+gem 'energy-sparks_analytics', git: 'https://github.com/Energy-Sparks/energy-sparks_analytics.git', branch: 'support-formatting-dates-from-strings'
 #gem 'energy-sparks_analytics', path: '../energy-sparks_analytics'
 
 # Using master due to it having a patch which doesn't override Enumerable#sum if it's already defined

--- a/Gemfile
+++ b/Gemfile
@@ -23,8 +23,8 @@ gem 'closed_struct'
 gem 'pg_search'
 
 # Dashboard analytics
-#gem 'energy-sparks_analytics', git: 'https://github.com/Energy-Sparks/energy-sparks_analytics.git', tag: '1.50.3'
-gem 'energy-sparks_analytics', git: 'https://github.com/Energy-Sparks/energy-sparks_analytics.git', branch: 'support-formatting-dates-from-strings'
+gem 'energy-sparks_analytics', git: 'https://github.com/Energy-Sparks/energy-sparks_analytics.git', tag: '1.50.4'
+#gem 'energy-sparks_analytics', git: 'https://github.com/Energy-Sparks/energy-sparks_analytics.git', branch: 'support-formatting-dates-from-strings'
 #gem 'energy-sparks_analytics', path: '../energy-sparks_analytics'
 
 # Using master due to it having a patch which doesn't override Enumerable#sum if it's already defined

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/Energy-Sparks/energy-sparks_analytics.git
-  revision: 495dc54f5e6c8daaa85dbd014e6550f135e61240
-  branch: support-formatting-dates-from-strings
+  revision: e39bd509b71c09cafc302e24d155f7d693cb3f3a
+  tag: 1.50.4
   specs:
     energy-sparks_analytics (1.2.1)
       activesupport (~> 6.0.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/Energy-Sparks/energy-sparks_analytics.git
-  revision: 2532190529f0d1a890d0bd3ed4054535d2216bf7
-  tag: 1.50.3
+  revision: 495dc54f5e6c8daaa85dbd014e6550f135e61240
+  branch: support-formatting-dates-from-strings
   specs:
     energy-sparks_analytics (1.2.1)
       activesupport (~> 6.0.0)

--- a/app/models/benchmark_result.rb
+++ b/app/models/benchmark_result.rb
@@ -8,6 +8,7 @@
 #  created_at                                :datetime         not null
 #  data                                      :text
 #  id                                        :bigint(8)        not null, primary key
+#  results                                   :json
 #  updated_at                                :datetime         not null
 #
 # Indexes

--- a/app/models/calendar_event.rb
+++ b/app/models/calendar_event.rb
@@ -3,12 +3,15 @@
 # Table name: calendar_events
 #
 #  academic_year_id       :bigint(8)        not null
+#  based_on_id            :bigint(8)
 #  calendar_event_type_id :bigint(8)        not null
 #  calendar_id            :bigint(8)        not null
+#  created_at             :datetime         not null
 #  description            :text
 #  end_date               :date             not null
 #  id                     :bigint(8)        not null, primary key
 #  start_date             :date             not null
+#  updated_at             :datetime         not null
 #
 # Indexes
 #

--- a/app/models/transport_survey.rb
+++ b/app/models/transport_survey.rb
@@ -10,8 +10,8 @@
 #
 # Indexes
 #
-#  index_transport_surveys_on_run_on     (run_on) UNIQUE
-#  index_transport_surveys_on_school_id  (school_id)
+#  index_transport_surveys_on_school_id             (school_id)
+#  index_transport_surveys_on_school_id_and_run_on  (school_id,run_on) UNIQUE
 #
 # Foreign Keys
 #

--- a/app/models/transport_type.rb
+++ b/app/models/transport_type.rb
@@ -9,6 +9,7 @@
 #  kg_co2e_per_km    :decimal(, )      default(0.0), not null
 #  name              :string           not null
 #  note              :string
+#  park_and_stride   :boolean          default(FALSE), not null
 #  speed_km_per_hour :decimal(, )      default(0.0), not null
 #  updated_at        :datetime         not null
 #

--- a/app/services/alerts/collate_benchmark_data.rb
+++ b/app/services/alerts/collate_benchmark_data.rb
@@ -15,11 +15,15 @@ module Alerts
 
     private
 
+    def result_column
+      EnergySparks::FeatureFlags.active?(:json_benchmarks) ? :results : :data
+    end
+
     def get_benchmarks_for_latest_run(latest_school_runs, benchmarks)
       latest_school_runs.each do |benchmark_result_school_generation_run|
         school_id = benchmark_result_school_generation_run.school_id
 
-        benchmark_result_school_generation_run.benchmark_results.pluck(:asof, :data).each do |benchmark_result|
+        benchmark_result_school_generation_run.benchmark_results.pluck(:asof, result_column).each do |benchmark_result|
           unless benchmarks.key?(benchmark_result[0])
             benchmarks[benchmark_result[0]] = { school_id => {} }
           end

--- a/app/services/alerts/generate_and_save_benchmarks.rb
+++ b/app/services/alerts/generate_and_save_benchmarks.rb
@@ -48,7 +48,7 @@ module Alerts
     def process_alert_report(alert_type, alert_report, asof_date)
       if alert_report.valid
         if alert_report.benchmark_data.present?
-          BenchmarkResult.create!(benchmark_result_school_generation_run: @benchmark_result_school_generation_run, asof: asof_date, alert_type: alert_type, data: alert_report.benchmark_data)
+          BenchmarkResult.create!(benchmark_result_school_generation_run: @benchmark_result_school_generation_run, asof: asof_date, alert_type: alert_type, data: alert_report.benchmark_data, results: alert_report.benchmark_data)
         end
       else
         BenchmarkResultError.create!(benchmark_result_school_generation_run: @benchmark_result_school_generation_run, asof_date: asof_date, information: "Relevance: #{alert_report.relevance}", alert_type: alert_type)

--- a/db/migrate/20220517085403_add_json_column_to_benchmark_result.rb
+++ b/db/migrate/20220517085403_add_json_column_to_benchmark_result.rb
@@ -1,0 +1,5 @@
+class AddJsonColumnToBenchmarkResult < ActiveRecord::Migration[6.0]
+  def change
+    add_column :benchmark_results, :results, :json, default: {}
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_05_13_160539) do
+ActiveRecord::Schema.define(version: 2022_05_17_085403) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
@@ -513,6 +513,7 @@ ActiveRecord::Schema.define(version: 2022_05_13_160539) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.bigint "benchmark_result_school_generation_run_id", null: false
+    t.json "results", default: {}
     t.index ["alert_type_id"], name: "index_benchmark_results_on_alert_type_id"
     t.index ["benchmark_result_school_generation_run_id"], name: "ben_rgr_index"
   end

--- a/lib/tasks/deployment/20220517150229_migrate_benchmark_result_data.rake
+++ b/lib/tasks/deployment/20220517150229_migrate_benchmark_result_data.rake
@@ -1,0 +1,16 @@
+namespace :after_party do
+  desc 'Deployment task: Migrate benchmark results to JSON'
+  task migrate_benchmark_result_data: :environment do
+    puts "Running deploy task 'migrate_benchmark_result_data'"
+
+    BenchmarkResultGenerationRun.latest.benchmark_results.each do |br|
+      br.results = br.data
+      br.save!
+    end
+
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord
+      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+  end
+end

--- a/spec/services/alerts/collate_benchmark_data_spec.rb
+++ b/spec/services/alerts/collate_benchmark_data_spec.rb
@@ -15,36 +15,29 @@ module Alerts
     let(:alert_type_1)        { create(:alert_type, benchmark: true, source: :analytics) }
     let(:alert_type_2)        { create(:alert_type, benchmark: true, source: :analytics) }
 
-    let(:benchmark_result_1)  { BenchmarkResult.create!(alert_type: alert_type_1, asof: date_1, benchmark_result_school_generation_run: school_run_1, data: {
-      "number_example"=>1.0, "string_example"=>"A", "time_of_day"=> TimeOfDay.new(0,10)
-    } )}
-    let(:benchmark_result_2)  { BenchmarkResult.create!(alert_type: alert_type_1, asof: date_2, benchmark_result_school_generation_run: school_run_1, data: {
-      "number_example"=>2.0, "string_example"=>"B", "time_of_day"=> TimeOfDay.new(0,20)
-    } )}
-    let(:benchmark_result_3)  { BenchmarkResult.create!(alert_type: alert_type_2, asof: date_1, benchmark_result_school_generation_run: school_run_1, data: {
-       "number_example_2"=>3.0, "string_example_2"=>"C", "time_of_day_2"=> TimeOfDay.new(1,30)
-    } )}
-    let(:benchmark_result_4)  { BenchmarkResult.create!(alert_type: alert_type_2, asof: date_2, benchmark_result_school_generation_run: school_run_1, data: {
-       "number_example_2"=>4.0, "string_example_2"=>"D", "time_of_day_2"=> TimeOfDay.new(1,40)
-    } )}
+    let(:variables_1)         { {"number_example"=>1.0, "string_example"=>"A", "time_of_day"=> TimeOfDay.new(0,10)} }
+    let(:variables_2)         { {"number_example"=>2.0, "string_example"=>"B", "time_of_day"=> TimeOfDay.new(0,20)} }
+    let(:variables_3)         { {"number_example_2"=>3.0, "string_example_2"=>"C", "time_of_day_2"=> TimeOfDay.new(1,30)} }
+    let(:variables_4)         { {"number_example_2"=>4.0, "string_example_2"=>"D", "time_of_day_2"=> TimeOfDay.new(1,40)} }
+    let(:variables_5)         { {"number_example"=>5.0, "string_example"=>"E", "time_of_day"=> TimeOfDay.new(0,15)} }
+    let(:variables_6)         { {"number_example"=>6.0, "string_example"=>"F", "time_of_day"=> TimeOfDay.new(0,30)} }
+    let(:variables_7)         { {"number_example_2"=>7.0, "string_example_2"=>"G", "time_of_day_2"=> TimeOfDay.new(1,35)} }
+    let(:variables_8)         { {"number_example_2"=>8.0, "string_example_2"=>"H", "time_of_day_2"=> TimeOfDay.new(1,45)} }
+    let(:variables_9)         { {"number_example_2"=>9.0, "string_example_2"=>"H", "time_of_day_2"=> TimeOfDay.new(1,45)} }
 
-    let(:benchmark_result_5)  { BenchmarkResult.create!(alert_type: alert_type_1, asof: date_1, benchmark_result_school_generation_run: school_run_2, data: {
-      "number_example"=>5.0, "string_example"=>"E", "time_of_day"=> TimeOfDay.new(0,15)
-    } )}
-    let(:benchmark_result_6)  { BenchmarkResult.create!(alert_type: alert_type_1, asof: date_2, benchmark_result_school_generation_run: school_run_2, data: {
-      "number_example"=>6.0, "string_example"=>"F", "time_of_day"=> TimeOfDay.new(0,30)
-    } )}
-    let(:benchmark_result_7)  { BenchmarkResult.create!(alert_type: alert_type_2, asof: date_1, benchmark_result_school_generation_run: school_run_2, data: {
-       "number_example_2"=>7.0, "string_example_2"=>"G", "time_of_day_2"=> TimeOfDay.new(1,35)
-    } )}
-    let(:benchmark_result_8)  { BenchmarkResult.create!(alert_type: alert_type_2, asof: date_2, benchmark_result_school_generation_run: school_run_2, data: {
-       "number_example_2"=>8.0, "string_example_2"=>"H", "time_of_day_2"=> TimeOfDay.new(1,45)
-    } )}
+    let(:benchmark_result_1)  { BenchmarkResult.create!(alert_type: alert_type_1, asof: date_1, benchmark_result_school_generation_run: school_run_1, data: variables_1, results: variables_1 )}
+
+    let(:benchmark_result_2)  { BenchmarkResult.create!(alert_type: alert_type_1, asof: date_2, benchmark_result_school_generation_run: school_run_1, data: variables_2, results: variables_2 )}
+    let(:benchmark_result_3)  { BenchmarkResult.create!(alert_type: alert_type_2, asof: date_1, benchmark_result_school_generation_run: school_run_1, data: variables_3, results: variables_3 )}
+    let(:benchmark_result_4)  { BenchmarkResult.create!(alert_type: alert_type_2, asof: date_2, benchmark_result_school_generation_run: school_run_1, data: variables_4, results: variables_4)}
+
+    let(:benchmark_result_5)  { BenchmarkResult.create!(alert_type: alert_type_1, asof: date_1, benchmark_result_school_generation_run: school_run_2, data: variables_5, results: variables_5 )}
+    let(:benchmark_result_6)  { BenchmarkResult.create!(alert_type: alert_type_1, asof: date_2, benchmark_result_school_generation_run: school_run_2, data: variables_6, results: variables_6 )}
+    let(:benchmark_result_7)  { BenchmarkResult.create!(alert_type: alert_type_2, asof: date_1, benchmark_result_school_generation_run: school_run_2, data: variables_7, results: variables_7 )}
+    let(:benchmark_result_8)  { BenchmarkResult.create!(alert_type: alert_type_2, asof: date_2, benchmark_result_school_generation_run: school_run_2, data: variables_8, results: variables_8 )}
 
     # this older run for school_2 should be overridden in the results by the later one
-    let!(:benchmark_result_9)  { BenchmarkResult.create!(alert_type: alert_type_2, asof: date_2, benchmark_result_school_generation_run: school_run_2_old, data: {
-      "number_example_2"=>9.0, "string_example_2"=>"H", "time_of_day_2"=> TimeOfDay.new(1,45)
-    } )}
+    let!(:benchmark_result_9)  { BenchmarkResult.create!(alert_type: alert_type_2, asof: date_2, benchmark_result_school_generation_run: school_run_2_old, data: variables_9, results: variables_9 )}
 
     let!(:example_output) {
       {
@@ -66,12 +59,25 @@ module Alerts
       }
     }
 
+    let!(:example_output_school_1_as_json) {
+      {
+        date_1 => { school_1.id => benchmark_result_1.results.merge(benchmark_result_3.results) },
+        date_2 => { school_1.id => benchmark_result_2.results.merge(benchmark_result_4.results) }
+      }
+    }
+
     it 'does the stuff' do
       expect(CollateBenchmarkData.new(run).perform).to eq example_output
     end
 
     it 'collates filtering by school' do
       expect(CollateBenchmarkData.new(run).perform([school_1])).to eq example_output_school_1
+    end
+
+    it 'uses json column when feature active' do
+      ClimateControl.modify FEATURE_FLAG_JSON_BENCHMARKS: 'true' do
+        expect(CollateBenchmarkData.new(run).perform([school_1])).to eq example_output_school_1_as_json
+      end
     end
   end
 end

--- a/spec/services/alerts/generate_and_save_benchmarks_spec.rb
+++ b/spec/services/alerts/generate_and_save_benchmarks_spec.rb
@@ -73,6 +73,14 @@ module Alerts
         expect(BenchmarkResultSchoolGenerationRun.first.benchmark_result_count).to be 2
       end
 
+      it 'store json results' do
+        allow_any_instance_of(GenerateAlertTypeRunResult).to receive(:perform).and_return(alert_type_run_result)
+        service = GenerateAndSaveBenchmarks.new(school: school, aggregate_school: aggregate_school, benchmark_result_generation_run: benchmark_result_generation_run)
+        service.perform
+        expect(BenchmarkResult.last.data).to_not eq({})
+        expect(BenchmarkResult.last.results).to_not eq({})
+      end
+
       it 'handles just errors' do
         allow_any_instance_of(GenerateAlertTypeRunResult).to receive(:perform).and_return(alert_type_run_result_just_errors)
 


### PR DESCRIPTION
* Add new JSON column for storing benchmark data, rather than YAML
* AfterParty task to convert benchmark results in latest run to JSON and store
* Store both JSON and YAML versions of benchmarks (for now, until we have completed switching over)
* Change how benchmark result data is loaded to use alternative column based on feature flag (`FEATURE_FLAG_JSON_BENCHMARKS`)

Relies on some code changes in analytics to handle round-tripping of Date/TimeOfData objects that are convered to strings when the benchmarks are stored as JSON