### PR TITLE
Add coming soon message to untranslated sections

### DIFF
--- a/app/views/benchmarks/index.html.erb
+++ b/app/views/benchmarks/index.html.erb
@@ -1,4 +1,5 @@
 <% content_for :page_title, 'School Comparison Tool' %>
+<%= render 'shared/translation_coming_soon' if I18n.locale.to_s != 'en' %>
 
 <% if @filter_names.present? %>
   <h1>School Comparison Tool for <%= @filter_names %></h1>

--- a/app/views/schools/analysis/index.html.erb
+++ b/app/views/schools/analysis/index.html.erb
@@ -1,3 +1,5 @@
+<%= render 'shared/translation_coming_soon' if I18n.locale.to_s != 'en' %>
+
 <div class="d-flex justify-content-between align-items-center">
   <h1>Analysis for <%= @school.name %></h1>
   <div class="h5">

--- a/app/views/schools/analysis/show.html.erb
+++ b/app/views/schools/analysis/show.html.erb
@@ -1,4 +1,6 @@
 <% content_for :page_title, @title %>
+<%= render 'shared/translation_coming_soon' if I18n.locale.to_s != 'en' %>
+
 <%= link_to 'Back', school_analysis_index_path(@school), class: 'btn btn-rounded mt-3 mb-2' %>
 
 <% if @structured_content %>

--- a/app/views/schools/find_out_more/show.html.erb
+++ b/app/views/schools/find_out_more/show.html.erb
@@ -1,4 +1,5 @@
 <% content_for :page_title, @content.find_out_more_title %>
+<%= render 'shared/translation_coming_soon' if I18n.locale.to_s != 'en' %>
 
 <h1 class="pt-4"><%= sanitize @content.find_out_more_title %></h1>
 

--- a/app/views/shared/_translation_coming_soon.html.erb
+++ b/app/views/shared/_translation_coming_soon.html.erb
@@ -1,0 +1,3 @@
+<div class="row alert text-dark bg-neutral">
+  We're still working towards having Energy Sparks fully translated into Welsh. We've prioritised translating our educational activities and pupil facing activities. Translating this section of the site is still in progress, so for now we are defaulting to English.
+</div>


### PR DESCRIPTION
This pr adds a "coming soon" message to untranslated sections of the platform

- [x] "Adult Star Page" (Analytics index) `/schools/:school/analysis`
- [x] Analytics pages `/schools/:school/analysis/:id`
- [x] Find out more pages `/:school/find_out_more/:id`
- [x] Compare schools pages (`/benchmarks`)

The message will be display in a neutral blue bar, prominently at the top of the page. See `_prompt_to_review_target.html.erb` as a reference for styling.

With suggested initial text:
"We're still working towards having Energy Sparks fully translated into Welsh. We've prioritised translating our educational activities and pupil facing activities. Translating this section of the site is still in progress, so for now we are defaulting to English."