### PR TITLE
Fix handling of custom tags

### DIFF
--- a/app/models/concerns/transifex_serialisable.rb
+++ b/app/models/concerns/transifex_serialisable.rb
@@ -1,4 +1,5 @@
 module TransifexSerialisable
+  # rubocop:disable Style/RegexpLiteral
   extend ActiveSupport::Concern
 
   TRIX_DIV = "<div class=\"trix-content\">".freeze
@@ -120,13 +121,14 @@ module TransifexSerialisable
     value.start_with?(TRIX_DIV) ? value.gsub(TRIX_DIV, '').chomp(CLOSE_DIV) : value
   end
 
-  #TODO this needs work
   def yaml_template_to_mustache(value)
-    value.gsub(/%{/, "{{").gsub(/}/, "}}")
+    value.gsub(/%{([a-z0-9_|£]+)}/, '{{#chart}}\1{{/chart}}')
   end
 
+  #we only have a single custom Mustache tag, see SchoolTemplate
+  #we will need to do something more sophisticated if we add more
   def mustache_to_yaml(value)
-    value.gsub(/{{/, "%{").gsub(/}}/, "}")
+    value.gsub(/{{#chart}}([a-z0-9_|£]+){{\/chart}}/, '%{\1}')
   end
 
   module ClassMethods
@@ -154,4 +156,5 @@ module TransifexSerialisable
       reflect_on_all_associations(:has_one).collect(&:name).include?("rich_text_#{name}".to_sym)
     end
   end
+  # rubocop:enable Style/RegexpLiteral
 end

--- a/spec/models/activity_type_spec.rb
+++ b/spec/models/activity_type_spec.rb
@@ -94,7 +94,7 @@ describe 'ActivityType' do
 
   context 'serialising for transifex' do
     context 'when mapping fields' do
-      let!(:activity_type) { create(:activity_type, name: "My activity", description: "description", school_specific_description: "Description {{chart}}")}
+      let!(:activity_type) { create(:activity_type, name: "My activity", description: "description", school_specific_description: "Description {{#chart}}chart_name{{/chart}} {{#chart}}chart_name2|£{{/chart}}")}
       it 'produces the expected key names' do
         expect(activity_type.tx_attribute_key("name")).to eq "name"
         expect(activity_type.tx_attribute_key("description")).to eq "description_html"
@@ -104,7 +104,7 @@ describe 'ActivityType' do
       it 'produces the expected tx values, removing trix content wrapper' do
         expect(activity_type.tx_value("name")).to eql activity_type.name
         expect(activity_type.tx_value("description")).to eql("description")
-        expect(activity_type.tx_value("school_specific_description")).to eql("Description %{chart}")
+        expect(activity_type.tx_value("school_specific_description")).to eql("Description %{chart_name} %{chart_name2|£}")
       end
       it 'produces the expected resource key' do
         expect(activity_type.resource_key).to eq "activity_type_#{activity_type.id}"
@@ -140,7 +140,7 @@ describe 'ActivityType' do
          resource_key => {
            "name" => "Welsh name",
            "description_html" => "The Welsh description",
-           "school_specific_description_html" => "Instructions for schools. %{chart|£}"
+           "school_specific_description_html" => "Instructions for schools. %{chart_name|£}"
          }
        }
      }
@@ -159,7 +159,7 @@ describe 'ActivityType' do
     end
     it 'translates the template syntax' do
       expect(subject.school_specific_description).to eq school_specific_description
-      expect(subject.school_specific_description_cy.to_s).to eql("<div class=\"trix-content\">\n  Instructions for schools. {{chart|£}}\n</div>\n")
+      expect(subject.school_specific_description_cy.to_s).to eql("<div class=\"trix-content\">\n  Instructions for schools. {{#chart}}chart_name|£{{/chart}}\n</div>\n")
     end
   end
 end


### PR DESCRIPTION
Thought the syntax was `{{...}}` but its: `{{#chart}...{{/chart}}` so fixed the regexp. 