### PR TITLE
Remove unnecessary SchoolTarget observations

### DIFF
--- a/app/models/school_target.rb
+++ b/app/models/school_target.rb
@@ -129,13 +129,15 @@ class SchoolTarget < ApplicationRecord
   end
 
   def add_observation
-    Observation.create!(
-      school: school,
-      observation_type: :school_target,
-      school_target: self,
-      at: start_date,
-      points: 0
-    )
+    unless observations.any?
+      Observation.create!(
+        school: school,
+        observation_type: :school_target,
+        school_target: self,
+        at: start_date,
+        points: 0
+      )
+    end
   end
 
   def ensure_observation_date_is_correct

--- a/lib/tasks/deployment/20221212165015_remove_duplicate_school_target_observations.rake
+++ b/lib/tasks/deployment/20221212165015_remove_duplicate_school_target_observations.rake
@@ -1,0 +1,18 @@
+namespace :after_party do
+  desc 'Deployment task: remove_duplicate_school_target_observations'
+  task remove_duplicate_school_target_observations: :environment do
+    puts "Running deploy task 'remove_duplicate_school_target_observations'"
+
+    SchoolTarget.all.each do |school_target|
+      obs = Observation.where(school_target: school_target).order(created_at: :desc)
+      if obs.length > 1
+        obs[0..-2].each do |obs| obs.destroy end
+      end
+    end
+
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord
+      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+  end
+end

--- a/spec/models/school_target_spec.rb
+++ b/spec/models/school_target_spec.rb
@@ -20,6 +20,10 @@ RSpec.describe SchoolTarget, type: :model do
       expect(Observation.first.observation_type).to eq "school_target"
       expect(Observation.first.school).to eq school
       expect(Observation.first.points).to eq 0
+
+      #creates only a single Observation
+      SchoolTarget.first.update!(electricity: 22)
+      expect(Observation.count).to eq 1
     end
 
     context "and dates are mismatched" do


### PR DESCRIPTION
A silly mistake(*) in an `after_save` method means we're creating duplicate `school_target` observations for schools.

This PR adds:

- check in SchoolTarget model to see if an observation already exists
- update to the spec
- after party task to remove all but one of the existing observations for a target

(*) by me! 