### PR TITLE
Count amr readings by mpan

### DIFF
--- a/app/services/amr/data_feed_upserter.rb
+++ b/app/services/amr/data_feed_upserter.rb
@@ -26,7 +26,7 @@ module Amr
       @array_of_data_feed_reading_hashes.each do |hash|
         mpans << hash[:mpan_mprn]
       end
-      AmrDataFeedReading.where(mpan_mprn: mpans).count
+      AmrDataFeedReading.where(mpan_mprn: mpans.uniq).count
     end
 
     def add_import_log_id_and_dates_to_hash

--- a/app/services/amr/data_feed_upserter.rb
+++ b/app/services/amr/data_feed_upserter.rb
@@ -6,11 +6,12 @@ module Amr
     end
 
     def perform
-      records_count_before = AmrDataFeedReading.count
+      records_count_before = count_by_mpan
+
       add_import_log_id_and_dates_to_hash
       result = AmrDataFeedReading.upsert_all(@array_of_data_feed_reading_hashes, unique_by: [:mpan_mprn, :reading_date])
 
-      inserted_count = AmrDataFeedReading.count - records_count_before
+      inserted_count = count_by_mpan - records_count_before
       updated_count = result.rows.flatten.size - inserted_count
 
       @amr_data_feed_import_log.update(records_imported: inserted_count, records_updated: updated_count)
@@ -19,6 +20,14 @@ module Amr
     end
 
   private
+
+    def count_by_mpan
+      mpans = []
+      @array_of_data_feed_reading_hashes.each do |hash|
+        mpans << hash[:mpan_mprn]
+      end
+      AmrDataFeedReading.where(mpan_mprn: mpans).count
+    end
 
     def add_import_log_id_and_dates_to_hash
       created_at = DateTime.now.utc

--- a/app/services/content_regenerator.rb
+++ b/app/services/content_regenerator.rb
@@ -5,7 +5,7 @@ class ContentRegenerator
   end
 
   def perform
-    total_amr_readings_before = AmrValidatedReading.count
+    total_amr_readings_before = @school.amr_validated_readings.count
 
     log('Validating and persisting...')
 
@@ -15,9 +15,9 @@ class ContentRegenerator
 
     AggregateSchoolService.new(@school).invalidate_cache
 
-    total_amr_readings_after = AmrValidatedReading.count
+    total_amr_readings_after = @school.amr_validated_readings.count
 
-    log("Total AMR Readings after: #{total_amr_readings_after} - inserted: #{total_amr_readings_after - total_amr_readings_before}")
+    log("Total validated AMR daily readings for school: #{total_amr_readings_after} - inserted: #{total_amr_readings_after - total_amr_readings_before}")
 
     ContentBatch.new([@school], @logger).regenerate
     log('Finished')


### PR DESCRIPTION
Rather than count all records, which is slow, just count those that are likely to match based on the provided list of mpans.