### PR TITLE
Translations from Transifex

### DIFF
--- a/config/locales/cy/en.yml
+++ b/config/locales/cy/en.yml
@@ -1,0 +1,49 @@
+cy:
+  date:
+    abbr_day_names:
+      - Sul
+      - Llun
+      - Maw
+      - Mer
+      - Iau
+      - Gwe
+      - Sad
+    abbr_month_names:
+      - Ion
+      - Chwe
+      - Maw
+      - Ebr
+      - Mai
+      - Meh
+      - Gorff
+      - Awst
+      - Medi
+      - Hyd
+      - Tach
+      - Rhag
+    day_names:
+      - Dydd Sul
+      - Dydd Llun
+      - Dydd Mawrth
+      - Dydd Mercher
+      - Dydd Iau
+      - Dydd Gwener
+      - Dydd Sadwrn
+    month_names:
+      - Ionawr
+      - Chwefror
+      - Mawrth
+      - Ebrill
+      - Mai
+      - Mehefin
+      - Gorffennaf
+      - Awst
+      - Medi
+      - Hydref
+      - Tachwedd
+      - Rhagfyr
+  support:
+    array:
+      last_word_connector: ", a"
+      two_words_connector: "a"
+      words_connector: ", "

--- a/config/locales/cy/en.yml
+++ b/config/locales/cy/en.yml
@@ -1,47 +1,50 @@
+---
 cy:
   date:
     abbr_day_names:
-      - Sul
-      - Llun
-      - Maw
-      - Mer
-      - Iau
-      - Gwe
-      - Sad
+    - Sul
+    - Llun
+    - Maw
+    - Mer
+    - Iau
+    - Gwe
+    - Sad
     abbr_month_names:
-      - Ion
-      - Chwe
-      - Maw
-      - Ebr
-      - Mai
-      - Meh
-      - Gorff
-      - Awst
-      - Medi
-      - Hyd
-      - Tach
-      - Rhag
+    - ''
+    - Ion
+    - Chwe
+    - Maw
+    - Ebr
+    - Mai
+    - Meh
+    - Gorff
+    - Awst
+    - Medi
+    - Hyd
+    - Tach
+    - Rhag
     day_names:
-      - Dydd Sul
-      - Dydd Llun
-      - Dydd Mawrth
-      - Dydd Mercher
-      - Dydd Iau
-      - Dydd Gwener
-      - Dydd Sadwrn
+    - Dydd Sul
+    - Dydd Llun
+    - Dydd Mawrth
+    - Dydd Mercher
+    - Dydd Iau
+    - Dydd Gwener
+    - Dydd Sadwrn
     month_names:
-      - Ionawr
-      - Chwefror
-      - Mawrth
-      - Ebrill
-      - Mai
-      - Mehefin
-      - Gorffennaf
-      - Awst
-      - Medi
-      - Hydref
-      - Tachwedd
-      - Rhagfyr
+    - ''
+    - Ionawr
+    - Chwefror
+    - Mawrth
+    - Ebrill
+    - Mai
+    - Mehefin
+    - Gorffennaf
+    - Awst
+    - Medi
+    - Hydref
+    - Tachwedd
+    - Rhagfyr
   support:
     array:
       last_word_connector: ", a"


### PR DESCRIPTION
The `en.yml` file is translated and fully reviewed. Have managed to pull that down, so this is the provided text.

The command I used was:

```
tx pull --mode onlyreviewed --all
```

The `mode` parameter ensures that the client only pulls reviewed translations. I think we need this and the `minimum_perc` setting in order to ensure we only pull down 100% complete YAML files with properly reviewed translations. (see [tx client code](https://github.com/transifex/cli/blob/f5034553805c2c726b3b2b23e32f88297b3c1ab8/internal/txlib/pull.go#L521)).

The `-a` (or `--all`) param controls "Whether to download all files". I found that without this, because the Welsh version of the file (`config/locales/cy/en.yml`) didn't exist locally, then it just skipped the download completely. So we need that parameter to ensure we pull down all files for checking in.

This at least demonstrates that we can pull down translated content as expected.

