### PR TITLE
Remove explicit count when deleting readings

### DIFF
--- a/app/services/amr/checking_validated_readings_for_a_meter.rb
+++ b/app/services/amr/checking_validated_readings_for_a_meter.rb
@@ -11,9 +11,11 @@ module Amr
       amr_data = @dashboard_meter.amr_data
 
       readings_to_delete = AmrValidatedReading.where(meter_id: @dashboard_meter.external_meter_id).where.not(reading_date: amr_data.keys)
-      deleted_count = readings_to_delete.count
-      readings_to_delete.delete_all
+
+      #this returns the number of rows affected, so no need for the count
+      deleted_count = readings_to_delete.delete_all
       pp "Checked: #{@dashboard_meter} - deleted: #{deleted_count}"
+      deleted_count
     end
   end
 end

--- a/app/services/amr/upsert_validated_readings.rb
+++ b/app/services/amr/upsert_validated_readings.rb
@@ -19,8 +19,14 @@ module Amr
     def process_dashboard_meters(dashboard_meters)
       return if dashboard_meters.empty?
       dashboard_meters.map do |dashboard_meter|
+        #skip if there are no amr data feed reading for this meter id
+        #external_meter_id == the active record id
+        #but where would this happen?
         next if AmrDataFeedReading.where(meter_id: dashboard_meter.external_meter_id).empty?
+
+        #single insert for all data
         upserted_dashboard_meter = UpsertValidatedReadingsForAMeter.new(dashboard_meter).perform
+
         CheckingValidatedReadingsForAMeter.new(upserted_dashboard_meter).perform
       end
     end

--- a/spec/services/amr/checking_validated_readings_for_a_meter_spec.rb
+++ b/spec/services/amr/checking_validated_readings_for_a_meter_spec.rb
@@ -18,10 +18,9 @@ describe Amr::CheckingValidatedReadingsForAMeter do
       gas_dashboard_meter.amr_data.delete(last_reading_date)
 
       upserted_meter_collection = upsert_gas_service.perform
-      Amr::CheckingValidatedReadingsForAMeter.new(upserted_meter_collection).perform
-
+      deleted = Amr::CheckingValidatedReadingsForAMeter.new(upserted_meter_collection).perform
+      expect(deleted).to eq 1
       expect(AmrValidatedReading.count).to be number_of_readings - 1
     end
   end
 end
-


### PR DESCRIPTION
During validation, we could up the rows to be deleted. But the delete method actually returns the number of affected rows. 