### PR TITLE
Assign Issues to Users

### DIFF
--- a/app/controllers/admin/school_groups_controller.rb
+++ b/app/controllers/admin/school_groups_controller.rb
@@ -52,6 +52,7 @@ module Admin
         :default_solar_pv_tuos_area_id,
         :default_weather_station_id,
         :default_chart_preference,
+        :default_notes_admin_user_id,
         :public
       )
     end

--- a/app/controllers/admin/schools/notes_controller.rb
+++ b/app/controllers/admin/schools/notes_controller.rb
@@ -48,7 +48,7 @@ module Admin
       private
 
       def note_params
-        params.require(:note).permit(:note_type, :title, :description, :fuel_type, :status)
+        params.require(:note).permit(:note_type, :title, :description, :fuel_type, :status, :owned_by_id)
       end
     end
   end

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -4,6 +4,7 @@ class Note < ApplicationRecord
   belongs_to :school
   belongs_to :created_by, class_name: 'User'
   belongs_to :updated_by, class_name: 'User'
+  belongs_to :owned_by, class_name: 'User', optional: true
 
   scope :by_updated_at, -> { order(updated_at: :desc) }
 
@@ -28,7 +29,7 @@ class Note < ApplicationRecord
   end
 
   def self.csv_attributes
-    %w{school.name title description.to_plain_text fuel_type created_by.email created_at updated_by.email updated_at}
+    %w{school.name title description.to_plain_text fuel_type created_by.display_name created_at updated_by.display_name updated_at}
   end
 
   # From rails 6.1 onwards, a default for enums can be specified by setting by _default: :open or rails 7: default: :open on the enum definition

--- a/app/models/school_group.rb
+++ b/app/models/school_group.rb
@@ -52,6 +52,7 @@ class SchoolGroup < ApplicationRecord
   belongs_to :default_dark_sky_area, class_name: 'DarkSkyArea', optional: true
   belongs_to :default_weather_station, class_name: 'WeatherStation', foreign_key: 'default_weather_station_id', optional: true
   belongs_to :default_scoreboard, class_name: 'Scoreboard', optional: true
+  belongs_to :default_notes_admin_user, class_name: 'User', foreign_key: 'default_notes_admin_user_id', optional: true
 
   has_many :meter_attributes, inverse_of: :school_group, class_name: 'SchoolGroupMeterAttribute'
 

--- a/app/views/admin/school_groups/_form.html.erb
+++ b/app/views/admin/school_groups/_form.html.erb
@@ -61,6 +61,11 @@
         <% end %>
       </div>
 
+      <div class="form-group">
+        <%= f.label :default_notes_admin_user_id, 'Default notes & issues admin user' %>
+        <%= f.select :default_notes_admin_user_id, options_from_collection_for_select(User.admin, 'id', 'display_name', (@school_group.default_notes_admin_user_id)), {include_blank: true}, { class: 'form-control' } %>
+      </div>
+
     </div>
   </div>
 

--- a/app/views/admin/school_groups/_issues.html.erb
+++ b/app/views/admin/school_groups/_issues.html.erb
@@ -4,6 +4,7 @@
       <th class="no-sort"></th>
       <th>Issue</th>
       <th>Fuel</th>
+      <th>Assigned to</th>
       <th>Updated by</th>
       <th>Updated</th>
       <th class="no-sort"></th>
@@ -18,6 +19,7 @@
             <span class="badge badge-secondary"><%= issue.fuel_type.capitalize %></span>
           <% end %>
         </td>
+        <td><%= issue.owned_by.display_name %></td>
         <td><%= issue.updated_by.display_name %></td>
         <td class="nowrap"><%= nice_date_times(issue.updated_at) %></td>
         <td class="nowrap text-right">

--- a/app/views/admin/school_groups/_issues.html.erb
+++ b/app/views/admin/school_groups/_issues.html.erb
@@ -18,7 +18,7 @@
             <span class="badge badge-secondary"><%= issue.fuel_type.capitalize %></span>
           <% end %>
         </td>
-        <td><%= issue.updated_by.email %></td>
+        <td><%= issue.updated_by.display_name %></td>
         <td class="nowrap"><%= nice_date_times(issue.updated_at) %></td>
         <td class="nowrap text-right">
           <%= link_to 'View', admin_school_note_path(issue.school, issue), class: "btn btn-sm" %>

--- a/app/views/admin/school_groups/_issues.html.erb
+++ b/app/views/admin/school_groups/_issues.html.erb
@@ -4,7 +4,7 @@
       <th class="no-sort"></th>
       <th>Issue</th>
       <th>Fuel</th>
-      <th>Assigned</th>
+      <th class="nowrap">Assigned to</th>
       <th>Updated</th>
       <th class="no-sort"></th>
     </tr>

--- a/app/views/admin/school_groups/_issues.html.erb
+++ b/app/views/admin/school_groups/_issues.html.erb
@@ -4,8 +4,7 @@
       <th class="no-sort"></th>
       <th>Issue</th>
       <th>Fuel</th>
-      <th>Assigned to</th>
-      <th>Updated by</th>
+      <th>Assigned</th>
       <th>Updated</th>
       <th class="no-sort"></th>
     </tr>
@@ -15,13 +14,9 @@
       <tr>
         <td><%= fa_icon('exclamation-circle text-secondary') %></td>
         <td><%= link_to issue.title, admin_school_note_path(issue.school, issue) %></td>
-        <td><% if issue.fuel_type %>
-            <span class="badge badge-secondary"><%= issue.fuel_type.capitalize %></span>
-          <% end %>
-        </td>
-        <td><%= issue.owned_by.display_name %></td>
-        <td><%= issue.updated_by.display_name %></td>
-        <td class="nowrap"><%= nice_date_times(issue.updated_at) %></td>
+        <td><%= render 'admin/schools/notes/fuel_type', note: issue %></td>
+        <td><%= render 'admin/schools/notes/owned_by', note: issue %></td>
+        <td data-order="<%= issue.updated_at %>"><div class="badge badge-pill bg-white text-dark font-weight-normal nowrap"><%= issue.updated_by.display_name %> • <%= nice_date_times_today(issue.updated_at) %></div></td>
         <td class="nowrap text-right">
           <%= link_to 'View', admin_school_note_path(issue.school, issue), class: "btn btn-sm" %>
         </td>

--- a/app/views/admin/schools/notes/_form.html.erb
+++ b/app/views/admin/schools/notes/_form.html.erb
@@ -4,6 +4,6 @@
   <%= f.input :fuel_type, collection: Note.fuel_types.keys, label_method: lambda {|k| k.humanize} %>
   <%= f.input :status, collection: Note.statuses.keys, label_method: lambda {|k| k.humanize}, include_blank: false unless note.new_record? %>
   <%= f.input :note_type, collection: Note.note_types.keys, label_method: lambda {|k| k.humanize}, include_blank: false %>
-  <%= f.input :owned_by_id, collection: User.admin, label_method: lambda {|k| k.display_name}, include_blank: true, selected: (f.object.new_record? && params.dig(:note,:owned_by_id).nil? ? school.school_group.try(:default_notes_admin_user_id) : f.object.owned_by_id) %>
+  <%= f.input :owned_by_id, collection: User.admin, label: "Assigned to", label_method: lambda {|k| k.display_name}, include_blank: true, selected: (f.object.new_record? && params.dig(:note,:owned_by_id).nil? ? school.school_group.try(:default_notes_admin_user_id) : f.object.owned_by_id) %>
   <%= f.submit 'Save', class: 'btn btn-primary' %>
 <% end %>

--- a/app/views/admin/schools/notes/_form.html.erb
+++ b/app/views/admin/schools/notes/_form.html.erb
@@ -4,5 +4,6 @@
   <%= f.input :fuel_type, collection: Note.fuel_types.keys, label_method: lambda {|k| k.humanize} %>
   <%= f.input :status, collection: Note.statuses.keys, label_method: lambda {|k| k.humanize}, include_blank: false unless note.new_record? %>
   <%= f.input :note_type, collection: Note.note_types.keys, label_method: lambda {|k| k.humanize}, include_blank: false %>
+  <%= f.input :owned_by_id, collection: User.admin, label_method: lambda {|k| k.display_name}, include_blank: true, selected: (f.object.new_record? && params.dig(:note,:owned_by_id).nil? ? school.school_group.try(:default_notes_admin_user_id) : f.object.owned_by_id) %>
   <%= f.submit 'Save', class: 'btn btn-primary' %>
 <% end %>

--- a/app/views/admin/schools/notes/_fuel_type.html.erb
+++ b/app/views/admin/schools/notes/_fuel_type.html.erb
@@ -1,0 +1,3 @@
+<% if note.fuel_type %>
+  <span class="badge badge-secondary"><%= note.fuel_type.capitalize %></span>
+<% end %>

--- a/app/views/admin/schools/notes/_header.html.erb
+++ b/app/views/admin/schools/notes/_header.html.erb
@@ -1,5 +1,9 @@
 <div class="d-flex justify-content-between align-items-center">
-  <h1><%= title %></h1>
+  <h1>
+    <% unless note.nil? %>
+      <%= fa_icon(note.issue? ? 'exclamation-circle text-secondary' : 'sticky-note text-secondary') %>
+    <% end %>
+    <%= title %></h1>
   <div>
     <%= yield %>
   </div>

--- a/app/views/admin/schools/notes/_note.html.erb
+++ b/app/views/admin/schools/notes/_note.html.erb
@@ -4,21 +4,22 @@
       <%= fa_icon(note.issue? ? 'exclamation-circle text-secondary' : 'sticky-note text-secondary') %> <%= note.title %>
       <div class="float-right">
         <small>
-          <% if note.fuel_type %>
-            <span class="badge badge-secondary"><%= note.fuel_type.capitalize %></span>
-          <% end %>
-          <% if note.issue? %>
-            <span class="badge <%= note.status_open? ? 'badge-primary' : 'badge-secondary' %>"><%= note.status.capitalize %></span>
+          <% if note.owned_by %>
+            <span class="badge badge-pill badge-secondary font-weight-normal"><%= note.owned_by == current_user ? "You" : note.owned_by.display_name %></span>
           <% end %>
           <%= nice_date_times_today(note.updated_at) %>
         </small>
       </div>
     </h4>
     <div class="clearfix">
-      <span class="badge badge-pill <%= note.issue? ? "badge-danger" : "badge-warning" %>"><%= note.note_type.capitalize %></span>
-      <% if note.owned_by %>
-        <span class="badge badge-pill badge-secondary font-weight-normal">Assigned to • <%= note.owned_by.display_name %></span>
+      <span class="badge <%= note.issue? ? "badge-danger" : "badge-warning" %>"><%= note.note_type.capitalize %></span>
+      <% if note.fuel_type %>
+        <span class="badge badge-secondary"><%= note.fuel_type.capitalize %></span>
       <% end %>
+      <% if note.issue? %>
+        <span class="badge <%= note.status_open? ? 'badge-primary' : 'badge-secondary' %>"><%= note.status.capitalize %></span>
+      <% end %>
+
       <span class='float-right'>
         <%= link_to 'Resolve', resolve_admin_school_note_path(@school, note), method: :post, class: 'btn btn-info btn-sm' if note.resolvable? %>
         <% if index %>

--- a/app/views/admin/schools/notes/_note.html.erb
+++ b/app/views/admin/schools/notes/_note.html.erb
@@ -4,18 +4,14 @@
       <%= fa_icon(note.issue? ? 'exclamation-circle text-secondary' : 'sticky-note text-secondary') %> <%= note.title %>
       <div class="float-right">
         <small>
-          <% if note.owned_by %>
-            <span class="badge badge-pill badge-secondary font-weight-normal"><%= note.owned_by == current_user ? "You" : note.owned_by.display_name %></span>
-          <% end %>
+          <%= render 'owned_by', note: note %>
           <%= nice_date_times_today(note.updated_at) %>
         </small>
       </div>
     </h4>
     <div class="clearfix">
       <span class="badge <%= note.issue? ? "badge-danger" : "badge-warning" %>"><%= note.note_type.capitalize %></span>
-      <% if note.fuel_type %>
-        <span class="badge badge-secondary"><%= note.fuel_type.capitalize %></span>
-      <% end %>
+      <%= render 'fuel_type', note: note %>
       <% if note.issue? %>
         <span class="badge <%= note.status_open? ? 'badge-primary' : 'badge-secondary' %>"><%= note.status.capitalize %></span>
       <% end %>

--- a/app/views/admin/schools/notes/_note.html.erb
+++ b/app/views/admin/schools/notes/_note.html.erb
@@ -27,8 +27,8 @@
     </div>
     <div class="bg-white p-2 my-2"><%= note.description %></div>
     <div class="pb-2">
-      <div class="badge badge-pill bg-white text-dark font-weight-normal">Created • <%= note.created_by.email %> • <%= nice_date_times_today(note.created_at) %></div>
-      <div class="badge badge-pill bg-white text-dark font-weight-normal">Updated • <%= note.updated_by.email %> • <%= nice_date_times_today(note.updated_at) %></div>
+      <div class="badge badge-pill bg-white text-dark font-weight-normal">Created • <%= note.created_by.display_name %> • <%= nice_date_times_today(note.created_at) %></div>
+      <div class="badge badge-pill bg-white text-dark font-weight-normal">Updated • <%= note.updated_by.display_name %> • <%= nice_date_times_today(note.updated_at) %></div>
     </div>
   </div>
 </div>

--- a/app/views/admin/schools/notes/_note.html.erb
+++ b/app/views/admin/schools/notes/_note.html.erb
@@ -4,6 +4,9 @@
       <%= fa_icon(note.issue? ? 'exclamation-circle text-secondary' : 'sticky-note text-secondary') %> <%= note.title %>
       <div class="float-right">
         <small>
+          <% if note.fuel_type %>
+            <span class="badge badge-secondary"><%= note.fuel_type.capitalize %></span>
+          <% end %>
           <% if note.issue? %>
             <span class="badge <%= note.status_open? ? 'badge-primary' : 'badge-secondary' %>"><%= note.status.capitalize %></span>
           <% end %>
@@ -13,8 +16,8 @@
     </h4>
     <div class="clearfix">
       <span class="badge badge-pill <%= note.issue? ? "badge-danger" : "badge-warning" %>"><%= note.note_type.capitalize %></span>
-      <% if note.fuel_type %>
-        <span class="badge badge-secondary"><%= note.fuel_type.capitalize %></span>
+      <% if note.owned_by %>
+        <span class="badge badge-pill badge-secondary font-weight-normal">Assigned to • <%= note.owned_by.display_name %></span>
       <% end %>
       <span class='float-right'>
         <%= link_to 'Resolve', resolve_admin_school_note_path(@school, note), method: :post, class: 'btn btn-info btn-sm' if note.resolvable? %>

--- a/app/views/admin/schools/notes/_owned_by.html.erb
+++ b/app/views/admin/schools/notes/_owned_by.html.erb
@@ -1,0 +1,3 @@
+<% if note.owned_by %>
+  <span class="badge badge-pill badge-secondary font-weight-normal"><%= note.owned_by == current_user ? "You" : note.owned_by.display_name %></span>
+<% end %>

--- a/app/views/admin/schools/notes/edit.html.erb
+++ b/app/views/admin/schools/notes/edit.html.erb
@@ -1,4 +1,4 @@
-<%= render 'header', title: "Edit #{@note.note_type.capitalize} for #{@school.name}" do %>
+<%= render 'header', note: @note, title: "Edit #{@school.name} #{@note.note_type.capitalize}" do %>
   <%= header_nav_link 'All school notes & issues', admin_school_notes_url(@school) %>
 <% end %>
 

--- a/app/views/admin/schools/notes/index.html.erb
+++ b/app/views/admin/schools/notes/index.html.erb
@@ -1,4 +1,4 @@
-<%= render 'header', title: "#{@school.name} Notes & Issues" do %>
+<%= render 'header', title: "#{@school.name} Notes & Issues", note: nil do %>
   <%= header_nav_link 'School group', admin_school_group_url(@school.school_group) if @school.school_group %>
 <% end %>
 

--- a/app/views/admin/schools/notes/new.html.erb
+++ b/app/views/admin/schools/notes/new.html.erb
@@ -1,4 +1,4 @@
-<%= render 'header', title: "New #{@note.note_type.capitalize} for #{@school.name}" do %>
+<%= render 'header', note: @note, title: "New #{@note.note_type.capitalize} for #{@school.name}" do %>
   <%= header_nav_link 'All school notes & issues', admin_school_notes_url(@school) %>
 <% end %>
 

--- a/app/views/admin/schools/notes/show.html.erb
+++ b/app/views/admin/schools/notes/show.html.erb
@@ -1,4 +1,4 @@
-<%= render 'header', title: "View #{@note.note_type.capitalize} for #{@school.name}" do %>
+<%= render 'header', note: @note, title: "View #{@note.note_type.capitalize} for #{@school.name}" do %>
   <%= header_nav_link 'All school notes & issues', admin_school_notes_url(@school) %>
 <% end %>
 

--- a/db/migrate/20221114113102_add_default_notes_admin_user_to_school_groups.rb
+++ b/db/migrate/20221114113102_add_default_notes_admin_user_to_school_groups.rb
@@ -1,0 +1,5 @@
+class AddDefaultNotesAdminUserToSchoolGroups < ActiveRecord::Migration[6.0]
+  def change
+    add_reference :school_groups, :default_notes_admin_user, foreign_key: {to_table: :users, on_delete: :nullify}
+  end
+end

--- a/db/migrate/20221114133851_add_owned_by_to_notes.rb
+++ b/db/migrate/20221114133851_add_owned_by_to_notes.rb
@@ -1,0 +1,5 @@
+class AddOwnedByToNotes < ActiveRecord::Migration[6.0]
+  def change
+    add_reference :notes, :owned_by, foreign_key: {to_table: :users}
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_11_14_113102) do
+ActiveRecord::Schema.define(version: 2022_11_14_133851) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
@@ -1054,7 +1054,9 @@ ActiveRecord::Schema.define(version: 2022_11_14_113102) do
     t.bigint "updated_by_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.bigint "owned_by_id"
     t.index ["created_by_id"], name: "index_notes_on_created_by_id"
+    t.index ["owned_by_id"], name: "index_notes_on_owned_by_id"
     t.index ["school_id"], name: "index_notes_on_school_id"
     t.index ["updated_by_id"], name: "index_notes_on_updated_by_id"
   end
@@ -1832,6 +1834,7 @@ ActiveRecord::Schema.define(version: 2022_11_14_113102) do
   add_foreign_key "meters", "schools", on_delete: :cascade
   add_foreign_key "meters", "solar_edge_installations", on_delete: :cascade
   add_foreign_key "notes", "users", column: "created_by_id"
+  add_foreign_key "notes", "users", column: "owned_by_id"
   add_foreign_key "notes", "users", column: "updated_by_id"
   add_foreign_key "observations", "activities", on_delete: :nullify
   add_foreign_key "observations", "audits"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_11_11_103603) do
+ActiveRecord::Schema.define(version: 2022_11_14_113102) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
@@ -1218,6 +1218,8 @@ ActiveRecord::Schema.define(version: 2022_11_11_103603) do
     t.bigint "default_weather_station_id"
     t.boolean "public", default: true
     t.integer "default_chart_preference", default: 0, null: false
+    t.bigint "default_notes_admin_user_id"
+    t.index ["default_notes_admin_user_id"], name: "index_school_groups_on_default_notes_admin_user_id"
     t.index ["default_scoreboard_id"], name: "index_school_groups_on_default_scoreboard_id"
     t.index ["default_solar_pv_tuos_area_id"], name: "index_school_groups_on_default_solar_pv_tuos_area_id"
     t.index ["default_template_calendar_id"], name: "index_school_groups_on_default_template_calendar_id"
@@ -1852,6 +1854,7 @@ ActiveRecord::Schema.define(version: 2022_11_11_103603) do
   add_foreign_key "school_groups", "areas", column: "default_solar_pv_tuos_area_id"
   add_foreign_key "school_groups", "calendars", column: "default_template_calendar_id", on_delete: :nullify
   add_foreign_key "school_groups", "scoreboards", column: "default_scoreboard_id"
+  add_foreign_key "school_groups", "users", column: "default_notes_admin_user_id", on_delete: :nullify
   add_foreign_key "school_key_stages", "key_stages", on_delete: :restrict
   add_foreign_key "school_key_stages", "schools", on_delete: :cascade
   add_foreign_key "school_meter_attributes", "school_meter_attributes", column: "replaced_by_id", on_delete: :nullify

--- a/spec/models/note_spec.rb
+++ b/spec/models/note_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe Note, type: :model do
       it { expect(subject.lines.count).to eq(3) }
       it { expect(subject.lines.first.chomp).to eq(header) }
       2.times do |i|
-        it { expect(subject.lines[i+1].chomp).to eq([notes[i].school.name, notes[i].title, notes[i].description.to_plain_text, notes[i].fuel_type, notes[i].created_by.email, notes[i].created_at, notes[i].updated_by.email, notes[i].updated_at].join(',')) }
+        it { expect(subject.lines[i+1].chomp).to eq([notes[i].school.name, notes[i].title, notes[i].description.to_plain_text, notes[i].fuel_type, notes[i].created_by.display_name, notes[i].created_at, notes[i].updated_by.display_name, notes[i].updated_at].join(',')) }
       end
     end
 

--- a/spec/system/admin/school_groups_spec.rb
+++ b/spec/system/admin/school_groups_spec.rb
@@ -101,12 +101,14 @@ RSpec.describe 'school groups', :school_groups, type: :system, include_applicati
           fill_in 'Description', with: 'Bath & North East Somerset'
           select 'BANES and Frome', from: 'Default scoreboard'
           select 'BANES dark sky weather', from: 'Default Dark Sky Weather Data Feed Area'
+          select 'Admin', from: 'Default notes & issues admin user'
           choose 'Display chart data in kwh, where available'
           click_on 'Create School group'
         end
         it "is created" do
           expect(SchoolGroup.where(name: 'BANES').count).to eq(1)
         end
+        it { expect(SchoolGroup.where(name: 'BANES').first.default_notes_admin_user).to eq(admin) }
       end
     end
 
@@ -346,11 +348,13 @@ RSpec.describe 'school groups', :school_groups, type: :system, include_applicati
         click_on 'Edit'
         fill_in 'Name', with: 'B & NES'
         uncheck 'Public'
+        select 'Admin', from: 'Default notes & issues admin user'
         click_on 'Update School group'
         school_group.reload
       end
       it { expect(school_group.name).to eq('B & NES') }
       it { expect(school_group).to_not be_public }
+      it { expect(school_group.default_notes_admin_user).to eq(admin)}
     end
 
     describe "Deleting a school group" do

--- a/spec/system/admin/school_groups_spec.rb
+++ b/spec/system/admin/school_groups_spec.rb
@@ -326,7 +326,7 @@ RSpec.describe 'school groups', :school_groups, type: :system, include_applicati
             within '#issues' do
               expect(page).to have_content issue.title
               expect(page).to have_content issue.fuel_type.capitalize
-              expect(page).to have_content admin.email
+              expect(page).to have_content admin.display_name
               expect(page).to have_content nice_date_times_today(issue.updated_at)
               expect(page).to have_link("View", href: admin_school_note_path(school, issue))
             end

--- a/spec/system/admin/schools/notes_spec.rb
+++ b/spec/system/admin/schools/notes_spec.rb
@@ -64,8 +64,8 @@ RSpec.describe 'school notes', :notes, type: :system, include_application_helper
                 expect(page).to have_content "#{note_type} title"
                 expect(page).to have_content "#{note_type} desc"
                 expect(page).to have_content "Gas"
-                expect(page).to have_content "Updated • #{user.email} • #{nice_date_times_today(frozen_time)}"
-                expect(page).to have_content "Created • #{user.email} • #{nice_date_times_today(frozen_time)}"
+                expect(page).to have_content "Updated • #{user.display_name} • #{nice_date_times_today(frozen_time)}"
+                expect(page).to have_content "Created • #{user.display_name} • #{nice_date_times_today(frozen_time)}"
               end
               after { Timecop.return }
             end
@@ -103,8 +103,8 @@ RSpec.describe 'school notes', :notes, type: :system, include_application_helper
                 expect(page).to have_content "#{note_type} title"
                 expect(page).to have_content "#{note_type} desc"
                 expect(page).to have_content "Gas"
-                expect(page).to have_content "Updated • #{user.email} • #{nice_date_times_today(frozen_time)}"
-                expect(page).to have_content "Created • #{user.email} • #{nice_date_times_today(note.created_at)}"
+                expect(page).to have_content "Updated • #{user.display_name} • #{nice_date_times_today(frozen_time)}"
+                expect(page).to have_content "Created • #{user.display_name} • #{nice_date_times_today(note.created_at)}"
                 expect(page).to have_content "Open" if note_type == "issue"
               end
               after { Timecop.return }
@@ -121,8 +121,8 @@ RSpec.describe 'school notes', :notes, type: :system, include_application_helper
           expect(page).to have_content note.title
           expect(page).to have_content note.description.to_plain_text
           expect(page).to have_content note.fuel_type.capitalize
-          expect(page).to have_content "Updated • #{user.email} • #{nice_date_times_today(note.updated_at)}"
-          expect(page).to have_content "Created • #{user.email} • #{nice_date_times_today(note.created_at)}"
+          expect(page).to have_content "Updated • #{user.display_name} • #{nice_date_times_today(note.updated_at)}"
+          expect(page).to have_content "Created • #{user.display_name} • #{nice_date_times_today(note.created_at)}"
           expect(page).to have_content note.status.capitalize
         end
 
@@ -148,8 +148,8 @@ RSpec.describe 'school notes', :notes, type: :system, include_application_helper
             expect(page).to have_content note.title
             expect(page).to have_content note.description.to_plain_text
             expect(page).to have_content note.fuel_type.capitalize
-            expect(page).to have_content "Updated • #{user.email} • #{nice_date_times_today(note.updated_at)}"
-            expect(page).to have_content "Created • #{user.email} • #{nice_date_times_today(note.created_at)}"
+            expect(page).to have_content "Updated • #{user.display_name} • #{nice_date_times_today(note.updated_at)}"
+            expect(page).to have_content "Created • #{user.display_name} • #{nice_date_times_today(note.created_at)}"
             expect(page).to have_content note.status.capitalize
           end
         end

--- a/spec/system/admin/schools/notes_spec.rb
+++ b/spec/system/admin/schools/notes_spec.rb
@@ -5,6 +5,19 @@ RSpec.describe 'school notes', :notes, type: :system, include_application_helper
   let!(:note)   {}
   let!(:user)   {}
 
+  shared_examples_for "a displayed note" do
+    it "displays note" do
+      expect(page).to have_content note.note_type.capitalize
+      expect(page).to have_content note.title
+      expect(page).to have_content note.description.to_plain_text
+      expect(page).to have_content note.fuel_type.capitalize
+      expect(page).to have_content note.owned_by.display_name
+      expect(page).to have_content "Updated • #{user.display_name} • #{nice_date_times_today(note.updated_at)}"
+      expect(page).to have_content "Created • #{user.display_name} • #{nice_date_times_today(note.created_at)}"
+      expect(page).to have_content note.status.capitalize
+    end
+  end
+
   describe "Viewing school notes admin page" do
     before do
       sign_in(user) if user
@@ -59,6 +72,7 @@ RSpec.describe 'school notes', :notes, type: :system, include_application_helper
                 select 'Gas', from: 'Fuel type'
                 click_button 'Save'
               end
+
               it "creates new note" do
                 expect(page).to have_content "#{note_type.capitalize}"
                 expect(page).to have_content "#{note_type} title"
@@ -98,6 +112,7 @@ RSpec.describe 'school notes', :notes, type: :system, include_application_helper
                 select new_note_type, from: 'Note type'
                 click_button 'Save'
               end
+
               it "saves new values" do
                 expect(page).to have_content new_note_type
                 expect(page).to have_content "#{note_type} title"
@@ -114,17 +129,9 @@ RSpec.describe 'school notes', :notes, type: :system, include_application_helper
       end
 
       context "and viewing index" do
-        let!(:note) { create(:note, school: school, note_type: :issue, fuel_type: :gas, created_by: user, updated_by: user) }
+        let!(:note) { create(:note, school: school, note_type: :issue, fuel_type: :gas, created_by: user, updated_by: user, owned_by: user) }
 
-        it "displays note" do
-          expect(page).to have_content note.note_type.capitalize
-          expect(page).to have_content note.title
-          expect(page).to have_content note.description.to_plain_text
-          expect(page).to have_content note.fuel_type.capitalize
-          expect(page).to have_content "Updated • #{user.display_name} • #{nice_date_times_today(note.updated_at)}"
-          expect(page).to have_content "Created • #{user.display_name} • #{nice_date_times_today(note.created_at)}"
-          expect(page).to have_content note.status.capitalize
-        end
+        it_behaves_like "a displayed note"
 
         it { expect(page).to have_link('Delete') }
         context "and deleting a note" do
@@ -143,15 +150,7 @@ RSpec.describe 'school notes', :notes, type: :system, include_application_helper
             click_link("View")
           end
           it { expect(page).to have_current_path(admin_school_note_path(school, note)) }
-          it "displays note" do
-            expect(page).to have_content note.note_type.capitalize
-            expect(page).to have_content note.title
-            expect(page).to have_content note.description.to_plain_text
-            expect(page).to have_content note.fuel_type.capitalize
-            expect(page).to have_content "Updated • #{user.display_name} • #{nice_date_times_today(note.updated_at)}"
-            expect(page).to have_content "Created • #{user.display_name} • #{nice_date_times_today(note.created_at)}"
-            expect(page).to have_content note.status.capitalize
-          end
+          it_behaves_like "a displayed note"
         end
 
         it { expect(page).to have_link('Resolve') }


### PR DESCRIPTION
When an issue is recorded or updated it should be possible to assign it to an EnergySparks admin who will be responsible for resolving it. This card covers:
- [x]  allowing an Energy Sparks admin to be assigned as the default owner of all issues for a School Group. This will be a property of the group and will be set by editing the group
- [x] updating the issue model to associate an issue with an admin user
- [x] update the forms to allow an issue to be assigned/reassigned
- [x] show the list of energy sparks admins in the options of who can be assigned an issue when it is being added/edited
- [x]  if there's a admin assigned to a school group, then default to this user when creating a new issue for the group
 