### PR TITLE
Analytics 2.2.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ gem 'pg_search'
 gem 'calculate_in_group'
 
 # Dashboard analytics
-gem 'energy-sparks_analytics', git: 'https://github.com/Energy-Sparks/energy-sparks_analytics.git', tag: '2.1.3'
+gem 'energy-sparks_analytics', git: 'https://github.com/Energy-Sparks/energy-sparks_analytics.git', tag: '2.2.1'
 #gem 'energy-sparks_analytics', git: 'https://github.com/Energy-Sparks/energy-sparks_analytics.git', branch: 'aws-eb-test'
 #gem 'energy-sparks_analytics', path: '../energy-sparks_analytics'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/Energy-Sparks/energy-sparks_analytics.git
-  revision: 1dac4aedaa6c256753c7f1ea4d31323cfaae8cfd
-  tag: 2.1.3
+  revision: ed98520e26020e589e36640be6c0454f09b8cf11
+  tag: 2.2.1
   specs:
     energy-sparks_analytics (1.2.1)
       activesupport (~> 6.0.0)

--- a/config/locales/analytics/alerts/common/common.yml
+++ b/config/locales/analytics/alerts/common/common.yml
@@ -17,3 +17,6 @@ en:
     alert_target_base:
       summary: "%{percent} %{above_or_below} target"
       timescale: at least 1 year
+    tariff_change:
+      change_between_periods_caveat: 'Warning: the school''s economic tariff has changed between the two periods being compared, this is not reflected in the cost savings where we have used the most recent tariff to calculate the savings.'
+      change_within_period_caveat: 'Warning: the school''s economic tariff has changed recently, this is not reflected in the cost savings where we have used the most recent tariff to calculate the savings.'

--- a/config/locales/analytics/common.yml
+++ b/config/locales/analytics/common.yml
@@ -94,7 +94,7 @@ en:
         solar_irradiance: Solar Irradiance
         solar_pv: Solar PV (consumed onsite)
         storage_heater_charge: Storage heater charge (school day)
-        storage_heaters: storage heaters
+        storage_heaters: Storage heaters
         target_degree_days: Target degree days
         temperature: Temperature
         useful_hot_water_usage: Hot Water Usage

--- a/config/locales/analytics/energy_units.yml
+++ b/config/locales/analytics/energy_units.yml
@@ -45,6 +45,7 @@ en:
       opt_start_standard_deviation: "%{value} standard deviation (hours)"
       optimum_start_sensitivity: "%{value} hours/C"
       p: "%{value}p"
+      p_per_kwh: "%{value}p/kWh"
       panels: "%{value} solar PV panels"
       percent: "%{value}%"
       percent_0dp: "%{value}%"
@@ -79,6 +80,7 @@ en:
       "£_per_kwh": "%{sign}£%{value}/kWh"
       "£_per_kwh_html": "%{sign}&pound;%{value}/kWh"
       "£_range": "%{low} to %{high}"
+      "£current": "%{sign}£%{value}"
     units:
       days:
         one: "%{count} day"


### PR DESCRIPTION
Update application to use Analytics 2.2.1

The change for this version is https://github.com/Energy-Sparks/energy-sparks_analytics/pull/361 that revises how much of the cost calculations are done to reduce use of hard-coded values and https://github.com/Energy-Sparks/energy-sparks_analytics/pull/365 which includes some updates to the former pr.  This needs review on test server before going to production.

This PR will be merged into the test server branch for release, but otherwise should stay open until any related issues have been resolved.