### PR TITLE
Ensure statistics for amr_data_feed_readings table are always up to date

### DIFF
--- a/app/jobs/manual_data_load_run_job.rb
+++ b/app/jobs/manual_data_load_run_job.rb
@@ -20,9 +20,9 @@ class ManualDataLoadRunJob < ApplicationJob
       amr_uploaded_reading.update!(imported: true)
       manual_data_load_run.info("Inserted: #{amr_data_feed_import_log.records_imported}")
       manual_data_load_run.info("Updated: #{amr_data_feed_import_log.records_updated}")
+      Database::VacuumService.new([:amr_data_feed_readings]).perform
       manual_data_load_run.info("SUCCESS")
       status = :done
-      Database::VacuumService.new([:amr_data_feed_readings]).perform
     rescue => e
       Rollbar.error(e, job: :manual_data_load_run, id: manual_data_load_run.id, filename: amr_uploaded_reading.file_name)
       manual_data_load_run.error("Error: #{e.message}")

--- a/app/jobs/manual_data_load_run_job.rb
+++ b/app/jobs/manual_data_load_run_job.rb
@@ -22,6 +22,7 @@ class ManualDataLoadRunJob < ApplicationJob
       manual_data_load_run.info("Updated: #{amr_data_feed_import_log.records_updated}")
       manual_data_load_run.info("SUCCESS")
       status = :done
+      Database::VacuumService.new([:amr_data_feed_readings]).perform
     rescue => e
       Rollbar.error(e, job: :manual_data_load_run, id: manual_data_load_run.id, filename: amr_uploaded_reading.file_name)
       manual_data_load_run.error("Error: #{e.message}")

--- a/app/services/database/vacuum_service.rb
+++ b/app/services/database/vacuum_service.rb
@@ -6,7 +6,13 @@ module Database
 
     def perform
       @tables.each do |table|
-        ActiveRecord::Base.connection.execute("VACUUM ANALYSE #{table}")
+        begin
+          ActiveRecord::Base.connection.execute("VACUUM ANALYSE #{table}")
+        rescue => exception
+          message = "VACUUM ANALYSE #{table} error: #{exception.message}"
+          Rails.logger.error(message)
+          Rollbar.error(message)
+        end
       end
     end
   end

--- a/app/services/database/vacuum_service.rb
+++ b/app/services/database/vacuum_service.rb
@@ -4,6 +4,8 @@ module Database
       @tables = tables
     end
 
+    ## NB: VACUUM does not work when run inside a transaction block
+    ## For rspec, use ts: false as an argument to the block to prevent tests being wrapped in a transaction block
     def perform
       @tables.each do |table|
         begin

--- a/app/services/database/vacuum_service.rb
+++ b/app/services/database/vacuum_service.rb
@@ -8,7 +8,7 @@ module Database
       @tables.each do |table|
         begin
           ActiveRecord::Base.connection.execute("VACUUM ANALYSE #{table}")
-        rescue => exception
+        rescue StandardError => exception
           message = "VACUUM ANALYSE #{table} error: #{exception.message}"
           Rails.logger.error(message)
           Rollbar.error(message)

--- a/lib/tasks/amr_importer/import_all.rake
+++ b/lib/tasks/amr_importer/import_all.rake
@@ -6,7 +6,7 @@ namespace :amr do
       begin
         FileUtils.mkdir_p config.local_bucket_path
         Amr::Importer.new(config).import_all
-        Database::VacuumService.new([:amr_data_feed_readings])
+        Database::VacuumService.new([:amr_data_feed_readings]).perform
       rescue => e
         puts "Exception: running import_all for #{config.description}: #{e.class} #{e.message}"
         puts e.backtrace.join("\n")

--- a/lib/tasks/amr_importer/import_all.rake
+++ b/lib/tasks/amr_importer/import_all.rake
@@ -6,7 +6,6 @@ namespace :amr do
       begin
         FileUtils.mkdir_p config.local_bucket_path
         Amr::Importer.new(config).import_all
-        Database::VacuumService.new([:amr_data_feed_readings]).perform
       rescue => e
         puts "Exception: running import_all for #{config.description}: #{e.class} #{e.message}"
         puts e.backtrace.join("\n")
@@ -16,5 +15,6 @@ namespace :amr do
       end
     end
     puts "#{DateTime.now.utc} amr import all end"
+    Database::VacuumService.new([:amr_data_feed_readings]).perform
   end
 end

--- a/lib/tasks/amr_importer/import_all.rake
+++ b/lib/tasks/amr_importer/import_all.rake
@@ -15,6 +15,7 @@ namespace :amr do
       end
     end
     puts "#{DateTime.now.utc} amr import all end"
+
     Database::VacuumService.new([:amr_data_feed_readings]).perform
   end
 end

--- a/lib/tasks/amr_importer/import_all.rake
+++ b/lib/tasks/amr_importer/import_all.rake
@@ -14,8 +14,7 @@ namespace :amr do
         Rollbar.error(e, job: :import_all, config: config.identifier)
       end
     end
-    puts "#{DateTime.now.utc} amr import all end"
-
     Database::VacuumService.new([:amr_data_feed_readings]).perform
+    puts "#{DateTime.now.utc} amr import all end"
   end
 end

--- a/lib/tasks/amr_importer/import_n3rgy_readings.rake
+++ b/lib/tasks/amr_importer/import_n3rgy_readings.rake
@@ -13,6 +13,6 @@ namespace :amr do
       Amr::N3rgyReadingsDownloadAndUpsert.new(meter: meter, config: config, start_date: start_date, end_date: end_date).perform
     end
     puts "#{DateTime.now.utc} #{config.description} end"
-    # Database::VacuumService.new([:amr_data_feed_readings]).perform
+    Database::VacuumService.new([:amr_data_feed_readings]).perform
   end
 end

--- a/lib/tasks/amr_importer/import_n3rgy_readings.rake
+++ b/lib/tasks/amr_importer/import_n3rgy_readings.rake
@@ -12,8 +12,7 @@ namespace :amr do
     Meter.where(dcc_meter: true, consent_granted: true).each do |meter|
       Amr::N3rgyReadingsDownloadAndUpsert.new(meter: meter, config: config, start_date: start_date, end_date: end_date).perform
     end
-    puts "#{DateTime.now.utc} #{config.description} end"
-
     Database::VacuumService.new([:amr_data_feed_readings]).perform
+    puts "#{DateTime.now.utc} #{config.description} end"
   end
 end

--- a/lib/tasks/amr_importer/import_n3rgy_readings.rake
+++ b/lib/tasks/amr_importer/import_n3rgy_readings.rake
@@ -13,5 +13,6 @@ namespace :amr do
       Amr::N3rgyReadingsDownloadAndUpsert.new(meter: meter, config: config, start_date: start_date, end_date: end_date).perform
     end
     puts "#{DateTime.now.utc} #{config.description} end"
+    # Database::VacuumService.new([:amr_data_feed_readings]).perform
   end
 end

--- a/lib/tasks/amr_importer/import_n3rgy_readings.rake
+++ b/lib/tasks/amr_importer/import_n3rgy_readings.rake
@@ -13,6 +13,7 @@ namespace :amr do
       Amr::N3rgyReadingsDownloadAndUpsert.new(meter: meter, config: config, start_date: start_date, end_date: end_date).perform
     end
     puts "#{DateTime.now.utc} #{config.description} end"
+
     Database::VacuumService.new([:amr_data_feed_readings]).perform
   end
 end

--- a/lib/tasks/solar/import_low_carbon_hub_readings.rake
+++ b/lib/tasks/solar/import_low_carbon_hub_readings.rake
@@ -10,8 +10,7 @@ namespace :solar do
       puts "Running for #{installation.rbee_meter_id}"
       Solar::LowCarbonHubDownloadAndUpsert.new(installation: installation, start_date: start_date, end_date: end_date).perform
     end
-    puts "#{DateTime.now.utc} import_low_carbon_hub_readings end"
-
     Database::VacuumService.new([:amr_data_feed_readings]).perform
+    puts "#{DateTime.now.utc} import_low_carbon_hub_readings end"
   end
 end

--- a/lib/tasks/solar/import_low_carbon_hub_readings.rake
+++ b/lib/tasks/solar/import_low_carbon_hub_readings.rake
@@ -11,5 +11,7 @@ namespace :solar do
       Solar::LowCarbonHubDownloadAndUpsert.new(installation: installation, start_date: start_date, end_date: end_date).perform
     end
     puts "#{DateTime.now.utc} import_low_carbon_hub_readings end"
+
+    Database::VacuumService.new([:amr_data_feed_readings]).perform
   end
 end

--- a/lib/tasks/solar/import_rtone_variant_readings.rake
+++ b/lib/tasks/solar/import_rtone_variant_readings.rake
@@ -11,5 +11,7 @@ namespace :solar do
       Solar::RtoneVariantDownloadAndUpsert.new(installation: installation, start_date: start_date, end_date: end_date).perform
     end
     puts "#{DateTime.now.utc} import_rtone_variant_readings end"
+
+    Database::VacuumService.new([:amr_data_feed_readings]).perform
   end
 end

--- a/lib/tasks/solar/import_rtone_variant_readings.rake
+++ b/lib/tasks/solar/import_rtone_variant_readings.rake
@@ -10,8 +10,7 @@ namespace :solar do
       puts "Running for #{installation.rtone_meter_id}"
       Solar::RtoneVariantDownloadAndUpsert.new(installation: installation, start_date: start_date, end_date: end_date).perform
     end
-    puts "#{DateTime.now.utc} import_rtone_variant_readings end"
-
     Database::VacuumService.new([:amr_data_feed_readings]).perform
+    puts "#{DateTime.now.utc} import_rtone_variant_readings end"
   end
 end

--- a/lib/tasks/solar/import_solar_edge_readings.rake
+++ b/lib/tasks/solar/import_solar_edge_readings.rake
@@ -11,5 +11,7 @@ namespace :solar do
       Solar::SolarEdgeDownloadAndUpsert.new(installation: installation, start_date: start_date, end_date: end_date).perform
     end
     puts "#{DateTime.now.utc} import_solar_edge_readings end"
+
+    Database::VacuumService.new([:amr_data_feed_readings]).perform
   end
 end

--- a/lib/tasks/solar/import_solar_edge_readings.rake
+++ b/lib/tasks/solar/import_solar_edge_readings.rake
@@ -10,8 +10,7 @@ namespace :solar do
       puts "Running for #{installation.site_id}"
       Solar::SolarEdgeDownloadAndUpsert.new(installation: installation, start_date: start_date, end_date: end_date).perform
     end
-    puts "#{DateTime.now.utc} import_solar_edge_readings end"
-
     Database::VacuumService.new([:amr_data_feed_readings]).perform
+    puts "#{DateTime.now.utc} import_solar_edge_readings end"
   end
 end

--- a/spec/jobs/manual_data_load_run_job_spec.rb
+++ b/spec/jobs/manual_data_load_run_job_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe ManualDataLoadRunJob do
+describe ManualDataLoadRunJob, ts: false do
 
   let!(:run)                { create(:manual_data_load_run) }
 
@@ -15,6 +15,7 @@ describe ManualDataLoadRunJob do
 
   context 'with a valid file' do
     before(:each) do
+      expect_any_instance_of(Database::VacuumService).to receive(:perform)
       expect(run.status).to eq "pending"
       job.load(run.amr_uploaded_reading.amr_data_feed_config, run.amr_uploaded_reading, run)
     end
@@ -39,6 +40,7 @@ describe ManualDataLoadRunJob do
       allow_any_instance_of(AmrDataFeedImportLog).to receive(:records_imported).and_return(0)
       allow_any_instance_of(AmrDataFeedImportLog).to receive(:records_updated).and_return(0)
       expect(run.status).to eq "pending"
+      expect_any_instance_of(Database::VacuumService).to_not receive(:perform)
       job.load(run.amr_uploaded_reading.amr_data_feed_config, run.amr_uploaded_reading, run)
     end
 

--- a/spec/services/database/vacuum_service_spec.rb
+++ b/spec/services/database/vacuum_service_spec.rb
@@ -1,0 +1,48 @@
+require 'rails_helper'
+
+describe Database::VacuumService do
+
+  let(:tables) { [:amr_data_feed_readings, :amr_reading_warnings] }
+  subject(:vacuum_service) { Database::VacuumService.new(tables) }
+
+  describe "#perform" do
+    context "under normal running conditions" do
+      it "calls vacuum analyse on each table" do
+        tables.each do |table|
+          expect(ActiveRecord::Base.connection).to receive(:execute).with("VACUUM ANALYSE #{table}")
+        end
+        subject.perform
+      end
+
+      it "doesn't raise" do
+        expect { subject.perform }.not_to raise_error
+      end
+    end
+
+    context "an error occurs" do
+      before do
+        tables.each do |table|
+          expect(ActiveRecord::Base.connection).to receive(:execute).with("VACUUM ANALYSE #{table}").and_raise("ERROR")
+        end
+      end
+
+      it "logs error" do
+        tables.each do |table|
+          expect(Rails.logger).to receive(:error).with("VACUUM ANALYSE #{table} error: ERROR")
+        end
+        subject.perform
+      end
+
+      it "calls rollbar" do
+        tables.each do |table|
+          expect(Rollbar).to receive(:error).with("VACUUM ANALYSE #{table} error: ERROR")
+        end
+        subject.perform
+      end
+
+      it "doesn't raise" do
+        expect { subject.perform }.not_to raise_error
+      end
+    end
+  end
+end

--- a/spec/support/database_cleaner.rb
+++ b/spec/support/database_cleaner.rb
@@ -8,6 +8,10 @@ RSpec.configure do |config|
     DatabaseCleaner.strategy = :transaction
   end
 
+  config.before(:each, ts: false) do
+    DatabaseCleaner.strategy = :truncation
+  end
+
   config.before(:each, js: true) do
     DatabaseCleaner.strategy = :truncation
   end


### PR DESCRIPTION
Enables vacuum service for the following:
- [x] import_all.rake (updates existing code)
- [x] after doing the N3rgy readings inserts, see `import_n3rgy_readings.rake`
- [x] after importing solar data, see the tasks in `lib/tasks/solar`
- [x] at the end of the `ManualDataLoadRunJob`

See note against import_all.rake about moving the Vacuum Service call out of the loop. I've not particularly been able to manually test the rake tasks, so suggest this needs doing on the test server (as you'd expect really I guess!)?

Worth noting for future implementation that a VACUUM can't be run inside a transaction block - this tripped me up for a while trying to work out why my rspec wasn't working.