### PR TITLE
Revise admin school group index

### DIFF
--- a/app/views/admin/school_groups/index.html.erb
+++ b/app/views/admin/school_groups/index.html.erb
@@ -1,7 +1,6 @@
-<h1>School groups</h1>
-
+<h1>Manage School Groups</h1>
+<%= link_to 'New School group', new_admin_school_group_path, class: 'btn btn-primary' %>
 <p></p>
-
 <% if @school_groups.any? %>
   <table class="table table-condensed table-sorted">
     <thead>
@@ -9,7 +8,7 @@
         <th>Name</th>
         <th title="Schools onboarding">Onboarding</th>
         <th title="Schools active (without data visible)">Active</th>
-        <th title="Schools active (with data visible)" class='nowrap'>Active + data</small></th>
+        <th title="Schools active (with data visible)" class='nowrap'>Data visible</small></th>
         <th title="Schools invisible">Invisible</th>
         <th title="Schools removed">Removed</th>
         <th class="no-sort"></th>
@@ -17,9 +16,6 @@
     </thead>
 
     <tbody>
-      <tr>
-        <td></td>
-      </tr>
       <% @school_groups.each do |school_group| %>
         <tr>
           <td><%= school_group.name %></td>
@@ -36,10 +32,17 @@
           </td>
         </tr>
       <% end %>
+      <tr class="font-weight-bold">
+        <td>All Energy Sparks Schools</td>
+        <td><%= SchoolOnboarding.all.select(&:incomplete?).count %></td>
+        <td><%= School.visible.count %></td>
+        <td><%= School.visible.data_enabled.count %></td>
+        <td><%= School.not_visible.count %></td>
+        <td><%= School.inactive.count %></td>
+        <td></td>
+      </tr>
     </tbody>
   </table>
 <% else %>
   <h2>There are no School groups</h2>
 <% end %>
-
-<%= link_to 'New School group', new_admin_school_group_path, class: 'btn btn-primary' %>

--- a/app/views/admin/school_groups/index.html.erb
+++ b/app/views/admin/school_groups/index.html.erb
@@ -3,27 +3,36 @@
 <p></p>
 
 <% if @school_groups.any? %>
-  <table class="table table-condensed">
+  <table class="table table-condensed table-sorted">
     <thead>
       <tr>
         <th>Name</th>
-        <th>Description</th>
-        <th></th>
+        <th title="Schools onboarding">Onboarding</th>
+        <th title="Schools active (without data visible)">Active</th>
+        <th title="Schools active (with data visible)" class='nowrap'>Active + data</small></th>
+        <th title="Schools invisible">Invisible</th>
+        <th title="Schools removed">Removed</th>
+        <th class="no-sort"></th>
       </tr>
     </thead>
 
     <tbody>
+      <tr>
+        <td></td>
+      </tr>
       <% @school_groups.each do |school_group| %>
         <tr>
           <td><%= school_group.name %></td>
-          <td><%= school_group.description %></td>
-          <td>
-            <div class='btn-group'>
-              <%= link_to 'Edit', edit_admin_school_group_path(school_group), class: 'btn btn-info' %>
-              <%= link_to 'Delete', admin_school_group_path(school_group), method: :delete, data: { confirm: 'Are you sure?' }, class: 'btn btn-danger' %>
-              <%= link_to 'Meter attributes', admin_school_group_meter_attributes_path(school_group), class: 'btn' %>
-              <%= link_to 'Manage Partners', admin_school_group_partners_path(school_group), class: 'btn' %>
-            </div>
+          <td><%= school_group.school_onboardings.select(&:incomplete?).count %></td>
+          <td><%= school_group.schools.visible.count %></td>
+          <td><%= school_group.schools.visible.data_enabled.count %></td>
+          <td><%= school_group.schools.not_visible.count %></td>
+          <td><%= school_group.schools.inactive.count %></td>
+          <td class="nowrap">
+            <%= link_to 'Edit', edit_admin_school_group_path(school_group), class: 'btn btn-sm' %>
+            <%= link_to 'Meter attributes', admin_school_group_meter_attributes_path(school_group), class: 'btn btn-sm' %>
+            <%= link_to 'Manage Partners', admin_school_group_partners_path(school_group), class: 'btn btn-sm' %>
+            <%= link_to 'Delete', admin_school_group_path(school_group), method: :delete, data: { confirm: 'Are you sure?' }, class: 'btn btn-sm btn-danger' %>
           </td>
         </tr>
       <% end %>

--- a/spec/system/admin/school_groups_spec.rb
+++ b/spec/system/admin/school_groups_spec.rb
@@ -14,6 +14,40 @@ RSpec.describe 'school groups', :school_groups, type: :system do
       click_on 'Admin'
     end
 
+    context "viewing a tabular list of school groups" do
+      before do
+        school_groups.each do |school_group|
+          onboarding = create :school_onboarding, created_by: admin, school_group: school_group
+          visble = create :school, visible: true, data_enabled: false, school_group: school_group
+          data_visible = create :school, visible: true, data_enabled: true, school_group: school_group
+          invisible = create :school, visible: false, school_group: school_group
+          removed = create :school, active: false, school_group: school_group
+        end
+        click_on 'Edit School Groups'
+      end
+
+      context "with multiple groups" do
+        let(:school_groups) { [create(:school_group), create(:school_group)] }
+
+        it "displays totals for each group" do
+          within('table') do
+            school_groups.each do |school_group|
+              expect(page).to have_selector(:table_row, { "Name" => school_group.name, "Onboarding" => 1 , "Active" => 2, "Data visible" => 1, "Invisible" => 1, "Removed" => 1 })
+            end
+          end
+        end
+        it "displays a grand total" do
+          within('table') do
+            expect(page).to have_selector(:table_row, { "Name" => "All Energy Sparks Schools", "Onboarding" => 2 , "Active" => 4, "Data visible" => 2, "Invisible" => 2, "Removed" => 2 })
+          end
+        end
+        it "has a link to manage school group" do
+          pending "2474-manage-school-group-page"
+          expect(page).to have_link('Manage school group')
+        end
+      end
+    end
+
     it 'can add a new school group with validation' do
       click_on 'Edit School Groups'
       click_on 'New School group'


### PR DESCRIPTION
This is as outlined, however, maintains the original buttons for each school group, as they're needed until the "Manage school group" ticket has been completed.