### PR TITLE
Support link rewriting in transifex sync

### DIFF
--- a/app/controllers/admin/activity_types_controller.rb
+++ b/app/controllers/admin/activity_types_controller.rb
@@ -28,6 +28,9 @@ module Admin
         # Top up to 8
         add_activity_type_suggestions(number_of_suggestions_so_far)
       end
+      3.times do
+        @activity_type.link_rewrites.build
+      end
     end
 
     def create
@@ -41,6 +44,8 @@ module Admin
 
     def update
       if @activity_type.update(activity_type_params)
+        #TODO improve
+        @activity_type.update(@activity_type.rewrite_all)
         redirect_to admin_activity_types_path, notice: 'Activity type was successfully updated.'
       else
         render :edit
@@ -79,11 +84,16 @@ module Admin
           subject_ids: [],
           topic_ids: [],
           activity_timing_ids: [],
+          link_rewrites_attributes: link_rewrites_params,
           activity_type_suggestions_attributes: suggestions_params)
     end
 
     def suggestions_params
       [:id, :suggested_type_id, :_destroy]
+    end
+
+    def link_rewrites_params
+      [:id, :source, :target, :_destroy]
     end
 
     def load_filters

--- a/app/controllers/admin/activity_types_controller.rb
+++ b/app/controllers/admin/activity_types_controller.rb
@@ -18,6 +18,9 @@ module Admin
 
     def new
       add_activity_type_suggestions
+      3.times do
+        @activity_type.link_rewrites.build
+      end
     end
 
     def edit

--- a/app/controllers/admin/activity_types_controller.rb
+++ b/app/controllers/admin/activity_types_controller.rb
@@ -44,9 +44,10 @@ module Admin
 
     def update
       if @activity_type.update(activity_type_params)
-        #TODO improve
-        @activity_type.update(@activity_type.rewrite_all)
-        redirect_to admin_activity_types_path, notice: 'Activity type was successfully updated.'
+        #Rewrite links in Welsh text
+        rewritten = @activity_type.update(@activity_type.rewrite_all)
+        notice = rewritten ? 'Activity type was successfully updated.' : 'Activity type was saved, but failed to rewrite links.'
+        redirect_to admin_activity_types_path, notice: notice
       else
         render :edit
       end

--- a/app/controllers/admin/intervention_types_controller.rb
+++ b/app/controllers/admin/intervention_types_controller.rb
@@ -9,6 +9,9 @@ module Admin
 
     def new
       add_intervention_type_suggestions
+      3.times do
+        @intervention_type.link_rewrites.build
+      end
     end
 
     def edit
@@ -18,6 +21,9 @@ module Admin
       else
         # Top up to 8
         add_intervention_type_suggestions(number_of_suggestions_so_far)
+      end
+      3.times do
+        @intervention_type.link_rewrites.build
       end
     end
 
@@ -32,7 +38,10 @@ module Admin
 
     def update
       if @intervention_type.update(intervention_type_params)
-        redirect_to admin_intervention_types_path, notice: 'Intervention type was successfully updated.'
+        #Rewrite links in Welsh text
+        rewritten = @intervention_type.update(@intervention_type.rewrite_all)
+        notice = rewritten ? 'Intervention type was successfully updated.' : 'Intervention type was saved, but failed to rewrite links.'
+        redirect_to admin_intervention_types_path, notice: notice
       else
         render :edit
       end
@@ -62,12 +71,17 @@ module Admin
           :intervention_type_group_id,
           :score,
           :custom,
+          link_rewrites_attributes: link_rewrites_params,
           intervention_type_suggestions_attributes: suggestions_params
       )
     end
 
     def suggestions_params
       [:id, :suggested_type_id, :_destroy]
+    end
+
+    def link_rewrites_params
+      [:id, :source, :target, :_destroy]
     end
   end
 end

--- a/app/models/activity_type.rb
+++ b/app/models/activity_type.rb
@@ -39,6 +39,8 @@ class ActivityType < ApplicationRecord
     school_specific_description: { templated: true },
   }.freeze
 
+  TX_REWRITEABLE_FIELDS = [:description_cy, :school_specific_description_cy, :download_links_cy].freeze
+
   belongs_to :activity_category
 
   has_one_attached :image
@@ -76,6 +78,10 @@ class ActivityType < ApplicationRecord
 
   has_many :audit_activity_types
   has_many :audits, through: :audit_activity_types
+
+  has_many :link_rewrites, as: :rewriteable
+
+  accepts_nested_attributes_for :link_rewrites, reject_if: proc { |attributes| attributes[:source].blank? }, allow_destroy: true
 
   accepts_nested_attributes_for :activity_type_suggestions, reject_if: proc { |attributes| attributes[:suggested_type_id].blank? }, allow_destroy: true
 

--- a/app/models/concerns/transifex_serialisable.rb
+++ b/app/models/concerns/transifex_serialisable.rb
@@ -56,6 +56,8 @@ module TransifexSerialisable
         name = tx_key_to_attribute_name(attr, locale)
         #get value, converting template formats if required
         value = tx_to_attribute_value(attr, tx_attributes)
+        #rewrite links
+        value = rewrite_links_in_value(value) if self.class.tx_rewrite_links?(name.to_sym)
         #add to hash for updating
         to_update[name] = value
       end
@@ -134,6 +136,24 @@ module TransifexSerialisable
     value
   end
 
+  def rewrite_links_in_value(value)
+    link_rewrites.each do |rewrite|
+      value.gsub!(rewrite.source, rewrite.target)
+    end
+    value
+  end
+
+  def rewrite_all
+    rewritten = {}
+    self.class.tx_rewriteable_fields.each do |attr|
+      value = send(attr).to_s.dup
+      value = remove_newlines(value)
+      value = remove_rich_text_wrapper(value)
+      rewritten[attr] = rewrite_links_in_value(value)
+    end
+    rewritten
+  end
+
   private
 
   def remove_newlines(value)
@@ -145,6 +165,11 @@ module TransifexSerialisable
   end
 
   module ClassMethods
+    def tx_rewriteable_fields
+      return [] unless const_defined?(:TX_REWRITEABLE_FIELDS)
+      const_get(:TX_REWRITEABLE_FIELDS)
+    end
+
     def tx_attribute_mapping(attr)
       return {} unless const_defined?(:TX_ATTRIBUTE_MAPPING)
       const_get(:TX_ATTRIBUTE_MAPPING).key?(attr.to_sym) ? const_get(:TX_ATTRIBUTE_MAPPING)[attr.to_sym] : {}
@@ -157,6 +182,10 @@ module TransifexSerialisable
     def tx_html_attribute?(attr)
       mapping = tx_attribute_mapping(attr)
       return mapping.key?(:html) && mapping[:html]
+    end
+
+    def tx_rewrite_links?(attr)
+      return tx_rewriteable_fields.include?(attr)
     end
 
     def tx_templated_attribute?(attr)

--- a/app/models/concerns/transifex_serialisable.rb
+++ b/app/models/concerns/transifex_serialisable.rb
@@ -185,7 +185,7 @@ module TransifexSerialisable
     end
 
     def tx_rewrite_links?(attr)
-      return tx_rewriteable_fields.include?(attr)
+      return tx_model_has_link_rewrites? && tx_rewriteable_fields.include?(attr)
     end
 
     def tx_templated_attribute?(attr)
@@ -196,6 +196,10 @@ module TransifexSerialisable
     #borrowed from: https://github.com/rails/rails/blob/3872bc0e54d32e8bf3a6299b0bfe173d94b072fc/actiontext/lib/action_text/attribute.rb#L61
     def tx_rich_text_field?(name)
       reflect_on_all_associations(:has_one).collect(&:name).include?("rich_text_#{name}".to_sym)
+    end
+
+    def tx_model_has_link_rewrites?
+      reflect_on_all_associations(:has_many).collect(&:name).include?(:link_rewrites)
     end
 
     def tx_resources

--- a/app/models/intervention_type.rb
+++ b/app/models/intervention_type.rb
@@ -26,6 +26,8 @@ class InterventionType < ApplicationRecord
   include TransifexSerialisable
   include Searchable
 
+  TX_REWRITEABLE_FIELDS = [:description_cy, :download_links_cy].freeze
+
   translates :name, type: :string, fallbacks: { cy: :en }
   translates :summary, type: :string, fallbacks: { cy: :en }
   translates :description, backend: :action_text
@@ -38,6 +40,10 @@ class InterventionType < ApplicationRecord
   has_many :suggested_types, through: :intervention_type_suggestions
 
   has_one_attached :image
+
+  has_many :link_rewrites, as: :rewriteable
+
+  accepts_nested_attributes_for :link_rewrites, reject_if: proc { |attributes| attributes[:source].blank? }, allow_destroy: true
 
   accepts_nested_attributes_for :intervention_type_suggestions, reject_if: proc { |attributes| attributes[:suggested_type_id].blank? }, allow_destroy: true
 

--- a/app/models/link_rewrite.rb
+++ b/app/models/link_rewrite.rb
@@ -1,0 +1,5 @@
+class LinkRewrite < ApplicationRecord
+  belongs_to :rewriteable, polymorphic: true
+  validates_presence_of :source, :target
+  validates_uniqueness_of :source, :scope => [:rewriteable_id, :rewriteable_type]
+end

--- a/app/models/link_rewrite.rb
+++ b/app/models/link_rewrite.rb
@@ -2,4 +2,6 @@ class LinkRewrite < ApplicationRecord
   belongs_to :rewriteable, polymorphic: true
   validates_presence_of :source, :target
   validates_uniqueness_of :source, :scope => [:rewriteable_id, :rewriteable_type]
+  validates :source, format: { with: URI::DEFAULT_PARSER.make_regexp }, if: proc { |a| a.source.present? }
+  validates :target, format: { with: URI::DEFAULT_PARSER.make_regexp }, if: proc { |a| a.target.present? }
 end

--- a/app/views/admin/activity_types/_form.html.erb
+++ b/app/views/admin/activity_types/_form.html.erb
@@ -42,39 +42,7 @@
     </div>
   <% end %>
 
-  <div class="row">
-    <div class="col-md-12 mb-3">
-      <h4>Link Rewrites</h4>
-      <small>If any of the original links listed below are found in the
-      Welsh text, they will be replaced with the specified replacement URL. Deleting a replacement will not recover any original links.</small>
-    </div>
-  </div>
-
-  <div class="row">
-    <div class="col-md-5 mb-3">
-      <label>Original URL</label>
-    </div>
-    <div class="col-md-5 mb-3">
-      <label>Replacement URL</label>
-    </div>
-    <div class="col-md-2 mb-3">
-      <label>Delete?</label>
-    </div>
-  </div>
-
-  <%= f.fields_for :link_rewrites do |rewrite| %>
-    <div class="row">
-      <div class="col-md-5 mb-3">
-        <%= rewrite.url_field :source, class: 'form-control' %>
-      </div>
-      <div class="col-md-5 mb-3">
-        <%= rewrite.url_field :target, class: 'form-control' %>
-      </div>
-      <div class="col-md-1 mb-3">
-        <%= rewrite.check_box :_destroy, label: 'Delete', class: 'form-control' %>
-      </div>
-    </div>
-  <% end %>
+  <%= render 'link_rewrites', f: f %>
 
   <%= render 'admin/shared/locale_tabs', f: f, field: :description do |locale| %>
     <div class="description-trix-editor <%= locale %>">

--- a/app/views/admin/activity_types/_form.html.erb
+++ b/app/views/admin/activity_types/_form.html.erb
@@ -44,7 +44,7 @@
 
   <div class="row">
     <div class="col-md-12 mb-3">
-      <h4>Rewrites</h4>
+      <h4>Link Rewrites</h4>
       <small>If any of the original links listed below are found in the
       Welsh text, they will be replaced with the specified replacement URL. Deleting a replacement will not recover any original links.</small>
     </div>
@@ -65,10 +65,10 @@
   <%= f.fields_for :link_rewrites do |rewrite| %>
     <div class="row">
       <div class="col-md-5 mb-3">
-        <%= rewrite.text_field :source, class: 'form-control' %>
+        <%= rewrite.url_field :source, class: 'form-control' %>
       </div>
       <div class="col-md-5 mb-3">
-        <%= rewrite.text_field :target, class: 'form-control' %>
+        <%= rewrite.url_field :target, class: 'form-control' %>
       </div>
       <div class="col-md-1 mb-3">
         <%= rewrite.check_box :_destroy, label: 'Delete', class: 'form-control' %>

--- a/app/views/admin/activity_types/_form.html.erb
+++ b/app/views/admin/activity_types/_form.html.erb
@@ -42,6 +42,40 @@
     </div>
   <% end %>
 
+  <div class="row">
+    <div class="col-md-12 mb-3">
+      <h4>Rewrites</h4>
+      <small>If any of the original links listed below are found in the
+      Welsh text, they will be replaced with the specified replacement URL. Deleting a replacement will not recover any original links.</small>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="col-md-5 mb-3">
+      <label>Original URL</label>
+    </div>
+    <div class="col-md-5 mb-3">
+      <label>Replacement URL</label>
+    </div>
+    <div class="col-md-2 mb-3">
+      <label>Delete?</label>
+    </div>
+  </div>
+
+  <%= f.fields_for :link_rewrites do |rewrite| %>
+    <div class="row">
+      <div class="col-md-5 mb-3">
+        <%= rewrite.text_field :source, class: 'form-control' %>
+      </div>
+      <div class="col-md-5 mb-3">
+        <%= rewrite.text_field :target, class: 'form-control' %>
+      </div>
+      <div class="col-md-1 mb-3">
+        <%= rewrite.check_box :_destroy, label: 'Delete', class: 'form-control' %>
+      </div>
+    </div>
+  <% end %>
+
   <%= render 'admin/shared/locale_tabs', f: f, field: :description do |locale| %>
     <div class="description-trix-editor <%= locale %>">
       <%= f.label ActivityType.human_attribute_name(:description) %>

--- a/app/views/admin/activity_types/_link_rewrites.html.erb
+++ b/app/views/admin/activity_types/_link_rewrites.html.erb
@@ -1,0 +1,33 @@
+<div class="row">
+  <div class="col-md-12 mb-3">
+    <h4>Link Rewrites</h4>
+    <small>If any of the original links listed below are found in the
+    Welsh text, they will be replaced with the specified replacement URL. Deleting a replacement will not recover any original links.</small>
+  </div>
+</div>
+
+<div class="row">
+  <div class="col-md-5 mb-3">
+    <label>Original URL</label>
+  </div>
+  <div class="col-md-5 mb-3">
+    <label>Replacement URL</label>
+  </div>
+  <div class="col-md-2 mb-3">
+    <label>Delete?</label>
+  </div>
+</div>
+
+<%= f.fields_for :link_rewrites do |rewrite| %>
+  <div class="row">
+    <div class="col-md-5 mb-3">
+      <%= rewrite.url_field :source, class: 'form-control' %>
+    </div>
+    <div class="col-md-5 mb-3">
+      <%= rewrite.url_field :target, class: 'form-control' %>
+    </div>
+    <div class="col-md-1 mb-3">
+      <%= rewrite.check_box :_destroy, label: 'Delete', class: 'form-control' %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/admin/activity_types/edit.html.erb
+++ b/app/views/admin/activity_types/edit.html.erb
@@ -1,5 +1,7 @@
 <h1>Editing Activity Type</h1>
 
+<%= render 'shared/errors', subject: @activity_type, subject_name: 'activity' %>
+
 <%= render 'form', activity_type: @activity_type %>
 
 <div class="other-actions">

--- a/app/views/admin/intervention_types/_form.html.erb
+++ b/app/views/admin/intervention_types/_form.html.erb
@@ -37,6 +37,8 @@
     </div>
   <% end %>
 
+  <%= render 'admin/activity_types/link_rewrites', f: f %>
+
   <%= render 'admin/shared/locale_tabs', f: f, field: :description do |locale| %>
     <div class="description-trix-editor <%= locale %>">
       <%= f.label InterventionType.human_attribute_name(:description) %>

--- a/app/views/admin/intervention_types/edit.html.erb
+++ b/app/views/admin/intervention_types/edit.html.erb
@@ -1,5 +1,7 @@
 <h1>Editing Intervention Type</h1>
 
+<%= render 'shared/errors', subject: @intervention_type, subject_name: 'action' %>
+
 <%= render 'form', intervention_type: @intervention_type %>
 
 <div class="other-actions">

--- a/db/migrate/20221012100700_rich_text_link_rewrites.rb
+++ b/db/migrate/20221012100700_rich_text_link_rewrites.rb
@@ -1,0 +1,10 @@
+class RichTextLinkRewrites < ActiveRecord::Migration[6.0]
+  def change
+    create_table :link_rewrites do |t|
+      t.string :source
+      t.string :target
+      t.references :rewriteable, polymorphic: true
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_10_04_165032) do
+ActiveRecord::Schema.define(version: 2022_10_12_100700) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
@@ -871,6 +871,16 @@ ActiveRecord::Schema.define(version: 2022_10_04_165032) do
   create_table "key_stages", force: :cascade do |t|
     t.string "name"
     t.index ["name"], name: "index_key_stages_on_name", unique: true
+  end
+
+  create_table "link_rewrites", force: :cascade do |t|
+    t.string "source"
+    t.string "target"
+    t.string "rewriteable_type"
+    t.bigint "rewriteable_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["rewriteable_type", "rewriteable_id"], name: "index_link_rewrites_on_rewriteable_type_and_rewriteable_id"
   end
 
   create_table "locations", force: :cascade do |t|

--- a/spec/factories/link_rewrites_factory.rb
+++ b/spec/factories/link_rewrites_factory.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :link_rewrite do
+    source { "http://old.example.org" }
+    target { "http://new.example.org" }
+  end
+end


### PR DESCRIPTION
We often need to link to alternate URLs in the Welsh translated version of our activity and action descriptions and download links. E.g. to our own translated resources.

Currently the workflow for this requires admins to use Transifex to modify the links, then wait for content to sync back to the database. This is awkward and might great issues if Welsh text and translations are not properly recreated, re-reviewed, etc.

This PR allows an admin to associate a set of link rewrites to an activity type and intervention type. 

These link rewrites will be applied when the content is updated from Transifex. They will also be applied whenever the model is edited.

This allows us to limit replacement of URLs to the Energy Sparks content management tools.