### PR TITLE
Use string keys when serialising to/from YAML

### DIFF
--- a/app/models/concerns/transifex_serialisable.rb
+++ b/app/models/concerns/transifex_serialisable.rb
@@ -22,23 +22,22 @@ module TransifexSerialisable
   # { attribute_name: {templated: true, html: true} }
   def tx_serialise
     attribs = {}
-    self.class.mobility_attributes.map(&:to_sym).each do |attr|
+    self.class.mobility_attributes.map.each do |attr|
       attr_key = tx_attribute_key(attr)
       attribs[attr_key] = tx_value(attr)
     end
     data = { resource_key => attribs }
-    return { en: data }
+    return { "en": data }
   end
 
   #Update the model using data from transifex
   def tx_update(data, locale)
     raise "Unexpected locale" unless I18n.available_locales.include?(locale)
-    raise "Unexpected i18n format" unless data[locale].present? && !data[locale][resource_key].nil?
+    raise "Unexpected i18n format" unless data[locale.to_s].present? && !data[locale.to_s][resource_key].nil?
 
-    translated_attributes = self.class.mobility_attributes.map(&:to_sym)
+    translated_attributes = self.class.mobility_attributes
     to_update = {}
-    tx_attributes = data[locale][resource_key]
-    tx_attributes.symbolize_keys!
+    tx_attributes = data[locale.to_s][resource_key]
     tx_attributes.each_key do |attr|
       #ignore any attributes that aren't translated
       if translated_attributes.include?(attr)
@@ -86,7 +85,7 @@ module TransifexSerialisable
   end
 
   def tx_attribute_key(attr)
-    self.class.tx_html_field?(attr) ? "#{attr}_html".to_sym : attr
+    self.class.tx_html_field?(attr) ? "#{attr}_html" : attr
   end
 
   def tx_value(attr)
@@ -96,7 +95,7 @@ module TransifexSerialisable
   end
 
   def resource_key
-    "#{self.class.model_name.i18n_key}_#{self.id}".to_sym
+    "#{self.class.model_name.i18n_key}_#{self.id}"
   end
 
   private
@@ -113,7 +112,7 @@ module TransifexSerialisable
   module ClassMethods
     def tx_attribute_mapping(attr)
       return {} unless const_defined?(:TX_ATTRIBUTE_MAPPING)
-      const_get(:TX_ATTRIBUTE_MAPPING).key?(attr) ? const_get(:TX_ATTRIBUTE_MAPPING)[attr] : {}
+      const_get(:TX_ATTRIBUTE_MAPPING).key?(attr.to_sym) ? const_get(:TX_ATTRIBUTE_MAPPING)[attr.to_sym] : {}
     end
 
     def tx_html_field?(attr)

--- a/spec/models/activity_type_spec.rb
+++ b/spec/models/activity_type_spec.rb
@@ -96,26 +96,26 @@ describe 'ActivityType' do
     context 'when mapping fields' do
       let!(:activity_type) { create(:activity_type, name: "My activity", description: "description", school_specific_description: "Description {{chart}}")}
       it 'produces the expected key names' do
-        expect(activity_type.tx_attribute_key(:name)).to eq :name
-        expect(activity_type.tx_attribute_key(:description)).to eq :description_html
-        expect(activity_type.tx_attribute_key(:school_specific_description)).to eq :school_specific_description_html
-        expect(activity_type.tx_attribute_key(:download_links)).to eq :download_links_html
+        expect(activity_type.tx_attribute_key("name")).to eq "name"
+        expect(activity_type.tx_attribute_key("description")).to eq "description_html"
+        expect(activity_type.tx_attribute_key("school_specific_description")).to eq "school_specific_description_html"
+        expect(activity_type.tx_attribute_key("download_links")).to eq "download_links_html"
       end
       it 'produces the expected tx values' do
-        expect(activity_type.tx_value(:name)).to eql activity_type.name
-        expect(activity_type.tx_value(:description)).to eql(
+        expect(activity_type.tx_value("name")).to eql activity_type.name
+        expect(activity_type.tx_value("description")).to eql(
         "<div class=\"trix-content\">\n  description\n</div>\n")
-        expect(activity_type.tx_value(:school_specific_description)).to eql("<div class=\"trix-content\">\n  Description %{chart}\n</div>\n")
+        expect(activity_type.tx_value("school_specific_description")).to eql("<div class=\"trix-content\">\n  Description %{chart}\n</div>\n")
       end
       it 'produces the expected resource key' do
-        expect(activity_type.resource_key).to eq "activity_type_#{activity_type.id}".to_sym
+        expect(activity_type.resource_key).to eq "activity_type_#{activity_type.id}"
       end
       it 'maps all translated fields' do
         data = activity_type.tx_serialise
         expect(data[:en]).to_not be nil
-        key = "activity_type_#{activity_type.id}".to_sym
+        key = "activity_type_#{activity_type.id}"
         expect(data[:en][key]).to_not be nil
-        expect(data[:en][key].keys).to match_array([:name, :description_html, :school_specific_description_html, :download_links_html])
+        expect(data[:en][key].keys).to match_array(["name", "description_html", "school_specific_description_html", "download_links_html"])
       end
       it 'created categories' do
         expect(activity_type.tx_categories).to match_array(["activity_type"])
@@ -130,37 +130,37 @@ describe 'ActivityType' do
         expect(activity_type.tx_status).to eq status
       end
     end
-    context 'when updating from transifex' do
-      let(:resource_key) { "activity_type_#{subject.id}".to_sym }
-      let(:name) { subject.name }
-      let(:description) { subject.description }
-      let(:school_specific_description) { subject.school_specific_description}
-      let(:data) { {
-        :cy => {
-           resource_key => {
-             name: "Welsh name",
-             description: "The Welsh description",
-             school_specific_description: "Instructions for schools. %{chart|£}"
-           }
+  end
+  context 'when updating from transifex' do
+    let(:resource_key) { "activity_type_#{subject.id}" }
+    let(:name) { subject.name }
+    let(:description) { subject.description }
+    let(:school_specific_description) { subject.school_specific_description}
+    let(:data) { {
+      "cy" => {
+         resource_key => {
+           "name" => "Welsh name",
+           "description" => "The Welsh description",
+           "school_specific_description" => "Instructions for schools. %{chart|£}"
          }
        }
-      }
-      before(:each) do
-        subject.tx_update(data, :cy)
-        subject.reload
-      end
-      it 'updates simple fields' do
-        expect(subject.name).to eq name
-        expect(subject.name_cy).to eq "Welsh name"
-      end
-      it 'updates HTML fields' do
-        expect(subject.description).to eq description
-        expect(subject.description_cy.to_s).to eql("<div class=\"trix-content\">\n  The Welsh description\n</div>\n")
-      end
-      it 'translates the template syntax' do
-        expect(subject.school_specific_description).to eq school_specific_description
-        expect(subject.school_specific_description_cy.to_s).to eql("<div class=\"trix-content\">\n  Instructions for schools. {{chart|£}}\n</div>\n")
-      end
+     }
+    }
+    before(:each) do
+      subject.tx_update(data, :cy)
+      subject.reload
+    end
+    it 'updates simple fields' do
+      expect(subject.name).to eq name
+      expect(subject.name_cy).to eq "Welsh name"
+    end
+    it 'updates HTML fields' do
+      expect(subject.description).to eq description
+      expect(subject.description_cy.to_s).to eql("<div class=\"trix-content\">\n  The Welsh description\n</div>\n")
+    end
+    it 'translates the template syntax' do
+      expect(subject.school_specific_description).to eq school_specific_description
+      expect(subject.school_specific_description_cy.to_s).to eql("<div class=\"trix-content\">\n  Instructions for schools. {{chart|£}}\n</div>\n")
     end
   end
 end

--- a/spec/services/transifex/synchroniser_spec.rb
+++ b/spec/services/transifex/synchroniser_spec.rb
@@ -280,7 +280,7 @@ describe Transifex::Synchroniser, type: :service do
       let(:tx_created_at) { Date.today }
       let(:tx_last_pushed) { Time.zone.now }
       let(:translations) { {
-          :cy => {
+          "cy" => {
             resource_key => {}
            }
          }

--- a/spec/services/transifex/synchroniser_spec.rb
+++ b/spec/services/transifex/synchroniser_spec.rb
@@ -147,9 +147,9 @@ describe Transifex::Synchroniser, type: :service do
     context 'when translations are reviewed' do
       let(:resource_key)  { activity_type.resource_key }
       let(:translations) { {
-          :cy => {
+          "cy" => {
             resource_key => {
-              name: "Welsh name"
+              "name" => "Welsh name"
             }
            }
          }
@@ -189,7 +189,7 @@ describe Transifex::Synchroniser, type: :service do
       let(:yesterday)      { Date.today - 1 }
       let(:tx_last_pulled) { yesterday }
       let(:translations) { {
-          :cy => {
+          "cy" => {
             resource_key => {}
            }
          }


### PR DESCRIPTION
Changes to use string based keys in the hash generated by `tx_serialise` and assumes string keys in `tx_update` this makes it compatible with round-tripping to Transifex.

Locale parameter remains a symbol, e.g. `:cy` to match what is returned by, e.g. `I18n.available_locales`.