### PR TITLE
Remove bullet charts from school target overview

### DIFF
--- a/app/views/schools/school_targets/_bullet_chart.html.erb
+++ b/app/views/schools/school_targets/_bullet_chart.html.erb
@@ -3,13 +3,9 @@
     <h4 class="card-title"><%= fuel_progress.fuel_type.to_s.humanize %></h4>
   </div>
   <div class="col-md-8 d-none d-sm-block" style="padding-right: 25px">
-    <div class="d-flex justify-content-center">
-      <span style="margin-left: 10px; width: 100%;" class="text-center work_week"><%= up_downify(format_target(fuel_progress.progress, :relative_percent))%> against target of <%=target%>%</span>
+    <div class="d-flex align-middle align-self-center justify-content-center">
+      <h4 style="margin-left: 10px; width: 100%;" class="text-center work_week"><%= up_downify(format_target(fuel_progress.progress, :relative_percent))%> against target of <%=-target%>%</h4>
     </div>
-    <figure class="highcharts-figure">
-        <div class="bullet-chart" id="bullet-chart-<%= fuel_progress.fuel_type.to_s %>" data-title="" data-series='<%= bullet_chart_series(fuel_progress) %>'
-        data-label="Consumption" data-units="kWh" data-start-date="<%=school_target.start_date.strftime("%b %Y")%>" data-bands='<%= bullet_chart_bands(fuel_progress) %>' data-month='<%= Time.now.strftime("%b %Y")%> '></div>
-    </figure>
   </div>
   <div class="col-md-2 align-self-center">
     <%= link_to "View report", progress_path, class: "btn btn-outline-dark font-weight-bold" %>

--- a/app/views/schools/school_targets/_limited_data.html.erb
+++ b/app/views/schools/school_targets/_limited_data.html.erb
@@ -4,13 +4,13 @@
   </div>
   <div class="col-md-8 align-self-center work_week d-none d-sm-block" style="padding-right: 25px">
     <div class="d-flex justify-content-center mt-2">
-      <span class="text-center">
+      <h4 class="text-center">
         <% if overview_data.present? && overview_data.work_week(fuel_type).has_data %>
-              <%= up_downify(overview_data.work_week(fuel_type).change) %> last week against target of <%= target %>%
+              <%= up_downify(overview_data.work_week(fuel_type).change) %> last week against target of -<%= target %>%
         <% else %>
           Target reduction of <%= target %>%
         <% end %>
-      </span>
+      </h4>
     </div>
   </div>
   <div class="col-md-2 align-self-center">

--- a/app/views/schools/school_targets/_limited_data.html.erb
+++ b/app/views/schools/school_targets/_limited_data.html.erb
@@ -6,7 +6,7 @@
     <div class="d-flex justify-content-center mt-2">
       <h4 class="text-center">
         <% if overview_data.present? && overview_data.work_week(fuel_type).has_data %>
-              <%= up_downify(overview_data.work_week(fuel_type).change) %> last week against target of -<%= target %>%
+              <%= up_downify(overview_data.work_week(fuel_type).change) %> last week against target of <%= -target %>%
         <% else %>
           Target reduction of <%= target %>%
         <% end %>

--- a/spec/system/schools/school_targets_spec.rb
+++ b/spec/system/schools/school_targets_spec.rb
@@ -225,12 +225,6 @@ RSpec.describe 'school targets', type: :system do
         expect(page).to have_link("View report", href: electricity_school_progress_index_path(school))
       end
 
-      it 'shows the bullet charts' do
-        expect(page).to have_css('#bullet-chart-electricity')
-        expect(page).to have_css('#bullet-chart-gas')
-        expect(page).to_not have_css('#bullet-chart-storage_heater')
-      end
-
       it 'does not show limited data' do
         expect(page).to_not have_content("against target reduction")
         expect(page).to_not have_content("last week")
@@ -243,11 +237,6 @@ RSpec.describe 'school targets', type: :system do
           school.configuration.update!(suggest_estimates_fuel_types: ["electricity"])
           refresh
         end
-        it 'doesnt show the electricity bullet chart' do
-          expect(page).to_not have_css('#bullet-chart-electricity')
-          expect(page).to have_css('#bullet-chart-gas')
-        end
-
         it 'shows limited data' do
           expect(page).to have_content("Target reduction")
           expect(page).to_not have_content("last week")


### PR DESCRIPTION
Feedback has been that its not clear what the bullet charts are showing on the school targets page.

So for now we'll remove then in favour of just showing their % progress.