### PR TITLE
2232 create transifex load service

### DIFF
--- a/app/models/activity_type.rb
+++ b/app/models/activity_type.rb
@@ -57,6 +57,8 @@ class ActivityType < ApplicationRecord
   has_and_belongs_to_many :topics, join_table: :activity_type_topics
   has_and_belongs_to_many :activity_timings, join_table: :activity_type_timings
 
+  scope :transifex_list, -> { active }
+
   scope :active, -> { where(active: true) }
   scope :not_custom, -> { where(custom: false) }
 

--- a/app/models/activity_type.rb
+++ b/app/models/activity_type.rb
@@ -57,8 +57,6 @@ class ActivityType < ApplicationRecord
   has_and_belongs_to_many :topics, join_table: :activity_type_topics
   has_and_belongs_to_many :activity_timings, join_table: :activity_type_timings
 
-  scope :transifex_list, -> { active }
-
   scope :active, -> { where(active: true) }
   scope :not_custom, -> { where(custom: false) }
 

--- a/app/models/transifex_load.rb
+++ b/app/models/transifex_load.rb
@@ -1,0 +1,19 @@
+# == Schema Information
+#
+# Table name: transifex_loads
+#
+#  created_at :datetime         not null
+#  id         :bigint(8)        not null, primary key
+#  pulled     :integer
+#  pushed     :integer
+#  updated_at :datetime         not null
+#
+class TransifexLoad < ApplicationRecord
+  has_many :transifex_load_errors
+
+  scope :by_date, -> { order(created_at: :desc) }
+
+  def errors?
+    transifex_load_errors.any?
+  end
+end

--- a/app/models/transifex_load_error.rb
+++ b/app/models/transifex_load_error.rb
@@ -1,0 +1,23 @@
+# == Schema Information
+#
+# Table name: transifex_load_errors
+#
+#  created_at        :datetime         not null
+#  error             :string
+#  id                :bigint(8)        not null, primary key
+#  record_id         :bigint(8)
+#  record_type       :string
+#  transifex_load_id :bigint(8)        not null
+#  updated_at        :datetime         not null
+#
+# Indexes
+#
+#  transifex_load_error_run_idx  (transifex_load_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (transifex_load_id => transifex_loads.id)
+#
+class TransifexLoadError < ApplicationRecord
+  validates_presence_of :record_type, :record_id, :error
+end

--- a/app/models/transifex_status.rb
+++ b/app/models/transifex_status.rb
@@ -1,3 +1,20 @@
+# == Schema Information
+#
+# Table name: transifex_statuses
+#
+#  created_at    :datetime         not null
+#  id            :bigint(8)        not null, primary key
+#  record_id     :bigint(8)        not null
+#  record_type   :string           not null
+#  tx_created_at :datetime
+#  tx_last_pull  :datetime
+#  tx_last_push  :datetime
+#  updated_at    :datetime         not null
+#
+# Indexes
+#
+#  index_transifex_statuses_uniqueness  (record_type,record_id) UNIQUE
+#
 class TransifexStatus < ApplicationRecord
   validates_presence_of :record_type, :record_id
   validates :record_id, uniqueness: { scope: :record_type }

--- a/app/services/transifex/loader.rb
+++ b/app/services/transifex/loader.rb
@@ -1,0 +1,58 @@
+module Transifex
+  class Loader
+    def initialize(logger = Rails.logger)
+      @logger = logger
+    end
+
+    def perform
+      transifex_load = TransifexLoad.new
+
+      log("Synchronising Activity Types")
+      synchronise_activity_types(transifex_load)
+    end
+
+    private
+
+    def synchronise_activity_types(transifex_load)
+      total_pulled = 0
+      total_pushed = 0
+      ActivityType.transifex_list.each do |at|
+        process_tx_serialisable(transifex_load, at, total_pulled, total_pushed)
+      end
+      #load.update!(
+      #   pushed: load.pushed + total_pushed,
+      #   pulled: load.pulled + total_pulled
+      #)
+    end
+
+    def process_tx_serialisable(transifex_load, tx_serialisable)
+      begin
+        synchroniser = Synchroniser.new(tx_serialisable)
+        synchroniser.pull
+        #total_pulled += 1 if pulled
+        synchroniser.push
+        #total_pushed += 1 if pushed
+      rescue => error
+        log_error(transifex_load, tx_serialisable, error)
+      end
+    end
+
+    def log_error(transifex_load, tx_serialisable, error)
+      Rollbar.error(error,
+        job: :transifex_load,
+        record_type: tx_serialisable.class.name,
+        record_id: tx_serialisable.id
+      )
+      transifex_load.transifex_load_errors.create!(
+        record_type: tx_serialisable.class.name,
+        record_id: tx_serialisable.id,
+        error: error.message
+      )
+    end
+
+    def log(msg)
+      puts msg
+      @logger.info(msg)
+    end
+  end
+end

--- a/app/services/transifex/synchroniser.rb
+++ b/app/services/transifex/synchroniser.rb
@@ -5,14 +5,9 @@ module Transifex
   #Creates and maintains a resource in transifex for the specific active record
   #instance
   class Synchroniser
-    def initialize(tx_serialisable)
+    def initialize(tx_serialisable, locale)
       @tx_serialisable = tx_serialisable
-    end
-
-    def synchronise
-      pulled = pull
-      pushed = push
-      return pulled, pushed
+      @locale = locale
     end
 
     def pull

--- a/db/migrate/20220621094121_create_transifex_loads.rb
+++ b/db/migrate/20220621094121_create_transifex_loads.rb
@@ -1,0 +1,10 @@
+class CreateTransifexLoads < ActiveRecord::Migration[6.0]
+  def change
+    create_table :transifex_loads do |t|
+      t.integer :pushed
+      t.integer :pulled
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20220621094121_create_transifex_loads.rb
+++ b/db/migrate/20220621094121_create_transifex_loads.rb
@@ -1,8 +1,8 @@
 class CreateTransifexLoads < ActiveRecord::Migration[6.0]
   def change
     create_table :transifex_loads do |t|
-      t.integer :pushed
-      t.integer :pulled
+      t.integer :pushed, default: 0, null: false
+      t.integer :pulled, default: 0, null: false
 
       t.timestamps
     end

--- a/db/migrate/20220621094238_create_transifex_load_errors.rb
+++ b/db/migrate/20220621094238_create_transifex_load_errors.rb
@@ -1,0 +1,11 @@
+class CreateTransifexLoadErrors < ActiveRecord::Migration[6.0]
+  def change
+    create_table :transifex_load_errors do |t|
+      t.string :record_type
+      t.bigint :record_id
+      t.string :error
+      t.references :transifex_load, null: false, foreign_key: true, index: { name: :transifex_load_error_run_idx }
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_06_15_090102) do
+ActiveRecord::Schema.define(version: 2022_06_21_094238) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
@@ -1466,6 +1466,23 @@ ActiveRecord::Schema.define(version: 2022_06_15_090102) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "transifex_load_errors", force: :cascade do |t|
+    t.string "record_type"
+    t.bigint "record_id"
+    t.string "error"
+    t.bigint "transifex_load_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["transifex_load_id"], name: "transifex_load_error_run_idx"
+  end
+
+  create_table "transifex_loads", force: :cascade do |t|
+    t.integer "pushed"
+    t.integer "pulled"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
   create_table "transifex_statuses", force: :cascade do |t|
     t.string "record_type", null: false
     t.bigint "record_id", null: false
@@ -1780,6 +1797,7 @@ ActiveRecord::Schema.define(version: 2022_06_15_090102) do
   add_foreign_key "subscription_generation_runs", "schools", on_delete: :cascade
   add_foreign_key "temperature_recordings", "locations", on_delete: :cascade
   add_foreign_key "temperature_recordings", "observations", on_delete: :cascade
+  add_foreign_key "transifex_load_errors", "transifex_loads"
   add_foreign_key "transport_survey_responses", "transport_surveys", on_delete: :cascade
   add_foreign_key "transport_survey_responses", "transport_types"
   add_foreign_key "transport_surveys", "schools", on_delete: :cascade

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1477,8 +1477,8 @@ ActiveRecord::Schema.define(version: 2022_06_21_094238) do
   end
 
   create_table "transifex_loads", force: :cascade do |t|
-    t.integer "pushed"
-    t.integer "pulled"
+    t.integer "pushed", default: 0, null: false
+    t.integer "pulled", default: 0, null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end

--- a/lib/tasks/i18n/copy_analytics_yaml.rake
+++ b/lib/tasks/i18n/copy_analytics_yaml.rake
@@ -1,0 +1,16 @@
+namespace :i18n do
+  desc 'copy YAML files from analytics to prepare a release'
+  task :copy_analytics_yaml, :dir do |t,args|
+    #provide a sensible default if not specified
+    args.with_defaults(dir: Rails.root.join('config', 'locales', 'analytics'))
+    dest = args.dir
+
+    analytics_gem_path = `bundle info energy-sparks_analytics --path`.chomp
+    analytics_yaml = File.join(analytics_gem_path, 'config', 'locales')
+    $stderr.puts "Copying files from #{dest} to #{analytics_yaml}"
+
+    FileUtils.cp_r "#{analytics_yaml}/.", dest
+
+    $stderr.puts "Done. Check in the updated files before the release"
+  end
+end

--- a/lib/tasks/i18n/generate_tx_config.rake
+++ b/lib/tasks/i18n/generate_tx_config.rake
@@ -1,25 +1,8 @@
 namespace :i18n do
-
-  desc 'copy YAML files from analytics to prepare a release'
-  task :copy_analytics_yaml, :dir do |t,args|
-    #provide a sensible default if not specified
-    args.with_defaults(dir: Rails.root.join('config', 'locales', 'analytics'))
-    dest = args.dir
-
-    analytics_gem_path = `bundle info energy-sparks_analytics --path`.chomp
-    analytics_yaml = File.join(analytics_gem_path, 'config', 'locales')
-    $stderr.puts "Copying files from #{dest} to #{analytics_yaml}"
-
-    FileUtils.cp_r "#{analytics_yaml}/.", dest
-
-    $stderr.puts "Done. Check in the updated files before the release"
-  end
-
   desc 'generate transifex config .tx/config'
   task :generate_tx_config, :dir do |t,args|
     args.with_defaults(dir: Rails.root.join('.tx'))
     dest = args.dir
-
     FileUtils.mkdir_p(dest)
     File.open(File.join(dest, "config"), "w") do |f|
       f.puts "[main]"
@@ -37,7 +20,5 @@ namespace :i18n do
         f.puts
       end
     end
-
   end
-
 end

--- a/lib/tasks/i18n/transifex_load.rake
+++ b/lib/tasks/i18n/transifex_load.rake
@@ -1,0 +1,16 @@
+namespace :i18n do
+  desc 'run transifex loader to synchronise content from the database'
+  task :transifex_load do
+    puts "#{DateTime.now.utc} transifex_load start"
+    begin
+      Transifex::Loader.new.perform
+    rescue => e
+      puts "Exception: running transifex_load: #{e.class} #{e.message}"
+      puts e.backtrace.join("\n")
+      Rails.logger.error "Exception: running transifex_load: #{e.class} #{e.message}"
+      Rails.logger.error e.backtrace.join("\n")
+      Rollbar.error(e, job: :transifex_load)
+    end
+    puts "#{DateTime.now.utc} transifex_load end"
+  end
+end

--- a/spec/factories/transifex_load_errors.rb
+++ b/spec/factories/transifex_load_errors.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :transifex_load_error do
+    record_type { "" }
+    record_id { "" }
+    error { "MyString" }
+  end
+end

--- a/spec/factories/transifex_loads.rb
+++ b/spec/factories/transifex_loads.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :transifex_load do
+    pushed { 1 }
+    pulled { 1 }
+  end
+end

--- a/spec/services/transifex/loader_spec.rb
+++ b/spec/services/transifex/loader_spec.rb
@@ -1,0 +1,55 @@
+require 'rails_helper'
+
+describe Transifex::Loader, type: :service do
+
+  let(:service)                  { Transifex::Loader.new }
+
+  describe 'synchronising resources' do
+    let!(:activity_type) { create(:activity_type, active: true) }
+
+    it 'creates a transifex load record' do
+      expect{ service.perform }.to change(TransifexLoad, :count).by(1)
+    end
+
+    context 'when there are errors' do
+      before(:each) do
+        allow_any_instance_of(Transifex::Synchroniser).to receive(:pull).and_raise("Sync error")
+      end
+      it 'logs errors in the database' do
+        expect{ service.perform }.to change(TransifexLoadError, :count).by(1)
+        expect(TransifexLoadError.first.record_type).to eq("ActivityType")
+        expect(TransifexLoadError.first.record_id).to eq activity_type.id
+        expect(TransifexLoadError.first.error).to eq("Sync error")
+      end
+      it 'logs errors in Rollbar' do
+        expect(Rollbar).to receive(:error).with(an_instance_of(RuntimeError), job: :transifex_load, record_type: "ActivityType", record_id: activity_type.id)
+        service.perform
+      end
+    end
+
+    context 'when there are no errors' do
+      let!(:activity_type2) { create(:activity_type, active: true) }
+
+      before(:each) do
+        allow_any_instance_of(Transifex::Synchroniser).to receive(:pull).and_return(true)
+        allow_any_instance_of(Transifex::Synchroniser).to receive(:push).and_return(true)
+
+        service.perform
+      end
+
+      it 'updates the pull count' do
+        expect(TransifexLoad.first.pulled).to eq 2
+      end
+
+      it 'updates the push count' do
+        expect(TransifexLoad.first.pushed).to eq 2
+      end
+    end
+
+  end
+
+  describe 'synchronising collections' do
+    it 'pulls the collection'
+    it 'pushes the collection'
+  end
+end

--- a/spec/services/transifex/synchroniser_spec.rb
+++ b/spec/services/transifex/synchroniser_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe Transifex::Synchroniser, type: :service do
 
   let(:activity_type) { create(:activity_type) }
-  let(:service)     { Transifex::Synchroniser.new(activity_type) }
+  let(:service)     { Transifex::Synchroniser.new(activity_type, :cy) }
   let(:resource_key)  { activity_type.resource_key }
 
   describe '#last_pushed' do
@@ -249,48 +249,4 @@ describe Transifex::Synchroniser, type: :service do
       end
     end
   end
-
-  describe '#synchronise' do
-    let(:tx_created_at)  { nil }
-    let(:tx_last_pushed) { nil }
-    let!(:status) { create(:transifex_status, record_type: "ActivityType", record_id: activity_type.id, tx_created_at: tx_created_at, tx_last_push: tx_last_pushed)}
-
-    context 'not created yet' do
-      before(:each) do
-        expect_any_instance_of(Transifex::Service).to receive(:create_resource).and_return true
-        expect_any_instance_of(Transifex::Service).to receive(:push).and_return true
-      end
-
-      it 'only does a push' do
-        pulled, pushed = service.synchronise
-        expect(pulled).to eq false
-        expect(pushed).to eq true
-        status.reload
-        expect(status.tx_created_at).to_not be_nil
-      end
-    end
-    context 'when changes to pull and no changes to push' do
-      let(:tx_created_at) { Date.today }
-      let(:tx_last_pushed) { Time.zone.now }
-      let(:translations) { {
-          :cy => {
-            resource_key => {}
-           }
-         }
-      }
-      before(:each) do
-        expect_any_instance_of(Transifex::Service).to receive(:reviews_completed?).and_return true
-        expect_any_instance_of(Transifex::Service).to receive(:pull).and_return(translations)
-      end
-
-      it 'does a pull only' do
-        pulled, pushed = service.synchronise
-        expect(pulled).to eq true
-        expect(pushed).to eq false
-        status.reload
-        expect(status.tx_last_pull).to_not be_nil
-      end
-    end
-  end
-
 end


### PR DESCRIPTION
* Adds a new Transifex::Loader which can iterate over a list of tx_serialisable objects and request the Transifex::Synchroniser to synchronise them
* Initially only synchronises activity types
* Adds database models for logging the results of a run (total pulls and pushes) as well as per record errors
* Removes the Transifex::Synchronise.synchronise method as its not really needed.