### PR TITLE
Allow editing of pseudo meters

### DIFF
--- a/app/helpers/schools_helper.rb
+++ b/app/helpers/schools_helper.rb
@@ -14,4 +14,8 @@ module SchoolsHelper
     meter = Meter.find_by_mpan_mprn(mpan_mprn)
     meter.present? ? meter.display_name : meter
   end
+
+  def disabled_for_pseudo_meter?(meter)
+    meter.pseudo && action_name == 'edit'
+  end
 end

--- a/app/models/meter.rb
+++ b/app/models/meter.rb
@@ -85,6 +85,8 @@ class Meter < ApplicationRecord
   validates_format_of :mpan_mprn, with: /\A[6,7,9]\d{13}\Z/, if: :pseudo?, message: 'for pseudo electricity meters should be a 14 digit number starting with 6, 7 or 9'
   validates_format_of :mpan_mprn, with: /\A[1-9]{1,3}\d{12}\Z/, if: :real_electric?, message: 'for electricity meters should be a 13 to 14 digit number'
   validates_format_of :mpan_mprn, with: /\A\d{1,15}\Z/, if: :gas?, message: 'for gas meters should be a 1-15 digit number'
+  validate :pseudo_meter_type_not_changed, on: :update, if: :pseudo
+  validate :pseudo_mpan_mprn_not_changed, on: :update, if: :pseudo
 
   def self.hash_of_meter_data
     meter_data_array = Meter.pluck(:mpan_mprn, :meter_type, :school_id)
@@ -183,6 +185,18 @@ class Meter < ApplicationRecord
   end
 
   private
+
+  def pseudo_mpan_mprn_not_changed
+    return unless pseudo && mpan_mprn_changed?
+
+    errors.add(:mpan_mprn, "Change of mpan mprn is not allowed for pseudo meters")
+  end
+
+  def pseudo_meter_type_not_changed
+    return unless pseudo && meter_type_changed?
+
+    errors.add(:meter_type, "Change of meter type is not allowed for pseudo meters")
+  end
 
   def real_electric?
     !gas? && !pseudo?

--- a/app/views/schools/meters/_active_meters.html.erb
+++ b/app/views/schools/meters/_active_meters.html.erb
@@ -31,12 +31,10 @@
       </div>
     </td>
     <td>
-      <% if ! meter.pseudo %>
-        <div class="btn-group btn-group-sm" role="group">
-          <%= link_to 'Edit', edit_school_meter_path(@school, meter), class: 'btn btn-sm' if can?(:edit, meter) %>
-          <%= link_to 'Deactivate', deactivate_school_meter_path(@school, meter), method: :put, class: 'btn btn-sm' if can?(:deactivate, meter) %>
-        </div>
-      <% end %>
+      <div class="btn-group btn-group-sm" role="group">
+        <%= link_to 'Edit', edit_school_meter_path(@school, meter), class: 'btn btn-sm' if can?(:edit, meter) %>
+        <%= link_to 'Deactivate', deactivate_school_meter_path(@school, meter), method: :put, class: 'btn btn-sm' if can?(:deactivate, meter) %>
+      </div>
     </td>
   </tr>
 <% end %>

--- a/app/views/schools/meters/_form.html.erb
+++ b/app/views/schools/meters/_form.html.erb
@@ -4,7 +4,12 @@
 
   <div class="form-group">
     <%= form.label :mpan_mprn, 'Meter Point Number' %>
-    <%= form.text_field :mpan_mprn, class: 'form-control' %>
+    <% if disabled_for_pseudo_meter?(meter) %>
+      <span class='badge badge-warning'>
+        Editing disabled for pseudo meters
+      </span>
+    <% end %>
+    <%= form.text_field :mpan_mprn, class: 'form-control', disabled: disabled_for_pseudo_meter?(meter) %>
   </div>
   <div class="form-group">
     <%= form.label :name, 'Name' %>
@@ -16,9 +21,14 @@
   </div>
   <div class="form-group">
     <%= form.label :meter_type, 'Type' %>
+    <% if disabled_for_pseudo_meter?(meter) %>
+      <span class='badge badge-warning'>
+        Editing disabled for pseudo meters
+      </span>
+    <% end %>
     <% Meter::CREATABLE_METER_TYPES.each do |meter_type| %>
       <div class="form-check">
-        <%= form.radio_button :meter_type, meter_type, class: "form-check-input" %>
+        <%= form.radio_button :meter_type, meter_type, class: "form-check-input", disabled: disabled_for_pseudo_meter?(meter) %>
         <%= form.label "meter_type_#{meter_type.to_sym}", meter_type.to_s.humanize,  class: "form-check-label col-form-label-sm" %>
       </div>
     <% end %>

--- a/app/views/schools/meters/_form.html.erb
+++ b/app/views/schools/meters/_form.html.erb
@@ -4,7 +4,7 @@
 
   <div class="form-group">
     <%= form.label :mpan_mprn, 'Meter Point Number' %>
-    <% if disabled_for_pseudo_meter?(meter) %>
+    <% if disabled_for_pseudo_meter?(meter) && current_user.admin? %>
       <span class='badge badge-warning'>
         Editing disabled for pseudo meters
       </span>
@@ -21,7 +21,7 @@
   </div>
   <div class="form-group">
     <%= form.label :meter_type, 'Type' %>
-    <% if disabled_for_pseudo_meter?(meter) %>
+    <% if disabled_for_pseudo_meter?(meter) && current_user.admin? %>
       <span class='badge badge-warning'>
         Editing disabled for pseudo meters
       </span>

--- a/spec/models/meter_spec.rb
+++ b/spec/models/meter_spec.rb
@@ -70,7 +70,8 @@ describe 'Meter', :meters do
 
       context 'with a pseudo solar electricity meter' do
 
-        let(:attributes) {attributes_for(:electricity_meter).merge(pseudo: true)}
+        let(:attributes) { attributes_for(:electricity_meter).merge(pseudo: true) }
+        let!(:school)    { create(:school) }
 
         it 'is valid with a 14 digit number' do
           meter = Meter.new(attributes.merge(mpan_mprn: 91098598765437))
@@ -94,6 +95,34 @@ describe 'Meter', :meters do
           meter = Meter.new(attributes.merge(mpan_mprn: 11098598765437))
           meter.valid?
           expect(meter.errors[:mpan_mprn]).to_not be_empty
+        end
+
+        it 'validates meter type is not changed when there is an update' do
+          meter = Meter.new(attributes.merge(pseudo: true, mpan_mprn: 91098598765437, meter_type: 'electricity', school: school))
+          meter.valid?
+          expect(meter.errors[:meter_type]).to be_empty
+          meter.save!
+          meter.meter_type = 'solar_pv'
+          meter.valid?
+          expect(meter.errors[:meter_type]).to eq(["Change of meter type is not allowed for pseudo meters"])
+          meter.pseudo = 'false'
+          meter.meter_type = 'solar_pv'
+          meter.valid?
+          expect(meter.errors[:meter_type]).to eq([])
+        end
+
+        it 'validates mpan mprn is not changed when there is an update' do
+          meter = Meter.new(attributes.merge(pseudo: true, mpan_mprn: 91098598765437, meter_type: 'electricity', school: school))
+          meter.valid?
+          expect(meter.errors[:mpan_mprn]).to be_empty
+          meter.save!
+          meter.mpan_mprn = 91000000000037
+          meter.valid?
+          expect(meter.errors[:mpan_mprn]).to eq(["Change of mpan mprn is not allowed for pseudo meters"])
+          meter.pseudo = 'false'
+          meter.mpan_mprn = 91000000000037
+          meter.valid?
+          expect(meter.errors[:mpan_mprn]).to eq([])
         end
       end
 


### PR DESCRIPTION
The Meter Management page does not provide a link to edit pseudo meters. But there is a link to edit them via the detail page.

The editing was originally disabled due to a limitation in the data loader, which has now been removed.

This pr:
- [x] allows the edit button to appear on the Meter Management (meters/index) page like other meters
- [x] adds a warning, for admins on the form for pseudo meters to warn about changing the type or mpan
- [x] adds validations to stop changing the type or mpan if its a pseudo meter (only)