### PR TITLE
Ignore Welsh sub-domains

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -1,7 +1,9 @@
-# This file is used by Rack-based servers to start the application.
-
 require_relative 'config/environment'
 
-use Rack::CanonicalHost, ENV['APPLICATION_HOST'], cache_control: "max-age=#{1.hour.to_i}" if ENV['APPLICATION_HOST']
+#Used to configure a redirects from www.energysparks.uk and www-test.energysparks.uk to
+#energysparks.uk and test.energysparks.uk.
+#
+#We exclude the Welsh subdomains (cy. and test-cy.)
+use Rack::CanonicalHost, ENV['APPLICATION_HOST'], ignore: /.*cy\.energysparks\.uk/, cache_control: "max-age=#{1.hour.to_i}" if ENV['APPLICATION_HOST']
 
 run Rails.application


### PR DESCRIPTION
Add the `:ignore` option to the Rack Canonical Host config. 

If any of the ignore options match, then the redirect is skipped. See:

https://github.com/tylerhunt/rack-canonical-host/blob/master/lib/rack/canonical_host/redirect.rb#L70
https://github.com/tylerhunt/rack-canonical-host/blob/master/lib/rack/canonical_host/redirect.rb#L49

Main docs:

https://github.com/tylerhunt/rack-canonical-host