### PR TITLE
Allow group admins to complete onboarding for schools

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -56,6 +56,11 @@ class Ability
         can :manage, CalendarEvent do |calendar_event|
           user.school_group.calendars.include?(calendar_event.calendar)
         end
+        #A group admin can manage onboarding for any school in their group
+        #The onboarding must be associated with the group
+        can :manage, SchoolOnboarding do |onboarding|
+          onboarding.school_group.present? && user.school_group == onboarding.school_group
+        end
       else
         school_scope = { id: user.school_id, visible: true }
         related_school_scope = { school_id: user.school_id }

--- a/app/services/school_creator.rb
+++ b/app/services/school_creator.rb
@@ -63,6 +63,8 @@ class SchoolCreator
 private
 
   def add_school(user, school)
+    return if user.group_admin?
+
     user.add_cluster_school(school)
     user.update!(school: school, role: :school_admin) unless user.school
   end
@@ -81,6 +83,7 @@ private
   end
 
   def create_default_contact(onboarding)
+    return if onboarding.created_user.group_admin?
     onboarding_service.record_event(onboarding, :alert_contact_created) do
       @school.contacts.create!(
         user: onboarding.created_user,

--- a/app/views/onboarding/clustering/new.html.erb
+++ b/app/views/onboarding/clustering/new.html.erb
@@ -3,7 +3,12 @@
     <h1>Step 1: Confirm your administrator account</h1>
 
     <p>You are currently logged in as <strong><%= current_user.email %></strong></p>
-    <p>Do you want to use this user as your administrator account for <%= @school_onboarding.school_name %>?</p>
+
+    <% if current_user.group_admin? %>
+      <p>Do you want to complete onboarding for <%= @school_onboarding.school_name %> using this school group admin account?</p>
+    <% else %>
+      <p>Do you want to use this user as your administrator account for <%= @school_onboarding.school_name %>?</p>
+    <% end %>
 
     <%= simple_form_for(current_user, url: onboarding_clustering_path(@school_onboarding), method: :post) do |f| %>
       <%= f.button :submit, 'Yes, use this account' %>

--- a/app/views/onboarding/completion/new.html.erb
+++ b/app/views/onboarding/completion/new.html.erb
@@ -29,10 +29,12 @@
                   <th>Email:</th>
                   <td><%=@school_onboarding.created_user.email%></td>
                 </tr>
-                <tr>
-                  <th>Role:</th>
-                  <td><%= t(@school_onboarding.created_user.staff_role.i18n_key) %></td>
-                </tr>
+                <% if @school_onboarding.created_user.staff_role.present? %>
+                  <tr>
+                    <th>Role:</th>
+                    <td><%= t(@school_onboarding.created_user.staff_role.i18n_key) %></td>
+                  </tr>
+                <% end %>
                 <tr>
                   <th>Password:</th>
                   <td>***********</td>

--- a/spec/factories/staff_role.rb
+++ b/spec/factories/staff_role.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :staff_role do
     trait :management do
-      title { 'Management' }
+      title { 'Business Manager' }
     end
 
     trait :teacher do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -120,10 +120,9 @@ describe User do
     end
 
     context "when a group admin" do
-      let(:public)       { true }
-      let(:school_group) { create(:school_group, public: public) }
-      let(:user)         { create(:user, role: :group_admin, school_group: school_group)}
-
+      let(:public)              { true }
+      let(:school_group)        { create(:school_group, public: public) }
+      let(:user)                { create(:user, role: :group_admin, school_group: school_group)}
       it { is_expected.to be_able_to(:compare, school_group) }
 
       context 'and group is private' do
@@ -136,8 +135,26 @@ describe User do
           let(:user)    {  create(:user, role: :group_admin, school_group: my_group) }
           it { is_expected.to be_able_to(:compare, my_group) }
           it { is_expected.to_not be_able_to(:compare, school_group) }
-
         end
+      end
+
+      context 'is onboarding' do
+
+        context 'a school in their group' do
+          let(:school_onboarding)   { create(:school_onboarding, school_group: school_group)}
+          it { is_expected.to be_able_to(:manage, school_onboarding)}
+        end
+
+        context 'but not for their group' do
+          let(:school_onboarding)   { create(:school_onboarding, school_group: create(:school_group)) }
+          it { is_expected.to_not be_able_to(:manage, school_onboarding)}
+        end
+
+        context 'for a different school' do
+          let(:school_onboarding)  { create(:school_onboarding, school: create(:school) ) }
+          it { is_expected.to_not be_able_to(:manage, school_onboarding) }
+        end
+
       end
     end
   end

--- a/spec/services/school_creator_spec.rb
+++ b/spec/services/school_creator_spec.rb
@@ -214,4 +214,46 @@ describe SchoolCreator, :schools, type: :service do
     end
 
   end
+
+  describe 'with a group admin' do
+    let(:school)                    { build :school}
+    let(:onboarding_user)           { create :group_admin, school_group: school_group }
+
+    let(:school_onboarding) do
+      create :school_onboarding,
+        created_user: onboarding_user,
+        template_calendar: template_calendar,
+        solar_pv_tuos_area: solar_pv_area,
+        dark_sky_area: dark_sky_area,
+        school_group: school_group,
+        scoreboard: scoreboard,
+        weather_station: weather_station,
+        school_will_be_public: true
+    end
+
+    describe '#onboard_school!' do
+      it 'saves the school' do
+        service.onboard_school!(school_onboarding)
+        expect(school).to be_persisted
+      end
+      it 'does not change role' do
+        service.onboard_school!(school_onboarding)
+        onboarding_user.reload
+        expect(onboarding_user.role).to eq('group_admin')
+      end
+      it 'does not assign the school to the onboarding user' do
+        service.onboard_school!(school_onboarding)
+        onboarding_user.reload
+        expect(onboarding_user.school).to be_nil
+      end
+      it 'does not create an alert contact for the school administrator' do
+        service.onboard_school!(school_onboarding)
+        expect(school.contacts).to be_empty
+      end
+      it 'does not add a cluster school' do
+        service.onboard_school!(school_onboarding)
+        expect(onboarding_user.cluster_schools).to be_empty
+      end
+    end
+  end
 end

--- a/spec/system/school_admin/user_management_spec.rb
+++ b/spec/system/school_admin/user_management_spec.rb
@@ -200,8 +200,6 @@ describe 'School admin user management' do
 
     describe 'managing school admins' do
 
-#      let!(:management_role){ create(:staff_role, :management, title: 'Business manager') }
-
       context 'when adding a user' do
         before(:each) do
           click_on 'Manage users'

--- a/spec/system/school_admin/user_management_spec.rb
+++ b/spec/system/school_admin/user_management_spec.rb
@@ -200,7 +200,7 @@ describe 'School admin user management' do
 
     describe 'managing school admins' do
 
-      let!(:management_role){ create(:staff_role, :management, title: 'Business manager') }
+#      let!(:management_role){ create(:staff_role, :management, title: 'Business manager') }
 
       context 'when adding a user' do
         before(:each) do

--- a/spec/system/school_onboarding_spec.rb
+++ b/spec/system/school_onboarding_spec.rb
@@ -111,7 +111,98 @@ RSpec.describe "onboarding", :schools, type: :system do
         expect(onboarding.created_user.role).to eq('school_onboarding')
       end
 
-      it 'allows an existing user to sign in'
+      context 'and user already has an account' do
+        let(:existing_user)    { nil }
+        let(:school_group)    { create(:school_group) }
+
+        before(:each) do
+          onboarding.update!(school_group: school_group)
+          click_on 'Start'
+          click_on 'Use an existing account'
+          fill_in 'Email', with: existing_user.email
+          fill_in 'Password', with: existing_user.password
+          within '#staff' do
+            click_on 'Sign in'
+          end
+        end
+
+        context 'as a school admin' do
+          let(:other_school)    { create(:school) }
+          let(:existing_user)   { create(:school_admin, school: other_school) }
+
+          it 'allows them to sign in' do
+            expect(page).to have_content("Step 1: Confirm your administrator account")
+            expect(page).to have_content("Do you want to use this user as your administrator account")
+          end
+          it 'allows them to complete onboarding' do
+            click_on 'Yes, use this account'
+
+            #School details
+            fill_in 'Unique Reference Number', with: '4444244'
+            fill_in 'Address', with: '1 Station Road'
+            fill_in 'Postcode', with: 'A1 2BC'
+            fill_in 'Website', with: 'http://oldfield.sch.uk'
+            choose('Primary')
+            click_on 'Save school details'
+
+            #Consent
+            fill_in 'Name', with: 'Boss user'
+            fill_in 'Job title', with: 'Boss'
+            fill_in 'School name', with: 'Boss school'
+            click_on 'Grant consent'
+
+            #Additional school accounts
+            click_on 'Skip for now'
+
+            #Pupils
+            fill_in 'Name', with: 'The energy savers'
+            fill_in 'Pupil password', with: 'theenergysavers'
+            click_on 'Create pupil account'
+
+            #Completion
+            click_on "Complete setup", match: :first
+            expect(page).to have_content("Setup completed")
+          end
+        end
+
+        context 'as a group admin' do
+          let(:existing_user)   { create(:group_admin, school_group: school_group) }
+
+          it 'allows them to sign in' do
+            expect(page).to have_content("Step 1: Confirm your administrator account")
+            expect(page).to have_content("Do you want to complete onboarding for Oldfield Park Infants using this school group admin account?")
+          end
+          it 'allows them to complete onboarding' do
+            click_on 'Yes, use this account'
+
+            #School details
+            fill_in 'Unique Reference Number', with: '4444244'
+            fill_in 'Address', with: '1 Station Road'
+            fill_in 'Postcode', with: 'A1 2BC'
+            fill_in 'Website', with: 'http://oldfield.sch.uk'
+            choose('Primary')
+            click_on 'Save school details'
+
+            #Consent
+            fill_in 'Name', with: 'Boss user'
+            fill_in 'Job title', with: 'Boss'
+            fill_in 'School name', with: 'Boss school'
+            click_on 'Grant consent'
+
+            #Additional school accounts
+            click_on 'Skip for now'
+
+            #Pupils
+            fill_in 'Name', with: 'The energy savers'
+            fill_in 'Pupil password', with: 'theenergysavers'
+            click_on 'Create pupil account'
+
+            #Completion
+            click_on "Complete setup", match: :first
+            expect(page).to have_content("Setup completed")
+          end
+        end
+      end
 
       context 'having created an account' do
         let(:user) { create(:onboarding_user) }


### PR DESCRIPTION
This PR revises the onboarding workflow to allow group admins to complete onboarding on behalf of the schools in their groups.

- ensures group admins have the right permissions to manage the onboardings for their group
- tweak message on login page
- revise School Creator to not associate user with school, or sign them up for alerts
- tweak confirmation page to not show staff role if not present, as group admins do not have them
- add tests for the ability, service and the workflow
