### PR TITLE
Revise dashboard for expired targets

### DIFF
--- a/app/classes/targets/progress_summary.rb
+++ b/app/classes/targets/progress_summary.rb
@@ -13,6 +13,10 @@ module Targets
       electricity_progress.present? || gas_progress.present? || storage_heater_progress.present?
     end
 
+    def current_target?
+      @school_target.current?
+    end
+
     def out_of_date_fuel_types
       out_of_date = []
       out_of_date << :electricity if electricity_progress.present? && !electricity_progress.recent_data?

--- a/app/controllers/concerns/school_progress.rb
+++ b/app/controllers/concerns/school_progress.rb
@@ -15,6 +15,10 @@ private
     Targets::SchoolTargetService.targets_enabled?(@school) && can?(:manage, SchoolTarget) && target_service.prompt_to_review_target?
   end
 
+  def prompt_to_set_new_target?
+    Targets::SchoolTargetService.targets_enabled?(@school) && can?(:manage, SchoolTarget) && @school.has_expired_target?
+  end
+
   def suggest_estimates_for_fuel_types(check_data: false)
     if EnergySparks::FeatureFlags.active?(:school_targets_v2) && can?(:manage, EstimatedAnnualConsumption)
       Targets::SuggestEstimatesService.new(@school).suggestions(check_data: check_data)

--- a/app/controllers/concerns/school_progress.rb
+++ b/app/controllers/concerns/school_progress.rb
@@ -16,7 +16,7 @@ private
   end
 
   def prompt_to_set_new_target?
-    Targets::SchoolTargetService.targets_enabled?(@school) && can?(:manage, SchoolTarget) && @school.has_expired_target?
+    Targets::SchoolTargetService.targets_enabled?(@school) && can?(:manage, SchoolTarget) && @school.has_expired_target? && !@school.has_current_target?
   end
 
   def suggest_estimates_for_fuel_types(check_data: false)

--- a/app/controllers/schools_controller.rb
+++ b/app/controllers/schools_controller.rb
@@ -169,6 +169,7 @@ private
     #to do that
     if can?(:show_management_dash, @school)
       @add_targets = prompt_for_target?
+      @set_new_target = prompt_to_set_new_target?
       @review_targets = prompt_to_review_target?
       @recent_audit = Audits::AuditService.new(@school).recent_audit
       @suggest_estimates_for_fuel_types = suggest_estimates_for_fuel_types(check_data: true)

--- a/app/helpers/targets_helper.rb
+++ b/app/helpers/targets_helper.rb
@@ -1,4 +1,8 @@
 module TargetsHelper
+  def reportable_progress?(progress_summary)
+    progress_summary.present? && progress_summary.current_target?
+  end
+
   def show_limited_data?(school_target, fuel_type)
     EnergySparks::FeatureFlags.active?(:school_targets_v2) && school_target[fuel_type].present?
   end

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -426,7 +426,7 @@ class School < ApplicationRecord
   end
 
   def expired_target
-    school_targets.by_start_date.select(&:expired?).first
+    school_targets.by_start_date.expired.first
   end
 
   def has_expired_target?

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -425,6 +425,14 @@ class School < ApplicationRecord
     school_targets.by_start_date.first
   end
 
+  def expired_target
+    school_targets.by_start_date.select(&:expired?).first
+  end
+
+  def has_expired_target?
+    expired_target.present?
+  end
+
   def has_school_target_event?(event_name)
     school_target_events.where(event: event_name).any?
   end

--- a/app/models/school_target.rb
+++ b/app/models/school_target.rb
@@ -35,7 +35,7 @@ class SchoolTarget < ApplicationRecord
 
   scope :by_date, -> { order(created_at: :desc) }
   scope :by_start_date, -> { order(start_date: :desc) }
-
+  scope :expired, -> { where(":now >= start_date and :now >= target_date", now: Time.zone.today) }
   scope :currently_active, -> { where('start_date <= ? and target_date <= ?', Time.zone.today, Time.zone.today.next_year) }
 
   before_save :adjust_target_date

--- a/app/models/school_target.rb
+++ b/app/models/school_target.rb
@@ -44,6 +44,10 @@ class SchoolTarget < ApplicationRecord
     Time.zone.now >= start_date && Time.zone.now <= target_date
   end
 
+  def expired?
+    Time.zone.now >= start_date && Time.zone.now >= target_date
+  end
+
   def meter_attributes_by_meter_type
     attributes = {}
     attributes[:aggregated_electricity] = [meter_attribute_for_electricity_target] if electricity.present?

--- a/app/views/management/schools/targets/_progress_notice.html.erb
+++ b/app/views/management/schools/targets/_progress_notice.html.erb
@@ -1,4 +1,4 @@
-<% if progress_summary.present? && progress_summary.any_failing_targets? %>
+<% if reportable_progress?(progress_summary) && progress_summary.any_failing_targets? %>
     <%= render 'schools/dashboard/info_bar',
       colour: 'bg-negative',
       icon: 'tachometer-alt fa-3x',
@@ -6,7 +6,7 @@
       buttons: {t('schools.show.review_progress') => school_school_targets_path(school)}
     %>
 <% end %>
-<% if progress_summary.present? && progress_summary.any_passing_targets? %>
+<% if reportable_progress?(progress_summary) && progress_summary.any_passing_targets? %>
   <%= render 'schools/dashboard/info_bar',
     colour: 'bg-positive',
     icon: 'tachometer-alt fa-3x',

--- a/app/views/management/schools/targets/_set_new_target.html.erb
+++ b/app/views/management/schools/targets/_set_new_target.html.erb
@@ -1,0 +1,6 @@
+<%= render 'schools/dashboard/info_bar',
+  colour: 'bg-neutral',
+  content: t('schools.show.set_new_target', target_date: I18n.l(school.expired_target.target_date, format: "%B %Y")),
+  icon: 'tachometer-alt fa-3x',
+  buttons: {t('schools.show.review_progress') => school_school_targets_path(school)}
+%>

--- a/app/views/schools/show.html.erb
+++ b/app/views/schools/show.html.erb
@@ -47,6 +47,10 @@
   <%= render 'management/schools/targets/review_targets', school: @school %>
 <% end %>
 
+<% if @set_new_target %>
+  <%= render 'management/schools/targets/set_new_target', school: @school %>
+<% end %>
+
 <% if @show_standard_prompts %>
   <%= render 'management/schools/complete_programmes', school: @school %>
 

--- a/config/locales/views/schools/schools.yml
+++ b/config/locales/views/schools/schools.yml
@@ -124,6 +124,7 @@ en:
       review_progress: Review progress
       review_target: Review your target
       revisit_targets: The configuration of your school has changed, you may need to revisit your targets for this year.
+      set_new_target: Your school set a target to reduce its energy usage by %{target_date}. It's time to review your progress and set a new target for the year ahead.
       set_target: Set energy saving target
       set_targets: Set targets to reduce your school's energy consumption over the next year. Energy Sparks will provide you with a recommended set of steps to help you achieve your targets and reduce your school's carbon footprint.
       setup_alert_contacts: Sign-up for Energy Sparks email or text alerts. Energy Sparks alerts give you early warning of changes in your school's energy use and highlight long term problems with your energy consumption with focused recommendations to save energy.

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -563,6 +563,8 @@ describe School do
         expect(subject.has_current_target?).to eql true
         expect(subject.current_target).to eql target
         expect(subject.most_recent_target).to eql target
+        expect(subject.expired_target).to be_nil
+        expect(subject.has_expired_target?).to eql false
       end
 
       it "the target should add meter attributes" do
@@ -577,6 +579,8 @@ describe School do
           expect(subject.has_current_target?).to be true
           expect(subject.current_target).to eql target
           expect(subject.most_recent_target).to eql future_target
+          expect(subject.expired_target).to be_nil
+          expect(subject.has_expired_target?).to eql false
         end
       end
 
@@ -590,6 +594,8 @@ describe School do
           expect(subject.has_current_target?).to be false
           expect(subject.current_target).to eql nil
           expect(subject.most_recent_target).to eql target
+          expect(subject.expired_target).to eq target
+          expect(subject.has_expired_target?).to eql true
         end
 
         it "should still produce meter attributes" do


### PR DESCRIPTION
We have some schools that are coming to the end of their energy saving target period.

This is first of some improvements to application views, prompts and other functionality for expired targets.

This PR has:

* new methods on School and School Target to identify expired vs current targets, with tests
* revised logic for school dashboard so that we don't show progress reports for expired targets
* adds a new dashboard prompt to set a new target if the current one has expired

