### PR TITLE
Display transport survey response times in London time zone

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -3,8 +3,9 @@ require 'pagy/extras/bootstrap'
 module ApplicationHelper
   include Pagy::Frontend
 
-  def nice_date_times(datetime)
+  def nice_date_times(datetime, options = {})
     return "" if datetime.nil?
+    datetime = datetime.in_time_zone(Rails.application.config.display_timezone) if options[:localtime] && Rails.application.config.display_timezone
     "#{datetime.strftime('%a')} #{datetime.day.ordinalize} #{datetime.strftime('%b %Y %H:%M')} "
   end
 

--- a/app/views/schools/transport_surveys/responses/index.html.erb
+++ b/app/views/schools/transport_surveys/responses/index.html.erb
@@ -25,7 +25,7 @@
             <td><%= response.transport_type.image %> <%= response.transport_type.name %></td>
             <td><%= response.passengers > 1 ? response.passengers : "" %></td>
             <td><%= response.carbon.round(3) %>kg CO2</td>
-            <td><%= nice_date_times response.surveyed_at.localtime %></td>
+            <td><%= nice_date_times response.surveyed_at, localtime: true %></td>
             <% if can? :delete, response %>
               <td><%= link_to t('common.labels.delete'), school_transport_survey_response_path(@school, @transport_survey, response), method: :delete, data: { confirm:  t('common.confirm') }, class: 'btn btn-sm btn-danger' %></td>
             <% end %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -28,6 +28,9 @@ module EnergySparks
     # HAS to be UTC for group by date to work
     config.active_record.default_timezone = :utc
 
+    # For our application date helpers to use to optionally display times in configured zone
+    config.display_timezone = 'London'
+
     config.middleware.use Rack::Attack
     config.middleware.use Rack::XRobotsTag
 

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -129,4 +129,37 @@ describe ApplicationHelper do
       expect(helper.spinner_icon).to include('fa-spinner fa-spin')
     end
   end
+
+  describe 'nice_date_times' do
+    let(:utc_date_time) { Time.zone.now }
+    let(:utc_nice_date_time) { nice_date_times(utc_date_time) }
+
+    context "localtime option is true" do
+      subject { nice_date_times(utc_date_time, localtime: true) }
+
+      context "and display_timezone config option is not set" do
+        before { Rails.application.config.display_timezone = nil }
+        it { expect(subject).to eql(utc_nice_date_time) }
+      end
+      context "and display_timezone config option is set" do
+        before { Rails.application.config.display_timezone = "Saskatchewan" }
+        it { expect(subject).to_not eql(utc_nice_date_time) }
+      end
+    end
+
+    context "localtime option is false" do
+      subject { nice_date_times(utc_date_time, localtime: false) }
+
+      context "and display_timezone config option is set" do
+        before { Rails.application.config.display_timezone = "Saskatchewan" }
+        it { expect(subject).to eql(utc_nice_date_time) }
+      end
+    end
+
+    context "when date is nil" do
+      subject {nice_date_times(nil)}
+      it { expect(nice_date_times(nil)).to be_blank }
+    end
+  end
+
 end

--- a/spec/system/schools/transport_surveys_spec.rb
+++ b/spec/system/schools/transport_surveys_spec.rb
@@ -148,7 +148,7 @@ describe 'TransportSurveys', type: :system do
             end
 
             it "displays added response" do
-              expect(page).to have_content(nice_date_times(transport_survey_response.surveyed_at.localtime))
+              expect(page).to have_content(nice_date_times(transport_survey_response.surveyed_at, localtime: true))
             end
 
             context "and deleting response" do
@@ -158,7 +158,7 @@ describe 'TransportSurveys', type: :system do
                 end
               end
               it "removes response" do
-                expect(page).to_not have_content(nice_date_times(transport_survey_response.surveyed_at.localtime))
+                expect(page).to_not have_content(nice_date_times(transport_survey_response.surveyed_at, localtime: true))
               end
             end
           end


### PR DESCRIPTION
This one is up here for discussion really. I could have just used datetime.in_time_zone('London') in the code where the time needed presenting in the right zone, but I already needed to do it 3 times for this bit of code, so it seemed right to attempt to make it configurable and reusable.
* I added a config item in application.rb for the display_timezone. Not sure how you feel about this going in here - seemed like as good a place as any for configuration but I might have missed somewhere else that is in use.
* Allow nice_date_times helper method to use the timezone if configured (and has the option localtime: true passed). These changes shouldn't affect any other times presented by nice_date_times helper as it is.

I know we will be revisiting this soon for i18n so it's not particularly good timing for this. Happy to just go back to datetime.in_time_zone('London') being in the code if you'd rather! 