### PR TITLE
2334 revise adult activity recording to only score points if pupils were involved

### DIFF
--- a/app/controllers/interventions_controller.rb
+++ b/app/controllers/interventions_controller.rb
@@ -43,6 +43,6 @@ class InterventionsController < ApplicationController
   private
 
   def observation_params
-    params.require(:observation).permit(:description, :at, :intervention_type_id)
+    params.require(:observation).permit(:description, :at, :intervention_type_id, :involved_pupils)
   end
 end

--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -9,6 +9,7 @@
 #  created_at           :datetime         not null
 #  id                   :bigint(8)        not null, primary key
 #  intervention_type_id :bigint(8)
+#  involved_pupils      :boolean          default(FALSE), not null
 #  observation_type     :integer          not null
 #  points               :integer
 #  school_id            :bigint(8)        not null

--- a/app/services/intervention_creator.rb
+++ b/app/services/intervention_creator.rb
@@ -7,7 +7,7 @@ class InterventionCreator
     @observation.observation_type = :intervention
     if @observation.valid?
       academic_year = @observation.school.academic_year_for(@observation.at)
-      if academic_year && academic_year.current?
+      if academic_year&.current? && @observation.involved_pupils?
         @observation.points = @observation.intervention_type.score
       end
       @observation.save

--- a/app/views/interventions/_form.html.erb
+++ b/app/views/interventions/_form.html.erb
@@ -8,6 +8,10 @@
   <small class="form-text text-muted">You can record both recent and older actions to build up a complete record of all of the energy saving activities you've carried out as a school.</small>
 </fieldset>
 <fieldset class="form-group mt-4">
+  <%= f.input :involved_pupils, as: :boolean, label: "Were the pupils involved?", inline_label: true %>
+  <small class="form-text text-muted">If pupils were involved in proposing, planning, fund-raising or carrying out this action then recording this action will score <span class="badge badge-success"><%= intervention_type.score %></span> points for your school.</small>
+</fieldset>
+<fieldset class="form-group mt-5">
   <%= f.label 'Tell us more about what you did', for: :description %>
   <small class="form-text text-muted">Adding some background detail can help you track and monitor improvements</small>
   <small class="form-text text-muted">You can add formatting, links and attach images using the toolbar below. Hover over each icon to learn what it does.</small>

--- a/app/views/schools/interventions/_points.html.erb
+++ b/app/views/schools/interventions/_points.html.erb
@@ -1,4 +1,7 @@
-<h4 class="text-center"><strong>You've just scored <%= points %> points!</strong></h4>
+<% if points&.positive? %>
+  <h4 class="text-center"><strong>You've just scored <%= points %> points!</strong></h4>
+<% end %>
+
 <% if podium && podium.includes_school? && can?(:read, podium.scoreboard) %>
   <% if podium.school_position.position == 1 %>
     <h4 class="text-center">

--- a/app/views/schools/interventions/completed.html.erb
+++ b/app/views/schools/interventions/completed.html.erb
@@ -7,7 +7,7 @@
     <div class="col card-deck actions">
       <div class="card surrounding-schools">
         <div class="card-body">
-          <%= render 'points', podium: current_school_podium, completed_actions: @completed_actions, points: @observation.intervention_type.score  %>
+          <%= render 'points', podium: current_school_podium, completed_actions: @completed_actions, points: @observation.points  %>
         </div>
       </div>
     </div>

--- a/db/migrate/20220804124332_add_involved_pupils_to_observation.rb
+++ b/db/migrate/20220804124332_add_involved_pupils_to_observation.rb
@@ -1,0 +1,5 @@
+class AddInvolvedPupilsToObservation < ActiveRecord::Migration[6.0]
+  def change
+    add_column :observations, :involved_pupils, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_07_25_152512) do
+ActiveRecord::Schema.define(version: 2022_08_04_124332) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
@@ -996,6 +996,7 @@ ActiveRecord::Schema.define(version: 2022_07_25_152512) do
     t.integer "points"
     t.boolean "visible", default: true
     t.bigint "audit_id"
+    t.boolean "involved_pupils", default: false, null: false
     t.index ["activity_id"], name: "index_observations_on_activity_id"
     t.index ["audit_id"], name: "index_observations_on_audit_id"
     t.index ["intervention_type_id"], name: "index_observations_on_intervention_type_id"

--- a/spec/services/intervention_creator_spec.rb
+++ b/spec/services/intervention_creator_spec.rb
@@ -16,14 +16,24 @@ describe InterventionCreator do
     expect(observation.observation_type).to eq("intervention")
   end
 
-  it 'creates an observation with the number of points from the type' do
-    observation = build(:observation, intervention_type: intervention_type)
+  it 'creates an observation with a score if pupils involved' do
+    observation = build(:observation, intervention_type: intervention_type, involved_pupils: true)
     InterventionCreator.new(observation).process
     expect(observation.points).to eq(50)
   end
 
+  it 'creates an observation with no score if pupils not involved' do
+    observation = build(:observation, intervention_type: intervention_type, involved_pupils: false)
+    InterventionCreator.new(observation).process
+    expect(observation.points).to eq(nil)
+  end
+
   it 'scores 0 points for previous academic years' do
-    observation = build(:observation, intervention_type: intervention_type, at: 3.years.ago)
+    observation = build(:observation, intervention_type: intervention_type, at: 3.years.ago, involved_pupils: true)
+    InterventionCreator.new(observation).process
+    expect(observation.points).to eq(nil)
+
+    observation = build(:observation, intervention_type: intervention_type, at: 3.years.ago, involved_pupils: false)
     InterventionCreator.new(observation).process
     expect(observation.points).to eq(nil)
   end

--- a/spec/system/interventions_spec.rb
+++ b/spec/system/interventions_spec.rb
@@ -114,7 +114,8 @@ describe 'viewing and recording action', type: :system do
 
         expect(page).to have_content("can't be blank")
 
-        fill_in 'observation_at', with: '01/07/2019'
+        fill_in 'observation_at', with: Date.today.strftime("%d/%m/%Y")
+        check 'Were the pupils involved?'
         click_on 'Record action'
 
         expect(page).to have_content("Congratulations! We've recorded your action")
@@ -126,7 +127,19 @@ describe 'viewing and recording action', type: :system do
 
         observation = school.observations.intervention.first
         expect(observation.intervention_type).to eq(intervention_type)
-        expect(observation.at.to_date).to eq(Date.new(2019, 7, 1))
+        expect(observation.points).to eq(intervention_type.score)
+        expect(observation.at.to_date).to eq(Date.today)
+      end
+
+      it 'does not show points if none scored' do
+        click_on 'Record this action'
+        fill_in_trix with: 'We changed to a more efficient boiler'
+        fill_in 'observation_at', with: Date.today.strftime("%d/%m/%Y")
+        click_on 'Record action'
+        expect(page).to have_content("Congratulations! We've recorded your action")
+        expect(page).to_not have_content("You've just scored #{intervention_type.score} points")
+        observation = school.observations.intervention.first
+        expect(observation.points).to be_nil
       end
 
       context 'on podium' do
@@ -138,7 +151,8 @@ describe 'viewing and recording action', type: :system do
           it 'records action' do
             click_on 'Record this action'
             fill_in_trix with: 'We changed to a more efficient boiler'
-            fill_in 'observation_at', with: '01/07/2019'
+            fill_in 'observation_at', with: Date.today.strftime("%d/%m/%Y")
+            check 'Were the pupils involved?'
             click_on 'Record action'
             expect(page).to have_content("Congratulations! We've recorded your action")
           end
@@ -152,11 +166,13 @@ describe 'viewing and recording action', type: :system do
             it 'records action' do
               click_on 'Record this action'
               fill_in_trix with: 'We changed to a more efficient boiler'
-              fill_in 'observation_at', with: '01/07/2019'
+              fill_in 'observation_at', with: Date.today.strftime("%d/%m/%Y")
+              check 'Were the pupils involved?'
               click_on 'Record action'
               expect(page).to have_content("Congratulations! We've recorded your action")
               expect(page).to have_content("You've just scored #{intervention_type.score} points")
-              expect(page).to have_content("You've recorded 1 action so far this year")
+              #2 actions, because one created via :with_points above
+              expect(page).to have_content("You've recorded 2 actions so far this year")
               expect(page).to have_content("and your school is currently in 1st place")
             end
           end
@@ -166,11 +182,13 @@ describe 'viewing and recording action', type: :system do
             it 'records action' do
               click_on 'Record this action'
               fill_in_trix with: 'We changed to a more efficient boiler'
-              fill_in 'observation_at', with: '01/07/2019'
+              fill_in 'observation_at', with: Date.today.strftime("%d/%m/%Y")
+              check 'Were the pupils involved?'
               click_on 'Record action'
               expect(page).to have_content("Congratulations! We've recorded your action")
               expect(page).to have_content("You've just scored #{intervention_type.score} points")
-              expect(page).to have_content("You've recorded 1 action so far this year")
+              #2 actions, because one created via :with_points above
+              expect(page).to have_content("You've recorded 2 actions so far this year")
               expect(page).not_to have_content("and your school is currently in 1st place")
               expect(page).to have_content("to reach 1st place")
             end
@@ -201,6 +219,8 @@ describe 'viewing and recording action', type: :system do
         expect(page).to have_content('We changed to a more efficient boiler')
 
       end
+
+      it 'updates points if pupils were actually involved'
 
       it 'can be deleted' do
         visit management_school_path(school)


### PR DESCRIPTION
* [ ] Add flag to observation to track if pupils involved
* [ ] Only score points for actions if pupils involved
* [ ] Revise forms to only show points scored if there were any
* [ ] When updating intervention, add scores if flag changed and still within academic year

