### PR TITLE
Fix typo in template

### DIFF
--- a/app/views/activities/show.html.erb
+++ b/app/views/activities/show.html.erb
@@ -47,7 +47,7 @@
 <div class="row">
   <div class="col-md-12 activity">
     <p></p>
-    <%= link_to t('activities.show.all_activities') %>, school_activities_path(@school), class: 'btn btn-success' %>
+    <%= link_to t('activities.show.all_activities'), school_activities_path(@school), class: 'btn btn-success' %>
     <% if can? :manage, @activity %>
       <%= link_to t('activities.actions.home'), school_path(@school), class: 'btn btn-primary' %>
       <%= link_to t('activities.actions.edit'), edit_school_activity_path(@school, @activity), class: 'btn btn-warning' %>


### PR DESCRIPTION
Extra `%>` in template, possibly added as part of i18n work meant that link was broken and code showing on page.