### PR TITLE
Equivalence generation localisation

### DIFF
--- a/app/controllers/schools/alert_reports_controller.rb
+++ b/app/controllers/schools/alert_reports_controller.rb
@@ -3,11 +3,12 @@ module Schools
     load_and_authorize_resource :school
 
     def index
-      authorize! :read, AlertType
+      authorize! :view_content_reports, @school
       @alert_generation_runs = @school.alert_generation_runs.order(created_at: :desc)
     end
 
     def show
+      authorize! :view_content_reports, @school
       @run = @school.alert_generation_runs.find(params[:id])
       @analytics_alerts = @run.alerts.analytics.by_type
       @system_alerts = @run.alerts.system.by_type

--- a/app/controllers/schools/content_reports_controller.rb
+++ b/app/controllers/schools/content_reports_controller.rb
@@ -6,13 +6,13 @@ module Schools
     load_and_authorize_resource :school
 
     def index
-      authorize! :read, ContentGenerationRun
+      authorize! :view_content_reports, @school
       @content_generation_runs = @school.content_generation_runs.order(created_at: :desc)
     end
 
     def show
+      authorize! :view_content_reports, @school
       @run = @school.content_generation_runs.find(params[:id])
-
       @pupil_dashboard_alerts = setup_alerts(@run.dashboard_alerts.pupil_dashboard, :pupil_dashboard_title, limit: nil)
       @management_dashboard_alerts = setup_alerts(@run.dashboard_alerts.management_dashboard, :management_dashboard_title, limit: nil)
       @management_priorities = setup_priorities(@run.management_priorities)

--- a/app/controllers/schools/equivalence_reports_controller.rb
+++ b/app/controllers/schools/equivalence_reports_controller.rb
@@ -1,0 +1,15 @@
+module Schools
+  class EquivalenceReportsController < ApplicationController
+    load_and_authorize_resource :school
+
+    def index
+      authorize! :view_content_reports, @school
+      @equivalences = @school.equivalences.order(created_at: :desc)
+    end
+
+    def show
+      authorize! :view_content_reports, @school
+      @equivalence = @school.equivalences.find(params[:id])
+    end
+  end
+end

--- a/app/models/equivalence.rb
+++ b/app/models/equivalence.rb
@@ -4,6 +4,7 @@
 #
 #  created_at                          :datetime         not null
 #  data                                :json
+#  data_cy                             :json
 #  equivalence_type_content_version_id :bigint(8)        not null
 #  from_date                           :date
 #  id                                  :bigint(8)        not null, primary key

--- a/app/models/equivalence.rb
+++ b/app/models/equivalence.rb
@@ -27,6 +27,8 @@ class Equivalence < ApplicationRecord
   belongs_to :school
   belongs_to :content_version, class_name: 'EquivalenceTypeContentVersion', foreign_key: :equivalence_type_content_version_id
 
+  delegate :equivalence_type, to: :content_version
+
   def formatted_variables
     variables.inject({}) do |formatted, (name, values)|
       formatted[name] = values[:formatted_equivalence]

--- a/app/models/equivalence.rb
+++ b/app/models/equivalence.rb
@@ -30,8 +30,8 @@ class Equivalence < ApplicationRecord
 
   delegate :equivalence_type, to: :content_version
 
-  def formatted_variables
-    variables.inject({}) do |formatted, (name, values)|
+  def formatted_variables(locale = I18n.locale)
+    variables(locale).inject({}) do |formatted, (name, values)|
       formatted[name] = values[:formatted_equivalence]
       formatted
     end
@@ -43,8 +43,13 @@ class Equivalence < ApplicationRecord
 
 private
 
-  def variables
-    data.deep_transform_keys do |key|
+  def variables(locale)
+    if locale == :cy
+      variables = data_cy&.any? ? data_cy : data
+    else
+      variables = data
+    end
+    variables.deep_transform_keys do |key|
       :"#{key.to_s.gsub('£', 'gbp')}"
     end
   end

--- a/app/services/equivalences/generate_equivalences.rb
+++ b/app/services/equivalences/generate_equivalences.rb
@@ -18,7 +18,7 @@ module Equivalences
             Rails.logger.debug("#{e.message} for #{@school.name}")
           rescue => e
             Rails.logger.error("#{e.message} for #{@school.name}")
-            Rollbar.error(e, job: :generate_equivalances, equivalence_type: equivalence_type, school_id: @school.id, school: @school.name)
+            Rollbar.error(e, job: :generate_equivalences, equivalence_type: equivalence_type, school_id: @school.id, school: @school.name)
           end
         end
       end

--- a/app/views/schools/equivalence_reports/index.html.erb
+++ b/app/views/schools/equivalence_reports/index.html.erb
@@ -1,0 +1,36 @@
+<% content_for :page_title do %>Equivalence report for <%= @school.name %><% end %>
+
+<h1>Current Equivalences</h1>
+
+<% if @equivalences.empty? %>
+  <%= @school.name %> currently has no equivalences. Either they have not been generated or an error was
+  encountered when attempting to produce the equivalences.
+<% else %>
+  <%= pluralize(@equivalences.count, 'equivalence') %> generated on <%= nice_date_times(@equivalences.first.created_at) %>
+  <table class="table table-sorted">
+    <thead>
+      <tr>
+        <th>Meter Type</th>
+        <th>Time Period</th>
+        <th>Image</th>
+        <th>From Date</th>
+        <th>To Date</th>
+        <th>Relevant</th>
+        <th></th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @equivalences.each do |equivalence| %>
+        <tr>
+          <td><%= equivalence.equivalence_type.meter_type.humanize %></td>
+          <td><%= equivalence.equivalence_type.time_period.humanize %></td>
+          <td><%= equivalence.equivalence_type.image_name.humanize %></td>
+          <td><%= nice_dates(equivalence.from_date) %></td>
+          <td><%= nice_dates(equivalence.to_date) %></td>
+          <td><%= equivalence.relevant %></td>
+          <td><%= link_to 'View', school_equivalence_report_path(@school, equivalence), class: 'btn' %></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+<% end %>

--- a/app/views/schools/equivalence_reports/show.html.erb
+++ b/app/views/schools/equivalence_reports/show.html.erb
@@ -1,0 +1,23 @@
+<% content_for :page_title do %>Equivalence for <%= @school.name %><% end %>
+<div class="row padded-row">
+  <div class="col-md-12">
+    <h1 property="name">Equivalence for <%= link_to @school.name, @school %></h1>
+  </div>
+
+  <div class="col-md-12">
+    <p><%= link_to "View all", school_equivalence_reports_path(@school) %></p>
+    <div class="card mb-3">
+      <div class="card-header">
+        <h4>Equivalence: <%= @equivalence.equivalence_type.meter_type.humanize %> - <%= @equivalence.equivalence_type.time_period.humanize %></h4>
+      </div>
+      <div class="card-body">
+        <h5>Equivalence variables (English)</h5>
+        <%= sanitize ap(@equivalence.data, index: false, plain: true)%>
+      </div>
+      <div class="card-footer text-muted">
+        <p class="card-text"><b>Relevant</b>: <%= @equivalence.relevant %></p>
+        <p class="card-text"><b>Run on date</b>: <%= nice_dates @equivalence.created_at %></p>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/schools/equivalence_reports/show.html.erb
+++ b/app/views/schools/equivalence_reports/show.html.erb
@@ -13,6 +13,8 @@
       <div class="card-body">
         <h5>Equivalence variables (English)</h5>
         <%= sanitize ap(@equivalence.data, index: false, plain: true)%>
+        <h5>Equivalence variables (Welsh)</h5>
+        <%= sanitize ap(@equivalence.data_cy, index: false, plain: true)%>
       </div>
       <div class="card-footer text-muted">
         <p class="card-text"><b>Relevant</b>: <%= @equivalence.relevant %></p>

--- a/app/views/schools/reports/index.html.erb
+++ b/app/views/schools/reports/index.html.erb
@@ -1,13 +1,16 @@
 <h1>Admin batch process reports for <%= @school.name %></h1>
 
 <ul>
-  <% if can? :index, ContentGenerationRun %>
+  <% if can? :view_content_reports, @school %>
     <li><%= link_to 'Content reports', school_content_reports_path(@school) %> -- view summary of content generation runs</li>
   <% end %>
-  <% if can? :index, Alert %>
+  <% if can? :view_content_reports, @school %>
     <li><%= link_to 'Alert reports', school_alert_reports_path(@school) %> -- view summary of recent alert runs</li>
   <% end %>
-  <% if can? :index, SubscriptionGenerationRun %>
+  <% if can? :view_content_reports, @school %>
+    <li><%= link_to 'Equivalences', school_equivalence_reports_path(@school) %> -- view details of generated equivalences</li>
+  <% end %>
+  <% if can? :view_content_reports, @school %>
     <li><%= link_to 'Email and SMS reports', school_subscription_generation_runs_path(@school) %> -- view recently sent alerts</li>
   <% end %>
 </ul>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -202,6 +202,7 @@ Rails.application.routes.draw do
 
       resources :alert_reports, only: [:index, :show]
       resources :content_reports, only: [:index, :show]
+      resources :equivalence_reports, only: [:index, :show]
       get :chart, to: 'charts#show'
       get :annotations, to: 'annotations#show'
 

--- a/db/migrate/20220825134314_add_welsh_template_data_to_equivalence.rb
+++ b/db/migrate/20220825134314_add_welsh_template_data_to_equivalence.rb
@@ -1,0 +1,5 @@
+class AddWelshTemplateDataToEquivalence < ActiveRecord::Migration[6.0]
+  def change
+    add_column :equivalences, :data_cy, :json, default: {}
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_08_23_162339) do
+ActiveRecord::Schema.define(version: 2022_08_25_134314) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
@@ -719,6 +719,7 @@ ActiveRecord::Schema.define(version: 2022_08_23_162339) do
     t.boolean "relevant", default: true
     t.date "from_date"
     t.date "to_date"
+    t.json "data_cy", default: {}
     t.index ["equivalence_type_content_version_id"], name: "index_equivalences_on_equivalence_type_content_version_id"
     t.index ["school_id"], name: "index_equivalences_on_school_id"
   end

--- a/spec/models/equivalence_spec.rb
+++ b/spec/models/equivalence_spec.rb
@@ -28,6 +28,20 @@ describe Equivalence do
         school_dinners_gbp: '£2.50'
       })
     end
+
+    it 'fetches right version for locale' do
+      equivalence = Equivalence.new(
+        data: {
+          'school_dinners_£' => {'formatted_equivalence' => '£2.50', 'conversion' => 0.5}
+        },
+        data_cy: {
+          'school_dinners_£' => {'formatted_equivalence' => 'WELSH', 'conversion' => 0.5}
+        }
+      )
+      expect(equivalence.formatted_variables(:cy)).to eq({
+        school_dinners_gbp: 'WELSH'
+      })
+    end
   end
 
 end

--- a/spec/system/admin/equivalence_management_spec.rb
+++ b/spec/system/admin/equivalence_management_spec.rb
@@ -95,13 +95,13 @@ RSpec.describe 'equivalence type management', type: :system do
       analytics = double :analytics
 
       expect(analytics).to receive(:new).and_return(analytics)
-      expect(analytics).to receive(:front_end_convert).with(:kwh, {month: -1}, :electricity).and_return(
+      expect(analytics).to receive(:front_end_convert).at_least(:once).with(:kwh, {month: -1}, :electricity).and_return(
         {
           formatted_equivalence: '100 kwh',
           show_equivalence: true
         }
       )
-      expect(analytics).to receive(:front_end_convert).with(:number_trees, {month: -1}, :electricity).and_return(
+      expect(analytics).to receive(:front_end_convert).at_least(:once).with(:number_trees, {month: -1}, :electricity).and_return(
         {
           formatted_equivalence: '200,000',
           show_equivalence: true

--- a/spec/system/admin/school_batch_reports_spec.rb
+++ b/spec/system/admin/school_batch_reports_spec.rb
@@ -13,7 +13,7 @@ describe "School Batch Reports", type: :system do
   describe 'equivalence reports' do
     let(:equivalence_type)          { create(:equivalence_type, time_period: :last_week )}
     let(:equivalence_type_content)  { create(:equivalence_type_content_version, equivalence_type: equivalence_type, equivalence: 'Your school spent {{gbp}} on electricity last year!')}
-    let!(:equivalence)              { create(:equivalence, school: school, content_version: equivalence_type_content, data: {'gbp' => {'formatted_equivalence' => '£2.00'}}, to_date: Date.today ) }
+    let!(:equivalence)              { create(:equivalence, school: school, content_version: equivalence_type_content, data: {'gbp' => {'formatted_equivalence' => '£2.00'}}, data_cy: {'welsh'=> {'today' => 'dydd Sadwrn'}}, to_date: Date.today ) }
 
     it 'has a link to equivalences report' do
       expect(page).to have_link(href: school_equivalence_reports_path(school))
@@ -29,6 +29,7 @@ describe "School Batch Reports", type: :system do
         expect(page).to have_content(equivalence_type.time_period.humanize)
         click_on 'View'
         expect(page).to have_content("formatted_equivalence")
+        expect(page).to have_content("dydd Sadwrn")
       end
     end
   end

--- a/spec/system/admin/school_batch_reports_spec.rb
+++ b/spec/system/admin/school_batch_reports_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+describe "School Batch Reports", type: :system do
+  let!(:school)             { create(:school) }
+
+  let!(:admin)  { create(:admin) }
+
+  before do
+    sign_in(admin)
+    visit school_reports_path(school)
+  end
+
+  describe 'equivalence reports' do
+    let(:equivalence_type)          { create(:equivalence_type, time_period: :last_week )}
+    let(:equivalence_type_content)  { create(:equivalence_type_content_version, equivalence_type: equivalence_type, equivalence: 'Your school spent {{gbp}} on electricity last year!')}
+    let!(:equivalence)              { create(:equivalence, school: school, content_version: equivalence_type_content, data: {'gbp' => {'formatted_equivalence' => '£2.00'}}, to_date: Date.today ) }
+
+    it 'has a link to equivalences report' do
+      expect(page).to have_link(href: school_equivalence_reports_path(school))
+    end
+
+    context 'with report' do
+      before(:each) do
+        click_on 'Equivalences'
+      end
+      it 'shows equivalence' do
+        expect(page).to have_content("1 equivalence generated")
+        expect(page).to have_content(equivalence_type.meter_type.humanize)
+        expect(page).to have_content(equivalence_type.time_period.humanize)
+        click_on 'View'
+        expect(page).to have_content("formatted_equivalence")
+      end
+    end
+  end
+end

--- a/spec/system/management/dashboard_spec.rb
+++ b/spec/system/management/dashboard_spec.rb
@@ -267,7 +267,7 @@ describe 'Management dashboard' do
               average_payback_years: '1 year'
             },
             template_data_cy: {
-              average_one_year_saving_gbp: '£5,000',
+              average_one_year_saving_gbp: '£7,000',
               average_payback_years: '1 flwyddyn'
             }
           )
@@ -287,7 +287,7 @@ describe 'Management dashboard' do
         context 'in Welsh' do
           it 'displays Welsh alert text' do
             visit management_school_path(school, locale: 'cy')
-            expect(page).to have_content('Gallwch arbed £5,000 mewn 1 flwyddyn')
+            expect(page).to have_content('Gallwch arbed £7,000 mewn 1 flwyddyn')
           end
         end
       end

--- a/spec/system/pupils/dashboard_spec.rb
+++ b/spec/system/pupils/dashboard_spec.rb
@@ -10,8 +10,8 @@ describe 'Pupil dashboard' do
   let!(:intervention)       { create(:observation, :temperature, school: school) }
 
   let(:equivalence_type)          { create(:equivalence_type, time_period: :last_week )}
-  let(:equivalence_type_content)  { create(:equivalence_type_content_version, equivalence_type: equivalence_type, equivalence: 'Your school spent {{gbp}} on electricity last year!')}
-  let!(:equivalence)              { create(:equivalence, school: school, content_version: equivalence_type_content, data: {'gbp' => {'formatted_equivalence' => '£2.00'}}, to_date: Date.today ) }
+  let(:equivalence_type_content)  { create(:equivalence_type_content_version, equivalence_type: equivalence_type, equivalence_en: 'Your school spent {{gbp}} on electricity last year!', equivalence_cy: 'Gwariodd eich ysgol {{gbp}} ar drydan y llynedd!')}
+  let!(:equivalence)              { create(:equivalence, school: school, content_version: equivalence_type_content, data: {'gbp' => {'formatted_equivalence' => '£2.00'}}, data_cy: {'gbp' => {'formatted_equivalence' => '£9.00'}}, to_date: Date.today ) }
 
   let(:pupil) { create(:pupil, school: school)}
 
@@ -56,6 +56,11 @@ describe 'Pupil dashboard' do
 
     it 'shows equivalences' do
       expect(page).to have_content('Your school spent £2.00 on electricity last year!')
+    end
+
+    it 'shows Welsh equivalences' do
+      visit pupils_school_path(school, locale: 'cy')
+      expect(page).to have_content('Gwariodd eich ysgol £9.00 ar drydan y llynedd')
     end
 
     it 'has navigation to adult dashboard' do


### PR DESCRIPTION
Generate and store English and Welsh formatted variable data for Equivalences. And then ensure this is used when generating text for display.

* [x] add a new admin-only report to allow viewing of detailed equivalence data, similar to what we have for alerts
* [x] add new `data_cy` column to store welsh variables
* [x] generate and store `data_cy` as well as English data
* [x] use right version of variables depending on locale