### PR TITLE
Add category to transport type

### DIFF
--- a/app/controllers/admin/transport_types_controller.rb
+++ b/app/controllers/admin/transport_types_controller.rb
@@ -28,7 +28,7 @@ module Admin
     private
 
     def transport_type_params
-      params.require(:transport_type).permit(:name, :image, :kg_co2e_per_km, :speed_km_per_hour, :can_share, :park_and_stride, :note)
+      params.require(:transport_type).permit(:name, :category, :image, :kg_co2e_per_km, :speed_km_per_hour, :can_share, :park_and_stride, :note)
     end
   end
 end

--- a/app/models/transport_survey.rb
+++ b/app/models/transport_survey.rb
@@ -28,7 +28,6 @@ class TransportSurvey < ApplicationRecord
     run_on.to_s
   end
 
-  # We will need to do something more robust than this!
   def responses=(responses_attributes)
     responses_attributes.each do |response_attributes|
       self.responses.create_with(response_attributes).find_or_create_by(response_attributes.slice(:run_identifier, :surveyed_at))

--- a/app/models/transport_survey_response.rb
+++ b/app/models/transport_survey_response.rb
@@ -4,7 +4,6 @@
 #
 #  created_at          :datetime         not null
 #  id                  :bigint(8)        not null, primary key
-#  integer             :integer          default(1), not null
 #  journey_minutes     :integer          default(0), not null
 #  passengers          :integer          default(1), not null
 #  run_identifier      :string           not null
@@ -28,10 +27,8 @@ class TransportSurveyResponse < ApplicationRecord
   belongs_to :transport_survey
   belongs_to :transport_type, inverse_of: :responses
 
-  # Until we decide if to use a table or not
   enum weather: [:sun, :cloud, :rain, :snow]
 
-  # These class helper methods may not stay here. They are currently helping with prototyping!
   def self.weather_symbols
     { sun: '☀️', cloud: '⛅', rain: '🌧️', snow: '❄️' }
   end

--- a/app/models/transport_type.rb
+++ b/app/models/transport_type.rb
@@ -24,6 +24,8 @@ class TransportType < ApplicationRecord
   validates :kg_co2e_per_km, :speed_km_per_hour, numericality: { greater_than_or_equal_to: 0 }
   validates :name, uniqueness: true
 
+  enum category: [:active_travel, :car, :public_transport]
+
   def safe_destroy
     raise EnergySparks::SafeDestroyError, 'Transport type has associated responses' if responses.any?
     destroy

--- a/app/models/transport_type.rb
+++ b/app/models/transport_type.rb
@@ -3,7 +3,7 @@
 # Table name: transport_types
 #
 #  can_share         :boolean          default(FALSE), not null
-#  category          :integer          default("active_travel"), not null
+#  category          :integer
 #  created_at        :datetime         not null
 #  id                :bigint(8)        not null, primary key
 #  image             :string           not null

--- a/app/models/transport_type.rb
+++ b/app/models/transport_type.rb
@@ -3,6 +3,7 @@
 # Table name: transport_types
 #
 #  can_share         :boolean          default(FALSE), not null
+#  category          :integer          default("active_travel"), not null
 #  created_at        :datetime         not null
 #  id                :bigint(8)        not null, primary key
 #  image             :string           not null

--- a/app/views/admin/transport_types/_form.html.erb
+++ b/app/views/admin/transport_types/_form.html.erb
@@ -1,6 +1,6 @@
 <%= simple_form_for([:admin, transport_type]) do |f| %>
   <%= f.input :name %>
-  <%= f.input :category, collection: TransportType.categories.keys, label_method: lambda {|k| k.humanize}, include_blank: false %>
+  <%= f.input :category, collection: TransportType.categories.keys, label_method: lambda {|k| k.humanize} %>
   <%= f.input :note %>
   <%= f.input :image %>
   <%= f.input :speed_km_per_hour, label: 'Speed (km/h)' %>

--- a/app/views/admin/transport_types/_form.html.erb
+++ b/app/views/admin/transport_types/_form.html.erb
@@ -1,5 +1,6 @@
 <%= simple_form_for([:admin, transport_type]) do |f| %>
   <%= f.input :name %>
+  <%= f.input :category, collection: TransportType.categories.keys, label_method: lambda {|k| k.humanize}, include_blank: false %>
   <%= f.input :note %>
   <%= f.input :image %>
   <%= f.input :speed_km_per_hour, label: 'Speed (km/h)' %>

--- a/app/views/admin/transport_types/index.html.erb
+++ b/app/views/admin/transport_types/index.html.erb
@@ -5,6 +5,7 @@
     <tr>
       <th>Image</th>
       <th>Name</th>
+      <th>Category</th>
       <th>Speed (km/h)</th>
       <th>Carbon (kg co2e/km)</th>
       <th>Can share</th>
@@ -19,6 +20,7 @@
       <tr>
         <td><%= transport_type.image %></td>
         <td><%= link_to transport_type.name, admin_transport_type_path(transport_type) %></td>
+        <td><%= transport_type.category.humanize %>
         <td><%= transport_type.speed_km_per_hour %></td>
         <td><%= transport_type.kg_co2e_per_km %></td>
         <td><span class="badge bg-primary text-light"><%= y_n(transport_type.can_share) %></span></td>

--- a/app/views/admin/transport_types/show.html.erb
+++ b/app/views/admin/transport_types/show.html.erb
@@ -6,6 +6,9 @@
   <dt class="col-md-2">Name</dt>
   <dd class="col-md-10"><%= @transport_type.name %></dd>
 
+  <dt class="col-md-2">Category</dt>
+  <dd class="col-md-10"><%= @transport_type.category.humanize %></dd>
+
   <dt class="col-md-2">Image</dt>
   <dd class="col-md-10"><%= @transport_type.image %></dd>
 

--- a/db/migrate/20220523102554_add_category_to_transport_type.rb
+++ b/db/migrate/20220523102554_add_category_to_transport_type.rb
@@ -1,0 +1,7 @@
+class AddCategoryToTransportType < ActiveRecord::Migration[6.0]
+
+  def change
+    add_column :transport_types, :category, :integer, null: false, default: 0
+  end
+
+end

--- a/db/migrate/20220523104145_remove_unused_column_from_transport_type_responses.rb
+++ b/db/migrate/20220523104145_remove_unused_column_from_transport_type_responses.rb
@@ -1,5 +1,5 @@
 class RemoveUnusedColumnFromTransportTypeResponses < ActiveRecord::Migration[6.0]
   def change
-    remove_column :transport_survey_responses, :integer, :integer
+    remove_column :transport_survey_responses, :integer, :integer, null: false, default: 1
   end
 end

--- a/db/migrate/20220523104145_remove_unused_column_from_transport_type_responses.rb
+++ b/db/migrate/20220523104145_remove_unused_column_from_transport_type_responses.rb
@@ -1,5 +1,5 @@
 class RemoveUnusedColumnFromTransportTypeResponses < ActiveRecord::Migration[6.0]
   def change
-    remove_column :transport_survey_responses, :integer
+    remove_column :transport_survey_responses, :integer, :integer
   end
 end

--- a/db/migrate/20220523104145_remove_unused_column_from_transport_type_responses.rb
+++ b/db/migrate/20220523104145_remove_unused_column_from_transport_type_responses.rb
@@ -1,0 +1,5 @@
+class RemoveUnusedColumnFromTransportTypeResponses < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :transport_survey_responses, :integer
+  end
+end

--- a/db/migrate/20220523152918_make_transport_type_category_optional.rb
+++ b/db/migrate/20220523152918_make_transport_type_category_optional.rb
@@ -1,0 +1,6 @@
+class MakeTransportTypeCategoryOptional < ActiveRecord::Migration[6.0]
+  def change
+    change_column_null :transport_types, :category, true, 1
+    change_column_default :transport_types, :category, from: 0, to: nil
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_05_20_152148) do
+ActiveRecord::Schema.define(version: 2022_05_23_102554) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
@@ -1474,6 +1474,7 @@ ActiveRecord::Schema.define(version: 2022_05_20_152148) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.boolean "park_and_stride", default: false, null: false
+    t.integer "category", default: 0, null: false
     t.index ["name"], name: "index_transport_types_on_name", unique: true
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_05_23_104145) do
+ActiveRecord::Schema.define(version: 2022_05_23_152918) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
@@ -1473,7 +1473,7 @@ ActiveRecord::Schema.define(version: 2022_05_23_104145) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.boolean "park_and_stride", default: false, null: false
-    t.integer "category", default: 0, null: false
+    t.integer "category"
     t.index ["name"], name: "index_transport_types_on_name", unique: true
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_05_23_102554) do
+ActiveRecord::Schema.define(version: 2022_05_23_104145) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
@@ -1444,7 +1444,6 @@ ActiveRecord::Schema.define(version: 2022_05_23_102554) do
     t.bigint "transport_survey_id", null: false
     t.bigint "transport_type_id", null: false
     t.integer "passengers", default: 1, null: false
-    t.integer "integer", default: 1, null: false
     t.string "run_identifier", null: false
     t.datetime "surveyed_at", null: false
     t.integer "journey_minutes", default: 0, null: false

--- a/lib/tasks/deployment/20220523110209_add_transport_type_categories.rake
+++ b/lib/tasks/deployment/20220523110209_add_transport_type_categories.rake
@@ -1,0 +1,18 @@
+namespace :after_party do
+  desc 'Deployment task: add_transport_type_categories'
+  task add_transport_type_categories: :environment do
+    puts "Running deploy task 'add_transport_type_categories'"
+
+    TransportType.where(name: ["Car", "Car (Diesel)", "Car (Petrol)", "Car (Hybrid)", "Electric Car", "Taxi", "Park and Stride", "Motorbike"]).update_all(category: :car)
+    TransportType.where(name: ["Walking", "Bike"]).update_all(category: :active_travel)
+    TransportType.where(name: ["Bus (London)", "Bus", "Train", "Tube", "School bus"]).update_all(category: :public_transport)
+
+    # Update electric car symbol while we're here
+    TransportType.where(name: "Electric Car").update_all(image: "🔌🚘")
+
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord
+      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+  end
+end

--- a/lib/tasks/deployment/20220523110209_add_transport_type_categories.rake
+++ b/lib/tasks/deployment/20220523110209_add_transport_type_categories.rake
@@ -3,8 +3,9 @@ namespace :after_party do
   task add_transport_type_categories: :environment do
     puts "Running deploy task 'add_transport_type_categories'"
 
-    TransportType.where(name: ["Car", "Car (Diesel)", "Car (Petrol)", "Car (Hybrid)", "Electric Car", "Taxi", "Park and Stride", "Motorbike"]).update_all(category: :car)
-    TransportType.where(name: ["Walking", "Bike"]).update_all(category: :active_travel)
+    TransportType.where(name: ["Car", "Car (Diesel)", "Car (Petrol)", "Car (Hybrid)", "Electric Car", "Taxi"]).update_all(category: :car)
+    TransportType.where(name: ["Motorbike"]).update_all(category: nil)
+    TransportType.where(name: ["Walking", "Bike", "Park and Stride"]).update_all(category: :active_travel)
     TransportType.where(name: ["Bus (London)", "Bus", "Train", "Tube", "School bus"]).update_all(category: :public_transport)
 
     # Update electric car symbol while we're here

--- a/spec/factories/transport_types.rb
+++ b/spec/factories/transport_types.rb
@@ -5,6 +5,7 @@ FactoryBot.define do
     kg_co2e_per_km { "0.17137" }
     speed_km_per_hour { "32" }
     note { "Average car, unknown size or fuel type" }
+    category { :car }
     can_share { true }
     park_and_stride { false }
   end

--- a/spec/system/admin/transport_types_spec.rb
+++ b/spec/system/admin/transport_types_spec.rb
@@ -41,6 +41,7 @@ describe "admin transport type", type: :system, include_application_helper: true
       'Can share' => y_n(transport_type.can_share),
       'Park and stride' => y_n(transport_type.park_and_stride),
       'Note' => transport_type.note,
+      'Category' => transport_type.category.humanize,
       'Created at' => nice_date_times(transport_type.created_at),
       'Updated at' => nice_date_times(transport_type.updated_at)
     } }
@@ -52,12 +53,14 @@ describe "admin transport type", type: :system, include_application_helper: true
       'Carbon (kg co2e/km)' => 0.146,
       'Can share' => 'Yes',
       'Park and stride' => 'Yes',
-      'Note' => 'Why not?'
+      'Note' => 'Why not?',
+      'Category' => 'Public transport'
     } }
 
-    let(:boolean_attributes) { ['Can share', 'Park and stride'] }
-    let(:viewable_attributes) { attributes.excluding('Created at', 'Updated at') }
-    let(:editable_attributes) { attributes.excluding('Created at', 'Updated at') }
+    let(:checkbox_attributes) { ['Can share', 'Park and stride'] }
+    let(:select_attributes) { ['Category'] }
+    let(:display_attributes) { attributes.except('Created at', 'Updated at') }
+    let(:form_attributes) { attributes.except('Created at', 'Updated at') }
 
     describe "Viewing the index" do
       before(:each) do
@@ -66,7 +69,7 @@ describe "admin transport type", type: :system, include_application_helper: true
 
       it "lists created transport type" do
         within('table') do
-          expect(page).to have_selector(:table_row, viewable_attributes)
+          expect(page).to have_selector(:table_row, display_attributes)
         end
       end
 
@@ -174,10 +177,13 @@ describe "admin transport type", type: :system, include_application_helper: true
 
       it "shows prefilled form elements" do
         within('form') do
-          editable_attributes.excluding(boolean_attributes).each do |key, value|
+          form_attributes.excluding(checkbox_attributes + select_attributes).each do |key, value|
             expect(page).to have_field(key, with: value)
           end
-          boolean_attributes.each do |field_name|
+          form_attributes.slice(*select_attributes).each do |key, value|
+            expect(page).to have_select(key, selected: value)
+          end
+          checkbox_attributes.each do |field_name|
             expect(page).to have_unchecked_field(field_name)
           end
         end
@@ -186,10 +192,13 @@ describe "admin transport type", type: :system, include_application_helper: true
       context "when entering new values" do
         context "with valid attributes" do
           before(:each) do
-            new_valid_attributes.excluding(boolean_attributes).each do |key, value|
+            new_valid_attributes.excluding(checkbox_attributes + select_attributes).each do |key, value|
               fill_in key, with: value
             end
-            boolean_attributes.each do |field_name|
+            new_valid_attributes.slice(*select_attributes).each do |key, value|
+              select value, from: key
+            end
+            checkbox_attributes.each do |field_name|
               check field_name
             end
             click_button 'Save'
@@ -242,7 +251,10 @@ describe "admin transport type", type: :system, include_application_helper: true
           ['Speed (km/h)', 'Carbon (kg co2e/km)'].each do |field_name|
             expect(page).to have_field(field_name, with: 0.0)
           end
-          boolean_attributes.each do |field_name|
+          select_attributes.each do |field_name|
+            expect(page).to have_select(field_name, selected: "Active travel")
+          end
+          checkbox_attributes.each do |field_name|
             expect(page).to have_unchecked_field(field_name)
           end
         end
@@ -251,10 +263,13 @@ describe "admin transport type", type: :system, include_application_helper: true
       context "when entering new values" do
         context "with valid attributes" do
           before(:each) do
-            new_valid_attributes.excluding(boolean_attributes).each do |key, value|
+            new_valid_attributes.excluding(checkbox_attributes + select_attributes).each do |key, value|
               fill_in key, with: value
             end
-            boolean_attributes.each do |field_name|
+            new_valid_attributes.slice(*select_attributes).each do |key, value|
+              select value, from: key
+            end
+            checkbox_attributes.each do |field_name|
               check field_name
             end
             click_button 'Save'
@@ -303,7 +318,7 @@ describe "admin transport type", type: :system, include_application_helper: true
             visit admin_transport_types_path
           end
 
-          it { expect(page).to have_selector(:table_row, viewable_attributes) }
+          it { expect(page).to have_selector(:table_row, display_attributes) }
 
           it "disables delete button" do
             expect(find_link("Delete")['class']).to match /disabled/
@@ -315,7 +330,7 @@ describe "admin transport type", type: :system, include_application_helper: true
             visit admin_transport_types_path
           end
 
-          it { expect(page).to have_selector(:table_row, viewable_attributes) }
+          it { expect(page).to have_selector(:table_row, display_attributes) }
 
           context "and clicking delete and confirming" do
             before(:each) do
@@ -334,7 +349,7 @@ describe "admin transport type", type: :system, include_application_helper: true
 
             it "removes transport type" do
               within('table') do
-                expect(page).to_not have_selector(:table_row, viewable_attributes)
+                expect(page).to_not have_selector(:table_row, display_attributes)
               end
             end
           end
@@ -348,7 +363,7 @@ describe "admin transport type", type: :system, include_application_helper: true
 
             it "does not remove transport type" do
               within('table') do
-                expect(page).to have_selector(:table_row, viewable_attributes)
+                expect(page).to have_selector(:table_row, display_attributes)
               end
             end
 

--- a/spec/system/admin/transport_types_spec.rb
+++ b/spec/system/admin/transport_types_spec.rb
@@ -252,7 +252,7 @@ describe "admin transport type", type: :system, include_application_helper: true
             expect(page).to have_field(field_name, with: 0.0)
           end
           select_attributes.each do |field_name|
-            expect(page).to have_select(field_name, selected: "Active travel")
+            expect(page).to have_select(field_name, selected: [])
           end
           checkbox_attributes.each do |field_name|
             expect(page).to have_unchecked_field(field_name)


### PR DESCRIPTION
Quick question before this is merged. I have put "motorbike" in the "car" category but this doesn't seem totally right. Or do we need to rename / broaden the "car" category to "motorised" or similar? I have put "park and stride" in the "car" category too?

Summary of changes:
* Add new enum field to transport types
* Make changes to admin interface to support new field + associated rspec
* This includes an after party task to assign a category to each transport type
* This also changes the image for the electric car transport type to be "🔌🚘" as requested by Claudia
* While I was doing this, I noticed an extra column had sneaked into the transport_survey_responses because of a mistake in a previous migration, so there is a migration to remove this too.