### PR TITLE
Make dashboard info button full width and height

### DIFF
--- a/app/views/schools/dashboard/_info_bar.html.erb
+++ b/app/views/schools/dashboard/_info_bar.html.erb
@@ -9,7 +9,7 @@
     </div>
     <% buttons.each do |title, path| %>
       <div class="col-md-3">
-        <%= link_to (sanitize title), path, class: "btn btn-light btn rounded-pill font-weight-bold" %>
+        <%= link_to (sanitize title), path, class: "btn btn-light btn rounded-pill font-weight-bold w-100 h-100" %>
       </div>
     <% end %>
   <% else %>

--- a/app/views/schools/dashboard/_info_bar.html.erb
+++ b/app/views/schools/dashboard/_info_bar.html.erb
@@ -9,7 +9,7 @@
     </div>
     <% buttons.each do |title, path| %>
       <div class="col-md-3">
-        <%= link_to (sanitize title), path, class: "btn btn-light btn rounded-pill font-weight-bold w-100 h-100" %>
+        <%= link_to (sanitize title), path, class: "btn btn-light btn rounded-pill font-weight-bold", style: 'height: fit-content;'%>
       </div>
     <% end %>
   <% else %>


### PR DESCRIPTION
"Record a pupil activity" text, as shown in dashboard prompt, is too long when shown in Welsh. This pr makes the button size full width and height so no text breaks out of the pill button. 

from
![Screenshot 2022-09-14 at 14 18 59](https://user-images.githubusercontent.com/25906/190164958-e0144a38-3731-4552-8b0e-ad76433233f2.png)


to


![Screenshot 2022-09-14 at 14 15 02](https://user-images.githubusercontent.com/25906/190164249-8c39f3ee-167c-4905-b4a4-f72e678ff60a.png)


![Screenshot 2022-09-14 at 14 15 19](https://user-images.githubusercontent.com/25906/190164273-a338d8aa-c966-4021-acbf-59e5d6f7e99b.png)


![Screenshot 2022-09-14 at 14 15 28](https://user-images.githubusercontent.com/25906/190164280-dbb0596b-4a6f-4f74-97a4-89cc485e36d7.png)

