### PR TITLE
Optimise chart loading on dashboards

### DIFF
--- a/app/assets/javascripts/analysis.js
+++ b/app/assets/javascripts/analysis.js
@@ -111,6 +111,7 @@ function processAnalysisCharts(){
     $("div.analysis-chart").each(function(){
       var chartConfig = $(this).data('chart-config');
       var autoLoadChart = $(this).data('autoload-chart');
+      // Autoload charts will only be set false for tabbed content (with the first tab being set true)
       if (autoLoadChart === true) {
         processAnalysisChart(this, chartConfig);
         setupAnalysisControls(this, chartConfig);

--- a/app/assets/javascripts/analysis.js
+++ b/app/assets/javascripts/analysis.js
@@ -110,9 +110,12 @@ function processAnalysisCharts(){
   if ($("div.analysis-chart").length ) {
     $("div.analysis-chart").each(function(){
       var chartConfig = $(this).data('chart-config');
-      processAnalysisChart(this, chartConfig);
-      setupAnalysisControls(this, chartConfig);
-      setupAxisControls(this, chartConfig);
+      var autoLoadChart = $(this).data('autoload-chart');
+      if (autoLoadChart === true) {
+        processAnalysisChart(this, chartConfig);
+        setupAnalysisControls(this, chartConfig);
+        setupAxisControls(this, chartConfig);
+      }
     });
   }
 

--- a/app/assets/javascripts/content.js
+++ b/app/assets/javascripts/content.js
@@ -69,10 +69,12 @@ $(document).ready(function() {
     chart = $(e.target.hash + '-chart')
     chartId = chart[0].children[0].id
     chart = $('#' + chartId)
-    chart.data('autoload-chart', true)
-    chartConfig = chart.data('chart-config');
-    processAnalysisChart(chart[0], chartConfig);
-    setupAnalysisControls(chart[0], chartConfig);
-    setupAxisControls(chart[0], chartConfig);
+    if (chart.data('autoload-chart') === false) {
+      chart.data('autoload-chart', true)
+      chartConfig = chart.data('chart-config');
+      processAnalysisChart(chart[0], chartConfig);
+      setupAnalysisControls(chart[0], chartConfig);
+      setupAxisControls(chart[0], chartConfig);
+    }
   });
 });

--- a/app/assets/javascripts/content.js
+++ b/app/assets/javascripts/content.js
@@ -70,16 +70,9 @@ $(document).ready(function() {
     chartId = chart[0].children[0].id
     chart = $('#' + chartId)
     chart.data('autoload-chart', true)
-    // console.log(chart.data('autoload-chart'))
-
-      var chartConfig = chart.data('chart-config');
-
-      console.log(chartConfig)
-      console.log(chart[0].id)
-
-      processAnalysisChart(chart[0], chartConfig);
-        setupAnalysisControls(chart[0], chartConfig);
-        setupAxisControls(chart[0], chartConfig);
-
+    chartConfig = chart.data('chart-config');
+    processAnalysisChart(chart[0], chartConfig);
+    setupAnalysisControls(chart[0], chartConfig);
+    setupAxisControls(chart[0], chartConfig);
   });
 });

--- a/app/assets/javascripts/content.js
+++ b/app/assets/javascripts/content.js
@@ -69,6 +69,7 @@ $(document).ready(function() {
     chart = $(e.target.hash + '-chart')
     chartId = chart[0].children[0].id
     chart = $('#' + chartId)
+    // Only re/load chart if autoload chart is false (first tab is true)
     if (chart.data('autoload-chart') === false) {
       chart.data('autoload-chart', true)
       chartConfig = chart.data('chart-config');

--- a/app/assets/javascripts/content.js
+++ b/app/assets/javascripts/content.js
@@ -64,4 +64,22 @@ $(document).ready(function() {
     var tab = $('#' + tab_pane.attr('aria-labelledby'));
     tab.find('.text-danger').removeClass('d-none');
   });
+
+  $('#management-energy-overview').on('show.bs.tab', function (e) {
+    chart = $(e.target.hash + '-chart')
+    chartId = chart[0].children[0].id
+    chart = $('#' + chartId)
+    chart.data('autoload-chart', true)
+    // console.log(chart.data('autoload-chart'))
+
+      var chartConfig = chart.data('chart-config');
+
+      console.log(chartConfig)
+      console.log(chart[0].id)
+
+      processAnalysisChart(chart[0], chartConfig);
+        setupAnalysisControls(chart[0], chartConfig);
+        setupAxisControls(chart[0], chartConfig);
+
+  });
 });

--- a/app/helpers/chart_helper.rb
+++ b/app/helpers/chart_helper.rb
@@ -1,5 +1,5 @@
 module ChartHelper
-  def chart_tag(school, chart_type, wrap: true, show_advice: true, no_zoom: false, chart_config: {}, html_class: 'analysis-chart')
+  def chart_tag(school, chart_type, wrap: true, show_advice: true, no_zoom: false, chart_config: {}, html_class: 'analysis-chart', autoload_chart: true)
     chart_config[:no_advice] = !show_advice
     chart_config[:no_zoom] = no_zoom
     chart_container = content_tag(
@@ -7,13 +7,14 @@ module ChartHelper
       '',
       id: chart_config[:mpan_mprn].present? ? "chart_#{chart_type}_#{chart_config[:mpan_mprn]}" : "chart_#{chart_type}",
       class: html_class,
+      "data-autoload-chart": autoload_chart,
       data: {
         chart_config: chart_config.merge(
           type: chart_type,
           annotations: school_annotations_path(school),
           jsonUrl: school_chart_path(school, format: :json),
           transformations: []
-        )
+        ),
       }
     )
     chart_container += "<div id='chart-error' class='d-none'>#{I18n.t('chart_data_values.standard_error_message')}</div>".html_safe

--- a/app/helpers/chart_helper.rb
+++ b/app/helpers/chart_helper.rb
@@ -7,8 +7,8 @@ module ChartHelper
       '',
       id: chart_config[:mpan_mprn].present? ? "chart_#{chart_type}_#{chart_config[:mpan_mprn]}" : "chart_#{chart_type}",
       class: html_class,
-      "data-autoload-chart": autoload_chart,
       data: {
+        autoload_chart: autoload_chart,
         chart_config: chart_config.merge(
           type: chart_type,
           annotations: school_annotations_path(school),

--- a/app/views/management/schools/_overview_charts.html.erb
+++ b/app/views/management/schools/_overview_charts.html.erb
@@ -10,7 +10,9 @@
     <div class="tab-pane fade show <%= 'active' if index == 0 %>" id="<%= energy %>-overview" role="tabpanel" aria-labelledby="<%= energy %>-tab">
       <div id="chart_wrapper_<%= chart_config[:chart] %>" class="chart-wrapper">
         <%= render 'shared/analysis_controls', chart_type: chart_config[:chart], axis_controls: true, analysis_controls: true %>
-        <%= chart_tag(@school, chart_config[:chart], show_advice: false, no_zoom: true, chart_config: {y_axis_units: select_y_axis(@school, chart_config[:chart], chart_config[:units])}, wrap: false) %>
+        <div id="<%= energy %>-overview-chart">
+          <%= chart_tag(@school, chart_config[:chart], show_advice: false, no_zoom: true, chart_config: {y_axis_units: select_y_axis(@school, chart_config[:chart], chart_config[:units])}, wrap: false, autoload_chart: index.zero? ) %>
+        </div>
       </div>
     </div>
   <% end %>


### PR DESCRIPTION
Currently we load all charts on the adult and mgt dashboard on page load.  But potentially 2 of them will never be displayed if a user doesn't switch tabs.

This pr covers changing how we load charts on the dashboards:
- [x] the chart on the active tab should be loaded initially
- [x] when a user switches tab, the chart on that tab should be loaded 
- [x] chart should then not be reloaded when a tab is switched (so each tab content is only loaded once)