### PR TITLE
Remove default dates on activity and action forms

### DIFF
--- a/app/controllers/interventions_controller.rb
+++ b/app/controllers/interventions_controller.rb
@@ -2,7 +2,7 @@ class InterventionsController < ApplicationController
   def new
     @intervention_type = InterventionType.find(params[:intervention_type_id])
     @intervention_type_group = @intervention_type.intervention_type_group
-    @observation = current_user.school.observations.new(intervention_type_id: @intervention_type.id, at: Time.zone.now)
+    @observation = current_user.school.observations.new(intervention_type_id: @intervention_type.id)
     authorize! :create, @observation
   end
 

--- a/app/views/activities/_form.html.erb
+++ b/app/views/activities/_form.html.erb
@@ -27,7 +27,7 @@
     <p class="small">
       <%= t('activities.form.build_a_record_message') %>.
     </p>
-    <%= f.input :happened_on, label: false, as: :tempus_dominus_date, default_date: Time.zone.today %>
+    <%= f.input :happened_on, label: false, as: :tempus_dominus_date %>
   </div>
 
   <%= f.hidden_field :activity_type_id, value: activity.activity_type.id, required: true %>

--- a/spec/system/activities_spec.rb
+++ b/spec/system/activities_spec.rb
@@ -149,7 +149,8 @@ describe 'viewing and recording activities', type: :system do
         visit activity_type_path(activity_type)
 
         click_on 'Record this activity'
-        expect(find_field(:activity_happened_on).value).to eq Date.today.strftime("%d/%m/%Y")
+        fill_in :activity_happened_on, with: Date.today.strftime("%d/%m/%Y")
+
         click_on 'Save activity'
         expect(page.has_content?("Congratulations! We've recorded your activity")).to be true
         expect(page.has_content?("You've just scored #{activity_type.score} points")).to be true
@@ -172,6 +173,7 @@ describe 'viewing and recording activities', type: :system do
           click_on 'Record this activity'
           fill_in :activity_title, with: custom_title
           fill_in_trix with: activity_description
+          fill_in :activity_happened_on, with: Date.today.strftime("%d/%m/%Y")
 
           click_on 'Save activity'
           expect(page.has_content?("Congratulations! We've recorded your activity")).to be true
@@ -191,7 +193,7 @@ describe 'viewing and recording activities', type: :system do
           it 'records activity' do
              visit activity_type_path(activity_type)
              click_on 'Record this activity'
-             expect(find_field(:activity_happened_on).value).to eq Date.today.strftime("%d/%m/%Y")
+             fill_in :activity_happened_on, with: Date.today.strftime("%d/%m/%Y")
              click_on 'Save activity'
              expect(page.has_content?("Congratulations! We've recorded your activity")).to be true
           end
@@ -205,7 +207,7 @@ describe 'viewing and recording activities', type: :system do
             it 'records activity' do
               visit activity_type_path(activity_type)
               click_on 'Record this activity'
-              expect(find_field(:activity_happened_on).value).to eq Date.today.strftime("%d/%m/%Y")
+              fill_in :activity_happened_on, with: Date.today.strftime("%d/%m/%Y")
               click_on 'Save activity'
               expect(page.has_content?("Congratulations! We've recorded your activity")).to be true
               expect(page.has_content?("You've just scored #{activity_type.score} points")).to be true
@@ -218,7 +220,7 @@ describe 'viewing and recording activities', type: :system do
             it 'records activity' do
               visit activity_type_path(activity_type)
               click_on 'Record this activity'
-              expect(find_field(:activity_happened_on).value).to eq Date.today.strftime("%d/%m/%Y")
+              fill_in :activity_happened_on, with: Date.today.strftime("%d/%m/%Y")
               click_on 'Save activity'
               expect(page.has_content?("Congratulations! We've recorded your activity")).to be true
               expect(page.has_content?("You've just scored #{activity_type.score} points")).to be true


### PR DESCRIPTION
We encourage schools to record activities and actions, they can record what they do each day but more frequently they log activities in a series of updates, specifying when they did them.

Currently we default the dates on the forms to the current date. This isn't encouraging users to pick the actual date they record an activity.

We've decided to remove the defaults for now