### PR TITLE
Change visibility of fixed dashboard prompts

### DIFF
--- a/app/views/schools/show.html.erb
+++ b/app/views/schools/show.html.erb
@@ -43,13 +43,15 @@
   <%= render 'management/schools/targets/review_targets', school: @school %>
 <% end %>
 
-<%= render 'management/schools/complete_programmes', school: @school %>
+<% if can?(:show_management_dash, @school) && current_user_school == @school %>
+  <%= render 'management/schools/complete_programmes', school: @school %>
 
-<%= render 'management/schools/record_activity', school: @school %>
+  <%= render 'management/schools/record_activity', school: @school %>
 
-<%= render 'management/schools/record_intervention', school: @school %>
+  <%= render 'management/schools/record_intervention', school: @school %>
 
-<%= render 'schools/dashboard/transport_surveys', school: @school %>
+  <%= render 'schools/dashboard/transport_surveys', school: @school %>
+<% end %>
 
 <% if @add_pupils %>
   <%= render 'management/schools/add_pupils', school: @school %>

--- a/spec/system/schools/dashboard/prompts_spec.rb
+++ b/spec/system/schools/dashboard/prompts_spec.rb
@@ -1,0 +1,108 @@
+require 'rails_helper'
+
+RSpec.shared_examples "dashboard prompts" do
+  before(:each) do
+    visit school_path(test_school, switch: true)
+  end
+
+  it 'has prompt to view programmes' do
+    expect(page).to have_content("Take the next step towards completing one of our short programmes of activity to increase your impact and score points for your school")
+  end
+
+  it 'has prompt to record activity' do
+    expect(page).to have_content("Teach pupils about energy and climate change within the context of your own school by completing our freely available activities")
+  end
+
+  it 'has prompt to record an action' do
+    expect(page).to have_content("Record energy saving actions made by school staff and facilities management to help to track whether your interventions have saved energy.")
+  end
+
+  it 'has prompt to start survey' do
+    expect(page).to have_content("Start a transport survey so that you can find out how much carbon your school community uses by travelling to school")
+  end
+end
+
+RSpec.describe "adult dashboard prompts", type: :system do
+  let(:school)             { create(:school) }
+
+  before(:each) do
+    sign_in(user) if user.present?
+  end
+
+  context 'as guest' do
+    let(:user)                { nil }
+    before(:each) do
+      visit school_path(school)
+    end
+
+    it 'does not have prompt to view programmes' do
+      expect(page).to_not have_content("Take the next step towards completing one of our short programmes of activity to increase your impact and score points for your school")
+    end
+
+    it 'does not have prompt to record activity' do
+      expect(page).to_not have_content("Teach pupils about energy and climate change within the context of your own school by completing our freely available activities")
+    end
+
+    it 'does not have prompt to record an action' do
+      expect(page).to_not have_content("Record energy saving actions made by school staff and facilities management to help to track whether your interventions have saved energy.")
+    end
+
+    it 'does not have prompt to start survey' do
+      expect(page).to_not have_content("Start a transport survey so that you can find out how much carbon your school community use")
+    end
+  end
+
+  context 'as user from another school' do
+    let(:school2) { create(:school) }
+    let(:user)    { create(:staff, school: school2) }
+    before(:each) do
+      visit school_path(school)
+    end
+
+    it 'does not have prompt to view programmes' do
+      expect(page).to_not have_content("Take the next step towards completing one of our short programmes of activity to increase your impact and score points for your school")
+    end
+
+    it 'does not have prompt to record activity' do
+      expect(page).to_not have_content("Teach pupils about energy and climate change within the context of your own school by completing our freely available activities")
+    end
+
+    it 'does not have prompt to record an action' do
+      expect(page).to_not have_content("Record energy saving actions made by school staff and facilities management to help to track whether your interventions have saved energy.")
+    end
+
+    it 'does not have prompt to start survey' do
+      expect(page).to_not have_content("Start a transport survey so that you can find out how much carbon your school community use")
+    end
+  end
+
+  context 'as pupil' do
+    let(:user)          { create(:pupil, school: school) }
+    include_examples "dashboard prompts" do
+      let(:test_school) { school }
+    end
+  end
+
+  context 'as staff' do
+    let(:user)   { create(:staff, school: school) }
+    include_examples "dashboard prompts" do
+      let(:test_school) { school }
+    end
+  end
+
+  context 'as school admin' do
+    let(:user)  { create(:school_admin, school: school) }
+    include_examples "dashboard prompts" do
+      let(:test_school) { school }
+    end
+  end
+
+  context 'as group admin' do
+    let(:school_group)  { create(:school_group) }
+    let(:school)        { create(:school, school_group: school_group) }
+    let(:user)          { create(:group_admin, school_group: school_group, school: school) }
+    include_examples "dashboard prompts" do
+      let(:test_school) { school }
+    end
+  end
+end


### PR DESCRIPTION
There are a few dashboard prompts that were only shown on the management dashboard, which could only have been accessed by signed in users from that schools, or users from other schools.

With the dashboard refactoring these were being shown to all users, including guests. While some are actually just links to other areas of the site, the transport survey actually requires authentication.

Rather than display the links and prompt for login, I've instead hidden them from unauthorised users. This aligns them better with other prompts, e.g. to set targets, so that they're only shown to users with permissions to take action.

This PR:

- adds a conditional around these prompts, so that they're only shown to users linked to this school and with the management dashboard permission
- adds a new set of specs that exercises this behaviour, checking that the messages are displayed as appropriate.

Longer term we need to tidy up the permissions checks and display of these messages. For now this just ensures the behaviour broadly matches the existing site.