### PR TITLE
Remove generation of old analysis pages

### DIFF
--- a/app/controllers/admin/analysis_controller.rb
+++ b/app/controllers/admin/analysis_controller.rb
@@ -9,14 +9,11 @@ module Admin
 
     before_action :check_aggregated_school_in_cache
     before_action :build_aggregate_school, except: [:analysis]
-    before_action :set_nav
     before_action :set_measurement_options
 
     def analysis
-      if @school.analysis?
-        # Redirect to correct dashboard
-        redirect_to admin_school_analysis_tab_path(school: @school, tab: pages.keys.first)
-      end
+      heat_meter = @aggregate_school.all_heat_meters.first
+      redirect_to admin_school_analysis_tab_path(@school, tab: :heating_model_fitting, mpan_mprn: heat_meter.mpan_mprn)
     end
 
     def show
@@ -28,16 +25,6 @@ module Admin
     def build_aggregate_school
       # use for heat model fitting tabs
       @aggregate_school = aggregate_school
-    end
-
-    def set_nav
-      @nav_array = pages.map do |page, config|
-        { name: config[:name], page: page }
-      end
-    end
-
-    def pages
-      @school.configuration.analysis_charts_as_symbols(:analysis_charts)
     end
 
     def render_generic_chart_template(extra_chart_config = {})

--- a/app/services/schools/generate_configuration.rb
+++ b/app/services/schools/generate_configuration.rb
@@ -19,9 +19,7 @@ module Schools
       configuration.update!(dashboard_charts: dashboard_charts)
 
       analysis_chart_configuration = GenerateAnalysisChartConfiguration.new(@school, @aggregated_meter_collection, fuel_configuration)
-      analysis_charts = analysis_chart_configuration.generate
-      configuration.update!(analysis_charts: analysis_charts)
-
+      configuration.update!(analysis_charts: {})
       pupil_analysis_charts = analysis_chart_configuration.generate([:pupil_analysis_page])
       configuration.update!(pupil_analysis_charts: pupil_analysis_charts)
 

--- a/app/views/admin/analysis/_nav.html.erb
+++ b/app/views/admin/analysis/_nav.html.erb
@@ -1,13 +1,5 @@
 <div class="row" id="nav-row">
   <ul class="nav nav-tabs">
-    <% @nav_array.each do |nav| %>
-      <li>
-        <%= nav_link(nav[:name], admin_school_analysis_tab_path(@school, tab: nav[:page])) %>
-      </li>
-    <% end %>
-
-    <li><%= nav_link('Test', admin_school_analysis_tab_path(tab: :test)) %></li>
-
     <li class="nav-item dropdown">
       <a class="nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button" aria-haspopup="true" aria-expanded="false">Heating Model Fitting</a>
       <div class="dropdown-menu">


### PR DESCRIPTION
There is an Expert Analysis page linked from the Manage School menu for each school (`/admin/schools/:school/analysis`).
which shows a tabbed view of analysis charts for the school. This is the old analysis pages and is now only visible to admins. Only the Heating Model Fitting page is used, to help review the thermostatic models. The page is driven by a list of page sections and charts that are stored in the `analysis_charts` in the `school.configuration`. This value is populated every time we run the content batch, via the `Schools::GenerateAnalysisChartConfiguration` service. The service reads a configuration for the analytics and runs every chart in that configuration, to determine which ones can be successfully run. If so then its added to the config. This was originally done so that we wouldn't display broken charts to users.  But this isn't needed any more as users don't see this page. This means we're unnecessarily running lots of charts every day. E.g. for Freshford Church School its ~18 charts.

This pr covers a first set of steps to remove this functionality:

- [x] Remove the call to `analysis_charts = analysis_chart_configuration.generate` in `GenerateConfiguration` and just set the value of the `analysis_charts` to `{}` (leave other calls in place, as we still need to run the pupil charts
- [x] Change the `Admin:AnalysisController` to always redirect to `admin_school_analysis_tab_path` even if the `analysis_charts` variable is empty
- [x] Update `admin/analysis/_nav.html` to leave only the "Heating Model Fitting" fit, so we can still view these charts
