### PR TITLE
Add helper for staff role dropdown

### DIFF
--- a/app/models/staff_role.rb
+++ b/app/models/staff_role.rb
@@ -24,4 +24,8 @@ class StaffRole < ApplicationRecord
   def as_symbol
     title.parameterize.underscore.to_sym
   end
+
+  def self.translated_names_and_ids
+    all.map { |staff_role| [staff_role.translated_title, staff_role.id] }.sort
+  end
 end

--- a/app/views/schools/contacts/_form.html.erb
+++ b/app/views/schools/contacts/_form.html.erb
@@ -4,7 +4,7 @@
 
 
 <% if f.object.user.nil? %>
-  <%= f.input :staff_role_id, label: t('schools.contacts.form.labels.role'), collection: StaffRole.all.map { |staff_role| [staff_role.translated_title, staff_role.id] }.sort %>
+  <%= f.input :staff_role_id, label: t('schools.contacts.form.labels.role'), collection: StaffRole.translated_names_and_ids %>
 
   <p><%= t('schools.contacts.form.enter_at_least_one_method_message') %></p>
 <% end %>

--- a/app/views/schools/users/_form.html.erb
+++ b/app/views/schools/users/_form.html.erb
@@ -1,3 +1,3 @@
 <%= f.input :name, required: :true, label: t('schools.users.form.name') %>
 <%= f.input :email, required: :true, label: t('schools.users.form.email') %>
-<%= f.input :staff_role_id, label: t('schools.users.form.role'), required: :true, collection: StaffRole.all.map { |staff_role| [staff_role.translated_title, staff_role.id] }.sort, hint: t('schools.users.form.what_is_their_primary_role') %>
+<%= f.input :staff_role_id, label: t('schools.users.form.role'), required: :true, collection: StaffRole.translated_names_and_ids, hint: t('schools.users.form.what_is_their_primary_role') %>

--- a/spec/models/staff_role_spec.rb
+++ b/spec/models/staff_role_spec.rb
@@ -5,4 +5,37 @@ describe StaffRole, type: :model do
     expect(StaffRole.new(title: 'Third-party/other').as_symbol).to eq :third_party_other
     expect(StaffRole.new(title: 'Building/site manager or caretaker').as_symbol).to eq :building_site_manager_or_caretaker
   end
+
+  describe '#translated_names_and_ids' do
+    it 'returns an array of arrays containing the translated staff role title and its id' do
+      staff_roles = [
+        "Building/site manager or caretaker",
+        "Business manager",
+        "Council or MAT staff",
+        "Governor",
+        "Headteacher or Deputy Head",
+        "Parent or volunteer",
+        "Public",
+        "Teacher or teaching assistant"
+      ]
+      staff_roles.each { |title| StaffRole.create!(title: title) }
+      I18n.with_locale(:cy) do
+        expect(StaffRole.translated_names_and_ids.map(&:first)).to eq(
+          [
+            'Athro neu gynorthwyydd addysgu',
+            'Cyhoedd',
+            'Cyngor neu staff MAT',
+            'Llywodraethwr',
+            'Pennaeth neu Ddirprwy Bennaeth',
+            'Rheolwr adeilad/safle neu ofalwr',
+            'Rheolwr busnes',
+            'Rhiant neu wirfoddolwr'
+          ]
+          )
+      end
+      I18n.with_locale(:en) do
+        expect(StaffRole.translated_names_and_ids.map(&:first)).to eq(staff_roles)
+      end
+    end
+  end
 end


### PR DESCRIPTION
We have a few places where we use the same sort pattern for the staff role dropdown.
```
<%= f.input :staff_role_id, label: t('schools.contacts.form.labels.role'), collection: StaffRole.all.map { |staff_role| [staff_role.translated_title, staff_role.id] }.sort %>
```
This pr extracts this to a method