### PR TITLE
Change push logic to avoid pushing immediately after a pull

### DIFF
--- a/app/services/transifex/synchroniser.rb
+++ b/app/services/transifex/synchroniser.rb
@@ -61,7 +61,15 @@ module Transifex
 
     #Has the model been updated since it was last pushed?
     def updated_since_last_pushed?
-      return @tx_serialisable.updated_at > last_pushed
+      #If we've just done a pull then we don't want to trigger an update, as all
+      #that's happened is the translated fields have been updated.
+      #So check if the update is after the pull timestamp AND since we last pushed
+      if last_pulled.present?
+        return @tx_serialisable.updated_at > last_pulled && @tx_serialisable.updated_at > last_pushed
+      else
+        #just check the timestamp
+        return @tx_serialisable.updated_at > last_pushed
+      end
     end
 
     #Has the resource been updated in Transifex since it was last pulled?

--- a/app/services/transifex/synchroniser.rb
+++ b/app/services/transifex/synchroniser.rb
@@ -10,12 +10,6 @@ module Transifex
       @locale = locale
     end
 
-    def synchronise
-      pulled = pull
-      pushed = push
-      return pulled, pushed
-    end
-
     def pull
       if created_in_transifex? && reviews_completed? && (last_pulled.nil? || translations_updated_since_last_pull?)
         data = transifex_service.pull(@tx_serialisable.tx_slug, @locale)

--- a/spec/services/transifex/synchroniser_spec.rb
+++ b/spec/services/transifex/synchroniser_spec.rb
@@ -256,48 +256,4 @@ describe Transifex::Synchroniser, type: :service do
     end
   end
 
-  describe '#synchronise' do
-    let(:tx_created_at)  { nil }
-    let(:tx_last_pushed) { nil }
-    let(:tx_last_pulled) { nil }
-    let!(:status) { create(:transifex_status, record_type: "ActivityType", record_id: activity_type.id, tx_created_at: tx_created_at, tx_last_push: tx_last_pushed, tx_last_pull: tx_last_pulled)}
-
-    context 'not created yet' do
-      before(:each) do
-        expect_any_instance_of(Transifex::Service).to receive(:create_resource).and_return true
-        expect_any_instance_of(Transifex::Service).to receive(:push).and_return true
-      end
-
-      it 'only does a push' do
-        pulled, pushed = service.synchronise
-        expect(pulled).to eq false
-        expect(pushed).to eq true
-        status.reload
-        expect(status.tx_created_at).to_not be_nil
-      end
-    end
-    context 'when changes to pull and no changes to push' do
-      let(:tx_created_at) { Date.today }
-      let(:tx_last_pushed) { Time.zone.now }
-      let(:translations) { {
-          "cy" => {
-            resource_key => {}
-           }
-         }
-      }
-      before(:each) do
-        expect_any_instance_of(Transifex::Service).to receive(:reviews_completed?).and_return true
-        expect_any_instance_of(Transifex::Service).to receive(:pull).and_return(translations)
-      end
-
-      it 'does a pull only' do
-        pulled, pushed = service.synchronise
-        expect(pulled).to eq true
-        expect(pushed).to eq false
-        status.reload
-        expect(status.tx_last_pull).to_not be_nil
-      end
-    end
-  end
-
 end

--- a/spec/services/transifex/synchroniser_spec.rb
+++ b/spec/services/transifex/synchroniser_spec.rb
@@ -196,7 +196,7 @@ describe Transifex::Synchroniser, type: :service do
       let(:tx_last_pulled) { yesterday }
       let(:translations) { {
           "cy" => {
-            resource_key => {}
+            resource_key => {"name": "Updated"}
            }
          }
       }
@@ -210,6 +210,12 @@ describe Transifex::Synchroniser, type: :service do
         expect(service.pull).to be true
         status.reload
         expect(status.tx_last_pull).to_not eq yesterday
+      end
+
+      it 'wont push after that pull' do
+        status.update!(tx_last_push: yesterday)
+        expect(service.pull).to be true
+        expect(service.push).to be false
       end
     end
   end
@@ -255,5 +261,4 @@ describe Transifex::Synchroniser, type: :service do
       end
     end
   end
-
 end


### PR DESCRIPTION
If we have just pulled down some updated translations then the ActivityType (or other record) will have been updated.

We don't want to immediately trigger a push based on that, so we need to check both the dates of last push and pull before deciding whether we have a local change.