### PR TITLE
Auto assign solar pv areas

### DIFF
--- a/app/jobs/solar_area_loader_job.rb
+++ b/app/jobs/solar_area_loader_job.rb
@@ -1,0 +1,12 @@
+class SolarAreaLoaderJob < ApplicationJob
+  queue_as :default
+
+  def priority
+    5
+  end
+
+  def perform(area)
+    start_date = Date.yesterday - 30.days
+    DataFeeds::SolarPvTuosLoader.new(start_date).import_area(area)
+  end
+end

--- a/app/services/solar/solar_area_lookup_service.rb
+++ b/app/services/solar/solar_area_lookup_service.rb
@@ -19,7 +19,7 @@ module Solar
     def assign
       solar_area = lookup
       if solar_area
-        solar_area.update(active: true) unless solar_area.active
+        update_and_load_area(solar_area) unless solar_area.active
         @school.update(solar_pv_tuos_area: solar_area)
       else
         Rollbar.error('No solar area found', scope: :solar_area_lookup_service, school: @school_onboarding.school_name)
@@ -28,6 +28,11 @@ module Solar
     end
 
     private
+
+    def update_and_load_area(solar_area)
+      SolarAreaLoaderJob.perform_later solar_area unless solar_area.solar_pv_tuos_readings.any?
+      solar_area.update(active: true)
+    end
 
     def find_nearest_area
       #nearest is last in list

--- a/app/views/admin/school_onboardings/configuration/edit.html.erb
+++ b/app/views/admin/school_onboardings/configuration/edit.html.erb
@@ -8,12 +8,14 @@
       <%= f.select :template_calendar_id, options_from_collection_for_select(Calendar.regional.order(:title), 'id', 'title', (@school_onboarding.template_calendar.id if @school_onboarding.template_calendar)),{},{class: 'form-control'}%>
     </div>
   </div>
-  <div class="form-row">
-    <div class="form-group col-md-6">
-      <%= f.label :solar_pv_tuos_area_id, 'Solar PV from The University of Sheffield Data Feed Area' %>
-      <%= f.select :solar_pv_tuos_area_id, options_from_collection_for_select(SolarPvTuosArea.all.active.order(:title), 'id', 'title', (@school_onboarding.solar_pv_tuos_area.id if @school_onboarding.solar_pv_tuos_area)),{}, { class: 'form-control' }%>
+  <% unless EnergySparks::FeatureFlags.active?(:auto_assign_solar_area) %>
+    <div class="form-row">
+      <div class="form-group col-md-6">
+        <%= f.label :solar_pv_tuos_area_id, 'Solar PV from The University of Sheffield Data Feed Area' %>
+        <%= f.select :solar_pv_tuos_area_id, options_from_collection_for_select(SolarPvTuosArea.all.active.order(:title), 'id', 'title', (@school_onboarding.solar_pv_tuos_area.id if @school_onboarding.solar_pv_tuos_area)),{}, { class: 'form-control' }%>
+      </div>
     </div>
-  </div>
+  <% end %>
   <div class="form-row">
     <div class="form-group col-md-6">
       <%= f.label :dark_sky_area_id, 'Dark Sky Data Feed Area' %>

--- a/app/views/schools/configuration/_form.html.erb
+++ b/app/views/schools/configuration/_form.html.erb
@@ -12,7 +12,6 @@
     <%= f.label :template_calendar_id, 'Template calendar' %>
     <%= f.select :template_calendar_id, options_from_collection_for_select(Calendar.regional.order(:title), 'id', 'title', (@school.template_calendar_id if @school.template_calendar)),{},{ disabled: !edit_template_calendar, class: 'form-control' }%>
   </div>
-
   <div class="form-row">
     <div class="form-group col-md-6">
       <%= f.label :solar_pv_tuos_area_id, 'Solar PV from The University of Sheffield Data Feed Area' %>

--- a/spec/services/solar/solar_area_lookup_service_spec.rb
+++ b/spec/services/solar/solar_area_lookup_service_spec.rb
@@ -40,6 +40,7 @@ describe Solar::SolarAreaLookupService, type: :service do
     end
     it 'assigns the nearest area' do
       ClimateControl.modify FEATURE_FLAG_AUTO_ASSIGN_SOLAR_AREA: 'true' do
+        expect(SolarAreaLoaderJob).to receive(:perform_later).with(bath_area)
         expect(service.assign).to eq bath_area
         expect(school.solar_pv_tuos_area).to eq bath_area
         bath_area.reload


### PR DESCRIPTION
Final changes to allow activation of the auto-assignment of solar area feature.

- removes the solar pv field when creating a school onboarding, as its not required
- adds a background job to load 30 days of data for any solar area that is made active and does not yet have any readings

