### PR TITLE
Wrap header example text

### DIFF
--- a/app/views/admin/amr_uploaded_readings/new.html.erb
+++ b/app/views/admin/amr_uploaded_readings/new.html.erb
@@ -73,6 +73,8 @@
 
       <p>The file will have a header that looks like:</p>
 
+      <p style="overflow-wrap: anywhere;">
       <%= @amr_data_feed_config.header_example %>
+      </p>
   </div>
 </div>


### PR DESCRIPTION
Minor change that ensures that long header examples in data feed configs wrap correctly.

