### PR TITLE
Translate transport type name

### DIFF
--- a/app/controllers/admin/transport_types_controller.rb
+++ b/app/controllers/admin/transport_types_controller.rb
@@ -1,5 +1,6 @@
 module Admin
   class TransportTypesController < AdminController
+    include LocaleHelper
     load_and_authorize_resource
 
     def index
@@ -32,7 +33,8 @@ module Admin
     private
 
     def transport_type_params
-      params.require(:transport_type).permit(:name, :category, :image, :kg_co2e_per_km, :speed_km_per_hour, :can_share, :park_and_stride, :position, :note)
+      translated_params = t_params(TransportType.mobility_attributes)
+      params.require(:transport_type).permit(translated_params, :name, :category, :image, :kg_co2e_per_km, :speed_km_per_hour, :can_share, :park_and_stride, :position, :note)
     end
   end
 end

--- a/app/controllers/schools/transport_surveys/responses_controller.rb
+++ b/app/controllers/schools/transport_surveys/responses_controller.rb
@@ -9,7 +9,7 @@ module Schools
 
       def destroy
         @response.destroy
-        redirect_to school_transport_survey_responses_url(@school, @transport_survey), notice: "Transport survey response was successfully removed."
+        redirect_to school_transport_survey_responses_url(@school, @transport_survey), notice: t('schools.transport_surveys.responses.destroy.notice')
       end
 
       def index

--- a/app/controllers/schools/transport_surveys_controller.rb
+++ b/app/controllers/schools/transport_surveys_controller.rb
@@ -36,7 +36,7 @@ module Schools
 
     def destroy
       @transport_survey.destroy
-      redirect_to school_transport_surveys_url(@school), notice: "Transport survey was successfully destroyed."
+      redirect_to school_transport_surveys_url(@school), notice: t('schools.transport_surveys.destroy.notice')
     end
 
     private

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -6,7 +6,7 @@ module ApplicationHelper
   def nice_date_times(datetime, options = {})
     return "" if datetime.nil?
     datetime = datetime.in_time_zone(Rails.application.config.display_timezone) if options[:localtime] && Rails.application.config.display_timezone
-    "#{datetime.strftime('%a')} #{datetime.day.ordinalize} #{datetime.strftime('%b %Y %H:%M')} "
+    "#{datetime.strftime('%a')} #{datetime.day.ordinalize} #{datetime.strftime('%b %Y %H:%M')}"
   end
 
   def nice_times_only(datetime)

--- a/app/models/transport_type.rb
+++ b/app/models/transport_type.rb
@@ -20,6 +20,9 @@
 #  index_transport_types_on_name  (name) UNIQUE
 #
 class TransportType < ApplicationRecord
+  extend Mobility
+  translates :name, type: :string, fallbacks: { cy: :en }
+
   has_many :responses, class_name: 'TransportSurveyResponse', inverse_of: :transport_type
 
   scope :by_position, -> { order(position: :asc) }

--- a/app/models/transport_type.rb
+++ b/app/models/transport_type.rb
@@ -21,6 +21,7 @@
 #
 class TransportType < ApplicationRecord
   extend Mobility
+  include TransifexSerialisable
   translates :name, type: :string, fallbacks: { cy: :en }
 
   has_many :responses, class_name: 'TransportSurveyResponse', inverse_of: :transport_type
@@ -44,5 +45,10 @@ class TransportType < ApplicationRecord
   def safe_destroy
     raise EnergySparks::SafeDestroyError, 'Transport type has associated responses' if responses.any?
     destroy
+  end
+
+  #override default name for this resource in transifex
+  def tx_name
+    name
   end
 end

--- a/app/services/transifex/loader.rb
+++ b/app/services/transifex/loader.rb
@@ -23,6 +23,8 @@ module Transifex
         synchronise_resources(transifex_load, HelpPage.all.order(:id))
         log("Synchronising Case Studies")
         synchronise_resources(transifex_load, CaseStudy.all.order(:id))
+        log("Synchronising Transport Types")
+        synchronise_resources(transifex_load, TransportType.all.order(:id))
       rescue => error
         #ensure all errors are caught and logged
         log_error(transifex_load, error)

--- a/app/views/admin/transport_types/_form.html.erb
+++ b/app/views/admin/transport_types/_form.html.erb
@@ -1,5 +1,8 @@
 <%= simple_form_for([:admin, transport_type]) do |f| %>
-  <%= f.input :name %>
+
+  <%= render 'admin/shared/locale_tabs', f: f, field: :name do |locale| %>
+    <%= f.input t_field(:name, locale), label: TransportType.human_attribute_name(:name), as: :string %>
+  <% end %>
   <%= f.input :category, collection: TransportType.categories.keys, label_method: lambda {|k| k.humanize} %>
   <%= f.input :note %>
   <%= f.input :image %>

--- a/app/views/admin/transport_types/show.html.erb
+++ b/app/views/admin/transport_types/show.html.erb
@@ -3,8 +3,12 @@
 <h2><%= @transport_type.image %> <%= @transport_type.name %></h2>
 
 <dl class="row">
-  <dt class="col-md-2">Name</dt>
-  <dd class="col-md-10"><%= @transport_type.name %></dd>
+  <% I18n.available_locales.each do |locale| %>
+    <dt class="col-md-2">Name (<%= t("languages.#{locale}") %>)</dt>
+    <dd class="col-md-10">
+      <%= @transport_type.name(locale: locale).present? ? @transport_type.name(locale: locale) : "No name present" %>
+    </dd>
+  <% end %>
 
   <dt class="col-md-2">Category</dt>
   <dd class="col-md-10"><%= @transport_type.category.humanize %></dd>

--- a/config/locales/activerecord.yml
+++ b/config/locales/activerecord.yml
@@ -14,6 +14,7 @@ en:
         name: Title
         summary: Summary
       transport_type:
+        name: Name
         category:
           car: Car
           one: Category

--- a/config/locales/activerecord.yml
+++ b/config/locales/activerecord.yml
@@ -14,7 +14,6 @@ en:
         name: Title
         summary: Summary
       transport_type:
-        name: Name
         category:
           car: Car
           one: Category
@@ -22,6 +21,7 @@ en:
           park_and_stride: Park and stride
           public_transport: Public transport
           walking_and_cycling: Walking and cycling
+        name: Name
     errors:
       messages:
         record_invalid: 'Validation failed: %{errors}'

--- a/config/locales/views/schools/transport_surveys.yml
+++ b/config/locales/views/schools/transport_surveys.yml
@@ -16,12 +16,17 @@ en:
         transport_category: Transport category
         transport_method: Transport method
         weather: Weather
+      destroy:
+        notice: Transport survey was successfully removed
       header_nav:
         survey_today: Survey today
         view_all: View all transport surveys
       index:
         no_surveys: No surveys have been completed yet
         start_surveying: Start surveying today
+      responses:
+        destroy:
+          notice: Transport survey response was successfully removed
       show:
         carbon_html: Their travel to school generated %{carbon}
         percentages_html: "%{walking_and_cycling} walked or cycled, generating zero CO2, %{public_transport} travelled by public transport, %{park_and_stride} used park and stride and %{car} travelled by car"
@@ -36,8 +41,3 @@ en:
         dated: Travel to school survey on %{date}
         default: Travel to school surveys
         today: Today's travel to school survey
-      destroy:
-        notice: "Transport survey was successfully removed"
-      responses:
-        destroy:
-          notice: "Transport survey response was successfully removed"

--- a/config/locales/views/schools/transport_surveys.yml
+++ b/config/locales/views/schools/transport_surveys.yml
@@ -36,3 +36,8 @@ en:
         dated: Travel to school survey on %{date}
         default: Travel to school surveys
         today: Today's travel to school survey
+      destroy:
+        notice: "Transport survey was successfully removed"
+      responses:
+        destroy:
+          notice: "Transport survey response was successfully removed"

--- a/db/migrate/20220718174747_allow_null_transport_type_name.rb
+++ b/db/migrate/20220718174747_allow_null_transport_type_name.rb
@@ -1,0 +1,5 @@
+class AllowNullTransportTypeName < ActiveRecord::Migration[6.0]
+  def change
+    change_column_null :transport_types, :name, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_07_12_105036) do
+ActiveRecord::Schema.define(version: 2022_07_18_174747) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
@@ -1517,7 +1517,7 @@ ActiveRecord::Schema.define(version: 2022_07_12_105036) do
   end
 
   create_table "transport_types", force: :cascade do |t|
-    t.string "name", null: false
+    t.string "name"
     t.string "image", null: false
     t.decimal "kg_co2e_per_km", default: "0.0", null: false
     t.decimal "speed_km_per_hour", default: "0.0", null: false

--- a/lib/tasks/deployment/20220718130842_copy_transport_type_names_to_mobility_tables.rake
+++ b/lib/tasks/deployment/20220718130842_copy_transport_type_names_to_mobility_tables.rake
@@ -1,0 +1,17 @@
+namespace :after_party do
+  desc 'Deployment task: copy_transport_type_names_to_mobility_tables'
+  task copy_transport_type_names_to_mobility_tables: :environment do
+    puts "Running deploy task 'copy_transport_type_names_to_mobility_tables'"
+
+    TransportType.transaction do
+      TransportType.all.each do |transport_type|
+        transport_type.update(name: transport_type.read_attribute(:name))
+      end
+    end
+
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord
+      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+  end
+end

--- a/spec/models/transport_type_spec.rb
+++ b/spec/models/transport_type_spec.rb
@@ -48,4 +48,5 @@ describe TransportType do
       expect(TransportType.categories_with_other['other']).to be_nil
     end
   end
+
 end

--- a/spec/services/transifex/loader_spec.rb
+++ b/spec/services/transifex/loader_spec.rb
@@ -60,6 +60,8 @@ describe Transifex::Loader, type: :service do
     let!(:programme_type)           { create(:programme_type) }
     let!(:programme_type2)           { create(:programme_type, active: false) }
 
+    let!(:transport_type)           { create(:transport_type) }
+
     before(:each) do
       allow_any_instance_of(Transifex::Synchroniser).to receive(:pull).and_return(true)
       allow_any_instance_of(Transifex::Synchroniser).to receive(:push).and_return(true)
@@ -67,11 +69,11 @@ describe Transifex::Loader, type: :service do
     end
 
     it 'updates the pull count' do
-      expect(TransifexLoad.first.pulled).to eq 7
+      expect(TransifexLoad.first.pulled).to eq 8
     end
 
     it 'updates the push count' do
-      expect(TransifexLoad.first.pushed).to eq 7
+      expect(TransifexLoad.first.pushed).to eq 8
     end
   end
 

--- a/spec/system/admin/transport_types_spec.rb
+++ b/spec/system/admin/transport_types_spec.rb
@@ -59,10 +59,13 @@ describe "admin transport type", type: :system, include_application_helper: true
       'Note' => 'Why not?'
     } }
 
-    let(:checkbox_attributes) { ['Can share', 'Park and stride'] }
-    let(:select_attributes) { ['Category'] }
-    let(:display_attributes) { attributes.except('Created at', 'Updated at') }
-    let(:form_attributes) { attributes.except('Created at', 'Updated at') }
+    let(:translated_fields) { {'Name' => :transport_type_name_en} }
+    let(:checkbox_fields) { ['Can share', 'Park and stride'] }
+    let(:select_fields) { ['Category'] }
+    let(:date_fields) { ['Created at', 'Updated at'] }
+    let(:text_fields) { attributes.keys.excluding(translated_fields.keys + checkbox_fields + select_fields + date_fields) }
+
+    let(:display_attributes) { attributes.slice(*attributes.keys.excluding(date_fields)) }
 
     describe "Viewing the index" do
       before(:each) do
@@ -179,13 +182,16 @@ describe "admin transport type", type: :system, include_application_helper: true
 
       it "shows prefilled form elements" do
         within('form') do
-          form_attributes.excluding(checkbox_attributes + select_attributes).each do |key, value|
+          attributes.slice(*text_fields).each do |key, value|
             expect(page).to have_field(key, with: value)
           end
-          form_attributes.slice(*select_attributes).each do |key, value|
+          attributes.slice(*translated_fields.keys).each do |key, value|
+            expect(page).to have_field(translated_fields[key], with: value)
+          end
+          attributes.slice(*select_fields).each do |key, value|
             expect(page).to have_select(key, selected: value)
           end
-          checkbox_attributes.each do |field_name|
+          checkbox_fields.each do |field_name|
             expect(page).to have_unchecked_field(field_name)
           end
         end
@@ -194,13 +200,16 @@ describe "admin transport type", type: :system, include_application_helper: true
       context "when entering new values" do
         context "with valid attributes" do
           before(:each) do
-            new_valid_attributes.excluding(checkbox_attributes + select_attributes).each do |key, value|
+            new_valid_attributes.slice(*text_fields).each do |key, value|
               fill_in key, with: value
             end
-            new_valid_attributes.slice(*select_attributes).each do |key, value|
+            new_valid_attributes.slice(*translated_fields.keys).each do |key, value|
+              fill_in translated_fields[key], with: value
+            end
+            new_valid_attributes.slice(*select_fields).each do |key, value|
               select value, from: key
             end
-            checkbox_attributes.each do |field_name|
+            checkbox_fields.each do |field_name|
               check field_name
             end
             click_button 'Save'
@@ -223,7 +232,7 @@ describe "admin transport type", type: :system, include_application_helper: true
 
         context 'when the form has an invalid entry' do
           before(:each) do
-            fill_in 'Name', with: ""
+            fill_in 'transport_type_name_en', with: ""
             click_button 'Save'
           end
 
@@ -234,7 +243,7 @@ describe "admin transport type", type: :system, include_application_helper: true
           end
 
           it "has error message on field" do
-            expect(page).to have_content "Name *\ncan't be blank"
+            expect(page).to have_content "Name\ncan't be blank"
           end
         end
       end
@@ -247,7 +256,7 @@ describe "admin transport type", type: :system, include_application_helper: true
 
       it "shows a blank form" do
         within('form') do
-          ["Name", "Image", "Note"].each do |field_name|
+          [:transport_type_name_en, "Image", "Note"].each do |field_name|
             expect(find_field(field_name).text).to be_blank
           end
           ['Speed (km/h)', 'Carbon (kg co2e/km)'].each do |field_name|
@@ -256,10 +265,10 @@ describe "admin transport type", type: :system, include_application_helper: true
           ['Position'].each do |field_name|
             expect(page).to have_field(field_name, with: 0)
           end
-          select_attributes.each do |field_name|
+          select_fields.each do |field_name|
             expect(page).to have_select(field_name, selected: [])
           end
-          checkbox_attributes.each do |field_name|
+          checkbox_fields.each do |field_name|
             expect(page).to have_unchecked_field(field_name)
           end
         end
@@ -268,13 +277,16 @@ describe "admin transport type", type: :system, include_application_helper: true
       context "when entering new values" do
         context "with valid attributes" do
           before(:each) do
-            new_valid_attributes.excluding(checkbox_attributes + select_attributes).each do |key, value|
+            new_valid_attributes.slice(*text_fields).each do |key, value|
               fill_in key, with: value
             end
-            new_valid_attributes.slice(*select_attributes).each do |key, value|
+            new_valid_attributes.slice(*translated_fields.keys).each do |key, value|
+              fill_in translated_fields[key], with: value
+            end
+            new_valid_attributes.slice(*select_fields).each do |key, value|
               select value, from: key
             end
-            checkbox_attributes.each do |field_name|
+            checkbox_fields.each do |field_name|
               check field_name
             end
             click_button 'Save'
@@ -297,7 +309,7 @@ describe "admin transport type", type: :system, include_application_helper: true
 
         context 'when the form has an invalid entry' do
           before(:each) do
-            fill_in 'Name', with: ""
+            fill_in 'transport_type_name_en', with: ""
             click_button 'Save'
           end
 
@@ -308,7 +320,7 @@ describe "admin transport type", type: :system, include_application_helper: true
           end
 
           it "has error message on field" do
-            expect(page).to have_content "Name *\ncan't be blank"
+            expect(page).to have_content "Name\ncan't be blank"
           end
         end
       end
@@ -395,5 +407,6 @@ describe "admin transport type", type: :system, include_application_helper: true
         end
       end
     end
+
   end
 end

--- a/spec/system/admin/transport_types_spec.rb
+++ b/spec/system/admin/transport_types_spec.rb
@@ -132,8 +132,10 @@ describe "admin transport type", type: :system, include_application_helper: true
 
       it "shows all attributes" do
         within('dl') do
-          attributes.values.each do |value|
-            expect(page).to have_content(value)
+          expect(page).to have_content("Name (English) #{attributes['Name']}")
+          expect(page).to have_content("Name (Welsh) No name present")
+          attributes.except(*translated_fields.keys).each do |key, value|
+            expect(page).to have_content("#{key} #{value}")
           end
         end
       end

--- a/spec/system/schools/transport_surveys_spec.rb
+++ b/spec/system/schools/transport_surveys_spec.rb
@@ -157,6 +157,7 @@ describe 'TransportSurveys', type: :system do
                   click_link('Delete')
                 end
               end
+              it { expect(page).to have_content("Transport survey response was successfully removed") }
               it "removes response" do
                 expect(page).to_not have_content(nice_date_times(transport_survey_response.surveyed_at, localtime: true))
               end
@@ -169,6 +170,7 @@ describe 'TransportSurveys', type: :system do
                 click_link('Delete')
               end
             end
+            it { expect(page).to have_content("Transport survey was successfully removed") }
             it "removes transport survey" do
               expect(page).to_not have_content(nice_dates(transport_survey.run_on))
             end


### PR DESCRIPTION
First pass at translating a database field - transport_types#name. Feedback welcome!
Also translates a couple of transport survey flash messages.
Needed to do this before finishing the [download to csv functionality](https://github.com/Energy-Sparks/energy-sparks/pull/1908)