### PR TITLE
Analytics 2.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ gem 'pg_search'
 gem 'calculate_in_group'
 
 # Dashboard analytics
-gem 'energy-sparks_analytics', git: 'https://github.com/Energy-Sparks/energy-sparks_analytics.git', tag: '2.1.3'
+gem 'energy-sparks_analytics', git: 'https://github.com/Energy-Sparks/energy-sparks_analytics.git', tag: '2.2'
 #gem 'energy-sparks_analytics', git: 'https://github.com/Energy-Sparks/energy-sparks_analytics.git', branch: 'aws-eb-test'
 #gem 'energy-sparks_analytics', path: '../energy-sparks_analytics'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/Energy-Sparks/energy-sparks_analytics.git
-  revision: 1dac4aedaa6c256753c7f1ea4d31323cfaae8cfd
-  tag: 2.1.3
+  revision: 06f86dd99de5e0dfafaa56a9ffe317e9a674bb66
+  tag: 2.2
   specs:
     energy-sparks_analytics (1.2.1)
       activesupport (~> 6.0.0)


### PR DESCRIPTION
Update application to use Analytics 2.2.

The change for this version is [a single large PR](https://github.com/Energy-Sparks/energy-sparks_analytics/pull/361) that revises how much of the cost calculations are done to reduce use of hard-coded values. This needs review on test server before going to production.

This PR will be merged into the test server branch for release, but otherwise should stay open until any related issues have been resolved.