### PR TITLE
Allow future observations

### DIFF
--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -41,7 +41,6 @@ class Observation < ApplicationRecord
   enum observation_type: [:temperature, :intervention, :activity, :event, :audit]
 
   validates_presence_of :at, :school
-  validate :at_date_cannot_be_in_the_future
   validates_associated :temperature_recordings
 
   validates :intervention_type_id, presence: { message: 'please select an option' }, if: :intervention?
@@ -60,10 +59,6 @@ class Observation < ApplicationRecord
   has_rich_text :description
 
   before_save :add_points_for_interventions
-
-  def at_date_cannot_be_in_the_future
-    errors.add(:at, "can't be in the future") if at.present? && at > Time.zone.today.end_of_day
-  end
 
 private
 

--- a/spec/models/observation_spec.rb
+++ b/spec/models/observation_spec.rb
@@ -5,18 +5,6 @@ describe Observation do
   let(:school_name) { 'Active school'}
   let!(:school)     { create(:school, name: school_name) }
 
-  it 'can have a date in the past' do
-    expect(Observation.new(at: Date.yesterday, school: school).valid?).to be true
-  end
-
-  it 'can have a date today' do
-    expect(Observation.new(at: DateTime.now, school: school).valid?).to be true
-  end
-
-  it 'cannot have a date in the future' do
-    expect(Observation.new(at: Date.tomorrow, school: school).valid?).to be false
-  end
-
   context 'interventions' do
     let!(:intervention_type){ create(:intervention_type, score: 50) }
 

--- a/spec/system/temperature_recordings_spec.rb
+++ b/spec/system/temperature_recordings_spec.rb
@@ -55,9 +55,6 @@ describe 'temperature recordings as school admin' do
           fill_in 'The Hall', with: 20
           fill_in 'At', with: ''
           expect { click_on('Create temperature recordings') }.to change { Observation.count }.by(0).and change { TemperatureRecording.count }.by(0)
-
-          fill_in 'At', with: Date.tomorrow
-          expect { click_on('Create temperature recordings') }.to change { Observation.count }.by(0).and change { TemperatureRecording.count }.by(0)
           fill_in 'At', with: Date.yesterday
           expect { click_on('Create temperature recordings') }.to change { Observation.count }.by(1).and change { TemperatureRecording.count }.by(1)
         end


### PR DESCRIPTION
Allow schools to record activities for future dates, e.g. as part of a campaign pledge.