### PR TITLE
Small time-based test fix

### DIFF
--- a/spec/system/admin/school_groups_spec.rb
+++ b/spec/system/admin/school_groups_spec.rb
@@ -61,7 +61,11 @@ RSpec.describe 'school groups', :school_groups, type: :system, include_applicati
         end
         context "and exporting detail" do
           before do
+            Timecop.freeze
             click_link('Export detail')
+          end
+          after do
+            Timecop.return
           end
           it "shows csv contents" do
             expect(page.body).to eq SchoolGroups::CsvGenerator.new(SchoolGroup.all.by_name).export_detail
@@ -70,9 +74,7 @@ RSpec.describe 'school groups', :school_groups, type: :system, include_applicati
             expect(response_headers['Content-Type']).to eq 'text/csv'
           end
           it "has expected file name" do
-            Timecop.freeze do
-              expect(response_headers['Content-Disposition']).to include(SchoolGroups::CsvGenerator.filename)
-            end
+            expect(response_headers['Content-Disposition']).to include(SchoolGroups::CsvGenerator.filename)
           end
         end
       end


### PR DESCRIPTION
Fix use of Timecop to freeze time before page load not just before test. Caused test failure (once) - test was still brittle though and needs fixing