### PR TITLE
Review/revise GoodJob configuration

### DIFF
--- a/.ebextensions/jobs-log.config
+++ b/.ebextensions/jobs-log.config
@@ -5,7 +5,7 @@ files:
       group: root
       content: |
         /var/app/current/log/jobs.log
-        /var/app/current/log/delayed_job.log
+        /var/app/current/log/good_job.log
 
     "/opt/elasticbeanstalk/tasks/bundlelogs.d/jobs.conf" :
       mode: "000755"
@@ -13,4 +13,4 @@ files:
       group: root
       content: |
         /var/app/current/log/jobs.log
-        /var/app/current/log/delayed_job.log
+        /var/app/current/log/good_job.log

--- a/config/application.rb
+++ b/config/application.rb
@@ -47,6 +47,11 @@ module EnergySparks
     end
 
     config.active_job.queue_adapter = :good_job
+    config.good_job.retry_on_unhandled_error = false
+    config.good_job.max_threads = 5
+    config.good_job.enable_cron = false
+    config.good_job.cleanup_preserved_jobs_before_seconds_ago = 30.days.to_i
+    config.good_job.logger = Logger.new(File.join(Rails.root, 'log', 'good_job.log'))
 
     config.i18n.available_locales = [:en, :cy]
     config.i18n.default_locale = :en


### PR DESCRIPTION
We need to configure some good job settings so we're not relying just on default values.

For the moment we want:

- [x] GoodJob to be default ActiveJob backend
- [x] `:external` to be the default method, except in development and test where we will use `:async`
- [x] all retries to be off, to mimic behaviour of current jobs, so `retry_on_unhandled_error` should be false
- [x] set max threads to 5, although we will override for specific queues
- [x] enable_cron: false (for now)
- [x] change `cleanup_preserved_jobs_before_seconds_ago` to retain for 30 days
- [x] Logger, ideally we want GoodJobs logging to a separate log file, and for that log file to be accessible via ElasticBeanstalk
