### PR TITLE
Change queues for active storage

### DIFF
--- a/config/initializers/new_framework_defaults_6_0.rb
+++ b/config/initializers/new_framework_defaults_6_0.rb
@@ -20,8 +20,8 @@ Rails.application.config.action_view.default_enforce_utf8 = false
 Rails.application.config.active_job.return_false_on_aborted_enqueue = true
 
 # Send Active Storage analysis and purge jobs to dedicated queues.
-Rails.application.config.active_storage.queues.analysis = :active_storage_analysis
-Rails.application.config.active_storage.queues.purge    = :active_storage_purge
+Rails.application.config.active_storage.queues.analysis = :default
+Rails.application.config.active_storage.queues.purge    = :default
 
 # Use ActionMailer::MailDeliveryJob for sending parameterized and normal mail.
 #


### PR DESCRIPTION
ActiveStorage apparently uses a couple of jobs for analysing/purging content.

The existing defaults for these use queues we don't have on test or production, so they'd don't run. This puts the jobs onto the default queue.