### PR TITLE
Allow admin to delete uploaded readings

### DIFF
--- a/app/controllers/admin/manual_data_load_runs_controller.rb
+++ b/app/controllers/admin/manual_data_load_runs_controller.rb
@@ -16,7 +16,7 @@ module Admin
 
     def destroy
       @manual_data_load_run = ManualDataLoadRun.find(params[:id])
-      @manual_data_load_run.destroy
+      @manual_data_load_run.destroy!
       respond_to do |format|
         format.html { redirect_to admin_reports_data_loads_path, notice: 'Manual data load was successfully deleted.' }
         format.json { head :no_content }

--- a/app/controllers/admin/manual_data_load_runs_controller.rb
+++ b/app/controllers/admin/manual_data_load_runs_controller.rb
@@ -13,5 +13,14 @@ module Admin
       ManualDataLoadRunJob.perform_later run
       redirect_to admin_amr_data_feed_config_amr_uploaded_reading_manual_data_load_run_path(@amr_uploaded_reading.amr_data_feed_config, @amr_uploaded_reading, run)
     end
+
+    def destroy
+      @manual_data_load_run = ManualDataLoadRun.find(params[:id])
+      @manual_data_load_run.destroy
+      respond_to do |format|
+        format.html { redirect_to admin_reports_data_loads_path, notice: 'Manual data load was successfully deleted.' }
+        format.json { head :no_content }
+      end
+    end
   end
 end

--- a/app/models/manual_data_load_run.rb
+++ b/app/models/manual_data_load_run.rb
@@ -17,7 +17,7 @@
 #  fk_rails_...  (amr_uploaded_reading_id => amr_uploaded_readings.id)
 #
 class ManualDataLoadRun < ApplicationRecord
-  belongs_to :amr_uploaded_reading
+  belongs_to :amr_uploaded_reading, dependent: :destroy
   enum status: [:pending, :running, :done, :failed]
   has_many :manual_data_load_run_log_entries, dependent: :destroy
 

--- a/app/models/manual_data_load_run.rb
+++ b/app/models/manual_data_load_run.rb
@@ -19,7 +19,7 @@
 class ManualDataLoadRun < ApplicationRecord
   belongs_to :amr_uploaded_reading
   enum status: [:pending, :running, :done, :failed]
-  has_many :manual_data_load_run_log_entries
+  has_many :manual_data_load_run_log_entries, dependent: :destroy
 
   scope :by_date, -> { order(created_at: :desc) }
 

--- a/app/views/admin/reports/data_loads/index.html.erb
+++ b/app/views/admin/reports/data_loads/index.html.erb
@@ -22,7 +22,7 @@ Listing the 50 most recent manual data loads and their status.
         <td><%= manual_data_load_run.status %></td>
         <td>
           <%= link_to "View", admin_amr_data_feed_config_amr_uploaded_reading_manual_data_load_run_path(manual_data_load_run.amr_uploaded_reading.amr_data_feed_config, manual_data_load_run.amr_uploaded_reading, manual_data_load_run), class: "btn btn-secondary" %>
-          <%= link_to "Delete", admin_amr_data_feed_config_amr_uploaded_reading_manual_data_load_run_path(manual_data_load_run.amr_uploaded_reading.amr_data_feed_config, manual_data_load_run.amr_uploaded_reading, manual_data_load_run), method: :delete, data: {confirm: t('activities.actions.are_you_sure')}, class: "btn btn-secondary" %>
+          <%= link_to "Delete", admin_amr_data_feed_config_amr_uploaded_reading_manual_data_load_run_path(manual_data_load_run.amr_uploaded_reading.amr_data_feed_config, manual_data_load_run.amr_uploaded_reading, manual_data_load_run), method: :delete, data: { confirm: 'Are you sure?' }, class: "btn btn-danger" %>
         </td>
       </tr>
     <% end %>

--- a/app/views/admin/reports/data_loads/index.html.erb
+++ b/app/views/admin/reports/data_loads/index.html.erb
@@ -22,6 +22,7 @@ Listing the 50 most recent manual data loads and their status.
         <td><%= manual_data_load_run.status %></td>
         <td>
           <%= link_to "View", admin_amr_data_feed_config_amr_uploaded_reading_manual_data_load_run_path(manual_data_load_run.amr_uploaded_reading.amr_data_feed_config, manual_data_load_run.amr_uploaded_reading, manual_data_load_run), class: "btn btn-secondary" %>
+          <%= link_to "Delete", admin_amr_data_feed_config_amr_uploaded_reading_manual_data_load_run_path(manual_data_load_run.amr_uploaded_reading.amr_data_feed_config, manual_data_load_run.amr_uploaded_reading, manual_data_load_run), method: :delete, data: {confirm: t('activities.actions.are_you_sure')}, class: "btn btn-secondary" %>
         </td>
       </tr>
     <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -343,7 +343,7 @@ Rails.application.routes.draw do
 
     resources :amr_data_feed_configs, only: [:index, :show, :edit, :update] do
       resources :amr_uploaded_readings, only: [:index, :show, :new, :create] do
-        resources :manual_data_load_runs, only: [:show, :create]
+        resources :manual_data_load_runs, only: [:show, :create, :destroy]
       end
     end
 

--- a/spec/models/manual_data_load_run_spec.rb
+++ b/spec/models/manual_data_load_run_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+RSpec.describe ManualDataLoadRun, type: :model do
+  before { @ManualDataLoadRun }
+
+  describe '#delete' do
+    before do
+      ManualDataLoadRun.delete_all
+      @new_manual_data_load_run = ManualDataLoadRun.create!(amr_uploaded_reading: create(:amr_uploaded_reading), status: 'done')
+      ManualDataLoadRunLogEntry.create(manual_data_load_run: @new_manual_data_load_run, message: "SUCCESS")
+      ManualDataLoadRunLogEntry.create(manual_data_load_run: @new_manual_data_load_run, message: "SUCCESS")
+    end
+
+    it 'destroys a manual data load run and all associated manual data load run log entries' do
+      expect(ManualDataLoadRun.count).to eq(1)
+      expect(@new_manual_data_load_run.manual_data_load_run_log_entries.count).to eq(2)
+      expect do
+        @new_manual_data_load_run.destroy
+      end.to change(ManualDataLoadRun, :count).by(-1) & change(ManualDataLoadRunLogEntry, :count).by(-2)
+    end
+  end
+end

--- a/spec/models/manual_data_load_run_spec.rb
+++ b/spec/models/manual_data_load_run_spec.rb
@@ -4,13 +4,18 @@ RSpec.describe ManualDataLoadRun, type: :model do
   describe '#delete' do
     it 'destroys a manual data load run and all associated manual data load run log entries' do
       ManualDataLoadRun.delete_all
-      new_manual_data_load_run = ManualDataLoadRun.create!(amr_uploaded_reading: create(:amr_uploaded_reading), status: 'done')
+      new_manual_data_load_run = ManualDataLoadRun.create!(
+        amr_uploaded_reading: create(:amr_uploaded_reading),
+        status: 'done'
+                                 )
       ManualDataLoadRunLogEntry.create(manual_data_load_run: new_manual_data_load_run, message: "SUCCESS")
       ManualDataLoadRunLogEntry.create(manual_data_load_run: new_manual_data_load_run, message: "SUCCESS")
       expect(new_manual_data_load_run.manual_data_load_run_log_entries.count).to eq(2)
       expect do
         new_manual_data_load_run.destroy
-      end.to change(ManualDataLoadRun, :count).by(-1) & change(ManualDataLoadRunLogEntry, :count).by(-2)
+      end.to change(ManualDataLoadRun, :count).by(-1) &
+             change(ManualDataLoadRunLogEntry, :count).by(-2) &
+             change(AmrUploadedReading, :count).by(-1)
     end
   end
 end

--- a/spec/models/manual_data_load_run_spec.rb
+++ b/spec/models/manual_data_load_run_spec.rb
@@ -6,16 +6,15 @@ RSpec.describe ManualDataLoadRun, type: :model do
   describe '#delete' do
     before do
       ManualDataLoadRun.delete_all
-      @new_manual_data_load_run = ManualDataLoadRun.create!(amr_uploaded_reading: create(:amr_uploaded_reading), status: 'done')
-      ManualDataLoadRunLogEntry.create(manual_data_load_run: @new_manual_data_load_run, message: "SUCCESS")
-      ManualDataLoadRunLogEntry.create(manual_data_load_run: @new_manual_data_load_run, message: "SUCCESS")
     end
 
     it 'destroys a manual data load run and all associated manual data load run log entries' do
-      expect(ManualDataLoadRun.count).to eq(1)
-      expect(@new_manual_data_load_run.manual_data_load_run_log_entries.count).to eq(2)
+      new_manual_data_load_run = ManualDataLoadRun.create!(amr_uploaded_reading: create(:amr_uploaded_reading), status: 'done')
+      ManualDataLoadRunLogEntry.create(manual_data_load_run: new_manual_data_load_run, message: "SUCCESS")
+      ManualDataLoadRunLogEntry.create(manual_data_load_run: new_manual_data_load_run, message: "SUCCESS")
+      expect(new_manual_data_load_run.manual_data_load_run_log_entries.count).to eq(2)
       expect do
-        @new_manual_data_load_run.destroy
+        new_manual_data_load_run.destroy
       end.to change(ManualDataLoadRun, :count).by(-1) & change(ManualDataLoadRunLogEntry, :count).by(-2)
     end
   end

--- a/spec/models/manual_data_load_run_spec.rb
+++ b/spec/models/manual_data_load_run_spec.rb
@@ -1,14 +1,9 @@
 require 'rails_helper'
 
 RSpec.describe ManualDataLoadRun, type: :model do
-  before { @ManualDataLoadRun }
-
   describe '#delete' do
-    before do
-      ManualDataLoadRun.delete_all
-    end
-
     it 'destroys a manual data load run and all associated manual data load run log entries' do
+      ManualDataLoadRun.delete_all
       new_manual_data_load_run = ManualDataLoadRun.create!(amr_uploaded_reading: create(:amr_uploaded_reading), status: 'done')
       ManualDataLoadRunLogEntry.create(manual_data_load_run: new_manual_data_load_run, message: "SUCCESS")
       ManualDataLoadRunLogEntry.create(manual_data_load_run: new_manual_data_load_run, message: "SUCCESS")


### PR DESCRIPTION
Allow an Energy Sparks admin to delete uploaded readings, by adding a delete button to this view:

https://energysparks.uk/admin/reports/data_loads

- [x] delete uploaded readings 
- [x] delete any associated run logs