### PR TITLE
Do not include school groups with no schools on benchmark page

### DIFF
--- a/app/models/school_group.rb
+++ b/app/models/school_group.rb
@@ -86,4 +86,8 @@ class SchoolGroup < ApplicationRecord
   def page_anchor
     name.parameterize
   end
+
+  def self.with_active_schools
+    joins(:schools).where('schools.active = true').distinct
+  end
 end

--- a/app/services/comparison_service.rb
+++ b/app/services/comparison_service.rb
@@ -16,9 +16,9 @@ class ComparisonService
 
   def list_school_groups
     if @user.present? && @user.admin?
-      return SchoolGroup.order(:name).to_a
+      return SchoolGroup.with_active_schools.order(:name).to_a
     end
-    groups = SchoolGroup.is_public.order(:name).to_a
+    groups = SchoolGroup.with_active_schools.is_public.order(:name).to_a
     if @user.present? && @user.school.present? && @user.school.school_group.present?
         groups << @user.school.school_group
     end

--- a/spec/models/school_group_spec.rb
+++ b/spec/models/school_group_spec.rb
@@ -26,6 +26,24 @@ describe SchoolGroup, :school_groups, type: :model do
 
   end
 
+  describe '#with_active_schools' do
+    before { SchoolGroup.delete_all }
+    it 'returns all school groups that have one or more associated active schools' do
+      sg1 = create(:school_group, public: public)
+      sg2 = create(:school_group, public: public)
+      sg3 = create(:school_group, public: public)
+      create(:school, school_group: sg1, active: true)
+      create(:school, school_group: sg1, active: true)
+      create(:school, school_group: sg1, active: true)
+      school2 = create(:school, school_group: sg2, active: false)
+      school3 = create(:school, school_group: sg2, active: false)
+      expect(SchoolGroup.all.count).to eq(3)
+      expect(SchoolGroup.with_active_schools.count).to eq(1)
+      school2.update(active: true)
+      expect(SchoolGroup.with_active_schools.count).to eq(2)
+    end
+  end
+
   context 'with partners' do
     let(:partner)       { create(:partner) }
     let(:other_partner) { create(:partner) }


### PR DESCRIPTION
The list of school groups on the Benchmark page, e.g. [here](https://energysparks.uk/benchmark?benchmark%5Bschool_types%5D%5B%5D=0&benchmark%5Bschool_types%5D%5B%5D=1&benchmark%5Bschool_types%5D%5B%5D=2&benchmark%5Bschool_types%5D%5B%5D=3&benchmark%5Bschool_types%5D%5B%5D=4&benchmark%5Bschool_types%5D%5B%5D=5&benchmark%5Bschool_types%5D%5B%5D=6&benchmark_type=annual_energy_costs_per_pupil) is produced by the `ComparisonService`

It's possible for a school group that doesn't yet have any visible schools to appear on this list. This is occasionally causing an analytics error.  This PR removes this from happening to ensure that any Rollbar issues are actually with the benchmarking code.

- [x] for an admin user, only include school groups that have schools
- [x] for other users, only include school groups that are public and which have at least one visible school (the users own group should always been in the list).