### PR TITLE
Queue configuration for Good Job

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
 web:  bundle exec puma -C config/puma.rb
-worker: bundle exec good_job start
+worker: bundle exec good_job --queues="regeneration:2;*;"

--- a/app/jobs/dcc_checker_job.rb
+++ b/app/jobs/dcc_checker_job.rb
@@ -1,6 +1,9 @@
 class DccCheckerJob < ApplicationJob
-  self.queue_adapter = :good_job
   queue_as :default
+
+  def priority
+    5
+  end
 
   def perform(meter)
     Meters::DccChecker.new([meter]).perform

--- a/app/jobs/dcc_grant_trusted_consents_job.rb
+++ b/app/jobs/dcc_grant_trusted_consents_job.rb
@@ -1,6 +1,9 @@
 class DccGrantTrustedConsentsJob < ApplicationJob
-  self.queue_adapter = :good_job
   queue_as :default
+
+  def priority
+    5
+  end
 
   def perform(meters)
     Meters::DccGrantTrustedConsents.new(meters).perform

--- a/app/jobs/manual_data_load_run_job.rb
+++ b/app/jobs/manual_data_load_run_job.rb
@@ -1,6 +1,9 @@
 class ManualDataLoadRunJob < ApplicationJob
-  self.queue_adapter = :good_job
   queue_as :default
+
+  def priority
+    10
+  end
 
   def perform(manual_data_load_run)
     load(manual_data_load_run.amr_uploaded_reading.amr_data_feed_config,

--- a/app/jobs/school_batch_run_job.rb
+++ b/app/jobs/school_batch_run_job.rb
@@ -1,6 +1,9 @@
 class SchoolBatchRunJob < ApplicationJob
-  self.queue_adapter = :good_job
   queue_as :default
+
+  def priority
+    10
+  end
 
   def perform(school_batch_run)
     school_batch_run.update(status: :running)


### PR DESCRIPTION
We will have the following jobs executing via Good Job:

- `DccCheckerJob`, checks meter status after it has been setup. Runs intermittently
- `GrantTrustedConsentsJob`, runs when admin completes review of a meter. So intermittently
- `ManualDataLoadRunJob` runs when admin uploads CSV file. Done regularly during the day
- `SchoolBatchRunJob` runs when admin regenerates a school. Done regularly during the day
- "DailyRegenerationJob" a new job (wip) to run validation and content generation, which will schedule several hundred jobs (one per school) every morning

So we want to ensure that we process the daily regeneration jobs as quickly as possible, so it is faster than the current batch processes. Whilst also ensuring that admin jobs are run as soon as possible, and that the daily regeneration jobs don't swamp the server.

Initially we will configure two queues so we need to update the GoodJob configuration to use:

- [x] `regeneration` queue, configured to use 2 workers. The new "DailyRegenerationJob" will submit jobs to this queue
- [x] `default` queue, configured to use 5 workers. All other jobs submitted to this queue
- [x] When `ManualDataLoadRunJob` and `SchoolBatchRunJob` are submitted give then a priority of `10` and the `DccCheckerJob` and `GrantTrustedConsentsJob` jobs a priority of `5`. This will allow admin jobs to take priority over the other infrequent jobs.