### PR TITLE
Optimise the Alert and Benchmark Generation Service

### DIFF
--- a/app/services/aggregate_school_service.rb
+++ b/app/services/aggregate_school_service.rb
@@ -38,6 +38,8 @@ class AggregateSchoolService
       meter_collection.aggregated_heat_meters.amr_data.end_date
     elsif fuel_type == :electricity
       meter_collection.aggregated_electricity_meters.amr_data.end_date
+    elsif fuel_type == :storage_heater
+      meter_collection.aggregated_electricity_meters.amr_data.end_date
     else
       Time.zone.today
     end

--- a/app/services/alerts/generate_and_save_alerts.rb
+++ b/app/services/alerts/generate_and_save_alerts.rb
@@ -10,8 +10,11 @@ module Alerts
         @alert_generation_run = AlertGenerationRun.create!(school: @school)
 
         relevant_alert_types.each do |alert_type|
-          alert_type_run_result = GenerateAlertTypeRunResult.new(school: @school, aggregate_school: @aggregate_school, alert_type: alert_type).perform
-          process_alert_type_run_result(alert_type_run_result)
+          service = GenerateAlertTypeRunResult.new(school: @school, aggregate_school: @aggregate_school, alert_type: alert_type, use_max_meter_date_if_less_than_asof_date: true)
+          service.benchmark_dates(asof_date).each do |benchmark_date|
+            alert_type_run_result = service.perform(benchmark_date)
+            process_alert_type_run_result(alert_type_run_result)
+          end
         end
       end
     end

--- a/app/services/alerts/generate_and_save_alerts.rb
+++ b/app/services/alerts/generate_and_save_alerts.rb
@@ -7,8 +7,12 @@ module Alerts
 
     def perform
       ActiveRecord::Base.transaction do
-        alert_type_run_result = GenerateAlertTypeRunResult.new(school: @school, aggregate_school: @aggregate_school, alert_type: alert_type).perform
-        process_alert_type_run_result(alert_type_run_result)
+        @alert_generation_run = AlertGenerationRun.create!(school: @school)
+
+        relevant_alert_types.each do |alert_type|
+          alert_type_run_result = GenerateAlertTypeRunResult.new(school: @school, aggregate_school: @aggregate_school, alert_type: alert_type).perform
+          process_alert_type_run_result(alert_type_run_result)
+        end
       end
     end
 

--- a/app/services/alerts/generate_and_save_alerts.rb
+++ b/app/services/alerts/generate_and_save_alerts.rb
@@ -7,15 +7,8 @@ module Alerts
 
     def perform
       ActiveRecord::Base.transaction do
-        @alert_generation_run = AlertGenerationRun.create!(school: @school)
-
-        relevant_alert_types.each do |alert_type|
-          service = GenerateAlertTypeRunResult.new(school: @school, aggregate_school: @aggregate_school, alert_type: alert_type, use_max_meter_date_if_less_than_asof_date: true)
-          service.benchmark_dates(asof_date).each do |benchmark_date|
-            alert_type_run_result = service.perform(benchmark_date)
-            process_alert_type_run_result(alert_type_run_result)
-          end
-        end
+        alert_type_run_result = GenerateAlertTypeRunResult.new(school: @school, aggregate_school: @aggregate_school, alert_type: alert_type).perform
+        process_alert_type_run_result(alert_type_run_result)
       end
     end
 

--- a/app/services/alerts/generate_and_save_alerts_and_benchmarks.rb
+++ b/app/services/alerts/generate_and_save_alerts_and_benchmarks.rb
@@ -19,7 +19,7 @@ module Alerts
             alert_type: alert_type,
             use_max_meter_date_if_less_than_asof_date: alert_type.fuel_type.present? ? true : false
           )
-          alert_type_run_result = service.perform
+          alert_type_run_result = service.perform(Time.zone.today)
           process_alert_type_run_result(alert_type_run_result)
           process_benchmark_type_run_result(alert_type_run_result) if alert_type.benchmark == true
         end

--- a/app/services/alerts/generate_and_save_alerts_and_benchmarks.rb
+++ b/app/services/alerts/generate_and_save_alerts_and_benchmarks.rb
@@ -17,6 +17,7 @@ module Alerts
             service = GenerateAlertTypeRunResult.new(school: @school, aggregate_school: @aggregate_school, alert_type: alert_type, use_max_meter_date_if_less_than_asof_date: true)
             service.benchmark_dates(asof_date).each do |benchmark_date|
               alert_type_run_result = service.perform(benchmark_date)
+              process_alert_type_run_result(alert_type_run_result)
               process_benchmark_type_run_result(alert_type_run_result)
             end
           else
@@ -29,7 +30,7 @@ module Alerts
 
     private
 
-    def process_alert_benchmark_type_run_result(alert_type_run_result)
+    def process_benchmark_type_run_result(alert_type_run_result)
       asof_date = alert_type_run_result.asof_date
       alert_type = alert_type_run_result.alert_type
 
@@ -42,7 +43,7 @@ module Alerts
       end
     end
 
-    def process_benchmark_report(alert_type, alert_report, asof_date)
+    def process_alert_benchmark_report(alert_type, alert_report, asof_date)
       if alert_report.valid
         if alert_report.benchmark_data.present?
           BenchmarkResult.create!(benchmark_result_school_generation_run: @benchmark_result_school_generation_run, asof: asof_date, alert_type: alert_type, data: alert_report.benchmark_data, results: BenchmarkResult.convert_for_storage(alert_report.benchmark_data))

--- a/app/services/alerts/generate_and_save_alerts_and_benchmarks.rb
+++ b/app/services/alerts/generate_and_save_alerts_and_benchmarks.rb
@@ -9,10 +9,16 @@ module Alerts
       ActiveRecord::Base.transaction do
         create_a_new_school_alert_generation_run
         generate_alert_type_run_results_for_relevant_alert_types
+        # generate_benchmarks
       end
     end
 
     private
+
+    # def generate_benchmarks
+    #   @benchmark_result_generation_run = benchmark_result_generation_run
+    #   @benchmark_result_school_generation_run = BenchmarkResultSchoolGenerationRun.create!(school: @school, benchmark_result_generation_run: @benchmark_result_generation_run)
+    # end
 
     def create_new_aggregate_school_service_for(school)
       AggregateSchoolService.new(school).aggregate_school
@@ -23,13 +29,10 @@ module Alerts
     end
 
     def generate_alert_type_run_results_for(alert_type)
-      alert_type_run_result = GenerateAlertTypeRunResult.new(
-        school: @school,
-        aggregate_school: @aggregate_school,
-        alert_type: alert_type
-                              ).perform
+      alert_type_run_result = GenerateAlertTypeRunResult.new(school: @school, aggregate_school: @aggregate_school, alert_type: alert_type).perform
 
       process_alert_type_run_result(alert_type_run_result)
+      alert_type_run_result
     end
 
     def create_a_new_school_alert_generation_run
@@ -42,10 +45,14 @@ module Alerts
 
     def process_alert_type_run_result(alert_type_run_result)
       # Create error messages
-      alert_type_run_result.error_messages.each { |error_message| create_alert_error_for(alert_type_run_result.asof_date, error_message, alert_type_run_result.alert_type) }
+      alert_type_run_result.error_messages.each do |error_message|
+        create_alert_error_for(alert_type_run_result.asof_date, error_message, alert_type_run_result.alert_type)
+      end
 
       # Process alert type run reports
-      alert_type_run_result.reports.each { |alert_report| process_alert_report(alert_type_run_result.alert_type, alert_report, alert_type_run_result.asof_date) }
+      alert_type_run_result.reports.each do |alert_report|
+        process_alert_report(alert_type_run_result.alert_type, alert_report, alert_type_run_result.asof_date)
+      end
     end
 
     def create_alert_error_for(asof_date, error_message, alert_type)

--- a/app/services/alerts/generate_and_save_alerts_and_benchmarks.rb
+++ b/app/services/alerts/generate_and_save_alerts_and_benchmarks.rb
@@ -1,0 +1,46 @@
+module Alerts
+  class GenerateAndSaveAlertsAndBenchmarks
+    def initialize(school:, aggregate_school: AggregateSchoolService.new(school).aggregate_school)
+      @school = school
+      @aggregate_school = aggregate_school
+    end
+
+    def perform
+      ActiveRecord::Base.transaction do
+        @alert_generation_run = AlertGenerationRun.create!(school: @school)
+
+        relevant_alert_types.each do |alert_type|
+          alert_type_run_result = GenerateAlertTypeRunResult.new(school: @school, aggregate_school: @aggregate_school, alert_type: alert_type).perform
+          process_alert_type_run_result(alert_type_run_result)
+        end
+      end
+    end
+
+    private
+
+    def relevant_alert_types
+      RelevantAlertTypes.new(@school).list
+    end
+
+    def process_alert_type_run_result(alert_type_run_result)
+      asof_date = alert_type_run_result.asof_date
+      alert_type = alert_type_run_result.alert_type
+
+      alert_type_run_result.error_messages.each do |error_message|
+        AlertError.create!(alert_generation_run: @alert_generation_run, asof_date: asof_date, information: error_message, alert_type: alert_type)
+      end
+
+      alert_type_run_result.reports.each do |alert_report|
+        process_alert_report(alert_type, alert_report, asof_date)
+      end
+    end
+
+    def process_alert_report(alert_type, alert_report, asof_date)
+      if alert_report.valid
+        Alert.create(AlertAttributesFactory.new(@school, alert_report, @alert_generation_run, alert_type, asof_date).generate)
+      else
+        AlertError.create!(alert_generation_run: @alert_generation_run, asof_date: asof_date, information: "INVALID. Relevance: #{alert_report.relevance}", alert_type: alert_type)
+      end
+    end
+  end
+end

--- a/app/services/alerts/generate_and_save_alerts_and_benchmarks.rb
+++ b/app/services/alerts/generate_and_save_alerts_and_benchmarks.rb
@@ -1,94 +1,79 @@
 module Alerts
   class GenerateAndSaveAlertsAndBenchmarks
-    def initialize(school:, aggregate_school: nil, benchmark_result_generation_run: nil)
+    def initialize(school:, aggregate_school: nil, benchmark_result_generation_run: nil, framework_adapter: FrameworkAdapter)
       @school = school
-      @aggregate_school = aggregate_school || create_new_aggregate_school_service_for(school)
-      @benchmark_result_generation_run = benchmark_result_generation_run || BenchmarkResultGenerationRun.latest
+      @aggregate_school = aggregate_school || AggregateSchoolService.new(school).aggregate_school
+      @benchmark_result_generation_run = benchmark_result_generation_run || BenchmarkResultGenerationRun.create!
+      @framework_adapter = framework_adapter
     end
 
-    def perform
+    def perform(asof_date = Time.zone.today)
       ActiveRecord::Base.transaction do
-        create_a_new_school_alert_generation_run
-        generate_alert_type_run_results_for_relevant_alert_types
+        @alert_generation_run = AlertGenerationRun.create!(school: @school)
+        @benchmark_result_school_generation_run = BenchmarkResultSchoolGenerationRun.create!(school: @school, benchmark_result_generation_run: @benchmark_result_generation_run)
+
+        relevant_alert_types.each do |alert_type|
+          if alert_type.benchmark == true
+            service = GenerateAlertTypeRunResult.new(school: @school, aggregate_school: @aggregate_school, alert_type: alert_type, use_max_meter_date_if_less_than_asof_date: true)
+            service.benchmark_dates(asof_date).each do |benchmark_date|
+              alert_type_run_result = service.perform(benchmark_date)
+              process_benchmark_type_run_result(alert_type_run_result)
+            end
+          else
+            alert_type_run_result = GenerateAlertTypeRunResult.new(school: @school, aggregate_school: @aggregate_school, alert_type: alert_type).perform
+            process_alert_type_run_result(alert_type_run_result)
+          end
+        end
       end
     end
 
     private
 
-    def create_new_aggregate_school_service_for(school)
-      AggregateSchoolService.new(school).aggregate_school
+    def process_alert_benchmark_type_run_result(alert_type_run_result)
+      asof_date = alert_type_run_result.asof_date
+      alert_type = alert_type_run_result.alert_type
+
+      alert_type_run_result.error_messages.each do |error_message|
+        BenchmarkResultError.create!(benchmark_result_school_generation_run: @benchmark_result_school_generation_run, asof_date: asof_date, information: error_message, alert_type: alert_type)
+      end
+
+      alert_type_run_result.reports.each do |alert_report|
+        process_alert_benchmark_report(alert_type, alert_report, asof_date)
+      end
     end
 
-    def generate_alert_type_run_results_for_relevant_alert_types
-      find_relevant_alert_types.each do |alert_type|
-        if alert_type.benchmark
-          generate_alert_type_and_benchmark_run_results_for(alert_type)
-        else
-          generate_alert_type_run_results_for(alert_type)
+    def process_benchmark_report(alert_type, alert_report, asof_date)
+      if alert_report.valid
+        if alert_report.benchmark_data.present?
+          BenchmarkResult.create!(benchmark_result_school_generation_run: @benchmark_result_school_generation_run, asof: asof_date, alert_type: alert_type, data: alert_report.benchmark_data, results: BenchmarkResult.convert_for_storage(alert_report.benchmark_data))
         end
+      else
+        BenchmarkResultError.create!(benchmark_result_school_generation_run: @benchmark_result_school_generation_run, asof_date: asof_date, information: "Relevance: #{alert_report.relevance}", alert_type: alert_type)
       end
     end
 
-    def generate_alert_type_and_benchmark_run_results_for(alert_type)
-      asof_date = Time.zone.today # placeholder until we know what to do with asof dates
-
-      service = GenerateAlertTypeRunResult.new(school: @school, aggregate_school: @aggregate_school, alert_type: alert_type, use_max_meter_date_if_less_than_asof_date: true)
-      service.benchmark_dates(asof_date).each do |benchmark_date|
-        alert_type_run_result = service.perform(benchmark_date)
-        process_alert_type_run_result(alert_type_run_result)
-      end
-    end
-
-    def generate_alert_type_run_results_for(alert_type)
-      alert_type_run_result = GenerateAlertTypeRunResult.new(school: @school, aggregate_school: @aggregate_school, alert_type: alert_type).perform
-
-      process_alert_type_run_result(alert_type_run_result)
-    end
-
-    def create_a_new_school_alert_generation_run
-      @alert_generation_run = AlertGenerationRun.create!(school: @school)
-    end
-
-    def find_relevant_alert_types
-      Alerts::RelevantAlertTypes.new(@school).list
+    def relevant_alert_types
+      RelevantAlertTypes.new(@school).list
     end
 
     def process_alert_type_run_result(alert_type_run_result)
-      # Create error messages
+      asof_date = alert_type_run_result.asof_date
+      alert_type = alert_type_run_result.alert_type
+
       alert_type_run_result.error_messages.each do |error_message|
-        create_alert_error_for(alert_type_run_result.asof_date, error_message, alert_type_run_result.alert_type)
+        AlertError.create!(alert_generation_run: @alert_generation_run, asof_date: asof_date, information: error_message, alert_type: alert_type)
       end
 
-      # Process alert type run reports
       alert_type_run_result.reports.each do |alert_report|
-        process_alert_report(alert_type_run_result.alert_type, alert_report, alert_type_run_result.asof_date)
+        process_alert_report(alert_type, alert_report, asof_date)
       end
-    end
-
-    def create_alert_error_for(asof_date, error_message, alert_type)
-      AlertError.create!(
-        alert_generation_run: @alert_generation_run,
-        asof_date: asof_date,
-        information: error_message,
-        alert_type: alert_type
-      )
-    end
-
-    def create_alert_for(asof_date, alert_report, alert_type)
-      alert_attributes = build_alert_attributes_for(alert_report, alert_type, asof_date)
-
-      Alert.create!(alert_attributes)
-    end
-
-    def build_alert_attributes_for(alert_report, alert_type, asof_date)
-      AlertAttributesFactory.new(@school, alert_report, @alert_generation_run, alert_type, asof_date).generate
     end
 
     def process_alert_report(alert_type, alert_report, asof_date)
       if alert_report.valid
-        create_alert_for(asof_date, alert_report, alert_type)
+        Alert.create(AlertAttributesFactory.new(@school, alert_report, @alert_generation_run, alert_type, asof_date).generate)
       else
-        create_alert_error_for(asof_date, "INVALID. Relevance: #{alert_report.relevance}", alert_type)
+        AlertError.create!(alert_generation_run: @alert_generation_run, asof_date: asof_date, information: "INVALID. Relevance: #{alert_report.relevance}", alert_type: alert_type)
       end
     end
   end

--- a/app/services/alerts/generate_and_save_alerts_and_benchmarks.rb
+++ b/app/services/alerts/generate_and_save_alerts_and_benchmarks.rb
@@ -10,7 +10,7 @@ module Alerts
       @benchmark_result_generation_run = benchmark_result_generation_run
     end
 
-    def perform
+    def perform(asof_date = Time.zone.today)
       ActiveRecord::Base.transaction do
         @alert_generation_run = AlertGenerationRun.create!(school: @school)
         @benchmark_result_school_generation_run = BenchmarkResultSchoolGenerationRun.create!(school: @school, benchmark_result_generation_run: @benchmark_result_generation_run)

--- a/app/services/alerts/generate_and_save_alerts_and_benchmarks.rb
+++ b/app/services/alerts/generate_and_save_alerts_and_benchmarks.rb
@@ -7,23 +7,16 @@ module Alerts
       @framework_adapter = framework_adapter
     end
 
-    def perform(asof_date = Time.zone.today)
+    def perform
       ActiveRecord::Base.transaction do
         @alert_generation_run = AlertGenerationRun.create!(school: @school)
         @benchmark_result_school_generation_run = BenchmarkResultSchoolGenerationRun.create!(school: @school, benchmark_result_generation_run: @benchmark_result_generation_run)
 
         relevant_alert_types.each do |alert_type|
-          if alert_type.benchmark == true
-            service = GenerateAlertTypeRunResult.new(school: @school, aggregate_school: @aggregate_school, alert_type: alert_type, use_max_meter_date_if_less_than_asof_date: true)
-            service.benchmark_dates(asof_date).each do |benchmark_date|
-              alert_type_run_result = service.perform(benchmark_date)
-              process_alert_type_run_result(alert_type_run_result)
-              process_benchmark_type_run_result(alert_type_run_result)
-            end
-          else
-            alert_type_run_result = GenerateAlertTypeRunResult.new(school: @school, aggregate_school: @aggregate_school, alert_type: alert_type).perform
-            process_alert_type_run_result(alert_type_run_result)
-          end
+          service = GenerateAlertTypeRunResult.new(school: @school, aggregate_school: @aggregate_school, alert_type: alert_type, use_max_meter_date_if_less_than_asof_date: true)
+          alert_type_run_result = service.perform
+          process_alert_type_run_result(alert_type_run_result)
+          process_benchmark_type_run_result(alert_type_run_result) if alert_type.benchmark == true
         end
       end
     end

--- a/app/services/alerts/generate_and_save_alerts_and_benchmarks.rb
+++ b/app/services/alerts/generate_and_save_alerts_and_benchmarks.rb
@@ -13,7 +13,12 @@ module Alerts
         @benchmark_result_school_generation_run = BenchmarkResultSchoolGenerationRun.create!(school: @school, benchmark_result_generation_run: @benchmark_result_generation_run)
 
         relevant_alert_types.each do |alert_type|
-          service = GenerateAlertTypeRunResult.new(school: @school, aggregate_school: @aggregate_school, alert_type: alert_type, use_max_meter_date_if_less_than_asof_date: true)
+          service = GenerateAlertTypeRunResult.new(
+            school: @school,
+            aggregate_school: @aggregate_school,
+            alert_type: alert_type,
+            use_max_meter_date_if_less_than_asof_date: alert_type.fuel_type.present? ? true : false
+          )
           alert_type_run_result = service.perform
           process_alert_type_run_result(alert_type_run_result)
           process_benchmark_type_run_result(alert_type_run_result) if alert_type.benchmark == true

--- a/app/services/alerts/generate_and_save_alerts_and_benchmarks.rb
+++ b/app/services/alerts/generate_and_save_alerts_and_benchmarks.rb
@@ -1,65 +1,77 @@
 module Alerts
   class GenerateAndSaveAlertsAndBenchmarks
-    def initialize(school, aggregate_school, benchmark_result_generation_run)
+    def initialize(school:, aggregate_school: nil)
       @school = school
-      @aggregate_school = aggregate_school || AggregateSchoolService.new(school).aggregate_school
-      @benchmark_result_generation_run = benchmark_result_generation_run || BenchmarkResultGenerationRun.latest
+      @aggregate_school = aggregate_school || create_new_aggregate_school_service_for(school)
     end
 
     def perform
       ActiveRecord::Base.transaction do
-        build_alerts_and_alert_types
-      end
-    end
-
-    def build_alerts_and_alert_types
-      # Run though all of the schools alerts
-      @alert_generation_run = AlertGenerationRun.create!(school: @school)
-
-      relevant_alert_types.each do |alert_type|
+        create_a_new_school_alert_generation_run
+        generate_alert_type_run_results_for_relevant_alert_types
       end
     end
 
     private
 
-    def relevant_alert_types
+    def create_new_aggregate_school_service_for(school)
+      AggregateSchoolService.new(school).aggregate_school
+    end
+
+    def generate_alert_type_run_results_for_relevant_alert_types
+      find_relevant_alert_types.each { |alert_type| generate_alert_type_run_results_for(alert_type) }
+    end
+
+    def generate_alert_type_run_results_for(alert_type)
+      alert_type_run_result = GenerateAlertTypeRunResult.new(
+        school: @school,
+        aggregate_school: @aggregate_school,
+        alert_type: alert_type
+                              ).perform
+
+      process_alert_type_run_result(alert_type_run_result)
+    end
+
+    def create_a_new_school_alert_generation_run
+      @alert_generation_run = AlertGenerationRun.create!(school: @school)
+    end
+
+    def find_relevant_alert_types
       RelevantAlertTypes.new(@school).list
     end
 
-    # def perform(asof_date = Time.zone.today)
-    #   ActiveRecord::Base.transaction do
-    #     @alert_generation_run = AlertGenerationRun.create!(school: @school)
-    #     @benchmark_result_school_generation_run = BenchmarkResultSchoolGenerationRun.create!(school: @school, benchmark_result_generation_run: @benchmark_result_generation_run)
-
-    #     relevant_alert_types.each do |alert_type|
-    #       service = alert_type_run_result = GenerateAlertTypeRunResult.new(school: @school, aggregate_school: @aggregate_school, alert_type: alert_type, use_max_meter_date_if_less_than_asof_date: true).perform
-
-    #       service.benchmark_dates(asof_date).each do |benchmark_date|
-    #         alert_type_run_result = service.perform(benchmark_date)
-    #         process_alert_type_run_result(alert_type_run_result)
-    #       end
-    #     end
-    #   end
-    # end
-
     def process_alert_type_run_result(alert_type_run_result)
-      asof_date = alert_type_run_result.asof_date
-      alert_type = alert_type_run_result.alert_type
+      # Create error messages
+      alert_type_run_result.error_messages.each { |error_message| create_alert_error_for(alert_type_run_result.asof_date, error_message, alert_type_run_result.alert_type) }
 
-      alert_type_run_result.error_messages.each do |error_message|
-        AlertError.create!(alert_generation_run: @alert_generation_run, asof_date: asof_date, information: error_message, alert_type: alert_type)
-      end
+      # Process alert type run reports
+      alert_type_run_result.reports.each { |alert_report| process_alert_report(alert_type_run_result.alert_type, alert_report, alert_type_run_result.asof_date) }
+    end
 
-      alert_type_run_result.reports.each do |alert_report|
-        process_alert_report(alert_type, alert_report, asof_date)
-      end
+    def create_alert_error_for(asof_date, error_message, alert_type)
+      AlertError.create!(
+        alert_generation_run: @alert_generation_run,
+        asof_date: asof_date,
+        information: error_message,
+        alert_type: alert_type
+      )
+    end
+
+    def create_alert_for(asof_date, alert_report, alert_type)
+      alert_attributes = build_alert_attributes_for(alert_report, alert_type, asof_date)
+
+      Alert.create!(alert_attributes)
+    end
+
+    def build_alert_attributes_for(alert_report, alert_type, asof_date)
+      AlertAttributesFactory.new(@school, alert_report, @alert_generation_run, alert_type, asof_date).generate
     end
 
     def process_alert_report(alert_type, alert_report, asof_date)
       if alert_report.valid
-        Alert.create(AlertAttributesFactory.new(@school, alert_report, @alert_generation_run, alert_type, asof_date).generate)
+        create_alert_for(asof_date, alert_report, alert_type)
       else
-        AlertError.create!(alert_generation_run: @alert_generation_run, asof_date: asof_date, information: "INVALID. Relevance: #{alert_report.relevance}", alert_type: alert_type)
+        create_alert_error_for(asof_date, "INVALID. Relevance: #{alert_report.relevance}", alert_type)
       end
     end
   end

--- a/app/services/content_batch.rb
+++ b/app/services/content_batch.rb
@@ -33,15 +33,16 @@ class ContentBatch
 
       @logger.info "Generated configuration"
 
-      # Generate alerts
-      suppress_output { Alerts::GenerateAndSaveAlerts.new(school: school, aggregate_school: aggregate_school).perform }
+      # Generate alerts & benchmarks
+      suppress_output do
+        Alerts::GenerateAndSaveAlertsAndBenchmarks.new(
+          school: school,
+          aggregate_school: aggregate_school,
+          benchmark_result_generation_run: benchmark_result_generation_run
+        ).perform
+      end
 
-      @logger.info "Generated alerts"
-
-      # Generate benchmarks
-      suppress_output { Alerts::GenerateAndSaveBenchmarks.new(school: school, aggregate_school: aggregate_school, benchmark_result_generation_run: benchmark_result_generation_run).perform }
-
-      @logger.info "Generated benchmarks"
+      @logger.info "Generated alerts & benchmarks"
 
       # Generate equivalences
       suppress_output { Equivalences::GenerateEquivalences.new(school: school, aggregate_school: aggregate_school).perform }

--- a/spec/services/aggregate_school_service_spec.rb
+++ b/spec/services/aggregate_school_service_spec.rb
@@ -22,27 +22,29 @@ describe AggregateSchoolService, type: :service do
   before(:each) do
     allow(electricity_amr_data).to receive(:end_date).and_return(electricity_end_date)
     allow(gas_amr_data).to receive(:end_date).and_return(gas_end_date)
-#    allow(heaters_amr_data).to receive(:end_date).and_return(heaters_end_date)
+    # allow(heaters_amr_data).to receive(:end_date).and_return(heaters_end_date)
 
     allow(electricity_aggregate_meter).to receive(:amr_data).and_return(electricity_amr_data)
     allow(gas_aggregate_meter).to receive(:amr_data).and_return(gas_amr_data)
-#    allow(heaters_aggregate_meter).to receive(:amr_data).and_return(heaters_amr_data)
+    # allow(heaters_aggregate_meter).to receive(:amr_data).and_return(heaters_amr_data)
 
     allow(meter_collection).to receive(:aggregated_electricity_meters).and_return(electricity_aggregate_meter)
     allow(meter_collection).to receive(:aggregated_heat_meters).and_return(gas_aggregate_meter)
-#    allow(meter_collection).to receive(:aggregate_meter).with(:storage_heater).and_return(heaters_aggregate_meter)
+    # allow(meter_collection).to receive(:aggregate_meter).with(:storage_heater).and_return(heaters_aggregate_meter)
   end
 
   context '#analysis_date' do
     it 'returns end date for gas' do
       expect( AggregateSchoolService.analysis_date(meter_collection, :gas)).to eq(gas_end_date)
     end
-    it 'returns end data for electricity' do
+    it 'returns end date for electricity' do
       expect( AggregateSchoolService.analysis_date(meter_collection, :electricity)).to eq(electricity_end_date)
+    end
+    it 'returns end date for storage heaters' do
+      expect( AggregateSchoolService.analysis_date(meter_collection, :storage_heater)).to eq(electricity_end_date)
     end
     it 'returns today otherwise' do
       expect( AggregateSchoolService.analysis_date(meter_collection, nil)).to eq(Date.today)
-      expect( AggregateSchoolService.analysis_date(meter_collection, :storage_heater)).to eq(Date.today)
       expect( AggregateSchoolService.analysis_date(meter_collection, :solar_pv)).to eq(Date.today)
     end
   end

--- a/spec/services/alerts/generate_and_save_alerts_and_benchmarks_spec.rb
+++ b/spec/services/alerts/generate_and_save_alerts_and_benchmarks_spec.rb
@@ -35,7 +35,7 @@ module Alerts
     let(:example_invalid_report) do
       invalid_alert_report_attributes = alert_report_attributes.clone
       invalid_alert_report_attributes[:valid] = false
-      invalid_alert_report_attributes[:template_data] = { template: 'invalid'}
+      invalid_alert_report_attributes[:template_data] = { template: 'invalid' }
       Adapters::Report.new(**invalid_alert_report_attributes)
     end
 
@@ -85,9 +85,9 @@ module Alerts
 
         service = GenerateAndSaveAlertsAndBenchmarks.new(school: school, aggregate_school: aggregate_school)
         expect { service.perform }.to change { Alert.count }.by(0) &&
-                                      change { AlertError.count }.by(1)
-        change { BenchmarkResult.count }.by(0) &&
-          change { BenchmarkResultError.count }.by(0)
+                                      change { AlertError.count }.by(1) &&
+                                      change { BenchmarkResult.count }.by(0) &&
+                                      change { BenchmarkResultError.count }.by(0)
       end
 
       it 'handles alert and benchmark reports' do
@@ -115,10 +115,10 @@ module Alerts
 
         service = GenerateAndSaveAlertsAndBenchmarks.new(school: school, aggregate_school: aggregate_school)
         expect { service.perform }.to change { Alert.count }.by(0) &&
-                                      change { AlertError.count }.by(1)
-        change { BenchmarkResult.count }.by(0) &&
-          change { BenchmarkResultError.count }.by(2) &&
-          change { BenchmarkResultSchoolGenerationRun.count }.by(1)
+                                      change { AlertError.count }.by(1) &&
+                                      change { BenchmarkResult.count }.by(0) &&
+                                      change { BenchmarkResultError.count }.by(2) &&
+                                      change { BenchmarkResultSchoolGenerationRun.count }.by(1)
 
         expect(BenchmarkResultSchoolGenerationRun.first.benchmark_result_error_count).to be 1
         expect(BenchmarkResultSchoolGenerationRun.first.benchmark_result_count).to be 0

--- a/spec/services/alerts/generate_and_save_alerts_and_benchmarks_spec.rb
+++ b/spec/services/alerts/generate_and_save_alerts_and_benchmarks_spec.rb
@@ -1,0 +1,78 @@
+require 'rails_helper'
+
+module Alerts
+  describe GenerateAndSaveAlertsAndBenchmarks do
+    let!(:school)                 { create(:school) }
+    let(:aggregate_school)        { double(:aggregate_school) }
+    let(:asof_date)               { Date.parse('01/01/2019') }
+    let(:alert_type)              { create(:alert_type, fuel_type: nil, frequency: :weekly, source: :analytics) }
+
+    let(:alert_report_attributes) {{
+      valid: true,
+      rating: 5.0,
+      enough_data: :enough,
+      relevance: :relevant,
+      template_data: {template: 'variables'},
+      template_data_cy: {template: 'welsh variables'},
+      chart_data: {chart: 'variables'},
+      table_data: {table: 'variables'},
+      priority_data: {priority: 'variables'},
+      benchmark_data: {benchmark: 'variables'}
+    }}
+
+    let(:alert_report)            { Adapters::Report.new(**alert_report_attributes) }
+
+    let(:example_alert_report)    { Adapters::Report.new(**alert_report_attributes) }
+    let(:example_benchmark_alert_report) do
+      benchmark_alert_report_attributes = alert_report_attributes.clone
+      benchmark_alert_report_attributes[:benchmark_data] = {}
+      Adapters::Report.new(**benchmark_alert_report_attributes)
+    end
+
+    let(:example_invalid_report) do
+      invalid_alert_report_attributes = alert_report_attributes.clone
+      invalid_alert_report_attributes[:valid] = false
+      Adapters::Report.new(**invalid_alert_report_attributes)
+    end
+
+    let(:error_messages) { ["Broken"] }
+
+    let(:alert_type_run_result) do
+      AlertTypeRunResult.new(alert_type: alert_type, reports: [example_alert_report, example_benchmark_alert_report, example_invalid_report], asof_date: asof_date )
+    end
+
+    let(:alert_type_run_result_just_errors) do
+      AlertTypeRunResult.new(alert_type: alert_type, reports: [], error_messages: error_messages, asof_date: asof_date)
+    end
+
+    before(:each) do
+      allow_any_instance_of(AggregateSchoolService).to receive(:aggregate_school).and_return(school)
+    end
+
+    describe '#perform' do
+      it 'handles empty results' do
+        expect_any_instance_of(GenerateAlertTypeRunResult).to receive(:perform).and_return(AlertTypeRunResult.new(alert_type: alert_type, asof_date: asof_date))
+
+        service = GenerateAndSaveAlerts.new(school: school, aggregate_school: aggregate_school)
+        expect { service.perform }.to change { Alert.count }.by(0).and change { AlertError.count }.by(0)
+      end
+
+      it 'handles just alert reports' do
+        expect_any_instance_of(GenerateAlertTypeRunResult).to receive(:perform).and_return(alert_type_run_result)
+
+        service = GenerateAndSaveAlertsAndBenchmarks.new(school: school, aggregate_school: aggregate_school)
+        expect { service.perform }.to change { Alert.count }.by(2).and change { AlertError.count }.by(1)
+        expect(Alert.first.run_on).to_not be_nil
+        expect(Alert.first.template_data).to_not be_nil
+        expect(Alert.first.template_data_cy).to_not be_nil
+      end
+
+      it 'handles just errors' do
+        expect_any_instance_of(GenerateAlertTypeRunResult).to receive(:perform).and_return(alert_type_run_result_just_errors)
+
+        service = GenerateAndSaveAlertsAndBenchmarks.new(school: school, aggregate_school: aggregate_school)
+        expect { service.perform }.to change { Alert.count }.by(0).and  change { AlertError.count }.by(1)
+      end
+    end
+  end
+end

--- a/spec/services/alerts/generate_and_save_alerts_and_benchmarks_spec.rb
+++ b/spec/services/alerts/generate_and_save_alerts_and_benchmarks_spec.rb
@@ -6,6 +6,7 @@ module Alerts
     let(:aggregate_school)        { double(:aggregate_school) }
     let(:asof_date)               { Date.parse('01/01/2019') }
     let(:alert_type)              { create(:alert_type, fuel_type: nil, frequency: :weekly, source: :analytics) }
+    let(:benchmark_result_generation_run) { BenchmarkResultGenerationRun.create! }
 
     let(:alert_report_attributes) {{
       valid: true,

--- a/spec/services/alerts/generate_and_save_alerts_and_benchmarks_spec.rb
+++ b/spec/services/alerts/generate_and_save_alerts_and_benchmarks_spec.rb
@@ -53,7 +53,7 @@ module Alerts
       it 'handles empty results' do
         expect_any_instance_of(GenerateAlertTypeRunResult).to receive(:perform).and_return(AlertTypeRunResult.new(alert_type: alert_type, asof_date: asof_date))
 
-        service = GenerateAndSaveAlerts.new(school: school, aggregate_school: aggregate_school)
+        service = GenerateAndSaveAlertsAndBenchmarks.new(school: school, aggregate_school: aggregate_school)
         expect { service.perform }.to change { Alert.count }.by(0).and change { AlertError.count }.by(0)
       end
 


### PR DESCRIPTION
At the moment in the Content Batch / SchoolBatchRunJob we have separate steps for:

- GenerateAndSaveAlerts
- GenerateAndSaveBenchmarks

Both of these services:

- loop through a list of alerts
- run them for a specific school
- insert new records into the database

This PR creates a new service that combines these steps into one. 