### PR TITLE
Remove wildcard in queue config

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
 web:  bundle exec puma -C config/puma.rb
-worker: bundle exec good_job start --queues=\"regeneration:2;*;\"
+worker: bundle exec good_job start --queues=\"regeneration:2;default:5;\"


### PR DESCRIPTION
Remove use of wildcard, otherwise the `regeneration` queue can have up to 7 threads running.

