### PR TITLE
Remove check for whether school is in cache on old controller

### DIFF
--- a/app/controllers/management/schools_controller.rb
+++ b/app/controllers/management/schools_controller.rb
@@ -2,10 +2,6 @@ module Management
   class SchoolsController < ApplicationController
     load_and_authorize_resource
 
-    include SchoolAggregation
-
-    before_action :check_aggregated_school_in_cache
-
     def show
       redirect_to school_path(@school), status: :moved_permanently
     end


### PR DESCRIPTION
This controller should only be hit if a user has a bookmarked link, but its possible there are some older links on the site.

I've removed the check for whether the school is cached as this will happen after the redirect.