### PR TITLE
i18n for pagy

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,6 +3,7 @@ class ApplicationController < ActionController::Base
   around_action :switch_locale
   before_action :authenticate_user!
   before_action :analytics_code
+  before_action :pagy_locale
   helper_method :site_settings, :current_school_podium, :current_user_school
 
   rescue_from CanCan::AccessDenied do |exception|
@@ -50,5 +51,9 @@ class ApplicationController < ActionController::Base
 
   def analytics_code
     @analytics_code ||= ENV['GOOGLE_ANALYTICS_CODE']
+  end
+
+  def pagy_locale
+    @pagy_locale = I18n.locale.to_s
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,5 +1,3 @@
-require 'pagy/extras/bootstrap'
-
 module ApplicationHelper
   include Pagy::Frontend
 

--- a/config/initializers/pagy.rb
+++ b/config/initializers/pagy.rb
@@ -117,7 +117,7 @@
 
 # Bootstrap extra: Add nav, nav_js and combo_nav_js helpers and templates for Bootstrap pagination
 # See https://ddnexus.github.io/pagy/extras/bootstrap
-# require 'pagy/extras/bootstrap'
+require 'pagy/extras/bootstrap'
 
 # Bulma extra: Add nav, nav_js and combo_nav_js helpers and templates for Bulma pagination
 # See https://ddnexus.github.io/pagy/extras/bulma
@@ -225,6 +225,9 @@
 #                   filepath: 'path/to/pagy-xyz.yml',
 #                   pluralize: lambda{ |count| ... } )
 
+Pagy::I18n.load(
+    { locale: 'en', filepath: 'config/locales/pagy.yml' },
+    { locale: 'cy', filepath: 'config/locales/cy/pagy.yml' } )
 
 # I18n extra: uses the standard i18n gem which is ~18x slower using ~10x more memory
 # than the default pagy internal i18n (see above)

--- a/config/locales/cy/pagy.yml
+++ b/config/locales/cy/pagy.yml
@@ -1,0 +1,16 @@
+---
+cy:
+  pagy:
+    combo_nav_js: "<label>Page %{page_input} of %{pages}</label>"
+    info:
+      multiple_pages: Displaying %{item_name} <b>%{from}-%{to}</b> of <b>%{count}</b> in total
+      no_items: No %{item_name} found
+      single_page: Displaying <b>%{count}</b> %{item_name}
+    item_name:
+      one: item
+      other: items
+    items_selector_js: "<label>Show %{items_input} %{item_name} per page</label>"
+    nav:
+      gap: "&hellip;"
+      next: Next&nbsp;&rsaquo;
+      prev: "&lsaquo;&nbsp;Prev"

--- a/config/locales/pagy.yml
+++ b/config/locales/pagy.yml
@@ -1,0 +1,16 @@
+---
+en:
+  pagy:
+    combo_nav_js: "<label>Page %{page_input} of %{pages}</label>"
+    info:
+      multiple_pages: Displaying %{item_name} <b>%{from}-%{to}</b> of <b>%{count}</b> in total
+      no_items: No %{item_name} found
+      single_page: Displaying <b>%{count}</b> %{item_name}
+    item_name:
+      one: item
+      other: items
+    items_selector_js: "<label>Show %{items_input} %{item_name} per page</label>"
+    nav:
+      gap: "&hellip;"
+      next: Next&nbsp;&rsaquo;
+      prev: "&lsaquo;&nbsp;Prev"


### PR DESCRIPTION
This PR covers i18n for pagy, which is used by transport surveys but also site-wide.

When doing this, I found that the pagy.rb, the pagy config file, was not being picked up by the app and so moved it to config/initializers where pagy expects it to be.

Also, I have added config/locales/pagy.yml, and config/locales/cy/pagy.yml. The Welsh version is actually English at the moment, but since I had to configure the app to use a locale file and did not have the welsh version yet, I thought this would be the best thing to do for now. Also technically, we do not need an English yml file for pagy as the translations are inbuilt but since we need to put one there for transifex, I thought it worth linking to from pagy.