### PR TITLE
Update different Stark datafeeds

### DIFF
--- a/lib/tasks/deployment/20220927125827_rename_smartest_energy_data_feed_config.rake
+++ b/lib/tasks/deployment/20220927125827_rename_smartest_energy_data_feed_config.rake
@@ -4,7 +4,7 @@ namespace :after_party do
     puts "Running deploy task 'rename_smartest_energy_data_feed_config'"
 
     amr_data_feed_config = AmrDataFeedConfig.find_by(identifier: 'smartestenergy')
-    amr_data_feed_config.update!(description: 'SmartestEnergy Stark daily', identifier: 'smartestenergy-stark-daily')
+    amr_data_feed_config.update!(description: 'SmartestEnergy Stark daily', identifier: 'smartestenergy-stark')
 
     # Update task as completed.  If you remove the line below, the task will
     # run with every deploy (or every time you call after_party:run).

--- a/lib/tasks/deployment/20220927125827_rename_smartest_energy_data_feed_config.rake
+++ b/lib/tasks/deployment/20220927125827_rename_smartest_energy_data_feed_config.rake
@@ -1,0 +1,14 @@
+namespace :after_party do
+  desc 'Deployment task: rename_smartest_energy_data_feed_config'
+  task rename_smartest_energy_data_feed_config: :environment do
+    puts "Running deploy task 'rename_smartest_energy_data_feed_config'"
+
+    amr_data_feed_config = AmrDataFeedConfig.find_by(identifier: 'smartestenergy')
+    amr_data_feed_config.update!(description: 'SmartestEnergy Stark daily', identifier: 'smartestenergystarkdaily')
+
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord
+      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+  end
+end

--- a/lib/tasks/deployment/20220927125827_rename_smartest_energy_data_feed_config.rake
+++ b/lib/tasks/deployment/20220927125827_rename_smartest_energy_data_feed_config.rake
@@ -4,7 +4,7 @@ namespace :after_party do
     puts "Running deploy task 'rename_smartest_energy_data_feed_config'"
 
     amr_data_feed_config = AmrDataFeedConfig.find_by(identifier: 'smartestenergy')
-    amr_data_feed_config.update!(description: 'SmartestEnergy Stark daily', identifier: 'smartestenergystarkdaily')
+    amr_data_feed_config.update!(description: 'SmartestEnergy Stark daily', identifier: 'smartestenergy-stark-daily')
 
     # Update task as completed.  If you remove the line below, the task will
     # run with every deploy (or every time you call after_party:run).

--- a/lib/tasks/deployment/20220927130324_create_stark_portal_energy_data_feed_config.rake
+++ b/lib/tasks/deployment/20220927130324_create_stark_portal_energy_data_feed_config.rake
@@ -1,0 +1,26 @@
+namespace :after_party do
+  desc 'Deployment task: create_stark_portal_energy_data_feed_config'
+  task create_stark_portal_energy_data_feed_config: :environment do
+    puts "Running deploy task 'create_stark_portal_energy_data_feed_config'"
+
+    new_config = {}
+    new_config['description'] = 'Stark portal'
+    new_config['identifier'] = 'stark-portal'
+    new_config['number_of_header_rows'] = 1
+    new_config['date_format'] = '%d/%m/%y'
+    new_config['mpan_mprn_field'] = 'MPAN'
+    new_config['reading_date_field'] = 'Date'
+    new_config['meter_description_field'] = 'Online Meter Name'
+    new_config['reading_fields'] = '00:30,01:00,01:30,02:00,02:30,03:00,03:30,04:00,04:30,05:00,05:30,06:00,06:30,07:00,07:30,08:00,08:30,09:00,09:30,10:00,10:30,11:00,11:30,12:00,12:30,13:00,13:30,14:00,14:30,15:00,15:30,16:00,16:30,17:00,17:30,18:00,18:30,19:00,19:30,20:00,20:30,21:00,21:30,22:00,22:30,23:00,23:30,00:00'.split(',')
+    new_config['header_example'] = 'Company Name,Site Name,Online Meter Name,MPAN,Meter ID,Type,Est,Date,00:30,01:00,01:30,02:00,02:30,03:00,03:30,04:00,04:30,05:00,05:30,06:00,06:30,07:00,07:30,08:00,08:30,09:00,09:30,10:00,10:30,11:00,11:30,12:00,12:30,13:00,13:30,14:00,14:30,15:00,15:30,16:00,16:30,17:00,17:30,18:00,18:30,19:00,19:30,20:00,20:30,21:00,21:30,22:00,22:30,23:00,23:30,00:00'
+    new_config['number_of_header_rows'] = 9
+    new_config['column_row_filters'] = { 'Est' => '^-$' } # Where 'Est' column is "-" there are no readings
+
+    AmrDataFeedConfig.create!(new_config)
+
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord
+      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+  end
+end

--- a/lib/tasks/deployment/20220927130324_create_stark_portal_energy_data_feed_config.rake
+++ b/lib/tasks/deployment/20220927130324_create_stark_portal_energy_data_feed_config.rake
@@ -13,7 +13,6 @@ namespace :after_party do
     new_config['meter_description_field'] = 'Online Meter Name'
     new_config['reading_fields'] = '00:30,01:00,01:30,02:00,02:30,03:00,03:30,04:00,04:30,05:00,05:30,06:00,06:30,07:00,07:30,08:00,08:30,09:00,09:30,10:00,10:30,11:00,11:30,12:00,12:30,13:00,13:30,14:00,14:30,15:00,15:30,16:00,16:30,17:00,17:30,18:00,18:30,19:00,19:30,20:00,20:30,21:00,21:30,22:00,22:30,23:00,23:30,00:00'.split(',')
     new_config['header_example'] = 'Company Name,Site Name,Online Meter Name,MPAN,Meter ID,Type,Est,Date,00:30,01:00,01:30,02:00,02:30,03:00,03:30,04:00,04:30,05:00,05:30,06:00,06:30,07:00,07:30,08:00,08:30,09:00,09:30,10:00,10:30,11:00,11:30,12:00,12:30,13:00,13:30,14:00,14:30,15:00,15:30,16:00,16:30,17:00,17:30,18:00,18:30,19:00,19:30,20:00,20:30,21:00,21:30,22:00,22:30,23:00,23:30,00:00'
-    new_config['number_of_header_rows'] = 9
     new_config['column_row_filters'] = { 'Est' => '^-$' } # Where 'Est' column is "-" there are no readings
 
     AmrDataFeedConfig.create!(new_config)

--- a/lib/tasks/deployment/20220927130324_create_stark_portal_energy_data_feed_config.rake
+++ b/lib/tasks/deployment/20220927130324_create_stark_portal_energy_data_feed_config.rake
@@ -6,7 +6,7 @@ namespace :after_party do
     new_config = {}
     new_config['description'] = 'Stark portal'
     new_config['identifier'] = 'stark-portal'
-    new_config['number_of_header_rows'] = 1
+    new_config['number_of_header_rows'] = 9
     new_config['date_format'] = '%d/%m/%y'
     new_config['mpan_mprn_field'] = 'MPAN'
     new_config['reading_date_field'] = 'Date'

--- a/lib/tasks/deployment/20220927131214_rename_stark_oxfordshire_data_feed_config.rake
+++ b/lib/tasks/deployment/20220927131214_rename_stark_oxfordshire_data_feed_config.rake
@@ -1,0 +1,14 @@
+namespace :after_party do
+  desc 'Deployment task: rename_stark_oxfordshire_data_feed_config'
+  task rename_stark_oxfordshire_data_feed_config: :environment do
+    puts "Running deploy task 'rename_stark_oxfordshire_data_feed_config'"
+
+    amr_data_feed_config = AmrDataFeedConfig.find_by(identifier: 'stark')
+    amr_data_feed_config.update!(description: 'Stark (daily)', identifier: 'starkdaily')
+
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord
+      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+  end
+end

--- a/lib/tasks/deployment/20220927131214_rename_stark_oxfordshire_data_feed_config.rake
+++ b/lib/tasks/deployment/20220927131214_rename_stark_oxfordshire_data_feed_config.rake
@@ -4,7 +4,7 @@ namespace :after_party do
     puts "Running deploy task 'rename_stark_oxfordshire_data_feed_config'"
 
     amr_data_feed_config = AmrDataFeedConfig.find_by(identifier: 'stark')
-    amr_data_feed_config.update!(description: 'Stark (daily)', identifier: 'starkdaily')
+    amr_data_feed_config.update!(description: 'Stark (daily)')
 
     # Update task as completed.  If you remove the line below, the task will
     # run with every deploy (or every time you call after_party:run).


### PR DESCRIPTION
We are now receiving 2 different formats of daily datafeeds from Stark - 1 format is processed and the other is not. The 1 that we don't process has been set up for schools that are customers of Smartest energy. It is similar, but not identical to the data we get from the Stark portal. The data we get from the Stark portal also now can't be easily loaded into Energy Sparks without data manipulation which is a pain. Please can you make the following changes to the data formats. We should be able to use the subject of the email to differentiate them.  This pr:

- [x] Renames the datafeed config `SmartestEnergy` to `SmartestEnergy Stark daily`. This one appears to be failing to load because of a different date format - see attached example of latest version (SmartestEnergy Stark daily)
- [x] Creates a new datafeed config `Stark portal` very similar to the above, just with an extra header row.  It would be good if this config could automatically ignore lines with  dashes (ie no data)
- [x] Renames the config `Stark (Oxfordshire etc)` to `Stark (daily)` (no other changes needed).




