### PR TITLE
Localise display of months in timeline helper

### DIFF
--- a/app/helpers/timeline_helper.rb
+++ b/app/helpers/timeline_helper.rb
@@ -1,10 +1,10 @@
 module TimelineHelper
   def title_for_month(month, year)
-    if month == Date.current.strftime("%B") && year == Date.current.strftime("%Y")
+    if month == Date.current.strftime("%-m") && year == Date.current.strftime("%Y")
       month_title = t('timeline.this_month')
       year_title = ""
     else
-      month_title = month
+      month_title = t('date.month_names')[month.to_i]
       year_title = year
     end
     content = content_tag(:span) do

--- a/app/views/home/training.html.erb
+++ b/app/views/home/training.html.erb
@@ -10,7 +10,7 @@
   <div class="row justify-content-md-center">
     <div class="col col-md-10">
       <table class="table timeline">
-        <% @events.group_by{|evt| [evt.date.strftime("%Y"), evt.date.strftime("%B")]}.each do |(year, month), grouped_events|%>
+        <% @events.group_by{|evt| [evt.date.strftime("%Y"), evt.date.strftime("%-m")]}.each do |(year, month), grouped_events|%>
         <thead>
           <tr>
             <th colspan="4">

--- a/spec/helpers/timeline_helper_spec.rb
+++ b/spec/helpers/timeline_helper_spec.rb
@@ -3,12 +3,12 @@ require "rails_helper"
 describe TimelineHelper do
   describe '.title_for_month' do
     it "should include month and year" do
-      expect(title_for_month("January", "2021")).to match("January")
-      expect(title_for_month("January", "2021")).to match("2021")
+      expect(title_for_month("1", "2021")).to match("January")
+      expect(title_for_month("1", "2021")).to match("2021")
     end
 
     it "should handle this month as special case" do
-      month = Date.current.strftime("%B")
+      month = Date.current.strftime("%-m")
       year = Date.current.strftime("%Y")
       expect(title_for_month(month, year)).to match("THIS MONTH")
       expect(title_for_month(month, year)).to_not match(year)


### PR DESCRIPTION
There's a helper used in formatting the timeline shown on the training page. It's not used elsewhere.

It previously accepted the name of the month, this has been changed to pass in the month number and then look up the month name via the I18n API.