### PR TITLE
Export detail for school groups

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -156,4 +156,5 @@ group :test do
   gem 'webdrivers'
   gem 'simplecov', :require => false, :group => :test
   gem 'shoulda-matchers'
+  gem 'timecop'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -613,6 +613,7 @@ GEM
     thor (1.2.1)
     thread_safe (0.3.6)
     tilt (2.0.10)
+    timecop (0.9.5)
     trix-rails (2.3.0)
       rails (> 4.1, < 7.0)
     twilio-ruby (5.61.2)
@@ -748,6 +749,7 @@ DEPENDENCIES
   terminal-notifier
   terminal-notifier-guard
   test-prof
+  timecop
   trix-rails
   twilio-ruby
   tzinfo-data

--- a/app/controllers/admin/school_groups/school_onboardings_controller.rb
+++ b/app/controllers/admin/school_groups/school_onboardings_controller.rb
@@ -35,11 +35,11 @@ module Admin
         CSV.generate do |csv|
           csv << ['School name', 'State', 'Contact email', 'Notes', 'Last event', 'Last event date', 'Public', 'Visible', 'Active']
 
-          school_group.school_onboardings.by_name.select(&:incomplete?).each do |school_onboarding|
+          school_group.school_onboardings.by_name.incomplete.each do |school_onboarding|
             csv << produce_csv_row_automatic(school_onboarding, 'In progress')
           end
 
-          school_group.school_onboardings.by_name.select(&:complete?).each do |school_onboarding|
+          school_group.school_onboardings.by_name.complete.each do |school_onboarding|
             csv << produce_csv_row_automatic(school_onboarding, 'Complete')
           end
 

--- a/app/controllers/admin/school_groups_controller.rb
+++ b/app/controllers/admin/school_groups_controller.rb
@@ -7,7 +7,7 @@ module Admin
         format.html { @school_groups = @school_groups.by_name }
         format.csv do
           send_data ::SchoolGroups::CsvGenerator.new(@school_groups.by_name).export_detail,
-          filename: "#{SchoolGroup.model_name.human.pluralize}-#{Time.zone.now.iso8601}".parameterize + '.csv'
+          filename: ::SchoolGroups::CsvGenerator.filename
         end
       end
     end

--- a/app/controllers/admin/school_groups_controller.rb
+++ b/app/controllers/admin/school_groups_controller.rb
@@ -3,7 +3,13 @@ module Admin
     load_and_authorize_resource
 
     def index
-      @school_groups = @school_groups.order(:name)
+      respond_to do |format|
+        format.html { @school_groups = @school_groups.by_name }
+        format.csv do
+          send_data ::SchoolGroups::CsvGenerator.new(@school_groups.by_name).export_detail,
+          filename: "#{SchoolGroup.model_name.human.pluralize}-#{Time.zone.now.iso8601}".parameterize + '.csv'
+        end
+      end
     end
 
     def new

--- a/app/controllers/admin/school_onboardings_controller.rb
+++ b/app/controllers/admin/school_onboardings_controller.rb
@@ -17,7 +17,7 @@ module Admin
     end
 
     def completed
-      @completed_schools = @school_onboardings.order(:updated_at).select(&:complete?)
+      @completed_schools = @school_onboardings.complete.order(:updated_at)
     end
 
     def create
@@ -54,7 +54,7 @@ module Admin
       CSV.generate do |csv|
         csv << ['School name', 'School Group Name', 'Contact email', 'Notes', 'Last event']
 
-        @school_onboardings.order(:school_group_id).select(&:incomplete?).each do |school_onboarding|
+        @school_onboardings.order(:school_group_id).incomplete.each do |school_onboarding|
           last_event = school_onboarding.events.order(event: :desc).first.event.to_s.humanize
           csv << [school_onboarding.school_name, school_onboarding.school_group.name, school_onboarding.contact_email, school_onboarding.notes, last_event]
         end

--- a/app/controllers/admin/school_onboardings_controller.rb
+++ b/app/controllers/admin/school_onboardings_controller.rb
@@ -55,7 +55,8 @@ module Admin
         csv << ['School name', 'School Group Name', 'Contact email', 'Notes', 'Last event']
 
         @school_onboardings.order(:school_group_id).incomplete.each do |school_onboarding|
-          last_event = school_onboarding.events.order(event: :desc).first.event.to_s.humanize
+          last_event = school_onboarding.events.order(event: :desc).first
+          last_event = last_event.event.to_s.humanize if last_event
           csv << [school_onboarding.school_name, school_onboarding.school_group.name, school_onboarding.contact_email, school_onboarding.notes, last_event]
         end
       end

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -508,6 +508,10 @@ class School < ApplicationRecord
     school_times.community_use.map(&:to_analytics)
   end
 
+  def self.status_counts
+    { active: self.visible.count, data_visible: self.visible.data_enabled.count, invisible: self.not_visible.count, removed: self.inactive.count }
+  end
+
   private
 
   def add_joining_observation

--- a/app/models/school_onboarding.rb
+++ b/app/models/school_onboarding.rb
@@ -63,6 +63,7 @@ class SchoolOnboarding < ApplicationRecord
   scope :by_name, -> { order(school_name: :asc) }
   scope :complete, -> { joins(:events).where(school_onboarding_events: { event: SchoolOnboardingEvent.events[:onboarding_complete] }) }
   scope :incomplete, ->(parent = nil) { where.not(id: parent ? parent.school_onboardings.complete : complete) }
+  scope :for_school_type, ->(school_type) { joins(:school).where(schools: { school_type: school_type }) }
 
   enum default_chart_preference: [:default, :carbon, :usage, :cost]
 

--- a/app/models/school_onboarding.rb
+++ b/app/models/school_onboarding.rb
@@ -61,6 +61,8 @@ class SchoolOnboarding < ApplicationRecord
   has_many :events, class_name: 'SchoolOnboardingEvent'
 
   scope :by_name, -> { order(school_name: :asc) }
+  scope :complete, -> { joins(:events).where(school_onboarding_events: { event: SchoolOnboardingEvent.events[:onboarding_complete] }) }
+  scope :incomplete, ->(parent = nil) { where.not(id: parent ? parent.school_onboardings.complete : complete) }
 
   enum default_chart_preference: [:default, :carbon, :usage, :cost]
 
@@ -82,10 +84,6 @@ class SchoolOnboarding < ApplicationRecord
 
   def incomplete?
     !complete?
-  end
-
-  def self.incomplete
-    all.select(&:incomplete?)
   end
 
   def started?

--- a/app/models/school_onboarding.rb
+++ b/app/models/school_onboarding.rb
@@ -84,6 +84,10 @@ class SchoolOnboarding < ApplicationRecord
     !complete?
   end
 
+  def self.incomplete
+    all.select(&:incomplete?)
+  end
+
   def started?
     !has_only_sent_email_or_reminder?
   end

--- a/app/services/school_groups/csv_generator.rb
+++ b/app/services/school_groups/csv_generator.rb
@@ -21,11 +21,11 @@ module SchoolGroups
     def export_detail
       CSV.generate(headers: true) do |csv|
         csv << self.class.csv_headers
-        @school_groups.find_each do |g|
-          csv << [g.name, "All school types", g.school_onboardings.incomplete.count] + g.schools.status_counts.slice(*self.class.count_fields).values
+        @school_groups.each do |g|
           School.school_types.each_key do |school_type|
             csv << [g.name, school_type.humanize, g.school_onboardings.for_school_type(school_type).incomplete.count] + g.schools.where(school_type: school_type).status_counts.slice(*self.class.count_fields).values
           end
+          csv << [g.name, "All school types", g.school_onboardings.incomplete.count] + g.schools.status_counts.slice(*self.class.count_fields).values
         end
         csv << ['All Energy Sparks schools', 'All school types', SchoolOnboarding.incomplete.count] + School.all.status_counts.slice(*self.class.count_fields).values
       end

--- a/app/services/school_groups/csv_generator.rb
+++ b/app/services/school_groups/csv_generator.rb
@@ -1,0 +1,30 @@
+module SchoolGroups
+  class CsvGenerator
+    class << self
+      def csv_headers
+        ['School group', 'School type', 'Onboarding', 'Active', 'Data visible', 'Invisible', 'Removed']
+      end
+
+      def count_fields
+        [:active, :data_visible, :invisible, :removed]
+      end
+    end
+
+    def initialize(school_groups)
+      @school_groups = school_groups
+    end
+
+    def export_detail
+      CSV.generate(headers: true) do |csv|
+        csv << self.class.csv_headers
+        @school_groups.find_each do |g|
+          csv << [g.name, "All school types", g.school_onboardings.incomplete.count] + g.schools.status_counts.slice(*self.class.count_fields).values
+          School.school_types.each_key do |school_type|
+            csv << [g.name, school_type.humanize, nil] + g.schools.where(school_type: school_type).status_counts.slice(*self.class.count_fields).values
+          end
+        end
+        csv << ['All Energy Sparks schools', 'All school types', SchoolOnboarding.incomplete.count] + School.all.status_counts.slice(*self.class.count_fields).values
+      end
+    end
+  end
+end

--- a/app/services/school_groups/csv_generator.rb
+++ b/app/services/school_groups/csv_generator.rb
@@ -8,6 +8,10 @@ module SchoolGroups
       def count_fields
         [:active, :data_visible, :invisible, :removed]
       end
+
+      def filename
+        "#{SchoolGroup.model_name.human.pluralize}-#{Time.zone.now.iso8601}".parameterize + '.csv'
+      end
     end
 
     def initialize(school_groups)

--- a/app/services/school_groups/csv_generator.rb
+++ b/app/services/school_groups/csv_generator.rb
@@ -20,7 +20,7 @@ module SchoolGroups
         @school_groups.find_each do |g|
           csv << [g.name, "All school types", g.school_onboardings.incomplete.count] + g.schools.status_counts.slice(*self.class.count_fields).values
           School.school_types.each_key do |school_type|
-            csv << [g.name, school_type.humanize, nil] + g.schools.where(school_type: school_type).status_counts.slice(*self.class.count_fields).values
+            csv << [g.name, school_type.humanize, g.school_onboardings.for_school_type(school_type).incomplete.count] + g.schools.where(school_type: school_type).status_counts.slice(*self.class.count_fields).values
           end
         end
         csv << ['All Energy Sparks schools', 'All school types', SchoolOnboarding.incomplete.count] + School.all.status_counts.slice(*self.class.count_fields).values

--- a/app/views/admin/school_groups/_onboarding_schools.html.erb
+++ b/app/views/admin/school_groups/_onboarding_schools.html.erb
@@ -11,7 +11,7 @@
       </tr>
     </thead>
     <tbody>
-      <% school_group.school_onboardings.by_name.select(&:incomplete?).each do |onboarding| %>
+      <% school_group.school_onboardings.by_name.incomplete.each do |onboarding| %>
         <tr>
           <td><%= f.check_box :school_onboarding_ids, { multiple: true, checked: false }, onboarding.id, nil %></td>
           <td><%= link_to onboarding.school_name, onboarding_path(onboarding) %></td>

--- a/app/views/admin/school_groups/index.html.erb
+++ b/app/views/admin/school_groups/index.html.erb
@@ -24,7 +24,7 @@
               <span class="badge badge-info" title="Dashboard message is shown for schools in this group: <%= school_group.dashboard_message.message %>"><%= fa_icon(:info) %></span>
             <% end %>
           </td>
-          <td><%= school_group.school_onboardings.select(&:incomplete?).count %></td>
+          <td><%= school_group.school_onboardings.incomplete.count %></td>
           <td><%= school_group.schools.visible.count %></td>
           <td><%= school_group.schools.visible.data_enabled.count %></td>
           <td><%= school_group.schools.not_visible.count %></td>
@@ -34,7 +34,7 @@
       <% end %>
       <tr class="font-weight-bold">
         <td>All Energy Sparks Schools</td>
-        <td><%= SchoolOnboarding.all.select(&:incomplete?).count %></td>
+        <td><%= SchoolOnboarding.incomplete.count %></td>
         <td><%= School.visible.count %></td>
         <td><%= School.visible.data_enabled.count %></td>
         <td><%= School.not_visible.count %></td>

--- a/app/views/admin/school_groups/index.html.erb
+++ b/app/views/admin/school_groups/index.html.erb
@@ -1,5 +1,6 @@
 <h1>Manage School Groups</h1>
 <%= link_to 'New school group', new_admin_school_group_path, class: 'btn btn-primary' %>
+<%= link_to "Export detail", admin_school_groups_path(format: :csv), class: 'btn' %>
 <p></p>
 <% if @school_groups.any? %>
   <table class="table table-condensed table-sorted">

--- a/app/views/admin/school_groups/show.html.erb
+++ b/app/views/admin/school_groups/show.html.erb
@@ -13,7 +13,7 @@
           <div>Active <span class="float-right badge badge-success"><%= @school_group.schools.visible.count %></span></div>
           <div>Active (with data visible) <span class="float-right badge badge-success"><%= @school_group.schools.visible.data_enabled.count %></span></div>
           <div>Invisible <span class="float-right badge badge-info"><%= @school_group.schools.not_visible.count %></span></div>
-          <div>Onboarding <span class="float-right badge badge-warning"><%= @school_group.school_onboardings.select(&:incomplete?).count %></span></div>
+          <div>Onboarding <span class="float-right badge badge-warning"><%= @school_group.school_onboardings.incomplete.count %></span></div>
           <div>Removed <span class="float-right badge badge-secondary"><%= @school_group.schools.inactive.count %></span></div>
         </div>
       </div>
@@ -53,7 +53,7 @@
     <% end %>
   </div>
   <div class="tab-pane fade" id="onboarding-content" role="tabpanel" aria-labelledby="onboarding-tab">
-    <% if @school_group.school_onboardings.select(&:incomplete?).any? %>
+    <% if @school_group.school_onboardings.incomplete.any? %>
       <%= render 'onboarding_schools', school_group: @school_group %>
     <% else %>
       <div class="bg-light p-2">No schools currently onboarding for <%= @school_group.name %>.</div>

--- a/app/views/admin/school_onboardings/index.html.erb
+++ b/app/views/admin/school_onboardings/index.html.erb
@@ -23,8 +23,8 @@
   <br/>
   <br/>
 
-  <% if school_group.school_onboardings.select(&:incomplete?).any? %>
-    <p>Schools onboarding: <%= school_group.school_onboardings.select(&:incomplete?).count %>
+  <% if school_group.school_onboardings.incomplete.any? %>
+    <p>Schools onboarding: <%= school_group.school_onboardings.incomplete.count %>
     <%= render 'admin/school_groups/onboarding_schools', school_group: school_group %>
   <% else %>
     <p>No schools are onboarding for <%= school_group.name %></p>

--- a/spec/models/school_onboarding_spec.rb
+++ b/spec/models/school_onboarding_spec.rb
@@ -35,6 +35,32 @@ describe SchoolOnboarding, type: :model do
       expect(onboarding.incomplete?).to be true
       expect(onboarding.complete?).to be false
     end
+  end
 
+  describe ".incomplete" do
+    context "when there is an onboarding with no events" do
+      let!(:incomplete) { create :school_onboarding }
+      it "returns onboarding" do
+        expect(SchoolOnboarding.incomplete).to eq([incomplete])
+      end
+    end
+    context "when an onboarding has events" do
+      let!(:complete) { create :school_onboarding, :with_events, event_names: [:onboarding_complete] }
+      let!(:incomplete) { create :school_onboarding, :with_events, event_names: [:email_sent] }
+      it "returns all incomplete onboardings only" do
+        expect(SchoolOnboarding.incomplete).to eq([incomplete])
+      end
+      context "scoped to school group" do
+        let(:school_group) { create :school_group }
+        let!(:group_complete) { create :school_onboarding, :with_events, event_names: [:onboarding_complete], school_group: school_group }
+        let!(:group_incomplete) { create :school_onboarding, :with_events, event_names: [:email_sent], school_group: school_group }
+        it "returns incomplete onboardings scoped to group only" do
+          expect(school_group.school_onboardings.incomplete).to eq([group_incomplete])
+        end
+        it "returns all incomplete onboardings" do
+          expect(SchoolOnboarding.incomplete).to eq([incomplete, group_incomplete])
+        end
+      end
+    end
   end
 end

--- a/spec/models/transport_survey_response_spec.rb
+++ b/spec/models/transport_survey_response_spec.rb
@@ -69,7 +69,7 @@ describe TransportSurveyResponse do
   describe ".to_csv" do
     let(:transport_survey) { create(:transport_survey) }
     subject { transport_survey.responses.to_csv }
-    let('header') { 'Id,Run identifier,Weather,Weather image,Journey minutes,Transport type name,Transport type image,Passengers,Surveyed at' }
+    let(:header) { 'Id,Run identifier,Weather,Weather image,Journey minutes,Transport type name,Transport type image,Passengers,Surveyed at' }
 
     context "with responses" do
       let!(:responses) do

--- a/spec/services/school_groups/csv_generator_spec.rb
+++ b/spec/services/school_groups/csv_generator_spec.rb
@@ -39,4 +39,13 @@ RSpec.describe SchoolGroups::CsvGenerator do
       expect(data.lines[i].chomp).to eq(['All Energy Sparks schools','All school types', 14, 14, 14, 14, 14].join(","))
     end
   end
+
+  describe ".filename" do
+    subject(:filename) { SchoolGroups::CsvGenerator.filename }
+    it "should include school-groups and time" do
+      Timecop.freeze do
+        expect(filename).to eq "school-groups-#{Time.zone.now.iso8601.parameterize}.csv"
+      end
+    end
+  end
 end

--- a/spec/services/school_groups/csv_generator_spec.rb
+++ b/spec/services/school_groups/csv_generator_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+RSpec.describe SchoolGroups::CsvGenerator do
+
+  def create_data_for_school_groups(school_groups)
+    school_groups.each do |school_group|
+      School.school_types.each_key do |school_type|
+        active_and_data_visible = create :school, visible: true, data_enabled: true, school_group: school_group, school_type: school_type
+        invisible = create :school, visible: false, school_group: school_group, school_type: school_type
+        removed = create :school, active: false, school_group: school_group, school_type: school_type
+        onboarding = create :school_onboarding, school_group: school_group, school: invisible
+      end
+    end
+  end
+
+  context "with school group data" do
+    let(:school_groups) { 2.times.collect { create(:school_group) } }
+    let(:header) { 'School group,School type,Onboarding,Active,Data visible,Invisible,Removed' }
+    subject(:data) { SchoolGroups::CsvGenerator.new(school_groups).export_detail }
+    let(:line_count) { 1 + (School.school_types.length * school_groups.length) + school_groups.length + 1 }
+
+    before do
+      create_data_for_school_groups(school_groups)
+    end
+
+    it { expect(data.lines.count).to eq(line_count) }
+    it { expect(data.lines.first.chomp).to eq(header) }
+
+    it "returns exported detail" do
+      i = 1
+      school_groups.each do |school_group|
+        School.school_types.each_key do |school_type|
+          expect(data.lines[i].chomp).to eq([school_group.name,school_type.humanize, 1, 1, 1, 1, 1].join(","))
+          i+=1
+        end
+        expect(data.lines[i].chomp).to eq([school_group.name,'All school types', 7, 7, 7, 7, 7].join(","))
+        i+=1
+      end
+      expect(data.lines[i].chomp).to eq(['All Energy Sparks schools','All school types', 14, 14, 14, 14, 14].join(","))
+    end
+  end
+end

--- a/spec/system/admin/school_groups_spec.rb
+++ b/spec/system/admin/school_groups_spec.rb
@@ -7,8 +7,7 @@ RSpec.describe 'school groups', :school_groups, type: :system, include_applicati
   def create_data_for_school_groups(school_groups)
     school_groups.each do |school_group|
       onboarding = create :school_onboarding, created_by: admin, school_group: school_group
-      visble = create :school, visible: true, data_enabled: false, school_group: school_group
-      data_visible = create :school, visible: true, data_enabled: true, school_group: school_group
+      active_and_data_visible = create :school, visible: true, data_enabled: true, school_group: school_group
       invisible = create :school, visible: false, school_group: school_group
       removed = create :school, active: false, school_group: school_group
     end
@@ -34,13 +33,13 @@ RSpec.describe 'school groups', :school_groups, type: :system, include_applicati
         it "displays totals for each group" do
           within('table') do
             school_groups.each do |school_group|
-              expect(page).to have_selector(:table_row, { "Name" => school_group.name, "Onboarding" => 1 , "Active" => 2, "Data visible" => 1, "Invisible" => 1, "Removed" => 1 })
+              expect(page).to have_selector(:table_row, { "Name" => school_group.name, "Onboarding" => 1 , "Active" => 1, "Data visible" => 1, "Invisible" => 1, "Removed" => 1 })
             end
           end
         end
         it "displays a grand total" do
           within('table') do
-            expect(page).to have_selector(:table_row, { "Name" => "All Energy Sparks Schools", "Onboarding" => 2 , "Active" => 4, "Data visible" => 2, "Invisible" => 2, "Removed" => 2 })
+            expect(page).to have_selector(:table_row, { "Name" => "All Energy Sparks Schools", "Onboarding" => 2 , "Active" => 2, "Data visible" => 2, "Invisible" => 2, "Removed" => 2 })
           end
         end
         it "has a link to manage school group" do
@@ -135,7 +134,7 @@ RSpec.describe 'school groups', :school_groups, type: :system, include_applicati
 
       describe "School counts by status panel" do
         let!(:setup_data) { create_data_for_school_groups([school_group]) }
-        it { expect(page).to have_content("Active 2") }
+        it { expect(page).to have_content("Active 1") }
         it { expect(page).to have_content("Active (with data visible) 1") }
         it { expect(page).to have_content("Invisible 1") }
         it { expect(page).to have_content("Onboarding 1") }

--- a/spec/system/admin/school_groups_spec.rb
+++ b/spec/system/admin/school_groups_spec.rb
@@ -56,6 +56,26 @@ RSpec.describe 'school groups', :school_groups, type: :system, include_applicati
           end
           it { expect(page).to have_current_path(admin_school_group_path(school_groups.first)) }
         end
+
+        it "displays a link to export detail" do
+          expect(page).to have_link('Export detail')
+        end
+        context "and exporting detail" do
+          before do
+            click_link('Export detail')
+          end
+          it "shows csv contents" do
+            expect(page.body).to eq SchoolGroups::CsvGenerator.new(SchoolGroup.all.by_name).export_detail
+          end
+          it "has csv content type" do
+            expect(response_headers['Content-Type']).to eq 'text/csv'
+          end
+          it "has expected file name" do
+            Timecop.freeze do
+              expect(response_headers['Content-Disposition']).to include(SchoolGroups::CsvGenerator.filename)
+            end
+          end
+        end
       end
     end
 


### PR DESCRIPTION
This PR allows detail for school groups to be exported.

While I was there, I switched out all use of select(&:incomplete?) and select(&:complete?) on school onboardings for new .incomplete and .complete scopes that should be much more efficient.

I put the school export code in it's own service as it didn't feel right to fill up the model or controller with it. Hope this is ok!

Also be aware that when breaking down onboarding counts by school type, that most onboardings don't have an associated school and therefore don't have a school type either - so for example, a school group may show 3 schools onboarding in total but when being broken down by school type, have 0 for each (see example here): [school-groups-2022-10-21t15-58-45z.csv](https://github.com/Energy-Sparks/energy-sparks/files/9840657/school-groups-2022-10-21t15-58-45z.csv)