### PR TITLE
Optimise loading of meters with readings

### DIFF
--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -257,11 +257,11 @@ class School < ApplicationRecord
   end
 
   def meters_with_readings(supply = Meter.meter_types.keys)
-    active_meters.includes(:amr_data_feed_readings).where(meter_type: supply).where.not(amr_data_feed_readings: { meter_id: nil })
+    active_meters.joins(:amr_data_feed_readings).where(meter_type: supply).where.not(amr_data_feed_readings: { meter_id: nil }).distinct
   end
 
   def meters_with_validated_readings(supply = Meter.meter_types.keys)
-    active_meters.includes(:amr_validated_readings).where(meter_type: supply).where.not(amr_validated_readings: { meter_id: nil })
+    active_meters.joins(:amr_validated_readings).where(meter_type: supply).where.not(amr_validated_readings: { meter_id: nil }).distinct
   end
 
   def fuel_types

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -51,59 +51,59 @@ describe School do
 
   describe '#meters_with_readings' do
     it 'works if explicitly giving a supply type of electricity' do
-      electricity_meter = create(:electricity_meter_with_reading, school: subject)
+      electricity_meter = create(:electricity_meter_with_reading, reading_count: 10, school: subject)
       expect(subject.meters_with_readings(:electricity).first).to eq electricity_meter
       expect(subject.meters_with_readings(:gas)).to be_empty
     end
 
     it 'works if explicitly giving a supply type of gas' do
-      gas_meter = create(:gas_meter_with_reading, school: subject)
+      gas_meter = create(:gas_meter_with_reading, reading_count: 10, school: subject)
       expect(subject.meters_with_readings(:gas).first).to eq gas_meter
       expect(subject.meters_with_readings(:electricity)).to be_empty
     end
 
     it 'works without a supply type for a gas meter' do
-      gas_meter = create(:gas_meter_with_reading, school: subject)
+      gas_meter = create(:gas_meter_with_reading, reading_count: 10, school: subject)
       expect(subject.meters_with_readings.first).to eq gas_meter
     end
 
     it 'works without a supply type for an electricity' do
-      electricity_meter = create(:electricity_meter_with_reading, school: subject)
+      electricity_meter = create(:electricity_meter_with_reading, reading_count: 10, school: subject)
       expect(subject.meters_with_readings.first).to eq electricity_meter
     end
 
     it 'ignores deactivated meters' do
-      electricity_meter = create(:electricity_meter_with_reading, school: subject)
-      electricity_meter_inactive = create(:electricity_meter_with_reading, school: subject, active: false)
+      electricity_meter = create(:electricity_meter_with_reading, reading_count: 10, school: subject)
+      electricity_meter_inactive = create(:electricity_meter_with_reading, reading_count: 10, school: subject, active: false)
       expect(subject.meters_with_readings(:electricity)).to match_array([electricity_meter])
     end
   end
 
   describe '#meters_with_validated_readings' do
     it 'works if explicitly giving a supply type of electricity' do
-      electricity_meter = create(:electricity_meter_with_validated_reading, school: subject)
+      electricity_meter = create(:electricity_meter_with_validated_reading, reading_count: 10, school: subject)
       expect(subject.meters_with_validated_readings(:electricity).first).to eq electricity_meter
       expect(subject.meters_with_validated_readings(:gas)).to be_empty
     end
 
     it 'works if explicitly giving a supply type of gas' do
-      gas_meter = create(:gas_meter_with_validated_reading, school: subject)
+      gas_meter = create(:gas_meter_with_validated_reading, reading_count: 10, school: subject)
       expect(subject.meters_with_validated_readings(:gas).first).to eq gas_meter
       expect(subject.meters_with_validated_readings(:electricity)).to be_empty
     end
 
     it 'works without a supply type for a gas meter' do
-      gas_meter = create(:gas_meter_with_validated_reading, school: subject)
+      gas_meter = create(:gas_meter_with_validated_reading, reading_count: 10, school: subject)
       expect(subject.meters_with_validated_readings.first).to eq gas_meter
     end
 
     it 'works without a supply type for an electricity' do
-      electricity_meter = create(:electricity_meter_with_validated_reading, school: subject)
+      electricity_meter = create(:electricity_meter_with_validated_reading, reading_count: 10, school: subject)
       expect(subject.meters_with_validated_readings.first).to eq electricity_meter
     end
 
     it 'ignores deactivated meters' do
-      electricity_meter = create(:electricity_meter_with_validated_reading, school: subject)
+      electricity_meter = create(:electricity_meter_with_validated_reading, reading_count: 10, school: subject)
       electricity_meter_inactive = create(:electricity_meter_with_validated_reading, school: subject, active: false)
       expect(subject.meters_with_validated_readings(:electricity)).to match_array([electricity_meter])
     end


### PR DESCRIPTION
When we either validate or aggregate schools we identify which of their meters have readings.

This query currently uses `includes` to join to either `amr_data_feed_readings` or `amr_validated_readings`. But this can be slow for schools with a lot of meters. Lots of examples of >500ms queries in the logs.

This PR changes the code to do an explicit `join` which is much quicker. Needed to add a `distinct` to just get the list of meters. Now takes a few milliseconds.

