### PR TITLE
Transport Survey UI - change passengers flow

### DIFF
--- a/app/javascript/packs/transport_surveys.js
+++ b/app/javascript/packs/transport_surveys.js
@@ -263,10 +263,11 @@ $(document).ready(function() {
     let response = readResponse();
     let transport_type = config.transport_types[response['transport_type_id']];
 
+    $('#confirm-passengers div.option-content').text(config.passenger_symbol.repeat(response['passengers']));
+    $('#confirm-passengers div.option-label').text((response['passengers'] > 1 ? "Group of " + response['passengers'] : "Single pupil"));
     $('#confirm-time div.option-content').text(response['journey_minutes']);
     $('#confirm-transport div.option-content').text(transport_type.image);
     $('#confirm-transport div.option-label').text(transport_type.name);
-    $('#confirm-passengers div.option-content').text(config.passenger_symbol.repeat(response['passengers']));
   }
 
   function displayCarbon() {

--- a/app/javascript/packs/transport_surveys.js
+++ b/app/javascript/packs/transport_surveys.js
@@ -21,7 +21,6 @@ $(document).ready(function() {
     /* onclick bindings */
     $('.start').on('click', start);
     $('.next').on('click', next);
-    $('.sharing').on('click', sharing);
     $('.previous').on('click', previous);
     $('.confirm').on('click', confirm);
     $('.store').on('click', store);
@@ -213,16 +212,6 @@ $(document).ready(function() {
   function resetSurveyCards() {
     let cards = $('#transport_survey .panel').find('.card');
     resetCards(cards);
-  }
-
-  function sharing() {
-    let transport_type = config.transport_types[$("#transport_type_id").val()];
-    if (transport_type.can_share) {
-      $("fieldset#sharing .card").show();
-    } else {
-      $("fieldset#sharing .card").not(":first").hide();
-      $("fieldset#sharing .card:first").show();
-    }
   }
 
   function resetSurveyPanels() {

--- a/app/javascript/packs/transport_surveys/carbon.js
+++ b/app/javascript/packs/transport_surveys/carbon.js
@@ -61,7 +61,9 @@ const parkAndStrideTimeMins = function(timeMins) {
 export const carbonCalc = function(transport, timeMins, passengers) {
   if (transport) {
     timeMins = transport.park_and_stride == true ? parkAndStrideTimeMins(timeMins) : timeMins;
-    return (((transport.speed_km_per_hour * timeMins) / 60) * transport.kg_co2e_per_km) / passengers ;
+    var total_carbon = ((transport.speed_km_per_hour * timeMins) / 60) * transport.kg_co2e_per_km;
+    total_carbon = transport.can_share == true ? (total_carbon / passengers) : total_carbon;
+    return total_carbon;
   } else {
     return 0;
   }

--- a/app/views/schools/transport_surveys/_progress_bar.html.erb
+++ b/app/views/schools/transport_surveys/_progress_bar.html.erb
@@ -1,6 +1,6 @@
 <ul class="nav nav-tabs nav-fill">
   <li class="nav-item">
-    <a class="nav-link active" href="#">Sharing</a>
+    <a class="nav-link disabled active" href="#">Sharing</a>
   </li>
   <li class="nav-item">
     <a class="nav-link disabled" href="#">Time</a>

--- a/app/views/schools/transport_surveys/_progress_bar.html.erb
+++ b/app/views/schools/transport_surveys/_progress_bar.html.erb
@@ -1,18 +1,18 @@
 <ul class="nav nav-tabs nav-fill">
   <li class="nav-item">
-    <a class="nav-link active disabled" href="#">Time</a>
+    <a class="nav-link active" href="#">Sharing</a>
+  </li>
+  <li class="nav-item">
+    <a class="nav-link disabled" href="#">Time</a>
   </li>
   <li class="nav-item">
     <a class="nav-link disabled" href="#">Transport</a>
   </li>
   <li class="nav-item">
-    <a class="nav-link disabled" href="#">Passengers</a>
+    <a class="nav-link disabled" href="#">Confirm</a>
   </li>
   <li class="nav-item">
-    <a class="nav-link disabled" href="#" tabindex="-1" aria-disabled="true">Confirm</a>
-  </li>
-  <li class="nav-item">
-    <a class="nav-link disabled" href="#" tabindex="-1" aria-disabled="true">Summary</a>
+    <a class="nav-link disabled" href="#">Summary</a>
   </li>
 
 </ul>

--- a/app/views/schools/transport_surveys/edit.html.erb
+++ b/app/views/schools/transport_surveys/edit.html.erb
@@ -92,9 +92,9 @@
               <h2>Confirm your selection</h2>
               <div class="container">
                 <div class="row">
+                  <%= render 'option', { label: "Pupil(s)", content: 'x', identifier: 'confirm-passengers', action: '' } %>
                   <%= render 'option', { label: "Minutes", content: 'x', identifier: 'confirm-time', action: '' } %>
                   <%= render 'option', { label: "Transport", content: 'x', identifier: 'confirm-transport', action: '' } %>
-                  <%= render 'option', { label: "Pupil(s)", content: 'x', identifier: 'confirm-passengers', action: '' } %>
                 </div>
               </div>
               <p><%= button_tag "Confirm", type: 'button', class: 'store btn btn-primary w-100' %></p>

--- a/app/views/schools/transport_surveys/edit.html.erb
+++ b/app/views/schools/transport_surveys/edit.html.erb
@@ -56,7 +56,7 @@
               <div class="container">
                 <div class="row">
                   <% TransportSurveyResponse.passengers_options.each do |passengers| %>
-                    <%= render 'option', { label: ((passengers > 1) ? "Me + #{passengers - 1} more" : "Just me"), content: TransportSurveyResponse.passenger_symbol * passengers, identifier: passengers, action: "next" } %>
+                    <%= render 'option', { label: ((passengers > 1) ? "Group of #{passengers}" : "Single pupil"), content: TransportSurveyResponse.passenger_symbol * passengers, identifier: passengers, action: "next" } %>
                   <% end %>
                 </div>
               </div>
@@ -68,7 +68,7 @@
               <div class="container">
                 <div class="row">
                   <% TransportSurveyResponse.journey_minutes_options.each do |time| %>
-                    <%= render 'option', { label: "minutes", content: time, identifier: time, action: "next" } %>
+                    <%= render 'option', { label: "Minutes", content: time, identifier: time, action: "next" } %>
                   <% end %>
                 </div>
               </div>
@@ -92,9 +92,9 @@
               <h2>Confirm your selection</h2>
               <div class="container">
                 <div class="row">
-                  <%= render 'option', { label: "minutes", content: 'x', identifier: 'confirm-time', action: '' } %>
-                  <%= render 'option', { label: "transport", content: 'x', identifier: 'confirm-transport', action: '' } %>
-                  <%= render 'option', { label: "pupil(s)", content: 'x', identifier: 'confirm-passengers', action: '' } %>
+                  <%= render 'option', { label: "Minutes", content: 'x', identifier: 'confirm-time', action: '' } %>
+                  <%= render 'option', { label: "Transport", content: 'x', identifier: 'confirm-transport', action: '' } %>
+                  <%= render 'option', { label: "Pupil(s)", content: 'x', identifier: 'confirm-passengers', action: '' } %>
                 </div>
               </div>
               <p><%= button_tag "Confirm", type: 'button', class: 'store btn btn-primary w-100' %></p>

--- a/app/views/schools/transport_surveys/edit.html.erb
+++ b/app/views/schools/transport_surveys/edit.html.erb
@@ -49,7 +49,20 @@
 
           <div id="survey" style="display: none;">
             <%= render partial: 'progress_bar' %>
+
             <fieldset class="panel">
+              <%= hidden_field_tag :passengers, "", class: 'selected' %>
+              <h2>Sharing: Are you recording this journey for a single pupil or a group?</h2>
+              <div class="container">
+                <div class="row">
+                  <% TransportSurveyResponse.passengers_options.each do |passengers| %>
+                    <%= render 'option', { label: ((passengers > 1) ? "Me + #{passengers - 1} more" : "Just me"), content: TransportSurveyResponse.passenger_symbol * passengers, identifier: passengers, action: "next" } %>
+                  <% end %>
+                </div>
+              </div>
+            </fieldset>
+
+            <fieldset class="panel" style="display: none;">
               <h2>Time: How many minutes did your journey take in total?</h2>
               <%= hidden_field_tag :journey_minutes, "", class: 'selected' %>
               <div class="container">
@@ -59,6 +72,7 @@
                   <% end %>
                 </div>
               </div>
+              <%= button_tag 'Back', type: 'button', class: "previous btn btn-default w-100" %>
             </fieldset>
 
             <fieldset class="panel" style="display: none;">
@@ -67,20 +81,7 @@
               <div class="container">
                 <div class="row">
                   <% TransportType.all.each do |transport_type| %>
-                    <%= render 'option', { label: transport_type.name, content: transport_type.image, identifier: transport_type.id, action: "next sharing" } %>
-                  <% end %>
-                </div>
-              </div>
-              <%= button_tag 'Back', type: 'button', class: "previous btn btn-default w-100" %>
-            </fieldset>
-
-            <fieldset class="panel" id="sharing" style="display: none;">
-              <%= hidden_field_tag :passengers, "", class: 'selected' %>
-              <h2>Pupil Passengers: How many pupils from school shared this mode of transport (including you)?</h2>
-              <div class="container">
-                <div class="row">
-                  <% TransportSurveyResponse.passengers_options.each do |passengers| %>
-                    <%= render 'option', { label: ((passengers > 1) ? "Me + #{passengers - 1} more" : "Just me"), content: TransportSurveyResponse.passenger_symbol * passengers, identifier: passengers, action: "confirm" } %>
+                    <%= render 'option', { label: transport_type.name, content: transport_type.image, identifier: transport_type.id, action: "confirm" } %>
                   <% end %>
                 </div>
               </div>

--- a/spec/system/schools/transport_surveys_spec.rb
+++ b/spec/system/schools/transport_surveys_spec.rb
@@ -41,32 +41,33 @@ describe 'TransportSurveys', type: :system do
                 click_link weather
               end
 
-              let(:time) { TransportSurveyResponse.journey_minutes_options.last }
-              it { expect(page).to have_content('Time: How many minutes did your journey take in total?') }
-              it { expect(page).to have_link(time.to_s) }
+              it { expect(page).to have_content('Sharing: Are you recording this journey for a single pupil or a group?') }
               it { expect(page).to_not have_button('Back') }
+              let(:passengers) { TransportSurveyResponse.passengers_options.last.to_i }
+              let(:passengers_link) { TransportSurveyResponse.passenger_symbol * passengers }
 
-              context "selecting a time" do
+              context "selecting passengers" do
                 before(:each) do
-                  click_link time.to_s
+                  click_link(passengers_link)
                 end
 
-                it { expect(page).to have_content('Transport: What mode of transport did you use to get to school?') }
-                it { expect(page).to have_link(transport_type.image) }
+                let(:time) { TransportSurveyResponse.journey_minutes_options.last }
+                it { expect(page).to have_content('Time: How many minutes did your journey take in total?') }
+                it { expect(page).to have_link(time.to_s) }
                 it { expect(page).to have_button('Back') }
 
-                context "selecting a transport type" do
+                context "selecting a time" do
                   before(:each) do
-                    click_link transport_type.image
+                    click_link time.to_s
                   end
 
-                  it { expect(page).to have_content('Pupil Passengers: How many pupils from school shared this mode of transport (including you)?') }
-                  let(:passengers) { TransportSurveyResponse.passengers_options.last.to_i }
-                  let(:passengers_link) { TransportSurveyResponse.passenger_symbol * passengers }
+                  it { expect(page).to have_content('Transport: What mode of transport did you use to get to school?') }
+                  it { expect(page).to have_link(transport_type.image) }
+                  it { expect(page).to have_button('Back') }
 
-                  context "selecting passengers" do
+                  context "selecting a transport type" do
                     before(:each) do
-                      click_link(passengers_link)
+                      click_link transport_type.image
                     end
 
                     it { expect(page).to have_content('Confirm your selection') }
@@ -90,6 +91,7 @@ describe 'TransportSurveys', type: :system do
                         expect(find("#display-carbon-equivalent")).to_not be_blank #the content of this is random, so this is as far as it can be tested without getting too complex
                       end
                       it { expect(page).to have_button('Finish & save results 1') }
+                      it { expect(page).to_not have_button('Back') }
 
                       context "Saving results" do
                         before(:each) do


### PR DESCRIPTION
* This changes the flow of the survey app so that the "passengers" question comes first.
* The carbon calculation has also had to change to reflect the new flow.
* This also changes the wording for the passengers icons to make more sense for the reworded question. We did talk about putting plain numbers for the labels but I thought this would be more clear. Easy to change if not! Not entirely convinced the passenger icon scales that well when there are 6 of them. I'll post some alternatives on the trello card but open to suggestions!

![Screenshot 2022-05-24 at 16 26 58](https://user-images.githubusercontent.com/6051/170073895-de0ff42a-369a-459b-ad8d-60094193df3b.png)
