### PR TITLE
Request advice pages in English only

### DIFF
--- a/app/controllers/schools/analysis_controller.rb
+++ b/app/controllers/schools/analysis_controller.rb
@@ -22,9 +22,10 @@ module Schools
         analysis_date: @page.alert.run_on,
         aggregate_school: aggregate_school
       )
-      @content = framework_adapter.content(user_type_hash)
-      @structured_content = framework_adapter.structured_content if framework_adapter.has_structured_content?
-
+      I18n.with_locale(:en) do
+        @content = framework_adapter.content(user_type_hash)
+        @structured_content = framework_adapter.structured_content if framework_adapter.has_structured_content?
+      end
       @title = page_title(@content, @school)
     rescue ActiveRecord::RecordNotFound
       if /\d/.match?(params[:id])


### PR DESCRIPTION
There are a couple of the analysis pages which don't work properly in Welsh. This is because in a couple of places they are reparsing data from charts to build page content, rather than using the underlying variables from the alert classes.

This parsing fails when the pages are generated in Welsh, because the chart series end up being translated.

This PR wraps the calls to the analytics that generates the content in an `I18n.with_locale` block, so they're run using an English locale. This avoids the bug until we've properly translated the pages.

This also avoids small sections of the page, eg. references to units being formatted in Welsh. At the moment the content that does work can end up having a mixture of English and Welsh phrases, which isn't ideal.

We've already got a disclaimer on the page that we're planning to add the translated content at a later date.