### PR TITLE
Make date time picker under usage charts a bit wider

### DIFF
--- a/app/views/schools/usage/show.html.erb
+++ b/app/views/schools/usage/show.html.erb
@@ -37,8 +37,7 @@
     <%= hidden_field_tag :configuration, nil, data: {configuration: @chart_config} %>
 
     <div class="row justify-content-md-center">
-
-      <div class="col-12 col-lg-3 col-md-4">
+      <div class="col-12 col-lg-4 col-md-4">
         <div class="<%= @supply %>-dark <%= @supply %>-dark-<%= @period %> p-2 mb-2">
           <%= label_tag 'first-date-picker', t("charts.usage.date_picker.#{@period}.first")%>
 
@@ -57,7 +56,7 @@
       </div>
 
       <% unless @split_meters %>
-        <div class="col-12 col-lg-3 col-md-4">
+        <div class="col-12 col-lg-4 col-md-4">
           <div class="<%= @supply %>-light <%= @supply %>-light-<%= @period %> p-2 mb-2">
             <%= label_tag 'second-date-picker', t("charts.usage.date_picker.#{@period}.second")%>
 


### PR DESCRIPTION
This pr makes the date time picker slightly wider so year isn't hidden when the selected locale is cy

from
![Screenshot 2022-09-09 at 16 03 25](https://user-images.githubusercontent.com/25906/189382226-203a08fe-f0fa-48aa-ace1-55a34667de5b.png)

to
![Screenshot 2022-09-09 at 16 04 14](https://user-images.githubusercontent.com/25906/189382321-aae44b6f-6f37-430b-a849-6c33741f34e9.png)
