### PR TITLE
2330 localise pupil dashboard templates to use i18n

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -373,4 +373,8 @@ module ApplicationHelper
     end
     preview_url + "locale=#{locale}"
   end
+
+  def i18n_key_from(str)
+    str.gsub('+', ' And ').delete(' ').underscore
+  end
 end

--- a/app/models/podium.rb
+++ b/app/models/podium.rb
@@ -10,7 +10,7 @@ class Podium
     end
 
     def ordinal
-      "#{@position}#{@position.ordinal}"
+      @position.ordinalize
     end
 
     def recent_points

--- a/app/models/podium.rb
+++ b/app/models/podium.rb
@@ -10,7 +10,7 @@ class Podium
     end
 
     def ordinal
-      @position.ordinalize
+      "#{@position}#{@position.ordinal}"
     end
 
     def recent_points

--- a/app/views/pupils/analysis/_top_level.html.erb
+++ b/app/views/pupils/analysis/_top_level.html.erb
@@ -6,7 +6,7 @@
           <%= fa_icon "#{fuel_type_icon(:electricity)} fa-3x" %>
           <%= fa_icon "sun fa-3x" %>
         </div>
-        <%= link_to 'Electricity & Solar PV', pupils_school_analysis_path(school, category: :solar), class: 'h2 stretched-link text-decoration-none' %>
+        <%= link_to t('pupils.analysis.electricity_and_solar_pv'), pupils_school_analysis_path(school, category: :solar), class: 'h2 stretched-link text-decoration-none' %>
       </div>
     </div>
   <% elsif school.has_electricity? %>
@@ -15,10 +15,10 @@
         <div class="p-4">
           <%= fa_icon "#{fuel_type_icon(:electricity)} fa-3x" %>
         </div>
-        <%= link_to 'Electricity', pupils_school_analysis_path(school, category: :electricity), class: 'h2 stretched-link text-decoration-none' %>
+        <%= link_to t('pupils.analysis.electricity'), pupils_school_analysis_path(school, category: :electricity), class: 'h2 stretched-link text-decoration-none' %>
         <div>
           <% if school.has_storage_heaters? %>
-            <span class="small" title="">(without storage heaters)</span>
+            <span class="small" title="">(<%= t('pupils.analysis.without_storage_heaters') %>)</span>
           <% end %>
         </div>
       </div>
@@ -30,7 +30,7 @@
         <div class="p-4">
           <%= fa_icon "#{fuel_type_icon(:gas)} fa-3x" %>
         </div>
-        <%= link_to 'Gas', pupils_school_analysis_path(school, category: :gas), class: 'h2 stretched-link text-decoration-none' %>
+        <%= link_to t('pupils.analysis.gas'), pupils_school_analysis_path(school, category: :gas), class: 'h2 stretched-link text-decoration-none' %>
       </div>
     </div>
   <% end %>
@@ -40,7 +40,7 @@
         <div class="p-4">
           <%= fab_icon('intercom fa-3x') %>
         </div>
-        <%= link_to 'Storage heaters', pupils_school_analysis_path(school, category: :storage_heaters), class: 'h2 stretched-link text-decoration-none' %>
+        <%= link_to t('pupils.analysis.storage_heaters'), pupils_school_analysis_path(school, category: :storage_heaters), class: 'h2 stretched-link text-decoration-none' %>
       </div>
     </div>
   <% end %>
@@ -50,7 +50,7 @@
         <div class="p-4">
           <%= fa_icon('tachometer-alt fa-3x') %>
         </div>
-        <%= link_to 'Live energy data', school_live_data_path(school), class: 'h2 stretched-link text-decoration-none' %>
+        <%= link_to t('pupils.analysis.live_energy_data'), school_live_data_path(school), class: 'h2 stretched-link text-decoration-none' %>
       </div>
     </div>
   <% end %>

--- a/app/views/pupils/analysis/_top_level.html.erb
+++ b/app/views/pupils/analysis/_top_level.html.erb
@@ -6,7 +6,7 @@
           <%= fa_icon "#{fuel_type_icon(:electricity)} fa-3x" %>
           <%= fa_icon "sun fa-3x" %>
         </div>
-        <%= link_to t('pupils.analysis.electricity_and_solar_pv'), pupils_school_analysis_path(school, category: :solar), class: 'h2 stretched-link text-decoration-none' %>
+        <%= link_to t('common.electricity_and_solar_pv'), pupils_school_analysis_path(school, category: :solar), class: 'h2 stretched-link text-decoration-none' %>
       </div>
     </div>
   <% elsif school.has_electricity? %>
@@ -15,7 +15,7 @@
         <div class="p-4">
           <%= fa_icon "#{fuel_type_icon(:electricity)} fa-3x" %>
         </div>
-        <%= link_to t('pupils.analysis.electricity'), pupils_school_analysis_path(school, category: :electricity), class: 'h2 stretched-link text-decoration-none' %>
+        <%= link_to t('common.electricity'), pupils_school_analysis_path(school, category: :electricity), class: 'h2 stretched-link text-decoration-none' %>
         <div>
           <% if school.has_storage_heaters? %>
             <span class="small" title="">(<%= t('pupils.analysis.without_storage_heaters') %>)</span>
@@ -30,7 +30,7 @@
         <div class="p-4">
           <%= fa_icon "#{fuel_type_icon(:gas)} fa-3x" %>
         </div>
-        <%= link_to t('pupils.analysis.gas'), pupils_school_analysis_path(school, category: :gas), class: 'h2 stretched-link text-decoration-none' %>
+        <%= link_to t('common.gas'), pupils_school_analysis_path(school, category: :gas), class: 'h2 stretched-link text-decoration-none' %>
       </div>
     </div>
   <% end %>
@@ -40,7 +40,7 @@
         <div class="p-4">
           <%= fab_icon('intercom fa-3x') %>
         </div>
-        <%= link_to t('pupils.analysis.storage_heaters'), pupils_school_analysis_path(school, category: :storage_heaters), class: 'h2 stretched-link text-decoration-none' %>
+        <%= link_to t('common.storage_heaters'), pupils_school_analysis_path(school, category: :storage_heaters), class: 'h2 stretched-link text-decoration-none' %>
       </div>
     </div>
   <% end %>

--- a/app/views/pupils/analysis/electricity.html.erb
+++ b/app/views/pupils/analysis/electricity.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, "Here's the electricity data for your school" %>
+<% content_for :page_title, strip_tags(t('pupils.analysis.electricity_data_html')) %>
 
 <div class="d-flex justify-content-between align-items-center">
   <div>

--- a/app/views/pupils/analysis/electricity.html.erb
+++ b/app/views/pupils/analysis/electricity.html.erb
@@ -2,48 +2,48 @@
 
 <div class="d-flex justify-content-between align-items-center">
   <div>
-    <%= link_to 'Back',  pupils_school_analysis_path(@school), class: 'btn btn-rounded' %>
+    <%= link_to t('common.labels.back'),  pupils_school_analysis_path(@school), class: 'btn btn-rounded' %>
   </div>
   <div>
-    <h1>Here's the <strong>electricity</strong> data for your school</h1>
+    <h1><%= t('pupils.analysis.electricity_data_html') %></h1>
   </div>
   <div></div>
 </div>
 <hr />
 
-<h2>I want to&hellip;</h2>
+<h2><%= sanitize t('pupils.analysis.i_want_to') %></h2>
 
 <div class="row">
 
   <%= render 'chart_link', school: @school, energy: :electricity, chart_config: {energy: 'Electricity', presentation: 'kWh'} do %>
-    find out <strong>when</strong> the electricity was used
+    <%= t('pupils.analysis.find_when_electricity_used_html') %>
   <% end %>
 
   <%= render 'chart_link', school: @school, energy: :electricity, chart_config: {energy: 'Electricity', presentation: 'Cost'} do %>
-    find out <strong>how much</strong> the electricity cost
+    <%= t('pupils.analysis.find_how_much_electricity_cost_html') %>
   <% end %>
 
   <%= render 'chart_link', school: @school, energy: :electricity, chart_config: {energy: 'Electricity', presentation: 'CO2'} do %>
-    find out how much <strong>carbon dioxide</strong> was generated
+    <%= t('pupils.analysis.find_how_much_co2_generated_html') %>
   <% end %>
 
   <%= render 'usage_link', school: @school, energy: :electricity, usage_config: {period: :weekly} do %>
-    compare the electricity used in two different weeks
+    <%= t('pupils.analysis.compare_electricity_in_2_weeks') %>
   <% end %>
 
   <%= render 'usage_link', school: @school, energy: :electricity, usage_config: {period: :daily} do %>
-    compare the electricity used on two different days
+    <%= t('pupils.analysis.compare_electricity_on_2_days') %>
   <% end %>
 
   <% if @school.filterable_meters.electricity.count > 1 %>
     <%= render 'usage_link', school: @school, energy: :electricity, usage_config: {period: :weekly, split_meters: true} do %>
-      compare the electricity use by different meters
+      <%= t('pupils.analysis.compare_electricity_use_by_meters') %>
     <% end %>
   <% end %>
 
 </div>
 
-<h2>I want to look at&hellip;</h2>
+<h2><%= sanitize t('pupils.analysis.i_want_to_look_at') %></h2>
 
 <div class="row">
 
@@ -51,11 +51,11 @@
     <div class="p-4">
       <%= fa_icon "chart-pie fa-3x" %>
     </div>
-    Pie charts
+    <%= t('common.pie_charts') %>
   <% end %>
 
-  <%= render 'category_link', school: @school, energy: :electricity, category: :electricity_bar, category_name: 'Bar charts', icon: 'chart-bar' %>
+  <%= render 'category_link', school: @school, energy: :electricity, category: :electricity_bar, category_name: t('common.bar_charts'), icon: 'chart-bar' %>
 
-  <%= render 'category_link', school: @school, energy: :electricity, category: :electricity_line, category_name: 'Line graphs', icon: 'chart-line' %>
+  <%= render 'category_link', school: @school, energy: :electricity, category: :electricity_line, category_name: t('common.line_graphs'), icon: 'chart-line' %>
 
 </div>

--- a/app/views/pupils/analysis/electricity.html.erb
+++ b/app/views/pupils/analysis/electricity.html.erb
@@ -11,7 +11,7 @@
 </div>
 <hr />
 
-<h2><%= sanitize t('pupils.analysis.i_want_to') %></h2>
+<h2><%= t('pupils.analysis.i_want_to') %></h2>
 
 <div class="row">
 
@@ -43,7 +43,7 @@
 
 </div>
 
-<h2><%= sanitize t('pupils.analysis.i_want_to_look_at') %></h2>
+<h2><%= t('pupils.analysis.i_want_to_look_at') %></h2>
 
 <div class="row">
 

--- a/app/views/pupils/analysis/electricity_bar.html.erb
+++ b/app/views/pupils/analysis/electricity_bar.html.erb
@@ -16,24 +16,24 @@
 <div class="row">
 
   <%= render 'chart_link', school: @school, energy: :electricity, chart_config: {energy: 'Electricity', presentation: 'Bar', secondary_presentation: 'Bench'} do %>
-    find out how my school's electricity use compares with other schools
+    <%= t('pupils.analysis.find_electricity_comparison') %>
   <% end %>
 
   <%= render 'chart_link', school: @school, energy: :electricity, chart_config: {energy: 'Electricity', presentation: 'Bar', secondary_presentation: 'Week'} do %>
-    find out how much electricity was used last year
+    <%= t('pupils.analysis.find_electricity_use_last_year') %>
   <% end %>
 
   <%= render 'chart_link', school: @school, energy: :electricity, chart_config: {energy: 'Electricity', presentation: 'Bar', secondary_presentation: 'Year'} do %>
-    find out how electricity use has changed long term
+    <%= t('pupils.analysis.find_electricity_use_long_term') %>
   <% end %>
 
   <%= render 'usage_link', school: @school, energy: :electricity, usage_config: {period: :weekly} do %>
-    compare the electricity used in two different weeks
+    <%= t('pupils.analysis.compare_electricity_in_2_weeks') %>
   <% end %>
 
   <% if @school.filterable_meters.electricity.count > 1 %>
     <%= render 'usage_link', school: @school, energy: :electricity, usage_config: {period: :weekly, split_meters: true} do %>
-      compare the electricity use by different meters
+      <%= t('pupils.analysis.compare_electricity_use_by_meters') %>
     <% end %>
   <% end %>
 

--- a/app/views/pupils/analysis/electricity_bar.html.erb
+++ b/app/views/pupils/analysis/electricity_bar.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, "Here's the electricity data for your school" %>
+<% content_for :page_title, strip_tags(t('pupils.analysis.electricity_data_html')) %>
 
 <div class="d-flex justify-content-between align-items-center">
   <div>

--- a/app/views/pupils/analysis/electricity_bar.html.erb
+++ b/app/views/pupils/analysis/electricity_bar.html.erb
@@ -2,10 +2,10 @@
 
 <div class="d-flex justify-content-between align-items-center">
   <div>
-    <%= link_to 'Back',  pupils_school_analysis_path(@school, category: :electricity), class: 'btn btn-rounded' %>
+    <%= link_to t('common.labels.back'),  pupils_school_analysis_path(@school, category: :electricity), class: 'btn btn-rounded' %>
   </div>
   <div>
-    <h1>Here's the <strong>electricity</strong> data for your school</h1>
+    <h1><%= t('pupils.analysis.electricity_data_html') %></h1>
   </div>
   <div></div>
 </div>

--- a/app/views/pupils/analysis/electricity_bar.html.erb
+++ b/app/views/pupils/analysis/electricity_bar.html.erb
@@ -11,7 +11,7 @@
 </div>
 <hr />
 
-<h2>I want to&hellip;</h2>
+<h2><%= t('pupils.analysis.i_want_to') %></h2>
 
 <div class="row">
 

--- a/app/views/pupils/analysis/electricity_line.html.erb
+++ b/app/views/pupils/analysis/electricity_line.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, "Here's the electricity data for your school" %>
+<% content_for :page_title, strip_tags(t('pupils.analysis.electricity_data_html')) %>
 
 <div class="d-flex justify-content-between align-items-center">
   <div>

--- a/app/views/pupils/analysis/electricity_line.html.erb
+++ b/app/views/pupils/analysis/electricity_line.html.erb
@@ -5,7 +5,7 @@
     <%= link_to 'Back',  pupils_school_analysis_path(@school, category: :electricity), class: 'btn btn-rounded' %>
   </div>
   <div>
-    <h1>Here's the <strong>electricity</strong> data for your school</h1>
+    <h1><%= t('pupils.analysis.electricity_data_html') %></h1>
   </div>
   <div></div>
 </div>

--- a/app/views/pupils/analysis/electricity_line.html.erb
+++ b/app/views/pupils/analysis/electricity_line.html.erb
@@ -11,7 +11,7 @@
 </div>
 <hr />
 
-<h2><%= sanitize t('pupils.analysis.i_want_to') %></h2>
+<h2><%= t('pupils.analysis.i_want_to') %></h2>
 
 <div class="row">
 

--- a/app/views/pupils/analysis/electricity_line.html.erb
+++ b/app/views/pupils/analysis/electricity_line.html.erb
@@ -2,7 +2,7 @@
 
 <div class="d-flex justify-content-between align-items-center">
   <div>
-    <%= link_to 'Back',  pupils_school_analysis_path(@school, category: :electricity), class: 'btn btn-rounded' %>
+    <%= link_to t('common.labels.back'),  pupils_school_analysis_path(@school, category: :electricity), class: 'btn btn-rounded' %>
   </div>
   <div>
     <h1><%= t('pupils.analysis.electricity_data_html') %></h1>
@@ -11,25 +11,25 @@
 </div>
 <hr />
 
-<h2>I want to&hellip;</h2>
+<h2><%= sanitize t('pupils.analysis.i_want_to') %></h2>
 
 <div class="row">
 
   <%= render 'chart_link', school: @school, energy: :electricity, chart_config: {energy: 'Electricity', presentation: 'Line', secondary_presentation: '7days'} do %>
-    find out how much electricity was used in the last 7 days
+    <%= t('pupils.analysis.find_electricity_use_7days') %>
   <% end %>
 
   <%= render 'chart_link', school: @school, energy: :electricity, chart_config: {energy: 'Electricity', presentation: 'Line', secondary_presentation: 'Base'} do %>
-    find out how much electricity was used by lights and appliances running all the time
+    <%= t('pupils.analysis.find_electricity_use_lights') %>
   <% end %>
 
   <%= render 'usage_link', school: @school, energy: :electricity, usage_config: {period: :daily} do %>
-    compare the electricity used on two different days
+    <%= t('pupils.analysis.compare_electricity_on_2_days') %>
   <% end %>
 
   <% if @school.filterable_meters.electricity.count > 1 %>
     <%= render 'usage_link', school: @school, energy: :electricity, usage_config: {period: :daily, split_meters: true} do %>
-      compare the electricity use by different meters
+      <%= t('pupils.analysis.compare_electricity_use_by_meters') %>
     <% end %>
   <% end %>
 

--- a/app/views/pupils/analysis/gas.html.erb
+++ b/app/views/pupils/analysis/gas.html.erb
@@ -2,57 +2,57 @@
 
 <div class="d-flex justify-content-between align-items-center">
   <div>
-    <%= link_to 'Back',  pupils_school_analysis_path(@school), class: 'btn btn-rounded' %>
+    <%= link_to t('common.labels.back'),  pupils_school_analysis_path(@school), class: 'btn btn-rounded' %>
   </div>
   <div>
-    <h1>Here's the <strong>gas</strong> data for your school</h1>
+    <h1><%= t('pupils.analysis.gas_data_html') %></h1>
   </div>
   <div></div>
 </div>
 <hr />
 
-<h2>I want to&hellip;</h2>
+<h2><%= sanitize t('pupils.analysis.i_want_to') %></h2>
 
 <div class="row">
 
   <%= render 'chart_link', school: @school, energy: :gas, chart_config: {energy: 'Gas', presentation: 'kWh'} do %>
-    find out <strong>when</strong> the gas was used
+    <%= t('pupils.analysis.find_when_gas_used_html') %>
   <% end %>
 
   <%= render 'chart_link', school: @school, energy: :gas, chart_config: {energy: 'Gas', presentation: 'Cost'} do %>
-    find out <strong>how much</strong> the gas cost
-  <% end %>
+    <%= t('pupils.analysis.find_how_much_gas_cost_html') %>
+<% end %>
 
   <%= render 'chart_link', school: @school, energy: :gas, chart_config: {energy: 'Gas', presentation: 'CO2'} do %>
-    find out how much <strong>carbon dioxide</strong> was generated
+    <%= t('pupils.analysis.find_how_much_co2_generated_html') %>
   <% end %>
 
   <%= render 'usage_link', school: @school, energy: :gas, usage_config: {period: :weekly} do %>
-    compare the gas used in two different weeks
+    <%= t('pupils.analysis.compare_gas_in_2_weeks') %>
   <% end %>
 
   <%= render 'usage_link', school: @school, energy: :gas, usage_config: {period: :daily} do %>
-    compare the gas used on two different days
+    <%= t('pupils.analysis.compare_gas_on_2_days') %>
   <% end %>
 
   <% if @school.filterable_meters.gas.count > 1 %>
     <%= render 'usage_link', school: @school, energy: :gas, usage_config: {period: :weekly, split_meters: true} do %>
-      compare the gas use by different meters
+      <%= t('pupils.analysis.compare_gas_use_by_meters') %>
     <% end %>
   <% end %>
 
 </div>
 
-<h2>I want to look at&hellip;</h2>
+<h2><%= sanitize t('pupils.analysis.i_want_to_look_at') %></h2>
 
 <div class="row">
   <%= render 'chart_link', school: @school, energy: :gas, chart_config: {energy: 'Gas', presentation: 'Pie'}, centre: true do %>
     <div class="p-4">
       <%= fa_icon "chart-pie fa-3x" %>
     </div>
-    Pie charts
+    <%= t('common.pie_charts') %>
   <% end %>
 
-  <%= render 'category_link', school: @school, energy: :gas, category: :gas_bar, category_name: 'Bar charts', icon: 'chart-bar' %>
-  <%= render 'category_link', school: @school, energy: :gas, category: :gas_line, category_name: 'Line graphs', icon: 'chart-line' %>
+  <%= render 'category_link', school: @school, energy: :gas, category: :gas_bar, category_name: t('common.bar_charts'), icon: 'chart-bar' %>
+  <%= render 'category_link', school: @school, energy: :gas, category: :gas_line, category_name: t('common.line_graphs'), icon: 'chart-line' %>
 </div>

--- a/app/views/pupils/analysis/gas.html.erb
+++ b/app/views/pupils/analysis/gas.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, "Here's the gas data for your school" %>
+<% content_for :page_title, strip_tags(t('pupils.analysis.gas_data_html')) %>
 
 <div class="d-flex justify-content-between align-items-center">
   <div>

--- a/app/views/pupils/analysis/gas.html.erb
+++ b/app/views/pupils/analysis/gas.html.erb
@@ -11,7 +11,7 @@
 </div>
 <hr />
 
-<h2><%= sanitize t('pupils.analysis.i_want_to') %></h2>
+<h2><%= t('pupils.analysis.i_want_to') %></h2>
 
 <div class="row">
 

--- a/app/views/pupils/analysis/gas_bar.html.erb
+++ b/app/views/pupils/analysis/gas_bar.html.erb
@@ -16,24 +16,24 @@
 <div class="row">
 
   <%= render 'chart_link', school: @school, energy: :gas, chart_config: {energy: 'Gas', presentation: 'Bar', secondary_presentation: 'Bench'} do %>
-    find out how my school's gas use compares with other schools
+    <%= t('pupils.analysis.find_gas_comparison') %>
   <% end %>
 
   <%= render 'chart_link', school: @school, energy: :gas, chart_config: {energy: 'Gas', presentation: 'Bar', secondary_presentation: 'Week'} do %>
-    find out how much gas was used last year
+    <%= t('pupils.analysis.find_gas_use_last_year') %>
   <% end %>
 
   <%= render 'chart_link', school: @school, energy: :gas, chart_config: {energy: 'Gas', presentation: 'Bar', secondary_presentation: 'Year'} do %>
-    find out how gas use has changed long term
+    <%= t('pupils.analysis.find_gas_use_long_term') %>
   <% end %>
 
   <%= render 'usage_link', school: @school, energy: :gas, usage_config: {period: :weekly} do %>
-    compare the gas used in two different weeks
+    <%= t('pupils.analysis.compare_gas_in_2_weeks') %>
   <% end %>
 
   <% if @school.filterable_meters.gas.count > 1 %>
     <%= render 'usage_link', school: @school, energy: :gas, usage_config: {period: :weekly, split_meters: true} do %>
-      compare the gas use by different meters
+      <%= t('pupils.analysis.compare_gas_use_by_meters') %>
     <% end %>
   <% end %>
 

--- a/app/views/pupils/analysis/gas_bar.html.erb
+++ b/app/views/pupils/analysis/gas_bar.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, "Here's the gas data for your school" %>
+<% content_for :page_title, strip_tags(t('pupils.analysis.gas_data_html')) %>
 
 <div class="d-flex justify-content-between align-items-center">
   <div>

--- a/app/views/pupils/analysis/gas_bar.html.erb
+++ b/app/views/pupils/analysis/gas_bar.html.erb
@@ -2,16 +2,16 @@
 
 <div class="d-flex justify-content-between align-items-center">
   <div>
-    <%= link_to 'Back',  pupils_school_analysis_path(@school, category: :gas), class: 'btn btn-rounded' %>
+    <%= link_to t('common.labels.back'),  pupils_school_analysis_path(@school, category: :gas), class: 'btn btn-rounded' %>
   </div>
   <div>
-    <h1>Here's the <strong>gas</strong> data for your school</h1>
+    <h1><%= t('pupils.analysis.gas_data_html') %></h1>
   </div>
   <div></div>
 </div>
 <hr />
 
-<h2>I want to&hellip;</h2>
+<h2><%= sanitize t('pupils.analysis.i_want_to') %></h2>
 
 <div class="row">
 

--- a/app/views/pupils/analysis/gas_bar.html.erb
+++ b/app/views/pupils/analysis/gas_bar.html.erb
@@ -11,7 +11,7 @@
 </div>
 <hr />
 
-<h2><%= sanitize t('pupils.analysis.i_want_to') %></h2>
+<h2><%= t('pupils.analysis.i_want_to') %></h2>
 
 <div class="row">
 

--- a/app/views/pupils/analysis/gas_line.html.erb
+++ b/app/views/pupils/analysis/gas_line.html.erb
@@ -15,16 +15,16 @@
 
 <div class="row">
   <%= render 'chart_link', school: @school, energy: :gas, chart_config: {energy: 'Gas', presentation: 'Line'} do %>
-    find out how much gas was used in the last 7 days
+    <%= t('pupils.analysis.find_gas_use_7days') %>
   <% end %>
 
   <%= render 'usage_link', school: @school, energy: :gas, usage_config: {period: :daily} do %>
-    compare the gas used on two different days
+    <%= t('pupils.analysis.compare_gas_on_2_days') %>
   <% end %>
 
   <% if @school.filterable_meters.gas.count > 1 %>
     <%= render 'usage_link', school: @school, energy: :gas, usage_config: {period: :daily, split_meters: true} do %>
-      compare the gas use by different meters
+      <%= t('pupils.analysis.compare_gas_use_by_meters') %>
     <% end %>
   <% end %>
 </div>

--- a/app/views/pupils/analysis/gas_line.html.erb
+++ b/app/views/pupils/analysis/gas_line.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, "Here's the gas data for your school" %>
+<% content_for :page_title, strip_tags(t('pupils.analysis.gas_data_html')) %>
 
 <div class="d-flex justify-content-between align-items-center">
   <div>

--- a/app/views/pupils/analysis/gas_line.html.erb
+++ b/app/views/pupils/analysis/gas_line.html.erb
@@ -2,16 +2,16 @@
 
 <div class="d-flex justify-content-between align-items-center">
   <div>
-    <%= link_to 'Back',  pupils_school_analysis_path(@school, category: :gas), class: 'btn btn-rounded' %>
+    <%= link_to t('common.labels.back'),  pupils_school_analysis_path(@school, category: :gas), class: 'btn btn-rounded' %>
   </div>
   <div>
-    <h1>Here's the <strong>gas</strong> data for your school</h1>
+    <h1><%= t('pupils.analysis.gas_data_html') %></h1>
   </div>
   <div></div>
 </div>
 <hr />
 
-<h2>I want to&hellip;</h2>
+<h2><%= sanitize t('pupils.analysis.i_want_to') %></h2>
 
 <div class="row">
   <%= render 'chart_link', school: @school, energy: :gas, chart_config: {energy: 'Gas', presentation: 'Line'} do %>

--- a/app/views/pupils/analysis/gas_line.html.erb
+++ b/app/views/pupils/analysis/gas_line.html.erb
@@ -11,7 +11,7 @@
 </div>
 <hr />
 
-<h2><%= sanitize t('pupils.analysis.i_want_to') %></h2>
+<h2><%= t('pupils.analysis.i_want_to') %></h2>
 
 <div class="row">
   <%= render 'chart_link', school: @school, energy: :gas, chart_config: {energy: 'Gas', presentation: 'Line'} do %>

--- a/app/views/pupils/analysis/index.html.erb
+++ b/app/views/pupils/analysis/index.html.erb
@@ -1,5 +1,5 @@
-<% content_for :page_title, "Let's look at the energy use data for your school" %>
+<% content_for :page_title, t('pupils.analysis.look_at_energy_use') %>
 
-<h1>Let's look at the energy use data for your school</h1>
+<h1><%= t('pupils.analysis.look_at_energy_use') %></h1>
 
 <%= render 'top_level', school: @school %>

--- a/app/views/pupils/analysis/show.html.erb
+++ b/app/views/pupils/analysis/show.html.erb
@@ -1,7 +1,7 @@
 <div class="d-flex justify-content-between align-items-center">
   <h1>Explore the <strong><%= @fuel_type %></strong> data for your school</h1>
   <div>
-    <%= link_to 'Explore data', pupils_school_analysis_path(@school), class: 'btn btn-outline-dark rounded-pill font-weight-bold' %>
+    <%= link_to t('pupils.analysis.explore_data'), pupils_school_analysis_path(@school), class: 'btn btn-outline-dark rounded-pill font-weight-bold' %>
   </div>
 </div>
 

--- a/app/views/pupils/analysis/show.html.erb
+++ b/app/views/pupils/analysis/show.html.erb
@@ -1,5 +1,5 @@
 <div class="d-flex justify-content-between align-items-center">
-  <h1>Explore the <strong><%= @fuel_type %></strong> data for your school</h1>
+  <h1><%= t('pupils.analysis.explore_energy_data_html', fuel_type: t('common.' + i18n_key_from(@fuel_type))) %></h1>
   <div>
     <%= link_to t('pupils.analysis.explore_data'), pupils_school_analysis_path(@school), class: 'btn btn-outline-dark rounded-pill font-weight-bold' %>
   </div>

--- a/app/views/pupils/analysis/solar.html.erb
+++ b/app/views/pupils/analysis/solar.html.erb
@@ -11,7 +11,7 @@
 </div>
 <hr />
 
-<h2>I want to&hellip;</h2>
+<h2><%= sanitize t('pupils.analysis.i_want_to') %></h2>
 
 <div class="row">
 

--- a/app/views/pupils/analysis/solar.html.erb
+++ b/app/views/pupils/analysis/solar.html.erb
@@ -2,7 +2,7 @@
 
 <div class="d-flex justify-content-between align-items-center">
   <div>
-    <%= link_to 'Back',  pupils_school_analysis_path(@school), class: 'btn btn-rounded' %>
+    <%= link_to t('common.labels.back'),  pupils_school_analysis_path(@school), class: 'btn btn-rounded' %>
   </div>
   <div>
     <h1>Here's the <strong>electricity and solar</strong> data for your school</h1>

--- a/app/views/pupils/analysis/solar.html.erb
+++ b/app/views/pupils/analysis/solar.html.erb
@@ -11,7 +11,7 @@
 </div>
 <hr />
 
-<h2><%= sanitize t('pupils.analysis.i_want_to') %></h2>
+<h2><%= t('pupils.analysis.i_want_to') %></h2>
 
 <div class="row">
 

--- a/app/views/pupils/analysis/solar.html.erb
+++ b/app/views/pupils/analysis/solar.html.erb
@@ -1,11 +1,11 @@
-<% content_for :page_title, "Here's the electricity and solar data for your school" %>
+<% content_for :page_title, strip_tags(t('pupils.analysis.electricity_and_solar_data_html')) %>
 
 <div class="d-flex justify-content-between align-items-center">
   <div>
     <%= link_to t('common.labels.back'),  pupils_school_analysis_path(@school), class: 'btn btn-rounded' %>
   </div>
   <div>
-    <h1>Here's the <strong>electricity and solar</strong> data for your school</h1>
+    <h1><%= t('pupils.analysis.electricity_and_solar_data_html') %></h1>
   </div>
   <div></div>
 </div>
@@ -16,24 +16,24 @@
 <div class="row">
 
   <%= render 'chart_link', school: @school, energy: :solar, chart_config: {energy: 'Electricity', presentation: 'kWh'} do %>
-    find out <strong>when</strong> the electricity was used
+    <%= t('pupils.analysis.find_when_electricity_used_html') %>
   <% end %>
 
   <%= render 'chart_link', school: @school, energy: :solar, chart_config: {energy: 'Electricity+Solar PV', presentation: 'Solar'} do %>
-    find out about <strong>solar</strong>
+    <%= t('pupils.analysis.find_out_about_solar_html') %>
   <% end %>
 
   <%= render 'usage_link', school: @school, energy: :solar, supply: :electricity, usage_config: {period: :weekly} do %>
-    compare the electricity used in two different weeks
+    <%= t('pupils.analysis.compare_electricity_in_2_weeks') %>
   <% end %>
 
   <%= render 'usage_link', school: @school, energy: :solar, supply: :electricity, usage_config: {period: :daily} do %>
-    compare the electricity used on two different days
+    <%= t('pupils.analysis.compare_electricity_on_2_days') %>
   <% end %>
 
 </div>
 
-<h2>I want to look at&hellip;</h2>
+<h2><%= sanitize t('pupils.analysis.i_want_to_look_at') %></h2>
 
 <div class="row">
 
@@ -41,11 +41,11 @@
     <div class="p-4">
       <%= fa_icon "chart-pie fa-3x" %>
     </div>
-    Pie charts
+    <%= t('common.pie_charts') %>
   <% end %>
 
-  <%= render 'category_link', school: @school, energy: :solar, category: :solar_bar, category_name: 'Bar charts', icon: 'chart-bar' %>
+  <%= render 'category_link', school: @school, energy: :solar, category: :solar_bar, category_name: t('common.bar_charts'), icon: 'chart-bar' %>
 
-  <%= render 'category_link', school: @school, energy: :solar, category: :solar_line, category_name: 'Line graphs', icon: 'chart-line' %>
+  <%= render 'category_link', school: @school, energy: :solar, category: :solar_line, category_name: t('common.line_graphs'), icon: 'chart-line' %>
 
 </div>

--- a/app/views/pupils/analysis/solar_bar.html.erb
+++ b/app/views/pupils/analysis/solar_bar.html.erb
@@ -1,11 +1,11 @@
-<% content_for :page_title, "Here's the electricity and solar data for your school" %>
+<% content_for :page_title, strip_tags(t('pupils.analysis.electricity_and_solar_data_html')) %>
 
 <div class="d-flex justify-content-between align-items-center">
   <div>
     <%= link_to t('common.labels.back'),  pupils_school_analysis_path(@school, category: :solar), class: 'btn btn-rounded' %>
   </div>
   <div>
-    <h1>Here's the <strong>electricity and solar</strong> data for your school</h1>
+    <h1><%= t('pupils.analysis.electricity_and_solar_data_html') %></h1>
   </div>
   <div></div>
 </div>
@@ -16,19 +16,19 @@
 <div class="row">
 
   <%= render 'chart_link', school: @school, energy: :solar, chart_config: {energy: 'Electricity', presentation: 'Bar', secondary_presentation: 'Bench'} do %>
-    find out how my school's electricity use compares with other schools
+    <%= t('pupils.analysis.find_electricity_comparison') %>
   <% end %>
 
   <%= render 'chart_link', school: @school, energy: :solar, chart_config: {energy: 'Electricity', presentation: 'Bar', secondary_presentation: 'Week'} do %>
-    find out how much electricity was used last year
+    <%= t('pupils.analysis.find_electricity_use_last_year') %>
   <% end %>
 
   <%= render 'chart_link', school: @school, energy: :solar, chart_config: {energy: 'Electricity', presentation: 'Bar', secondary_presentation: 'Year'} do %>
-    find out how electricity use has changed long term
+    <%= t('pupils.analysis.find_electricity_use_long_term') %>
   <% end %>
 
   <%= render 'usage_link', school: @school, energy: :solar, supply: :electricity, usage_config: {period: :weekly} do %>
-    compare the electricity used in two different weeks
+    <%= t('pupils.analysis.compare_electricity_in_2_weeks') %>
   <% end %>
 
 </div>

--- a/app/views/pupils/analysis/solar_bar.html.erb
+++ b/app/views/pupils/analysis/solar_bar.html.erb
@@ -11,7 +11,7 @@
 </div>
 <hr />
 
-<h2>I want to&hellip;</h2>
+<h2><%= sanitize t('pupils.analysis.i_want_to') %></h2>
 
 <div class="row">
 

--- a/app/views/pupils/analysis/solar_bar.html.erb
+++ b/app/views/pupils/analysis/solar_bar.html.erb
@@ -2,7 +2,7 @@
 
 <div class="d-flex justify-content-between align-items-center">
   <div>
-    <%= link_to 'Back',  pupils_school_analysis_path(@school, category: :solar), class: 'btn btn-rounded' %>
+    <%= link_to t('common.labels.back'),  pupils_school_analysis_path(@school, category: :solar), class: 'btn btn-rounded' %>
   </div>
   <div>
     <h1>Here's the <strong>electricity and solar</strong> data for your school</h1>

--- a/app/views/pupils/analysis/solar_bar.html.erb
+++ b/app/views/pupils/analysis/solar_bar.html.erb
@@ -11,7 +11,7 @@
 </div>
 <hr />
 
-<h2><%= sanitize t('pupils.analysis.i_want_to') %></h2>
+<h2><%= t('pupils.analysis.i_want_to') %></h2>
 
 <div class="row">
 

--- a/app/views/pupils/analysis/solar_line.html.erb
+++ b/app/views/pupils/analysis/solar_line.html.erb
@@ -11,7 +11,7 @@
 </div>
 <hr />
 
-<h2>I want to&hellip;</h2>
+<h2><%= sanitize t('pupils.analysis.i_want_to') %></h2>
 
 <div class="row">
 

--- a/app/views/pupils/analysis/solar_line.html.erb
+++ b/app/views/pupils/analysis/solar_line.html.erb
@@ -1,11 +1,11 @@
-<% content_for :page_title, "Here's the electricity and solar data for your school" %>
+<% content_for :page_title, strip_tags(t('pupils.analysis.electricity_and_solar_data_html')) %>
 
 <div class="d-flex justify-content-between align-items-center">
   <div>
     <%= link_to t('common.labels.back'),  pupils_school_analysis_path(@school, category: :solar), class: 'btn btn-rounded' %>
   </div>
   <div>
-    <h1>Here's the <strong>electricity and solar </strong> data for your school</h1>
+    <h1><%= t('pupils.analysis.electricity_and_solar_data_html') %></h1>
   </div>
   <div></div>
 </div>
@@ -16,15 +16,15 @@
 <div class="row">
 
   <%= render 'chart_link', school: @school, energy: :solar, chart_config: {energy: 'Electricity', presentation: 'Line', secondary_presentation: '7days'} do %>
-    find out how much electricity was used in the last 7 days
+    <%= t('pupils.analysis.find_electricity_use_7days') %>
   <% end %>
 
   <%= render 'chart_link', school: @school, energy: :solar, chart_config: {energy: 'Electricity', presentation: 'Line', secondary_presentation: 'Base'} do %>
-    find out how much electricity was used by lights and appliances running all the time
+    <%= t('pupils.analysis.find_electricity_use_lights') %>
   <% end %>
 
   <%= render 'usage_link', school: @school, energy: :solar, supply: :electricity, usage_config: {period: :daily} do %>
-    compare the electricity used on two different days
+    <%= t('pupils.analysis.compare_electricity_on_2_days') %>
   <% end %>
 
 </div>

--- a/app/views/pupils/analysis/solar_line.html.erb
+++ b/app/views/pupils/analysis/solar_line.html.erb
@@ -11,7 +11,7 @@
 </div>
 <hr />
 
-<h2><%= sanitize t('pupils.analysis.i_want_to') %></h2>
+<h2><%= t('pupils.analysis.i_want_to') %></h2>
 
 <div class="row">
 

--- a/app/views/pupils/analysis/solar_line.html.erb
+++ b/app/views/pupils/analysis/solar_line.html.erb
@@ -2,7 +2,7 @@
 
 <div class="d-flex justify-content-between align-items-center">
   <div>
-    <%= link_to 'Back',  pupils_school_analysis_path(@school, category: :solar), class: 'btn btn-rounded' %>
+    <%= link_to t('common.labels.back'),  pupils_school_analysis_path(@school, category: :solar), class: 'btn btn-rounded' %>
   </div>
   <div>
     <h1>Here's the <strong>electricity and solar </strong> data for your school</h1>

--- a/app/views/pupils/analysis/storage_heaters.html.erb
+++ b/app/views/pupils/analysis/storage_heaters.html.erb
@@ -11,7 +11,7 @@
 </div>
 <hr />
 
-<h2>I want to&hellip;</h2>
+<h2><%= sanitize t('pupils.analysis.i_want_to') %></h2>
 
 <div class="row">
 

--- a/app/views/pupils/analysis/storage_heaters.html.erb
+++ b/app/views/pupils/analysis/storage_heaters.html.erb
@@ -1,11 +1,11 @@
-<% content_for :page_title, "Here's the storage heater data for your school" %>
+<% content_for :page_title, strip_tags(t('pupils.analysis.storage_heater_data_html')) %>
 
 <div class="d-flex justify-content-between align-items-center">
   <div>
     <%= link_to t('common.labels.back'),  pupils_school_analysis_path(@school), class: 'btn btn-rounded' %>
   </div>
   <div>
-    <h1>Here's the <strong>storage heater</strong> data for your school</h1>
+    <h1><%= t('pupils.analysis.storage_heater_data_html') %></h1>
   </div>
   <div></div>
 </div>
@@ -16,35 +16,35 @@
 <div class="row">
 
   <%= render 'chart_link', school: @school, energy: :storage, chart_config: {energy: 'Storage Heaters', presentation: 'kWh'} do %>
-    find out <strong>when</strong> the storage heaters used electricity
+    <%= t('pupils.analysis.find_when_storage_heaters_used_html') %>
   <% end %>
 
   <%= render 'chart_link', school: @school, energy: :storage, chart_config: {energy: 'Storage Heaters', presentation: 'Cost'} do %>
-    find out <strong>how much</strong> the storage heaters cost
+    <%= t('pupils.analysis.find_how_much_storage_heaters_cost_html') %>
   <% end %>
 
   <%= render 'chart_link', school: @school, energy: :storage, chart_config: {energy: 'Storage Heaters', presentation: 'CO2'} do %>
-    find out how much <strong>carbon dioxide</strong> was generated
+    <%= t('pupils.analysis.find_how_much_co2_generated_html') %>
   <% end %>
 
 </div>
 
-<h2>I want to look at&hellip;</h2>
+<h2><%= sanitize t('pupils.analysis.i_want_to_look_at') %></h2>
 
 <div class="row">
   <%= render 'chart_link', school: @school, energy: :storage, chart_config: {energy: 'Storage Heaters', presentation: 'Pie'}, centre: true do %>
     <div class="p-4">
       <%= fa_icon "chart-pie fa-3x" %>
     </div>
-    Pie charts
+    <%= t('common.pie_charts') %>
   <% end %>
 
-  <%= render 'category_link', school: @school, energy: :storage, category: :storage_heaters_bar, category_name: 'Bar charts', icon: 'chart-bar' %>
+  <%= render 'category_link', school: @school, energy: :storage, category: :storage_heaters_bar, category_name: t('common.bar_charts'), icon: 'chart-bar' %>
 
   <%= render 'chart_link', school: @school, energy: :storage, chart_config: {energy: 'Storage Heaters', presentation: 'Line'}, centre: true do %>
     <div class="p-4">
       <%= fa_icon "chart-line fa-3x" %>
     </div>
-    Line graphs
+    t('common.line_graphs')
   <% end %>
 </div>

--- a/app/views/pupils/analysis/storage_heaters.html.erb
+++ b/app/views/pupils/analysis/storage_heaters.html.erb
@@ -2,7 +2,7 @@
 
 <div class="d-flex justify-content-between align-items-center">
   <div>
-    <%= link_to 'Back',  pupils_school_analysis_path(@school), class: 'btn btn-rounded' %>
+    <%= link_to t('common.labels.back'),  pupils_school_analysis_path(@school), class: 'btn btn-rounded' %>
   </div>
   <div>
     <h1>Here's the <strong>storage heater</strong> data for your school</h1>

--- a/app/views/pupils/analysis/storage_heaters.html.erb
+++ b/app/views/pupils/analysis/storage_heaters.html.erb
@@ -11,7 +11,7 @@
 </div>
 <hr />
 
-<h2><%= sanitize t('pupils.analysis.i_want_to') %></h2>
+<h2><%= t('pupils.analysis.i_want_to') %></h2>
 
 <div class="row">
 

--- a/app/views/pupils/analysis/storage_heaters.html.erb
+++ b/app/views/pupils/analysis/storage_heaters.html.erb
@@ -45,6 +45,6 @@
     <div class="p-4">
       <%= fa_icon "chart-line fa-3x" %>
     </div>
-    t('common.line_graphs')
+    <%= t('common.line_graphs') %>
   <% end %>
 </div>

--- a/app/views/pupils/analysis/storage_heaters_bar.html.erb
+++ b/app/views/pupils/analysis/storage_heaters_bar.html.erb
@@ -11,7 +11,7 @@
 </div>
 <hr />
 
-<h2>I want to&hellip;</h2>
+<h2><%= sanitize t('pupils.analysis.i_want_to') %></h2>
 
 <div class="row">
 

--- a/app/views/pupils/analysis/storage_heaters_bar.html.erb
+++ b/app/views/pupils/analysis/storage_heaters_bar.html.erb
@@ -2,7 +2,7 @@
 
 <div class="d-flex justify-content-between align-items-center">
   <div>
-    <%= link_to 'Back',  pupils_school_analysis_path(@school, category: :storage_heaters), class: 'btn btn-rounded' %>
+    <%= link_to t('common.labels.back'),  pupils_school_analysis_path(@school, category: :storage_heaters), class: 'btn btn-rounded' %>
   </div>
   <div>
     <h1>Here's the <strong>storage heater</strong> data for your school</h1>

--- a/app/views/pupils/analysis/storage_heaters_bar.html.erb
+++ b/app/views/pupils/analysis/storage_heaters_bar.html.erb
@@ -11,7 +11,7 @@
 </div>
 <hr />
 
-<h2><%= sanitize t('pupils.analysis.i_want_to') %></h2>
+<h2><%= t('pupils.analysis.i_want_to') %></h2>
 
 <div class="row">
 

--- a/app/views/pupils/analysis/storage_heaters_bar.html.erb
+++ b/app/views/pupils/analysis/storage_heaters_bar.html.erb
@@ -1,11 +1,11 @@
-<% content_for :page_title, "Here's the storage heater data for your school" %>
+<% content_for :page_title, strip_tags(t('pupils.analysis.storage_heater_data_html')) %>
 
 <div class="d-flex justify-content-between align-items-center">
   <div>
     <%= link_to t('common.labels.back'),  pupils_school_analysis_path(@school, category: :storage_heaters), class: 'btn btn-rounded' %>
   </div>
   <div>
-    <h1>Here's the <strong>storage heater</strong> data for your school</h1>
+    <h1><%= t('pupils.analysis.storage_heater_data_html') %></h1>
   </div>
   <div></div>
 </div>
@@ -16,15 +16,15 @@
 <div class="row">
 
   <%= render 'chart_link', school: @school, energy: :storage, chart_config: {energy: 'Storage Heaters', presentation: 'Bar', secondary_presentation: 'Bench'} do %>
-    find out how my school's storage heater use compares with other schools
+    <%= t('pupils.analysis.find_storage_heaters_comparison') %>
   <% end %>
 
   <%= render 'chart_link', school: @school, energy: :storage, chart_config: {energy: 'Storage Heaters', presentation: 'Bar', secondary_presentation: 'Week'} do %>
-    find out how much electricity was used by storage heaters last year
+    <%= t('pupils.analysis.find_storage_heaters_use_last_year') %>
   <% end %>
 
   <%= render 'chart_link', school: @school, energy: :storage, chart_config: {energy: 'Storage Heaters', presentation: 'Bar', secondary_presentation: 'Year'} do %>
-    find out how storage heater electricity use has changed long term
+    <%= t('pupils.analysis.find_storage_heaters_use_long_term') %>
   <% end %>
 
 </div>

--- a/app/views/pupils/schools/_default_equivalences.html.erb
+++ b/app/views/pupils/schools/_default_equivalences.html.erb
@@ -6,7 +6,7 @@
           <div class="col-lg-6 equivalence-wrapper">
             <div><%= equivalence[:measure].html_safe %></div>
             <h1><%= equivalence[:equivalence] %></h1>
-            <p>How will your school compare? You'll soon be able to find out!</p>
+            <p><%= t('pupils.schools.show.how_will_school_compare') %></p>
           </div>
           <div class="col-lg-6 illustration-wrapper">
             <%= image_tag("equivalences/#{equivalence[:image_name]}.svg") if equivalence[:image_name].present? %>
@@ -17,10 +17,10 @@
   </div>
   <a class="carousel-control-prev" href="#pupil_carousel" role="button" data-slide="prev">
     <span class="carousel-control-prev-icon" aria-hidden="true"></span>
-    <span class="sr-only">Previous</span>
+    <span class="sr-only"><%= t('common.labels.previous') %></span>
   </a>
   <a class="carousel-control-next" href="#pupil_carousel" role="button" data-slide="next">
     <span class="carousel-control-next-icon" aria-hidden="true"></span>
-    <span class="sr-only">Next</span>
+    <span class="sr-only"><%= t('common.labels.next') %></span>
   </a>
 </div>

--- a/app/views/pupils/schools/_equivalences.html.erb
+++ b/app/views/pupils/schools/_equivalences.html.erb
@@ -5,7 +5,7 @@
         <div class="row illustration-background">
           <div class="col-lg-6 equivalence-wrapper">
             <%= equivalence_content.equivalence %>
-            <p><%= link_to 'Find out how much energy has been used', pupils_school_analysis_path(school), class: 'btn btn-outline-dark rounded-pill font-weight-bold' %></p>
+            <p><%= link_to t('pupils.schools.show.find_how_much_energy_used'), pupils_school_analysis_path(school), class: 'btn btn-outline-dark rounded-pill font-weight-bold' %></p>
           </div>
           <div class="col-lg-6 illustration-wrapper">
             <%= image_tag("equivalences/#{equivalence_content.equivalence_type.image_name}.svg") if equivalence_content.equivalence_type.show_image? %>
@@ -16,11 +16,11 @@
   </div>
   <a class="carousel-control-prev" href="#pupil_carousel" role="button" data-slide="prev">
     <span class="carousel-control-prev-icon" aria-hidden="true"></span>
-    <span class="sr-only">Previous</span>
+    <span class="sr-only"><%= t('common.labels.previous') %></span>
   </a>
   <a class="carousel-control-next" href="#pupil_carousel" role="button" data-slide="next">
     <span class="carousel-control-next-icon" aria-hidden="true"></span>
-    <span class="sr-only">Next</span>
+    <span class="sr-only"><%= t('common.labels.next') %></span>
   </a>
 </div>
 

--- a/app/views/pupils/schools/_no_points_podium.html.erb
+++ b/app/views/pupils/schools/_no_points_podium.html.erb
@@ -1,6 +1,4 @@
-<h4>Your school hasn't scored any points yet this school year</h4>
-<p>Complete an activity to score points on Energy Sparks.
-  <% if podium.low_to_high.any? %>
-    You only need to score <%= podium.low_to_high.first.points %> points to overtake the next school!
-  <% end %>
+<h4><%= t('pupils.schools.show.no_points_this_year') %></h4>
+<p><%= t('pupils.schools.show.complete_an_activity') %>.
+  <%= t('pupils.schools.show.points_needed_to_overtake', points: podium.low_to_high.first.points) if podium.low_to_high.any? %>
 </p>

--- a/app/views/pupils/schools/_podium.html.erb
+++ b/app/views/pupils/schools/_podium.html.erb
@@ -1,4 +1,6 @@
-<h4 class="text-center">Your school is in <strong><%= podium.school_position.ordinal %> place.</strong></h4>
+<h4 class="text-center">
+  <%= t('pupils.schools.show.school_podium_position_html', position_ordinal: podium.school_position.ordinal) %>.
+</h4>
 <div class="row align-items-end border-bottom grey">
   <% podium.low_to_high.each do |position| %>
     <div class="col-4 text-center">

--- a/app/views/pupils/schools/_podium.html.erb
+++ b/app/views/pupils/schools/_podium.html.erb
@@ -7,12 +7,12 @@
       <h5>
         <% if podium.current_school?(position) %>
           <%= fa_icon('crown fa-2x') %>
-          <p class='h2'><%= position.ordinal%></p>
+          <p class='h2'><%= position.ordinal %></p>
         <% else %>
-          <p><%= position.ordinal%></p>
+          <p><%= position.ordinal %></p>
           <% if (position.normalised_points * 149).to_i < 70 %>
             <p class="mb-1"><strong><%= position.points %></strong></p>
-            <p class="text-uppercase">points</p>
+            <p class="text-uppercase"><%= t('pupils.schools.show.points') %></p>
           <% end %>
         <% end %>
       </h5>
@@ -22,7 +22,7 @@
         <div class="bar-body" style="height:<%= (position.normalised_points * 149).to_i + 1 %>px">
           <% if (position.normalised_points * 149).to_i > 70 %>
             <p class="pt-2 mb-0"><strong><%= position.points %></strong></p>
-            <p class="text-uppercase">points</p>
+            <p class="text-uppercase"><%= t('pupils.schools.show.points') %></p>
           <% end %>
         </div>
       </div>

--- a/app/views/pupils/schools/show.html.erb
+++ b/app/views/pupils/schools/show.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, "Pupil dashboard for #{@school.name}" %>
+<%= content_for :page_title, t('pupils.schools.show.title', school_name: @school.name) %>
 
 <% if show_admin_page_switch?(@school) %>
   <div class="row mt-2 mb-2">
@@ -17,7 +17,7 @@
 <% if @show_data_enabled_features %>
   <%= render 'equivalences', equivalences_content: @equivalences_content, school: @school if @equivalences_content.present? %>
 
-  <h2 class="mt-2">Let's look at the energy use data for your school:</h2>
+  <h2 class="mt-2"><%= t('pupils.schools.show.look_at_the_energy_use') %>:</h2>
   <%= render 'pupils/analysis/top_level', school: @school %>
 <% else %>
   <%= render 'default_equivalences', equivalences: @default_equivalences, chool: @school %>
@@ -66,19 +66,21 @@
         <h4 class="text-center">
           <strong>
             <% if @first %>
-              No activities completed, make a start!
+              <%= t('pupils.schools.show.no_activities_completed') %>
             <% else %>
-              You've completed <%= @activities_count %> activities
+              <%= t('pupils.schools.show.activities_completed', count: @activities_count) %>
             <% end %>
           </strong>
         </h4>
         <% if @suggestion %>
-          <h5 class="text-center">Try this one <%= @first ? 'first' : 'next' %>:</h5>
+          <h5 class="text-center">
+            <%= @first ? t('pupils.schools.show.try_this_first') : t('pupils.schools.show.try_this_next') %>:
+          </h5>
           <div class="activity-suggestion">
             <p><%= link_to @suggestion.name, activity_type_path(@suggestion) %></p>
             <span class="btn bg-neutral rounded-pill">
               <strong class="text-uppercase">
-                <%= @suggestion.score %><span class="small"> points</span>
+                <%= @suggestion.score %><span class="small"> <%= t('pupils.schools.show.points') %></span>
               </strong>
               /
               <span class="key-stages"><%= @suggestion.key_stage_list %></span>
@@ -87,7 +89,7 @@
         <% end %>
       </div>
       <div class="card-footer text-center">
-        <%= link_to 'Choose another activity', activity_categories_path, class: 'btn btn-lg btn-light rounded-pill font-weight-bold' %>
+        <%= link_to t('pupils.schools.show.choose_another_activity'), activity_categories_path, class: 'btn btn-lg btn-light rounded-pill font-weight-bold' %>
       </div>
     </div>
   </div>
@@ -103,7 +105,7 @@
           <% end %>
         </div>
         <div class="card-footer text-center">
-          <%= link_to 'See the scoreboard', scoreboard_path(current_school_podium.scoreboard), class: "btn btn-lg btn-light rounded-pill font-weight-bold" %>
+          <%= link_to t('pupils.schools.show.see_scoreboard'), scoreboard_path(current_school_podium.scoreboard), class: "btn btn-lg btn-light rounded-pill font-weight-bold" %>
         </div>
       </div>
     <% end %>

--- a/app/views/pupils/schools/show.html.erb
+++ b/app/views/pupils/schools/show.html.erb
@@ -5,9 +5,9 @@
     <div class="col">
       <div class="float-right">
         <% if params[:no_data] %>
-          <%= link_to 'Admin view', pupils_school_path(@school), class: 'btn btn-outline-dark bg-warning rounded-pill font-weight-bold' %>
+          <%= link_to t('pupils.schools.show.admin_view'), pupils_school_path(@school), class: 'btn btn-outline-dark bg-warning rounded-pill font-weight-bold' %>
         <% else %>
-          <%= link_to 'User view', pupils_school_path(@school, no_data: true), class: 'btn btn-outline-dark bg-warning rounded-pill font-weight-bold' %>
+          <%= link_to t('pupils.schools.show.user_view'), pupils_school_path(@school, no_data: true), class: 'btn btn-outline-dark bg-warning rounded-pill font-weight-bold' %>
         <% end %>
       </div>
     </div>
@@ -24,19 +24,19 @@
   <%= render 'schools/dashboard/info_bar',
         colour: 'bg-neutral',
         icon: 'info-circle fa-3x',
-        content: "We're setting up this school's energy data and will update this page when it is ready to explore",
+        content: t('pupils.schools.show.setting_up'),
         buttons: {}
   %>
 <% end %>
 
-<h2 class="mt-2">Things to do</h2>
+<h2 class="mt-2"><%= t('pupils.schools.show.things_to_do') %></h2>
 <% if @dashboard_alerts && @dashboard_alerts.any? %>
   <% @dashboard_alerts.each do |content| %>
     <%= render 'schools/dashboard/info_bar',
           colour: class_for_alert_colour(content.colour),
           icon: alert_icon(content.alert, 'fa-3x'),
           content: content.pupil_dashboard_title,
-          buttons: content.find_out_more ? { 'Find out more&hellip;' => school_find_out_more_path(@school, content.find_out_more) } : {}
+          buttons: content.find_out_more ? { t('pupils.schools.show.find_out_more') => school_find_out_more_path(@school, content.find_out_more) } : {}
     %>
    <% end %>
 <% end %>
@@ -46,15 +46,15 @@
     <%= render 'schools/dashboard/info_bar',
           colour: 'bg-positive',
           icon: 'temperature-high fa-3x',
-          content: 'Measure classroom temperatures to find out whether you should turn down the heating to save energy',
-          buttons: { 'Enter temperatures' => new_school_temperature_observation_path(@school, introduction: true) }
+          content: t('pupils.schools.show.measure_temperatures'),
+          buttons: { t('pupils.schools.show.enter_temperatures') => new_school_temperature_observation_path(@school, introduction: true) }
     %>
   <% else %>
     <%= render 'schools/dashboard/info_bar',
           colour: 'bg-positive',
           icon: 'temperature-high fa-3x',
-          content: 'Update your classroom temperatures to see if you are saving energy',
-          buttons: { 'Previous temperatures' => school_temperature_observations_path(@school), 'Update temperatures' => new_school_temperature_observation_path(@school, introduction: true) }
+          content: t('pupils.schools.show.update_temperatures'),
+          buttons: { t('pupils.schools.show.previous_temperatures') => school_temperature_observations_path(@school), t('pupils.schools.show.update_temperatures') => new_school_temperature_observation_path(@school, introduction: true) }
     %>
   <% end %>
 <% end %>
@@ -93,6 +93,8 @@
       </div>
     </div>
   </div>
+
+
 
   <div class="col card-deck actions">
     <% if current_school_podium && can?(:read, current_school_podium.scoreboard) %>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -73,7 +73,7 @@ Rails.application.configure do
   config.log_level = :debug
 
   # Raises error for missing translations
-  # config.action_view.raise_on_missing_translations = true
+  config.action_view.raise_on_missing_translations = true
 
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.

--- a/config/locales/common.yml
+++ b/config/locales/common.yml
@@ -19,8 +19,8 @@ en:
     line_graphs: Line graphs
     pie_charts: Pie charts
     school: School
+    storage_heaters: Storage heaters
   kwh: kWh
   school_types:
     mixed_primary_and_secondary: 'Mixed: Primary and Secondary'
-    storage_heaters: Storage heaters
   "£": "£"

--- a/config/locales/common.yml
+++ b/config/locales/common.yml
@@ -4,8 +4,15 @@ en:
   common:
     application: Energy Sparks
     confirm: Are you sure?
+    electricity: Electricity
+    electricity_and_solar_pv: Electricity & Solar PV
+    gas: Gas
+    pie_charts: Pie charts
+    bar_charts: Bar charts
+    line_graphs: Line graphs
     labels:
       actions: Actions
+      back: Back
       delete: Delete
       manage: Manage
       next: Next
@@ -15,4 +22,5 @@ en:
   kwh: kWh
   school_types:
     mixed_primary_and_secondary: 'Mixed: Primary and Secondary'
+    storage_heaters: Storage heaters
   "£": "£"

--- a/config/locales/common.yml
+++ b/config/locales/common.yml
@@ -3,13 +3,11 @@ en:
   co2: CO2
   common:
     application: Energy Sparks
+    bar_charts: Bar charts
     confirm: Are you sure?
     electricity: Electricity
     electricity_and_solar_pv: Electricity & Solar PV
     gas: Gas
-    pie_charts: Pie charts
-    bar_charts: Bar charts
-    line_graphs: Line graphs
     labels:
       actions: Actions
       back: Back
@@ -18,6 +16,8 @@ en:
       next: Next
       previous: Previous
       view_results: View results
+    line_graphs: Line graphs
+    pie_charts: Pie charts
     school: School
   kwh: kWh
   school_types:

--- a/config/locales/views/pupils/pupils.yml
+++ b/config/locales/views/pupils/pupils.yml
@@ -1,36 +1,36 @@
 ---
 en:
   pupils:
-    schools:
-      show:
-        title: Pupil dashboard for %{school_name}
-        look_at_the_energy_use: Let's look at the energy use data for your school
-        activities_completed: You've completed %{count} activities
-        no_activities_completed: No activities completed, make a start!
-        complete_an_activity: Complete an activity to score points on Energy Sparks
-        try_this_first: Try this one first
-        try_this_next: Try this one next
-        choose_another_activity: Choose another activity
-        see_scoreboard: See the scoreboard
-        points: points
-        admin_view: Admin view
-        user_view: User view
-        setting_up: We're setting up this school's energy data and will update this page when it is ready to explore
-        find_out_more: Find out more&hellip;
-        things_to_do: Things to do
-        measure_temperatures: Measure classroom temperatures to find out whether you should turn down the heating to save energy
-        enter_temperatures: Enter temperatures
-        update_temperatures: Update your classroom temperatures to see if you are saving energy
-        previous_temperatures: Previous temperatures
-        how_will_school_compare: How will your school compare? You'll soon be able to find out!
-        find_how_much_energy_used: Find out how much energy has been used
-        no_points_this_year: Your school hasn't scored any points yet this school year
-        points_needed_to_overtake: You only need to score %{points} points to overtake the next school!
-        school_podium_position_html: Your school is in <strong>%{position_ordinal} place</strong>
     analysis:
       electricity: Electricity
-      gas: Gas
-      storage_heaters: Storage heaters
       electricity_and_solar_pv: Electricity & Solar PV
-      without_storage_heaters: without storage heaters
+      gas: Gas
       live_energy_data: Live energy data
+      storage_heaters: Storage heaters
+      without_storage_heaters: without storage heaters
+    schools:
+      show:
+        activities_completed: You've completed %{count} activities
+        admin_view: Admin view
+        choose_another_activity: Choose another activity
+        complete_an_activity: Complete an activity to score points on Energy Sparks
+        enter_temperatures: Enter temperatures
+        find_how_much_energy_used: Find out how much energy has been used
+        find_out_more: Find out more&hellip;
+        how_will_school_compare: How will your school compare? You'll soon be able to find out!
+        look_at_the_energy_use: Let's look at the energy use data for your school
+        measure_temperatures: Measure classroom temperatures to find out whether you should turn down the heating to save energy
+        no_activities_completed: No activities completed, make a start!
+        no_points_this_year: Your school hasn't scored any points yet this school year
+        points: points
+        points_needed_to_overtake: You only need to score %{points} points to overtake the next school!
+        previous_temperatures: Previous temperatures
+        school_podium_position_html: Your school is in <strong>%{position_ordinal} place</strong>
+        see_scoreboard: See the scoreboard
+        setting_up: We're setting up this school's energy data and will update this page when it is ready to explore
+        things_to_do: Things to do
+        title: Pupil dashboard for %{school_name}
+        try_this_first: Try this one first
+        try_this_next: Try this one next
+        update_temperatures: Update your classroom temperatures to see if you are saving energy
+        user_view: User view

--- a/config/locales/views/pupils/pupils.yml
+++ b/config/locales/views/pupils/pupils.yml
@@ -7,11 +7,26 @@ en:
         look_at_the_energy_use: Let's look at the energy use data for your school
         activities_completed: You've completed %{count} activities
         no_activities_completed: No activities completed, make a start!
+        complete_an_activity: Complete an activity to score points on Energy Sparks
         try_this_first: Try this one first
         try_this_next: Try this one next
         choose_another_activity: Choose another activity
         see_scoreboard: See the scoreboard
         points: points
+        admin_view: Admin view
+        user_view: User view
+        setting_up: We're setting up this school's energy data and will update this page when it is ready to explore
+        find_out_more: Find out more&hellip;
+        things_to_do: Things to do
+        measure_temperatures: Measure classroom temperatures to find out whether you should turn down the heating to save energy
+        enter_temperatures: Enter temperatures
+        update_temperatures: Update your classroom temperatures to see if you are saving energy
+        previous_temperatures: Previous temperatures
+        how_will_school_compare: How will your school compare? You'll soon be able to find out!
+        find_how_much_energy_used: Find out how much energy has been used
+        no_points_this_year: Your school hasn't scored any points yet this school year
+        points_needed_to_overtake: You only need to score %{points} points to overtake the next school!
+        school_podium_position_html: Your school is in <strong>%{position_ordinal} place</strong>
     analysis:
       electricity: Electricity
       gas: Gas

--- a/config/locales/views/pupils/pupils.yml
+++ b/config/locales/views/pupils/pupils.yml
@@ -8,7 +8,9 @@ en:
       compare_gas_in_2_weeks: compare the gas used in two different weeks
       compare_gas_on_2_days: compare the gas used on two different days
       compare_gas_use_by_meters: compare the gas use by different meters
+      electricity_and_solar_data_html: Here's the <strong>electricity and solar</strong> data for your school
       electricity_data_html: Here's the <strong>electricity</strong> data for your school
+      explore_data: Explore data
       find_electricity_comparison: find out how my school's electricity use compares with other schools
       find_electricity_use_7days: find out how much electricity was used in the last 7 days
       find_electricity_use_last_year: find out how much electricity was used last year
@@ -21,13 +23,20 @@ en:
       find_how_much_co2_generated_html: find out how much <strong>carbon dioxide</strong> was generated
       find_how_much_electricity_cost_html: find out <strong>how much</strong> the electricity cost
       find_how_much_gas_cost_html: find out <strong>how much</strong> the gas cost
+      find_how_much_storage_heaters_cost_html: find out <strong>how much</strong> the storage heaters cost
+      find_out_about_solar_html: find out about <strong>solar</strong>
+      find_storage_heaters_comparison: find out how my school's storage heater use compares with other schools
+      find_storage_heaters_use_last_year: find out how much electricity was used by storage heaters last year
+      find_storage_heaters_use_long_term: find out how storage heater electricity use has changed long term
       find_when_electricity_used_html: find out <strong>when</strong> the electricity was used
       find_when_gas_used_html: find out <strong>when</strong> the gas was used
+      find_when_storage_heaters_used_html: find out <strong>when</strong> the storage heaters used electricity
       gas_data_html: Here's the <strong>gas</strong> data for your school
       i_want_to: I want to&hellip;
       i_want_to_look_at: I want to look at&hellip;
       live_energy_data: Live energy data
       look_at_energy_use: Let's look at the energy use data for your school
+      storage_heater_data_html: Here's the <strong>storage heater</strong> data for your school
       without_storage_heaters: without storage heaters
     schools:
       show:

--- a/config/locales/views/pupils/pupils.yml
+++ b/config/locales/views/pupils/pupils.yml
@@ -33,8 +33,8 @@ en:
       find_when_gas_used_html: find out <strong>when</strong> the gas was used
       find_when_storage_heaters_used_html: find out <strong>when</strong> the storage heaters used electricity
       gas_data_html: Here's the <strong>gas</strong> data for your school
-      i_want_to: I want to&hellip;
-      i_want_to_look_at: I want to look at&hellip;
+      i_want_to: I want to…
+      i_want_to_look_at: I want to look at…
       live_energy_data: Live energy data
       look_at_energy_use: Let's look at the energy use data for your school
       storage_heater_data_html: Here's the <strong>storage heater</strong> data for your school

--- a/config/locales/views/pupils/pupils.yml
+++ b/config/locales/views/pupils/pupils.yml
@@ -2,12 +2,17 @@
 en:
   pupils:
     analysis:
-      electricity: Electricity
-      electricity_and_solar_pv: Electricity & Solar PV
-      gas: Gas
       live_energy_data: Live energy data
-      storage_heaters: Storage heaters
       without_storage_heaters: without storage heaters
+      electricity_data_html: Here's the <strong>electricity</strong> data for your school
+      i_want_to: I want to&hellip;
+      i_want_to_look_at: I want to look at&hellip;
+      find_when_electricity_used_html: find out <strong>when</strong> the electricity was used
+      find_how_much_electricity_cost_html: find out <strong>how much</strong> the electricity cost
+      find_how_much_co2_generated_html: find out how much <strong>carbon dioxide</strong> was generated
+      compare_electricity_in_2_weeks: compare the electricity used in two different weeks
+      compare_electricity_on_2_days: compare the electricity used on two different days
+      compare_electricity_use_by_meters: compare the electricity use by different meters
     schools:
       show:
         activities_completed: You've completed %{count} activities

--- a/config/locales/views/pupils/pupils.yml
+++ b/config/locales/views/pupils/pupils.yml
@@ -2,20 +2,28 @@
 en:
   pupils:
     analysis:
-      live_energy_data: Live energy data
-      without_storage_heaters: without storage heaters
-      electricity_data_html: Here's the <strong>electricity</strong> data for your school
-      i_want_to: I want to&hellip;
-      i_want_to_look_at: I want to look at&hellip;
-      find_when_electricity_used_html: find out <strong>when</strong> the electricity was used
-      find_how_much_electricity_cost_html: find out <strong>how much</strong> the electricity cost
-      find_how_much_co2_generated_html: find out how much <strong>carbon dioxide</strong> was generated
       compare_electricity_in_2_weeks: compare the electricity used in two different weeks
       compare_electricity_on_2_days: compare the electricity used on two different days
       compare_electricity_use_by_meters: compare the electricity use by different meters
+      compare_gas_in_2_weeks: compare the gas used in two different weeks
+      compare_gas_on_2_days: compare the gas used on two different days
+      compare_gas_use_by_meters: compare the gas use by different meters
+      electricity_data_html: Here's the <strong>electricity</strong> data for your school
       find_electricity_comparison: find out how my school's electricity use compares with other schools
+      find_electricity_use_7days: find out how much electricity was used in the last 7 days
       find_electricity_use_last_year: find out how much electricity was used last year
+      find_electricity_use_lights: find out how much electricity was used by lights and appliances running all the time
       find_electricity_use_long_term: find out how electricity use has changed long term
+      find_how_much_co2_generated_html: find out how much <strong>carbon dioxide</strong> was generated
+      find_how_much_electricity_cost_html: find out <strong>how much</strong> the electricity cost
+      find_how_much_gas_cost_html: find out <strong>how much</strong> the gas cost
+      find_when_electricity_used_html: find out <strong>when</strong> the electricity was used
+      find_when_gas_used_html: find out <strong>when</strong> the gas was used
+      gas_data_html: Here's the <strong>gas</strong> data for your school
+      i_want_to: I want to&hellip;
+      i_want_to_look_at: I want to look at&hellip;
+      live_energy_data: Live energy data
+      without_storage_heaters: without storage heaters
     schools:
       show:
         activities_completed: You've completed %{count} activities

--- a/config/locales/views/pupils/pupils.yml
+++ b/config/locales/views/pupils/pupils.yml
@@ -14,6 +14,10 @@ en:
       find_electricity_use_last_year: find out how much electricity was used last year
       find_electricity_use_lights: find out how much electricity was used by lights and appliances running all the time
       find_electricity_use_long_term: find out how electricity use has changed long term
+      find_gas_comparison: find out how my school's gas use compares with other schools
+      find_gas_use_7days: find out how much gas was used in the last 7 days
+      find_gas_use_last_year: find out how much gas was used last year
+      find_gas_use_long_term: find out how gas use has changed long term
       find_how_much_co2_generated_html: find out how much <strong>carbon dioxide</strong> was generated
       find_how_much_electricity_cost_html: find out <strong>how much</strong> the electricity cost
       find_how_much_gas_cost_html: find out <strong>how much</strong> the gas cost
@@ -23,6 +27,7 @@ en:
       i_want_to: I want to&hellip;
       i_want_to_look_at: I want to look at&hellip;
       live_energy_data: Live energy data
+      look_at_energy_use: Let's look at the energy use data for your school
       without_storage_heaters: without storage heaters
     schools:
       show:

--- a/config/locales/views/pupils/pupils.yml
+++ b/config/locales/views/pupils/pupils.yml
@@ -11,6 +11,7 @@ en:
       electricity_and_solar_data_html: Here's the <strong>electricity and solar</strong> data for your school
       electricity_data_html: Here's the <strong>electricity</strong> data for your school
       explore_data: Explore data
+      explore_energy_data_html: Explore the <strong>%{fuel_type}</strong> data for your school
       find_electricity_comparison: find out how my school's electricity use compares with other schools
       find_electricity_use_7days: find out how much electricity was used in the last 7 days
       find_electricity_use_last_year: find out how much electricity was used last year

--- a/config/locales/views/pupils/pupils.yml
+++ b/config/locales/views/pupils/pupils.yml
@@ -13,6 +13,9 @@ en:
       compare_electricity_in_2_weeks: compare the electricity used in two different weeks
       compare_electricity_on_2_days: compare the electricity used on two different days
       compare_electricity_use_by_meters: compare the electricity use by different meters
+      find_electricity_comparison: find out how my school's electricity use compares with other schools
+      find_electricity_use_last_year: find out how much electricity was used last year
+      find_electricity_use_long_term: find out how electricity use has changed long term
     schools:
       show:
         activities_completed: You've completed %{count} activities

--- a/config/locales/views/pupils/pupils.yml
+++ b/config/locales/views/pupils/pupils.yml
@@ -1,0 +1,21 @@
+---
+en:
+  pupils:
+    schools:
+      show:
+        title: Pupil dashboard for %{school_name}
+        look_at_the_energy_use: Let's look at the energy use data for your school
+        activities_completed: You've completed %{count} activities
+        no_activities_completed: No activities completed, make a start!
+        try_this_first: Try this one first
+        try_this_next: Try this one next
+        choose_another_activity: Choose another activity
+        see_scoreboard: See the scoreboard
+        points: points
+    analysis:
+      electricity: Electricity
+      gas: Gas
+      storage_heaters: Storage heaters
+      electricity_and_solar_pv: Electricity & Solar PV
+      without_storage_heaters: without storage heaters
+      live_energy_data: Live energy data

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -181,4 +181,22 @@ describe ApplicationHelper do
       expect(helper.path_with_locale('/search', :cy)).to eq('/search?locale=cy')
     end
   end
+
+  describe '#i18n_key_from' do
+    it 'handles simple strings' do
+      expect(helper.i18n_key_from('Electricity+Solar PV')).to eq('electricity_and_solar_pv')
+    end
+    it 'handles simple strings' do
+      expect(helper.i18n_key_from('Gas')).to eq('gas')
+    end
+    it 'removes spaces' do
+      expect(helper.i18n_key_from('some thing')).to eq('something')
+    end
+    it 'adds underscores between caps' do
+      expect(helper.i18n_key_from('SomeThing')).to eq('some_thing')
+    end
+    it 'applies both' do
+      expect(helper.i18n_key_from('Some Thing')).to eq('some_thing')
+    end
+  end
 end


### PR DESCRIPTION
Extracting text strings from the templates for pupil dashboard and analysis pages.

A few points:

- some strings have embedded html tags (mostly "strong") and so have "_html" suffixes on keys
- those strings may be used in title tags, in which case they need to have "strip_tags" applies
- some strings have ellipses, which are encoded as &hellip; , in which case they need "sanitize" to be applied
- some strings have interpolated values which are themselves translated
- the values for interpolation are converted to i18n keys (these are basically energy types)
- "Storage Heaters" gets converted to 'storage_heaters'
- "Electricity+Solar PV" gets converted to 'electricity_and_solar_pv' (original string is used as part of url path, hence "+" character)
- some common strings for links (e.g. "Back") are in common.labels
- ordinals (e.g. on podium) will be handled by custom ordinal i18n code elsewhere
- some of the strings in the analysis pages could almost certainly be parameterised to reduce number