### PR TITLE
Display table of journey times by car

### DIFF
--- a/app/models/transport_survey.rb
+++ b/app/models/transport_survey.rb
@@ -53,12 +53,11 @@ class TransportSurvey < ApplicationRecord
   def responses_per_time_for_category(category)
     responses_per_time = responses.with_transport_type.where(transport_types: { category: category }).group(:journey_minutes).count
     # also include counts of zero for times without responses
-    TransportSurveyResponse.journey_minutes_options.each { |v| responses_per_time[v] ||= 0 }
-    responses_per_time
+    TransportSurveyResponse.journey_minutes_options.index_with { |mins| responses_per_time[mins] || 0 }
   end
 
   def responses_per_time_for_category_car
-    results, thirty_plus = responses_per_time_for_category(:car).partition { |time, _count| time < 30 }.map(&:to_h)
+    results, thirty_plus = responses_per_time_for_category(:car).partition { |mins, _count| mins < 30 }.map(&:to_h)
     results['30+'] = thirty_plus.values.sum || 0
     results
   end

--- a/app/views/schools/transport_surveys/show.html.erb
+++ b/app/views/schools/transport_surveys/show.html.erb
@@ -13,25 +13,47 @@
 
   <div id="transport_surveys_pie" class="mb-3"></div>
 
-  <table class="table">
+  <h4><%= t('schools.transport_surveys.show.transport_categories_title') %></h4>
+
+  <table class="table" id="responses_per_category">
     <thead class="thead-light">
       <tr>
-        <th><%= t('schools.transport_surveys.common.transport_category') %></th>
-        <th><%= t('schools.transport_surveys.common.total_pupils_and_staff') %></th>
-        <th><%= t('schools.transport_surveys.common.percentage_pupils_and_staff') %></th>
+        <th class="col-md-4"><%= t('schools.transport_surveys.common.transport_category') %></th>
+        <th class="col-md-4"><%= t('schools.transport_surveys.common.total_pupils_and_staff') %></th>
+        <th class="col-md-4"><%= t('schools.transport_surveys.common.percentage_pupils_and_staff') %></th>
       </tr>
     </thead>
     <tbody>
       <% TransportType.categories_with_other.each do |cat, value| %>
         <tr>
-          <td><%= TransportType.human_enum_name(:category, cat) %></td>
-          <td><%= @transport_survey.responses_per_category[cat] %></td>
-          <td><%= @transport_survey.percentage_per_category[cat].round %>%</td>
+          <td class="col-md-4"><%= TransportType.human_enum_name(:category, cat) %></td>
+          <td class="col-md-4"><%= @transport_survey.responses_per_category[cat] %></td>
+          <td class="col-md-4"><%= @transport_survey.percentage_per_category[cat].round %>%</td>
         </tr>
       <% end %>
     </tbody>
   </table>
 
+  <h4><%= t('schools.transport_surveys.show.cars_title') %></h4>
+  <p><%= t('schools.transport_surveys.show.cars_summary') %></p>
+
+  <table class="table" id='time_travelled_by_car'>
+    <thead class="thead-light">
+      <tr>
+        <th class="col-md-8"><%= t('schools.transport_surveys.show.time_travelled_by_car') %></th>
+        <th class="col-md-4"><%= t('schools.transport_surveys.common.total_pupils_and_staff') %></th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @transport_survey.responses_per_time_for_category_car.each do |time, value| %>
+        <tr>
+          <td class="col-md-8">
+            <%= time == '30+' ? t('schools.transport_surveys.show.30_or_more_minutes') : t('common.units.minutes', count: time) %></td>
+          <td class="col-md-4"><%= value %></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
 <% else %>
   <h4><%= t('schools.transport_surveys.common.no_responses') %></h4>
 <% end %>

--- a/config/locales/common.yml
+++ b/config/locales/common.yml
@@ -16,11 +16,10 @@ en:
       next: Next
       previous: Previous
       view_results: View results
-    line_graphs: Line graphs
-    pie_charts: Pie charts
-    school: School
-    storage_heaters: Storage heaters
-  kwh: kWh
+    units:
+      minutes:
+        one: "%{count} minute"
+        other: "%{count} minutes"
   school_types:
     mixed_primary_and_secondary: 'Mixed: Primary and Secondary'
   "£": "£"

--- a/config/locales/common.yml
+++ b/config/locales/common.yml
@@ -16,10 +16,15 @@ en:
       next: Next
       previous: Previous
       view_results: View results
+    line_graphs: Line graphs
+    pie_charts: Pie charts
+    school: School
+    storage_heaters: Storage heaters
     units:
       minutes:
         one: "%{count} minute"
         other: "%{count} minutes"
+  kwh: kWh
   school_types:
     mixed_primary_and_secondary: 'Mixed: Primary and Secondary'
   "£": "£"

--- a/config/locales/views/schools/transport_surveys.yml
+++ b/config/locales/views/schools/transport_surveys.yml
@@ -49,15 +49,15 @@ en:
         destroy:
           notice: Transport survey response was successfully removed
       show:
+        30_or_more_minutes: 30 or more minutes
+        cars_summary: Persuading people who travel only 5 minutes by car to switch to coming to school by foot or bike is a great first step to reducing the school's carbon footprint from travel.
+        cars_title: Breakdown of journeys by car
         more_detail: 'Let''s look at this in more detail:'
         percentages:
           car_html: "%{amount} travelled by car"
           park_and_stride_html: "%{amount} used park and stride"
           public_transport_html: "%{amount} travelled by public transport"
           walking_and_cycling_html: "%{amount} walked or cycled, generating zero CO2"
-        30_or_more_minutes: 30 or more minutes
-        cars_summary: Persuading people who travel only 5 minutes by car to switch to coming to school by foot or bike is a great first step to reducing the school's carbon footprint from travel.
-        cars_title: Breakdown of journeys by car
         summary_html:
           one: "<strong>1 pupil or staff member</strong> included in this survey generated <strong>%{carbon}kg</strong> carbon by travelling to school"
           other: "<strong>%{count} pupils and staff</strong> included in this survey generated <strong>%{carbon}kg</strong> carbon by travelling to school"

--- a/config/locales/views/schools/transport_surveys.yml
+++ b/config/locales/views/schools/transport_surveys.yml
@@ -55,9 +55,14 @@ en:
           park_and_stride_html: "%{amount} used park and stride"
           public_transport_html: "%{amount} travelled by public transport"
           walking_and_cycling_html: "%{amount} walked or cycled, generating zero CO2"
+        30_or_more_minutes: 30 or more minutes
+        cars_summary: Persuading people who travel only 5 minutes by car to switch to coming to school by foot or bike is a great first step to reducing the school's carbon footprint from travel.
+        cars_title: Breakdown of journeys by car
         summary_html:
           one: "<strong>1 pupil or staff member</strong> included in this survey generated <strong>%{carbon}kg</strong> carbon by travelling to school"
           other: "<strong>%{count} pupils and staff</strong> included in this survey generated <strong>%{carbon}kg</strong> carbon by travelling to school"
+        time_travelled_by_car: Time travelled by car
+        transport_categories_title: Breakdown of journeys by transport category
       tab_nav:
         manage_responses: Manage responses
         results: Results


### PR DESCRIPTION
This adds a table at the bottom of the transport survey results page, which shows the amount of journeys taken by car for each journey time.

This is now ready for review / merging if all ok.