### PR TITLE
Welsh translation snagging list 2

### DIFF
--- a/app/views/management/schools/_overview_data.html.erb
+++ b/app/views/management/schools/_overview_data.html.erb
@@ -17,7 +17,7 @@
       <tr>
         <% if data.period == I18n.t('classes.tables.summary_table_data.last_week') %>
           <td class="icon"><%= fa_icon fuel_type_icon(data.fuel_type) %></td>
-          <td class="text-left"><%= data.fuel_type.to_s.humanize %></td>
+          <td class="text-left"><%= t('common.' + data.fuel_type.to_s) %></td>
         <% else %>
           <td></td>
           <td></td>

--- a/app/views/schools/observations/timeline/_audit.html.erb
+++ b/app/views/schools/observations/timeline/_audit.html.erb
@@ -3,17 +3,17 @@
 </td>
 <td>
   <% if can?(:show, observation.audit) && observation.audit.published? %>
-    <h3 class="pt-1"><strong>Received an energy audit:</strong> <%= link_to observation.audit.title, school_audit_path(@school, observation.audit)%></h3>
+    <h3 class="pt-1"><strong><%= t('schools.observations.timeline.audit.received_an_audit') %>:</strong> <%= link_to observation.audit.title, school_audit_path(@school, observation.audit)%></h3>
   <% else %>
-    <h3 class="pt-1"><strong>Received an energy audit</strong></h3>
+    <h3 class="pt-1"><strong><%= t('schools.observations.timeline.audit.received_an_audit') %></strong></h3>
   <% end %>
   <span class="text-muted"><%= nice_dates(observation.at) %></span>
 </td>
 <% if show_actions && can?(:manage, observation.audit) %>
   <td class="text-right">
     <div class="btn-group">
-      <%= link_to 'Edit', edit_school_audit_path(@school, observation.audit), class: 'btn btn-warning' %>
-      <%= link_to 'Delete', school_audit_path(@school, observation.audit), method: :delete, data: { confirm: 'Are you sure?' }, class: 'btn btn-danger' %>
+      <%= link_to t('common.labels.edit'), edit_school_audit_path(@school, observation.audit), class: 'btn btn-warning' %>
+      <%= link_to t('common.labels.delete'), school_audit_path(@school, observation.audit), method: :delete, data: { confirm: t('common.confirm') }, class: 'btn btn-danger' %>
     </div>
   </td>
 <% end %>

--- a/app/views/schools/observations/timeline/_intervention.html.erb
+++ b/app/views/schools/observations/timeline/_intervention.html.erb
@@ -8,8 +8,8 @@
 <% if show_actions && can?(:manage, observation) %>
   <td class="text-right">
     <div class="btn-group">
-      <%= link_to 'Edit', edit_intervention_path(observation), class: 'btn btn-warning' %>
-      <%= link_to 'Delete', school_intervention_path(@school, observation), method: :delete, data: { confirm: 'Are you sure?' }, class: 'btn btn-danger' %>
+      <%= link_to t('common.labels.edit'), edit_intervention_path(observation), class: 'btn btn-warning' %>
+      <%= link_to t('common.labels.delete'), school_intervention_path(@school, observation), method: :delete, data: { confirm: t('common.confirm') }, class: 'btn btn-danger' %>
     </div>
   </td>
 <% end %>

--- a/app/views/schools/observations/timeline/_temperature.html.erb
+++ b/app/views/schools/observations/timeline/_temperature.html.erb
@@ -2,13 +2,13 @@
   <%= fa_icon("temperature-high fa-2x") %>
 </td>
 <td>
-  <h3 class="pt-1"><%= link_to "Recorded temperatures in #{observation.locations.map(&:name).uniq.to_sentence}", school_temperature_observations_path(@school)%></h3>
+  <h3 class="pt-1"><strong><%= t('schools.observations.timeline.temperatures.recorded_temperatures_in') %></strong>: <%= link_to observation.locations.map(&:name).uniq.to_sentence, school_temperature_observations_path(@school) %></h3>
   <span class="text-muted"><%= nice_dates(observation.at) %></span>
 </td>
 <% if show_actions && can?(:delete, observation) %>
   <td class="text-right">
     <div class="btn-group">
-      <%= link_to 'Delete', school_temperature_observation_path(@school, observation), method: :delete, data: { confirm: 'Are you sure?' }, class: 'btn btn-danger' %>
+      <%= link_to t('common.labels.delete'), school_temperature_observation_path(@school, observation), method: :delete, data: { confirm: t('common.confirm') }, class: 'btn btn-danger' %>
     </div>
   </td>
 <% end %>

--- a/app/views/shared/_dashboard_title.html.erb
+++ b/app/views/shared/_dashboard_title.html.erb
@@ -7,7 +7,7 @@
       <% end %>
       <% if co2_pages && co2_pages.any? %>
         <% co2_pages.each do |page| %>
-          <%= link_to page.analysis_title, school_analysis_path(school, page.analysis_page), class: 'btn btn-outline-dark rounded-pill font-weight-bold' %>
+          <%= link_to t('schools.schools.carbon_emissions'), school_analysis_path(school, page.analysis_page), class: 'btn btn-outline-dark rounded-pill font-weight-bold' %>
         <% end %>
       <% end %>
       <% if school.configuration %>

--- a/config/locales/views/schools/schools.yml
+++ b/config/locales/views/schools/schools.yml
@@ -86,9 +86,9 @@ en:
       compare_schools: Compare schools
       view_schools: View schools
     schools:
+      carbon_emissions: Carbon emissions
       compare_schools: Compare schools
       explore_data: Explore data
-      carbon_emissions: Carbon emissions
       review_energy_analysis: Review energy analysis
     show:
       act_on_energy_usage: Act on energy usage

--- a/config/locales/views/schools/schools.yml
+++ b/config/locales/views/schools/schools.yml
@@ -78,6 +78,10 @@ en:
           other: "%{count} actions"
         activity:
           completed_an_activity: Completed an activity
+        audit:
+          received_an_audit: Received an energy audit
+        temperatures:
+          recorded_temperatures_in: Recorded temperatures in
     school_group:
       compare_schools: Compare schools
       view_schools: View schools

--- a/config/locales/views/schools/schools.yml
+++ b/config/locales/views/schools/schools.yml
@@ -84,6 +84,7 @@ en:
     schools:
       compare_schools: Compare schools
       explore_data: Explore data
+      carbon_emissions: Carbon emissions
       review_energy_analysis: Review energy analysis
     show:
       act_on_energy_usage: Act on energy usage

--- a/spec/system/schools/dashboard/navigation_spec.rb
+++ b/spec/system/schools/dashboard/navigation_spec.rb
@@ -40,7 +40,7 @@ RSpec.shared_examples "navigation" do
       visit school_path(test_school, switch: true)
     end
     it 'shows link to co2 analysis page' do
-      expect(page).to have_link("Some CO2 page")
+      expect(page).to have_link("Carbon emissions")
     end
   end
 


### PR DESCRIPTION
Adds translations for:

- Carbon emissions link on dashboard
- Fuel types in management table
- School timeline partials which didn't have translated timeline entries and button text.