### PR TITLE
Handle Infinite and NaN values in benchmark results

### DIFF
--- a/app/models/benchmark_result.rb
+++ b/app/models/benchmark_result.rb
@@ -39,13 +39,17 @@ class BenchmarkResult < ApplicationRecord
     json.transform_values { |v| for_processing(v) }
   end
 
+  private_class_method def self.needs_conversion?(val)
+    val.is_a?(Float) || val.is_a?(BigDecimal)
+  end
+
   private_class_method def self.for_storage(val)
-    return val if val.nil? || !val.is_a?(Float)
+    return val if val.nil? || !needs_conversion?(val)
     if val.infinite? == 1
       ".inf"
     elsif val.infinite? == -1
       "-.Inf"
-    elsif (val.is_a?(Float) || val.is_a?(BigDecimal)) && val.nan?
+    elsif val.nan?
       ".NAN"
     else
       val

--- a/app/services/alerts/collate_benchmark_data.rb
+++ b/app/services/alerts/collate_benchmark_data.rb
@@ -30,7 +30,7 @@ module Alerts
           unless benchmarks[benchmark_result[0]].key?(school_id)
             benchmarks[benchmark_result[0]][school_id] = {}
           end
-          benchmarks[benchmark_result[0]][school_id] = benchmarks[benchmark_result[0]][school_id].merge!(benchmark_result[1])
+          benchmarks[benchmark_result[0]][school_id] = benchmarks[benchmark_result[0]][school_id].merge!(BenchmarkResult.convert_for_processing(benchmark_result[1]))
         end
       end
     end

--- a/app/services/alerts/generate_and_save_benchmarks.rb
+++ b/app/services/alerts/generate_and_save_benchmarks.rb
@@ -48,7 +48,7 @@ module Alerts
     def process_alert_report(alert_type, alert_report, asof_date)
       if alert_report.valid
         if alert_report.benchmark_data.present?
-          BenchmarkResult.create!(benchmark_result_school_generation_run: @benchmark_result_school_generation_run, asof: asof_date, alert_type: alert_type, data: alert_report.benchmark_data, results: alert_report.benchmark_data)
+          BenchmarkResult.create!(benchmark_result_school_generation_run: @benchmark_result_school_generation_run, asof: asof_date, alert_type: alert_type, data: alert_report.benchmark_data, results: BenchmarkResult.convert_for_storage(alert_report.benchmark_data))
         end
       else
         BenchmarkResultError.create!(benchmark_result_school_generation_run: @benchmark_result_school_generation_run, asof_date: asof_date, information: "Relevance: #{alert_report.relevance}", alert_type: alert_type)

--- a/spec/factories/benchmark_result_generation_run_factory.rb
+++ b/spec/factories/benchmark_result_generation_run_factory.rb
@@ -1,0 +1,4 @@
+FactoryBot.define do
+  factory :benchmark_result_generation_run do
+  end
+end

--- a/spec/factories/benchmark_result_school_generation_run_factory.rb
+++ b/spec/factories/benchmark_result_school_generation_run_factory.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :benchmark_result_school_generation_run do
+    school
+    benchmark_result_generation_run
+  end
+end

--- a/spec/models/benchmark_result_spec.rb
+++ b/spec/models/benchmark_result_spec.rb
@@ -6,10 +6,12 @@ describe BenchmarkResult do
 
   context '#convert_for_processing' do
     it 'returns simple json unchanged' do
-      data = {foo: 123, bar: 1.2, var: Date.new(2022,4,1)}
+      data = {foo: 123, bar: 1.2, other: "String", check: true, var: Date.new(2022,4,1)}
       expect(BenchmarkResult.convert_for_processing(data)).to eq({
           foo: 123,
           bar: 1.2,
+          other: "String",
+          check: true,
           var: Date.new(2022,4,1)
         })
     end
@@ -55,6 +57,12 @@ describe BenchmarkResult do
           bar: 1.2,
           var: ".inf"
         })
+        data = {foo: 123, bar: 1.2, var: BigDecimal('Infinity')}
+        expect(BenchmarkResult.convert_for_storage(data)).to eq({
+            foo: 123,
+            bar: 1.2,
+            var: ".inf"
+          })
     end
     it 'replaces -Infinity with -.Inf' do
       data = {foo: 123, bar: 1.2, var: -Float::INFINITY}
@@ -63,6 +71,12 @@ describe BenchmarkResult do
           bar: 1.2,
           var: "-.Inf"
         })
+        data = {foo: 123, bar: 1.2, var: BigDecimal('-Infinity')}
+        expect(BenchmarkResult.convert_for_storage(data)).to eq({
+            foo: 123,
+            bar: 1.2,
+            var: "-.Inf"
+          })
     end
     it 'replaces with NaN with .NaN' do
       data = {foo: 123, bar: 1.2, var: Float::NAN}

--- a/spec/models/benchmark_result_spec.rb
+++ b/spec/models/benchmark_result_spec.rb
@@ -1,0 +1,77 @@
+require 'rails_helper'
+
+describe BenchmarkResult do
+  let(:alert_type)     { create(:alert_type, fuel_type: nil, frequency: :weekly, source: :analytics, benchmark: true) }
+  let!(:benchmark_run) { create(:benchmark_result_school_generation_run) }
+
+  context '#convert_for_processing' do
+    it 'returns simple json unchanged' do
+      data = {foo: 123, bar: 1.2, var: Date.new(2022,4,1)}
+      expect(BenchmarkResult.convert_for_processing(data)).to eq({
+          foo: 123,
+          bar: 1.2,
+          var: Date.new(2022,4,1)
+        })
+    end
+    it 'replaces .inf with Infinity' do
+      data = {foo: 123, bar: 1.2, var: ".inf"}
+      expect(BenchmarkResult.convert_for_processing(data)).to eq({
+          foo: 123,
+          bar: 1.2,
+          var: Float::INFINITY
+        })
+    end
+    it 'replaces -.Inf with -Infinity' do
+      data = {foo: 123, bar: 1.2, var: "-.Inf"}
+      expect(BenchmarkResult.convert_for_processing(data)).to eq({
+          foo: 123,
+          bar: 1.2,
+          var: -Float::INFINITY
+        })
+    end
+    it 'replaces .Nan with NaN' do
+      data = {foo: 123, bar: 1.2, var: ".NAN"}
+      expect(BenchmarkResult.convert_for_processing(data)).to eq({
+          foo: 123,
+          bar: 1.2,
+          var: Float::NAN
+        })
+    end
+  end
+
+  context '#convert_for_storage' do
+    it 'leaves simple json unchanged' do
+      data = {foo: 123, bar: 1.2, var: Date.new(2022,4,1)}
+      expect(BenchmarkResult.convert_for_storage(data)).to eq({
+          foo: 123,
+          bar: 1.2,
+          var: Date.new(2022,4,1)
+        })
+    end
+    it 'replaces Infinity with .inf' do
+      data = {foo: 123, bar: 1.2, var: Float::INFINITY}
+      expect(BenchmarkResult.convert_for_storage(data)).to eq({
+          foo: 123,
+          bar: 1.2,
+          var: ".inf"
+        })
+    end
+    it 'replaces -Infinity with -.Inf' do
+      data = {foo: 123, bar: 1.2, var: -Float::INFINITY}
+      expect(BenchmarkResult.convert_for_storage(data)).to eq({
+          foo: 123,
+          bar: 1.2,
+          var: "-.Inf"
+        })
+    end
+    it 'replaces with NaN with .NaN' do
+      data = {foo: 123, bar: 1.2, var: Float::NAN}
+      expect(BenchmarkResult.convert_for_storage(data)).to eq({
+          foo: 123,
+          bar: 1.2,
+          var: ".NAN"
+        })
+    end
+  end
+
+end

--- a/spec/services/alerts/collate_benchmark_data_spec.rb
+++ b/spec/services/alerts/collate_benchmark_data_spec.rb
@@ -18,7 +18,7 @@ module Alerts
     let(:variables_1)         { {"number_example"=>1.0, "string_example"=>"A", "time_of_day"=> TimeOfDay.new(0,10)} }
     let(:variables_2)         { {"number_example"=>2.0, "string_example"=>"B", "time_of_day"=> TimeOfDay.new(0,20)} }
     let(:variables_3)         { {"number_example_2"=>3.0, "string_example_2"=>"C", "time_of_day_2"=> TimeOfDay.new(1,30)} }
-    let(:variables_4)         { {"number_example_2"=>4.0, "string_example_2"=>"D", "time_of_day_2"=> TimeOfDay.new(1,40)} }
+    let(:variables_4)         { {"number_example_2"=>4.0, "string_example_2"=>"D", "time_of_day_2"=> TimeOfDay.new(1,40) } }
     let(:variables_5)         { {"number_example"=>5.0, "string_example"=>"E", "time_of_day"=> TimeOfDay.new(0,15)} }
     let(:variables_6)         { {"number_example"=>6.0, "string_example"=>"F", "time_of_day"=> TimeOfDay.new(0,30)} }
     let(:variables_7)         { {"number_example_2"=>7.0, "string_example_2"=>"G", "time_of_day_2"=> TimeOfDay.new(1,35)} }

--- a/spec/services/alerts/generate_and_save_benchmarks_spec.rb
+++ b/spec/services/alerts/generate_and_save_benchmarks_spec.rb
@@ -19,7 +19,7 @@ module Alerts
       chart_data: {chart: 'variables'},
       table_data: {table: 'variables'},
       priority_data: {priority: 'variables'},
-      benchmark_data: {benchmark: 'variables'}
+      benchmark_data: {benchmark: 'variables', var: Float::INFINITY}
     }}
 
     let(:example_benchmark_report)    { Adapters::Report.new(**alert_report_attributes) }
@@ -79,6 +79,7 @@ module Alerts
         service.perform
         expect(BenchmarkResult.last.data).to_not eq({})
         expect(BenchmarkResult.last.results).to_not eq({})
+        expect(BenchmarkResult.last.results["var"]).to eq ".inf"
       end
 
       it 'handles just errors' do


### PR DESCRIPTION
We have started to store benchmark results as JSON, as it uses less memory when fetching from database.

The analytics is sending some special values (`Float::INFINITY`, `-Float::INFINITY`, `Float::NAN`) for some benchmark comparisons. These currently aren't being round-tripped properly with the new JSON column, but were ok in the YAML version.

The default json serialiser converts these values to nil. So when re-parsed and passed to the analytics, the code is not working as expected.

This add some code to `BenchmarkResult` which round-trips these values using strings [similar to YAML](https://yaml.org/refcard.html). 

This code is called when we save the benchmark results, and when its read back from the database.

Note: I've not used a before/after callback here as ActiveRecord seems to do the transformation immediately so couldn't hook into the change within the model. So I've put the conversion methods on the model and updated the relevant services.

This needs further testing in staging as there's specific combinations of data that generate the Infinite values.