### PR TITLE
Show infinite float values on charts

### DIFF
--- a/app/models/chart_data_values.rb
+++ b/app/models/chart_data_values.rb
@@ -114,7 +114,15 @@ class ChartDataValues
 
     # Temporary TOFIX TODO as analytics should not return negative values
     @series_data.map do |series|
-      series[:data] = series[:data].map { |v| v.is_a?(Float) ? v.round(8) : v }
+      series[:data] = series[:data].map do |v|
+        if v.is_a?(Float)
+          # Convert infinity values to the Maximum representable finite float so it's not
+          # converted to null in the chart json
+          v.infinite? ? Float::MAX : v.round(8)
+        else
+          v
+        end
+      end
       series
     end
   end


### PR DESCRIPTION
Infinite values don't show on charts as they are converted to null in the chart json files. e.g.
```
irb(main):106:0> {a: Float::INFINITY}.to_json
=> "{\"a\":null}"
irb(main):106:0> {a: -Float::INFINITY}.to_json
=> "{\"a\":null}"
irb(main):107:0> {a: Float::MAX}.to_json
=> "{\"a\":1.7976931348623157e+308}"
```
This PR converts all infinity values (`Float::INFINITY`) to the maximum representable finite float (`Float::MAX`) - for chart values only.  This is represented on the charts tooltip as 
![Screenshot 2022-11-10 at 09 57 52](https://user-images.githubusercontent.com/25906/201061193-e67039dd-7585-456e-98a6-fe397d969682.png)
Note: This is specific to the benchmarks chart where the chart is bound -100% to 100% (so the 
