### PR TITLE
Disable advice generation on charts

### DIFF
--- a/app/assets/javascripts/analysis.js
+++ b/app/assets/javascripts/analysis.js
@@ -132,6 +132,7 @@ function processAnalysisChartAjax(chartId, chartConfig, highchartsChart) {
   var dateRanges = chartConfig.date_ranges;
   var dataPath = chartConfig.jsonUrl;
   var transformations = chartConfig.transformations;
+  var noAdvice = chartConfig.no_advice;
   var requestData = {
     chart_type: chartType,
     chart_y_axis_units: yAxisUnits,
@@ -140,6 +141,10 @@ function processAnalysisChartAjax(chartId, chartConfig, highchartsChart) {
     series_breakdown: seriesBreakdown,
     date_ranges: dateRanges
   };
+
+  if (! noAdvice) {
+    requestData['provide_advice'] = true
+  }
 
   highchartsChart.showLoading();
 

--- a/app/controllers/schools/charts_controller.rb
+++ b/app/controllers/schools/charts_controller.rb
@@ -39,7 +39,7 @@ private
     }
     y_axis_units = params[:chart_y_axis_units]
     chart_config[:y_axis_units] = y_axis_units.to_sym if y_axis_units.present?
-    provide_advice = params[:provide_advice]
+    provide_advice = params[:provide_advice] || false
     output = ChartData.new(@school, aggregate_school, @chart_type, chart_config, transformations: get_transformations, provide_advice: provide_advice).data
     if output
       render json: ChartDataValues.as_chart_json(output)

--- a/app/controllers/schools/charts_controller.rb
+++ b/app/controllers/schools/charts_controller.rb
@@ -39,7 +39,8 @@ private
     }
     y_axis_units = params[:chart_y_axis_units]
     chart_config[:y_axis_units] = y_axis_units.to_sym if y_axis_units.present?
-    output = ChartData.new(@school, aggregate_school, @chart_type, chart_config, transformations: get_transformations).data
+    provide_advice = params[:provide_advice]
+    output = ChartData.new(@school, aggregate_school, @chart_type, chart_config, transformations: get_transformations, provide_advice: provide_advice).data
     if output
       render json: ChartDataValues.as_chart_json(output)
     else

--- a/app/helpers/chart_helper.rb
+++ b/app/helpers/chart_helper.rb
@@ -1,5 +1,5 @@
 module ChartHelper
-  def chart_tag(school, chart_type, wrap: true, show_advice: true, no_zoom: false, chart_config: {}, html_class: 'analysis-chart', autoload_chart: true)
+  def chart_tag(school, chart_type, wrap: true, show_advice: false, no_zoom: false, chart_config: {}, html_class: 'analysis-chart', autoload_chart: true)
     chart_config[:no_advice] = !show_advice
     chart_config[:no_zoom] = no_zoom
     chart_container = content_tag(

--- a/app/models/chart_data.rb
+++ b/app/models/chart_data.rb
@@ -25,7 +25,7 @@ class ChartData
     parent_timescale_description = I18n.t("chart_data.timescale_description.#{parent_timescale_description}", default: nil) || parent_timescale_description
 
     values = ChartDataValues.new(
-      chart_manager.run_chart(transformed_chart_config, transformed_chart_type),
+      chart_manager.run_chart(transformed_chart_config, transformed_chart_type, provide_advice: false),
       transformed_chart_type,
       transformations: @transformations,
       allowed_operations: allowed_operations,
@@ -70,7 +70,7 @@ private
   end
 
   def apply_drilldown(x_axis_range, chart_type, chart_config, chart_manager)
-    original_chart_results = chart_manager.run_chart(chart_config, chart_type)
+    original_chart_results = chart_manager.run_chart(chart_config, chart_type, provide_advice: false)
     drill_down_range = original_chart_results[:x_axis_ranges][x_axis_range]
     chart_manager.drilldown(chart_type, chart_config, nil, drill_down_range)
   end

--- a/app/models/chart_data.rb
+++ b/app/models/chart_data.rb
@@ -3,12 +3,13 @@ require 'dashboard'
 class ChartData
   OPERATIONS = %i[move extend contract compare].freeze
 
-  def initialize(school, aggregated_school, original_chart_type, chart_config, transformations: [])
+  def initialize(school, aggregated_school, original_chart_type, chart_config, transformations: [], provide_advice: false)
     @school = school
     @aggregated_school = aggregated_school
     @original_chart_type = original_chart_type
     @chart_config_overrides = chart_config
     @transformations = transformations
+    @provide_advice = provide_advice
   end
 
   def data
@@ -25,7 +26,7 @@ class ChartData
     parent_timescale_description = I18n.t("chart_data.timescale_description.#{parent_timescale_description}", default: nil) || parent_timescale_description
 
     values = ChartDataValues.new(
-      chart_manager.run_chart(transformed_chart_config, transformed_chart_type, provide_advice: false),
+      chart_manager.run_chart(transformed_chart_config, transformed_chart_type, provide_advice: @provide_advice),
       transformed_chart_type,
       transformations: @transformations,
       allowed_operations: allowed_operations,
@@ -70,7 +71,7 @@ private
   end
 
   def apply_drilldown(x_axis_range, chart_type, chart_config, chart_manager)
-    original_chart_results = chart_manager.run_chart(chart_config, chart_type, provide_advice: false)
+    original_chart_results = chart_manager.run_chart(chart_config, chart_type, provide_advice: @provide_advice)
     drill_down_range = original_chart_results[:x_axis_ranges][x_axis_range]
     chart_manager.drilldown(chart_type, chart_config, nil, drill_down_range)
   end

--- a/app/views/admin/analysis/generic_chart_template.html.erb
+++ b/app/views/admin/analysis/generic_chart_template.html.erb
@@ -21,7 +21,7 @@ with <%= @school.number_of_pupils %> pupils and a floor area of <%= @school.floo
     <h3 class="analysis">Loading: <%= chart.to_s.humanize %></h3>
     <div class="advice-header"></div>
     <%= render 'shared/analysis_controls', chart_type: chart.to_s, axis_controls: true, analysis_controls: true %>
-    <%= chart_tag(@school, chart.to_s, chart_config: @chart_config, wrap: false) %>
+    <%= chart_tag(@school, chart.to_s, chart_config: @chart_config, wrap: false, show_advice: true) %>
     <div class="advice-footer"></div>
   </div>
 <% end %>

--- a/app/views/management/schools/_overview_charts.html.erb
+++ b/app/views/management/schools/_overview_charts.html.erb
@@ -11,7 +11,7 @@
       <div id="chart_wrapper_<%= chart_config[:chart] %>" class="chart-wrapper">
         <%= render 'shared/analysis_controls', chart_type: chart_config[:chart], axis_controls: true, analysis_controls: true %>
         <div id="<%= energy %>-overview-chart">
-          <%= chart_tag(@school, chart_config[:chart], show_advice: false, no_zoom: true, chart_config: {y_axis_units: select_y_axis(@school, chart_config[:chart], chart_config[:units])}, wrap: false, autoload_chart: index.zero? ) %>
+          <%= chart_tag(@school, chart_config[:chart], no_zoom: true, chart_config: {y_axis_units: select_y_axis(@school, chart_config[:chart], chart_config[:units])}, wrap: false, autoload_chart: index.zero? ) %>
         </div>
       </div>
     </div>

--- a/app/views/management/schools/report.html.erb
+++ b/app/views/management/schools/report.html.erb
@@ -14,7 +14,7 @@
 
 <% @overview_charts.each_with_index do |(energy, chart_config), index| %>
   <h2><%= t("management.schools.overview_charts.overview.#{energy.to_s}") %></h2>
-  <%= chart_tag(@school, chart_config[:chart], show_advice: false, no_zoom: true, chart_config: {y_axis_units: select_y_axis(@school, chart_config[:chart], chart_config[:units])}) %>
+  <%= chart_tag(@school, chart_config[:chart], no_zoom: true, chart_config: {y_axis_units: select_y_axis(@school, chart_config[:chart], chart_config[:units])}) %>
 <% end %>
 
 <% unless @management_priorities.empty? %>

--- a/app/views/pupils/analysis/show.html.erb
+++ b/app/views/pupils/analysis/show.html.erb
@@ -11,5 +11,5 @@
       <h5></h5>
   </div>
   <%= render 'shared/analysis_controls', chart_type: @chart_type.to_s, analysis_controls: true %>
-  <%= chart_tag(@school, @chart_type.to_s, show_advice: true, no_zoom: true, wrap: false, chart_config: create_chart_config(@school, @chart_type)) %>
+  <%= chart_tag(@school, @chart_type.to_s, no_zoom: true, wrap: false, chart_config: create_chart_config(@school, @chart_type)) %>
 </div>

--- a/app/views/schools/analysis/_chart_name.html.erb
+++ b/app/views/schools/analysis/_chart_name.html.erb
@@ -1,5 +1,5 @@
 <div id="chart_wrapper_<%= content %>" class="pt-3 chart-wrapper">
   <%= render 'shared/analysis_controls', chart_type: content, axis_controls: true, analysis_controls: true %>
   <h5 class="text-center"></h5>
-  <%= chart_tag(school, content, show_advice: false, no_zoom: true, wrap: false, chart_config: create_chart_config(school, content, mpan_mprn)) %>
+  <%= chart_tag(school, content, no_zoom: true, wrap: false, chart_config: create_chart_config(school, content, mpan_mprn)) %>
 </div>

--- a/app/views/schools/find_out_more/_chart.html.erb
+++ b/app/views/schools/find_out_more/_chart.html.erb
@@ -2,5 +2,5 @@
   <% unless content.find_out_more_chart_title.blank? %>
     <h4 class="analysis text-center"><%= content.find_out_more_chart_title %></h4>
   <% end %>
-  <%= chart_tag(school, chart.to_s, wrap: false, show_advice: false, chart_config: create_chart_config(school, chart.to_sym), html_class: 'analysis-chart find-out-more') %>
+  <%= chart_tag(school, chart.to_s, wrap: false, chart_config: create_chart_config(school, chart.to_sym), html_class: 'analysis-chart find-out-more') %>
 </div>

--- a/app/views/schools/usage/show.html.erb
+++ b/app/views/schools/usage/show.html.erb
@@ -27,7 +27,7 @@
   <div class="row">
     <div class="col-md-12 chart-wrapper" id="chart_wrapper_<%=@chart_config[@period]%>">
       <%= render 'shared/analysis_controls', chart_type: @chart_config[@period].to_s, analysis_controls: false, axis_controls: @show_measurements %>
-      <%= chart_tag(@school, @chart_config[@period], show_advice: false, no_zoom: true, wrap: false, html_class: 'usage-chart', chart_config: create_chart_config(@school, @chart_config[@period])) %>
+      <%= chart_tag(@school, @chart_config[@period], no_zoom: true, wrap: false, html_class: 'usage-chart', chart_config: create_chart_config(@school, @chart_config[@period])) %>
     </div>
   </div>
 

--- a/app/views/shared/_chart_with_controls.html.erb
+++ b/app/views/shared/_chart_with_controls.html.erb
@@ -1,4 +1,4 @@
 <div id="chart_wrapper_<%= chart_type %>" class="chart-wrapper">
   <%= render 'shared/analysis_controls', chart_type: chart_type, axis_controls: true, analysis_controls: true %>
-  <%= chart_tag(school, chart_type, chart_config: chart_config, wrap: false, show_advice: false) %>
+  <%= chart_tag(school, chart_type, chart_config: chart_config, wrap: false) %>
 </div>


### PR DESCRIPTION
The ChartManager is responsible for generating some of the advice that is added displayed above and below the charts on the advice pages. This includes both static and dynamic text, with the latter including content generated by running additional analysis code.  By default it is always generated, but there is an option to disable it.

This wasn't being used by the application, possibly because we used to have a mixture of pages that did rely on adding some of this content dynamically to the web page. This was done in the old "Expert Analysis" pages which have now largely been removed. None of the other pages on the site now rely on fetching the `advice_header` and `advice_footer` content from the chart JSON.

This PR changes how we run the charts so by default we no longer generate the advice. A new URL parameter has been added to allow the advice to be generated on request.

The javascript has been updated to set this parameter using the existing `no-advice` setting.

The `chart_tag` has also been updated to change the `show_advice` parameter to be `false` by default. I've also updated the templates that use it to remove the parameter when not needed.

The net result is:

- only the remaining expert analysis pages now request the advice
- all other requests for charts no longer request advice by default, saving both some execution time per chart and reducing the size of the JSON returned

I've done manual testing to confirm that charts disable correctly and that the expert analysis pages still include the advice.