### PR TITLE
Data Feed Config Changes

### DIFF
--- a/app/controllers/admin/amr_data_feed_configs_controller.rb
+++ b/app/controllers/admin/amr_data_feed_configs_controller.rb
@@ -24,7 +24,7 @@ module Admin
     private
 
     def amr_data_feed_config_params
-      params.require(:amr_data_feed_config).permit(:import_warning_days, :missing_readings_limit)
+      params.require(:amr_data_feed_config).permit(:import_warning_days, :missing_readings_limit, :notes)
     end
   end
 end

--- a/app/models/amr_data_feed_config.rb
+++ b/app/models/amr_data_feed_config.rb
@@ -43,6 +43,8 @@ class AmrDataFeedConfig < ApplicationRecord
   has_many :amr_data_feed_import_logs
   has_many :meters, -> { distinct }, through: :amr_data_feed_import_logs
 
+  has_rich_text :notes
+
   validates :identifier, :description, uniqueness: true
 
   def map_of_fields_to_indexes(header = nil)

--- a/app/views/admin/amr_data_feed_configs/edit.html.erb
+++ b/app/views/admin/amr_data_feed_configs/edit.html.erb
@@ -3,5 +3,6 @@
 <%= simple_form_for [:admin, @configuration] do |f| %>
   <%= f.input :import_warning_days %>
   <%= f.input :missing_readings_limit, hint: 'This is the maximum number of missing data points allowed in a day, above which the entire day will be ignored (without reporting)' %>
+  <%= f.rich_text_area :notes, hint: 'Notes' %>
   <%= f.submit 'Update', class: 'btn'%>
 <% end %>

--- a/app/views/admin/amr_data_feed_configs/show.html.erb
+++ b/app/views/admin/amr_data_feed_configs/show.html.erb
@@ -18,6 +18,10 @@
         <td><%= value %></td>
       </tr>
     <% end %>
+    <tr>
+      <td>Notes</td>
+      <td><%= @configuration.notes %></td>
+    </tr>
   </tbody>
 </table>
 

--- a/app/views/admin/reports/amr_data_feed_import_logs/index.html.erb
+++ b/app/views/admin/reports/amr_data_feed_import_logs/index.html.erb
@@ -27,7 +27,7 @@
   <% @amr_data_feed_configs.each do |config| %>
     <tr>
     <% import_logs = config.amr_data_feed_import_logs.where('import_time >= ?', Date.today - Admin::Reports::AmrDataFeedImportLogsController::SUMMARY_PERIOD_IN_DAYS.days) %>
-    <td class='text-left'><%= config.description %></td>
+    <td class='text-left'><%= link_to config.description, admin_amr_data_feed_config_path(config) %></td>
     <td><%= import_logs.count %></td>
     <td><%= link_to import_logs.successful.count, admin_reports_amr_data_feed_import_logs_successes_path({config: {config_id: config.id}}) %></td>
     <td><%= link_to import_logs.with_warnings.count, admin_reports_amr_data_feed_import_logs_warnings_path({config: {config_id: config.id}}) %></td>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_11_24_140114) do
+ActiveRecord::Schema.define(version: 2022_11_23_143039) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_11_23_143039) do
+ActiveRecord::Schema.define(version: 2022_11_24_140114) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"


### PR DESCRIPTION
To support review of existing data feed configs, this PR:

- [x] adds a rich text description to data feed configs to allow us to describe what its for
- [x] updates the relevant form to allow this to be edited
- [x] updates the amr data load report to link to the feed config
