### PR TITLE
Fix TypeError from Mobility Backend

### DIFF
--- a/app/models/activity_type.rb
+++ b/app/models/activity_type.rb
@@ -80,6 +80,7 @@ class ActivityType < ApplicationRecord
 
   before_save :copy_searchable_attributes
 
+
   def suggested_from
     ActivityType.joins(:activity_type_suggestions).where("activity_type_suggestions.suggested_type_id = ?", id)
   end

--- a/app/models/activity_type.rb
+++ b/app/models/activity_type.rb
@@ -80,7 +80,6 @@ class ActivityType < ApplicationRecord
 
   before_save :copy_searchable_attributes
 
-
   def suggested_from
     ActivityType.joins(:activity_type_suggestions).where("activity_type_suggestions.suggested_type_id = ?", id)
   end

--- a/app/services/template_interpolation.rb
+++ b/app/services/template_interpolation.rb
@@ -19,6 +19,8 @@ class TemplateInterpolation
       template = @object.send(field) || ""
       collection[field] = if template.is_a?(ActionText::RichText)
                             process_rich_text_template(template, with)
+                          elsif template.is_a?(Mobility::Backends::ActionText::RichTextTranslation)
+                            process_rich_text_template(template, with)
                           else
                             process_string_template(template, with)
                           end


### PR DESCRIPTION
From https://trello.com/c/H62XMjMj/2371-typeerror-from-mobility-backend

This pr (hopefully) fixes the error seen occasionally in development when there have been some code changes in the application

```
TypeError - no implicit conversion of Mobility::Backends::ActionText::RichTextTranslation into String:
  app/services/template_interpolation.rb:40:in `process_string_template'
  app/services/template_interpolation.rb:23:in `block in interpolate'
  app/services/template_interpolation.rb:18:in `interpolate'
  app/controllers/concerns/dashboard_alerts.rb:14:in `block in setup_alerts'
  app/controllers/concerns/dashboard_alerts.rb:5:in `setup_alerts'
  app/controllers/pupils/schools_controller.rb:36:in `setup_data_enabled_features'
  app/controllers/pupils/schools_controller.rb:22:in `show'
  app/controllers/application_controller.rb:14:in `switch_locale'
  lib/rack/x_robots_tag.rb:8:in `call'
```
