### PR TITLE
Fix trendlines for series name starting with Trendline

### DIFF
--- a/app/assets/javascripts/common_chart_options.js
+++ b/app/assets/javascripts/common_chart_options.js
@@ -251,7 +251,6 @@ function scatter(chartData, highchartsChart, seriesData) {
   highchartsChart.update({chart: { type: 'scatter', zoomType: 'xy'}, subtitle: { text: document.ontouchstart === undefined ? chartData.click_and_drag_message : chartData.pinch_and_zoom_message }});
 
   Object.keys(seriesData).forEach(function (key) {
-    //console.log(seriesData[key].name);
     if (seriesData[key].name.toLowerCase().startsWith("trendline")) {
       highchartsChart.addSeries(
         {

--- a/app/assets/javascripts/common_chart_options.js
+++ b/app/assets/javascripts/common_chart_options.js
@@ -250,17 +250,23 @@ function scatter(chartData, highchartsChart, seriesData) {
   updateChartLabels(chartData, highchartsChart);
   highchartsChart.update({chart: { type: 'scatter', zoomType: 'xy'}, subtitle: { text: document.ontouchstart === undefined ? chartData.click_and_drag_message : chartData.pinch_and_zoom_message }});
 
+console.log(seriesData)
 
   Object.keys(seriesData).forEach(function (key) {
     //console.log(seriesData[key].name);
-    if (seriesData[key].name.startsWith("trendline_")) {
+    if (seriesData[key].name.toLowerCase().startsWith("trendline")) {
       dataValues = seriesData[key].data.map(a=>a[1])
 
-      min = Math.min(...dataValues.filter(function(val) { return val !== null }))
-      max = Math.max(...dataValues.filter(function(val) { return val !== null }))
+      minValue = Math.min(...dataValues.filter(function(val) { return val !== null }))
+      maxValue = Math.max(...dataValues.filter(function(val) { return val !== null }))
 
-      minIndex = dataValues.indexOf(min)
-      maxIndex = dataValues.indexOf(max)
+      if (minValue == maxValue) {
+        minIndex = dataValues.indexOf(minValue)
+        maxIndex = dataValues.lastIndexOf(maxValue)
+      } else {
+        minIndex = dataValues.indexOf(minValue)
+        maxIndex = dataValues.indexOf(maxValue)
+      }
 
       trendlineData = [seriesData[key].data[minIndex], seriesData[key].data[maxIndex]]
 

--- a/app/assets/javascripts/common_chart_options.js
+++ b/app/assets/javascripts/common_chart_options.js
@@ -250,31 +250,15 @@ function scatter(chartData, highchartsChart, seriesData) {
   updateChartLabels(chartData, highchartsChart);
   highchartsChart.update({chart: { type: 'scatter', zoomType: 'xy'}, subtitle: { text: document.ontouchstart === undefined ? chartData.click_and_drag_message : chartData.pinch_and_zoom_message }});
 
-console.log(seriesData)
-
   Object.keys(seriesData).forEach(function (key) {
     //console.log(seriesData[key].name);
     if (seriesData[key].name.toLowerCase().startsWith("trendline")) {
-      dataValues = seriesData[key].data.map(a=>a[1])
-
-      minValue = Math.min(...dataValues.filter(function(val) { return val !== null }))
-      maxValue = Math.max(...dataValues.filter(function(val) { return val !== null }))
-
-      if (minValue == maxValue) {
-        minIndex = dataValues.indexOf(minValue)
-        maxIndex = dataValues.lastIndexOf(maxValue)
-      } else {
-        minIndex = dataValues.indexOf(minValue)
-        maxIndex = dataValues.indexOf(maxValue)
-      }
-
-      trendlineData = [seriesData[key].data[minIndex], seriesData[key].data[maxIndex]]
-
       highchartsChart.addSeries(
         {
           type: 'line',
           name: seriesData[key].name,
-          data: trendlineData
+          data: seriesData[key].data,
+          connectNulls: true
         }
       )
     } else {


### PR DESCRIPTION
This pr fixes the trend line plotting to work for series names starting 'Trendline ...' as well as 'trendline_' it also replaces the first and last point code with `connectNulls: true` to conserve data points (the line was previously breaking due to missing (null) values).