### PR TITLE
Add last term date to calendar overview

### DIFF
--- a/app/models/calendar_event.rb
+++ b/app/models/calendar_event.rb
@@ -40,6 +40,7 @@ class CalendarEvent < ApplicationRecord
   scope :bank_holidays,     -> { joins(:calendar_event_type).merge(CalendarEventType.bank_holiday) }
   scope :outside_term_time, -> { joins(:calendar_event_type).merge(CalendarEventType.outside_term_time) }
 
+  scope :by_end_date,       -> { order(end_date: :asc)}
   before_validation :update_academic_year
 
   validates :calendar, :calendar_event_type, :start_date, :end_date, presence: true

--- a/app/views/admin/calendars/_regional_calendars.html.erb
+++ b/app/views/admin/calendars/_regional_calendars.html.erb
@@ -16,7 +16,7 @@
         <td><%= link_to calendar.based_on.title, calendar_path(calendar.based_on) unless calendar.based_on.nil? %></td>
         <td><%= calendar.calendars.count %></td>
         <% last_term_date = calendar.calendar_events.terms.by_end_date.last %>
-        <td data-order="<%= last_term_date&.end_date.strftime("%Y-%m-%d") %>"><%= nice_dates(last_term_date&.end_date) %></td>
+        <td data-order="<%= last_term_date.end_date.strftime("%Y-%m-%d") if last_term_date.present? %>"><%= nice_dates(last_term_date&.end_date) %></td>
         <td>
           <div class='btn-group'>
           <%= link_to 'Show', calendar, class: 'btn btn-info' if can?(:read, calendar) %>

--- a/app/views/admin/calendars/_regional_calendars.html.erb
+++ b/app/views/admin/calendars/_regional_calendars.html.erb
@@ -1,9 +1,10 @@
-<table class="table table-condensed regional-calendars">
+<table class="table table-condensed regional-calendars table-sorted">
   <thead>
     <tr>
       <th>Name</th>
       <th>Based on</th>
       <th>Dependent Calendars</th>
+      <th>Last term date</th>
       <th></th>
     </tr>
   </thead>
@@ -14,6 +15,8 @@
         <td><%= calendar.title %></td>
         <td><%= link_to calendar.based_on.title, calendar_path(calendar.based_on) unless calendar.based_on.nil? %></td>
         <td><%= calendar.calendars.count %></td>
+        <% last_term_date = calendar.calendar_events.terms.by_end_date.last %>
+        <td data-order="<%= last_term_date&.end_date.strftime("%Y-%m-%d") %>"><%= nice_dates(last_term_date&.end_date) %></td>
         <td>
           <div class='btn-group'>
           <%= link_to 'Show', calendar, class: 'btn btn-info' if can?(:read, calendar) %>


### PR DESCRIPTION
Make it easier for admins to see at a glance how far ahead the term dates are for a regional calendar.