### PR TITLE
Transport Survey Alerts

### DIFF
--- a/app/assets/javascripts/templates/transport_surveys.hbs
+++ b/app/assets/javascripts/templates/transport_surveys.hbs
@@ -1,7 +1,7 @@
 {{#each responses}}
 <div class="alert alert-warning alert-dismissible fade show clearfix" role="alert">
   <span>There are <strong>{{this.length}}</strong> unsaved survey response(s) from <strong>{{@key}}</strong>. Do you want to save or delete them?</span>
-  <button data-date="{{@key}}" type="button" class="responses-save btn btn-primary float-right ml-2" data-dismiss="alert" aria-label="Close">Save</button>
+  <button data-date="{{@key}}" type="button" class="responses-save btn btn-primary float-right ml-2">Save</button>
   <button data-date="{{@key}}" type="button" class="responses-remove btn btn-primary float-right">Delete</button>
 </div>
 {{/each}}

--- a/app/assets/javascripts/templates/transport_surveys.hbs
+++ b/app/assets/javascripts/templates/transport_surveys.hbs
@@ -1,7 +1,7 @@
 {{#each responses}}
-<div class="alert alert-warning alert-dismissible fade show clearfix" role="alert">
-  <span>There are <strong>{{this.length}}</strong> unsaved survey response(s) from <strong>{{@key}}</strong>. Do you want to save or delete them?</span>
-  <button data-date="{{@key}}" type="button" class="responses-save btn btn-primary float-right ml-2">Save</button>
-  <button data-date="{{@key}}" type="button" class="responses-remove btn btn-primary float-right">Delete</button>
+<div class="alert alert-warning alert-dismissible fade show clearfix px-3" role="alert">
+  <span>There are <strong>{{this.length}}</strong> unsaved survey response(s) from <strong>{{@key}}</strong>. Do you want to save or remove them?</span>
+  <button data-date="{{@key}}" type="button" class="responses-remove btn-no-border btn-sm btn-light rounded-pill float-right ml-2">Remove</button>
+  <button data-date="{{@key}}" type="button" class="responses-save btn-no-border btn-sm btn-dark rounded-pill float-right">Save</button>
 </div>
 {{/each}}

--- a/app/assets/stylesheets/links.scss
+++ b/app/assets/stylesheets/links.scss
@@ -65,6 +65,10 @@ a.badge.outline {
   background-image: none;
 }
 
+.btn-no-border {
+  border: $btn-border-width solid transparent;
+}
+
 .btn-group {
   .btn {
     margin-left: 5px;

--- a/app/javascript/packs/transport_surveys.js
+++ b/app/javascript/packs/transport_surveys.js
@@ -80,12 +80,17 @@ $(document).ready(function() {
     storage.syncResponses(config.run_on, notifier, 'app', true);
   }
 
-  function notifier(where, level, message) {
+  function notifier(where, level, message, fade = true) {
     // where = page or app
     // level = boostrap alert level
     let identifier = '#' + where + '-notifier';
     let classes = 'alert alert-' + level;
-    $(identifier).removeClass().addClass(classes).text(message).fadeTo(5000, 500).slideUp(1000);
+    $(identifier).removeClass().addClass(classes).text(message);
+    if(fade) {
+      $(identifier).fadeTo(5000, 500).slideUp(1000);
+    } else {
+      $(identifier).show();
+    }
   }
 
   function hideAlert(current) {
@@ -127,14 +132,9 @@ $(document).ready(function() {
 
   /* end of onclick handlers */
 
-  function fatalError(error) {
-    setPageError(error);
+  function fatalError(message) {
+    notifier('page', 'danger', message, false)
     hideAppButton();
-  }
-
-  function setPageError(error) {
-    $('#page-error').text(error);
-    $('#page-error').show();
   }
 
   function hideAppButton() {

--- a/app/javascript/packs/transport_surveys.js
+++ b/app/javascript/packs/transport_surveys.js
@@ -77,30 +77,9 @@ $(document).ready(function() {
 
   function submit(event) {
     event.preventDefault(); // disable form submitting
-    storage.syncResponses(config.run_on, appNotifier, true).done( function() {
+    storage.syncResponses(config.run_on, appNotifier).done( function() {
       window.location.href = config.base_url + "/" + config.run_on;
     });
-  }
-
-  function pageNotifier(level, message, fade = true) {
-    notifier('page', level, message, fade);
-  }
-
-  function appNotifier(level, message, fade = true) {
-    notifier('app', level, message, fade);
-  }
-
-  function notifier(where, level, message, fade = true) {
-    // where = page or app
-    // level = boostrap alert level
-    let alert = $('#' + where + '-notifier');
-    let classes = 'alert alert-' + level;
-    alert.removeClass().addClass(classes).text(message);
-    if(fade) {
-      alert.fadeTo(5000, 500).slideUp(1000);
-    } else {
-      alert.show();
-    }
   }
 
   // Save responses for a specific date to server
@@ -123,8 +102,8 @@ $(document).ready(function() {
     let date = $(this).attr('data-date');
     if (window.confirm('Are you sure you want to remove ' + storage.getResponsesCount(date) + ' unsaved result(s) from ' + date + '?')) {
       storage.removeResponses(date);
-      alert.hide();
       pageNotifier('success', 'Unsaved responses removed!');
+      alert.hide();
       if (date == config.run_on) fullSurveyReset();
     }
   }
@@ -138,6 +117,27 @@ $(document).ready(function() {
   }
 
   /* end of onclick handlers */
+
+  function pageNotifier(level, message, fade = true) {
+    notifier('page', level, message, fade);
+  }
+
+  function appNotifier(level, message, fade = true) {
+    notifier('app', level, message, fade);
+  }
+
+  function notifier(where, level, message, fade = true) {
+    // where = page or app
+    // level = boostrap alert level
+    let alert = $('#' + where + '-notifier');
+    let classes = 'alert alert-' + level;
+    alert.removeClass().addClass(classes).text(message);
+    if(fade) {
+      alert.fadeTo(5000, 500).slideUp(1000);
+    } else {
+      alert.show();
+    }
+  }
 
   function fatalError(message) {
     pageNotifier('danger', message, false)

--- a/app/javascript/packs/transport_surveys.js
+++ b/app/javascript/packs/transport_surveys.js
@@ -1,7 +1,8 @@
 "use strict"
 
 import { storage } from './transport_surveys/storage';
-import { carbonCalc, carbonExamples, funWeight } from './transport_surveys/carbon'
+import { carbonCalc, carbonExamples, funWeight } from './transport_surveys/carbon';
+import { notifier } from './transport_surveys/notifier';
 
 $(document).ready(function() {
 
@@ -74,7 +75,7 @@ $(document).ready(function() {
   }
 
   function finishAndSave() {
-    storage.syncResponses(config.run_on, appNotifier).done( function() {
+    storage.syncResponses(config.run_on, notifier.app).done( function() {
       window.location.href = config.base_url + "/" + config.run_on;
     });
   }
@@ -85,7 +86,7 @@ $(document).ready(function() {
     let alert = button.closest('.alert');
     let date = button.attr('data-date');
     if (window.confirm('Are you sure you want to save ' + storage.getResponsesCount(date) + ' unsaved result(s) from ' + date + '?')) {
-      storage.syncResponses(date, pageNotifier).done( function() {
+      storage.syncResponses(date, notifier.page).done( function() {
         alert.hide();
         if (date == config.run_on) fullSurveyReset();
       });
@@ -99,7 +100,7 @@ $(document).ready(function() {
     let date = $(this).attr('data-date');
     if (window.confirm('Are you sure you want to remove ' + storage.getResponsesCount(date) + ' unsaved result(s) from ' + date + '?')) {
       storage.removeResponses(date);
-      pageNotifier('success', 'Unsaved responses removed!');
+      notifier.page('success', 'Unsaved responses removed!');
       alert.hide();
       if (date == config.run_on) fullSurveyReset();
     }
@@ -115,29 +116,8 @@ $(document).ready(function() {
 
   /* end of onclick handlers */
 
-  function pageNotifier(level, message, fade = true) {
-    notifier('page', level, message, fade);
-  }
-
-  function appNotifier(level, message, fade = true) {
-    notifier('app', level, message, fade);
-  }
-
-  function notifier(where, level, message, fade = true) {
-    // where = page or app
-    // level = boostrap alert level
-    let alert = $('#' + where + '-notifier');
-    let classes = 'alert alert-' + level;
-    alert.removeClass().addClass(classes).text(message);
-    if(fade) {
-      alert.fadeTo(5000, 500).slideUp(1000);
-    } else {
-      alert.show();
-    }
-  }
-
   function fatalError(message) {
-    pageNotifier('danger', message, false)
+    notifier.page('danger', message, false)
     hideAppButton();
   }
 

--- a/app/javascript/packs/transport_surveys.js
+++ b/app/javascript/packs/transport_surveys.js
@@ -77,7 +77,7 @@ $(document).ready(function() {
     storage.syncResponses(config.run_on, notifier.app).done( function() {
       let button = $("[data-date='" + config.run_on + "']");
       button.closest('.alert').hide();
-      fullSurveyReset();
+      setResponsesCount(0);
       window.location.href = config.base_url + "/" + config.run_on;
     });
   }

--- a/app/javascript/packs/transport_surveys.js
+++ b/app/javascript/packs/transport_surveys.js
@@ -26,9 +26,7 @@ $(document).ready(function() {
     $('.store').on('click', store);
     $('.next-pupil').on('click', nextSurveyRun);
     $('#reset').on('click', fullReset);
-
-    $('#save-results').on('click', function(e) { $('#transport_survey').submit(); });
-    $('#transport_survey').on('submit', function(e) { submit(e); });
+    $('#save-results').on('click', finishAndSave);
 
   } else {
     fatalError("Your browser does not support a feature required by our survey tool. Either upgrade your browser, use an alternative or enable 'localStorage'.");
@@ -75,8 +73,7 @@ $(document).ready(function() {
     setProgressBar(window.step = 1);
   }
 
-  function submit(event) {
-    event.preventDefault(); // disable form submitting
+  function finishAndSave() {
     storage.syncResponses(config.run_on, appNotifier).done( function() {
       window.location.href = config.base_url + "/" + config.run_on;
     });

--- a/app/javascript/packs/transport_surveys.js
+++ b/app/javascript/packs/transport_surveys.js
@@ -76,6 +76,9 @@ $(document).ready(function() {
 
   function finishAndSave() {
     storage.syncResponses(config.run_on, notifier.app).done( function() {
+      let button = $("[data-date='" + config.run_on + "']");
+      button.closest('.alert').hide();
+      fullSurveyReset();
       window.location.href = config.base_url + "/" + config.run_on;
     });
   }

--- a/app/javascript/packs/transport_surveys.js
+++ b/app/javascript/packs/transport_surveys.js
@@ -26,7 +26,6 @@ $(document).ready(function() {
     $('.confirm').on('click', confirm);
     $('.store').on('click', store);
     $('.next-pupil').on('click', nextSurveyRun);
-    $('#reset').on('click', fullReset);
     $('#save-results').on('click', finishAndSave);
 
   } else {
@@ -104,14 +103,6 @@ $(document).ready(function() {
       notifier.page('success', 'Unsaved responses removed!');
       button.closest('.alert').hide();
       if (date == config.run_on) fullSurveyReset();
-    }
-  }
-
-  // Remove survey data for current date and reset survey form
-  function fullReset() {
-    if (window.confirm('Are you sure you want to reset and remove ' + storage.getResponsesCount(config.run_on) + ' unsaved result(s) from ' + config.run_on + '?')) {
-      storage.removeResponses(config.run_on);
-      fullSurveyReset();
     }
   }
 

--- a/app/javascript/packs/transport_surveys.js
+++ b/app/javascript/packs/transport_surveys.js
@@ -83,13 +83,13 @@ $(document).ready(function() {
   function notifier(where, level, message, fade = true) {
     // where = page or app
     // level = boostrap alert level
-    let identifier = '#' + where + '-notifier';
+    let alert = $('#' + where + '-notifier');
     let classes = 'alert alert-' + level;
-    $(identifier).removeClass().addClass(classes).text(message);
+    alert.removeClass().addClass(classes).text(message);
     if(fade) {
-      $(identifier).fadeTo(5000, 500).slideUp(1000);
+      alert.fadeTo(5000, 500).slideUp(1000);
     } else {
-      $(identifier).show();
+      alert.show();
     }
   }
 
@@ -104,7 +104,7 @@ $(document).ready(function() {
       storage.syncResponses(date, notifier, 'page', false);
       hideAlert(this);
       if (date == config.run_on) {
-        setResponsesCount(0);
+        fullSurveyReset();
       }
     }
   }
@@ -142,7 +142,7 @@ $(document).ready(function() {
   }
 
   function fullSurveyReset() {
-    updateResponsesCounts();
+    setResponsesCount(0);
     resetSetupFields();
     resetSetupCards();
     nextSurveyRun();

--- a/app/javascript/packs/transport_surveys.js
+++ b/app/javascript/packs/transport_surveys.js
@@ -83,11 +83,10 @@ $(document).ready(function() {
   // Save responses for a specific date to server
   function saveResponses() {
     let button = $(this);
-    let alert = button.closest('.alert');
     let date = button.attr('data-date');
     if (window.confirm('Are you sure you want to save ' + storage.getResponsesCount(date) + ' unsaved result(s) from ' + date + '?')) {
       storage.syncResponses(date, notifier.page).done( function() {
-        alert.hide();
+        button.closest('.alert').hide();
         if (date == config.run_on) fullSurveyReset();
       });
     }
@@ -96,12 +95,11 @@ $(document).ready(function() {
   // Remove survey data from localstorage for given date
   function deleteResponses() {
     let button = $(this);
-    let alert = button.closest('.alert');
-    let date = $(this).attr('data-date');
+    let date = button.attr('data-date');
     if (window.confirm('Are you sure you want to remove ' + storage.getResponsesCount(date) + ' unsaved result(s) from ' + date + '?')) {
       storage.removeResponses(date);
       notifier.page('success', 'Unsaved responses removed!');
-      alert.hide();
+      button.closest('.alert').hide();
       if (date == config.run_on) fullSurveyReset();
     }
   }

--- a/app/javascript/packs/transport_surveys/notifier.js
+++ b/app/javascript/packs/transport_surveys/notifier.js
@@ -1,0 +1,32 @@
+"use strict"
+
+export const notifier = ( function() {
+
+  function page(level, message, fade = true) {
+    notify('page', level, message, fade);
+  }
+
+  function app(level, message, fade = true) {
+    notify('app', level, message, fade);
+  }
+
+  function notify(where, level, message, fade = true) {
+    // where = page or app
+    // level = boostrap alert level
+    let alert = $('#' + where + '-notifier');
+    let classes = 'alert alert-' + level;
+    alert.removeClass().addClass(classes).text(message);
+    if(fade) {
+      alert.fadeTo(5000, 500).slideUp(1000);
+    } else {
+      alert.show();
+    }
+  }
+
+  // public methods
+  return {
+    app: app,
+    page: page
+  }
+
+}());

--- a/app/javascript/packs/transport_surveys/storage.js
+++ b/app/javascript/packs/transport_surveys/storage.js
@@ -68,7 +68,7 @@ export const storage = ( function() {
         notifier('danger', 'Error saving responses - please make sure you have a wifi connection before saving!');
       });
     } else {
-      return { done: function(done) { done(); notifier('warning', 'Nothing to save - please collect some survey responses first!'); } }
+      return { done: function() { notifier('warning', 'Nothing to save - please collect some survey responses first!'); } };
     }
   }
 

--- a/app/javascript/packs/transport_surveys/storage.js
+++ b/app/javascript/packs/transport_surveys/storage.js
@@ -45,7 +45,7 @@ export const storage = ( function() {
     localStorage.setItem(local.key, JSON.stringify( responses ));
   }
 
-  function syncResponses(date, redirect = true) {
+  function syncResponses(date, notifier, location, redirect = false) {
     let responses = getResponses(date);
     if (responses.length > 0) {
       let url = local.base_url + "/" + date;
@@ -57,15 +57,15 @@ export const storage = ( function() {
         contentType: "application/json; charset=utf-8",
         dataType: "text" })
       .done(function(data) {
-        alert("Responses saved!");
         removeResponses(date);
-        if (redirect) {
+        notifier(location, 'success', 'Responses saved!');
+        if (redirect == true) {
           window.location.href = url;
         }
       })
-      .fail(function() { alert("Error saving responses - please make sure you have a wifi connection before saving! "); });
+      .fail(function() { notifier(location, 'danger', 'Error saving responses - please make sure you have a wifi connection before saving! '); });
     } else {
-      alert("Nothing to save - please collect some survey responses first!");
+      notifier(location, 'warning', 'Nothing to save - please collect some survey responses first!');
     }
   }
 

--- a/app/javascript/packs/transport_surveys/storage.js
+++ b/app/javascript/packs/transport_surveys/storage.js
@@ -45,27 +45,30 @@ export const storage = ( function() {
     localStorage.setItem(local.key, JSON.stringify( responses ));
   }
 
-  function syncResponses(date, notifier, location, redirect = false) {
+  function ajaxCall(url, data) {
+    return $.ajax({
+      url: url,
+      type: 'PUT',
+      data: JSON.stringify(data),
+      contentType: "application/json; charset=utf-8",
+      dataType: "text" });
+  }
+
+  function syncResponses(date, notifier) {
     let responses = getResponses(date);
     if (responses.length > 0) {
       let url = local.base_url + "/" + date;
       let data = { transport_survey: { run_on: date, responses: responses }};
-      $.ajax({
-        url: url,
-        type: 'PUT',
-        data: JSON.stringify(data),
-        contentType: "application/json; charset=utf-8",
-        dataType: "text" })
-      .done(function(data) {
+      return ajaxCall(url, data)
+      .done(function() {
         removeResponses(date);
-        notifier(location, 'success', 'Responses saved!');
-        if (redirect == true) {
-          window.location.href = url;
-        }
+        notifier('success', 'Responses saved!');
       })
-      .fail(function() { notifier(location, 'danger', 'Error saving responses - please make sure you have a wifi connection before saving! '); });
+      .fail(function() {
+        notifier('danger', 'Error saving responses - please make sure you have a wifi connection before saving!');
+      });
     } else {
-      notifier(location, 'warning', 'Nothing to save - please collect some survey responses first!');
+      return { done: function(done) { done(); notifier('warning', 'Nothing to save - please collect some survey responses first!'); } }
     }
   }
 

--- a/app/views/schools/transport_surveys/edit.html.erb
+++ b/app/views/schools/transport_surveys/edit.html.erb
@@ -112,9 +112,6 @@
         <% end %>
       </div>
       <div class="modal-footer">
-        <%= button_tag(class: 'btn btn-primary', id: 'reset') do %>
-          Reset & clear results</span>
-        <% end %>
         <%= button_tag(type: 'submit', class: 'submit btn btn-primary', id: 'save-results') do %>
           Finish & save results <span id="unsaved-responses-count" class="badge badge-primary"></span>
         <% end %>

--- a/app/views/schools/transport_surveys/edit.html.erb
+++ b/app/views/schools/transport_surveys/edit.html.erb
@@ -8,7 +8,6 @@
 
 <%= render partial: 'no_javascript_warning' %>
 
-<div id="page-error" class="alert alert-danger hide" role="alert"></div>
 <div id="page-notifier" role="alert"></div>
 
 <div id="unsaved-responses"></div>

--- a/app/views/schools/transport_surveys/edit.html.erb
+++ b/app/views/schools/transport_surveys/edit.html.erb
@@ -9,6 +9,8 @@
 <%= render partial: 'no_javascript_warning' %>
 
 <div id="page-error" class="alert alert-danger hide" role="alert"></div>
+<div id="page-notifier" role="alert"></div>
+
 <div id="unsaved-responses"></div>
 
 <%= render 'intro' %>
@@ -29,6 +31,8 @@
         </button>
       </div>
       <div class="modal-body">
+        <div id="app-notifier" role="alert"></div>
+
         <%= form_with(url: school_transport_surveys_url(@school), method: :patch, local: true, id: 'transport_survey') do |f| %>
           <%= hidden_field_tag :run_on, @transport_survey.run_on %>
           <%= hidden_field_tag :run_identifier, TransportSurveyResponse.generate_unique_secure_token %>

--- a/app/views/schools/transport_surveys/edit.html.erb
+++ b/app/views/schools/transport_surveys/edit.html.erb
@@ -7,9 +7,7 @@
 <h3>Surveying on <%= @transport_survey.run_on %></h3>
 
 <%= render partial: 'no_javascript_warning' %>
-
 <div id="page-notifier" role="alert"></div>
-
 <div id="unsaved-responses"></div>
 
 <%= render 'intro' %>

--- a/app/views/schools/transport_surveys/index.html.erb
+++ b/app/views/schools/transport_surveys/index.html.erb
@@ -1,5 +1,3 @@
-<p id="notice"><%= notice %></p>
-
 <h1>Travel to School Surveys</h1>
 
 <div class="table-responsive mt-2">

--- a/spec/system/schools/transport_surveys_spec.rb
+++ b/spec/system/schools/transport_surveys_spec.rb
@@ -93,12 +93,9 @@ describe 'TransportSurveys', type: :system do
 
                       context "Saving results" do
                         before(:each) do
-                          accept_alert do
-                            click_button("Finish & save results 1")
-                          end
+                          click_button("Finish & save results 1")
                         end
 
-                        # PAGE CONTENT WILL CHANGE SHORTLY
                         it { expect(page).to have_content("Responses for: #{Date.today}") }
                         it "displays added response" do
                           expect(page).to have_content(weather)

--- a/spec/system/schools/transport_surveys_spec.rb
+++ b/spec/system/schools/transport_surveys_spec.rb
@@ -95,7 +95,6 @@ describe 'TransportSurveys', type: :system do
                         before(:each) do
                           click_button("Finish & save results 1")
                         end
-
                         it { expect(page).to have_content("Responses for: #{Date.today}") }
                         it "displays added response" do
                           expect(page).to have_content(weather)
@@ -108,6 +107,12 @@ describe 'TransportSurveys', type: :system do
                   end
                 end
               end
+            end
+            context "when there is nothing to save" do
+              before(:each) do
+                click_button("Finish & save results 0")
+              end
+              it { expect(page).to have_content("Nothing to save - please collect some survey responses first!") }
             end
           end
         end


### PR DESCRIPTION
- Rather than using js alerts, use bootstrap ones. Unless alerts are fatal / blocking, they fade after a period. See what you think, the alternative would be to allow them to be dismissed rather than fading.
- Spruce up the 'remove and save unsaved responses' styling and functionality on the main page. Have re-styled the buttons - couldn't find any working button css that did primary / secondary styling, so I improvised with a tiny bit of custom css and along with other standard bootstrap styles.
- Also remove the "reset and clear" functionality from the app (https://trello.com/c/zr26HkFa/2181-transport-survey-ui-remove-ability-to-reset-and-clear-results) as it relied on changes in this PR.