### PR TITLE
Reschedule s3 uploads

### DIFF
--- a/.ebextensions/cronjob.config
+++ b/.ebextensions/cronjob.config
@@ -146,24 +146,24 @@ files:
             00 6 * * * root /bin/bash -l -c 'cd /var/app/current && RAILS_ENV=production bin/run_as_webapp bundle exec rake content:batch >> log/jobs.log 2>&1'
 
     #
-    # Upload aggregate schools to S3. Weekly on Monday
+    # Upload aggregate schools to S3.
     #
     "/etc/cron.d/daily-s3-aggregate-upload":
         mode: "000644"
         owner: root
         group: root
         content: |
-            00 22 * * 1 root /bin/bash -l -c 'cd /var/app/current && RAILS_ENV=production bin/run_as_webapp bundle exec rake utility:save_aggregate_schools_to_s3 >> log/jobs.log 2>&1'
+            00 22 * * 0 root /bin/bash -l -c 'cd /var/app/current && RAILS_ENV=production bin/run_as_webapp bundle exec rake utility:save_aggregate_schools_to_s3 >> log/jobs.log 2>&1'
 
     #
-    # Upload unvalidated schools to S3. Tuesday and Friday
+    # Upload unvalidated schools to S3.
     #
     "/etc/cron.d/daily-s3-unvalidated-upload":
         mode: "000644"
         owner: root
         group: root
         content: |
-            00 21 * * 1,4 root /bin/bash -l -c 'cd /var/app/current && RAILS_ENV=production bin/run_as_webapp bundle exec rake utility:save_unvalidated_schools_to_s3 >> log/jobs.log 2>&1'
+            00 21 * * 0 root /bin/bash -l -c 'cd /var/app/current && RAILS_ENV=production bin/run_as_webapp bundle exec rake utility:save_unvalidated_schools_to_s3 >> log/jobs.log 2>&1'
 
     #
     # Generate subscriptions


### PR DESCRIPTION
Move the S3 jobs to Sunday nights, to further minimise any disruption due to CPU/Memory overheads.