### PR TITLE
Add admin reports to view benchmark result data

### DIFF
--- a/app/controllers/schools/benchmark_reports_controller.rb
+++ b/app/controllers/schools/benchmark_reports_controller.rb
@@ -1,0 +1,15 @@
+module Schools
+  class BenchmarkReportsController < ApplicationController
+    load_and_authorize_resource :school
+
+    def index
+      authorize! :view_content_reports, @school
+      @benchmark_result_school_generation_runs = @school.benchmark_result_school_generation_runs.order(created_at: :desc)
+    end
+
+    def show
+      authorize! :view_content_reports, @school
+      @run = @school.benchmark_result_school_generation_runs.find(params[:id])
+    end
+  end
+end

--- a/app/controllers/schools/benchmark_results_controller.rb
+++ b/app/controllers/schools/benchmark_results_controller.rb
@@ -1,0 +1,10 @@
+module Schools
+  class BenchmarkResultsController < ApplicationController
+    load_and_authorize_resource :school
+
+    def show
+      @result = BenchmarkResult.find(params[:id])
+      authorize! :read, @result
+    end
+  end
+end

--- a/app/views/schools/benchmark_reports/index.html.erb
+++ b/app/views/schools/benchmark_reports/index.html.erb
@@ -1,0 +1,24 @@
+<% content_for :page_title do %>Benchmark run reports for <%= @school.name %><% end %>
+
+<h1>Benchmark result generation runs</h1>
+
+<table class="table">
+  <thead>
+    <tr>
+      <th>Date</th>
+      <th>Successful results</th>
+      <th>Errors</th>
+      <th>Action</th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @benchmark_result_school_generation_runs.each do |run| %>
+      <tr>
+        <td><%= nice_date_times(run.created_at) %></td>
+        <td><%= run.benchmark_results.count %></td>
+        <td><%= run.benchmark_result_errors.count %></td>
+        <td><%= link_to 'View', school_benchmark_report_path(@school, run), class: 'btn' %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/schools/benchmark_reports/show.html.erb
+++ b/app/views/schools/benchmark_reports/show.html.erb
@@ -1,0 +1,51 @@
+<h2>Benchmarks</h2>
+
+<%= link_to "View all runs", school_benchmark_reports_path(@school) %>
+
+<h3>Success</h3>
+
+<table class="table table-sm table-sorted">
+  <thead>
+    <tr>
+      <th>Alert Type</th>
+      <th>Alert Class</th>
+      <th>Using data up to</th>
+      <th>Run on</th>
+    </tr>
+  </thead>
+  <tbody>
+      <% @run.benchmark_results.each do |benchmark_result| %>
+        <tr>
+          <td><%= link_to benchmark_result.alert_type.title, school_benchmark_result_path(@school, benchmark_result) %></td>
+          <td><%= benchmark_result.alert_type.class_name %></td>
+          <td><%= nice_dates(benchmark_result.asof) %></td>
+          <td><%= nice_date_times(benchmark_result.created_at) %></td>
+        </tr>
+      <% end %>
+  </tbody>
+</table>
+
+<h3>Errors</h3>
+
+<table class="table table-sm table-sorted">
+  <thead>
+    <tr>
+      <th>Alert Type</th>
+      <th>Alert Class</th>
+      <th>Asof</th>
+      <th>Using data up to</th>
+      <th>Information</th>
+    </tr>
+  </thead>
+  <tbody>
+      <% @run.benchmark_result_errors.each do |benchmark_result_error| %>
+        <tr>
+          <td><%= benchmark_result_error.alert_type.title %></td>
+          <td><%= benchmark_result_error.alert_type.class_name %></td>
+          <td><%= nice_dates(benchmark_result_error.asof_date) %></td>
+          <td><%= nice_date_times(benchmark_result_error.created_at) %></td>
+          <td><%= benchmark_result_error.information %></td>
+        </tr>
+      <% end %>
+  </tbody>
+</table>

--- a/app/views/schools/benchmark_results/show.html.erb
+++ b/app/views/schools/benchmark_results/show.html.erb
@@ -1,0 +1,22 @@
+<% content_for :page_title do %>Benchmark Result for <%= @school.name %><% end %>
+<div class="row padded-row">
+  <div class="col-md-12">
+    <h1 property="name">Benchmark Result for <%= link_to @school.name, @school %></h1>
+  </div>
+
+  <div class="col-md-12">
+    <p><%= link_to "View all benchmark results in this run", school_benchmark_report_path(@school, @result.benchmark_result_school_generation_run) %></p>
+    <div class="card mb-3">
+      <div class="card-header">
+        <h4>Benchmark Result: <%= @result.alert_type.title %></h4>
+      </div>
+      <div class="card-body">
+        <h5>Benchmark variables (English)</h5>
+        <%= sanitize ap(@result.data, index: false, plain: true)%>
+      </div>
+      <div class="card-footer text-muted">
+        <p class="card-text"><b>Run on date</b>: <%= nice_dates @result.created_at %></p>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/schools/reports/index.html.erb
+++ b/app/views/schools/reports/index.html.erb
@@ -8,6 +8,9 @@
     <li><%= link_to 'Alert reports', school_alert_reports_path(@school) %> -- view summary of recent alert runs</li>
   <% end %>
   <% if can? :view_content_reports, @school %>
+    <li><%= link_to 'Benchmark reports', school_benchmark_reports_path(@school) %> -- view summary of recent benchmark runs</li>
+  <% end %>
+  <% if can? :view_content_reports, @school %>
     <li><%= link_to 'Equivalences', school_equivalence_reports_path(@school) %> -- view details of generated equivalences</li>
   <% end %>
   <% if can? :view_content_reports, @school %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -209,6 +209,8 @@ Rails.application.routes.draw do
       end
 
       resources :alert_reports, only: [:index, :show]
+      resources :benchmark_reports, only: [:index, :show]
+      resources :benchmark_results, only: [:show]
       resources :content_reports, only: [:index, :show]
       resources :equivalence_reports, only: [:index, :show]
       get :chart, to: 'charts#show'


### PR DESCRIPTION
We've had some issues with the benchmark generation recently. It's hard to debug because of lack of easy access to the result / error data.

This PR is a quick and dirty copy of the similar reports that we have for alerts and equivalences, making it possible to browse the data as an admin.