### PR TITLE
Add CloudWatch metrics for DelayedJob

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,8 +44,9 @@ gem 'pagy'
 gem 'geocoder'
 gem 'rgeo-geojson'
 
-# AWS S3 api
+# AWS
 gem 'aws-sdk-s3'
+gem 'aws-sdk-cloudwatch'
 
 # Assets for Emails
 gem 'bootstrap-email'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -118,6 +118,9 @@ GEM
       execjs (~> 2)
     aws-eventstream (1.2.0)
     aws-partitions (1.538.0)
+    aws-sdk-cloudwatch (1.59.0)
+      aws-sdk-core (~> 3, >= 3.122.0)
+      aws-sigv4 (~> 1.1)
     aws-sdk-core (3.124.0)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.525.0)
@@ -662,6 +665,7 @@ DEPENDENCIES
   after_party
   annotate
   auto_strip_attributes (~> 2.5)
+  aws-sdk-cloudwatch
   aws-sdk-s3
   better_errors
   binding_of_caller

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -2,11 +2,29 @@ class ApplicationJob < ActiveJob::Base
   after_perform :send_metrics_to_cloudwatch
 
   def send_metrics_to_cloudwatch
-    Aws::Metrics.new(namespace: 'delayed-job', aws_metrics: counts_of_delayed_job_work_processes).send_to_cloudwatch
-    Aws::Metrics.new(namespace: 'delayed-job', aws_metrics: memory_usage_of_the_delayed_job_processes).send_to_cloudwatch
+    send_memory_usage_of_the_delayed_job_processes_to_cloudwatch
+    send_counts_of_delayed_job_work_processes_to_cloudwatch
   end
 
   private
+
+  def send_memory_usage_of_the_delayed_job_processes_to_cloudwatch
+    Aws::Metrics.new(
+      namespace: 'delayed-job',
+      metric_name: 'DelayedJobMemoryUsage',
+      value: delayed_job_memory_usage,
+      aws_unit_string: 'Kilobytes'
+    ).send_to_cloudwatch
+  end
+
+  def send_counts_of_delayed_job_work_processes_to_cloudwatch
+    Aws::Metrics.new(
+      namespace: 'delayed-job',
+      metric_name: 'DelayedJobWorkerProcesses',
+      value: pids.size,
+      aws_unit_string: 'Count'
+    ).send_to_cloudwatch
+  end
 
   def pids
     `pgrep -f jobs:work`.split
@@ -14,28 +32,5 @@ class ApplicationJob < ActiveJob::Base
 
   def delayed_job_memory_usage
     pids.split.map { |pid| `ps -o rss= -p #{pid}`.to_i }.sum # Total in Kilobytes
-  end
-
-  def memory_usage_of_the_delayed_job_processes
-    build_aws_metrics_for(metric_name: 'DelayedJobMemoryUsage', value: delayed_job_memory_usage, aws_unit_string: 'Kilobytes')
-  end
-
-  def counts_of_delayed_job_work_processes
-    build_aws_metrics_for(metric_name: 'DelayedJobWorkerProcesses', value: pids.size, aws_unit_string: 'Count')
-  end
-
-  def build_aws_metrics_for(metric_name:, value:, aws_unit_string:)
-    {
-      metric_name: metric_name,
-      dimensions: [
-        {
-          name: 'hostname',
-          value: Socket.gethostname
-        }
-      ],
-      timestamp: Time.now.utc,
-      value: value,
-      unit: aws_unit_string
-    }
   end
 end

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -2,6 +2,23 @@ class ApplicationJob < ActiveJob::Base
   after_perform :send_metrics_to_cloudwatch
 
   def send_metrics_to_cloudwatch
-    Aws::Metrics.new(namespace: '', aws_metrics: '').send_to_cloudwatch
+    Aws::Metrics.new(namespace: '', aws_metrics: aws_metrics).send_to_cloudwatch
+  end
+
+  private
+
+  def aws_metrics
+    {
+      metric_name: '',
+      dimensions: [
+        {
+          name: 'hostname',
+          value: ''
+        }
+      ],
+      timestamp: DateTime.now,
+      value: '',
+      unit: ''
+    }
   end
 end

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,2 +1,7 @@
 class ApplicationJob < ActiveJob::Base
+  after_perform :send_metrics_to_cloudwatch
+
+  def send_metrics_to_cloudwatch
+    Aws::Metrics.new(namespace: '', aws_metrics: '').send_to_cloudwatch
+  end
 end

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -2,23 +2,40 @@ class ApplicationJob < ActiveJob::Base
   after_perform :send_metrics_to_cloudwatch
 
   def send_metrics_to_cloudwatch
-    Aws::Metrics.new(namespace: '', aws_metrics: aws_metrics).send_to_cloudwatch
+    Aws::Metrics.new(namespace: 'delayed-job', aws_metrics: counts_of_delayed_job_work_processes).send_to_cloudwatch
+    Aws::Metrics.new(namespace: 'delayed-job', aws_metrics: memory_usage_of_the_delayed_job_processes).send_to_cloudwatch
   end
 
   private
 
-  def aws_metrics
+  def pids
+    `pgrep -f jobs:work`.split
+  end
+
+  def delayed_job_memory_usage
+    pids.split.map { |pid| `ps -o rss= -p #{pid}`.to_i }.sum # Total in Kilobytes
+  end
+
+  def memory_usage_of_the_delayed_job_processes
+    build_aws_metrics_for(metric_name: 'DelayedJobMemoryUsage', value: delayed_job_memory_usage, aws_unit_string: 'Kilobytes')
+  end
+
+  def counts_of_delayed_job_work_processes
+    build_aws_metrics_for(metric_name: 'DelayedJobWorkerProcesses', value: pids.size, aws_unit_string: 'Count')
+  end
+
+  def build_aws_metrics_for(metric_name:, value:, aws_unit_string:)
     {
-      metric_name: '',
+      metric_name: metric_name,
       dimensions: [
         {
           name: 'hostname',
-          value: ''
+          value: Socket.gethostname
         }
       ],
-      timestamp: DateTime.now,
-      value: '',
-      unit: ''
+      timestamp: Time.now.utc,
+      value: value,
+      unit: aws_unit_string
     }
   end
 end

--- a/app/services/aws/metrics.rb
+++ b/app/services/aws/metrics.rb
@@ -1,15 +1,13 @@
 module Aws
   class Metrics
-    VALID_UNITS = [
-      'Seconds', 'Microseconds', 'Milliseconds',
-      'Bytes', 'Kilobytes', 'Megabytes', 'Gigabytes', 'Terabytes',
-      'Bits', 'Kilobits', 'Megabits', 'Gigabits', 'Terabits',
-      'Percent', 'Count',
-      'Bytes/Second', 'Kilobytes/Second', 'Megabytes/Second', 'Gigabytes/Second', 'Terabytes/Second',
-      'Bits/Second', 'Kilobits/Second', 'Megabits/Second', 'Gigabits/Second', 'Terabits/Second',
-      'Count/Second',
-      'None'
-    ].freeze
+    VALID_UNITS = %w(
+      Seconds Microseconds Milliseconds
+      Bytes Kilobytes Megabytes Gigabytes Terabytes
+      Bits Kilobits Megabits Gigabits Terabits
+      Percent Count
+      Bytes/Second Kilobytes/Second Megabytes/Second Gigabytes/Second Terabytes/Second Bits/Second Kilobits/Second Megabits/Second Gigabits/Second Terabits/Second Count/Second
+      None
+    ).freeze
 
     def initialize(namespace:, metric_name:, value:, aws_unit_string:)
       raise 'Invalid CloudWatch Unit' unless VALID_UNITS.include?(aws_unit_string)
@@ -21,31 +19,47 @@ module Aws
     end
 
     def send_to_cloudwatch
-      cloudwatch_client.put_metric_data(
-        namespace: @namespace,
-        metric_data: aws_metrics_payload
-      )
+      cloudwatch_client.put_metric_data(aws_metrics_payload)
     end
 
     private
 
     def aws_metrics_payload
+      # see https://docs.aws.amazon.com/sdk-for-ruby/v2/api/Aws/CloudWatch/Client.html#put_metric_data-instance_method
       {
-        metric_name: @metric_name,
-        dimensions: [
+        namespace: @namespace, # required
+        metric_data: [ # required
           {
-            name: 'hostname',
-            value: Socket.gethostname
+            metric_name: @metric_name, # required
+            dimensions: [
+              {
+                name: 'hostname', # required
+                value: Socket.gethostname, # required
+              },
+            ],
+            timestamp: Time.zone.now,
+            value: @value,
+            # statistic_values: {
+            #   sample_count: 1.0, # required
+            #   sum: 1.0, # required
+            #   minimum: 1.0, # required
+            #   maximum: 1.0, # required
+            # },
+            # values: [1.0],
+            # counts: [1.0],
+            unit: @aws_unit_string
+            # , storage_resolution: 1,
           }
         ],
-        timestamp: Time.now.utc,
-        value: @value,
-        unit: @aws_unit_string
       }
     end
 
     def cloudwatch_client
-      Aws::CloudWatch::Client.new(region: 'eu-west-2')
+      Aws::CloudWatch::Client.new(
+        region: 'eu-west-2',
+        access_key_id: ENV['AWS_ACCESS_KEY_ID'],
+        secret_access_key: ENV['AWS_SECRET_ACCESS_KEY']
+      )
     end
   end
 end

--- a/app/services/aws/metrics.rb
+++ b/app/services/aws/metrics.rb
@@ -1,18 +1,48 @@
 module Aws
   class Metrics
-    def initialize(namespace:, aws_metrics:)
+    VALID_UNITS = [
+      'Seconds', 'Microseconds', 'Milliseconds',
+      'Bytes', 'Kilobytes', 'Megabytes', 'Gigabytes', 'Terabytes',
+      'Bits', 'Kilobits', 'Megabits', 'Gigabits', 'Terabits',
+      'Percent', 'Count',
+      'Bytes/Second', 'Kilobytes/Second', 'Megabytes/Second', 'Gigabytes/Second', 'Terabytes/Second',
+      'Bits/Second', 'Kilobits/Second', 'Megabits/Second', 'Gigabits/Second', 'Terabits/Second',
+      'Count/Second',
+      'None'
+    ].freeze
+
+    def initialize(namespace:, metric_name:, value:, aws_unit_string:)
+      raise 'Invalid CloudWatch Unit' unless VALID_UNITS.include?(aws_unit_string)
+
       @namespace = namespace
-      @aws_metrics = aws_metrics
+      @metric_name = metric_name
+      @value = value
+      @aws_unit_string = aws_unit_string
     end
 
     def send_to_cloudwatch
       cloudwatch_client.put_metric_data(
         namespace: @namespace,
-        metric_data: @aws_metrics
+        metric_data: aws_metrics_payload
       )
     end
 
     private
+
+    def aws_metrics_payload
+      {
+        metric_name: @metric_name,
+        dimensions: [
+          {
+            name: 'hostname',
+            value: Socket.gethostname
+          }
+        ],
+        timestamp: Time.now.utc,
+        value: @value,
+        unit: @aws_unit_string
+      }
+    end
 
     def cloudwatch_client
       Aws::CloudWatch::Client.new(region: 'eu-west-2')

--- a/app/services/aws/metrics.rb
+++ b/app/services/aws/metrics.rb
@@ -1,0 +1,21 @@
+module Aws
+  class Metrics
+    def initialize(namespace:, aws_metrics:)
+      @namespace = namespace
+      @aws_metrics = aws_metrics
+    end
+
+    def send_to_cloudwatch
+      cloudwatch_client.put_metric_data(
+        namespace: @namespace,
+        metric_data: @aws_metrics
+      )
+    end
+
+    private
+
+    def cloudwatch_client
+      Aws::CloudWatch::Client.new(region: 'eu-west-2')
+    end
+  end
+end

--- a/spec/services/aws/metrics_spec.rb
+++ b/spec/services/aws/metrics_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+describe Aws::Metrics, type: :service do
+  describe '#send_to_cloudwatch' do
+    it 'logs metrics to Cloudwatch' do
+      allow_any_instance_of(Aws::CloudWatch::Client).to receive(:put_metric_data) { true }
+
+      expect(Aws::Metrics.new(namespace: 'es', aws_metrics: {}).send_to_cloudwatch).to eq(true)
+    end
+  end
+end


### PR DESCRIPTION
When DelayedJob is running we will want to be able to monitor it automatically.

We need to add some CloudWatch metrics that log:

- [ ] number of work processes as a way to ensure that the process is running
- [ ]  memory usage of the DelayedJob Ruby process, as a way to get a bit more insight beyond the total memory usage of the server
