### PR TITLE
Fix progress reporting when target is expired

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ gem 'pg_search'
 gem 'calculate_in_group'
 
 # Dashboard analytics
-gem 'energy-sparks_analytics', git: 'https://github.com/Energy-Sparks/energy-sparks_analytics.git', tag: '2.0.9'
+gem 'energy-sparks_analytics', git: 'https://github.com/Energy-Sparks/energy-sparks_analytics.git', tag: '2.1'
 #gem 'energy-sparks_analytics', git: 'https://github.com/Energy-Sparks/energy-sparks_analytics.git', branch: 'aws-eb-test'
 #gem 'energy-sparks_analytics', path: '../energy-sparks_analytics'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/Energy-Sparks/energy-sparks_analytics.git
-  revision: 230e27df3c733e1dba4dc27f66b87a739adec9fd
-  tag: 2.0.9
+  revision: de187d5fbe02b52ca8864dee1a74f9b55bf9d2a6
+  tag: 2.1
   specs:
     energy-sparks_analytics (1.2.1)
       activesupport (~> 6.0.0)

--- a/app/controllers/schools/progress_controller.rb
+++ b/app/controllers/schools/progress_controller.rb
@@ -61,7 +61,13 @@ module Schools
     end
 
     def this_month
-      Time.zone.today.beginning_of_month
+      #if target is expired, then use the final month, otherwise report on
+      #current progress
+      if @school_target.expired?
+        @school_target.target_date.prev_month.beginning_of_month
+      else
+        Time.zone.today.beginning_of_month
+      end
     end
 
     def bad_estimate?(type)

--- a/app/controllers/schools/progress_controller.rb
+++ b/app/controllers/schools/progress_controller.rb
@@ -39,6 +39,9 @@ module Schools
         @recent_data = service.recent_data?
         @progress = service.progress
         @this_month_target = @progress.cumulative_targets_kwh[this_month]
+        #the analytics can return a report with >12 months
+        #but we only want to report on a year at a time
+        @reporting_months = @progress.months[0..11]
         @suggest_estimate_important = suggest_estimate_for_fuel_type?(@fuel_type, check_data: true)
         @debug_content = service.analytics_debug_info if current_user.present? && current_user.analytics?
       rescue => e

--- a/app/controllers/schools/progress_controller.rb
+++ b/app/controllers/schools/progress_controller.rb
@@ -58,7 +58,7 @@ module Schools
     end
 
     def this_month
-      Time.zone.now.strftime("%b")
+      Time.zone.today.beginning_of_month
     end
 
     def bad_estimate?(type)

--- a/app/services/targets/generate_progress_service.rb
+++ b/app/services/targets/generate_progress_service.rb
@@ -8,17 +8,17 @@ module Targets
 
     def cumulative_progress(fuel_type)
       target_progress = target_progress(fuel_type)
-      target_progress.present? ? target_progress.current_cumulative_performance_versus_synthetic_last_year : nil
+      target_progress.present? ? target_progress.cumulative_performance_versus_synthetic_last_year[reporting_month] : nil
     end
 
     def current_monthly_target(fuel_type)
       target_progress = target_progress(fuel_type)
-      target_progress.present? ? target_progress.cumulative_targets_kwh[this_month] : nil
+      target_progress.present? ? target_progress.cumulative_targets_kwh[reporting_month] : nil
     end
 
     def current_monthly_usage(fuel_type)
       target_progress = target_progress(fuel_type)
-      target_progress.present? ? target_progress.current_cumulative_usage_kwh : nil
+      target_progress.present? ? target_progress.cumulative_usage_kwh[reporting_month] : nil
     end
 
     def generate!
@@ -84,8 +84,14 @@ module Targets
       end
     end
 
-    def this_month
-      Time.zone.today.beginning_of_month
+    def reporting_month
+      #if target is expired, then use the final month, otherwise report on
+      #current progress
+      if target.expired?
+        target.target_date.prev_month.beginning_of_month
+      else
+        Time.zone.today.beginning_of_month
+      end
     end
 
     def target_progress(fuel_type)

--- a/app/services/targets/generate_progress_service.rb
+++ b/app/services/targets/generate_progress_service.rb
@@ -85,7 +85,7 @@ module Targets
     end
 
     def this_month
-      Time.zone.now.strftime("%b")
+      Time.zone.today.beginning_of_month
     end
 
     def target_progress(fuel_type)

--- a/app/views/schools/progress/index.html.erb
+++ b/app/views/schools/progress/index.html.erb
@@ -60,7 +60,7 @@
       </th>
       <% @progress.months.each do |month| %>
         <th class="text-right">
-          <%= month %>
+          <%= month.strftime('%b') %>
         </th>
       <% end %>
     </tr>

--- a/app/views/schools/progress/index.html.erb
+++ b/app/views/schools/progress/index.html.erb
@@ -58,7 +58,7 @@
       <th>
         Month
       </th>
-      <% @progress.months.each do |month| %>
+      <% @reporting_months.each do |month| %>
         <th class="text-right">
           <%= month.strftime('%b') %>
         </th>
@@ -66,9 +66,9 @@
     </tr>
     </thead>
     <tbody>
-    <%= render 'row', title: 'Target Consumption (kWh)', progress: @progress, data: @progress.monthly_targets_kwh, keys: @progress.months, partial_months: {}, percentage_synthetic: @progress.percentage_synthetic, units: :kwh, final_row: false %>
-    <%= render 'row', title: 'Actual Consumption (kWh)', progress: @progress, data: @progress.monthly_usage_kwh, keys: @progress.months, partial_months: @progress.partial_months, percentage_synthetic: {}, units: :kwh, final_row: false %>
-    <%= render 'row', title: 'Overall change since last year', progress: @progress, data: @progress.monthly_performance_versus_synthetic_last_year, keys: @progress.months, partial_months: @progress.partial_months, percentage_synthetic: {}, units: :relative_percent, final_row: true %>
+    <%= render 'row', title: 'Target Consumption (kWh)', progress: @progress, data: @progress.monthly_targets_kwh, keys: @reporting_months, partial_months: {}, percentage_synthetic: @progress.percentage_synthetic, units: :kwh, final_row: false %>
+    <%= render 'row', title: 'Actual Consumption (kWh)', progress: @progress, data: @progress.monthly_usage_kwh, keys: @reporting_months, partial_months: @progress.partial_months, percentage_synthetic: {}, units: :kwh, final_row: false %>
+    <%= render 'row', title: 'Overall change since last year', progress: @progress, data: @progress.monthly_performance_versus_synthetic_last_year, keys: @reporting_months, partial_months: @progress.partial_months, percentage_synthetic: {}, units: :relative_percent, final_row: true %>
     </tbody>
   </table>
 
@@ -80,17 +80,17 @@
       <th>
         Month
       </th>
-      <% @progress.months.each do |month| %>
+      <% @reporting_months.each do |month| %>
         <th class="text-right">
-          <%= month %>
+          <%= month.strftime('%b') %>
         </th>
       <% end %>
     </tr>
     </thead>
     <tbody>
-    <%= render 'row', title: 'Target Consumption (kWh)', data: @progress.cumulative_targets_kwh, keys: @progress.months, partial_months: {}, percentage_synthetic: @progress.percentage_synthetic, units: :kwh, final_row: false %>
-    <%= render 'row', title: 'Actual Consumption (kWh)', data: @progress.cumulative_usage_kwh, keys: @progress.months, partial_months: @progress.partial_months, percentage_synthetic: {}, units: :kwh, final_row: false %>
-    <%= render 'row', title: 'Overall performance since last year', data: @progress.cumulative_performance_versus_synthetic_last_year, keys: @progress.months, partial_months: @progress.partial_months, percentage_synthetic: {}, units: :relative_percent, final_row: true %>
+    <%= render 'row', title: 'Target Consumption (kWh)', data: @progress.cumulative_targets_kwh, keys: @reporting_months, partial_months: {}, percentage_synthetic: @progress.percentage_synthetic, units: :kwh, final_row: false %>
+    <%= render 'row', title: 'Actual Consumption (kWh)', data: @progress.cumulative_usage_kwh, keys: @reporting_months, partial_months: @progress.partial_months, percentage_synthetic: {}, units: :kwh, final_row: false %>
+    <%= render 'row', title: 'Overall performance since last year', data: @progress.cumulative_performance_versus_synthetic_last_year, keys: @reporting_months, partial_months: @progress.partial_months, percentage_synthetic: {}, units: :relative_percent, final_row: true %>
     </tbody>
   </table>
 
@@ -104,7 +104,7 @@
     <% end %>
 
     <p>
-    We use colour coding to indicate when you have <span class="bg-positive-dark">met your target</span> or <span class="bg-negative-dark">exceeded your target</span> in a given month
+    We use colour coding to indicate when you have <span class="bg-positive-dark">met your target</span> or <span class="bg-negative-dark">failed to meet your target</span> in a given month
     </p>
 
     <% if @progress.partial_consumption_data? %>

--- a/spec/services/targets/generate_progress_service_spec.rb
+++ b/spec/services/targets/generate_progress_service_spec.rb
@@ -13,7 +13,7 @@ describe Targets::GenerateProgressService do
 
   let!(:service)                  { Targets::GenerateProgressService.new(school, aggregated_school) }
 
-  let(:months)                    { [Date.today.last_month.strftime("%b"), Date.today.strftime("%b")] }
+  let(:months)                    { [Date.today.last_month.beginning_of_month, Date.today.beginning_of_month] }
   let(:fuel_type)                 { :electricity }
   let(:monthly_targets_kwh)       { [10,10] }
   let(:monthly_usage_kwh)         { [10,5] }
@@ -21,7 +21,7 @@ describe Targets::GenerateProgressService do
   let(:cumulative_targets_kwh)    { [10,20] }
   let(:cumulative_usage_kwh)      { [10,15] }
   let(:cumulative_performance)    { [-0.99,0.99] }
-  let(:partial_months)            { [Date.today.strftime("%b")] }
+  let(:partial_months)            { [Date.today.beginning_of_month] }
   let(:percentage_synthetic)      { [0, 0]}
 
   let(:progress) do

--- a/spec/system/schools/progress_spec.rb
+++ b/spec/system/schools/progress_spec.rb
@@ -11,7 +11,9 @@ describe 'targets', type: :system do
   let(:fuel_electricity)          { Schools::FuelConfiguration.new(has_electricity: true) }
   let(:school_target_fuel_types)  { ["electricity"] }
 
-  let(:months)                    { ['jan', 'feb'] }
+  let(:january)                   { Date.new(Date.today.year, 1, 1) }
+  let(:february)                  { Date.new(Date.today.year, 2, 1) }
+  let(:months)                    { [january, february] }
   let(:fuel_type)                 { :electricity }
 
   let(:monthly_usage_kwh)         { [10,20] }
@@ -77,8 +79,8 @@ describe 'targets', type: :system do
       it 'shows electricity progress' do
         visit electricity_school_progress_index_path(school)
         expect(page).to have_content('Tracking progress')
-        expect(page).to have_content('jan')
-        expect(page).to have_content('feb')
+        expect(page).to have_content('Jan')
+        expect(page).to have_content('Feb')
         expect(page).to have_content('-25%')
         expect(page).to have_content('+35%')
         expect(page).to have_content('-99%')
@@ -178,8 +180,8 @@ describe 'targets', type: :system do
         it 'renders the other data' do
           visit electricity_school_progress_index_path(school)
           expect(page).to have_content('Tracking progress')
-          expect(page).to have_content('jan')
-          expect(page).to have_content('feb')
+          expect(page).to have_content('Jan')
+          expect(page).to have_content('Feb')
           expect(page).to have_content('20')
           expect(page).to have_content('30')
         end


### PR DESCRIPTION
The progress report for a school target is broken when a target has expired as the analytics is returning >12 months of data, leading to some duplicate columns in the tables.

This PR

* picks up changes in the analytics which key the `TargetsProgress` data using dates, not strings
* changes the `Targets::GenerateProgressService` to use the new interface
* changes the `ProgressController` to use the interface
* updates the templates so that we only report the first 12 months of data, which is the period for the target
* for both the `Targets::GenerateProgressService` and `ProgressController` we now key the data via `reporting_month`. For current targets this is just the current month. But if the target has expired, it uses the last month of data for the data. This avoids us displaying different values on the school targets overview page vs the detailed progress report
