### PR TITLE
Add an order column to transport types

### DIFF
--- a/app/controllers/admin/transport_types_controller.rb
+++ b/app/controllers/admin/transport_types_controller.rb
@@ -2,6 +2,10 @@ module Admin
   class TransportTypesController < AdminController
     load_and_authorize_resource
 
+    def index
+      @transport_types = @transport_types.by_position
+    end
+
     def create
       if @transport_type.save
         redirect_to admin_transport_types_path, notice: 'Transport type was successfully created.'

--- a/app/controllers/admin/transport_types_controller.rb
+++ b/app/controllers/admin/transport_types_controller.rb
@@ -32,7 +32,7 @@ module Admin
     private
 
     def transport_type_params
-      params.require(:transport_type).permit(:name, :category, :image, :kg_co2e_per_km, :speed_km_per_hour, :can_share, :park_and_stride, :note)
+      params.require(:transport_type).permit(:name, :category, :image, :kg_co2e_per_km, :speed_km_per_hour, :can_share, :park_and_stride, :position, :note)
     end
   end
 end

--- a/app/controllers/transport_types_controller.rb
+++ b/app/controllers/transport_types_controller.rb
@@ -2,6 +2,6 @@ class TransportTypesController < ApplicationController
   respond_to :json
 
   def index
-    respond_with TransportType.select(:id, :name, :image, :kg_co2e_per_km, :speed_km_per_hour, :can_share, :park_and_stride).index_by(&:id)
+    respond_with TransportType.select(:id, :name, :image, :kg_co2e_per_km, :speed_km_per_hour, :can_share, :park_and_stride).order(position: :asc).index_by(&:id)
   end
 end

--- a/app/controllers/transport_types_controller.rb
+++ b/app/controllers/transport_types_controller.rb
@@ -2,6 +2,6 @@ class TransportTypesController < ApplicationController
   respond_to :json
 
   def index
-    respond_with TransportType.select(:id, :name, :image, :kg_co2e_per_km, :speed_km_per_hour, :can_share, :park_and_stride).order(position: :asc).index_by(&:id)
+    respond_with TransportType.select(:id, :name, :image, :kg_co2e_per_km, :speed_km_per_hour, :can_share, :park_and_stride).index_by(&:id)
   end
 end

--- a/app/models/transport_type.rb
+++ b/app/models/transport_type.rb
@@ -22,6 +22,8 @@
 class TransportType < ApplicationRecord
   has_many :responses, class_name: 'TransportSurveyResponse', inverse_of: :transport_type
 
+  scope :by_position, -> { order(position: :asc) }
+
   validates :name, :image, :speed_km_per_hour, :kg_co2e_per_km, :position, presence: true
   validates :kg_co2e_per_km, :speed_km_per_hour, :position, numericality: { greater_than_or_equal_to: 0 }
   validates :name, uniqueness: true

--- a/app/models/transport_type.rb
+++ b/app/models/transport_type.rb
@@ -11,6 +11,7 @@
 #  name              :string           not null
 #  note              :string
 #  park_and_stride   :boolean          default(FALSE), not null
+#  position          :integer          default(0), not null
 #  speed_km_per_hour :decimal(, )      default(0.0), not null
 #  updated_at        :datetime         not null
 #
@@ -21,8 +22,8 @@
 class TransportType < ApplicationRecord
   has_many :responses, class_name: 'TransportSurveyResponse', inverse_of: :transport_type
 
-  validates :name, :image, :speed_km_per_hour, :kg_co2e_per_km, presence: true
-  validates :kg_co2e_per_km, :speed_km_per_hour, numericality: { greater_than_or_equal_to: 0 }
+  validates :name, :image, :speed_km_per_hour, :kg_co2e_per_km, :position, presence: true
+  validates :kg_co2e_per_km, :speed_km_per_hour, :position, numericality: { greater_than_or_equal_to: 0 }
   validates :name, uniqueness: true
 
   enum category: [:active_travel, :car, :public_transport]

--- a/app/views/admin/transport_types/_form.html.erb
+++ b/app/views/admin/transport_types/_form.html.erb
@@ -5,6 +5,7 @@
   <%= f.input :image %>
   <%= f.input :speed_km_per_hour, label: 'Speed (km/h)' %>
   <%= f.input :kg_co2e_per_km, label: 'Carbon (kg co2e/km)' %>
+  <%= f.input :position %>
   <%= f.input :can_share, as: :boolean %>
   <%= f.input :park_and_stride, as: :boolean %>
   <%= f.submit 'Save', class: 'btn btn-primary' %>

--- a/app/views/admin/transport_types/index.html.erb
+++ b/app/views/admin/transport_types/index.html.erb
@@ -11,6 +11,7 @@
       <th>Can share</th>
       <th>Park and stride</th>
       <th>Note</th>
+      <th>Position</th>
       <th>Actions</th>
     </tr>
   </thead>
@@ -26,6 +27,7 @@
         <td><span class="badge bg-primary text-light"><%= y_n(transport_type.can_share) %></span></td>
         <td><span class="badge bg-primary text-light"><%= y_n(transport_type.park_and_stride) %></span></td>
         <td><%= transport_type.note %></td>
+        <td><%= transport_type.position %></td>
         <td>
           <div class="btn-group">
             <%= render partial: "buttons", locals: { transport_type: transport_type } %>

--- a/app/views/admin/transport_types/show.html.erb
+++ b/app/views/admin/transport_types/show.html.erb
@@ -21,6 +21,9 @@
   <dt class="col-md-2">Carbon (kg co2e/km)</dt>
   <dd class="col-md-10"><%= @transport_type.kg_co2e_per_km %></dd>
 
+  <dt class="col-md-2">Position</dt>
+  <dd class="col-md-10"><%= @transport_type.position %></dd>
+
   <dt class="col-md-2">Can share</dt>
   <dd class="col-md-10"><span class="badge bg-primary text-light"><%= y_n(@transport_type.can_share) %></span></dd>
 

--- a/app/views/schools/transport_surveys/edit.html.erb
+++ b/app/views/schools/transport_surveys/edit.html.erb
@@ -80,7 +80,7 @@
               <%= hidden_field_tag :transport_type_id, "", class: 'selected' %>
               <div class="container">
                 <div class="row">
-                  <% TransportType.all.each do |transport_type| %>
+                  <% TransportType.all.by_position.each do |transport_type| %>
                     <%= render 'option', { label: transport_type.name, content: transport_type.image, identifier: transport_type.id, action: "confirm" } %>
                   <% end %>
                 </div>

--- a/db/migrate/20220523135758_add_position_to_transport_types.rb
+++ b/db/migrate/20220523135758_add_position_to_transport_types.rb
@@ -1,0 +1,5 @@
+class AddPositionToTransportTypes < ActiveRecord::Migration[6.0]
+  def change
+    add_column :transport_types, :position, :integer, null: false, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_05_23_135758) do
+ActiveRecord::Schema.define(version: 2022_05_23_152918) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_05_23_152918) do
+ActiveRecord::Schema.define(version: 2022_05_23_135758) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
@@ -1474,6 +1474,7 @@ ActiveRecord::Schema.define(version: 2022_05_23_152918) do
     t.datetime "updated_at", precision: 6, null: false
     t.boolean "park_and_stride", default: false, null: false
     t.integer "category"
+    t.integer "position", default: 0, null: false
     t.index ["name"], name: "index_transport_types_on_name", unique: true
   end
 

--- a/lib/tasks/deployment/20220524100658_update_transport_type_position.rake
+++ b/lib/tasks/deployment/20220524100658_update_transport_type_position.rake
@@ -1,0 +1,20 @@
+namespace :after_party do
+  desc 'Deployment task: update_transport_type_position'
+  task update_transport_type_position: :environment do
+    puts "Running deploy task 'update_transport_type_position'"
+
+    order = [ "Walking", "Bike",
+              "Park and Stride", "Car", "Car (Petrol)", "Car (Diesel)", "Car (Hybrid)", "Electric Car", "Taxi",
+              "Bus", "School bus", "Bus (London)", "Tube", "Train",
+              "Motorbike"]
+
+    order.each_with_index do |name, position|
+      TransportType.find_by(name: name).update(position: position)
+    end
+
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord
+      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+  end
+end

--- a/lib/tasks/deployment/20220524100658_update_transport_type_position.rake
+++ b/lib/tasks/deployment/20220524100658_update_transport_type_position.rake
@@ -5,7 +5,7 @@ namespace :after_party do
 
     order = [ "Walking", "Bike",
               "Park and Stride", "Car", "Car (Petrol)", "Car (Diesel)", "Car (Hybrid)", "Electric Car", "Taxi",
-              "Bus", "School bus", "Bus (London)", "Tube", "Train",
+              "School bus", "Bus", "Bus (London)", "Train", "Tube",
               "Motorbike"]
 
     order.each_with_index do |name, position|

--- a/spec/factories/transport_types.rb
+++ b/spec/factories/transport_types.rb
@@ -8,5 +8,6 @@ FactoryBot.define do
     category { :car }
     can_share { true }
     park_and_stride { false }
+    position { 0 }
   end
 end

--- a/spec/models/transport_type_spec.rb
+++ b/spec/models/transport_type_spec.rb
@@ -8,11 +8,11 @@ describe TransportType do
     it { is_expected.to be_valid }
     it { is_expected.to validate_uniqueness_of(:name) }
 
-    [:name, :image, :kg_co2e_per_km, :speed_km_per_hour].each do |attribute|
+    [:name, :image, :kg_co2e_per_km, :speed_km_per_hour, :position].each do |attribute|
       it { is_expected.to validate_presence_of(attribute) }
     end
 
-    [:kg_co2e_per_km, :speed_km_per_hour].each do |attribute|
+    [:kg_co2e_per_km, :speed_km_per_hour, :position].each do |attribute|
       it { is_expected.to validate_numericality_of(attribute).is_greater_than_or_equal_to(0) }
     end
   end

--- a/spec/system/admin/transport_types_spec.rb
+++ b/spec/system/admin/transport_types_spec.rb
@@ -42,6 +42,7 @@ describe "admin transport type", type: :system, include_application_helper: true
       'Park and stride' => y_n(transport_type.park_and_stride),
       'Note' => transport_type.note,
       'Category' => transport_type.category.humanize,
+      'Position' => transport_type.position,
       'Created at' => nice_date_times(transport_type.created_at),
       'Updated at' => nice_date_times(transport_type.updated_at)
     } }
@@ -53,8 +54,9 @@ describe "admin transport type", type: :system, include_application_helper: true
       'Carbon (kg co2e/km)' => 0.146,
       'Can share' => 'Yes',
       'Park and stride' => 'Yes',
-      'Note' => 'Why not?',
-      'Category' => 'Public transport'
+      'Category' => 'Public transport',
+      'Position' => 1,
+      'Note' => 'Why not?'
     } }
 
     let(:checkbox_attributes) { ['Can share', 'Park and stride'] }
@@ -251,8 +253,11 @@ describe "admin transport type", type: :system, include_application_helper: true
           ['Speed (km/h)', 'Carbon (kg co2e/km)'].each do |field_name|
             expect(page).to have_field(field_name, with: 0.0)
           end
+          ['Position'].each do |field_name|
+            expect(page).to have_field(field_name, with: 0)
+          end
           select_attributes.each do |field_name|
-            expect(page).to have_select(field_name, selected: [])
+              expect(page).to have_select(field_name, selected: [])
           end
           checkbox_attributes.each do |field_name|
             expect(page).to have_unchecked_field(field_name)

--- a/spec/system/admin/transport_types_spec.rb
+++ b/spec/system/admin/transport_types_spec.rb
@@ -257,7 +257,7 @@ describe "admin transport type", type: :system, include_application_helper: true
             expect(page).to have_field(field_name, with: 0)
           end
           select_attributes.each do |field_name|
-              expect(page).to have_select(field_name, selected: [])
+            expect(page).to have_select(field_name, selected: [])
           end
           checkbox_attributes.each do |field_name|
             expect(page).to have_unchecked_field(field_name)


### PR DESCRIPTION
* Adds new position column to transport types
* Includes an after party task to order existing transport types
* Hook up new column in the transport types admin interface
* Use the new position column to order transport types in the javascript app

Just waiting on Claudia to check the default order I have set in the after party task (have added it to the Trello card).