### PR TITLE
Add rake task for database content deletion

### DIFF
--- a/app/services/alerts/delete_alert_generation_run_service.rb
+++ b/app/services/alerts/delete_alert_generation_run_service.rb
@@ -8,10 +8,8 @@ module Alerts
     end
 
     def delete!
-      ActiveRecord::Base.transaction do
-        alert_generation_runs = AlertGenerationRun.where("created_at <= ?", @older_than)
-        alert_generation_runs.destroy_all
-      end
+      alert_generation_runs = AlertGenerationRun.where("created_at <= ?", @older_than)
+      alert_generation_runs.destroy_all
     end
   end
 end

--- a/app/services/alerts/delete_benchmark_run_service.rb
+++ b/app/services/alerts/delete_benchmark_run_service.rb
@@ -8,9 +8,7 @@ module Alerts
     end
 
     def delete!
-      ActiveRecord::Base.transaction do
-        BenchmarkResultGenerationRun.where("created_at <= ?", @older_than).destroy_all
-      end
+      BenchmarkResultGenerationRun.where("created_at <= ?", @older_than).destroy_all
     end
   end
 end

--- a/app/services/alerts/delete_content_generation_run_service.rb
+++ b/app/services/alerts/delete_content_generation_run_service.rb
@@ -8,10 +8,8 @@ module Alerts
     end
 
     def delete!
-      ActiveRecord::Base.transaction do
-        content_generation_runs = ContentGenerationRun.where("created_at <= ?", @older_than)
-        content_generation_runs.destroy_all
-      end
+      content_generation_runs = ContentGenerationRun.where("created_at <= ?", @older_than)
+      content_generation_runs.destroy_all
     end
   end
 end

--- a/lib/tasks/alerts/delete_benchmark_runs.rake
+++ b/lib/tasks/alerts/delete_benchmark_runs.rake
@@ -2,7 +2,9 @@ namespace :alerts do
   desc 'Delete benchmark runs'
   task delete_benchmark_runs: [:environment] do
     puts "#{DateTime.now.utc} Delete benchmark runs start"
-    Alerts::DeleteBenchmarkRunService.new.delete!
+    ActiveRecord::Base.transaction do
+      Alerts::DeleteBenchmarkRunService.new.delete!
+    end
     puts "#{DateTime.now.utc} Delete benchmark runs end"
   end
 end

--- a/lib/tasks/database/content_deletion.rake
+++ b/lib/tasks/database/content_deletion.rake
@@ -1,0 +1,35 @@
+namespace :database do
+  desc 'manually delete all old database content'
+  # Run with:
+  # bundle exec rake 'database:content_deletion['31-12-2020']'
+  task :content_deletion, [:older_than] => :environment do |_t, args|
+    begin
+      older_than = Date.parse(args[:older_than], '%Y-%m-%d').end_of_day
+      default_older_than = Alerts::ContentDeletionService::DEFAULT_OLDER_THAN
+
+      if older_than > default_older_than
+        STDOUT.puts "Warning: Date is less than default (#{default_older_than}). Enter [Y] to continue:"
+        input = STDIN.gets.chomp
+        if ['Y','y'].include? input
+          puts "#{DateTime.now.utc} manually delete all old content start"
+          Alerts::ContentDeletionService.new(older_than).delete!
+          puts "#{DateTime.now.utc} manually delete all old content end"
+        else
+          puts 'Ok, cancelling.'
+        end
+      else
+        puts "#{DateTime.now.utc} manually delete all old content start"
+        Alerts::ContentDeletionService.new(older_than).delete!
+        puts "#{DateTime.now.utc} manually delete all old content end"
+      end
+
+    rescue => e
+      puts "Exception: running content_deletion: #{e.class} #{e.message}"
+      puts e.backtrace.join("\n")
+      Rails.logger.error "Exception: running content_deletion: #{e.class} #{e.message}"
+      Rails.logger.error e.backtrace.join("\n")
+      Rollbar.error(e, job: :content_deletion)
+    end
+    puts "#{DateTime.now.utc} manually delete all old content end"
+  end
+end

--- a/lib/tasks/database/content_deletion.rake
+++ b/lib/tasks/database/content_deletion.rake
@@ -8,7 +8,7 @@ namespace :database do
       default_older_than = Alerts::ContentDeletionService::DEFAULT_OLDER_THAN
 
       if older_than > default_older_than
-        STDOUT.puts "Warning: Date is less than default (#{default_older_than}). Enter [Y] to continue:"
+        STDOUT.puts "Warning: Older than date is earlier than the default (#{default_older_than}). Enter [Y] to continue:"
         input = STDIN.gets.chomp
         if ['Y','y'].include? input
           puts "#{DateTime.now.utc} manually delete all old content start"
@@ -22,7 +22,6 @@ namespace :database do
         Alerts::ContentDeletionService.new(older_than).delete!
         puts "#{DateTime.now.utc} manually delete all old content end"
       end
-
     rescue => e
       puts "Exception: running content_deletion: #{e.class} #{e.message}"
       puts e.backtrace.join("\n")
@@ -30,6 +29,5 @@ namespace :database do
       Rails.logger.error e.backtrace.join("\n")
       Rollbar.error(e, job: :content_deletion)
     end
-    puts "#{DateTime.now.utc} manually delete all old content end"
   end
 end

--- a/lib/tasks/database/content_deletion.rake
+++ b/lib/tasks/database/content_deletion.rake
@@ -1,21 +1,20 @@
 namespace :database do
   desc 'manually delete all old database content'
-  # Run with:
-  # bundle exec rake 'database:content_deletion['31-12-2020']'
+  # Run with: bundle exec rake 'database:content_deletion['2020-12-31']'
   task :content_deletion, [:older_than] => :environment do |_t, args|
     begin
       older_than = Date.parse(args[:older_than], '%Y-%m-%d').end_of_day
       default_older_than = Alerts::ContentDeletionService::DEFAULT_OLDER_THAN
 
       if older_than > default_older_than
-        STDOUT.puts "Warning: Older than date is earlier than the default (#{default_older_than}). Enter [Y] to continue:"
+        STDOUT.puts "Warning: older than date is earlier than the default (#{default_older_than}). Enter [Y] to continue:"
         input = STDIN.gets.chomp
         if ['Y','y'].include? input
           puts "#{DateTime.now.utc} manually delete all old content start"
           Alerts::ContentDeletionService.new(older_than).delete!
           puts "#{DateTime.now.utc} manually delete all old content end"
         else
-          puts 'Ok, cancelling.'
+          puts 'Ok, cancelled ...'
         end
       else
         puts "#{DateTime.now.utc} manually delete all old content start"


### PR DESCRIPTION
The changes made in https://github.com/Energy-Sparks/energy-sparks/pull/1999 will work fine when we're running the database cleanup on a regular basis.

However, for the initial run, when we have ~3 years of data to delete, it's very slow and could potentially interfere with the live system.

This PR implements a separate rake task (and any other code changes) to allow us to run the database cleanup for 6/12 months at a time, so we can do this progressively and in smaller chunks. E.g. first deleting 2019 data.

We can run the rake task manually for each year and it will delete all content older than the date passed
```
bundle exec rake 'database:content_deletion['2019-12-31']'
bundle exec rake 'database:content_deletion['2020-12-31']'
bundle exec rake 'database:content_deletion['2021-12-31']'
bundle exec rake 'database:content_deletion['2022-07-01']'
```
(the last date being beginning of the month, 3 months ago as per the default in `Alerts::ContentDeletionService` - the rake task also warns and requires confirmation if a date passed is earlier than `Alerts::ContentDeletionService::DEFAULT_OLDER_THAN`)
