### PR TITLE
2620 Issues Improvements

### DIFF
--- a/app/views/admin/school_groups/_issues.html.erb
+++ b/app/views/admin/school_groups/_issues.html.erb
@@ -3,6 +3,7 @@
     <tr>
       <th class="no-sort"></th>
       <th>Issue</th>
+      <th>School</th>
       <th>Fuel</th>
       <th class="nowrap">Assigned to</th>
       <th>Updated</th>
@@ -14,6 +15,7 @@
       <tr>
         <td><%= fa_icon('exclamation-circle text-secondary') %></td>
         <td><%= link_to issue.title, admin_school_issue_path(issue.school, issue) %></td>
+        <td><%= link_to issue.school.name, admin_school_issues_path(issue.school) %></td>
         <td><%= render 'admin/schools/issues/fuel_type', issue: issue %></td>
         <td><%= render 'admin/schools/issues/owned_by', issue: issue %></td>
         <td data-order="<%= issue.updated_at %>"><div class="badge badge-pill bg-white text-dark font-weight-normal nowrap"><%= issue.updated_by.display_name %> • <%= nice_date_times_today(issue.updated_at) %></div></td>

--- a/app/views/admin/school_groups/_onboarding_schools.html.erb
+++ b/app/views/admin/school_groups/_onboarding_schools.html.erb
@@ -20,6 +20,9 @@
             <span class="badge badge-secondary"><%= SchoolOnboardingEvent.events.key(onboarding.events.maximum(:event)).try(:humanize) %></span>
           </td>
           <td class="nowrap text-right">
+            <% if onboarding.school %>
+              <%= link_to 'Issues', admin_school_issues_path(onboarding.school), class: "btn btn-sm" %>
+            <% end %>
             <%= link_to 'Send reminder email', admin_school_onboarding_reminder_path(onboarding), class: 'btn btn-warning btn-sm', method: :post %>
             <% if onboarding.school && onboarding.school.consent_grants.any? %>
               <%= link_to 'Make visible', school_visibility_path(onboarding.school), class: 'btn btn-sm', method: :post %>

--- a/app/views/admin/school_groups/_removed_schools.html.erb
+++ b/app/views/admin/school_groups/_removed_schools.html.erb
@@ -11,7 +11,10 @@
       <tr>
         <td><%= link_to school.name, school_path(school) %></td>
         <td><%= nice_dates(school.removal_date) %></td>
-        <td class="nowrap text-right"><%= link_to 'Meters', school_meters_path(school), class: "btn btn-sm" %></td>
+        <td class="nowrap text-right">
+          <%= link_to 'Issues', admin_school_issues_path(school), class: "btn btn-sm" %>
+          <%= link_to 'Meters', school_meters_path(school), class: "btn btn-sm" %>
+        </td>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/admin/schools/issues/_form.html.erb
+++ b/app/views/admin/schools/issues/_form.html.erb
@@ -8,9 +8,17 @@
   <%= simple_form_for([:admin, school, issue]) do |f| %>
     <%= f.input :title %>
     <%= f.input :description, as: :rich_text_area %>
-    <%= f.input :fuel_type, collection: Issue.fuel_types.keys, label_method: lambda {|k| k.humanize} %>
-    <%= f.input :status, collection: Issue.statuses.keys, label_method: lambda {|k| k.humanize}, include_blank: false unless issue.new_record? %>
-    <%= f.input :issue_type, collection: Issue.issue_types.keys, label_method: lambda {|k| k.humanize}, include_blank: false %>
+    <%= f.input :fuel_type, collection: Issue.fuel_types.keys, label_method: lambda {|k| k.humanize}, include_blank: "Not applicable" %>
+    <% if issue.issue? %>
+      <%= f.input :status, collection: Issue.statuses.keys, label_method: lambda {|k| k.humanize}, include_blank: false %>
+    <% else %>
+      <%= f.hidden_field :status %>
+    <% end %>
+    <% unless issue.new_record? %>
+      <%= f.input :issue_type, collection: Issue.issue_types.keys, label_method: lambda {|k| k.humanize}, include_blank: false unless issue.new_record? %>
+    <% else %>
+      <%= f.hidden_field :issue_type %>
+    <% end %>
     <%= f.input :owned_by_id, collection: User.admin, label: "Assigned to", label_method: lambda {|k| k.display_name}, include_blank: true, selected: (f.object.new_record? && params.dig(:issue,:owned_by_id).nil? ? school.school_group.try(:default_issues_admin_user_id) : f.object.owned_by_id) %>
     <%= f.submit 'Save', class: 'btn btn-primary' %>
   <% end %>

--- a/app/views/admin/schools/issues/_form.html.erb
+++ b/app/views/admin/schools/issues/_form.html.erb
@@ -1,9 +1,19 @@
-<%= simple_form_for([:admin, school, issue]) do |f| %>
-  <%= f.input :title %>
-  <%= f.input :description, as: :rich_text_area %>
-  <%= f.input :fuel_type, collection: Issue.fuel_types.keys, label_method: lambda {|k| k.humanize} %>
-  <%= f.input :status, collection: Issue.statuses.keys, label_method: lambda {|k| k.humanize}, include_blank: false unless issue.new_record? %>
-  <%= f.input :issue_type, collection: Issue.issue_types.keys, label_method: lambda {|k| k.humanize}, include_blank: false %>
-  <%= f.input :owned_by_id, collection: User.admin, label: "Assigned to", label_method: lambda {|k| k.display_name}, include_blank: true, selected: (f.object.new_record? && params.dig(:issue,:owned_by_id).nil? ? school.school_group.try(:default_issues_admin_user_id) : f.object.owned_by_id) %>
-  <%= f.submit 'Save', class: 'btn btn-primary' %>
-<% end %>
+<div class="row p-2">
+  <div class="admin-issue col-md-12 bg-light border-left rounded border-6 pb-2 <%= issue.issue? ? "border-danger" : "border-warning" %>">
+
+  <%= render 'header', issue: @issue, title: title do %>
+    <%= header_nav_link 'All school issues & notes', admin_school_issues_url(school) %>
+  <% end %>
+
+  <%= simple_form_for([:admin, school, issue]) do |f| %>
+    <%= f.input :title %>
+    <%= f.input :description, as: :rich_text_area %>
+    <%= f.input :fuel_type, collection: Issue.fuel_types.keys, label_method: lambda {|k| k.humanize} %>
+    <%= f.input :status, collection: Issue.statuses.keys, label_method: lambda {|k| k.humanize}, include_blank: false unless issue.new_record? %>
+    <%= f.input :issue_type, collection: Issue.issue_types.keys, label_method: lambda {|k| k.humanize}, include_blank: false %>
+    <%= f.input :owned_by_id, collection: User.admin, label: "Assigned to", label_method: lambda {|k| k.display_name}, include_blank: true, selected: (f.object.new_record? && params.dig(:issue,:owned_by_id).nil? ? school.school_group.try(:default_issues_admin_user_id) : f.object.owned_by_id) %>
+    <%= f.submit 'Save', class: 'btn btn-primary' %>
+  <% end %>
+
+  </div>
+</div>

--- a/app/views/admin/schools/issues/edit.html.erb
+++ b/app/views/admin/schools/issues/edit.html.erb
@@ -1,5 +1,1 @@
-<%= render 'header', issue: @issue, title: "Edit #{@school.name} #{@issue.issue_type.capitalize}" do %>
-  <%= header_nav_link 'All school issues & notes', admin_school_issues_url(@school) %>
-<% end %>
-
-<%= render 'form', school: @school, issue: @issue, index: false %>
+<%= render 'form', school: @school, issue: @issue, title: "Edit #{@school.name} #{@issue.issue_type.capitalize}" %>

--- a/app/views/admin/schools/issues/new.html.erb
+++ b/app/views/admin/schools/issues/new.html.erb
@@ -1,5 +1,1 @@
-<%= render 'header', issue: @issue, title: "New #{@issue.issue_type.capitalize} for #{@school.name}" do %>
-  <%= header_nav_link 'All school issues & notes', admin_school_issues_url(@school) %>
-<% end %>
-
-<%= render 'form', school: @school, issue: @issue %>
+<%= render 'form', school: @school, issue: @issue, title: "New #{@issue.issue_type.capitalize} for #{@school.name}" %>

--- a/spec/support/admin_school_group_onboardings.rb
+++ b/spec/support/admin_school_group_onboardings.rb
@@ -1,112 +1,126 @@
 RSpec.shared_examples "admin school group onboardings" do
-  let(:school_group_onboardings) { 3.times.collect { create :school_onboarding, :with_school, school_group: school_group, created_by: admin } }
-  let(:setup_data) { school_group_onboardings }
 
-  context 'for selected' do
+  context "selectable actions" do
 
-    describe "first onboarding checked" do
-      let(:onboarding) { school_group_onboardings.first }
-      before do
-        check "school_group_school_onboarding_ids_#{onboarding.id}"
-      end
+    context 'for selected' do
+      let(:school_group_onboardings) { 3.times.collect { create :school_onboarding, :with_school, school_group: school_group, created_by: admin } }
+      let(:setup_data) { school_group_onboardings }
 
-      describe "Make selected visible" do
-        before {  onboarding.school.update!(visible: false) }
+      describe "first onboarding checked" do
+        let(:onboarding) { school_group_onboardings.first }
+        before do
+          check "school_group_school_onboarding_ids_#{onboarding.id}"
+        end
 
-        it { expect(onboarding.school).to_not be_visible }
-        it { expect(onboarding).to be_incomplete }
+        describe "Make selected visible" do
+          before {  onboarding.school.update!(visible: false) }
 
-        context "without consents" do
+          it { expect(onboarding.school).to_not be_visible }
+          it { expect(onboarding).to be_incomplete }
+
+          context "without consents" do
+            before do
+              @back = current_path
+              click_button "Make selected visible"
+            end
+            it { expect(page).to have_current_path(@back) }
+            it { expect(page).to have_content('School cannot be made visible as we dont have a record of consent') }
+            it { expect(page).to_not have_content('schools made visible') }
+            it { expect(onboarding.reload.school).to_not be_visible }
+          end
+
+          context "with consent" do
+            before  { Wisper.clear; Wisper.subscribe(Onboarding::OnboardingDataEnabledListener.new) }
+            after   { Wisper.clear }
+
+            before do
+              create(:consent_grant, school: onboarding.school)
+              click_button "Make selected visible"
+            end
+
+            it { expect(page).to have_content("#{school_group.name} schools made visible") }
+            it { expect(onboarding.reload.school).to be_visible }
+            it { expect(ActionMailer::Base.deliveries.count).to eq(2) }
+            it "sends onboarding complete email" do
+              email = ActionMailer::Base.deliveries.first
+              expect(email.to).to include('operations@energysparks.uk')
+              expect(email.subject).to eq("#{onboarding.school.name} has completed the onboarding process")
+            end
+            it "sends school live email" do
+              email = ActionMailer::Base.deliveries.second
+              expect(email.to).to include(onboarding.created_user.email)
+              expect(email.subject).to eq("#{onboarding.school.name} is now live on Energy Sparks")
+            end
+          end
+        end
+
+        describe "Send reminders to selected" do
           before do
             @back = current_path
-            click_button "Make selected visible"
+            click_button "Send reminders to selected"
           end
           it { expect(page).to have_current_path(@back) }
-          it { expect(page).to have_content('School cannot be made visible as we dont have a record of consent') }
-          it { expect(page).to_not have_content('schools made visible') }
-          it { expect(onboarding.reload.school).to_not be_visible }
-        end
-
-        context "with consent" do
-          before  { Wisper.clear; Wisper.subscribe(Onboarding::OnboardingDataEnabledListener.new) }
-          after   { Wisper.clear }
-
-          before do
-            create(:consent_grant, school: onboarding.school)
-            click_button "Make selected visible"
-          end
-
-          it { expect(page).to have_content("#{school_group.name} schools made visible") }
-          it { expect(onboarding.reload.school).to be_visible }
-          it { expect(ActionMailer::Base.deliveries.count).to eq(2) }
-          it "sends onboarding complete email" do
-            email = ActionMailer::Base.deliveries.first
-            expect(email.to).to include('operations@energysparks.uk')
-            expect(email.subject).to eq("#{onboarding.school.name} has completed the onboarding process")
-          end
-          it "sends school live email" do
-            email = ActionMailer::Base.deliveries.second
-            expect(email.to).to include(onboarding.created_user.email)
-            expect(email.subject).to eq("#{onboarding.school.name} is now live on Energy Sparks")
+          it { expect(onboarding.reload.events.map(&:event)).to include('reminder_sent') }
+          it { expect(page).to have_content("#{school_group.name} schools reminders sent") }
+          it "sends email" do
+            email = ActionMailer::Base.deliveries.last
+            expect(email.subject).to include("Don't forget to set up your school on Energy Sparks")
+            expect(email.body.to_s).to include(onboarding_path(onboarding))
           end
         end
+      end
+    end
+
+    context 'Nothing selected' do
+      describe "Make selected visible" do
+        before do
+          click_button "Make selected visible"
+        end
+        it { expect(page).to_not have_content('schools made visible') }
+        it { expect(page).to have_content('Nothing selected') }
       end
 
       describe "Send reminders to selected" do
         before do
-          @back = current_path
           click_button "Send reminders to selected"
         end
-        it { expect(page).to have_current_path(@back) }
-        it { expect(onboarding.reload.events.map(&:event)).to include('reminder_sent') }
-        it { expect(page).to have_content("#{school_group.name} schools reminders sent") }
-        it "sends email" do
-          email = ActionMailer::Base.deliveries.last
-          expect(email.subject).to include("Don't forget to set up your school on Energy Sparks")
-          expect(email.body.to_s).to include(onboarding_path(onboarding))
-        end
+        it { expect(page).to_not have_content('schools reminders sent') }
+        it { expect(page).to have_content('Nothing selected') }
       end
     end
-  end
 
-  context 'Nothing selected' do
-    describe "Make selected visible" do
+    context "Checking all", js: true do
       before do
-        click_button "Make selected visible"
+        check "check-all-#{school_group.id}"
       end
-      it { expect(page).to_not have_content('schools made visible') }
-      it { expect(page).to have_content('Nothing selected') }
-    end
 
-    describe "Send reminders to selected" do
-      before do
-        click_button "Send reminders to selected"
-      end
-      it { expect(page).to_not have_content('schools reminders sent') }
-      it { expect(page).to have_content('Nothing selected') }
-    end
-  end
-
-  context "Checking all", js: true do
-    before do
-      check "check-all-#{school_group.id}"
-    end
-
-    it "checks all group's checkboxes" do
-      school_group.school_onboardings.each do |onboarding|
-        expect(page).to have_checked_field("school_group_school_onboarding_ids_#{onboarding.id}")
-      end
-    end
-
-    context "then unchecking all" do
-      before do
-        uncheck "check-all-#{school_group.id}"
-      end
-      it "unchecks all checkboxes" do
+      it "checks all group's checkboxes" do
         school_group.school_onboardings.each do |onboarding|
-          expect(page).to have_unchecked_field("school_group_school_onboarding_ids_#{onboarding.id}")
+          expect(page).to have_checked_field("school_group_school_onboarding_ids_#{onboarding.id}")
         end
       end
+
+      context "then unchecking all" do
+        before do
+          uncheck "check-all-#{school_group.id}"
+        end
+        it "unchecks all checkboxes" do
+          school_group.school_onboardings.each do |onboarding|
+            expect(page).to have_unchecked_field("school_group_school_onboarding_ids_#{onboarding.id}")
+          end
+        end
+      end
+    end
+  end
+
+  context 'linking to issues' do
+    context "when there is an associated school" do
+      let!(:setup_data) { create :school_onboarding, :with_school }
+      it { expect(page).to have_link('Issues') }
+    end
+    context "without an associated school" do
+      let!(:setup_data) { create :school_onboarding }
+      it { expect(page).to_not have_link('Issues') }
     end
   end
 end

--- a/spec/support/admin_school_group_onboardings.rb
+++ b/spec/support/admin_school_group_onboardings.rb
@@ -1,10 +1,16 @@
 RSpec.shared_examples "admin school group onboardings" do
 
+  before do
+    setup_data
+    after_setup_data
+  end
+
   context "selectable actions" do
 
+    let(:school_group_onboardings) { 3.times.collect { create :school_onboarding, :with_school, school_group: school_group, created_by: admin } }
+    let(:setup_data) { school_group_onboardings }
+
     context 'for selected' do
-      let(:school_group_onboardings) { 3.times.collect { create :school_onboarding, :with_school, school_group: school_group, created_by: admin } }
-      let(:setup_data) { school_group_onboardings }
 
       describe "first onboarding checked" do
         let(:onboarding) { school_group_onboardings.first }
@@ -115,12 +121,20 @@ RSpec.shared_examples "admin school group onboardings" do
 
   context 'linking to issues' do
     context "when there is an associated school" do
-      let!(:setup_data) { create :school_onboarding, :with_school }
-      it { expect(page).to have_link('Issues') }
+      let(:setup_data) { create :school_onboarding, :with_school, school_group: school_group }
+      it "has issues link" do
+        within "table" do
+          expect(page).to have_link('Issues')
+        end
+      end
     end
     context "without an associated school" do
-      let!(:setup_data) { create :school_onboarding }
-      it { expect(page).to_not have_link('Issues') }
+      let(:setup_data) { create :school_onboarding, school_group: school_group }
+      it "does not have issues link" do
+        within "table" do
+          expect(page).to_not have_link('Issues')
+        end
+      end
     end
   end
 end

--- a/spec/system/admin/school_groups_spec.rb
+++ b/spec/system/admin/school_groups_spec.rb
@@ -302,6 +302,7 @@ RSpec.describe 'school groups', :school_groups, type: :system, include_applicati
               expect(page).to have_link(school.name, href: school_path(school))
               expect(page).to have_content(nice_dates(school.removal_date))
               expect(page).to have_link("Meters")
+              expect(page).to have_link("Issues")
             end
           end
         end

--- a/spec/system/admin/school_groups_spec.rb
+++ b/spec/system/admin/school_groups_spec.rb
@@ -326,6 +326,7 @@ RSpec.describe 'school groups', :school_groups, type: :system, include_applicati
           it "lists issue in issues tab" do
             within '#issues' do
               expect(page).to have_content issue.title
+              expect(page).to have_content issue.school.name
               expect(page).to have_content issue.fuel_type.capitalize
               expect(page).to have_content admin.display_name
               expect(page).to have_content nice_date_times_today(issue.updated_at)

--- a/spec/system/admin/school_groups_spec.rb
+++ b/spec/system/admin/school_groups_spec.rb
@@ -2,7 +2,11 @@ require 'rails_helper'
 
 RSpec.describe 'school groups', :school_groups, type: :system, include_application_helper: true do
   let!(:admin)                  { create(:admin) }
-  let!(:setup_data)             {}
+  let(:setup_data)             {}
+
+  before do
+    setup_data
+  end
 
   def create_data_for_school_groups(school_groups)
     school_groups.each do |school_group|
@@ -22,7 +26,7 @@ RSpec.describe 'school groups', :school_groups, type: :system, include_applicati
     end
 
     describe "Viewing school groups index page" do
-      let!(:setup_data) { create_data_for_school_groups(school_groups) }
+      let(:setup_data) { create_data_for_school_groups(school_groups) }
       before do
         click_on 'Edit School Groups'
       end
@@ -115,7 +119,6 @@ RSpec.describe 'school groups', :school_groups, type: :system, include_applicati
     describe "Viewing school group page" do
       let!(:school_group) { create :school_group }
       before do
-        setup_data
         click_on 'Edit School Groups'
         within "table" do
           click_on 'Manage'
@@ -137,7 +140,7 @@ RSpec.describe 'school groups', :school_groups, type: :system, include_applicati
       end
 
       describe "School counts by status panel" do
-        let!(:setup_data) { create_data_for_school_groups([school_group]) }
+        let(:setup_data) { create_data_for_school_groups([school_group]) }
         it { expect(page).to have_content("Active 1") }
         it { expect(page).to have_content("Active (with data visible) 1") }
         it { expect(page).to have_content("Invisible 1") }
@@ -210,8 +213,8 @@ RSpec.describe 'school groups', :school_groups, type: :system, include_applicati
       describe "Active schools tab" do
         context "when there are active schools" do
           let(:school_onboarding) { create :school_onboarding, school_group: school_group }
-          let!(:school) { create(:school, active: true, name: "A School", school_group: school_group, school_onboarding: school_onboarding) }
-          let!(:setup_data) { school }
+          let(:school) { create(:school, active: true, name: "A School", school_group: school_group, school_onboarding: school_onboarding) }
+          let(:setup_data) { school }
 
           it "lists school in active tab" do
             within '#active' do
@@ -270,8 +273,8 @@ RSpec.describe 'school groups', :school_groups, type: :system, include_applicati
           end
         end
         context "when there are inactive schools only" do
-          let!(:school) { create(:school, active: false, name: "A School", school_group: school_group) }
-          let!(:setup_data) { school }
+          let(:school) { create(:school, active: false, name: "A School", school_group: school_group) }
+          let(:setup_data) { school }
           it "doesn't show school active tab" do
             within '#active' do
               expect(page).to_not have_link(school.name)
@@ -282,15 +285,21 @@ RSpec.describe 'school groups', :school_groups, type: :system, include_applicati
       end
 
       describe "Onboarding schools tab" do
-        before do
-          click_on "Onboarding"
-        end
-        it "displays a message when there are no onboarding schools" do
-          within '#onboarding' do
-            expect(page).to have_content("No schools currently onboarding for #{school_group.name}.")
+        context "with no onboarding schools" do
+          before do
+            click_on "Onboarding"
+          end
+          it "displays a message" do
+            within '#onboarding' do
+              expect(page).to have_content("No schools currently onboarding for #{school_group.name}.")
+            end
           end
         end
-        it_behaves_like "admin school group onboardings"
+        it_behaves_like "admin school group onboardings" do
+          def after_setup_data
+            click_on "Onboarding"
+          end
+        end
       end
 
       describe "Removed schools tab" do
@@ -379,7 +388,7 @@ RSpec.describe 'school groups', :school_groups, type: :system, include_applicati
         end
       end
       context "when the school group can not be deleted" do
-        let!(:setup_data) { create(:school, school_group: school_group) }
+        let(:setup_data) { create(:school, school_group: school_group) }
         it "has a disabled delete button" do
           expect(page).to have_link('Delete', class: 'disabled')
         end

--- a/spec/system/admin/school_onboarding_spec.rb
+++ b/spec/system/admin/school_onboarding_spec.rb
@@ -38,11 +38,11 @@ RSpec.describe "onboarding", :schools, type: :system do
     end
 
     context "selectable actions" do
-      let!(:setup_data) {} # call to create all objects required by tests before page is loaded, overriden in contexts
-      before do
-        click_on 'Manage school onboarding'
+      it_behaves_like "admin school group onboardings" do
+        def after_setup_data
+          click_on 'Manage school onboarding'
+        end
       end
-      it_behaves_like "admin school group onboardings"
     end
 
     it 'allows a new onboarding to be setup and sends an email to the school' do

--- a/spec/system/admin/school_onboarding_spec.rb
+++ b/spec/system/admin/school_onboarding_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe "onboarding", :schools, type: :system do
     end
 
     context "selectable actions" do
-      let!(:setup_data)  { } # call to create all objects required by tests before page is loaded, overriden in contexts
+      let!(:setup_data) {} # call to create all objects required by tests before page is loaded, overriden in contexts
       before do
         click_on 'Manage school onboarding'
       end

--- a/spec/system/admin/schools/issues_spec.rb
+++ b/spec/system/admin/schools/issues_spec.rb
@@ -54,7 +54,6 @@ RSpec.describe 'school issues', :issues, type: :system, include_application_help
               expect(find_field('Title').text).to be_blank
               expect(find('trix-editor#issue_description')).to have_text('')
               expect(page).to have_select('Fuel type', selected: [])
-              expect(page).to have_select('Issue type', selected: issue_type.capitalize)
               expect(page).to have_select('Assigned to', selected: school_group.default_issues_admin_user.display_name)
             end
 
@@ -105,7 +104,6 @@ RSpec.describe 'school issues', :issues, type: :system, include_application_help
               expect(page).to have_field('Title', with: issue.title)
               expect(find_field('issue[description]', type: :hidden).value).to eq(issue.description.to_plain_text)
               expect(page).to have_select('Fuel type', selected: issue.fuel_type.capitalize)
-              expect(page).to have_select('Issue type', selected: issue_type.capitalize)
               expect(page).to have_select('Assigned to', selected: school_group_issues_admin.display_name)
             end
             context "and saving new values" do


### PR DESCRIPTION
This PR does the following:
- Add "Not applicable" label to select for fuel type
- Add issue links to Onboarding and Removed
- Add school name to issues tab
- Also adds some further styling to issue form to have the same styling as when viewing
- Also removes the ability to be able to set the issue type (issue or note) on create as it simplifies form
- Makes tests more obvious in terms of the setup flow