### PR TITLE
Add jquery carousel to results page

### DIFF
--- a/app/javascript/packs/transport_surveys.js
+++ b/app/javascript/packs/transport_surveys.js
@@ -16,7 +16,7 @@ $(document).ready(function() {
 
   const config = Object.assign({}, local_config, $('#config').data());
 
-  carbon.init({rates: config.rates, parkAndStrideMins: config.parkAndStrideMins});
+  carbon.init({equivalences: config.equivalences, neutral: config.neutral, parkAndStrideMins: config.parkAndStrideMins});
 
   if (storage.init({key: config.storageKey, baseUrl: config.baseUrl})) {
     setupSurvey();

--- a/app/javascript/packs/transport_surveys/carbon.js
+++ b/app/javascript/packs/transport_surveys/carbon.js
@@ -15,7 +15,7 @@ export const carbon = ( function() {
   }
 
   function statement(statement, amount, image) {
-    return statement.replace(/\${amount}/, amount).replace(/(\${image})/, image);
+    return statement.replace(/%{amount}/, amount).replace(/(%{image})/, image);
   }
 
   function parkAndStrideTimeMins(timeMins) {

--- a/app/javascript/packs/transport_surveys/carbon.js
+++ b/app/javascript/packs/transport_surveys/carbon.js
@@ -4,7 +4,8 @@ export const carbon = ( function() {
 
 
   var local = {
-    rates: '',
+    neutral: '',
+    equivalences: '',
     parkAndStrideMins: ''
   }
 
@@ -13,45 +14,9 @@ export const carbon = ( function() {
     local = cfg;
   }
 
-  const equivalences = [
-    {
-      name: 'tree',
-      emoji: '🌳',
-      unit: 'day',
-      rate: () => local.rates.tree / 365,
-      statement: (amount, unit, emoji) => `1 tree would absorb this amount of CO2 in ${amount} ${unit} ${emoji}!`,
-    }, {
-      name: 'tv',
-      emoji: '📺',
-      unit: 'hour',
-      rate: () => local.rates.tv,
-      statement: (amount, unit, emoji) => `That\'s the same as ${amount} ${unit} of TV ${emoji}!`,
-    }, {
-      name: 'computer_console',
-      emoji: '🎮',
-      unit: 'hour',
-      rate: () => local.rates.computerConsole,
-      statement: (amount, unit, emoji) => `That\'s the same as playing ${amount} ${unit} of computer games ${emoji}!`,
-    }, {
-      name: 'smartphone',
-      emoji: '📱',
-      unit: 'smart phone',
-      rate: () => local.rates.smartphone,
-      statement: (amount, unit, emoji) => `That\'s the same as charging ${amount} ${unit} ${emoji}!`,
-    } , {
-      name: 'carnivore_dinner',
-      emoji: '🍲',
-      unit: 'meat dinner',
-      rate: () => local.rates.carnivoreDinner,
-      statement: (amount, unit, emoji) => `That\'s the same as ${amount} ${unit} ${emoji}!`,
-    }, {
-      name: 'vegetarian_dinner',
-      emoji: '🥗',
-      unit: 'veggie dinner',
-      rate: () => local.rates.vegetarianDinner,
-      statement: (amount, unit, emoji) => `That\'s the same as ${amount} ${unit} ${emoji}!`,
-    }
-  ];
+  function statement(statement, amount, image) {
+    return statement.replace(/\${amount}/, amount).replace(/(\${image})/, image);
+  }
 
   function parkAndStrideTimeMins(timeMins) {
     // take 10 mins off a park and stride journey
@@ -60,16 +25,18 @@ export const carbon = ( function() {
 
   function equivalence(carbonKgs) {
     if (carbonKgs === 0) {
-      return "That's Carbon Neutral 🌳!";
+      return local.neutral;
     } else {
       // pick random equivalence until one returning a non-zero amount is found
-      let tried = [...equivalences.keys()];
+      let tried = [...local.equivalences.keys()];
       while (tried.length > 0) {
         let i = Math.floor(Math.random() * tried.length);
-        let example = equivalences[tried[i]];
-        let amount = Math.round(carbonKgs / example.rate());
-        if (amount >= 1) {
-          return example.statement(amount, pluralise(example.unit, amount), example.emoji);
+        let example = local.equivalences[tried[i]];
+        let amount = Math.round(carbonKgs / example.rate);
+        if (amount > 1) {
+          return statement(example.statement.other, amount, example.image);
+        } else if (amount == 1) {
+          return statement(example.statement.one, amount, example.image);
         } else {
           tried.splice(i, 1); // remove as tried this example
         }

--- a/app/javascript/packs/transport_surveys/carbon.js
+++ b/app/javascript/packs/transport_surveys/carbon.js
@@ -15,7 +15,7 @@ export const carbon = ( function() {
   }
 
   function statement(statement, amount, image) {
-    return statement.replace(/%{amount}/, amount).replace(/(%{image})/, image);
+    return statement.replace(/%{count}/, amount).replace(/(%{image})/, image);
   }
 
   function parkAndStrideTimeMins(timeMins) {

--- a/app/models/transport_survey.rb
+++ b/app/models/transport_survey.rb
@@ -53,9 +53,19 @@ class TransportSurvey < ApplicationRecord
     percentage_per_category.collect { |k, v| { name: TransportType.human_enum_name(:category, k), y: v } }
   end
 
-  def self.equivalence_rates
-    [:tree, :tv, :computer_console, :smartphone, :carnivore_dinner, :vegetarian_dinner].index_with do |type|
-      EnergyEquivalences.all_equivalences[type][:conversions][:co2][:rate]
+  def self.equivalence_images
+    { tree: '🌳', tv: '📺', computer_console: '🎮', smartphone: '📱', carnivore_dinner: '🍲', vegetarian_dinner: '🥗' }
+  end
+
+  def self.equivalence_devisors
+    { tree: 365 }
+  end
+
+  def self.equivalences
+    equivalence_images.collect do |name, image|
+      { rate: EnergyEquivalences.all_equivalences[name][:conversions][:co2][:rate] / (equivalence_devisors[name] || 1),
+        statement: I18n.t(name, scope: 'schools.transport_surveys.equivalences'),
+        image: image }
     end
   end
 

--- a/app/models/transport_survey.rb
+++ b/app/models/transport_survey.rb
@@ -57,6 +57,10 @@ class TransportSurvey < ApplicationRecord
     { tree: '🌳', tv: '📺', computer_console: '🎮', smartphone: '📱', carnivore_dinner: '🍲', vegetarian_dinner: '🥗' }
   end
 
+  def self.equivalence_svgs
+    { tree: 'tree', tv: 'television', computer_console: 'video_game', smartphone: 'phone', carnivore_dinner: 'roast_meal', vegetarian_dinner: 'meal' }
+  end
+
   def self.equivalence_devisors
     { tree: 365 }
   end
@@ -65,8 +69,20 @@ class TransportSurvey < ApplicationRecord
     equivalence_images.collect do |name, image|
       { rate: EnergyEquivalences.all_equivalences[name][:conversions][:co2][:rate] / (equivalence_devisors[name] || 1),
         statement: I18n.t(name, scope: 'schools.transport_surveys.equivalences'),
-        image: image }
+        image: image,
+        name: name }
     end
+  end
+
+  def equivalences
+    self.class.equivalences.collect do |equivalence|
+      amount = (total_carbon / equivalence[:rate]).round
+      if amount > 0
+        { name: equivalence[:name],
+          statement: I18n.t(equivalence[:name], scope: 'schools.transport_surveys.equivalences', image: equivalence[:image], amount: amount, count: amount),
+          svg: self.class.equivalence_svgs[equivalence[:name]] }
+      end
+    end.compact.shuffle
   end
 
   def responses=(responses_attributes)

--- a/app/models/transport_survey.rb
+++ b/app/models/transport_survey.rb
@@ -79,7 +79,7 @@ class TransportSurvey < ApplicationRecord
       amount = (total_carbon / equivalence[:rate]).round
       if amount > 0
         { name: equivalence[:name],
-          statement: I18n.t(equivalence[:name], scope: 'schools.transport_surveys.equivalences', image: equivalence[:image], amount: amount, count: amount),
+          statement: I18n.t(equivalence[:name], scope: 'schools.transport_surveys.equivalences', image: equivalence[:image], count: amount),
           svg: self.class.equivalence_svgs[equivalence[:name]] }
       end
     end.compact.shuffle

--- a/app/models/transport_survey.rb
+++ b/app/models/transport_survey.rb
@@ -58,7 +58,7 @@ class TransportSurvey < ApplicationRecord
   end
 
   def self.equivalence_svgs
-    { tree: 'tree', tv: 'television', computer_console: 'video_game', smartphone: 'phone', carnivore_dinner: 'roast_meal', vegetarian_dinner: 'meal' }
+    { tree: 'tree', tv: 'television', computer_console: 'video_game', smartphone: 'phone', carnivore_dinner: 'roast_meal', vegetarian_dinner: 'meal', neutral: 'tree' }
   end
 
   def self.equivalence_devisors
@@ -75,14 +75,17 @@ class TransportSurvey < ApplicationRecord
   end
 
   def equivalences
-    self.class.equivalences.collect do |equivalence|
-      amount = (total_carbon / equivalence[:rate]).round
-      if amount > 0
-        { name: equivalence[:name],
-          statement: I18n.t(equivalence[:name], scope: 'schools.transport_surveys.equivalences', image: equivalence[:image], count: amount),
-          svg: self.class.equivalence_svgs[equivalence[:name]] }
-      end
-    end.compact.shuffle
+    if total_carbon == 0
+      return [{ statement: I18n.t('schools.transport_surveys.equivalences.neutral'), svg: self.class.equivalence_svgs[:neutral] }]
+    else
+      self.class.equivalences.collect do |equivalence|
+        amount = (total_carbon / equivalence[:rate]).round
+        if amount > 0
+          { statement: I18n.t(equivalence[:name], scope: 'schools.transport_surveys.equivalences', image: equivalence[:image], count: amount),
+                    svg: self.class.equivalence_svgs[equivalence[:name]] }
+        end
+      end.compact.shuffle
+    end
   end
 
   def responses=(responses_attributes)

--- a/app/views/schools/transport_surveys/_equivalences.html.erb
+++ b/app/views/schools/transport_surveys/_equivalences.html.erb
@@ -1,3 +1,5 @@
+
+
 <div id="survey_carousel" class="carousel slide" data-wrap="true" data-interval="false">
   <div class="carousel-inner">
     <% @transport_survey.equivalences.each_with_index do |equivalence, index| %>
@@ -21,13 +23,15 @@
       </div>
     <% end %>
   </div>
-  <a class="carousel-control-prev" href="#survey_carousel" role="button" data-slide="prev">
-    <span class="carousel-control-prev-icon" aria-hidden="true"></span>
-    <span class="sr-only">Previous</span>
-  </a>
-  <a class="carousel-control-next" href="#survey_carousel" role="button" data-slide="next">
-    <span class="carousel-control-next-icon" aria-hidden="true"></span>
-    <span class="sr-only">Next</span>
-  </a>
+  <% if @transport_survey.equivalences.length > 1 %>
+    <a class="carousel-control-prev" href="#survey_carousel" role="button" data-slide="prev">
+      <span class="carousel-control-prev-icon" aria-hidden="true"></span>
+      <span class="sr-only">Previous</span>
+    </a>
+    <a class="carousel-control-next" href="#survey_carousel" role="button" data-slide="next">
+      <span class="carousel-control-next-icon" aria-hidden="true"></span>
+      <span class="sr-only">Next</span>
+    </a>
+  <% end %>
 </div>
 

--- a/app/views/schools/transport_surveys/_equivalences.html.erb
+++ b/app/views/schools/transport_surveys/_equivalences.html.erb
@@ -26,11 +26,11 @@
   <% if @transport_survey.equivalences.length > 1 %>
     <a class="carousel-control-prev" href="#survey_carousel" role="button" data-slide="prev">
       <span class="carousel-control-prev-icon" aria-hidden="true"></span>
-      <span class="sr-only">Previous</span>
+      <span class="sr-only"><%= t('common.labels.previous') %></span>
     </a>
     <a class="carousel-control-next" href="#survey_carousel" role="button" data-slide="next">
       <span class="carousel-control-next-icon" aria-hidden="true"></span>
-      <span class="sr-only">Next</span>
+      <span class="sr-only"><%= t('common.labels.next') %></span>
     </a>
   <% end %>
 </div>

--- a/app/views/schools/transport_surveys/_equivalences.html.erb
+++ b/app/views/schools/transport_surveys/_equivalences.html.erb
@@ -1,0 +1,25 @@
+<div id="survey_carousel" class="carousel slide" data-wrap="true" data-interval="false">
+  <div class="carousel-inner">
+    <% @transport_survey.equivalences.each_with_index do |equivalence, index| %>
+      <div class="carousel-item <%= 'active' if index == 0 %>">
+        <div class="row illustration-background">
+          <div class="col-lg-6 equivalence-wrapper">
+            <h4><%= equivalence[:statement] %></h4>
+          </div>
+          <div class="col-lg-6 illustration-wrapper">
+            <%= image_tag("equivalences/#{equivalence[:svg]}.svg") %>
+          </div>
+        </div>
+      </div>
+    <% end %>
+  </div>
+  <a class="carousel-control-prev" href="#survey_carousel" role="button" data-slide="prev">
+    <span class="carousel-control-prev-icon" aria-hidden="true"></span>
+    <span class="sr-only">Previous</span>
+  </a>
+  <a class="carousel-control-next" href="#survey_carousel" role="button" data-slide="next">
+    <span class="carousel-control-next-icon" aria-hidden="true"></span>
+    <span class="sr-only">Next</span>
+  </a>
+</div>
+

--- a/app/views/schools/transport_surveys/_equivalences.html.erb
+++ b/app/views/schools/transport_surveys/_equivalences.html.erb
@@ -4,7 +4,15 @@
       <div class="carousel-item <%= 'active' if index == 0 %>">
         <div class="row illustration-background">
           <div class="col-lg-6 equivalence-wrapper">
-            <h4><%= equivalence[:statement] %></h4>
+            <div><%= t('schools.transport_surveys.show.summary_html', count: @transport_survey.total_responses, carbon: @transport_survey.total_carbon.round(2)) %></div>
+            <h1><%= equivalence[:statement] %></h1>
+            <div>
+              <ul>
+                <% TransportType.categories.keys.each do |cat| %>
+                  <li><%= t("schools.transport_surveys.show.percentages.#{cat}_html", amount: "#{@transport_survey.percentage_per_category[cat].round}%") %></li>
+                <% end %>
+              </ul>
+            </div>
           </div>
           <div class="col-lg-6 illustration-wrapper">
             <%= image_tag("equivalences/#{equivalence[:svg]}.svg") %>

--- a/app/views/schools/transport_surveys/_equivalences.html.erb
+++ b/app/views/schools/transport_surveys/_equivalences.html.erb
@@ -11,7 +11,7 @@
             <div>
               <ul>
                 <% TransportType.categories.keys.each do |cat| %>
-                  <li><%= t("schools.transport_surveys.show.percentages.#{cat}_html", amount: "#{@transport_survey.percentage_per_category[cat].round}%") %></li>
+                  <li><%= t("schools.transport_surveys.show.percentages.#{cat}_html", amount: tag.strong("#{@transport_survey.percentage_per_category[cat].round}%")) %></li>
                 <% end %>
               </ul>
             </div>

--- a/app/views/schools/transport_surveys/edit.html.erb
+++ b/app/views/schools/transport_surveys/edit.html.erb
@@ -28,8 +28,10 @@
         <div id="app-notifier" role="alert"></div>
 
         <%= form_with(url: school_transport_surveys_url(@school), method: :patch, local: true, id: 'transport_survey') do |f| %>
-          <%= hidden_field_tag :config, "", data: { rates: TransportSurvey.equivalence_rates, run_on: @transport_survey.run_on.to_s, run_identifier: TransportSurveyResponse.generate_unique_secure_token, passenger_symbol: TransportSurveyResponse.passenger_symbol, park_and_stride_mins: TransportSurveyResponse.park_and_stride_mins, transport_types: TransportType.app_data } %>
-
+          <%= hidden_field_tag :config, "", data: { equivalences: TransportSurvey.equivalences,
+            neutral: t('schools.transport_surveys.equivalences.neutral'), run_on: @transport_survey.run_on.to_s,
+            run_identifier: TransportSurveyResponse.generate_unique_secure_token, passenger_symbol: TransportSurveyResponse.passenger_symbol,
+            park_and_stride_mins: TransportSurveyResponse.park_and_stride_mins, transport_types: TransportType.app_data } %>
           <div id="setup" class="panel">
             <h2>Please select today's weather</h2>
             <%= hidden_field_tag :weather, "", class: 'selected' %>

--- a/app/views/schools/transport_surveys/show.html.erb
+++ b/app/views/schools/transport_surveys/show.html.erb
@@ -7,7 +7,7 @@
 
 <% if @transport_survey.responses.any? %>
 
-  <%#= render :equivalences %>
+  <%= render 'equivalences' %>
 
   <div class="mb-3">
     <div><%= t('schools.transport_surveys.show.summary_html', count: @transport_survey.total_responses, date: nice_dates(@transport_survey.run_on)) %>.</div>

--- a/app/views/schools/transport_surveys/show.html.erb
+++ b/app/views/schools/transport_surveys/show.html.erb
@@ -9,18 +9,7 @@
 
   <%= render 'equivalences' %>
 
-  <div class="mb-3">
-    <div><%= t('schools.transport_surveys.show.summary_html', count: @transport_survey.total_responses, date: nice_dates(@transport_survey.run_on)) %>.</div>
-    <div><%= t('schools.transport_surveys.show.carbon_html', carbon: tag.strong("#{@transport_survey.total_carbon.round(2)}kg CO2")) %>.</div>
-    <div>
-      <% percentages = @transport_survey.percentage_per_category %>
-      <%= t('schools.transport_surveys.show.percentages_html',
-      walking_and_cycling: tag.strong("#{percentages["walking_and_cycling"].round}%"),
-      public_transport: tag.strong("#{percentages["public_transport"].round}%"),
-      park_and_stride: tag.strong("#{percentages["park_and_stride"].round}%"),
-      car: tag.strong("#{percentages["car"].round}%")) %>.
-    </div>
-  </div>
+  <h2 class="mt-3">Let's look at this in more detail here:</h2>
 
   <div id="transport_surveys_pie" class="mb-3"></div>
 

--- a/app/views/schools/transport_surveys/show.html.erb
+++ b/app/views/schools/transport_surveys/show.html.erb
@@ -6,6 +6,9 @@
 <%= render 'tab_nav' %>
 
 <% if @transport_survey.responses.any? %>
+
+  <%#= render :equivalences %>
+
   <div class="mb-3">
     <div><%= t('schools.transport_surveys.show.summary_html', count: @transport_survey.total_responses, date: nice_dates(@transport_survey.run_on)) %>.</div>
     <div><%= t('schools.transport_surveys.show.carbon_html', carbon: tag.strong("#{@transport_survey.total_carbon.round(2)}kg CO2")) %>.</div>

--- a/app/views/schools/transport_surveys/show.html.erb
+++ b/app/views/schools/transport_surveys/show.html.erb
@@ -9,7 +9,7 @@
 
   <%= render 'equivalences' %>
 
-  <h2 class="mt-3">Let's look at this in more detail here:</h2>
+  <h2 class="mt-3"><%= t('schools.transport_surveys.show.more_detail') %></h2>
 
   <div id="transport_surveys_pie" class="mb-3"></div>
 

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -125,6 +125,8 @@ ignore_unused:
   - 'staff_role.*'
   - 'subject.*'
   - 'charts.*'
+  - 'schools.transport_surveys.equivalences.*'
+  - 'schools.transport_surveys.show.percentages.*'
 # - '{devise,kaminari,will_paginate}.*'
 # - 'simple_form.{yes,no}'
 # - 'simple_form.{placeholders,hints,labels}.*'

--- a/config/locales/common.yml
+++ b/config/locales/common.yml
@@ -8,5 +8,7 @@ en:
       delete: Delete
       manage: Manage
       view_results: View results
+      next: Next
+      previous: Previous
   school_types:
     mixed_primary_and_secondary: 'Mixed: Primary and Secondary'

--- a/config/locales/common.yml
+++ b/config/locales/common.yml
@@ -7,8 +7,8 @@ en:
       actions: Actions
       delete: Delete
       manage: Manage
-      view_results: View results
       next: Next
       previous: Previous
+      view_results: View results
   school_types:
     mixed_primary_and_secondary: 'Mixed: Primary and Secondary'

--- a/config/locales/views/schools/transport_surveys.yml
+++ b/config/locales/views/schools/transport_surveys.yml
@@ -19,6 +19,26 @@ en:
         weather: Weather
       destroy:
         notice: Transport survey was successfully removed
+      equivalences:
+        carnivore_dinner:
+          one: That's the same as 1 meat dinner ${image}!
+          other: That's the same as ${amount} meat dinners ${image}!
+        computer_console:
+          one: That's the same as playing 1 hour of computer games ${image}!
+          other: That's the same as playing ${amount} hours of computer games ${image}!
+        neutral: "That's Carbon Neutral 🌳!"
+        smartphone:
+          one: That's the same as charging 1 smart phone ${image}!
+          other: That's the same as charging ${amount} smart phones ${image}!
+        tree:
+          one: 1 tree would absorb this amount of CO2 in 1 day ${image}!
+          other: 1 tree would absorb this amount of CO2 in ${amount} days ${image}!
+        tv:
+          one: That's the same as 1 hour of TV ${image}!
+          other: That's the same as ${amount} hours of TV ${image}!
+        vegetarian_dinner:
+          one: That's the same as 1 veggie dinner ${image}!
+          other: That's the same as ${amount} veggie dinners ${image}!
       header_nav:
         survey_today: Survey today
         view_all: View all transport surveys

--- a/config/locales/views/schools/transport_surveys.yml
+++ b/config/locales/views/schools/transport_surveys.yml
@@ -53,10 +53,11 @@ en:
           one: "<strong>%{count} pupil or staff member</strong> included in this survey generated <strong>%{carbon}kg</strong> carbon by travelling to school"
           other: "<strong>%{count} pupils and staff</strong> included in this survey generated <strong>%{carbon}kg</strong> carbon by travelling to school"
         percentages:
-          walking_and_cycling_html: "%{amount} walked or cycled, generating zero C02"
+          walking_and_cycling_html: "%{amount} walked or cycled, generating zero CO2"
           public_transport_html: "%{amount} travelled by public transport"
           park_and_stride_html: "%{amount} used park and stride"
           car_html: "%{amount} travelled by car"
+        more_detail: "Let's look at this in more detail:"
       tab_nav:
         manage_responses: Manage responses
         results: Results

--- a/config/locales/views/schools/transport_surveys.yml
+++ b/config/locales/views/schools/transport_surveys.yml
@@ -56,7 +56,7 @@ en:
           public_transport_html: "%{amount} travelled by public transport"
           walking_and_cycling_html: "%{amount} walked or cycled, generating zero CO2"
         summary_html:
-          one: "<strong>%{count} pupil or staff member</strong> included in this survey generated <strong>%{carbon}kg</strong> carbon by travelling to school"
+          one: "<strong>1 pupil or staff member</strong> included in this survey generated <strong>%{carbon}kg</strong> carbon by travelling to school"
           other: "<strong>%{count} pupils and staff</strong> included in this survey generated <strong>%{carbon}kg</strong> carbon by travelling to school"
       tab_nav:
         manage_responses: Manage responses

--- a/config/locales/views/schools/transport_surveys.yml
+++ b/config/locales/views/schools/transport_surveys.yml
@@ -49,15 +49,15 @@ en:
         destroy:
           notice: Transport survey response was successfully removed
       show:
+        more_detail: 'Let''s look at this in more detail:'
+        percentages:
+          car_html: "%{amount} travelled by car"
+          park_and_stride_html: "%{amount} used park and stride"
+          public_transport_html: "%{amount} travelled by public transport"
+          walking_and_cycling_html: "%{amount} walked or cycled, generating zero CO2"
         summary_html:
           one: "<strong>%{count} pupil or staff member</strong> included in this survey generated <strong>%{carbon}kg</strong> carbon by travelling to school"
           other: "<strong>%{count} pupils and staff</strong> included in this survey generated <strong>%{carbon}kg</strong> carbon by travelling to school"
-        percentages:
-          walking_and_cycling_html: "%{amount} walked or cycled, generating zero CO2"
-          public_transport_html: "%{amount} travelled by public transport"
-          park_and_stride_html: "%{amount} used park and stride"
-          car_html: "%{amount} travelled by car"
-        more_detail: "Let's look at this in more detail:"
       tab_nav:
         manage_responses: Manage responses
         results: Results

--- a/config/locales/views/schools/transport_surveys.yml
+++ b/config/locales/views/schools/transport_surveys.yml
@@ -22,23 +22,23 @@ en:
       equivalences:
         carnivore_dinner:
           one: That's the same as 1 meat dinner %{image}!
-          other: That's the same as %{amount} meat dinners %{image}!
+          other: That's the same as %{count} meat dinners %{image}!
         computer_console:
           one: That's the same as playing 1 hour of computer games text_fieldsimage}!
-          other: That's the same as playing %{amount} hours of computer games %{image}!
+          other: That's the same as playing %{count} hours of computer games %{image}!
         neutral: "That's Carbon Neutral 🌳!"
         smartphone:
           one: That's the same as charging 1 smart phone %{image}!
-          other: That's the same as charging %{amount} smart phones %{image}!
+          other: That's the same as charging %{count} smart phones %{image}!
         tree:
           one: 1 tree would absorb this amount of CO2 in 1 day %{image}!
-          other: 1 tree would absorb this amount of CO2 in %{amount} days %{image}!
+          other: 1 tree would absorb this amount of CO2 in %{count} days %{image}!
         tv:
           one: That's the same as 1 hour of TV %{image}!
-          other: That's the same as %{amount} hours of TV %{image}!
+          other: That's the same as %{count} hours of TV %{image}!
         vegetarian_dinner:
           one: That's the same as 1 veggie dinner %{image}!
-          other: That's the same as %{amount} veggie dinners %{image}!
+          other: That's the same as %{count} veggie dinners %{image}!
       header_nav:
         survey_today: Survey today
         view_all: View all transport surveys
@@ -49,11 +49,14 @@ en:
         destroy:
           notice: Transport survey response was successfully removed
       show:
-        carbon_html: Their travel to school generated %{carbon}
-        percentages_html: "%{walking_and_cycling} walked or cycled, generating zero CO2, %{public_transport} travelled by public transport, %{park_and_stride} used park and stride and %{car} travelled by car"
         summary_html:
-          one: "<strong>1 pupil or staff member</strong> was surveyed on <strong>%{date}</strong>"
-          other: "<strong>%{count} pupils and staff</strong> were surveyed on <strong>%{date}</strong>"
+          one: "<strong>%{count} pupil or staff member</strong> included in this survey generated <strong>%{carbon}kg</strong> carbon by travelling to school"
+          other: "<strong>%{count} pupils and staff</strong> included in this survey generated <strong>%{carbon}kg</strong> carbon by travelling to school"
+        percentages:
+          walking_and_cycling_html: "%{amount} walked or cycled, generating zero C02"
+          public_transport_html: "%{amount} travelled by public transport"
+          park_and_stride_html: "%{amount} used park and stride"
+          car_html: "%{amount} travelled by car"
       tab_nav:
         manage_responses: Manage responses
         results: Results

--- a/config/locales/views/schools/transport_surveys.yml
+++ b/config/locales/views/schools/transport_surveys.yml
@@ -24,7 +24,7 @@ en:
           one: That's the same as 1 meat dinner %{image}!
           other: That's the same as %{count} meat dinners %{image}!
         computer_console:
-          one: That's the same as playing 1 hour of computer games text_fieldsimage}!
+          one: That's the same as playing 1 hour of computer games %{image}!
           other: That's the same as playing %{count} hours of computer games %{image}!
         neutral: "That's Carbon Neutral 🌳!"
         smartphone:

--- a/config/locales/views/schools/transport_surveys.yml
+++ b/config/locales/views/schools/transport_surveys.yml
@@ -21,24 +21,24 @@ en:
         notice: Transport survey was successfully removed
       equivalences:
         carnivore_dinner:
-          one: That's the same as 1 meat dinner ${image}!
-          other: That's the same as ${amount} meat dinners ${image}!
+          one: That's the same as 1 meat dinner %{image}!
+          other: That's the same as %{amount} meat dinners %{image}!
         computer_console:
-          one: That's the same as playing 1 hour of computer games ${image}!
-          other: That's the same as playing ${amount} hours of computer games ${image}!
+          one: That's the same as playing 1 hour of computer games text_fieldsimage}!
+          other: That's the same as playing %{amount} hours of computer games %{image}!
         neutral: "That's Carbon Neutral 🌳!"
         smartphone:
-          one: That's the same as charging 1 smart phone ${image}!
-          other: That's the same as charging ${amount} smart phones ${image}!
+          one: That's the same as charging 1 smart phone %{image}!
+          other: That's the same as charging %{amount} smart phones %{image}!
         tree:
-          one: 1 tree would absorb this amount of CO2 in 1 day ${image}!
-          other: 1 tree would absorb this amount of CO2 in ${amount} days ${image}!
+          one: 1 tree would absorb this amount of CO2 in 1 day %{image}!
+          other: 1 tree would absorb this amount of CO2 in %{amount} days %{image}!
         tv:
-          one: That's the same as 1 hour of TV ${image}!
-          other: That's the same as ${amount} hours of TV ${image}!
+          one: That's the same as 1 hour of TV %{image}!
+          other: That's the same as %{amount} hours of TV %{image}!
         vegetarian_dinner:
-          one: That's the same as 1 veggie dinner ${image}!
-          other: That's the same as ${amount} veggie dinners ${image}!
+          one: That's the same as 1 veggie dinner %{image}!
+          other: That's the same as %{amount} veggie dinners %{image}!
       header_nav:
         survey_today: Survey today
         view_all: View all transport surveys

--- a/spec/system/schools/transport_surveys_app_spec.rb
+++ b/spec/system/schools/transport_surveys_app_spec.rb
@@ -175,8 +175,7 @@ describe 'TransportSurveys - App', type: :system do
                         end
 
                         it { expect(page).to have_css('#transport_surveys_pie') }
-                        it { expect(page).to have_content(Time.zone.today.to_s(:es_full)) }
-                        it { expect(page).to have_content("1 pupil") }
+                        it { expect(page).to have_content("1 pupil or staff member") }
                         it { expect(page).to_not have_link("Manage responses") }
                       end
                     end

--- a/spec/system/schools/transport_surveys_spec.rb
+++ b/spec/system/schools/transport_surveys_spec.rb
@@ -53,7 +53,6 @@ describe 'TransportSurveys', type: :system do
           it { expect(page).to_not have_content("meat dinner") }
           it { expect(page).to_not have_content("That's Carbon Neutral 🌳!") }
 
-
           it { expect(page).to have_content("1 pupil or staff member included in this survey generated 0.46kg carbon by travelling to school") }
           it { expect(page).to have_content("0% walked or cycled, generating zero CO2") }
           it { expect(page).to have_content("0% travelled by public transport") }


### PR DESCRIPTION
* This task has meant that the equivalences have needed to be moved out of the js and into rails & passed through to the JS via config. 
* A side effect of this is that they are now translatable (which is also part of another task coming up).

The carousel now looks like this:
![Screenshot 2022-07-22 at 12 31 46](https://user-images.githubusercontent.com/6051/180472585-c5c21112-6a09-4cf9-96ce-c4f26155eec5.png)

An alternative would be this (with the % information formatted as it was originally):
![Screenshot 2022-07-22 at 12 57 11](https://user-images.githubusercontent.com/6051/180472677-63fa0f56-1130-4dda-a44f-785fc743f719.png)

* Point to note here (and as before) is that responses with transport types in no category are not included in this summary (happy to add if required)!
* Also happy to move the emojis out of the equivalence statements used on the results page (or otherwise) if it looks too much (with the svg images being there too).