### PR TITLE
Clean up DashboardAlert records to remove all unused public & teacher alerts

### DIFF
--- a/lib/tasks/deployment/20220913102909_clean_up_dashboard_alerts.rake
+++ b/lib/tasks/deployment/20220913102909_clean_up_dashboard_alerts.rake
@@ -3,7 +3,7 @@ namespace :after_party do
   task clean_up_dashboard_alerts: :environment do
     puts "Running deploy task 'clean_up_dashboard_alerts'"
 
-    DashboardAlert.where(dashboard: ['teacher', 'pupil']).delete_all
+    DashboardAlert.where(dashboard: ['teacher', 'public']).delete_all
 
     # Update task as completed.  If you remove the line below, the task will
     # run with every deploy (or every time you call after_party:run).

--- a/lib/tasks/deployment/20220913102909_clean_up_dashboard_alerts.rake
+++ b/lib/tasks/deployment/20220913102909_clean_up_dashboard_alerts.rake
@@ -1,0 +1,13 @@
+namespace :after_party do
+  desc 'Deployment task: Clean up DashboardAlert records to remove all unused public & teacher alerts'
+  task clean_up_dashboard_alerts: :environment do
+    puts "Running deploy task 'clean_up_dashboard_alerts'"
+
+    DashboardAlert.where(dashboard: ['teacher', 'pupil']).delete_all
+
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord
+      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+  end
+end

--- a/lib/tasks/deployment/20220913102909_clean_up_dashboard_alerts.rake
+++ b/lib/tasks/deployment/20220913102909_clean_up_dashboard_alerts.rake
@@ -3,7 +3,7 @@ namespace :after_party do
   task clean_up_dashboard_alerts: :environment do
     puts "Running deploy task 'clean_up_dashboard_alerts'"
 
-    DashboardAlert.where(dashboard: ['teacher', 'public']).delete_all
+    DashboardAlert.where(dashboard: ['public', 'teacher']).delete_all
 
     # Update task as completed.  If you remove the line below, the task will
     # run with every deploy (or every time you call after_party:run).


### PR DESCRIPTION
We no longer generate DashboardAlert records for teacher or public dashboard types.

This pr covers writing an AfterParty tasks to delete the older records for these dashboards.