### PR TITLE
Update the Equivalences report to show via units

### DIFF
--- a/app/models/equivalence.rb
+++ b/app/models/equivalence.rb
@@ -37,11 +37,26 @@ class Equivalence < ApplicationRecord
     end
   end
 
+  def via_unit
+    data_via_units.join(' ')
+  end
+
   def hide_preview?
     ! relevant
   end
 
 private
+
+  def data_via_units
+    energy_conversion_units.each_with_object([]) do |unit, via|
+      next unless data.key?(unit.to_s)
+      via << data.dig(unit&.to_s, 'via')
+    end
+  end
+
+  def energy_conversion_units
+    EnergyConversions.additional_frontend_only_variable_descriptions.map { |units| units.last[:via] }
+  end
 
   def variables(locale)
     if locale == :cy

--- a/app/models/equivalence.rb
+++ b/app/models/equivalence.rb
@@ -38,7 +38,7 @@ class Equivalence < ApplicationRecord
   end
 
   def via_unit
-    data_via_units.join(' ')
+    data_via_units.compact.join(' ')
   end
 
   def hide_preview?
@@ -48,14 +48,11 @@ class Equivalence < ApplicationRecord
 private
 
   def data_via_units
-    energy_conversion_units.each_with_object([]) do |unit, via|
-      next unless data.key?(unit.to_s)
-      via << data.dig(unit&.to_s, 'via')
-    end
+    energy_conversion_units.map { |unit| data.dig(unit.to_s, 'via') }
   end
 
   def energy_conversion_units
-    EnergyConversions.additional_frontend_only_variable_descriptions.map { |units| units.last[:via] }
+    EnergyConversions.additional_frontend_only_variable_descriptions.map { |unit| unit.last[:via] }
   end
 
   def variables(locale)

--- a/app/views/schools/equivalence_reports/index.html.erb
+++ b/app/views/schools/equivalence_reports/index.html.erb
@@ -13,6 +13,7 @@
         <th>Meter Type</th>
         <th>Time Period</th>
         <th>Image</th>
+        <th>Via Unit</th>
         <th>From Date</th>
         <th>To Date</th>
         <th>Relevant</th>
@@ -25,6 +26,7 @@
           <td><%= equivalence.equivalence_type.meter_type.humanize %></td>
           <td><%= equivalence.equivalence_type.time_period.humanize %></td>
           <td><%= equivalence.equivalence_type.image_name.humanize %></td>
+          <td><%= equivalence.via_unit %> </td>
           <td><%= nice_dates(equivalence.from_date) %></td>
           <td><%= nice_dates(equivalence.to_date) %></td>
           <td><%= equivalence.relevant %></td>

--- a/app/views/schools/equivalence_reports/show.html.erb
+++ b/app/views/schools/equivalence_reports/show.html.erb
@@ -1,5 +1,4 @@
 <% content_for :page_title do %>Equivalence for <%= @school.name %><% end %>
-
 <div class="row padded-row">
   <div class="col-md-12">
     <h1 property="name">Equivalence for <%= link_to @school.name, @school %></h1>

--- a/app/views/schools/equivalence_reports/show.html.erb
+++ b/app/views/schools/equivalence_reports/show.html.erb
@@ -1,4 +1,5 @@
 <% content_for :page_title do %>Equivalence for <%= @school.name %><% end %>
+
 <div class="row padded-row">
   <div class="col-md-12">
     <h1 property="name">Equivalence for <%= link_to @school.name, @school %></h1>

--- a/spec/models/equivalence_spec.rb
+++ b/spec/models/equivalence_spec.rb
@@ -3,6 +3,27 @@ require 'rails_helper'
 
 describe Equivalence do
 
+  describe '#via_unit' do
+    it 'returns the unit used' do
+      equivalence = Equivalence.new(
+        data: {
+          '£' => { 'via' => '£'},
+          'carnivore_dinner_£_carnivore_dinner' => { 'via' => 'this should not show' }
+        }
+      )
+      expect(equivalence.via_unit).to eq('£')
+      equivalence = Equivalence.new(
+        data: {
+          'kwh' => { 'via' => 'kwh' },
+          'co2' => { 'via' => 'co2' },
+          '£' => { 'via' => '£'},
+          'carnivore_dinner_£_carnivore_dinner' => { 'via' => 'this should not show' }
+        }
+      )
+      expect(equivalence.via_unit).to eq('kwh co2 £')
+    end
+  end
+
   describe 'formatted_variables' do
 
     it 'pulls out the formatted equivalence value' do


### PR DESCRIPTION
This pr adds an extra column to the [tabular summary](https://test.energysparks.uk/schools/king-james-1-community-academy/equivalence_reports) for the ‘via unit’ (as per Philips suggestion)
http://localhost:3000/schools/king-james-1-community-academy/equivalence_reports

"Each of the equivalences e.g. a smartphone can be converted via one or more of £, kWh or CO2 and you get different results depending on the conversion.  In theory you could have 3 lines on the [tabular summary report](https://test.energysparks.uk/schools/king-james-1-community-academy/equivalence_reports/2718924) for a given equivalence, time period and fuel type, one for each of CO2, £ or kWh but at the moment you couldn’t differentiate between each of the £, CO2 and kWh conversions. In practice we are only likely to pick 1, but it would be helpful to know which 1 at the summary level."


![Screenshot 2022-09-13 at 14 38 50](https://user-images.githubusercontent.com/25906/189916654-7d007b94-f3f4-417c-a310-e97a8cd9ca02.png)

