### PR TITLE
Fix finder to not use meter name

### DIFF
--- a/app/services/solar/low_carbon_hub_upserter.rb
+++ b/app/services/solar/low_carbon_hub_upserter.rb
@@ -15,14 +15,15 @@ module Solar
         mpan_mprn = details[:mpan_mprn]
         readings_hash = details[:readings]
 
-        meter = Meter.where(
+        meter = Meter.find_or_create_by!(
           meter_type: meter_type,
           mpan_mprn: mpan_mprn,
-          name: meter_type.to_s.humanize,
           low_carbon_hub_installation_id: @low_carbon_hub_installation.id,
           school: @low_carbon_hub_installation.school,
           pseudo: true
-        ).first_or_create!
+        ) do |new_record|
+          new_record.name = meter_type.to_s.humanize
+        end
 
         Amr::DataFeedUpserter.new(data_feed_reading_array(readings_hash, meter.id, mpan_mprn), @amr_data_feed_import_log).perform
         Rails.logger.info "Upserted #{@amr_data_feed_import_log.records_updated} inserted #{@amr_data_feed_import_log.records_imported}for #{@low_carbon_hub_installation.rbee_meter_id} at #{@low_carbon_hub_installation.school.name}"

--- a/app/services/solar/solar_edge_upserter.rb
+++ b/app/services/solar/solar_edge_upserter.rb
@@ -15,14 +15,15 @@ module Solar
         mpan_mprn = synthetic_mpan(meter_type, @solar_edge_installation.mpan)
         readings_hash = details[:readings]
 
-        meter = Meter.where(
+        meter = Meter.find_or_create_by!(
           meter_type: meter_type,
           mpan_mprn: mpan_mprn,
-          name: meter_type.to_s.humanize,
           solar_edge_installation_id: @solar_edge_installation.id,
           school: @solar_edge_installation.school,
           pseudo: true
-        ).first_or_create!
+        ) do |new_record|
+          new_record.name = meter_type.to_s.humanize
+        end
 
         Amr::DataFeedUpserter.new(data_feed_reading_array(readings_hash, meter.id, mpan_mprn), @amr_data_feed_import_log).perform
         Rails.logger.info "Upserted #{@amr_data_feed_import_log.records_updated} inserted #{@amr_data_feed_import_log.records_imported}for #{@solar_edge_installation.site_id} at #{@solar_edge_installation.school.name}"

--- a/spec/services/solar/low_carbon_hub_download_and_upsert_spec.rb
+++ b/spec/services/solar/low_carbon_hub_download_and_upsert_spec.rb
@@ -5,7 +5,7 @@ module Solar
 
     let!(:school)               { create(:school) }
     let(:rbee_meter_id)         { "216057958" }
-    let(:meter)         { create(:electricity_meter, low_carbon_hub_installation: installation) }
+    let(:meter)         { create(:electricity_meter, low_carbon_hub_installation: installation, mpan_mprn: 90000000123085, pseudo: true, name: "Test", school: school) }
 
     let(:installation)  { create(:low_carbon_hub_installation, rbee_meter_id: rbee_meter_id, school: school)}
 
@@ -102,6 +102,11 @@ module Solar
         let(:expected_end) { Date.yesterday }
         it "should default to reloading last 6 days" do
           upserter.perform
+        end
+        it "should insert data" do
+          expect(AmrDataFeedReading.count).to eql 1
+          upserter.perform
+          expect(AmrDataFeedReading.count).to eql 7
         end
       end
     end

--- a/spec/services/solar/solar_edge_upserter_spec.rb
+++ b/spec/services/solar/solar_edge_upserter_spec.rb
@@ -23,32 +23,68 @@ module Solar
     let(:expected_electricity_mpan) { "9#{mpan.to_s}".to_i }
     let(:expected_exported_solar_pv_mpan) { "6#{mpan.to_s}".to_i }
 
-    it 'creates new pseudo meters' do
-      expect {
+    context 'with no existing meters' do
+      it 'creates new pseudo meters' do
+        expect {
+          SolarEdgeUpserter.new(solar_edge_installation: solar_edge_installation, readings: readings, import_log: import_log).perform
+        }.to change { Meter.count }.by(3)
+        expect(solar_edge_installation.meters.solar_pv.first.mpan_mprn).to eq(expected_solar_pv_mpan)
+        expect(solar_edge_installation.meters.solar_pv.first.name).to eq("Solar pv")
+        expect(solar_edge_installation.meters.electricity.last.mpan_mprn).to eq(expected_electricity_mpan)
+        expect(solar_edge_installation.meters.electricity.last.name).to eq("Electricity")
+        expect(solar_edge_installation.meters.exported_solar_pv.last.mpan_mprn).to eq(expected_exported_solar_pv_mpan)
+        expect(solar_edge_installation.meters.exported_solar_pv.last.name).to eq("Exported solar pv")
+
+      end
+
+      it 'creates amr readings' do
+        expect {
+          SolarEdgeUpserter.new(solar_edge_installation: solar_edge_installation, readings: readings, import_log: import_log).perform
+        }.to change { AmrDataFeedReading.count }.by(6)
+        amr_reading = solar_edge_installation.meters.find_by_mpan_mprn(expected_solar_pv_mpan).amr_data_feed_readings.last
+        expect(amr_reading.readings[0]).to eq('2.0')
+        amr_reading = solar_edge_installation.meters.find_by_mpan_mprn(expected_electricity_mpan).amr_data_feed_readings.last
+        expect(amr_reading.readings[0]).to eq('4.0')
+        amr_reading = solar_edge_installation.meters.find_by_mpan_mprn(expected_exported_solar_pv_mpan).amr_data_feed_readings.last
+        expect(amr_reading.readings[0]).to eq('6.0')
+      end
+
+      it 'does not log any errors or warnings' do
         SolarEdgeUpserter.new(solar_edge_installation: solar_edge_installation, readings: readings, import_log: import_log).perform
-      }.to change { Meter.count }.by(3)
-      expect(solar_edge_installation.meters.solar_pv.first.mpan_mprn).to eq(expected_solar_pv_mpan)
-      expect(solar_edge_installation.meters.electricity.last.mpan_mprn).to eq(expected_electricity_mpan)
-      expect(solar_edge_installation.meters.exported_solar_pv.last.mpan_mprn).to eq(expected_exported_solar_pv_mpan)
+        amr_data_feed_import_log = AmrDataFeedImportLog.last
+        expect(amr_data_feed_import_log.error_messages).to be_blank
+        expect(amr_data_feed_import_log.amr_reading_warnings).to be_empty
+      end
     end
 
-    it 'creates amr readings' do
-      expect {
-        SolarEdgeUpserter.new(solar_edge_installation: solar_edge_installation, readings: readings, import_log: import_log).perform
-      }.to change { AmrDataFeedReading.count }.by(6)
-      amr_reading = solar_edge_installation.meters.find_by_mpan_mprn(expected_solar_pv_mpan).amr_data_feed_readings.last
-      expect(amr_reading.readings[0]).to eq('2.0')
-      amr_reading = solar_edge_installation.meters.find_by_mpan_mprn(expected_electricity_mpan).amr_data_feed_readings.last
-      expect(amr_reading.readings[0]).to eq('4.0')
-      amr_reading = solar_edge_installation.meters.find_by_mpan_mprn(expected_exported_solar_pv_mpan).amr_data_feed_readings.last
-      expect(amr_reading.readings[0]).to eq('6.0')
-    end
+    context 'when pseudo meter exists' do
+      let!(:existing_pseudo_meter) { create(:electricity_meter, solar_edge_installation: solar_edge_installation, name: "Existing meter", mpan_mprn: expected_electricity_mpan, school: solar_edge_installation.school, pseudo: true )}
 
-    it 'does not log any errors or warnings' do
-      SolarEdgeUpserter.new(solar_edge_installation: solar_edge_installation, readings: readings, import_log: import_log).perform
-      amr_data_feed_import_log = AmrDataFeedImportLog.last
-      expect(amr_data_feed_import_log.error_messages).to be_blank
-      expect(amr_data_feed_import_log.amr_reading_warnings).to be_empty
+      it 'creates new pseudo meters where required' do
+        expect {
+          SolarEdgeUpserter.new(solar_edge_installation: solar_edge_installation, readings: readings, import_log: import_log).perform
+        }.to change { Meter.count }.by(2)
+        expect(solar_edge_installation.meters.solar_pv.first.mpan_mprn).to eq(expected_solar_pv_mpan)
+        expect(solar_edge_installation.meters.solar_pv.first.name).to eq("Solar pv")
+        expect(solar_edge_installation.meters.exported_solar_pv.last.mpan_mprn).to eq(expected_exported_solar_pv_mpan)
+        expect(solar_edge_installation.meters.exported_solar_pv.last.name).to eq("Exported solar pv")
+
+        existing_pseudo_meter.reload
+        expect(existing_pseudo_meter.name).to eq("Existing meter")
+      end
+
+      it 'creates all the amr readings' do
+        expect {
+          SolarEdgeUpserter.new(solar_edge_installation: solar_edge_installation, readings: readings, import_log: import_log).perform
+        }.to change { AmrDataFeedReading.count }.by(6)
+        amr_reading = solar_edge_installation.meters.find_by_mpan_mprn(expected_solar_pv_mpan).amr_data_feed_readings.last
+        expect(amr_reading.readings[0]).to eq('2.0')
+        amr_reading = solar_edge_installation.meters.find_by_mpan_mprn(expected_electricity_mpan).amr_data_feed_readings.last
+        expect(amr_reading.readings[0]).to eq('4.0')
+        amr_reading = solar_edge_installation.meters.find_by_mpan_mprn(expected_exported_solar_pv_mpan).amr_data_feed_readings.last
+        expect(amr_reading.readings[0]).to eq('6.0')
+      end
+
     end
   end
 end


### PR DESCRIPTION
The Solar Edge and Low Carbon Hub loaders were using `first_or_create!` with a set of attributes that included the meter `name`.

But meters can be renamed by admins. This caused a bug where a meter wasn't being properly found after being renamed, but then data failed to insert as the meter did exist.

Switch to use `find_or_create_by!` and passed in a block to set attributes on create.