### PR TITLE
2174 revise transport survey carbon calculations

### DIFF
--- a/app/controllers/schools/transport_surveys_controller.rb
+++ b/app/controllers/schools/transport_surveys_controller.rb
@@ -4,7 +4,7 @@ module Schools
     skip_before_action :authenticate_user!, only: [:index, :show]
 
     load_resource :school
-    load_resource :transport_survey, find_by: :run_on, id_param: :run_on, through: :school, except: [:edit, :update]
+    load_resource :transport_survey, find_by: :run_on, id_param: :run_on, through: :school, except: [:update]
 
     authorize_resource :transport_survey
     before_action :load_or_create, only: [:update]
@@ -17,12 +17,6 @@ module Schools
     def start
       @transport_survey = @school.transport_surveys.find_or_initialize_by(run_on: Time.zone.today)
       render :edit
-    end
-
-    # We need to decide how we are going to lock this down. For example, we shouldn't allow surveying in the future (or the past really). Maybe Just today?
-    def edit
-      @transport_survey = @school.transport_surveys.find_or_initialize_by(run_on: params[:run_on])
-      # authorize! :read, @transport_survey
     end
 
     def update

--- a/app/javascript/packs/transport_surveys.js
+++ b/app/javascript/packs/transport_surveys.js
@@ -3,7 +3,7 @@
 import { storage } from './transport_surveys/storage';
 import { carbon } from './transport_surveys/carbon';
 import { notifier } from './transport_surveys/notifier';
-import { pluralise } from './transport_surveys/helpers';
+import { pluralise, nice_date } from './transport_surveys/helpers';
 import * as handlebarsHelpers from './transport_surveys/handlebars_helpers';
 
 $(document).ready(function() {
@@ -91,7 +91,8 @@ $(document).ready(function() {
   function saveResponses() {
     let button = $(this);
     let date = button.attr('data-date');
-    if (window.confirm('Are you sure you want to save ' + storage.getResponsesCount(date) + ' unsaved result(s) from ' + date + '?')) {
+    let count = storage.getResponsesCount(date);
+    if (window.confirm(`Are you sure you want to save ${count} unsaved ${pluralise("response", count)} from ${nice_date(date)}?`)) {
       storage.syncResponses(date, notifier.page).done( function() {
         button.closest('.alert').hide();
         if (date == config.run_on) {
@@ -106,7 +107,8 @@ $(document).ready(function() {
   function deleteResponses() {
     let button = $(this);
     let date = button.attr('data-date');
-    if (window.confirm('Are you sure you want to remove ' + storage.getResponsesCount(date) + ' unsaved result(s) from ' + date + '?')) {
+    let count = storage.getResponsesCount(date);
+    if (window.confirm(`Are you sure you want to remove ${count} unsaved ${pluralise("response", count)} from ${nice_date(date)}?`)) {
       storage.removeResponses(date);
       notifier.page('success', 'Unsaved responses removed!');
       button.closest('.alert').hide();

--- a/app/javascript/packs/transport_surveys.js
+++ b/app/javascript/packs/transport_surveys.js
@@ -1,10 +1,9 @@
 "use strict"
 
 import { storage } from './transport_surveys/storage';
-import { carbonCalc, carbonExamples, carbonEquivalence, pluralise } from './transport_surveys/carbon';
+import { carbonCalc, carbonEquivalence, pluralise } from './transport_surveys/carbon';
 import { notifier } from './transport_surveys/notifier';
 import * as handlebarsHelpers from './transport_surveys/handlebars_helpers';
-
 
 $(document).ready(function() {
 

--- a/app/javascript/packs/transport_surveys.js
+++ b/app/javascript/packs/transport_surveys.js
@@ -1,7 +1,7 @@
 "use strict"
 
 import { storage } from './transport_surveys/storage';
-import { carbonCalc, carbonExamples, funWeight } from './transport_surveys/carbon';
+import { carbonCalc, carbonExamples, carbonEquivalence } from './transport_surveys/carbon';
 import { notifier } from './transport_surveys/notifier';
 import * as handlebarsHelpers from './transport_surveys/handlebars_helpers';
 
@@ -282,13 +282,12 @@ $(document).ready(function() {
 
     let carbon = carbonCalc(transport_type, response['journey_minutes'], response['passengers']);
     let nice_carbon = carbon === 0 ? '0' : carbon.toFixed(3)
-    let fun_weight = funWeight(carbon);
 
     $('#display-time').text(response['journey_minutes']);
     $('#display-transport').text(transport_type.image + " " + transport_type.name);
     $('#display-passengers').text(response['passengers']);
     $('#display-carbon').text(nice_carbon + "kg");
-    $('#display-carbon-equivalent').text(funWeight(carbon));
+    $('#display-carbon-equivalent').text(carbonEquivalence(carbon));
   }
 
 });

--- a/app/javascript/packs/transport_surveys.js
+++ b/app/javascript/packs/transport_surveys.js
@@ -1,8 +1,9 @@
 "use strict"
 
 import { storage } from './transport_surveys/storage';
-import { carbonCalc, carbonEquivalence, pluralise } from './transport_surveys/carbon';
+import { carbon } from './transport_surveys/carbon';
 import { notifier } from './transport_surveys/notifier';
+import { pluralise } from './transport_surveys/helpers';
 import * as handlebarsHelpers from './transport_surveys/handlebars_helpers';
 
 $(document).ready(function() {
@@ -13,8 +14,11 @@ $(document).ready(function() {
     run_on: $("#run_on").val(),
     base_url: $('#transport_survey').attr('action'),
     transport_types: loadTransportTypes('/transport_types.json'),
-    passenger_symbol: $("#passenger_symbol").val()
+    passenger_symbol: $("#passenger_symbol").val(),
+    rates: $('#rates').data()
   }
+
+  carbon.init(config.rates);
 
   if (storage.init({key: config.storage_key, base_url: config.base_url})) {
     setupSurvey();
@@ -279,14 +283,14 @@ $(document).ready(function() {
     let response = readResponse();
     let transport_type = config.transport_types[response['transport_type_id']];
 
-    let carbon = carbonCalc(transport_type, response['journey_minutes'], response['passengers']);
-    let nice_carbon = carbon === 0 ? '0' : carbon.toFixed(3)
+    let co2 = carbon.calc(transport_type, response['journey_minutes'], response['passengers']);
+    let nice_carbon = co2 === 0 ? '0' : co2.toFixed(3)
 
     $('#display-time').text(response['journey_minutes']);
     $('#display-transport').text(transport_type.image + " " + transport_type.name);
     $('#display-passengers').text(response['passengers'] + " " + pluralise("pupil", response['passengers']));
     $('#display-carbon').text(nice_carbon + "kg");
-    $('#display-carbon-equivalent').text(carbonEquivalence(carbon));
+    $('#display-carbon-equivalent').text(carbon.equivalence(co2));
   }
 
 });

--- a/app/javascript/packs/transport_surveys.js
+++ b/app/javascript/packs/transport_surveys.js
@@ -1,7 +1,7 @@
 "use strict"
 
 import { storage } from './transport_surveys/storage';
-import { carbonCalc, carbonExamples, carbonEquivalence } from './transport_surveys/carbon';
+import { carbonCalc, carbonExamples, carbonEquivalence, pluralise } from './transport_surveys/carbon';
 import { notifier } from './transport_surveys/notifier';
 import * as handlebarsHelpers from './transport_surveys/handlebars_helpers';
 
@@ -285,7 +285,7 @@ $(document).ready(function() {
 
     $('#display-time').text(response['journey_minutes']);
     $('#display-transport').text(transport_type.image + " " + transport_type.name);
-    $('#display-passengers').text(response['passengers']);
+    $('#display-passengers').text(response['passengers'] + " " + pluralise("pupil", response['passengers']));
     $('#display-carbon').text(nice_carbon + "kg");
     $('#display-carbon-equivalent').text(carbonEquivalence(carbon));
   }

--- a/app/javascript/packs/transport_surveys/carbon.js
+++ b/app/javascript/packs/transport_surveys/carbon.js
@@ -32,16 +32,26 @@ export const carbonExamples = [
     kgPerActivity: 0.5,
     unit: 'veggie dinner',
     statement: (amount, unit, emoji) => `That\'s the same as ${amount} ${unit} ${emoji}!`,
-  },
+  }
 ];
 
-export const funWeight = function(carbonKgs) {
+export const carbonEquivalence = function(carbonKgs) {
   if (carbonKgs === 0) {
     return "That's Carbon Neutral 🌳!";
   } else {
-    let example = carbonExamples[Math.floor(Math.random() * carbonExamples.length)];
-    let amount = Math.round(carbonKgs / example.kgPerActivity);
-    return example.statement(amount, pluralise(example.unit, amount), example.emoji);
+    // pick random example until one returning a non-zero amount is found
+    var examples = carbonExamples;
+    while (examples.length > 0) {
+      let i = Math.floor(Math.random() * examples.length);
+      let example = examples[i];
+      let amount = Math.round(carbonKgs / example.kgPerActivity);
+      if (amount >= 1) {
+        return example.statement(amount, pluralise(example.unit, amount), example.emoji);
+      } else {
+        examples.splice(i, 1); // remove as tried this example
+      }
+    }
+    return ""; // no equivalence found
   }
 };
 

--- a/app/javascript/packs/transport_surveys/carbon.js
+++ b/app/javascript/packs/transport_surveys/carbon.js
@@ -55,8 +55,8 @@ export const carbonEquivalence = function(carbonKgs) {
   }
 };
 
-const pluralise = function(word, amount = 1) {
-  return `${word}${amount === 1 ? '' : 's'}`;
+export const pluralise = function(word, amount = 1) {
+  return `${word}${amount == 1 ? '' : 's'}`;
 }
 
 const parkAndStrideTimeMins = function(timeMins) {

--- a/app/javascript/packs/transport_surveys/carbon.js
+++ b/app/javascript/packs/transport_surveys/carbon.js
@@ -1,4 +1,3 @@
-
 import { pluralise } from './helpers';
 
 export const carbon = ( function() {

--- a/app/javascript/packs/transport_surveys/carbon.js
+++ b/app/javascript/packs/transport_surveys/carbon.js
@@ -1,88 +1,95 @@
-// Would be nice to pull these straight from Analytics at some point
-const UK_ELECTRIC_GRID_CO2_KG_KWH = 0.230;
-const TREE_CO2_KG_YEAR = 22;
-const TV_POWER_KW = 0.04;
-const COMPUTER_CONSOLE_POWER_KW = 0.2;
-const CARNIVORE_DINNER_CO2_KG = 1.0;
-const VEGETARIAN_DINNER_CO2_KG = 0.5;
-const SMARTPHONE_CHARGE_kWH = 3.6 * 2.0 / 1000.0;
 
-const carbonExamples = [
-  {
-    name: 'Tree',
-    emoji: '🌳',
-    co2_kg: TREE_CO2_KG_YEAR / 365,
-    unit: 'day',
-    statement: (amount, unit, emoji) => `1 tree would absorb this amount of CO2 in ${amount} ${unit} ${emoji}!`,
-  }, {
-    name: 'TV',
-    emoji: '📺',
-    co2_kg: TV_POWER_KW * UK_ELECTRIC_GRID_CO2_KG_KWH,
-    unit: 'hour',
-    statement: (amount, unit, emoji) => `That\'s the same as ${amount} ${unit} of TV ${emoji}!`,
-  }, {
-    name: 'Gaming',
-    emoji: '🎮',
-    co2_kg: COMPUTER_CONSOLE_POWER_KW * UK_ELECTRIC_GRID_CO2_KG_KWH,
-    unit: 'hour',
-    statement: (amount, unit, emoji) => `That\'s the same as playing ${amount} ${unit} of computer games ${emoji}!`,
-  }, {
-    name: 'Meat dinners',
-    emoji: '🍲',
-    co2_kg: CARNIVORE_DINNER_CO2_KG,
-    unit: 'meat dinner',
-    statement: (amount, unit, emoji) => `That\'s the same as ${amount} ${unit} ${emoji}!`,
-  }, {
-    name: 'Veggie dinners',
-    emoji: '🥗',
-    co2_kg: VEGETARIAN_DINNER_CO2_KG,
-    unit: 'veggie dinner',
-    statement: (amount, unit, emoji) => `That\'s the same as ${amount} ${unit} ${emoji}!`,
-  }, {
-    name: 'Smart phones',
-    emoji: '📱',
-    co2_kg: SMARTPHONE_CHARGE_kWH * UK_ELECTRIC_GRID_CO2_KG_KWH,
-    unit: 'smart phone',
-    statement: (amount, unit, emoji) => `That\'s the same as charging ${amount} ${unit} ${emoji}!`,
+import { pluralise } from './helpers';
+
+export const carbon = ( function() {
+
+  var rates = {};
+
+  function init(cfg) {
+    rates = cfg;
   }
-];
 
-const parkAndStrideTimeMins = function(timeMins) {
-  // take 15 mins off a park and stride journey
-  return (timeMins > 15 ? timeMins - 15 : 0);
-};
-
-export const carbonEquivalence = function(carbonKgs) {
-  if (carbonKgs === 0) {
-    return "That's Carbon Neutral 🌳!";
-  } else {
-    // pick random example until one returning a non-zero amount is found
-    var examples = carbonExamples;
-    while (examples.length > 0) {
-      let i = Math.floor(Math.random() * examples.length);
-      let example = examples[i];
-      let amount = Math.round(carbonKgs / example.co2_kg);
-      if (amount >= 1) {
-        return example.statement(amount, pluralise(example.unit, amount), example.emoji);
-      } else {
-        examples.splice(i, 1); // remove as tried this example
-      }
+  const equivalences = [
+    {
+      name: 'tree',
+      emoji: '🌳',
+      unit: 'day',
+      rate: () => rates.tree / 365,
+      statement: (amount, unit, emoji) => `1 tree would absorb this amount of CO2 in ${amount} ${unit} ${emoji}!`,
+    }, {
+      name: 'tv',
+      emoji: '📺',
+      unit: 'hour',
+      rate: () => rates.tv,
+      statement: (amount, unit, emoji) => `That\'s the same as ${amount} ${unit} of TV ${emoji}!`,
+    }, {
+      name: 'computer_console',
+      emoji: '🎮',
+      unit: 'hour',
+      rate: () => rates.computerConsole,
+      statement: (amount, unit, emoji) => `That\'s the same as playing ${amount} ${unit} of computer games ${emoji}!`,
+    }, {
+      name: 'smartphone',
+      emoji: '📱',
+      unit: 'smart phone',
+      rate: () => rates.smartphone,
+      statement: (amount, unit, emoji) => `That\'s the same as charging ${amount} ${unit} ${emoji}!`,
+    } , {
+      name: 'carnivore_dinner',
+      emoji: '🍲',
+      unit: 'meat dinner',
+      rate: () => rates.carnivoreDinner,
+      statement: (amount, unit, emoji) => `That\'s the same as ${amount} ${unit} ${emoji}!`,
+    }, {
+      name: 'vegetarian_dinner',
+      emoji: '🥗',
+      unit: 'veggie dinner',
+      rate: () => rates.vegetarianDinner,
+      statement: (amount, unit, emoji) => `That\'s the same as ${amount} ${unit} ${emoji}!`,
     }
-    return ""; // no equivalence found
-  }
-};
+  ];
 
-export const pluralise = function(word, amount = 1) {
-  return `${word}${amount == 1 ? '' : 's'}`;
-}
-
-export const carbonCalc = function(transport, timeMins, passengers) {
-  if (transport) {
-    timeMins = transport.park_and_stride == true ? parkAndStrideTimeMins(timeMins) : timeMins;
-    var total_carbon = ((transport.speed_km_per_hour * timeMins) / 60) * transport.kg_co2e_per_km;
-    total_carbon = transport.can_share == true ? (total_carbon / passengers) : total_carbon;
-    return total_carbon;
-  } else {
-    return 0;
+  function parkAndStrideTimeMins(timeMins) {
+    // take 15 mins off a park and stride journey
+    return (timeMins > 15 ? timeMins - 15 : 0);
   }
-};
+
+  function equivalence(carbonKgs) {
+    if (carbonKgs === 0) {
+      return "That's Carbon Neutral 🌳!";
+    } else {
+      // pick random equivalence until one returning a non-zero amount is found
+      let tried = [...equivalences.keys()];
+      while (tried.length > 0) {
+        let i = Math.floor(Math.random() * tried.length);
+        let example = equivalences[tried[i]];
+        let amount = Math.round(carbonKgs / example.rate());
+        if (amount >= 1) {
+          return example.statement(amount, pluralise(example.unit, amount), example.emoji);
+        } else {
+          tried.splice(i, 1); // remove as tried this example
+        }
+      }
+      return ""; // no equivalence found
+    }
+  }
+
+  function calc(transport, timeMins, passengers) {
+    if (transport) {
+      timeMins = transport.park_and_stride == true ? parkAndStrideTimeMins(timeMins) : timeMins;
+      var total_carbon = ((transport.speed_km_per_hour * timeMins) / 60) * transport.kg_co2e_per_km;
+      total_carbon = transport.can_share == true ? (total_carbon / passengers) : total_carbon;
+      return total_carbon;
+    } else {
+      return 0;
+    }
+  };
+
+  // public methods
+  return {
+    init: init,
+    calc: calc,
+    equivalence: equivalence
+  }
+
+}());

--- a/app/javascript/packs/transport_surveys/carbon.js
+++ b/app/javascript/packs/transport_surveys/carbon.js
@@ -1,46 +1,37 @@
 // logic mostly lifted from the old app.
 
+
 export const carbonExamples = [
   {
     name: 'Tree',
     emoji: '🌳',
-    equivalentStatement: function(carbonKgs) {
-      const treeAbsorbsionKgPerDay = 0.06;
-      let days = Math.round(carbonKgs / treeAbsorbsionKgPerDay);
-      return `1 tree would absorb this amount of CO2 in ${days} day(s) 🌳!`;
-    }
+    kgPerActivity: 0.06,
+    unit: 'day',
+    statement: (amount, unit, emoji) => `1 tree would absorb this amount of CO2 in ${amount} ${unit} ${emoji}!`,
   }, {
     name: 'TV',
     emoji: '📺',
-    equivalentStatement: function(carbonKgs) {
-      const tvKgPerHour = 0.008;
-      let hours = Math.round(carbonKgs / tvKgPerHour);
-      return `That's the same as ${hours} hour${hours === 1 ? '' : 's'} of TV 📺!`;
-    },
+    kgPerActivity: 0.008,
+    unit: 'hour',
+    statement: (amount, unit, emoji) => `That\'s the same as ${amount} ${unit} of TV! ${emoji}!`,
   }, {
     name: 'Gaming',
     emoji: '🎮',
-    equivalentStatement: function(carbonKgs) {
-      const gamingKgPerHour = 0.008;
-      let hours = Math.round(carbonKgs / gamingKgPerHour);
-      return `That's the same as playing ${hours} hour${hours === 1 ? '' : 's'} of computer games 🎮!`;
-    },
+    kgPerActivity: 0.008,
+    unit: 'hour',
+    statement: (amount, unit, emoji) => `That\'s the same as playing ${amount} ${unit} of computer games! ${emoji}!`,
   }, {
     name: 'Meat dinners',
     emoji: '🍲',
-    equivalentStatement: function(carbonKgs) {
-      const kgPerMeatDinner = 1;
-      let meatDinners = Math.round(carbonKgs / kgPerMeatDinner);
-      return `That's the same as ${meatDinners} meat dinner${meatDinners === 1 ? '' : 's'} 🍲!`;
-    },
+    kgPerActivity: 1,
+    unit: 'meat dinner',
+    statement: (amount, unit, emoji) => `That\'s the same as ${amount} ${unit} ${emoji}!`,
   }, {
     name: 'Veggie dinners',
     emoji: '🥗',
-    equivalentStatement: function(carbonKgs) {
-      const kgPerVeggieDinner = 0.5;
-      let veggieDinners = Math.round(carbonKgs / kgPerVeggieDinner);
-      return `That's the same as ${veggieDinners} veggie dinner${veggieDinners === 1 ? '' : 's'} 🥗!`;
-    },
+    kgPerActivity: 0.5,
+    unit: 'veggie dinner',
+    statement: (amount, unit, emoji) => `That\'s the same as ${amount} ${unit} ${emoji}!`,
   },
 ];
 
@@ -48,10 +39,15 @@ export const funWeight = function(carbonKgs) {
   if (carbonKgs === 0) {
     return "That's Carbon Neutral 🌳!";
   } else {
-    let randomEquivalent = carbonExamples[Math.floor(Math.random() * carbonExamples.length)];
-    return randomEquivalent.equivalentStatement(carbonKgs);
+    let example = carbonExamples[Math.floor(Math.random() * carbonExamples.length)];
+    let amount = Math.round(carbonKgs / example.kgPerActivity);
+    return example.statement(amount, pluralise(example.unit, amount), example.emoji);
   }
 };
+
+const pluralise = function(word, amount = 1) {
+  return `${word}${amount === 1 ? '' : 's'}`;
+}
 
 const parkAndStrideTimeMins = function(timeMins) {
   // take 15 mins off a park and stride journey

--- a/app/javascript/packs/transport_surveys/carbon.js
+++ b/app/javascript/packs/transport_surveys/carbon.js
@@ -1,39 +1,56 @@
-// logic mostly lifted from the old app.
+// Would be nice to pull these straight from Analytics at some point
+const UK_ELECTRIC_GRID_CO2_KG_KWH = 0.230;
+const TREE_CO2_KG_YEAR = 22;
+const TV_POWER_KW = 0.04;
+const COMPUTER_CONSOLE_POWER_KW = 0.2;
+const CARNIVORE_DINNER_CO2_KG = 1.0;
+const VEGETARIAN_DINNER_CO2_KG = 0.5;
+const SMARTPHONE_CHARGE_kWH = 3.6 * 2.0 / 1000.0;
 
-
-export const carbonExamples = [
+const carbonExamples = [
   {
     name: 'Tree',
     emoji: '🌳',
-    kgPerActivity: 0.06,
+    co2_kg: TREE_CO2_KG_YEAR / 365,
     unit: 'day',
     statement: (amount, unit, emoji) => `1 tree would absorb this amount of CO2 in ${amount} ${unit} ${emoji}!`,
   }, {
     name: 'TV',
     emoji: '📺',
-    kgPerActivity: 0.008,
+    co2_kg: TV_POWER_KW * UK_ELECTRIC_GRID_CO2_KG_KWH,
     unit: 'hour',
-    statement: (amount, unit, emoji) => `That\'s the same as ${amount} ${unit} of TV! ${emoji}!`,
+    statement: (amount, unit, emoji) => `That\'s the same as ${amount} ${unit} of TV ${emoji}!`,
   }, {
     name: 'Gaming',
     emoji: '🎮',
-    kgPerActivity: 0.04,
+    co2_kg: COMPUTER_CONSOLE_POWER_KW * UK_ELECTRIC_GRID_CO2_KG_KWH,
     unit: 'hour',
-    statement: (amount, unit, emoji) => `That\'s the same as playing ${amount} ${unit} of computer games! ${emoji}!`,
+    statement: (amount, unit, emoji) => `That\'s the same as playing ${amount} ${unit} of computer games ${emoji}!`,
   }, {
     name: 'Meat dinners',
     emoji: '🍲',
-    kgPerActivity: 1,
+    co2_kg: CARNIVORE_DINNER_CO2_KG,
     unit: 'meat dinner',
     statement: (amount, unit, emoji) => `That\'s the same as ${amount} ${unit} ${emoji}!`,
   }, {
     name: 'Veggie dinners',
     emoji: '🥗',
-    kgPerActivity: 0.5,
+    co2_kg: VEGETARIAN_DINNER_CO2_KG,
     unit: 'veggie dinner',
     statement: (amount, unit, emoji) => `That\'s the same as ${amount} ${unit} ${emoji}!`,
+  }, {
+    name: 'Smart phones',
+    emoji: '📱',
+    co2_kg: SMARTPHONE_CHARGE_kWH * UK_ELECTRIC_GRID_CO2_KG_KWH,
+    unit: 'smart phone',
+    statement: (amount, unit, emoji) => `That\'s the same as charging ${amount} ${unit} ${emoji}!`,
   }
 ];
+
+const parkAndStrideTimeMins = function(timeMins) {
+  // take 15 mins off a park and stride journey
+  return (timeMins > 15 ? timeMins - 15 : 0);
+};
 
 export const carbonEquivalence = function(carbonKgs) {
   if (carbonKgs === 0) {
@@ -44,7 +61,7 @@ export const carbonEquivalence = function(carbonKgs) {
     while (examples.length > 0) {
       let i = Math.floor(Math.random() * examples.length);
       let example = examples[i];
-      let amount = Math.round(carbonKgs / example.kgPerActivity);
+      let amount = Math.round(carbonKgs / example.co2_kg);
       if (amount >= 1) {
         return example.statement(amount, pluralise(example.unit, amount), example.emoji);
       } else {
@@ -58,11 +75,6 @@ export const carbonEquivalence = function(carbonKgs) {
 export const pluralise = function(word, amount = 1) {
   return `${word}${amount == 1 ? '' : 's'}`;
 }
-
-const parkAndStrideTimeMins = function(timeMins) {
-  // take 15 mins off a park and stride journey
-  return (timeMins > 15 ? timeMins - 15 : 0);
-};
 
 export const carbonCalc = function(transport, timeMins, passengers) {
   if (transport) {

--- a/app/javascript/packs/transport_surveys/carbon.js
+++ b/app/javascript/packs/transport_surveys/carbon.js
@@ -17,7 +17,7 @@ export const carbonExamples = [
   }, {
     name: 'Gaming',
     emoji: '🎮',
-    kgPerActivity: 0.008,
+    kgPerActivity: 0.04,
     unit: 'hour',
     statement: (amount, unit, emoji) => `That\'s the same as playing ${amount} ${unit} of computer games! ${emoji}!`,
   }, {

--- a/app/javascript/packs/transport_surveys/handlebars_helpers.js
+++ b/app/javascript/packs/transport_surveys/handlebars_helpers.js
@@ -1,3 +1,5 @@
+import { nice_date } from './helpers';
+
 Handlebars.registerHelper('pluralise', function(number, single, plural) {
   if (number > 1) {
     return plural;
@@ -7,10 +9,5 @@ Handlebars.registerHelper('pluralise', function(number, single, plural) {
 });
 
 Handlebars.registerHelper('nice_date', function(dateString) {
-  let date = moment(dateString);
-  if (date.isSame(moment().format("YYYY-MM-DD"))) {
-    return "today";
-  } else {
-    return date.format("ddd Do MMM YYYY");
-  }
+  return nice_date(dateString);
 });

--- a/app/javascript/packs/transport_surveys/helpers.js
+++ b/app/javascript/packs/transport_surveys/helpers.js
@@ -3,3 +3,12 @@
 export function pluralise(word, amount = 1) {
   return `${word}${amount == 1 ? '' : 's'}`;
 };
+
+export function nice_date(dateString) {
+  let date = moment(dateString);
+  if (date.isSame(moment().format("YYYY-MM-DD"))) {
+    return "today";
+  } else {
+    return date.format("ddd Do MMM YYYY");
+  }
+};

--- a/app/javascript/packs/transport_surveys/helpers.js
+++ b/app/javascript/packs/transport_surveys/helpers.js
@@ -1,0 +1,5 @@
+"use strict"
+
+export function pluralise(word, amount = 1) {
+  return `${word}${amount == 1 ? '' : 's'}`;
+};

--- a/app/models/transport_survey.rb
+++ b/app/models/transport_survey.rb
@@ -53,6 +53,12 @@ class TransportSurvey < ApplicationRecord
     percentage_per_category.collect { |k, v| { name: k.humanize, y: v } }
   end
 
+  def self.equivalence_rates
+    [:tree, :tv, :computer_console, :smartphone, :carnivore_dinner, :vegetarian_dinner].index_with do |type|
+      EnergyEquivalences.all_equivalences[type][:conversions][:co2][:rate]
+    end
+  end
+
   def responses=(responses_attributes)
     responses_attributes.each do |response_attributes|
       self.responses.create_with(response_attributes).find_or_create_by(response_attributes.slice(:run_identifier, :surveyed_at))

--- a/app/views/admin/transport_types/index.html.erb
+++ b/app/views/admin/transport_types/index.html.erb
@@ -21,7 +21,7 @@
       <tr>
         <td><%= transport_type.image %></td>
         <td><%= link_to transport_type.name, admin_transport_type_path(transport_type) %></td>
-        <td><%= transport_type.category.humanize %>
+        <td><%= transport_type.category.try(:humanize) %>
         <td><%= transport_type.speed_km_per_hour %></td>
         <td><%= transport_type.kg_co2e_per_km %></td>
         <td><span class="badge bg-primary text-light"><%= y_n(transport_type.can_share) %></span></td>

--- a/app/views/schools/transport_surveys/edit.html.erb
+++ b/app/views/schools/transport_surveys/edit.html.erb
@@ -15,6 +15,8 @@
   Launch survey app
 </button>
 
+
+
 <div class="modal fade modal-fullscreen-xs modal-fullscreen-sm modal-fullscreen-md" id="transport_survey_modal" data-backdrop="true" data-keyboard="false" tabindex="-1" aria-labelledby="transport_survey_modal_label" aria-hidden="true">
   <div class="modal-dialog modal-xl">
     <div class="modal-content">
@@ -28,6 +30,7 @@
         <div id="app-notifier" role="alert"></div>
 
         <%= form_with(url: school_transport_surveys_url(@school), method: :patch, local: true, id: 'transport_survey') do |f| %>
+          <%= hidden_field_tag :rates, "", data: TransportSurvey.equivalence_rates %>
           <%= hidden_field_tag :run_on, @transport_survey.run_on %>
           <%= hidden_field_tag :run_identifier, TransportSurveyResponse.generate_unique_secure_token %>
           <%= hidden_field_tag :passenger_symbol, TransportSurveyResponse.passenger_symbol %>

--- a/app/views/schools/transport_surveys/edit.html.erb
+++ b/app/views/schools/transport_surveys/edit.html.erb
@@ -99,7 +99,7 @@
             </fieldset>
 
             <fieldset class="panel" style="display: none;">
-              <h2>For your <span id="display-time"></span> minute journey to school by <span id="display-transport"></span> for <span id="display-passengers"></span> pupil(s).</h2>
+              <h2>For your <span id="display-time"></span> minute journey to school by <span id="display-transport"></span> for <span id="display-passengers"></span>.</h2>
               <hr />
               <h2>You used <span id="display-carbon" class="badge badge-secondary"></span> of carbon each!</h2>
               <hr />

--- a/app/views/schools/transport_surveys/edit.html.erb
+++ b/app/views/schools/transport_surveys/edit.html.erb
@@ -15,8 +15,6 @@
   Launch survey app
 </button>
 
-
-
 <div class="modal fade modal-fullscreen-xs modal-fullscreen-sm modal-fullscreen-md" id="transport_survey_modal" data-backdrop="true" data-keyboard="false" tabindex="-1" aria-labelledby="transport_survey_modal_label" aria-hidden="true">
   <div class="modal-dialog modal-xl">
     <div class="modal-content">

--- a/app/views/schools/transport_surveys/responses/index.html.erb
+++ b/app/views/schools/transport_surveys/responses/index.html.erb
@@ -18,7 +18,7 @@
         </tr>
       </thead>
       <tbody>
-        <% @transport_survey.responses.each do |response| %>
+        <% @responses.each do |response| %>
           <tr scope="row">
             <td><%= response.weather_symbol %></td>
             <td><%= response.passengers %></td>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -147,7 +147,7 @@ Rails.application.routes.draw do
       resources :audits
 
       resources :temperature_observations, only: [:show, :new, :create, :index, :destroy]
-      resources :transport_surveys, only: [:show, :edit, :update, :index, :destroy], param: :run_on do
+      resources :transport_surveys, only: [:show, :update, :index, :destroy], param: :run_on do
         collection do
           get :start
         end

--- a/spec/system/schools/transport_surveys_app_spec.rb
+++ b/spec/system/schools/transport_surveys_app_spec.rb
@@ -86,7 +86,7 @@ describe 'TransportSurveys - App', type: :system do
                       let(:carbon) { ((((transport_type.speed_km_per_hour * time) / 60) * transport_type.kg_co2e_per_km) / passengers).round(3) }
 
                       it "displays carbon summary" do
-                        expect(page).to have_content("For your #{time} minute journey to school by #{transport_type.image} #{transport_type.name} for #{passengers} pupil(s).")
+                        expect(page).to have_content("For your #{time} minute journey to school by #{transport_type.image} #{transport_type.name} for #{passengers} #{'pupil'.pluralize(passengers)}.")
                         expect(page).to have_content("You used #{carbon}kg of carbon each!")
                         expect(find("#display-carbon-equivalent")).to_not be_blank #the content of this is random, so this is as far as it can be tested without getting too complex
                       end


### PR DESCRIPTION
This PR revises the carbon calculation & equivalences code as follows:
* Ensures a non-zero equivalence statement is returned
* Now takes the conversion rates from Analytics. I've only taken the rates and not the statements themselves. The statements in analytics seemed a bit too long winded / grown up but I could be wrong.
* Hook pluralisation up in equivalences and in a couple of other places too
* Formats dates better
* Also fixes a results / pagey issue on the responses page
* Also removes unused functionality that allowed users to survey on a day other than today