### PR TITLE
Exclude files with a prefix when copying YAML

### DIFF
--- a/lib/tasks/i18n/copy_analytics_yaml.rake
+++ b/lib/tasks/i18n/copy_analytics_yaml.rake
@@ -7,9 +7,14 @@ namespace :i18n do
 
     analytics_gem_path = `bundle info energy-sparks_analytics --path`.chomp
     analytics_yaml = File.join(analytics_gem_path, 'config', 'locales')
-    $stderr.puts "Copying files from #{dest} to #{analytics_yaml}"
+    $stderr.puts "Copying files from #{analytics_yaml} to #{dest}"
 
-    FileUtils.cp_r "#{analytics_yaml}/.", dest
+    #Copy all of the analytics YAML files, excluding any named with a x- prefix,
+    #e.g. x-activesupport-dates.yml
+    yaml = Dir["**/*.yml", base: analytics_yaml].reject {|f| f.match /^x-/}.sort
+    yaml.each do |yml|
+      FileUtils.cp File.join(analytics_gem_path, 'config', 'locales', yml), File.join(dest, yml)
+    end
 
     $stderr.puts "Done. Check in the updated files before the release"
   end


### PR DESCRIPTION
Exclude any files with a `x-` prefix when copying the analytics YAML files into the main project. This allows us to exclude, e.g. files containing copies of the active support date keys.