### PR TITLE
Allow relative links in Trix

### DIFF
--- a/app/assets/javascripts/trix_customisations.js
+++ b/app/assets/javascripts/trix_customisations.js
@@ -19,3 +19,10 @@ document.addEventListener("trix-action-invoke", function(event) {
     element.editor.insertHTML("{{#chart}}" + $('select[name="chart-list-chart"]').val() + "{{/chart}}");
   }
 })
+
+addEventListener("trix-initialize", event => {
+  const { toolbarElement } = event.target
+  const inputElement = toolbarElement.querySelector("input[name=href]")
+  inputElement.type = "text"
+  inputElement.pattern = "(https?://|/).+"
+})


### PR DESCRIPTION
Trix only allows absolute URLs by default. But we want to allow relative links so that we don't have to maintain English and Welsh versions of links for simple links within the site.

This adds an event listener, as per: https://github.com/basecamp/trix/issues/624 to enable relative links