### PR TITLE
Add disk usage logging

### DIFF
--- a/.ebextensions/cloudwatch.config
+++ b/.ebextensions/cloudwatch.config
@@ -23,4 +23,4 @@ option_settings:
   "aws:autoscaling:launchconfiguration" :
     IamInstanceProfile : "aws-elasticbeanstalk-ec2-role"
   "aws:elasticbeanstalk:customoption" :
-    CloudWatchMetrics : "--mem-util --mem-used --mem-avail --auto-scaling"
+    CloudWatchMetrics : "--mem-util --mem-used --mem-avail --auto-scaling -disk-path=/ --disk-space-used --disk-space-avail"


### PR DESCRIPTION
Update CloudWatch configuration to add disk space usage and availability metrics, this will let us monitor disk usage on test and production machines.