### PR TITLE
Manage school group page

### DIFF
--- a/app/controllers/admin/school_groups/partners_controller.rb
+++ b/app/controllers/admin/school_groups/partners_controller.rb
@@ -14,7 +14,7 @@ module Admin
       def update
         position_attributes = params.permit(school_group_partners: [:position, :partner_id]).fetch(:school_group_partners) { {} }
         @school_group.update_school_partner_positions!(position_attributes)
-        redirect_to admin_school_groups_path, notice: 'Partners updated'
+        redirect_to admin_school_group_path(@school_group), notice: 'Partners updated'
       end
     end
   end

--- a/app/helpers/nav_helper.rb
+++ b/app/helpers/nav_helper.rb
@@ -77,4 +77,10 @@ module NavHelper
       end
     end
   end
+
+  def header_nav_link(link_text, link_path)
+    nav_class = 'btn btn-outline-dark rounded-pill font-weight-bold'
+    nav_class += ' disabled' if current_page?(link_path)
+    link_to link_text, link_path, class: nav_class
+  end
 end

--- a/app/helpers/transport_surveys_helper.rb
+++ b/app/helpers/transport_surveys_helper.rb
@@ -7,10 +7,4 @@ module TransportSurveysHelper
       link_to link_text, link_path, class: nav_class
     end
   end
-
-  def header_nav_link(link_text, link_path)
-    nav_class = 'btn btn-outline-dark rounded-pill font-weight-bold'
-    nav_class += ' disabled' if current_page?(link_path)
-    link_to link_text, link_path, class: nav_class
-  end
 end

--- a/app/models/school_group.rb
+++ b/app/models/school_group.rb
@@ -66,6 +66,10 @@ class SchoolGroup < ApplicationRecord
     schools.awaiting_activation.any?
   end
 
+  def safe_to_destroy?
+    !(schools.any? || users.any?)
+  end
+
   def safe_destroy
     raise EnergySparks::SafeDestroyError, 'Group has associated schools' if schools.any?
     raise EnergySparks::SafeDestroyError, 'Group has associated users' if users.any?

--- a/app/views/admin/school_groups/index.html.erb
+++ b/app/views/admin/school_groups/index.html.erb
@@ -18,7 +18,7 @@
     <tbody>
       <% @school_groups.each do |school_group| %>
         <tr>
-          <td><%= school_group.name %></td>
+          <td><%= link_to school_group.name, admin_school_group_path(school_group) %></td>
           <td><%= school_group.school_onboardings.select(&:incomplete?).count %></td>
           <td><%= school_group.schools.visible.count %></td>
           <td><%= school_group.schools.visible.data_enabled.count %></td>

--- a/app/views/admin/school_groups/index.html.erb
+++ b/app/views/admin/school_groups/index.html.erb
@@ -18,7 +18,7 @@
     <tbody>
       <% @school_groups.each do |school_group| %>
         <tr>
-          <td><%= link_to school_group.name, admin_school_group_path(school_group) %></td>
+          <td><%= school_group.name %></td>
           <td><%= school_group.school_onboardings.select(&:incomplete?).count %></td>
           <td><%= school_group.schools.visible.count %></td>
           <td><%= school_group.schools.visible.data_enabled.count %></td>

--- a/app/views/admin/school_groups/index.html.erb
+++ b/app/views/admin/school_groups/index.html.erb
@@ -24,12 +24,7 @@
           <td><%= school_group.schools.visible.data_enabled.count %></td>
           <td><%= school_group.schools.not_visible.count %></td>
           <td><%= school_group.schools.inactive.count %></td>
-          <td class="nowrap">
-            <%= link_to 'Edit', edit_admin_school_group_path(school_group), class: 'btn btn-sm' %>
-            <%= link_to 'Meter attributes', admin_school_group_meter_attributes_path(school_group), class: 'btn btn-sm' %>
-            <%= link_to 'Manage Partners', admin_school_group_partners_path(school_group), class: 'btn btn-sm' %>
-            <%= link_to 'Delete', admin_school_group_path(school_group), method: :delete, data: { confirm: 'Are you sure?' }, class: 'btn btn-sm btn-danger' %>
-          </td>
+          <td><%= link_to 'Manage', admin_school_group_path(school_group), class: 'btn btn-sm' %></td>
         </tr>
       <% end %>
       <tr class="font-weight-bold">

--- a/app/views/admin/school_groups/index.html.erb
+++ b/app/views/admin/school_groups/index.html.erb
@@ -1,5 +1,5 @@
 <h1>Manage School Groups</h1>
-<%= link_to 'New School group', new_admin_school_group_path, class: 'btn btn-primary' %>
+<%= link_to 'New school group', new_admin_school_group_path, class: 'btn btn-primary' %>
 <p></p>
 <% if @school_groups.any? %>
   <table class="table table-condensed table-sorted">

--- a/app/views/admin/school_groups/show.html.erb
+++ b/app/views/admin/school_groups/show.html.erb
@@ -27,3 +27,15 @@
     </div>
   </div>
 </div>
+
+<div class="bg-light p-2 my-2 d-flex justify-content-between">
+  <%= link_to 'View', school_group_path(@school_group), class: 'btn btn-sm' %>
+  <%= link_to 'Edit', edit_admin_school_group_path(@school_group), class: 'btn btn-sm' %>
+  <%= link_to 'Manage partners', admin_school_group_partners_path(@school_group), class: 'btn btn-sm' %>
+  <%= link_to 'Meter attributes', admin_school_group_meter_attributes_path(@school_group), class: 'btn btn-sm' %>
+  <%= link_to 'Meter report', admin_school_group_meter_report_path(@school_group), class: 'btn btn-sm' %>
+  <%= link_to 'Download meter report', admin_school_group_meter_report_path(@school_group, format: :csv) , class: 'btn btn-sm' %>
+  <div title="School groups can only be deleted when all schools in group are inactive" rel="tooltip">
+    <%= link_to 'Delete', admin_school_group_path(@school_group), method: :delete, data: { confirm: 'Are you sure?' }, class: "btn btn-sm#{' disabled' if @school_group.schools.active.any?}" %>
+  </div>
+</div>

--- a/app/views/admin/school_groups/show.html.erb
+++ b/app/views/admin/school_groups/show.html.erb
@@ -1,6 +1,7 @@
 <div class="d-flex justify-content-between align-items-center">
   <h1><%= @school_group.name %> School Group</h1>
   <div>
+    <%= header_nav_link 'All school groups', admin_school_groups_url %>
   </div>
 </div>
 

--- a/app/views/admin/school_groups/show.html.erb
+++ b/app/views/admin/school_groups/show.html.erb
@@ -19,6 +19,9 @@
       </div>
       <div class="card">
         <div class="card-body">
+          <% School.school_types.keys.each do |school_type| %>
+            <div><%= school_type.humanize %> <span class="float-right"><%= @school_group.schools.visible.where(school_type: school_type).count %></span></div>
+          <% end %>
         </div>
       </div>
     </div>

--- a/app/views/admin/school_groups/show.html.erb
+++ b/app/views/admin/school_groups/show.html.erb
@@ -20,7 +20,7 @@
       <div class="card">
         <div class="card-body">
           <% School.school_types.keys.each do |school_type| %>
-            <div><%= school_type.humanize %> <span class="float-right"><%= @school_group.schools.visible.where(school_type: school_type).count %></span></div>
+            <div><%= school_type.humanize %><span class="float-right"><%= @school_group.schools.visible.where(school_type: school_type).count %></span></div>
           <% end %>
         </div>
       </div>
@@ -35,7 +35,7 @@
   <%= link_to 'Meter attributes', admin_school_group_meter_attributes_path(@school_group), class: 'btn btn-sm' %>
   <%= link_to 'Meter report', admin_school_group_meter_report_path(@school_group), class: 'btn btn-sm' %>
   <%= link_to 'Download meter report', admin_school_group_meter_report_path(@school_group, format: :csv) , class: 'btn btn-sm' %>
-  <div title="School groups can only be deleted when all schools in group are inactive" rel="tooltip">
-    <%= link_to 'Delete', admin_school_group_path(@school_group), method: :delete, data: { confirm: 'Are you sure?' }, class: "btn btn-sm#{' disabled' if @school_group.schools.active.any?}" %>
+  <div title="School groups can only be deleted if there are no associated schools or users" rel="tooltip">
+    <%= link_to 'Delete', admin_school_group_path(@school_group), method: :delete, data: { confirm: 'Are you sure?' }, class: "btn btn-sm#{' disabled' unless @school_group.safe_to_destroy?}" %>
   </div>
 </div>

--- a/app/views/admin/school_groups/show.html.erb
+++ b/app/views/admin/school_groups/show.html.erb
@@ -4,23 +4,23 @@
     <%= header_nav_link 'All school groups', admin_school_groups_url %>
   </div>
 </div>
-<p>Pupils in active schools: <%= number_with_delimiter @school_group.schools.visible.map(&:number_of_pupils).compact.sum %></p>
+<p>Pupils in active schools: <span class="badge badge-success"><%= number_with_delimiter @school_group.schools.visible.map(&:number_of_pupils).compact.sum %></span></p>
 <div class="row">
   <div class="col-lg-12">
     <div class="card-deck">
       <div class="card">
         <div class="card-body">
-          <div>Active <span class="float-right"><%= @school_group.schools.visible.count %></span></div>
-          <div>Active (with data visible) <span class="float-right"><%= @school_group.schools.visible.data_enabled.count %></span></div>
-          <div>Invisible <span class="float-right"><%= @school_group.schools.not_visible.count %></span></div>
-          <div>Onboarding <span class="float-right"><%= @school_group.school_onboardings.select(&:incomplete?).count %></span></div>
-          <div>Removed <span class="float-right"><%= @school_group.schools.inactive.count %></span></div>
+          <div>Active <span class="float-right badge badge-success"><%= @school_group.schools.visible.count %></span></div>
+          <div>Active (with data visible) <span class="float-right badge badge-success"><%= @school_group.schools.visible.data_enabled.count %></span></div>
+          <div>Invisible <span class="float-right badge badge-info"><%= @school_group.schools.not_visible.count %></span></div>
+          <div>Onboarding <span class="float-right badge badge-warning"><%= @school_group.school_onboardings.select(&:incomplete?).count %></span></div>
+          <div>Removed <span class="float-right badge badge-secondary"><%= @school_group.schools.inactive.count %></span></div>
         </div>
       </div>
       <div class="card">
         <div class="card-body">
           <% School.school_types.keys.each do |school_type| %>
-            <div><%= school_type.humanize %> <span class="float-right"><%= @school_group.schools.visible.where(school_type: school_type).count %></span></div>
+            <div><%= school_type.humanize %> <span class="float-right badge badge-success"><%= @school_group.schools.visible.where(school_type: school_type).count %></span></div>
           <% end %>
         </div>
       </div>

--- a/app/views/admin/school_groups/show.html.erb
+++ b/app/views/admin/school_groups/show.html.erb
@@ -20,7 +20,7 @@
       <div class="card">
         <div class="card-body">
           <% School.school_types.keys.each do |school_type| %>
-            <div><%= school_type.humanize %><span class="float-right"><%= @school_group.schools.visible.where(school_type: school_type).count %></span></div>
+            <div><%= school_type.humanize %> <span class="float-right"><%= @school_group.schools.visible.where(school_type: school_type).count %></span></div>
           <% end %>
         </div>
       </div>

--- a/app/views/admin/school_groups/show.html.erb
+++ b/app/views/admin/school_groups/show.html.erb
@@ -4,4 +4,23 @@
     <%= header_nav_link 'All school groups', admin_school_groups_url %>
   </div>
 </div>
-
+<p>Pupils in active schools: <%= number_with_delimiter @school_group.schools.visible.map(&:number_of_pupils).compact.sum %></p>
+<div class="row">
+  <div class="col-lg-12">
+    <div class="card-deck">
+      <div class="card">
+        <div class="card-body">
+          <div>Active <span class="float-right"><%= @school_group.schools.visible.count %></span></div>
+          <div>Active (with data visible) <span class="float-right"><%= @school_group.schools.visible.data_enabled.count %></span></div>
+          <div>Invisible <span class="float-right"><%= @school_group.schools.not_visible.count %></span></div>
+          <div>Onboarding <span class="float-right"><%= @school_group.school_onboardings.select(&:incomplete?).count %></span></div>
+          <div>Removed <span class="float-right"><%= @school_group.schools.inactive.count %></span></div>
+        </div>
+      </div>
+      <div class="card">
+        <div class="card-body">
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/admin/school_groups/show.html.erb
+++ b/app/views/admin/school_groups/show.html.erb
@@ -1,0 +1,6 @@
+<div class="d-flex justify-content-between align-items-center">
+  <h1><%= @school_group.name %> School Group</h1>
+  <div>
+  </div>
+</div>
+

--- a/spec/models/school_group_spec.rb
+++ b/spec/models/school_group_spec.rb
@@ -23,7 +23,24 @@ describe SchoolGroup, :school_groups, type: :model do
         subject.safe_destroy
       }.to change{SchoolGroup.count}.from(1).to(0)
     end
+  end
 
+  describe "#safe_to_destroy?" do
+    context "with no associated schools or users" do
+      it { expect(subject).to be_safe_to_destroy }
+    end
+    context "with associated schools" do
+      let!(:school) { create(:school, school_group: subject) }
+      it { expect(subject).to_not be_safe_to_destroy }
+    end
+    context "with associated users" do
+      let!(:user) { create(:user, school_group: subject) }
+      it { expect(subject).to_not be_safe_to_destroy }
+      context "and school" do
+        let!(:user) { create(:user, school_group: subject) }
+        it { expect(subject).to_not be_safe_to_destroy }
+      end
+    end
   end
 
   describe '#with_active_schools' do

--- a/spec/system/admin/meter_attributes_spec.rb
+++ b/spec/system/admin/meter_attributes_spec.rb
@@ -142,6 +142,9 @@ RSpec.describe "meter attribute management", :meters, type: :system do
       click_on 'Manage'
       click_on 'Admin'
       click_on 'School Groups'
+      within 'table' do
+        click_on 'Manage'
+      end
       click_on 'Meter attributes'
       select 'Tariff', from: 'type'
       click_on 'New attribute'
@@ -155,7 +158,6 @@ RSpec.describe "meter attribute management", :meters, type: :system do
       attribute = school_group.meter_attributes.first
       expect{ attribute.to_analytics }.to_not raise_error
       expect(attribute.to_analytics.to_s).to include('economy_7')
-
 
       click_on 'Edit'
 
@@ -174,7 +176,6 @@ RSpec.describe "meter attribute management", :meters, type: :system do
       expect(school_group.meter_attributes.active.size).to eq(0)
       new_attribute.reload
       expect(new_attribute.deleted_by).to eq(admin)
-
     end
 
     it 'allow the admin to download all meter attributes' do

--- a/spec/system/admin/school_groups_spec.rb
+++ b/spec/system/admin/school_groups_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe 'school groups', :school_groups, type: :system do
       click_on 'Admin'
     end
 
-    describe "Viewing school groups admin page" do
+    describe "Viewing school groups index page" do
       let!(:setup_data) { create_data_for_school_groups(school_groups) }
       before do
         click_on 'Edit School Groups'
@@ -57,20 +57,26 @@ RSpec.describe 'school groups', :school_groups, type: :system do
       let!(:school_group) { create :school_group }
       before do
         setup_data
-        visit admin_school_group_path(school_group)
+        click_on 'Edit School Groups'
+        click_on "#{school_group.name}" # change to "Manage"
       end
 
-      it "has a button to view all school groups" do
-        expect(page).to have_link('All school groups')
+      describe "Header" do
+        it { expect(page).to have_content("#{school_group.name} School Group")}
+        it "has a button to view all school groups" do
+          expect(page).to have_link('All school groups')
+        end
+        context "clicking on 'All school groups'" do
+          before { click_link "All school groups" }
+          it { expect(page).to have_current_path(admin_school_groups_path) }
+        end
+        it "displays pupils in active schools count" do
+          expect(page).to have_content("Pupils in active schools: #{school_group.schools.visible.map(&:number_of_pupils).compact.sum}")
+        end
       end
 
-      it "displays pupils in active schools count" do
-        expect(page).to have_content("Pupils in active schools: #{school_group.schools.visible.map(&:number_of_pupils).compact.sum}")
-      end
-
-      context "school counts by status panel" do
+      describe "School counts by status panel" do
         let!(:setup_data) { create_data_for_school_groups([school_group]) }
-
         it { expect(page).to have_content("Active 2") }
         it { expect(page).to have_content("Active (with data visible) 1") }
         it { expect(page).to have_content("Invisible 1") }
@@ -78,29 +84,57 @@ RSpec.describe 'school groups', :school_groups, type: :system do
         it { expect(page).to have_content("Removed 1") }
       end
 
-      context "school counts by school type panel" do
+      describe "School counts by school type panel" do
         School.school_types.keys.each do |school_type|
           context "active #{school_type} schools" do
             let!(:setup_data) { create(:school, school_group: school_group, school_type: school_type, active: true) }
-            it "should be counted" do
-              expect(page).to have_content("#{school_type.humanize} 1")
-            end
+            it { expect(page).to have_content("#{school_type.humanize} 1") }
           end
           context "inactive #{school_type} schools" do
             let!(:setup_data) { create(:school, school_group: school_group, school_type: school_type, active: false) }
-            it "should not be counted" do
-              expect(page).to have_content("#{school_type.humanize} 0")
-            end
+            it { expect(page).to have_content("#{school_type.humanize} 0") }
           end
         end
       end
 
-      context "clicking on 'All school groups'" do
-        before do
-          click_link "All school groups"
+      describe "Button panel" do
+        it { expect(page).to have_link('View') }
+        context "clicking 'View'" do
+          before { click_link 'View' }
+          it { expect(page).to have_current_path(school_group_path(school_group)) }
         end
-        it { expect(page).to have_current_path(admin_school_groups_path) }
+        it { expect(page).to have_link('Edit') }
+        context "clicking 'Edit'" do
+          before { click_link 'Edit' }
+          it { expect(page).to have_current_path(edit_admin_school_group_path(school_group)) }
+        end
+        it { expect(page).to have_link('Manage partners') }
+        context "clicking 'Manage partners'" do
+          before { click_link 'Manage partners' }
+          it { expect(page).to have_current_path(admin_school_group_partners_path(school_group)) }
+        end
+        it { expect(page).to have_link('Meter attributes') }
+        context "clicking 'Meter attributes'" do
+          before { click_link 'Meter attributes' }
+          it { expect(page).to have_current_path(admin_school_group_meter_attributes_path(school_group)) }
+        end
+        it { expect(page).to have_link('Meter report') }
+        context "clicking 'Meter report'" do
+          before { click_link 'Meter report' }
+          it { expect(page).to have_current_path(admin_school_group_meter_report_path(school_group)) }
+        end
+        it { expect(page).to have_link('Download meter report') }
+        context "clicking 'Download meter report'" do
+          before { click_link 'Download meter report' }
+          it { expect(page).to have_current_path(admin_school_group_meter_report_path(school_group, format: :csv)) }
+        end
+        it { expect(page).to have_link('Delete') }
+        context "clicking 'Delete'" do
+          before { click_link 'Delete' }
+          it { expect(page).to have_current_path(admin_school_groups_path) }
+        end
       end
+
     end
 
     it 'can add a new school group with validation' do

--- a/spec/system/admin/school_groups_spec.rb
+++ b/spec/system/admin/school_groups_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'school groups', :school_groups, type: :system do
   let!(:scoreboard)           { create(:scoreboard, name: 'BANES and Frome') }
   let!(:dark_sky_weather_area) { create(:dark_sky_area, title: 'BANES dark sky weather') }
 
-  def create_school_groups_data(school_groups)
+  def create_data_for_school_groups(school_groups)
     school_groups.each do |school_group|
       onboarding = create :school_onboarding, created_by: admin, school_group: school_group
       visble = create :school, visible: true, data_enabled: false, school_group: school_group
@@ -26,7 +26,7 @@ RSpec.describe 'school groups', :school_groups, type: :system do
 
     describe "Viewing school groups admin page" do
       before do
-        create_school_groups_data(school_groups)
+        create_data_for_school_groups(school_groups)
         click_on 'Edit School Groups'
       end
 
@@ -54,7 +54,9 @@ RSpec.describe 'school groups', :school_groups, type: :system do
 
     describe "Viewing school group page" do
       let(:school_group) { create :school_group }
+
       before do
+        create_data_for_school_groups([school_group])
         visit admin_school_group_path(school_group)
       end
 
@@ -62,12 +64,21 @@ RSpec.describe 'school groups', :school_groups, type: :system do
         expect(page).to have_link('All school groups')
       end
 
-      context "clicking on All school groups" do
+      context "school group status panel" do
+        it { expect(page).to have_content("Active 2") }
+        it { expect(page).to have_content("Active (with data visible) 1") }
+        it { expect(page).to have_content("Invisible 1") }
+        it { expect(page).to have_content("Onboarding 1") }
+        it { expect(page).to have_content("Removed 1") }
+      end
+
+      context "clicking on 'All school groups'" do
         before do
           click_link "All school groups"
         end
         it { expect(page).to have_current_path(admin_school_groups_path) }
       end
+
     end
 
     it 'can add a new school group with validation' do

--- a/spec/system/admin/school_groups_spec.rb
+++ b/spec/system/admin/school_groups_spec.rb
@@ -6,6 +6,16 @@ RSpec.describe 'school groups', :school_groups, type: :system do
   let!(:scoreboard)           { create(:scoreboard, name: 'BANES and Frome') }
   let!(:dark_sky_weather_area) { create(:dark_sky_area, title: 'BANES dark sky weather') }
 
+  def create_school_groups_data(school_groups)
+    school_groups.each do |school_group|
+      onboarding = create :school_onboarding, created_by: admin, school_group: school_group
+      visble = create :school, visible: true, data_enabled: false, school_group: school_group
+      data_visible = create :school, visible: true, data_enabled: true, school_group: school_group
+      invisible = create :school, visible: false, school_group: school_group
+      removed = create :school, active: false, school_group: school_group
+    end
+  end
+
   describe 'when logged in' do
     before(:each) do
       sign_in(admin)
@@ -14,15 +24,9 @@ RSpec.describe 'school groups', :school_groups, type: :system do
       click_on 'Admin'
     end
 
-    describe "Viewing school groups list page" do
+    describe "Viewing school groups admin page" do
       before do
-        school_groups.each do |school_group|
-          onboarding = create :school_onboarding, created_by: admin, school_group: school_group
-          visble = create :school, visible: true, data_enabled: false, school_group: school_group
-          data_visible = create :school, visible: true, data_enabled: true, school_group: school_group
-          invisible = create :school, visible: false, school_group: school_group
-          removed = create :school, active: false, school_group: school_group
-        end
+        create_school_groups_data(school_groups)
         click_on 'Edit School Groups'
       end
 
@@ -49,7 +53,6 @@ RSpec.describe 'school groups', :school_groups, type: :system do
     end
 
     describe "Viewing school group page" do
-      let(:schools) { [] }
       let(:school_group) { create :school_group }
       before do
         visit admin_school_group_path(school_group)

--- a/spec/system/admin/school_groups_spec.rb
+++ b/spec/system/admin/school_groups_spec.rb
@@ -64,6 +64,10 @@ RSpec.describe 'school groups', :school_groups, type: :system do
         expect(page).to have_link('All school groups')
       end
 
+      it "displays pupils in active schools count" do
+        expect(page).to have_content("Pupils in active schools: #{school_group.schools.visible.map(&:number_of_pupils).compact.sum}")
+      end
+
       context "school group status panel" do
         it { expect(page).to have_content("Active 2") }
         it { expect(page).to have_content("Active (with data visible) 1") }

--- a/spec/system/admin/school_groups_spec.rb
+++ b/spec/system/admin/school_groups_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'school groups', :school_groups, type: :system do
       click_on 'Admin'
     end
 
-    context "viewing a tabular list of school groups" do
+    describe "Viewing school groups list page" do
       before do
         school_groups.each do |school_group|
           onboarding = create :school_onboarding, created_by: admin, school_group: school_group
@@ -45,6 +45,25 @@ RSpec.describe 'school groups', :school_groups, type: :system do
           pending "2474-manage-school-group-page"
           expect(page).to have_link('Manage school group')
         end
+      end
+    end
+
+    describe "Viewing school group page" do
+      let(:schools) { [] }
+      let(:school_group) { create :school_group }
+      before do
+        visit admin_school_group_path(school_group)
+      end
+
+      it "has a button to view all school groups" do
+        expect(page).to have_link('All school groups')
+      end
+
+      context "clicking on All school groups" do
+        before do
+          click_link "All school groups"
+        end
+        it { expect(page).to have_current_path(admin_school_groups_path) }
       end
     end
 

--- a/spec/system/admin/school_groups_spec.rb
+++ b/spec/system/admin/school_groups_spec.rb
@@ -1,10 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe 'school groups', :school_groups, type: :system do
-
   let!(:admin)                  { create(:admin) }
-  let!(:scoreboard)             { create(:scoreboard, name: 'BANES and Frome') }
-  let!(:dark_sky_weather_area)  { create(:dark_sky_area, title: 'BANES dark sky weather') }
   let!(:setup_data)             {}
 
   def create_data_for_school_groups(school_groups)
@@ -50,19 +47,26 @@ RSpec.describe 'school groups', :school_groups, type: :system do
           expect(page).to have_link('Manage')
         end
         context "clicking 'Manage'" do
-          before { click_on "Manage", match: :first }
-        #  it { expect(page).to have_current_path(admin_school_group_path(school_groups.first)) }
+          before do
+            within "table" do
+              click_on "Manage", match: :first
+            end
+          end
+          it { expect(page).to have_current_path(admin_school_group_path(school_groups.first)) }
         end
       end
     end
 
     describe "Adding a new school group" do
+      let!(:scoreboard)             { create(:scoreboard, name: 'BANES and Frome') }
+      let!(:dark_sky_weather_area)  { create(:dark_sky_area, title: 'BANES dark sky weather') }
+
       before do
         click_on 'Edit School Groups'
         click_on 'New School group'
       end
 
-      context "when required data is missing" do
+      context "when required data has not been entered" do
         before do
           click_on 'Create School group'
         end
@@ -88,7 +92,9 @@ RSpec.describe 'school groups', :school_groups, type: :system do
       before do
         setup_data
         click_on 'Edit School Groups'
-        click_on "#{school_group.name}" # change to "Manage"
+        within "table" do
+          click_on 'Manage'
+        end
       end
 
       describe "Header" do

--- a/spec/system/admin/school_groups_spec.rb
+++ b/spec/system/admin/school_groups_spec.rb
@@ -44,7 +44,9 @@ RSpec.describe 'school groups', :school_groups, type: :system do
           end
         end
         it "has a link to manage school group" do
-          expect(page).to have_link('Manage')
+          within('table') do
+            expect(page).to have_link('Manage')
+          end
         end
         context "clicking 'Manage'" do
           before do
@@ -63,7 +65,7 @@ RSpec.describe 'school groups', :school_groups, type: :system do
 
       before do
         click_on 'Edit School Groups'
-        click_on 'New School group'
+        click_on 'New school group'
       end
 
       context "when required data has not been entered" do


### PR DESCRIPTION
This PR contains the school group admin page outlined in the trello card, minus, the tabbed list of schools functionality (which has been broken out in to another card):
[Add list of schools tabs to manage school group admin page](https://trello.com/c/tlBW6Ou1/2501-add-list-of-schools-tabs-to-manage-school-group-admin-page)