### PR TITLE
Allow admins to see all dashboard prompts

### DIFF
--- a/app/controllers/schools_controller.rb
+++ b/app/controllers/schools_controller.rb
@@ -134,10 +134,21 @@ private
     redirect_to pupils_school_path(@school) if not_signed_in? && !@school.data_enabled
   end
 
+  def show_standard_prompts?
+    if user_signed_in? && current_user.admin?
+      true
+    elsif user_signed_in_and_linked_to_school? && can?(:show_management_dash, @school)
+      true
+    else
+      false
+    end
+  end
+
   def setup_default_features
     @observations = setup_timeline(@school.observations)
     #Setup management dashboard features if users has permission
     #to do that
+    @show_standard_prompts = show_standard_prompts?
     if can?(:show_management_dash, @school)
       @add_contacts = site_settings.message_for_no_contacts && @school.contacts.empty? && can?(:manage, Contact)
       @add_pupils = site_settings.message_for_no_pupil_accounts && @school.users.pupil.empty? && can?(:manage_users, @school)

--- a/app/views/schools/show.html.erb
+++ b/app/views/schools/show.html.erb
@@ -43,7 +43,7 @@
   <%= render 'management/schools/targets/review_targets', school: @school %>
 <% end %>
 
-<% if can?(:show_management_dash, @school) && current_user_school == @school %>
+<% if @show_standard_prompts %>
   <%= render 'management/schools/complete_programmes', school: @school %>
 
   <%= render 'management/schools/record_activity', school: @school %>

--- a/spec/system/schools/dashboard/prompts_spec.rb
+++ b/spec/system/schools/dashboard/prompts_spec.rb
@@ -105,4 +105,11 @@ RSpec.describe "adult dashboard prompts", type: :system do
       let(:test_school) { school }
     end
   end
+
+  context 'as admin' do
+    let(:user)  { create(:admin) }
+    include_examples "dashboard prompts" do
+      let(:test_school) { school }
+    end
+  end
 end


### PR DESCRIPTION
Further tweak to the dashboards.  Allows an admin to see the default standard prompts, even though they're not linked to the school.

Extracted logic from templated into controller method. Added tests.