### PR TITLE
Make response survey time locale aware

### DIFF
--- a/app/javascript/packs/transport_surveys.js
+++ b/app/javascript/packs/transport_surveys.js
@@ -226,7 +226,7 @@ $(document).ready(function() {
       response[element] = $("#" + element).val();
     }
     response['passengers'] ||= 1;
-    response['surveyed_at'] = moment().toISOString(true);
+    response['surveyed_at'] = moment().toISOString();
     return response;
   }
 

--- a/app/views/schools/transport_surveys/responses/index.html.erb
+++ b/app/views/schools/transport_surveys/responses/index.html.erb
@@ -25,7 +25,7 @@
             <td><%= response.transport_type.image %> <%= response.transport_type.name %></td>
             <td><%= response.passengers > 1 ? response.passengers : "" %></td>
             <td><%= response.carbon.round(3) %>kg CO2</td>
-            <td><%= nice_date_times response.surveyed_at %></td>
+            <td><%= nice_date_times response.surveyed_at.localtime %></td>
             <% if can? :delete, response %>
               <td><%= link_to 'Delete', school_transport_survey_response_path(@school, @transport_survey, response), method: :delete, data: { confirm: 'Are you sure?' }, class: 'btn btn-sm btn-danger' %></td>
             <% end %>


### PR DESCRIPTION
There was an issue where the response surveyed_at times were out by an hour. I thought I had fixed it but alas, no.
After some investigation, it looks like DateTimes in the database are stored as UTC and also displayed as UTC by default (sounds obvious now I say it I know). Which is fine in the winter but not BST. This PR makes sure the dates are sent from the javascript in UTC and then formatted in localtime when displayed in rails.