### PR TITLE
Add school targets to main school timeline

### DIFF
--- a/app/controllers/concerns/dashboard_timeline.rb
+++ b/app/controllers/concerns/dashboard_timeline.rb
@@ -7,6 +7,6 @@ module DashboardTimeline
 
   def setup_target_timeline(school_target)
     school = school_target.school
-    school.observations.where("at >= :start_date AND at <= :target_date AND visible = TRUE", start_date: school_target.start_date, target_date: school_target.target_date).order('at DESC')
+    school.observations.where("at >= :start_date AND at <= :target_date AND visible = TRUE", start_date: school_target.start_date, target_date: school_target.target_date).where.not(observation_type: :school_target).order('at DESC')
   end
 end

--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -1,3 +1,33 @@
+# == Schema Information
+#
+# Table name: issues
+#
+#  created_at    :datetime         not null
+#  created_by_id :bigint(8)
+#  fuel_type     :integer
+#  id            :bigint(8)        not null, primary key
+#  issue_type    :integer          default("issue"), not null
+#  owned_by_id   :bigint(8)
+#  pinned        :boolean          default(FALSE)
+#  school_id     :bigint(8)
+#  status        :integer          default("open"), not null
+#  title         :string           not null
+#  updated_at    :datetime         not null
+#  updated_by_id :bigint(8)
+#
+# Indexes
+#
+#  index_issues_on_created_by_id  (created_by_id)
+#  index_issues_on_owned_by_id    (owned_by_id)
+#  index_issues_on_school_id      (school_id)
+#  index_issues_on_updated_by_id  (updated_by_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (created_by_id => users.id)
+#  fk_rails_...  (owned_by_id => users.id)
+#  fk_rails_...  (updated_by_id => users.id)
+#
 class Issue < ApplicationRecord
   include CsvExportable
 

--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -13,6 +13,7 @@
 #  observation_type     :integer          not null
 #  points               :integer
 #  school_id            :bigint(8)        not null
+#  school_target_id     :bigint(8)
 #  updated_at           :datetime         not null
 #  visible              :boolean          default(TRUE)
 #
@@ -22,6 +23,7 @@
 #  index_observations_on_audit_id              (audit_id)
 #  index_observations_on_intervention_type_id  (intervention_type_id)
 #  index_observations_on_school_id             (school_id)
+#  index_observations_on_school_target_id      (school_target_id)
 #
 # Foreign Keys
 #
@@ -29,6 +31,7 @@
 #  fk_rails_...  (audit_id => audits.id)
 #  fk_rails_...  (intervention_type_id => intervention_types.id) ON DELETE => restrict
 #  fk_rails_...  (school_id => schools.id) ON DELETE => cascade
+#  fk_rails_...  (school_target_id => school_targets.id)
 #
 
 class Observation < ApplicationRecord
@@ -38,7 +41,8 @@ class Observation < ApplicationRecord
   belongs_to :intervention_type, optional: true
   belongs_to :activity, optional: true
   belongs_to :audit, optional: true
-  enum observation_type: [:temperature, :intervention, :activity, :event, :audit]
+  belongs_to :school_target, optional: true
+  enum observation_type: [:temperature, :intervention, :activity, :event, :audit, :school_target]
 
   validates_presence_of :at, :school
   validates_associated :temperature_recordings
@@ -46,6 +50,7 @@ class Observation < ApplicationRecord
   validates :intervention_type_id, presence: { message: 'please select an option' }, if: :intervention?
   validates :activity_id, presence: true, if: :activity?
   validates :audit_id, presence: true, if: :audit?
+  validates :school_target_id, presence: true, if: :school_target?
 
   accepts_nested_attributes_for :temperature_recordings, reject_if: :reject_temperature_recordings
 

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -2,51 +2,63 @@
 #
 # Table name: schools
 #
-#  activation_date                       :date
-#  active                                :boolean          default(TRUE)
-#  address                               :text
-#  bill_requested                        :boolean          default(FALSE)
-#  calendar_id                           :bigint(8)
-#  chart_preference                      :integer          default("default"), not null
-#  cooks_dinners_for_other_schools       :boolean          default(FALSE), not null
-#  cooks_dinners_for_other_schools_count :integer
-#  cooks_dinners_onsite                  :boolean          default(FALSE), not null
-#  country                               :integer          default("england"), not null
-#  created_at                            :datetime         not null
-#  dark_sky_area_id                      :bigint(8)
-#  data_enabled                          :boolean          default(FALSE)
-#  enable_targets_feature                :boolean          default(TRUE)
-#  floor_area                            :decimal(, )
-#  funding_status                        :integer          default("state_school"), not null
-#  has_swimming_pool                     :boolean          default(FALSE), not null
-#  id                                    :bigint(8)        not null, primary key
-#  indicated_has_solar_panels            :boolean          default(FALSE), not null
-#  indicated_has_storage_heaters         :boolean          default(FALSE)
-#  latitude                              :decimal(10, 6)
-#  level                                 :integer          default(0)
-#  longitude                             :decimal(10, 6)
-#  met_office_area_id                    :bigint(8)
-#  name                                  :string
-#  number_of_pupils                      :integer
-#  percentage_free_school_meals          :integer
-#  postcode                              :string
-#  process_data                          :boolean          default(FALSE)
-#  public                                :boolean          default(TRUE)
-#  removal_date                          :date
-#  school_group_id                       :bigint(8)
-#  school_type                           :integer          not null
-#  scoreboard_id                         :bigint(8)
-#  serves_dinners                        :boolean          default(FALSE), not null
-#  slug                                  :string
-#  solar_pv_tuos_area_id                 :bigint(8)
-#  temperature_area_id                   :bigint(8)
-#  template_calendar_id                  :integer
-#  updated_at                            :datetime         not null
-#  urn                                   :integer          not null
-#  validation_cache_key                  :string           default("initial")
-#  visible                               :boolean          default(FALSE)
-#  weather_station_id                    :bigint(8)
-#  website                               :string
+#  activation_date                              :date
+#  active                                       :boolean          default(TRUE)
+#  address                                      :text
+#  alternative_heating_biomass                  :boolean          default(FALSE), not null
+#  alternative_heating_biomass_notes            :text
+#  alternative_heating_biomass_percent          :integer          default(0)
+#  alternative_heating_district_heating         :boolean          default(FALSE), not null
+#  alternative_heating_district_heating_notes   :text
+#  alternative_heating_district_heating_percent :integer          default(0)
+#  alternative_heating_lpg                      :boolean          default(FALSE), not null
+#  alternative_heating_lpg_notes                :text
+#  alternative_heating_lpg_percent              :integer          default(0)
+#  alternative_heating_oil                      :boolean          default(FALSE), not null
+#  alternative_heating_oil_notes                :text
+#  alternative_heating_oil_percent              :integer          default(0)
+#  bill_requested                               :boolean          default(FALSE)
+#  calendar_id                                  :bigint(8)
+#  chart_preference                             :integer          default("default"), not null
+#  cooks_dinners_for_other_schools              :boolean          default(FALSE), not null
+#  cooks_dinners_for_other_schools_count        :integer
+#  cooks_dinners_onsite                         :boolean          default(FALSE), not null
+#  country                                      :integer          default("england"), not null
+#  created_at                                   :datetime         not null
+#  dark_sky_area_id                             :bigint(8)
+#  data_enabled                                 :boolean          default(FALSE)
+#  enable_targets_feature                       :boolean          default(TRUE)
+#  floor_area                                   :decimal(, )
+#  funding_status                               :integer          default("state_school"), not null
+#  has_swimming_pool                            :boolean          default(FALSE), not null
+#  id                                           :bigint(8)        not null, primary key
+#  indicated_has_solar_panels                   :boolean          default(FALSE), not null
+#  indicated_has_storage_heaters                :boolean          default(FALSE)
+#  latitude                                     :decimal(10, 6)
+#  level                                        :integer          default(0)
+#  longitude                                    :decimal(10, 6)
+#  met_office_area_id                           :bigint(8)
+#  name                                         :string
+#  number_of_pupils                             :integer
+#  percentage_free_school_meals                 :integer
+#  postcode                                     :string
+#  process_data                                 :boolean          default(FALSE)
+#  public                                       :boolean          default(TRUE)
+#  removal_date                                 :date
+#  school_group_id                              :bigint(8)
+#  school_type                                  :integer          not null
+#  scoreboard_id                                :bigint(8)
+#  serves_dinners                               :boolean          default(FALSE), not null
+#  slug                                         :string
+#  solar_pv_tuos_area_id                        :bigint(8)
+#  temperature_area_id                          :bigint(8)
+#  template_calendar_id                         :integer
+#  updated_at                                   :datetime         not null
+#  urn                                          :integer          not null
+#  validation_cache_key                         :string           default("initial")
+#  visible                                      :boolean          default(FALSE)
+#  weather_station_id                           :bigint(8)
+#  website                                      :string
 #
 # Indexes
 #

--- a/app/models/school_group.rb
+++ b/app/models/school_group.rb
@@ -5,6 +5,7 @@
 #  created_at                    :datetime         not null
 #  default_chart_preference      :integer          default("default"), not null
 #  default_dark_sky_area_id      :bigint(8)
+#  default_issues_admin_user_id  :bigint(8)
 #  default_scoreboard_id         :bigint(8)
 #  default_solar_pv_tuos_area_id :bigint(8)
 #  default_template_calendar_id  :bigint(8)
@@ -18,12 +19,14 @@
 #
 # Indexes
 #
+#  index_school_groups_on_default_issues_admin_user_id   (default_issues_admin_user_id)
 #  index_school_groups_on_default_scoreboard_id          (default_scoreboard_id)
 #  index_school_groups_on_default_solar_pv_tuos_area_id  (default_solar_pv_tuos_area_id)
 #  index_school_groups_on_default_template_calendar_id   (default_template_calendar_id)
 #
 # Foreign Keys
 #
+#  fk_rails_...  (default_issues_admin_user_id => users.id) ON DELETE => nullify
 #  fk_rails_...  (default_scoreboard_id => scoreboards.id)
 #  fk_rails_...  (default_solar_pv_tuos_area_id => areas.id)
 #  fk_rails_...  (default_template_calendar_id => calendars.id) ON DELETE => nullify

--- a/app/models/school_onboarding.rb
+++ b/app/models/school_onboarding.rb
@@ -2,26 +2,24 @@
 #
 # Table name: school_onboardings
 #
-#  contact_email                 :string           not null
-#  created_at                    :datetime         not null
-#  created_by_id                 :bigint(8)
-#  created_user_id               :bigint(8)
-#  dark_sky_area_id              :bigint(8)
-#  default_chart_preference      :integer          default("default"), not null
-#  id                            :bigint(8)        not null, primary key
-#  notes                         :text
-#  school_group_id               :bigint(8)
-#  school_id                     :bigint(8)
-#  school_name                   :string           not null
-#  school_will_be_public         :boolean          default(TRUE)
-#  scoreboard_id                 :bigint(8)
-#  solar_pv_tuos_area_id         :bigint(8)
-#  subscribe_to_newsletter       :boolean          default(TRUE)
-#  subscribe_users_to_newsletter :bigint(8)        default([]), not null, is an Array
-#  template_calendar_id          :bigint(8)
-#  updated_at                    :datetime         not null
-#  uuid                          :string           not null
-#  weather_station_id            :bigint(8)
+#  contact_email            :string           not null
+#  created_at               :datetime         not null
+#  created_by_id            :bigint(8)
+#  created_user_id          :bigint(8)
+#  dark_sky_area_id         :bigint(8)
+#  default_chart_preference :integer          default("default"), not null
+#  id                       :bigint(8)        not null, primary key
+#  notes                    :text
+#  school_group_id          :bigint(8)
+#  school_id                :bigint(8)
+#  school_name              :string           not null
+#  school_will_be_public    :boolean          default(TRUE)
+#  scoreboard_id            :bigint(8)
+#  solar_pv_tuos_area_id    :bigint(8)
+#  template_calendar_id     :bigint(8)
+#  updated_at               :datetime         not null
+#  uuid                     :string           not null
+#  weather_station_id       :bigint(8)
 #
 # Indexes
 #

--- a/app/models/school_target.rb
+++ b/app/models/school_target.rb
@@ -139,8 +139,6 @@ class SchoolTarget < ApplicationRecord
   end
 
   def ensure_observation_date_is_correct
-    observations.each do |observation|
-      observation.update!(at: start_date)
-    end
+    observations.update_all(at: start_date)
   end
 end

--- a/app/models/school_target.rb
+++ b/app/models/school_target.rb
@@ -46,6 +46,7 @@ class SchoolTarget < ApplicationRecord
 
   before_save :adjust_target_date
   after_save :add_observation
+  after_update :ensure_observation_date_is_correct
 
   def current?
     Time.zone.now >= start_date && Time.zone.now <= target_date
@@ -135,5 +136,11 @@ class SchoolTarget < ApplicationRecord
       at: start_date,
       points: 0
     )
+  end
+
+  def ensure_observation_date_is_correct
+    observations.each do |observation|
+      observation.update!(at: start_date)
+    end
   end
 end

--- a/app/views/schools/observations/timeline/_school_target.html.erb
+++ b/app/views/schools/observations/timeline/_school_target.html.erb
@@ -1,0 +1,15 @@
+<td class="p-3 text-center">
+  <%= fa_icon("tachometer-alt fa-2x") %>
+</td>
+<td>
+  <h3 class="pt-1"><strong><%= link_to "Started working towards an energy saving target", school_school_target_path(@school, observation.school_target)%></strong></h3>
+  <span class="text-muted"><%= nice_dates(observation.at) %></span>
+</td>
+<% if show_actions && can?(:manage, observation) %>
+  <td class="text-right">
+    <div class="btn-group">
+      <%= link_to t('common.labels.edit'), edit_school_school_target_path(observation.school, observation.school_target), class: 'btn btn-warning' unless observation.school_target.expired? %>
+      <%= link_to t('common.labels.delete'), school_school_target_path(observation.school, observation.school_target), method: :delete, data: { confirm: t('common.confirm') }, class: 'btn btn-danger' %>
+    </div>
+  </td>
+<% end %>

--- a/db/migrate/20221123143039_add_target_id_to_observation.rb
+++ b/db/migrate/20221123143039_add_target_id_to_observation.rb
@@ -1,0 +1,6 @@
+class AddTargetIdToObservation < ActiveRecord::Migration[6.0]
+  def change
+    add_reference :observations, :school_target
+    add_foreign_key :observations, :school_targets
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_11_17_133438) do
+ActiveRecord::Schema.define(version: 2022_11_23_143039) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
@@ -1075,10 +1075,12 @@ ActiveRecord::Schema.define(version: 2022_11_17_133438) do
     t.boolean "visible", default: true
     t.bigint "audit_id"
     t.boolean "involved_pupils", default: false, null: false
+    t.bigint "school_target_id"
     t.index ["activity_id"], name: "index_observations_on_activity_id"
     t.index ["audit_id"], name: "index_observations_on_audit_id"
     t.index ["intervention_type_id"], name: "index_observations_on_intervention_type_id"
     t.index ["school_id"], name: "index_observations_on_school_id"
+    t.index ["school_target_id"], name: "index_observations_on_school_target_id"
   end
 
   create_table "partners", force: :cascade do |t|
@@ -1840,6 +1842,7 @@ ActiveRecord::Schema.define(version: 2022_11_17_133438) do
   add_foreign_key "observations", "activities", on_delete: :nullify
   add_foreign_key "observations", "audits"
   add_foreign_key "observations", "intervention_types", on_delete: :restrict
+  add_foreign_key "observations", "school_targets"
   add_foreign_key "observations", "schools", on_delete: :cascade
   add_foreign_key "programmes", "programme_types", on_delete: :cascade
   add_foreign_key "programmes", "schools", on_delete: :cascade

--- a/lib/tasks/deployment/20221123145618_add_school_target_observations.rake
+++ b/lib/tasks/deployment/20221123145618_add_school_target_observations.rake
@@ -1,0 +1,22 @@
+namespace :after_party do
+  desc 'Deployment task: add_school_target_observations'
+  task add_school_target_observations: :environment do
+    puts "Running deploy task 'add_school_target_observations'"
+
+    #Create an observation for every existing target in the system
+    SchoolTarget.all.each do |school_target|
+      Observation.create!(
+        school: school_target.school,
+        observation_type: :school_target,
+        school_target: school_target,
+        at: school_target.start_date,
+        points: 0
+      )
+    end
+
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord
+      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+  end
+end

--- a/spec/models/school_target_spec.rb
+++ b/spec/models/school_target_spec.rb
@@ -16,6 +16,12 @@ RSpec.describe SchoolTarget, type: :model do
       expect(SchoolTarget.first.target_date).to eq target_date
     end
 
+    it 'creates an observation' do
+      expect(Observation.first.observation_type).to eq "school_target"
+      expect(Observation.first.school).to eq school
+      expect(Observation.first.points).to eq 0
+    end
+
     context "and dates are mismatched" do
       let(:start_date) { Date.today.last_year }
 
@@ -23,6 +29,18 @@ RSpec.describe SchoolTarget, type: :model do
         expect(SchoolTarget.first.start_date).to eq start_date
         expect(SchoolTarget.first.target_date).to eq start_date.next_year
       end
+    end
+  end
+
+  context "when updating" do
+    before(:each) do
+      school.school_targets.create!(start_date: start_date, target_date: target_date, electricity: 10)
+    end
+
+    it 'updates the observation date' do
+      expect(Observation.first.at.to_date).to eql SchoolTarget.first.start_date
+      SchoolTarget.first.update!(start_date: Date.today.beginning_of_month.prev_month)
+      expect(Observation.first.at.to_date).to eql SchoolTarget.first.start_date
     end
   end
 

--- a/spec/system/schools/dashboard/timeline_spec.rb
+++ b/spec/system/schools/dashboard/timeline_spec.rb
@@ -7,6 +7,8 @@ RSpec.shared_examples "dashboard timeline" do
     create(:observation_with_temperature_recording_and_location, school: test_school)
     activity_type = create(:activity_type) # doesn't get saved if built with activity below
     create(:activity, school: test_school, activity_type: activity_type)
+    #will automatically add observation
+    create(:school_target, school: test_school, start_date: Date.today)
     visit school_path(test_school, switch: true)
   end
 
@@ -14,10 +16,12 @@ RSpec.shared_examples "dashboard timeline" do
     expect(page).to have_content('Recorded temperatures in')
     expect(page).to have_content('Upgraded insulation')
     expect(page).to have_content('Completed an activity')
+    expect(page).to have_content('Started working towards an energy saving target')
     click_on 'View all events'
     expect(page).to have_content('Recorded temperatures in')
     expect(page).to have_content('Upgraded insulation')
     expect(page).to have_content('Completed an activity')
+    expect(page).to have_content('Started working towards an energy saving target')
   end
 end
 

--- a/spec/system/schools/school_targets_spec.rb
+++ b/spec/system/schools/school_targets_spec.rb
@@ -102,9 +102,6 @@ RSpec.shared_examples "managing targets" do
         click_on 'Set this target'
         school.reload
         expect(school.current_target.observations.size).to eql 1
-        expect(school.current_target.observations.first.observation_type).to eql "school_target"
-        expect(school.current_target.observations.first.school).to eql school
-        expect(school.current_target.observations.first.points).to eql 0
       end
 
     end

--- a/spec/system/schools/school_targets_spec.rb
+++ b/spec/system/schools/school_targets_spec.rb
@@ -98,6 +98,15 @@ RSpec.shared_examples "managing targets" do
         expect(school.most_recent_target.target_date).to eql last_year.next_year
       end
 
+      it 'adds observation for target' do
+        click_on 'Set this target'
+        school.reload
+        expect(school.current_target.observations.size).to eql 1
+        expect(school.current_target.observations.first.observation_type).to eql "school_target"
+        expect(school.current_target.observations.first.school).to eql school
+        expect(school.current_target.observations.first.points).to eql 0
+      end
+
     end
 
     context "with only electricity meters" do


### PR DESCRIPTION
Adds support for including school targets into the schools timeline of activities

* adds a new `:school_target` `Observartion` type and links to `SchoolTarget` model
* automatically add an Observation when creating a target
* add template for displaying school target observations in timeline
* exclude these observations from the custom timeline we should on the expired target page
* adds an after party task to create observations for all existing targets, to populate the database