### PR TITLE
Remove link to report if we have limited target data

### DIFF
--- a/app/views/schools/school_targets/_limited_data.html.erb
+++ b/app/views/schools/school_targets/_limited_data.html.erb
@@ -14,8 +14,5 @@
     </div>
   </div>
   <div class="col-md-2 align-self-center">
-    <% if link_to_progress_report?(school_target, fuel_type) %>
-      <%= link_to "View report", progress_path, class: "btn btn-outline-dark font-weight-bold" %>
-    <% end %>
   </div>
 </div>


### PR DESCRIPTION
If we're showing the `_limited_data.html.erb` partial then we can't currently provide a progress report for a school, so removing this link as it shouldn't be shown. Avoids users seeing an error.

Am leaving in the helper for now as I continue to rework these pages. 