### PR TITLE
Infinite increases on school comparison charts

### DIFF
--- a/app/assets/javascripts/common_chart_options.js
+++ b/app/assets/javascripts/common_chart_options.js
@@ -143,13 +143,11 @@ function barColumnLine(chartData, highchartsChart, seriesData, chartConfig) {
       highchartsChart.update({yAxis: { type: 'datetime', dateTimeLabelFormats: { day: '%H:%M'} }})
     }
 
-
     highchartsChart.update({ chart: { inverted: true, marginLeft: 200, marginRight: 100 }, yAxis: [{ reversedStacks: false, stackLabels: { style: { fontWeight: 'bold',  color: '#232b49' } } }], plotOptions: { bar: { tooltip: { headerFormat: '<b>{series.name}</b><br>', pointFormat: orderedPointFormat(yAxisLabel)}}}});
 
     if (chartData.x_max_value) {
       highchartsChart.update({yAxis: { max: chartData.x_max_value }})
     }
-
   }
 
   // LINE charts

--- a/app/assets/javascripts/common_chart_options.js
+++ b/app/assets/javascripts/common_chart_options.js
@@ -142,7 +142,8 @@ function barColumnLine(chartData, highchartsChart, seriesData, chartConfig) {
       //console.log('time of day set');
       highchartsChart.update({yAxis: { type: 'datetime', dateTimeLabelFormats: { day: '%H:%M'} }})
     }
-    highchartsChart.update({ chart: { inverted: true, marginLeft: 200, marginRight: 100 }, yAxis: [{ reversedStacks: false, stackLabels: { style: { fontWeight: 'bold',  color: '#232b49' } } }], plotOptions: { bar: { tooltip: { headerFormat: '<b>{series.name}</b><br>', pointFormat: orderedPointFormat(yAxisLabel)}}}});
+
+    highchartsChart.update({ chart: { inverted: true, marginLeft: 200, marginRight: 100 }, yAxis: [{ max: chartData.x_max_value, reversedStacks: false, stackLabels: { style: { fontWeight: 'bold',  color: '#232b49' } } }], plotOptions: { bar: { tooltip: { headerFormat: '<b>{series.name}</b><br>', pointFormat: orderedPointFormat(yAxisLabel)}}}});
   }
 
   // LINE charts

--- a/app/assets/javascripts/common_chart_options.js
+++ b/app/assets/javascripts/common_chart_options.js
@@ -146,7 +146,11 @@ function barColumnLine(chartData, highchartsChart, seriesData, chartConfig) {
     highchartsChart.update({ chart: { inverted: true, marginLeft: 200, marginRight: 100 }, yAxis: [{ reversedStacks: false, stackLabels: { style: { fontWeight: 'bold',  color: '#232b49' } } }], plotOptions: { bar: { tooltip: { headerFormat: '<b>{series.name}</b><br>', pointFormat: orderedPointFormat(yAxisLabel)}}}});
 
     if (chartData.x_max_value) {
-      highchartsChart.update({yAxis: { max: chartData.x_max_value, min: -chartData.x_max_value }})
+      highchartsChart.update({yAxis: { max: chartData.x_max_value }})
+    }
+
+    if (chartData.x_min_value) {
+      highchartsChart.update({yAxis: { min: chartData.x_min_value }})
     }
   }
 

--- a/app/assets/javascripts/common_chart_options.js
+++ b/app/assets/javascripts/common_chart_options.js
@@ -147,7 +147,6 @@ function barColumnLine(chartData, highchartsChart, seriesData, chartConfig) {
 
     if (chartData.x_max_value) {
       highchartsChart.update({yAxis: { max: chartData.x_max_value, min: -chartData.x_max_value }})
-
     }
   }
 

--- a/app/assets/javascripts/common_chart_options.js
+++ b/app/assets/javascripts/common_chart_options.js
@@ -143,7 +143,13 @@ function barColumnLine(chartData, highchartsChart, seriesData, chartConfig) {
       highchartsChart.update({yAxis: { type: 'datetime', dateTimeLabelFormats: { day: '%H:%M'} }})
     }
 
-    highchartsChart.update({ chart: { inverted: true, marginLeft: 200, marginRight: 100 }, yAxis: [{ max: chartData.x_max_value, reversedStacks: false, stackLabels: { style: { fontWeight: 'bold',  color: '#232b49' } } }], plotOptions: { bar: { tooltip: { headerFormat: '<b>{series.name}</b><br>', pointFormat: orderedPointFormat(yAxisLabel)}}}});
+
+    highchartsChart.update({ chart: { inverted: true, marginLeft: 200, marginRight: 100 }, yAxis: [{ reversedStacks: false, stackLabels: { style: { fontWeight: 'bold',  color: '#232b49' } } }], plotOptions: { bar: { tooltip: { headerFormat: '<b>{series.name}</b><br>', pointFormat: orderedPointFormat(yAxisLabel)}}}});
+
+    if (chartData.x_max_value) {
+      highchartsChart.update({yAxis: { max: chartData.x_max_value }})
+    }
+
   }
 
   // LINE charts

--- a/app/assets/javascripts/common_chart_options.js
+++ b/app/assets/javascripts/common_chart_options.js
@@ -146,7 +146,8 @@ function barColumnLine(chartData, highchartsChart, seriesData, chartConfig) {
     highchartsChart.update({ chart: { inverted: true, marginLeft: 200, marginRight: 100 }, yAxis: [{ reversedStacks: false, stackLabels: { style: { fontWeight: 'bold',  color: '#232b49' } } }], plotOptions: { bar: { tooltip: { headerFormat: '<b>{series.name}</b><br>', pointFormat: orderedPointFormat(yAxisLabel)}}}});
 
     if (chartData.x_max_value) {
-      highchartsChart.update({yAxis: { max: chartData.x_max_value }})
+      highchartsChart.update({yAxis: { max: chartData.x_max_value, min: -chartData.x_max_value }})
+
     }
   }
 

--- a/app/models/chart_data_values.rb
+++ b/app/models/chart_data_values.rb
@@ -1,6 +1,6 @@
 class ChartDataValues
   attr_reader :anaylsis_type, :title, :subtitle, :chart1_type, :chart1_subtype,
-              :y_axis_label, :x_axis_label, :x_axis_categories, :x_max_value,
+              :y_axis_label, :x_axis_label, :x_axis_categories, :x_max_value, :x_min_value,
               :advice_header, :advice_footer, :y2_axis_label, :y2_point_format, :y2_max, :x_axis_ranges, :annotations,
               :transformations, :allowed_operations, :drilldown_available, :parent_timescale_description,
               :uses_time_of_day, :y1_axis_choices, :explore_message, :pinch_and_zoom_message, :click_and_drag_message
@@ -32,6 +32,7 @@ class ChartDataValues
       @x_axis_categories  = translate_categories_for(chart[:x_axis])
       @x_axis_ranges      = chart[:x_axis_ranges] # Not actually used but range of actual dates
       @x_max_value        = chart[:x_max_value]
+      @x_min_value        = chart[:x_min_value]
       @chart1_type        = chart[:chart1_type]
       @chart1_subtype     = chart[:chart1_subtype]
       @x_axis_label       = chart[:x_axis_label]
@@ -166,6 +167,7 @@ class ChartDataValues
       :x_axis_label,
       :x_axis_categories,
       :x_max_value,
+      :x_min_value,
       :advice_header,
       :advice_footer,
       :y2_axis_label,

--- a/app/models/chart_data_values.rb
+++ b/app/models/chart_data_values.rb
@@ -1,6 +1,6 @@
 class ChartDataValues
   attr_reader :anaylsis_type, :title, :subtitle, :chart1_type, :chart1_subtype,
-              :y_axis_label, :x_axis_label, :x_axis_categories,
+              :y_axis_label, :x_axis_label, :x_axis_categories, :x_max_value,
               :advice_header, :advice_footer, :y2_axis_label, :y2_point_format, :y2_max, :x_axis_ranges, :annotations,
               :transformations, :allowed_operations, :drilldown_available, :parent_timescale_description,
               :uses_time_of_day, :y1_axis_choices, :explore_message, :pinch_and_zoom_message, :click_and_drag_message
@@ -31,6 +31,7 @@ class ChartDataValues
       @subtitle           = chart[:subtitle]
       @x_axis_categories  = translate_categories_for(chart[:x_axis])
       @x_axis_ranges      = chart[:x_axis_ranges] # Not actually used but range of actual dates
+      @x_max_value        = chart[:x_max_value]
       @chart1_type        = chart[:chart1_type]
       @chart1_subtype     = chart[:chart1_subtype]
       @x_axis_label       = chart[:x_axis_label]
@@ -164,6 +165,7 @@ class ChartDataValues
       :y_axis_label,
       :x_axis_label,
       :x_axis_categories,
+      :x_max_value,
       :advice_header,
       :advice_footer,
       :y2_axis_label,


### PR DESCRIPTION
Some school comparison charts return "infinite" values, e.g. percent change in gas usage between last week and this week, where last week there was no gas consumption i.e. this week divided by last week = Infinity. 

The analytics has been updated to add configuration specifying min/max values for charts. See code changed in: https://github.com/Energy-Sparks/energy-sparks_analytics/pull/292

This pr fixes the front-end application needs by applying the max x axis value to highcharts

from
![Screenshot 2022-08-26 at 14 35 15](https://user-images.githubusercontent.com/25906/186924094-49b0513c-1502-464e-84b6-2a30c3f5cbcf.png)

to
![Screenshot 2022-08-26 at 15 16 11](https://user-images.githubusercontent.com/25906/186924106-ea0a3f4b-6a4c-47ee-bcbd-41d836ee4c0a.png)
