### PR TITLE
Remove auth check on holding page

### DIFF
--- a/app/controllers/schools/aggregated_meter_collections_controller.rb
+++ b/app/controllers/schools/aggregated_meter_collections_controller.rb
@@ -4,7 +4,6 @@ module Schools
     skip_before_action :authenticate_user!
 
     def post
-      authorize! :show, @school
       # JSON request to load cache
       service = AggregateSchoolService.new(@school)
       service.aggregate_school unless service.in_cache?
@@ -15,7 +14,7 @@ module Schools
     rescue => e
       Rollbar.error(e)
       respond_to do |format|
-        format.json { render json: { status: 'error', message: e.message }, status: :unauthorized}
+        format.json { render json: { status: 'error', message: e.message }, status: :bad_request}
       end
     end
   end

--- a/spec/controllers/schools/aggregated_meter_collections_controller_spec.rb
+++ b/spec/controllers/schools/aggregated_meter_collections_controller_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe Schools::AggregatedMeterCollectionsController, type: :controller 
         let(:public)  { true }
         it "can request a load" do
           post :post, format: :json, params: { school_id: school.id }
-          expect(response).to have_http_status(401)
+          expect(response).to have_http_status(200)
         end
       end
       context "that is private" do
@@ -81,7 +81,7 @@ RSpec.describe Schools::AggregatedMeterCollectionsController, type: :controller 
 
         it "can request a load" do
           post :post, format: :json, params: { school_id: school.id }
-          expect(response).to have_http_status(401)
+          expect(response).to have_http_status(200)
         end
       end
     end


### PR DESCRIPTION
If a school isn't in the aggregated school cache we serve a holding page. This gives time for the school to be added to the cache and then the user is redirected to the appropriate dashboard. This ensures that the charts will work correctly. The holding page polls to check to see if the school is cached by doing a XHR POST request.

If a school is not public, then there's a bug here as the controller checks to see if the user is authorised to `:show` the school, but authentication isn't actually required. So the user gets an error, rather than a redirect to a login form.

This removes the auth check and updates the status code for any error response. This is safe to do as any subsequent redirect will do the appropriate access control checks.

This error is unlikely to happen in practice, as a user needs to be logged in to see non-public schools, but the problem has cropped up during testing.

