### PR TITLE
Add ActiveRecord::RecordNotFound to filter

### DIFF
--- a/config/initializers/rollbar.rb
+++ b/config/initializers/rollbar.rb
@@ -26,7 +26,13 @@ Rollbar.configure do |config|
   # via the rollbar interface.
   # Valid levels: 'critical', 'error', 'warning', 'info', 'debug', 'ignore'
   # 'ignore' will cause the exception to not be reported at all.
-  config.exception_level_filters.merge!('ActionController::RoutingError' => 'ignore')
+  #
+  #Added RecordNotFound to ignore list as we're getting quite a few hits to
+  #schools and scoreboard pages for old or non-existent schools (e.g. made up ids)
+  config.exception_level_filters.merge!({
+    'ActionController::RoutingError' => 'ignore',
+    'ActiveRecord::RecordNotFound' => 'ignore'
+  })
   #
   # You can also specify a callable, which will be called with the exception instance.
   # config.exception_level_filters.merge!('MyCriticalException' => lambda { |e| 'critical' })


### PR DESCRIPTION
Add ActiveRecord::RecordNotFound exceptions to ignore list.

Rollbar currently logs these as warnings. But we're getting quite a few of them and they're either from crawlers accessing scoreboards or schools that no longer exist, or crawlers/bots  requesting random ids. So lets exclude for now.

https://docs.rollbar.com/docs/ruby#exception-level-filters