### PR TITLE
Change how we load environment variables

### DIFF
--- a/.platform/hooks/predeploy/99_after_party.sh
+++ b/.platform/hooks/predeploy/99_after_party.sh
@@ -5,7 +5,7 @@ EB_APP_STAGING_DIR=$(/opt/elasticbeanstalk/bin/get-config platformconfig -k AppS
 EB_APP_USER=$(/opt/elasticbeanstalk/bin/get-config platformconfig -k AppUser)
 
 set +x
-export $(cat /opt/elasticbeanstalk/deployment/env | xargs)
+export $(/opt/elasticbeanstalk/bin/get-config --output YAML environment | sed -r 's/: /=/' | xargs)
 set -x
 
 cd $EB_APP_STAGING_DIR

--- a/.platform/hooks/predeploy/99_after_party.sh
+++ b/.platform/hooks/predeploy/99_after_party.sh
@@ -8,6 +8,10 @@ set +x
 export $(/opt/elasticbeanstalk/bin/get-config --output YAML environment | sed -r 's/: /=/' | xargs)
 set -x
 
+PATH=/opt/elasticbeanstalk/.rbenv/shims:/opt/elasticbeanstalk/.rbenv/bin:$PATH
+RBENV_ROOT=/opt/elasticbeanstalk/.rbenv
+RBENV_VERSION=$(cat $RBENV_ROOT/version)
+
 cd $EB_APP_STAGING_DIR
 
 if [ "$EB_IS_COMMAND_LEADER" = "true" ]; then

--- a/bin/run_as_webapp
+++ b/bin/run_as_webapp
@@ -7,6 +7,6 @@ EB_APP_USER=$(sudo /opt/elasticbeanstalk/bin/get-config platformconfig -k AppUse
 
 #envvars
 set +x
-export $(sudo cat /opt/elasticbeanstalk/deployment/env | xargs)
+export $(sudo /opt/elasticbeanstalk/bin/get-config --output YAML environment | sed -r 's/: /=/' | xargs)
 set -x
 su -s /bin/bash -c "${*}" $EB_APP_USER

--- a/bin/run_as_webapp
+++ b/bin/run_as_webapp
@@ -2,9 +2,6 @@
 set -xe
 EB_APP_USER=$(sudo /opt/elasticbeanstalk/bin/get-config platformconfig -k AppUser)
 
-#. $EB_SUPPORT_DIR/envvars-wrapper.sh
-#. $EB_SCRIPT_DIR/use-app-ruby.sh
-
 #envvars
 set +x
 export $(sudo /opt/elasticbeanstalk/bin/get-config --output YAML environment | sed -r 's/: /=/' | xargs)

--- a/bin/run_as_webapp
+++ b/bin/run_as_webapp
@@ -6,4 +6,9 @@ EB_APP_USER=$(sudo /opt/elasticbeanstalk/bin/get-config platformconfig -k AppUse
 set +x
 export $(sudo /opt/elasticbeanstalk/bin/get-config --output YAML environment | sed -r 's/: /=/' | xargs)
 set -x
+
+PATH=/opt/elasticbeanstalk/.rbenv/shims:/opt/elasticbeanstalk/.rbenv/bin:$PATH
+RBENV_ROOT=/opt/elasticbeanstalk/.rbenv
+RBENV_VERSION=$(cat $RBENV_ROOT/version)
+
 su -s /bin/bash -c "${*}" $EB_APP_USER


### PR DESCRIPTION
In the upgrade from Amazon Linux 1 to Amazon Linux 2 we had to change how we load environment variables. There were some helper scripts and files created in AL1 which were no longer available.

In AL2 I started using this to load the variables:

```
export $(cat /opt/elasticbeanstalk/deployment/env | xargs)
```

This works fine. However, when attempting to clone an existing environment I found that the file `/opt/elasticbeanstalk/deployment/env` does not seem to be created until right at the end of a successful deployment **after** the after party tasks are run.

This means I was getting an error in the log from the script as it could not load the environment variables. 

I think this also means that the first deployment of code to a new platform version has previously been failing to run those scripts.

There are various solutions but the simplest option was to use:

```
export $(/opt/elasticbeanstalk/bin/get-config --output YAML environment | sed -r 's/: /=/' | xargs)
```

This uses an AWS utility to show the environment variables as YAML. Sed is used to turn them into the expected format which is `NAME=VALUE` rather than `NAME: VALUE`.

I've run this command on the test server to confirm it works OK.