### PR TITLE
Save target progress report to School Target

### DIFF
--- a/app/models/school_target.rb
+++ b/app/models/school_target.rb
@@ -81,7 +81,23 @@ class SchoolTarget < ApplicationRecord
     )
   end
 
+  def saved_progress_report_for(fuel_type)
+    raise "Invalid fuel type" unless [:electricity, :gas, :storage_heaters].include?(fuel_type)
+    report = self["#{fuel_type}_report".to_sym]
+    return nil unless report&.any?
+    TargetsProgress.new(reformat_saved_report(report))
+  end
+
   private
+
+  #ensure TargetsProgress is round-tripped properly
+  def reformat_saved_report(report)
+    report.symbolize_keys!
+    report[:fuel_type] = report[:fuel_type].to_sym
+    #reparse to Dates from yyyy-mm-dd format
+    report[:months].map! {|m| Date.parse(m)}
+    report
+  end
 
   def target_to_hash(target)
     {

--- a/app/models/school_target.rb
+++ b/app/models/school_target.rb
@@ -95,7 +95,7 @@ class SchoolTarget < ApplicationRecord
     report.symbolize_keys!
     report[:fuel_type] = report[:fuel_type].to_sym
     #reparse to Dates from yyyy-mm-dd format
-    report[:months].map! {|m| Date.parse(m)}
+    report[:months].map! {|m| Date.strptime(m, '%Y-%m-%d')}
     report
   end
 

--- a/app/services/targets/generate_progress_service.rb
+++ b/app/services/targets/generate_progress_service.rb
@@ -25,8 +25,11 @@ module Targets
       if Targets::SchoolTargetService.targets_enabled?(@school) && target.present?
         target.update!(
           electricity_progress: fuel_type_progress(:electricity),
+          electricity_report: target_progress(:electricity),
           gas_progress: fuel_type_progress(:gas),
+          gas_report: target_progress(:gas),
           storage_heaters_progress: fuel_type_progress(:storage_heaters),
+          storage_heaters_report: target_progress(:storage_heaters),
           report_last_generated: Time.zone.now
         )
         return target
@@ -36,12 +39,7 @@ module Targets
     private
 
     def can_generate_fuel_type?(fuel_type)
-      if EnergySparks::FeatureFlags.active?(:school_targets_v2)
-        has_fuel_type_and_target?(fuel_type)
-      else
-        has_fuel_type_and_target?(fuel_type) &&
-          @school.configuration.enough_data_to_set_target_for_fuel_type?(fuel_type)
-      end
+      has_fuel_type_and_target?(fuel_type)
     end
 
     def fuel_type_progress(fuel_type)

--- a/db/migrate/20221110133928_add_progress_reports_to_school_target.rb
+++ b/db/migrate/20221110133928_add_progress_reports_to_school_target.rb
@@ -1,0 +1,7 @@
+class AddProgressReportsToSchoolTarget < ActiveRecord::Migration[6.0]
+  def change
+    add_column :school_targets, :electricity_report, :jsonb, default: {}
+    add_column :school_targets, :gas_report, :jsonb, default: {}
+    add_column :school_targets, :storage_heaters_report, :jsonb, default: {}
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_10_31_115646) do
+ActiveRecord::Schema.define(version: 2022_11_10_133928) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
@@ -1320,6 +1320,9 @@ ActiveRecord::Schema.define(version: 2022_10_31_115646) do
     t.json "electricity_progress", default: {}
     t.json "gas_progress", default: {}
     t.json "storage_heaters_progress", default: {}
+    t.jsonb "electricity_report", default: {}
+    t.jsonb "gas_report", default: {}
+    t.jsonb "storage_heaters_report", default: {}
     t.index ["school_id"], name: "index_school_targets_on_school_id"
   end
 

--- a/spec/models/school_target_spec.rb
+++ b/spec/models/school_target_spec.rb
@@ -93,4 +93,63 @@ RSpec.describe SchoolTarget, type: :model do
     end
   end
 
+  context '#saved_progress_report_for' do
+    let(:january)                   { Date.new(Date.today.year, 1, 1) }
+    let(:february)                  { Date.new(Date.today.year, 2, 1) }
+    let(:months)                    { [january, february] }
+    let(:fuel_type)                 { :electricity }
+
+    let(:monthly_usage_kwh)         { [10,20] }
+    let(:monthly_targets_kwh)       { [8,15] }
+    let(:monthly_performance)       { [-0.25,0.35] }
+
+    let(:cumulative_usage_kwh)      { [10,30] }
+    let(:cumulative_targets_kwh)    { [8,25] }
+    let(:cumulative_performance)    { [-0.99,0.99] }
+
+    let(:partial_months)            { [false, true] }
+    let(:percentage_synthetic)      { [0.0, 0.5]}
+
+    let(:progress) do
+      TargetsProgress.new(
+          fuel_type: fuel_type,
+          months: months,
+          monthly_targets_kwh: monthly_targets_kwh,
+          monthly_usage_kwh: monthly_usage_kwh,
+          monthly_performance: monthly_performance,
+          cumulative_targets_kwh: cumulative_targets_kwh,
+          cumulative_usage_kwh: cumulative_usage_kwh,
+          cumulative_performance: cumulative_performance,
+          cumulative_performance_versus_synthetic_last_year: cumulative_performance,
+          monthly_performance_versus_synthetic_last_year: monthly_performance,
+          partial_months: partial_months,
+          percentage_synthetic: percentage_synthetic
+      )
+    end
+
+    before(:each) do
+      school.school_targets.create!(start_date: start_date, target_date: target_date, electricity: 10, electricity_report: progress)
+    end
+
+    it 'returns nil if no there is no saved report' do
+      expect(SchoolTarget.first.saved_progress_report_for(:gas)).to be_nil
+    end
+
+    it 'returns a progress report' do
+      report = SchoolTarget.first.saved_progress_report_for(:electricity)
+      expect(report.fuel_type).to eql(progress.fuel_type)
+      expect(report.months).to eql(progress.months)
+      expect(report.monthly_targets_kwh).to eql(progress.monthly_targets_kwh)
+      expect(report.monthly_usage_kwh).to eql(progress.monthly_usage_kwh)
+      expect(report.monthly_performance).to eql(progress.monthly_performance)
+      expect(report.cumulative_targets_kwh).to eql(progress.cumulative_targets_kwh)
+      expect(report.cumulative_usage_kwh).to eql(progress.cumulative_usage_kwh)
+      expect(report.cumulative_performance).to eql(progress.cumulative_performance)
+      expect(report.cumulative_performance_versus_synthetic_last_year).to eql(progress.cumulative_performance_versus_synthetic_last_year)
+      expect(report.monthly_performance_versus_synthetic_last_year).to eql(progress.monthly_performance_versus_synthetic_last_year)
+      expect(report.partial_months).to eql(progress.partial_months)
+      expect(report.percentage_synthetic).to eql(progress.percentage_synthetic)
+    end
+  end
+
 end

--- a/spec/services/targets/generate_progress_service_spec.rb
+++ b/spec/services/targets/generate_progress_service_spec.rb
@@ -21,7 +21,7 @@ describe Targets::GenerateProgressService do
   let(:cumulative_targets_kwh)    { [10,20] }
   let(:cumulative_usage_kwh)      { [10,15] }
   let(:cumulative_performance)    { [-0.99,0.99] }
-  let(:partial_months)            { [Date.today.beginning_of_month] }
+  let(:partial_months)            { [false, true] }
   let(:percentage_synthetic)      { [0, 0]}
 
   let(:progress) do
@@ -117,6 +117,10 @@ describe Targets::GenerateProgressService do
         expect( target ).to eql school_target
       end
 
+      it 'saved the progress report' do
+        expect( target.saved_progress_report_for(:electricity).to_json ).to eq(progress.to_json)
+      end
+
       it 'records when last run' do
         expect( target.report_last_generated ).to_not be_nil
       end
@@ -137,23 +141,13 @@ describe Targets::GenerateProgressService do
     context 'and not enough data' do
       let(:school_target_fuel_types)  { [] }
 
-      context 'v1' do
-        before(:each) do
-          allow(EnergySparks::FeatureFlags).to receive(:active?).with(:school_targets_v2).and_return(false)
-        end
-        it 'does nothing' do
-          expect( service.generate! ).to eq school_target
-        end
+      before(:each) do
+        allow(EnergySparks::FeatureFlags).to receive(:active?).with(:school_targets_v2).and_return(true)
+        allow_any_instance_of(TargetsService).to receive(:progress).and_return(progress)
+        allow_any_instance_of(TargetsService).to receive(:recent_data?).and_return(true)
       end
-      context 'v2' do
-        before(:each) do
-          allow(EnergySparks::FeatureFlags).to receive(:active?).with(:school_targets_v2).and_return(true)
-          allow_any_instance_of(TargetsService).to receive(:progress).and_return(progress)
-          allow_any_instance_of(TargetsService).to receive(:recent_data?).and_return(true)
-        end
-        it 'generates' do
-          expect( service.generate! ).to eq school_target
-        end
+      it 'generates' do
+        expect( service.generate! ).to eq school_target
       end
     end
   end


### PR DESCRIPTION
Save a full copy of the progress report for each school target to the School Target model

* Adds new JSONB columns to store the progress reports
* Updates the `GenerateProgressService` to save the progress for each fuel type, alongside the existing summary
* Adds support to `SchoolTarget` for turning the saved JSON data back into a `TargetsProgress` instance which can be used by the reports
* Removed feature flag from the service
* Tests for the above

This should add little overhead as the full progress report has to be generated anyway and this is cached in the `GenerateProgressService`.

This PR proceeds further changes to the feature, e.g. using cached progress report for expired target and removal of the feature flags