### PR TITLE
Update scatter charts to plot regression as a line

### DIFF
--- a/app/assets/javascripts/common_chart_options.js
+++ b/app/assets/javascripts/common_chart_options.js
@@ -244,7 +244,19 @@ function scatter(chartData, highchartsChart, seriesData) {
 
   Object.keys(seriesData).forEach(function (key) {
     //console.log(seriesData[key].name);
-    highchartsChart.addSeries(seriesData[key], false);
+    if (seriesData[key].name.startsWith("trendline_")) {
+      highchartsChart.addSeries(
+        {
+          type: 'line',
+          name: seriesData[key].name,
+          data: seriesData[key].data.filter(function( obj ) {
+            return obj[1] !== null; // Remove nulls so there's no gap in the line
+          })
+        }
+      )
+    } else {
+      highchartsChart.addSeries(seriesData[key], false)
+    }
   });
   normaliseYAxis(highchartsChart);
   highchartsChart.redraw();


### PR DESCRIPTION
This pr makes all data series with a name starting `trendline_` plot with a line instead of as individual scatter plot points.

![Screenshot 2022-08-31 at 08 51 46](https://user-images.githubusercontent.com/25906/187623254-fa68d5e7-e6e3-4952-96db-e495af817b26.png)


