### PR TITLE
Display school group wide messages

### DIFF
--- a/app/views/admin/school_groups/index.html.erb
+++ b/app/views/admin/school_groups/index.html.erb
@@ -18,7 +18,11 @@
     <tbody>
       <% @school_groups.each do |school_group| %>
         <tr>
-          <td><%= school_group.name %></td>
+          <td><%= school_group.name %>
+            <% if school_group.dashboard_message %>
+              <span class="badge badge-info" title="Dashboard message is shown for schools in this group: <%= school_group.dashboard_message.message %>"><%= fa_icon(:info) %></span>
+            <% end %>
+          </td>
           <td><%= school_group.school_onboardings.select(&:incomplete?).count %></td>
           <td><%= school_group.schools.visible.count %></td>
           <td><%= school_group.schools.visible.data_enabled.count %></td>

--- a/app/views/admin/school_groups/show.html.erb
+++ b/app/views/admin/school_groups/show.html.erb
@@ -5,7 +5,7 @@
   </div>
 </div>
 <p>Pupils in active schools: <span class="badge badge-success"><%= number_with_delimiter @school_group.schools.visible.map(&:number_of_pupils).compact.sum %></span></p>
-<div class="row">
+<div class="row pb-2">
   <div class="col-lg-12">
     <div class="card-deck">
       <div class="card">
@@ -28,6 +28,8 @@
   </div>
 </div>
 
+<%= render 'admin/shared/dashboard_message', object: @school_group %>
+
 <div class="bg-light p-2 my-2 d-flex justify-content-between">
   <%= link_to 'View', school_group_path(@school_group), class: 'btn btn-sm' %>
   <%= link_to 'Edit', edit_admin_school_group_path(@school_group), class: 'btn btn-sm' %>
@@ -40,7 +42,6 @@
   </div>
 </div>
 
-<%= render 'admin/shared/dashboard_message', object: @school_group %>
 <%= render 'schools_tabs' %>
 
 <div class="tab-content" id="school-group-schools-content">

--- a/app/views/management/schools/_dashboard_message.html.erb
+++ b/app/views/management/schools/_dashboard_message.html.erb
@@ -1,0 +1,8 @@
+<% if school.school_group && school.school_group.dashboard_message.try(:dashboard_message) %>
+  <%= render 'schools/dashboard/info_bar',
+    colour: 'bg-neutral',
+    icon: 'info fa-3x',
+    content: school.school_group.dashboard_message,
+    buttons: { }
+  %>
+<% end %>

--- a/app/views/management/schools/_dashboard_message.html.erb
+++ b/app/views/management/schools/_dashboard_message.html.erb
@@ -1,8 +1,8 @@
-<% if school.school_group && school.school_group.dashboard_message.try(:dashboard_message) %>
+<% if school.school_group && school.school_group.dashboard_message %>
   <%= render 'schools/dashboard/info_bar',
     colour: 'bg-neutral',
-    icon: 'info fa-3x',
-    content: school.school_group.dashboard_message,
+    icon: 'info-circle fa-3x',
+    content: school.school_group.dashboard_message.message,
     buttons: { }
   %>
 <% end %>

--- a/app/views/schools/show.html.erb
+++ b/app/views/schools/show.html.erb
@@ -19,6 +19,10 @@
   <%= render 'shared/dashboard_alerts', dashboard_alerts: @dashboard_alerts, school: @school, content_field: :management_dashboard_title %>
 <% end %>
 
+<% if @show_standard_prompts %>
+  <%= render 'management/schools/dashboard_message', school: @school %>
+<% end %>
+
 <% if @suggest_estimates_for_fuel_types.present? && @suggest_estimates_for_fuel_types.any? %>
   <%= render 'management/schools/prompt_for_estimate', school: @school, fuel_types: @suggest_estimates_for_fuel_types %>
 <% end %>
@@ -44,8 +48,6 @@
 <% end %>
 
 <% if @show_standard_prompts %>
-  <%= render 'management/schools/dashboard_message', school: @school %>
-
   <%= render 'management/schools/complete_programmes', school: @school %>
 
   <%= render 'management/schools/record_activity', school: @school %>

--- a/app/views/schools/show.html.erb
+++ b/app/views/schools/show.html.erb
@@ -44,6 +44,8 @@
 <% end %>
 
 <% if @show_standard_prompts %>
+  <%= render 'management/schools/dashboard_message', school: @school %>
+
   <%= render 'management/schools/complete_programmes', school: @school %>
 
   <%= render 'management/schools/record_activity', school: @school %>

--- a/spec/factories/dashboard_messages.rb
+++ b/spec/factories/dashboard_messages.rb
@@ -1,5 +1,6 @@
 FactoryBot.define do
   factory :dashboard_message do
     message { "MyText" }
+    messageable { create(:school_group) }
   end
 end

--- a/spec/models/dashboard_message_spec.rb
+++ b/spec/models/dashboard_message_spec.rb
@@ -1,5 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe DashboardMessage, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe 'validations' do
+    subject { build(:dashboard_message) }
+
+    it { is_expected.to be_valid }
+    it { is_expected.to validate_presence_of(:message) }
+  end
 end

--- a/spec/support/admin_dashboard_messages.rb
+++ b/spec/support/admin_dashboard_messages.rb
@@ -19,6 +19,11 @@ RSpec.shared_examples "admin dashboard messages" do
           click_on 'Save'
         end
         it { expect(page).to have_content message }
+        context "visiting a school dashboard" do
+          let!(:school) { object.is_a?(School) ? object : create(:school, school_group: school_group) }
+          before { visit school_path(school, switch: true) }
+          it { expect(page).to have_content message }
+        end
       end
       context "when message is invalid" do
         before do
@@ -49,6 +54,11 @@ RSpec.shared_examples "admin dashboard messages" do
           click_on 'Delete'
         end
         it { expect(page).to have_content "No message is currently set to display on dashboards for this #{object.model_name.human.downcase}" }
+        context "visiting a school dashboard" do
+          let!(:school) { object.is_a?(School) ? object : create(:school, school_group: school_group) }
+          before { visit school_path(school, switch: true) }
+          it { expect(page).to_not have_content message }
+        end
       end
     end
   end

--- a/spec/system/schools/dashboard/prompts_spec.rb
+++ b/spec/system/schools/dashboard/prompts_spec.rb
@@ -20,10 +20,15 @@ RSpec.shared_examples "dashboard prompts" do
   it 'has prompt to start survey' do
     expect(page).to have_content("Start a transport survey so that you can find out how much carbon your school community uses by travelling to school")
   end
+
+  it 'has school group dashboard message' do
+    expect(page).to have_content("School group message")
+  end
 end
 
 RSpec.describe "adult dashboard prompts", type: :system do
-  let(:school)             { create(:school) }
+  let(:school)             { create(:school, :with_school_group) }
+  let!(:dashboard_message) { school.school_group.create_dashboard_message(message: "School group message") }
 
   before(:each) do
     sign_in(user) if user.present?
@@ -50,6 +55,10 @@ RSpec.describe "adult dashboard prompts", type: :system do
     it 'does not have prompt to start survey' do
       expect(page).to_not have_content("Start a transport survey so that you can find out how much carbon your school community use")
     end
+
+    it 'does not display school group dashboard message' do
+      expect(page).to_not have_content("School group message")
+    end
   end
 
   context 'as user from another school' do
@@ -73,6 +82,10 @@ RSpec.describe "adult dashboard prompts", type: :system do
 
     it 'does not have prompt to start survey' do
       expect(page).to_not have_content("Start a transport survey so that you can find out how much carbon your school community use")
+    end
+
+    it 'does not display school group dashboard message' do
+      expect(page).to_not have_content("School group message")
     end
   end
 


### PR DESCRIPTION
This displays the school group message on the dashboard - hopefully in the right place @ldodds - let me know if it needs changing! 

In the admin / school groups index, I also added a little info symbol against school groups with a dashboard message set - just to give quick visibility on those with messages set (otherwise you have to click through to each school group to check which ones had messages). Hope that's ok, if not, I can take it out.