### PR TITLE
Ensure correct month name and abbr month name array formatting

### DIFF
--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -17,7 +17,7 @@ default: &default
   cache_manifest: false
 
   # Extract and emit a css file
-  extract_css: false
+  extract_css: true
 
   static_assets_extensions:
     - .jpg

--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -17,7 +17,7 @@ default: &default
   cache_manifest: false
 
   # Extract and emit a css file
-  extract_css: true
+  extract_css: false
 
   static_assets_extensions:
     - .jpg

--- a/spec/i18n_spec.rb
+++ b/spec/i18n_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'i18n/tasks'
+require 'rails_helper'
 
 RSpec.describe I18n do
   let(:i18n) { I18n::Tasks::BaseTask.new }
@@ -30,5 +31,17 @@ RSpec.describe I18n do
     error_message = "#{inconsistent_interpolations.leaves.count} i18n keys have inconsistent interpolations.\n" \
                     "Run `i18n-tasks check-consistent-interpolations' to show them"
     expect(inconsistent_interpolations).to be_empty, error_message
+  end
+
+  it "ensures the 'date.month_names' array follows the conventional format (empty 0th element)" do
+    # see https://github.com/rails/rails/blob/main/activesupport/lib/active_support/locale/en.yml
+    expect(I18n.t('date.month_names', locale: 'en')).to eq(['', 'January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'])
+    expect(I18n.t('date.month_names', locale: 'cy')).to eq(['', 'Ionawr', 'Chwefror', 'Mawrth', 'Ebrill', 'Mai', 'Mehefin', 'Gorffennaf', 'Awst', 'Medi', 'Hydref', 'Tachwedd', 'Rhagfyr'])
+  end
+
+  it "ensures the 'date.abbr_month_names' array follows the conventional format (empty 0th element)" do
+    # see https://github.com/rails/rails/blob/main/activesupport/lib/active_support/locale/en.yml
+    expect(I18n.t('date.abbr_month_names', locale: 'en')).to eq(['', 'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'])
+    expect(I18n.t('date.abbr_month_names', locale: 'cy')).to eq(['', 'Ion', 'Chwe', 'Maw', 'Ebr', 'Mai', 'Meh', 'Gorff', 'Awst', 'Medi', 'Hyd', 'Tach', 'Rhag'])
   end
 end


### PR DESCRIPTION
`month_names` and `abbr_month_names` are still being pulled from TX with a missing empty 0th element (needed as there's no zero month see https://github.com/rails/rails/blob/main/activesupport/lib/active_support/locale/en.yml).  

This pr adds a a test to ensure `month_names` and `abbr_month_names` for both `en` and `cy` locales are in the correct format in case the missing empty 0th element is accidentally checked in.