### PR TITLE
Include seconds in timestamp for school batch run job

### DIFF
--- a/app/views/schools/batch_runs/show.html.erb
+++ b/app/views/schools/batch_runs/show.html.erb
@@ -26,10 +26,9 @@
   <tbody>
   <% @school_batch_run.school_batch_run_log_entries.by_date.each do |entry| %>
     <tr>
-      <td><%= nice_date_times(entry.created_at) %></td>
+      <td><%= nice_dates(entry.created_at) %> <%= entry.created_at.strftime("%H:%M:%S") %></td>
       <td><%= entry.message %></td>
     </tr>
   <% end %>
   </tbody>
 </table>
-


### PR DESCRIPTION
Some of the steps in the school regeneration job are quite quick but we don't log seconds.

Just tweak the page so it adds seconds to help with identifying any bottlenecks, etc.