### PR TITLE
Handle escaped parameters in rewrite

### DIFF
--- a/app/models/concerns/transifex_serialisable.rb
+++ b/app/models/concerns/transifex_serialisable.rb
@@ -138,7 +138,7 @@ module TransifexSerialisable
 
   def rewrite_links_in_value(value)
     link_rewrites.each do |rewrite|
-      value.gsub!(rewrite.source, rewrite.target)
+      value.gsub!(rewrite.escaped_source, rewrite.target)
     end
     value
   end

--- a/app/models/link_rewrite.rb
+++ b/app/models/link_rewrite.rb
@@ -20,4 +20,8 @@ class LinkRewrite < ApplicationRecord
   validates_uniqueness_of :source, :scope => [:rewriteable_id, :rewriteable_type]
   validates :source, format: { with: URI::DEFAULT_PARSER.make_regexp }, if: proc { |a| a.source.present? }
   validates :target, format: { with: URI::DEFAULT_PARSER.make_regexp }, if: proc { |a| a.target.present? }
+
+  def escaped_source
+    CGI.escape_html(source)
+  end
 end

--- a/spec/models/activity_type_spec.rb
+++ b/spec/models/activity_type_spec.rb
@@ -200,42 +200,66 @@ describe 'ActivityType' do
     end
 
     context 'when there are rewriteable links' do
-      let(:data) { {
-        "cy" => {
-           resource_key => {
-             "name" => "Welsh name",
-             "description_html" => "The Welsh description <a href=\"http://old.example.org\">Link</a>",
-             "school_specific_description_html" => "Instructions for schools. %{chart_name|£}. <a href=\"http://old.example.org\">Link</a>"
-           }
-         }
-       }
-      }
-      let(:rewrite)   { build(:link_rewrite) }
+      let(:source)    { "http://old.example.org" }
+      let(:target)    { "http://new.example.org" }
 
       before(:each) do
-        subject.link_rewrites << rewrite
-        subject.save
-        subject.tx_update(data, :cy)
-        subject.reload
+        subject.link_rewrites.create(source: source, target: target)
       end
 
       it 'correctly identifies rewriteable fields' do
         expect(ActivityType.tx_rewriteable_fields).to match_array([:description_cy, :school_specific_description_cy, :download_links_cy])
       end
 
-      it 'automatically rewrites links on an update' do
-        expect(subject.description_cy.to_s).to eq "<div class=\"trix-content\">\n  The Welsh description <a href=\"http://new.example.org\">Link</a>\n</div>\n"
+      context 'when updating from transifex' do
+        let(:data) { {
+          "cy" => {
+             resource_key => {
+               "name" => "Welsh name",
+               "description_html" => "The Welsh description <a href=\"http://old.example.org\">Link</a>",
+               "school_specific_description_html" => "Instructions for schools. %{chart_name|£}. <a href=\"http://old.example.org\">Link</a>"
+             }
+           }
+         }
+        }
+
+        before(:each) do
+          subject.tx_update(data, :cy)
+          subject.reload
+        end
+
+        context 'and source link is escaped' do
+          let(:source)    { "http://old.example.org?param1=x&param2=y" }
+
+          let(:data) { {
+            "cy" => {
+               resource_key => {
+                 "name" => "Welsh name",
+                 "description_html" => "The Welsh description <a href=\"http://old.example.org?param1=x&amp;param2=y\">Link</a>",
+                 "school_specific_description_html" => "Instructions for schools. %{chart_name|£}. <a href=\"http://old.example.org\">Link</a>"
+               }
+             }
+           }
+          }
+          it 'automatically rewrites links' do
+            expect(subject.description_cy.to_s).to eq "<div class=\"trix-content\">\n  The Welsh description <a href=\"http://new.example.org\">Link</a>\n</div>\n"
+            expect(subject.school_specific_description_cy.to_s).to eq "<div class=\"trix-content\">\n  Instructions for schools. {{#chart}}chart_name|£{{/chart}}. <a href=\"http://old.example.org\">Link</a>\n</div>\n"
+          end
+        end
+
+        it 'automatically rewrites links' do
+          expect(subject.description_cy.to_s).to eq "<div class=\"trix-content\">\n  The Welsh description <a href=\"http://new.example.org\">Link</a>\n</div>\n"
+        end
+
+        it 'rewrites links across all fields' do
+          subject.update!(school_specific_description_cy: '<a href="http://old.example.org">Link</a><a href="http://example.com">Link2</a>')
+
+          rewritten = subject.rewrite_all
+
+          expect(rewritten[:description_cy].to_s).to eq "  The Welsh description <a href=\"http://new.example.org\">Link</a>"
+          expect(rewritten[:school_specific_description_cy].to_s).to eq "  <a href=\"http://new.example.org\">Link</a><a href=\"http://example.com\">Link2</a>"
+        end
       end
-
-      it 'can directly rewrite links across all fields' do
-        subject.update!(school_specific_description_cy: '<a href="http://old.example.org">Link</a><a href="http://example.com">Link2</a>')
-
-        rewritten = subject.rewrite_all
-
-        expect(rewritten[:description_cy].to_s).to eq "  The Welsh description <a href=\"http://new.example.org\">Link</a>"
-        expect(rewritten[:school_specific_description_cy].to_s).to eq "  <a href=\"http://new.example.org\">Link</a><a href=\"http://example.com\">Link2</a>"
-      end
-
     end
 
   end


### PR DESCRIPTION
Turns out that during round-trip to database and converting to string, the links in the HTML description may have escaping applied. This means that link rewriting is failing for some links which have parameters.

A small change (and restructured tests) to escape the URLs before we do the replacement.

