### PR TITLE
Improve display of switch school menu

### DIFF
--- a/app/assets/stylesheets/nav.scss
+++ b/app/assets/stylesheets/nav.scss
@@ -48,6 +48,11 @@
     left: auto;
   }
 
+  .scrollable-dropdown-menu {
+    max-height: 300px;
+    overflow-y: auto;
+  }
+
   .dropdown-item:hover {
     color: $dark;
   }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -102,7 +102,7 @@ class User < ApplicationRecord
   end
 
   def cluster_schools_for_switching
-    cluster_schools.visible.excluding(school)
+    cluster_schools.visible.by_name.excluding(school)
   end
 
   def add_cluster_school(school)

--- a/app/views/shared/_switch_schools.html.erb
+++ b/app/views/shared/_switch_schools.html.erb
@@ -1,6 +1,6 @@
 <li class="nav-item dropdown">
   <a class="nav-link dropdown-toggle" href="#" id="switch_school" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"><%= t('switch_schools_menu.switch_school') %></a>
-  <div class="dropdown-menu" aria-labelledby="switch_school">
+  <div class="dropdown-menu scrollable-dropdown-menu" aria-labelledby="switch_school">
       <% current_user.cluster_schools_for_switching.each do |school| %>
         <%= link_to school.name, school_switcher_path(school_id: school.id), method: :post, class: 'dropdown-item' %>
       <% end %>


### PR DESCRIPTION
When a user is associated with a large number of schools, the list of schools in the "Switch schools" menu gets very long.

This PR:

* Ensures the list is sorted by name (previously it was in an arbitrary order)
* Sets a max height (arbitrary value) for the menu to make it scrollable. ([Example](https://www.codeply.com/p/pHbaRmjRgn)

