### PR TITLE
Fix temperature range error for targets

### DIFF
--- a/app/services/schedule_data_manager_service.rb
+++ b/app/services/schedule_data_manager_service.rb
@@ -115,6 +115,9 @@ class ScheduleDataManagerService
   end
 
   def temperature_days_offset
+    # The projected future temperature is calculated from an average of the past temperatures at the same time
+    # of year in previous years, the number needs to be smooth and not too noisy, '4 days either side' provides
+    # this averaging, otherwise you get a much more volatile temperature adjustment.
     if TargetMeterTemperatureCompensatedDailyDayTypeBase.const_defined?('TARGET_TEMPERATURE_DAYS_EITHER_SIDE')
        TargetMeterTemperatureCompensatedDailyDayTypeBase::TARGET_TEMPERATURE_DAYS_EITHER_SIDE
     else

--- a/app/services/schedule_data_manager_service.rb
+++ b/app/services/schedule_data_manager_service.rb
@@ -105,19 +105,21 @@ class ScheduleDataManagerService
     # Only use temperature data within lower datetime bounds of school meter readings
     return cached_temperatures unless use_date_bounded_schedule_data?
 
-    school_minimum_reading_date = school_minimum_reading_date_with_temperature_day_offset
+    school_minimum_reading_date = school_minimum_reading_date_with_temperature_days_offset
     dates_to_remove = cached_temperatures.keys.select { |date| date < school_minimum_reading_date }
     cached_temperatures.remove_dates!(*dates_to_remove)
   end
 
-  def school_minimum_reading_date_with_temperature_day_offset
-    day_offset = if TargetMeterTemperatureCompensatedDailyDayTypeBase.const_defined?('TARGET_TEMPERATURE_DAYS_EITHER_SIDE')
-                    TargetMeterTemperatureCompensatedDailyDayTypeBase::TARGET_TEMPERATURE_DAYS_EITHER_SIDE
-                 else
-                    DEFAULT_TARGET_TEMPERATURE_DAYS_EITHER_SIDE
-                 end
+  def school_minimum_reading_date_with_temperature_days_offset
+    @school.minimum_reading_date - temperature_days_offset.days
+  end
 
-    @school.minimum_reading_date - day_offset.days
+  def temperature_days_offset
+    if TargetMeterTemperatureCompensatedDailyDayTypeBase.const_defined?('TARGET_TEMPERATURE_DAYS_EITHER_SIDE')
+       TargetMeterTemperatureCompensatedDailyDayTypeBase::TARGET_TEMPERATURE_DAYS_EITHER_SIDE
+    else
+       DEFAULT_TARGET_TEMPERATURE_DAYS_EITHER_SIDE
+    end
   end
 
   def find_holidays


### PR DESCRIPTION
This PR adds a minimum 4 day offset for all loaded temperature schedule data.  This is related to changes in https://github.com/Energy-Sparks/energy-sparks_analytics/pull/351
