### PR TITLE
Missing chart_type param

### DIFF
--- a/app/controllers/schools/charts_controller.rb
+++ b/app/controllers/schools/charts_controller.rb
@@ -34,6 +34,8 @@ class Schools::ChartsController < ApplicationController
         end
       end
     end
+  rescue => error
+    render json: { error: error, status: 400 }.to_json
   end
 
 private

--- a/app/controllers/schools/charts_controller.rb
+++ b/app/controllers/schools/charts_controller.rb
@@ -10,7 +10,12 @@ class Schools::ChartsController < ApplicationController
   before_action :check_aggregated_school_in_cache
 
   def show
-    @chart_type = params.require(:chart_type).to_sym
+    @chart_type ||= begin
+                      params.require(:chart_type).to_sym
+                    rescue => error
+                      render json: { error: error, status: 400 }.to_json and return
+                    end
+
     respond_to do |format|
       format.html do
         set_measurement_options
@@ -34,8 +39,6 @@ class Schools::ChartsController < ApplicationController
         end
       end
     end
-  rescue => error
-    render json: { error: error, status: 400 }.to_json
   end
 
 private

--- a/app/views/robots_txts/allow.raw
+++ b/app/views/robots_txts/allow.raw
@@ -14,6 +14,7 @@ Disallow: /rails/*
 Disallow: /schools/scoreboard
 Disallow: /schools/*/analysis
 Disallow: /schools/*/find_out_more/*
+Disallow: /schools/*/chart.json
 Disallow: /pupils/schools/*/analysis
 Disallow: /benchmark
 Disallow: /all_benchmarks

--- a/spec/controllers/schools/charts_controller_spec.rb
+++ b/spec/controllers/schools/charts_controller_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe Schools::ChartsController, type: :controller do
+  context 'GET #show' do
+    describe "format json" do
+      it 'returns a json error message if a chart type param is missing' do
+        school = FactoryBot.create :school, visible: false
+        get :show, params: { school_id: school.to_param }, format: :json
+        expect(JSON.parse(response.body)).to eq({'error' => 'param is missing or the value is empty: chart_type','status' => 400})
+      end
+    end
+
+    describe "format html" do
+      it 'fails if a chart type param is missing' do
+        school = FactoryBot.create :school, visible: false
+        expect { get :show, params: { school_id: school.to_param }, format: :html }.to raise_error(ActionController::ParameterMissing)
+      end
+    end
+  end
+end

--- a/spec/controllers/schools/charts_controller_spec.rb
+++ b/spec/controllers/schools/charts_controller_spec.rb
@@ -2,18 +2,24 @@ require 'rails_helper'
 
 RSpec.describe Schools::ChartsController, type: :controller do
   context 'GET #show' do
+    before { @school = FactoryBot.create :school, visible: false }
+
     describe "format json" do
-      it 'returns a json error message if a chart type param is missing' do
-        school = FactoryBot.create :school, visible: false
-        get :show, params: { school_id: school.to_param }, format: :json
-        expect(JSON.parse(response.body)).to eq({'error' => 'param is missing or the value is empty: chart_type','status' => 400})
+      it 'returns a json error message with 400 bad request if a chart type param is missing' do
+        get :show, params: { school_id: @school.to_param }, format: :json
+        expect(JSON.parse(response.body)).to eq({ 'error' => 'param is missing or the value is empty: chart_type', 'status' => 400 })
+      end
+
+      it 'returns a json response if a chart type param is present' do
+        get :show, params: { school_id: @school.to_param, chart_type: 'pupil_dashboard_group_by_week_electricity_kwh' }, format: :json
+        expect(response).to have_http_status(:success)
+        expect(JSON.parse(response.body)['title']).to eq('We do not have enough data to display this chart at the moment: Pupil_dashboard_group_by_week_electricity_kwh chart')
       end
     end
 
     describe "format html" do
       it 'fails if a chart type param is missing' do
-        school = FactoryBot.create :school, visible: false
-        expect { get :show, params: { school_id: school.to_param }, format: :html }.to raise_error(ActionController::ParameterMissing)
+        expect { get :show, params: { school_id: @school.to_param }, format: :html }.to raise_error(ActionController::ParameterMissing)
       end
     end
   end


### PR DESCRIPTION
We are getting a flurry of Rollbar errors due to a missing chart_type parameter:

https://rollbar.com/energysparks/EnergySparksProduction/items/1238/?item_page=0&#instances

Its not clear why this is happening, but looking at the error, these all(?) seem to have a From header of "googlebot(at)googlebot.com".

So this might be a search engine error, e.g. following a URL in the response but without adding a parameter (which might have been injected via JS?)

Need to:

- [x] check whether we can end up having any direct links to chart.json without a chart_type
- [x] ensure we return a 400 Bad Request error for the missing param, not a 500. This might discourage repeated requests
- [x] perhaps add a search engine exclusion for that url to robots.txt



Returns 
`{"error":"param is missing or the value is empty: chart_type","status":400}`