### PR TITLE
Revise layout of the scoreboard pages

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -14,6 +14,7 @@
 @import "home";
 @import "site";
 @import "school";
+@import "scoreboard";
 @import "activities";
 @import "activity_type";
 

--- a/app/assets/stylesheets/school.scss
+++ b/app/assets/stylesheets/school.scss
@@ -159,14 +159,6 @@ div.school-card-row {
 
 }
 
-#scoreboard {
-  thead {
-  }
-  .fa-arrow-up {
-    color: $green;
-  }
-}
-
 div.award {
   border: none;
 

--- a/app/assets/stylesheets/scoreboard.scss
+++ b/app/assets/stylesheets/scoreboard.scss
@@ -1,0 +1,28 @@
+#scoreboard {
+  thead {
+    tr {
+      th {
+        h2 {
+          font-weight: bolder;
+        }
+      }
+    }
+  }
+  .fa-arrow-up {
+    color: $green;
+  }
+}
+
+#scoreboards {
+  h3 {
+    font-weight: bolder;
+  }
+  h4 {
+    padding-top: 0px;
+    padding-bottom: 5px;
+  }
+  .card-footer {
+    border-top: none;
+    background-color: white;
+  }
+}

--- a/app/controllers/scoreboards_controller.rb
+++ b/app/controllers/scoreboards_controller.rb
@@ -9,12 +9,14 @@ class ScoreboardsController < ApplicationController
 
   def show
     authorize! :read, @scoreboard
+    @current_year = @scoreboard.current_academic_year
+    @previous_year = @scoreboard.previous_academic_year
+
     @academic_year = if params[:academic_year]
                        @scoreboard.academic_year_calendar.academic_years.find(params[:academic_year])
                      else
-                       @scoreboard.academic_year_calendar.academic_year_for(Time.zone.today)
+                       @current_year
                      end
-    @active_academic_years = @scoreboard.active_academic_years
     @schools = @scoreboard.scored_schools(academic_year: @academic_year)
   end
 end

--- a/app/models/academic_year.rb
+++ b/app/models/academic_year.rb
@@ -22,6 +22,10 @@ class AcademicYear < ApplicationRecord
     (start_date <= today) && (end_date >= today)
   end
 
+  def previous_year
+    AcademicYear.for_date(self.start_date - 1).where(calendar: self.calendar).reject(&:current?).first
+  end
+
   def next_year
     AcademicYear.for_date(self.end_date + 1).where(calendar: self.calendar).reject(&:current?).first
   end

--- a/app/models/podium.rb
+++ b/app/models/podium.rb
@@ -24,7 +24,7 @@ class Podium
     school_index = schools_with_points.index(school)
 
     final = if schools_with_points.size > 3
-              schools_with_points.schools_at(starting_index(school_index, schools_with_points), 3).compact
+              schools_with_points.schools_at(index: starting_index(school_index, schools_with_points), length: 3).compact
             else
               schools_with_points
             end

--- a/app/models/scoreboard.rb
+++ b/app/models/scoreboard.rb
@@ -51,10 +51,6 @@ class Scoreboard < ApplicationRecord
     academic_year_calendar.academic_year_for(today).previous_year
   end
 
-  def active_academic_years(today: Time.zone.today)
-    [current_academic_year(today), previous_academic_year(today)]
-  end
-
   def scored_schools(recent_boundary: 1.month.ago, academic_year: this_academic_year)
     scored = schools.visible.select('schools.*, SUM(observations.points) AS sum_points, MAX(observations.at) AS recent_observation').select(
       self.class.sanitize_sql_array(

--- a/app/models/scoreboard.rb
+++ b/app/models/scoreboard.rb
@@ -43,8 +43,16 @@ class Scoreboard < ApplicationRecord
     name_changed? || super
   end
 
+  def current_academic_year(today: Time.zone.today)
+    academic_year_calendar.academic_year_for(today)
+  end
+
+  def previous_academic_year(today: Time.zone.today)
+    academic_year_calendar.academic_year_for(today).previous_year
+  end
+
   def active_academic_years(today: Time.zone.today)
-    academic_year_calendar.academic_years.where("date_part('year', start_date) >= ? AND start_date <= ?", FIRST_YEAR, today).order(:start_date)
+    [current_academic_year(today), previous_academic_year(today)]
   end
 
   def scored_schools(recent_boundary: 1.month.ago, academic_year: this_academic_year)

--- a/app/models/scored_schools_list.rb
+++ b/app/models/scored_schools_list.rb
@@ -18,11 +18,11 @@ class ScoredSchoolsList
   end
 
   def top_three
-    with_points.schools_at(0, 3)
+    with_points.schools_at(index: 0, length: 3)
   end
 
   def with_points
-    self.class.new(@scored_schools.reject {|scored_school| scored_school.sum_points.nil? || scored_school.sum_points <= 0})
+    self.class.new(positive_scored_schools)
   end
 
   def without_points
@@ -37,11 +37,17 @@ class ScoredSchoolsList
     @scored_schools.size
   end
 
-  def schools_at(index, length)
+  def schools_at(index:, length:)
     @scored_schools.slice(index, length)
   end
 
   def each
     @scored_schools.each {|school| yield school}
+  end
+
+  private
+
+  def positive_scored_schools
+    @scored_schools.select {|scored_school| scored_school.sum_points&.positive?}
   end
 end

--- a/app/models/scored_schools_list.rb
+++ b/app/models/scored_schools_list.rb
@@ -17,6 +17,10 @@ class ScoredSchoolsList
     schools_with_positions.select {|_position, schools| schools.include?(school)}.first.first
   end
 
+  def top_three
+    with_points.schools_at(0, 3)
+  end
+
   def with_points
     self.class.new(@scored_schools.reject {|scored_school| scored_school.sum_points.nil? || scored_school.sum_points <= 0})
   end

--- a/app/views/scoreboards/_table.html.erb
+++ b/app/views/scoreboards/_table.html.erb
@@ -1,0 +1,41 @@
+<table id='scoreboard' class='table'>
+  <thead>
+    <tr>
+      <th><h2><%= t('scoreboard.position') %></h2></th>
+      <th><h2><%= t('common.school') %></h2></th>
+      <th><h2><%= t('scoreboard.score') %></h2></th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @schools.with_points.schools_with_positions.each do |position, schools| %>
+      <% schools.each do |school|%>
+        <tr>
+          <td scope="row">
+            <h2><span class="badge badge-primary"><%= '=' if schools.size > 1 %><%= position %></span></h2>
+          </td>
+          <td>
+            <h2><%= link_to school.name, school_path(school) %></h2>
+          </td>
+          <td>
+            <h2>
+              <%= link_to school.sum_points, school_timeline_path(school, academic_year: @academic_year), class: 'badge badge-success' %>
+              &nbsp;
+              <% if school.recent_points && school.recent_points > 0 %>
+                <i class="fa fa-arrow-up" data-toggle="tooltip" title="<%= t('scoreboard.score_tooltip') %>"></i>
+              <% end %>
+            </h2>
+          </td>
+        </tr>
+      <% end %>
+    <% end %>
+    <% @schools.without_points.each do |school| %>
+      <tr>
+        <td><h2><span class="badge badge-secondary">-</span></h2></td>
+        <td>
+          <h2><%= link_to school.name, school_path(school) %></h2>
+        </td>
+        <td><h2><span class="badge badge-secondary">0</span></h2></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/scoreboards/_table.html.erb
+++ b/app/views/scoreboards/_table.html.erb
@@ -20,7 +20,7 @@
             <h2>
               <%= link_to school.sum_points, school_timeline_path(school, academic_year: @academic_year), class: 'badge badge-success' %>
               &nbsp;
-              <% if school.recent_points && school.recent_points > 0 %>
+              <% if school.recent_points&.positive? %>
                 <i class="fa fa-arrow-up" data-toggle="tooltip" title="<%= t('scoreboard.score_tooltip') %>"></i>
               <% end %>
             </h2>

--- a/app/views/scoreboards/index.html.erb
+++ b/app/views/scoreboards/index.html.erb
@@ -1,27 +1,54 @@
 
 
 <div class="row padded-row">
-  <div class="col-lg-8">
-    <h1>Scoreboards</h1>
-    <p>See how well each of our Energy Sparks schools are recording their energy saving activities! Scoreboard points are earned from recording activities investigating energy use, learning about energy and taking energy saving action around their school. Schools choose a scoreboard to join, normally competing against other schools in their local area.</p>
-    <p>Click on a scoreboard to see how the schools are doing!</p>
-  </div>
-  <div class="col-lg-4">
+  <div class="col-lg-3">
     <%= image_tag("actions/podium.png", class: "img-fluid ") %>
+  </div>
+  <div class="col-lg-9">
+    <h1 class="display-3"><strong>Scoreboards</strong></h1>
+    <p>
+      See how well each of our Energy Sparks schools are recording their energy saving activities!
+    </p>
+    <p>
+      Scoreboard points are earned from recording activities investigating energy use, learning about energy and taking energy saving action around their school. Schools choose a scoreboard to join, normally competing against other schools in their local area.
+    </p>
+    <p>
+      Click on a scoreboard to see how the schools are doing!
+    </p>
   </div>
 </div>
 
 <% if @scoreboards.any? %>
-  <table class="table table-condensed">
-    <tbody>
-      <% @scoreboards.each do |scoreboard| %>
-        <tr>
-          <td><%= link_to scoreboard.name, scoreboard_path(scoreboard) %></td>
-          <td><%= scoreboard.description %></td>
-        </tr>
-      <% end %>
-    </tbody>
-  </table>
+  <% @scoreboards.each_slice(2) do |row| %>
+    <div class="row">
+      <div class="col-lg-12">
+        <div class="card-deck">
+          <% row.each do |scoreboard| %>
+            <div class="card mt-4">
+              <div class="card-body">
+                <h3 style="font-weight: bolder;"><%= scoreboard.name %></h3>
+                  <% scoreboard.scored_schools.with_points.schools_at(0, 3).each_with_index do |s, idx| %>
+                  <div class="row">
+                    <div class="col-1"><h4 style="padding-top: 0px; padding-bottom: 5px;"><span class="badge badge-success"><%= s.sum_points %></span></h4></div>
+                    <div class="col-11"><h4 style="padding-top: 0px; padding-bottom: 5px;"><%= s.name %></h4></div>
+                  </div>
+                  <% end %>
+              </div>
+              <div class="card-footer text-right" style="border-top: none; background-color: white;">
+                <%= link_to scoreboard_path(scoreboard) do %>
+                  View scores for all <%= scoreboard.schools.visible.count %> schools
+                <% end %>
+              </div>
+            </div>
+          <% end %>
+        </div>
+      </div>
+    </div>
+  <% end %>
+  <div class="row">
+    <div class="col">
+    </div>
+  </div>
 <% else %>
   <h2>There are no Scoreboards</h2>
 <% end %>

--- a/app/views/scoreboards/index.html.erb
+++ b/app/views/scoreboards/index.html.erb
@@ -24,7 +24,7 @@
             <div class="card mt-4">
               <div class="card-body">
                 <h3><%= scoreboard.name %></h3>
-                  <% scoreboard.scored_schools.with_points.schools_at(0, 3).each_with_index do |s, idx| %>
+                  <% scoreboard.scored_schools.top_three.each do |s| %>
                     <h4><span class="badge badge-success"><%= s.sum_points %></span> <%= s.name %></h4>
                   <% end %>
               </div>

--- a/app/views/scoreboards/index.html.erb
+++ b/app/views/scoreboards/index.html.erb
@@ -25,10 +25,7 @@
               <div class="card-body">
                 <h3><%= scoreboard.name %></h3>
                   <% scoreboard.scored_schools.with_points.schools_at(0, 3).each_with_index do |s, idx| %>
-                  <div class="row">
-                    <div class="col-1"><h4><span class="badge badge-success"><%= s.sum_points %></span></h4></div>
-                    <div class="col-11"><h4><%= s.name %></h4></div>
-                  </div>
+                    <h4><span class="badge badge-success"><%= s.sum_points %></span> <%= s.name %></h4>
                   <% end %>
               </div>
               <div class="card-footer text-right">

--- a/app/views/scoreboards/index.html.erb
+++ b/app/views/scoreboards/index.html.erb
@@ -1,19 +1,16 @@
-
+<% content_for :page_title, t('scoreboards.page_title') %>
 
 <div class="row padded-row">
   <div class="col-lg-3">
     <%= image_tag("actions/podium.png", class: "img-fluid ") %>
   </div>
   <div class="col-lg-9">
-    <h1 class="display-3"><strong>Scoreboards</strong></h1>
+    <h1 class="display-3"><strong><%= t('scoreboards.page_title') %></strong></h1>
     <p>
-      See how well each of our Energy Sparks schools are recording their energy saving activities!
+      <%= t('scoreboards.intro_para_1') %>
     </p>
     <p>
-      Scoreboard points are earned from recording activities investigating energy use, learning about energy and taking energy saving action around their school. Schools choose a scoreboard to join, normally competing against other schools in their local area.
-    </p>
-    <p>
-      Click on a scoreboard to see how the schools are doing!
+      <%= t('scoreboards.intro_para_2') %>
     </p>
   </div>
 </div>
@@ -22,21 +19,21 @@
   <% @scoreboards.each_slice(2) do |row| %>
     <div class="row">
       <div class="col-lg-12">
-        <div class="card-deck">
+        <div class="card-deck" id="scoreboards">
           <% row.each do |scoreboard| %>
             <div class="card mt-4">
               <div class="card-body">
-                <h3 style="font-weight: bolder;"><%= scoreboard.name %></h3>
+                <h3><%= scoreboard.name %></h3>
                   <% scoreboard.scored_schools.with_points.schools_at(0, 3).each_with_index do |s, idx| %>
                   <div class="row">
-                    <div class="col-1"><h4 style="padding-top: 0px; padding-bottom: 5px;"><span class="badge badge-success"><%= s.sum_points %></span></h4></div>
-                    <div class="col-11"><h4 style="padding-top: 0px; padding-bottom: 5px;"><%= s.name %></h4></div>
+                    <div class="col-1"><h4><span class="badge badge-success"><%= s.sum_points %></span></h4></div>
+                    <div class="col-11"><h4><%= s.name %></h4></div>
                   </div>
                   <% end %>
               </div>
-              <div class="card-footer text-right" style="border-top: none; background-color: white;">
+              <div class="card-footer text-right">
                 <%= link_to scoreboard_path(scoreboard) do %>
-                  View scores for all <%= scoreboard.schools.visible.count %> schools
+                  <%= t('scoreboards.view_all', count: scoreboard.schools.visible.count) %>
                 <% end %>
               </div>
             </div>
@@ -45,10 +42,4 @@
       </div>
     </div>
   <% end %>
-  <div class="row">
-    <div class="col">
-    </div>
-  </div>
-<% else %>
-  <h2>There are no Scoreboards</h2>
 <% end %>

--- a/app/views/scoreboards/show.html.erb
+++ b/app/views/scoreboards/show.html.erb
@@ -61,11 +61,11 @@
         <% end %>
         <% @schools.without_points.each do |school| %>
           <tr>
-            <td />
+            <td><h2><span class="badge badge-secondary">-</span></h2></td>
             <td>
               <h2><%= link_to school.name, school_path(school) %></h2>
             </td>
-            <td />
+            <td><h2><span class="badge badge-secondary">0</span></h2></td>
           </tr>
         <% end %>
       </tbody>

--- a/app/views/scoreboards/show.html.erb
+++ b/app/views/scoreboards/show.html.erb
@@ -1,74 +1,30 @@
-<% content_for :page_title, 'Scoreboard' %>
+<% content_for :page_title, @scoreboard.name %>
 
+<div class="row padded-row">
+  <div class="col-lg-3">
+    <%= image_tag("actions/podium.png", class: "img-fluid ") %>
+  </div>
+  <div class="col-lg-9">
+    <h1 class="display-3"><strong><%= @scoreboard.name %></strong></h1>
+    <p>
+      <%= t('scoreboards.intro_para_1') %>
+    </p>
+    <p>
+      <%= t('scoreboard.intro_para_1', count: @schools.count) %>
+    </p>
+    <p>
+      <% if @academic_year == @current_year %>
+        <%= t('scoreboard.current_scores') %>. <%= link_to t('scoreboard.previous_scoreboard'), scoreboard_path(@scoreboard, academic_year: @previous_year) %>.
+      <% else %>
+        <%= t('scoreboard.previous_scores') %>. <strong><%= link_to t('scoreboard.current_scoreboard'), scoreboard_path(@scoreboard) %></strong>
+      <% end %>
+    </p>
+  </div>
+</div>
 <div class="container mt-2">
   <div class="row">
-    <div class="col-md-8">
-      <h1>Scoreboard <%= @academic_year.title %>: <%= @scoreboard.name %></h1>
+    <div class="col">
+      <%= render 'table', schools: @schools %>
     </div>
-    <div class="col-md-4">
-      <div class='btn-group float-right mt-4'>
-      </div>
-    </div>
-    <div class="col-md-12">
-      <p>
-        See how well each of our <%= @scoreboard.name%> Energy Sparks schools are recording their energy saving <%= link_to 'activities', activity_categories_path %>!
-        Scoreboard points are earned from recording <%= link_to 'activities', activity_categories_path %> investigating energy use, learning about energy and taking energy saving action around their school.
-      </p>
-    </div>
-  </div>
-
-
-  <ul class="nav nav-pills mb-3">
-    <% @active_academic_years.each do |academic_year| %>
-      <li class="nav-item">
-        <%= link_to academic_year.title, scoreboard_path(@scoreboard, academic_year: academic_year), class: "nav-link #{'active' if academic_year == @academic_year}"%>
-      </li>
-    <% end %>
-  </ul>
-
-
-  <div class="row">
-    <table id='scoreboard' class='table'>
-      <thead>
-        <tr>
-          <th><h4>Position</h4></th>
-          <th><h4>School</h4></th>
-          <th><h4>Score</h4></th>
-        </tr>
-      </thead>
-
-      <tbody>
-        <% @schools.with_points.schools_with_positions.each do |position, schools| %>
-          <% schools.each do |school|%>
-            <tr>
-              <td scope="row">
-                <h2><span class="badge badge-primary"><%= '=' if schools.size > 1 %><%= position %></span></h2>
-              </td>
-              <td>
-                <h2><%= link_to school.name, school_path(school) %></h2>
-              </td>
-              <td>
-                <h2>
-                  <%= link_to school.sum_points, school_timeline_path(school, academic_year: @academic_year), class: 'badge badge-success' %>
-                  &nbsp;
-                  <% if school.recent_points && school.recent_points > 0 %>
-                    <i class="fa fa-arrow-up" data-toggle="tooltip" title="School has scored points in the last month"></i>
-                  <% end %>
-                </h2>
-              </td>
-            </tr>
-          <% end %>
-        <% end %>
-        <% @schools.without_points.each do |school| %>
-          <tr>
-            <td><h2><span class="badge badge-secondary">-</span></h2></td>
-            <td>
-              <h2><%= link_to school.name, school_path(school) %></h2>
-            </td>
-            <td><h2><span class="badge badge-secondary">0</span></h2></td>
-          </tr>
-        <% end %>
-      </tbody>
-    </table>
   </div>
 </div>

--- a/config/locales/common.yml
+++ b/config/locales/common.yml
@@ -2,6 +2,7 @@
 en:
   co2: CO2
   common:
+    school: School
     application: Energy Sparks
     confirm: Are you sure?
     labels:

--- a/config/locales/common.yml
+++ b/config/locales/common.yml
@@ -11,8 +11,8 @@ en:
       next: Next
       previous: Previous
       view_results: View results
+    school: School
   kwh: kWh
-  school: School
   school_types:
     mixed_primary_and_secondary: 'Mixed: Primary and Secondary'
   "£": "£"

--- a/config/locales/common.yml
+++ b/config/locales/common.yml
@@ -2,7 +2,6 @@
 en:
   co2: CO2
   common:
-    school: School
     application: Energy Sparks
     confirm: Are you sure?
     labels:
@@ -13,6 +12,7 @@ en:
       previous: Previous
       view_results: View results
   kwh: kWh
+  school: School
   school_types:
     mixed_primary_and_secondary: 'Mixed: Primary and Secondary'
   "£": "£"

--- a/config/locales/views/scoreboards/scoreboards.yml
+++ b/config/locales/views/scoreboards/scoreboards.yml
@@ -1,0 +1,20 @@
+---
+en:
+  scoreboards:
+    page_title: Scoreboards
+    intro_para_1: Schools score points by recording their activities to investigate their energy use, learning about energy, and taking energy saving actions around their school.
+    intro_para_2: Our scoreboards show which schools are most active across England, Scotland and Wales.
+    view_all:
+      one: View scores for 1 school
+      other: View scores for %{count} schools
+  scoreboard:
+    intro_para_1:
+      one: There is only 1 school on this scoreboard
+      other: There are %{count} schools competing on this scoreboard
+    current_scores: These are the current scores for this academic year
+    current_scoreboard: View the current scoreboard
+    previous_scores: These were the final scores from last year
+    previous_scoreboard: View the final scores from last year
+    position: Position
+    score: Score
+    score_tooltip: School has scored points in the last month

--- a/config/locales/views/scoreboards/scoreboards.yml
+++ b/config/locales/views/scoreboards/scoreboards.yml
@@ -1,20 +1,20 @@
 ---
 en:
-  scoreboards:
-    page_title: Scoreboards
-    intro_para_1: Schools score points by recording their activities to investigate their energy use, learning about energy, and taking energy saving actions around their school.
-    intro_para_2: Our scoreboards show which schools are most active across England, Scotland and Wales.
-    view_all:
-      one: View scores for 1 school
-      other: View scores for %{count} schools
   scoreboard:
+    current_scoreboard: View the current scoreboard
+    current_scores: These are the current scores for this academic year
     intro_para_1:
       one: There is only 1 school on this scoreboard
       other: There are %{count} schools competing on this scoreboard
-    current_scores: These are the current scores for this academic year
-    current_scoreboard: View the current scoreboard
-    previous_scores: These were the final scores from last year
-    previous_scoreboard: View the final scores from last year
     position: Position
+    previous_scoreboard: View the final scores from last year
+    previous_scores: These were the final scores from last year
     score: Score
     score_tooltip: School has scored points in the last month
+  scoreboards:
+    intro_para_1: Schools score points by recording their activities to investigate their energy use, learning about energy, and taking energy saving actions around their school.
+    intro_para_2: Our scoreboards show which schools are most active across England, Scotland and Wales.
+    page_title: Scoreboards
+    view_all:
+      one: View scores for 1 school
+      other: View scores for %{count} schools

--- a/spec/models/scoreboard_spec.rb
+++ b/spec/models/scoreboard_spec.rb
@@ -88,4 +88,17 @@ describe Scoreboard, :scoreboards, type: :model do
     end
 
   end
+
+  describe '#current_academic_year' do
+    it 'finds the right year'
+  end
+
+  describe '#previous_academic_year' do
+    it 'finds the right year'
+  end
+
+  describe '#active_academic_years' do
+    it 'returns this year and last year'
+  end
+
 end

--- a/spec/models/scoreboard_spec.rb
+++ b/spec/models/scoreboard_spec.rb
@@ -90,15 +90,17 @@ describe Scoreboard, :scoreboards, type: :model do
   end
 
   describe '#current_academic_year' do
-    it 'finds the right year'
+    it 'finds the right year' do
+      expect(scoreboard.current_academic_year).to eq AcademicYear.first
+    end
   end
 
   describe '#previous_academic_year' do
-    it 'finds the right year'
-  end
+    let!(:previous_year) { create(:academic_year, calendar: scoreboard.academic_year_calendar, start_date: AcademicYear.first.start_date.prev_year, end_date: AcademicYear.first.start_date.prev_day) }
 
-  describe '#active_academic_years' do
-    it 'returns this year and last year'
+    it 'finds the right year' do
+      expect(scoreboard.previous_academic_year).to eq AcademicYear.first.previous_year
+    end
   end
 
 end

--- a/spec/models/scored_schools_list_spec.rb
+++ b/spec/models/scored_schools_list_spec.rb
@@ -3,6 +3,19 @@ require 'rails_helper'
 
 describe ScoredSchoolsList do
 
+  describe '#with_points' do
+    let(:school_a){ double(:school, sum_points: 30)}
+    let(:school_b){ double(:school, sum_points: 20)}
+    let(:school_c){ double(:school, sum_points: 0)}
+    let(:school_d){ double(:school, sum_points: nil)}
+
+    it 'returns just those with points' do
+      expect(ScoredSchoolsList.new([school_a, school_b, school_c, school_d]).with_points).to match_array(
+        [school_a, school_b]
+      )
+    end
+  end
+
   describe '#schools_with_positions' do
 
     context 'schools with unique points' do

--- a/spec/system/scoreboard_spec.rb
+++ b/spec/system/scoreboard_spec.rb
@@ -9,7 +9,9 @@ RSpec.describe 'scoreboards', :scoreboards, type: :system do
       it 'allows anyone to see the scoreboard' do
         visit schools_path
         click_on 'Scoreboards'
-        click_on 'Super scoreboard'
+        expect(page).to have_content('Super scoreboard')
+        expect(page).to have_link(href: scoreboard_path(scoreboard))
+        visit scoreboard_path(scoreboard)
         expect(page).to have_content('Super scoreboard')
         expect(page).to have_content(school.name)
       end
@@ -42,7 +44,8 @@ RSpec.describe 'scoreboards', :scoreboards, type: :system do
         visit scoreboards_path
         expect(page).to have_content('Super scoreboard')
         expect(page).to have_content('Private scoreboard')
-        click_on 'Private scoreboard'
+        expect(page).to have_link(href: scoreboard_path(private_scoreboard))
+        visit scoreboard_path(private_scoreboard)
         expect(page).to have_content('Private scoreboard')
         expect(page).to have_content(other_school.name)
       end

--- a/spec/system/scoreboard_spec.rb
+++ b/spec/system/scoreboard_spec.rb
@@ -2,19 +2,41 @@ require 'rails_helper'
 
 RSpec.describe 'scoreboards', :scoreboards, type: :system do
 
-  let!(:scoreboard)   { create(:scoreboard, name: 'Super scoreboard')}
-  let!(:school)       { create(:school, :with_school_group, scoreboard: scoreboard) }
+  let!(:scoreboard)         { create(:scoreboard, name: 'Super scoreboard')}
+  let!(:school)             { create(:school, :with_school_group, scoreboard: scoreboard, name: "No points" ) }
+  let(:points)              { 123 }
+  let!(:school_with_points) { create :school, :with_points, score_points: points, scoreboard: scoreboard }
 
   describe 'with public scoreboards' do
+
+    describe 'on the index page' do
+      before(:each) do
+        visit scoreboards_path
+      end
+
       it 'allows anyone to see the scoreboard' do
-        visit schools_path
-        click_on 'Scoreboards'
         expect(page).to have_content('Super scoreboard')
         expect(page).to have_link(href: scoreboard_path(scoreboard))
         visit scoreboard_path(scoreboard)
         expect(page).to have_content('Super scoreboard')
         expect(page).to have_content(school.name)
       end
+
+      it 'includes top ranking schools' do
+        expect(page).to have_content(school_with_points.name)
+        expect(page).to have_content(points)
+        expect(page).to_not have_content(school.name)
+        expect(page).to have_link('View scores for 2 schools')
+      end
+    end
+
+    it 'includes schools and points on the scoreboard' do
+      visit scoreboard_path(scoreboard)
+      expect(page).to have_content(school_with_points.name)
+      expect(page).to have_content(points)
+      expect(page).to have_content(school.name)
+      expect(page).to have_content("0")
+    end
   end
 
   describe 'with private scoreboards' do


### PR DESCRIPTION
Improving the UX of the scoreboard pages

* [x] add top 3 schools and points to scoreboard index page
* [x] tidy up layout of scoreboard index page
* [x] improve title and layout of scoreboard page, including showing only current and previous academic years
* [x] improve table entry of schools with no points on the scoreboard
* [x] ensure both pages look OK on mobile
* [x] refactor revised code and queries used in the initial prototype
* [x] add additional tests