### PR TITLE
Fix flickering tests

### DIFF
--- a/spec/system/activity_types_spec.rb
+++ b/spec/system/activity_types_spec.rb
@@ -5,7 +5,7 @@ describe 'activity types', type: :system do
   context 'activity types search page' do
 
     let!(:activity_type_1) { create(:activity_type, name: 'foo', description: 'activity') }
-    let!(:activity_type_2) { create(:activity_type, name: 'bar', description: 'activity the second') }
+    let!(:activity_type_2) { create(:activity_type, name: 'bar', description: 'second activity') }
 
     it 'links from activity categories page and shows empty page' do
       ClimateControl.modify FEATURE_FLAG_ACTIVITY_TYPE_SEARCH: 'true' do

--- a/spec/system/activity_types_spec.rb
+++ b/spec/system/activity_types_spec.rb
@@ -74,65 +74,67 @@ describe 'activity types', type: :system do
       let!(:activity_type_1) { create(:activity_type, name: 'baz one', key_stages: [key_stage_1], subjects: [subject_1]) }
       let!(:activity_type_2) { create(:activity_type, name: 'baz two', key_stages: [key_stage_2], subjects: [subject_2]) }
 
-      before :each do
-        visit search_activity_types_path
-      end
+      context "visiting the seach page" do
+        before :each do
+          visit search_activity_types_path
+        end
 
-      it 'finds all with no filter' do
-        fill_in 'query', with: 'baz'
-        click_on 'Search'
-        #flickering?
-        expect(page).to have_content('baz one')
-        expect(page).to have_content('baz two')
-      end
+        it 'finds all with no filter' do
+          fill_in 'query', with: 'baz'
+          click_on 'Search'
+          #flickering?
+          expect(page).to have_content('baz one')
+          expect(page).to have_content('baz two')
+        end
 
-      it 'shows result count' do
-        fill_in 'query', with: 'baz'
-        click_on 'Search'
-        expect(page).to have_content('2 results found')
-      end
+        it 'shows result count' do
+          fill_in 'query', with: 'baz'
+          click_on 'Search'
+          expect(page).to have_content('2 results found')
+        end
 
-      it 'finds result with key stage filter' do
-        fill_in 'query', with: 'baz'
-        click_on 'Search'
-        click_on key_stage_1.name
-        expect(page).to have_content('baz one')
-        expect(page).not_to have_content('baz two')
-      end
+        it 'finds result with key stage filter' do
+          fill_in 'query', with: 'baz'
+          click_on 'Search'
+          click_on key_stage_1.name
+          expect(page).to have_content('baz one')
+          expect(page).not_to have_content('baz two')
+        end
 
-      it 'keeps filters for next search' do
-        fill_in 'query', with: 'baz'
-        click_on 'Search'
-        click_on key_stage_1.name
-        expect(page).to have_content('baz one')
-        expect(page).not_to have_content('baz two')
-        fill_in 'query', with: 'baz'
-        click_on 'Search'
-        expect(page).to have_content('baz one')
-        expect(page).not_to have_content('baz two')
-      end
+        it 'keeps filters for next search' do
+          fill_in 'query', with: 'baz'
+          click_on 'Search'
+          click_on key_stage_1.name
+          expect(page).to have_content('baz one')
+          expect(page).not_to have_content('baz two')
+          fill_in 'query', with: 'baz'
+          click_on 'Search'
+          expect(page).to have_content('baz one')
+          expect(page).not_to have_content('baz two')
+        end
 
-      it 'shows result count' do
-        fill_in 'query', with: 'baz'
-        click_on 'Search'
-        click_on key_stage_1.name
-        expect(page).to have_content('1 result found')
-      end
+        it 'shows result count' do
+          fill_in 'query', with: 'baz'
+          click_on 'Search'
+          click_on key_stage_1.name
+          expect(page).to have_content('1 result found')
+        end
 
-      it 'finds result with subject filter' do
-        fill_in 'query', with: 'baz'
-        click_on 'Search'
-        click_on subject_1.name
-        expect(page).to have_content('baz one')
-        expect(page).not_to have_content('baz two')
-      end
+        it 'finds result with subject filter' do
+          fill_in 'query', with: 'baz'
+          click_on 'Search'
+          click_on subject_1.name
+          expect(page).to have_content('baz one')
+          expect(page).not_to have_content('baz two')
+        end
 
-      it 'finds none if key stage and subject filtered' do
-        fill_in 'query', with: 'baz'
-        click_on 'Search'
-        click_on key_stage_1.name
-        click_on subject_2.name
-        expect(page).to have_content('No results found')
+        it 'finds none if key stage and subject filtered' do
+          fill_in 'query', with: 'baz'
+          click_on 'Search'
+          click_on key_stage_1.name
+          click_on subject_2.name
+          expect(page).to have_content('No results found')
+        end
       end
     end
   end

--- a/spec/system/admin/issues_spec.rb
+++ b/spec/system/admin/issues_spec.rb
@@ -216,26 +216,30 @@ RSpec.describe 'issues', :issues, type: :system, include_application_helper: tru
 
   context 'as an admin' do
     let!(:user) { create(:admin) }
+    let!(:setup_data) {}
+
     before do
       sign_in(user)
     end
 
     describe 'index' do
+      before do
+        setup_data
+        visit admin_issues_url
+      end
+
+      it { expect(page).to have_select('User', selected: []) }
+      it { expect(page).to have_checked_field('Issue') }
+      it { expect(page).to have_checked_field('Note') }
+      it { expect(page).to have_checked_field('Open') }
+      it { expect(page).to have_checked_field('Closed') }
+
       context "showing defaults" do
-        let!(:open_issue) { create :issue, status: :open }
-        let!(:closed_issue) { create :issue, status: :closed }
-        let!(:issue_issue) { create :issue }
-        let!(:note_issue) { create :issue, issue_type: :note, pinned: true}
-
-        before do
-          visit admin_issues_url
-        end
-
-        it { expect(page).to have_select('User', selected: []) }
-        it { expect(page).to have_checked_field('Issue') }
-        it { expect(page).to have_checked_field('Note') }
-        it { expect(page).to have_checked_field('Open') }
-        it { expect(page).to have_checked_field('Closed') }
+        let(:open_issue) { create :issue, status: :open }
+        let(:closed_issue) { create :issue, status: :closed }
+        let(:issue_issue) { create :issue }
+        let(:note_issue) { create :issue, issue_type: :note, pinned: true}
+        let(:setup_data) { [open_issue, closed_issue, issue_issue, note_issue]}
 
         it_behaves_like "a displayed list issue" do
           let(:issue) { open_issue }
@@ -295,8 +299,9 @@ RSpec.describe 'issues', :issues, type: :system, include_application_helper: tru
       context "and selecting a user" do
         let!(:user_issue) { create(:issue, owned_by: user)}
         let!(:other_user_issue) { create(:issue, owned_by: create(:admin, name: "Not you"))}
+        let(:setup_data) { [user_issue, other_user_issue] }
+
         before do
-          visit admin_issues_url
           select user.display_name, from: 'User'
           click_button 'Filter'
         end
@@ -309,9 +314,7 @@ RSpec.describe 'issues', :issues, type: :system, include_application_helper: tru
       end
 
       context "when there are no issues" do
-        before do
-          visit admin_issues_url
-        end
+        let(:setup_data) {}
         it { expect(page).to have_content("No issues or notes to display")}
       end
     end

--- a/spec/system/intervention_types_spec.rb
+++ b/spec/system/intervention_types_spec.rb
@@ -5,7 +5,7 @@ describe 'intervention types', type: :system do
   context 'intervention types search page' do
 
     let!(:intervention_type_1) { create(:intervention_type, name: 'foo', description: 'intervention') }
-    let!(:intervention_type_2) { create(:intervention_type, name: 'bar', description: 'intervention') }
+    let!(:intervention_type_2) { create(:intervention_type, name: 'bar', description: 'second intervention') }
 
     it 'links from intervention groups page and shows empty page' do
       ClimateControl.modify FEATURE_FLAG_INTERVENTION_TYPE_SEARCH: 'true' do


### PR DESCRIPTION
Background: This build failed (which passed locally): https://github.com/Energy-Sparks/energy-sparks/actions/runs/3628959858/jobs/6120599772

For the issues tests, I am wondering if sometimes that let! and before statements, if in the same block, do not always execute in their given order. So I am thinking in the case of the issues tests, that sometimes the test data might not have been setup before the page loaded.

./spec/system/activity_types_spec.rb:49 & ./spec/system/intervention_types_spec.rb:55
For these two, it could be because when doing a search, postgres is calculating a rank for the results, and then ordering by this rank. Wonder if this can be different sometimes.

./spec/system/activity_types_spec.rb:86
For this one, I think it could be a similar issue as for issues tests. i.e. the let! and before execution order not being consistent