### PR TITLE
Reconfigure & Upgrade Font Awesome

### DIFF
--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -13,6 +13,7 @@ require("trix")
 require("@rails/actiontext")
 require('awesomplete')
 
+import "@fortawesome/fontawesome-free/css/all.css";
 import Trix from 'trix'
 
 Trix.config.attachments.preview.caption = { name: false, size: false }

--- a/app/javascript/packs/stylesheets.scss
+++ b/app/javascript/packs/stylesheets.scss
@@ -1,9 +1,2 @@
 @import '~awesomplete/awesomplete';
 @import '../src/stylesheets';
-
-$fa-font-path: '~@fortawesome/fontawesome-free/webfonts';
-
-@import '~@fortawesome/fontawesome-free/scss/fontawesome';
-@import '~@fortawesome/fontawesome-free/scss/regular';
-@import '~@fortawesome/fontawesome-free/scss/solid';
-@import '~@fortawesome/fontawesome-free/scss/brands';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "@fortawesome/fontawesome-free": "^5.11.2",
+    "@fortawesome/fontawesome-free": "^6.2.1",
     "@rails/actiontext": "^6.0.3-2",
     "@rails/activestorage": "^6.0.3-2",
     "@rails/webpacker": "^5.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -843,10 +843,10 @@
   resolved "https://registry.yarnpkg.com/@csstools/convert-colors/-/convert-colors-1.4.0.tgz#ad495dc41b12e75d588c6db8b9834f08fa131eb7"
   integrity sha512-5a6wqoJV/xEdbRNKVo6I4hO3VjyDq//8q2f9I6PBAvMesJHFauXDorcNCsr9RzvsZnaWi5NYCcfyqP1QeFHFbw==
 
-"@fortawesome/fontawesome-free@^5.11.2":
-  version "5.14.0"
-  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-free/-/fontawesome-free-5.14.0.tgz#a371e91029ebf265015e64f81bfbf7d228c9681f"
-  integrity sha512-OfdMsF+ZQgdKHP9jUbmDcRrP0eX90XXrsXIdyjLbkmSBzmMXPABB8eobUJtivaupucYaByz6WNe1PI1JuYm3qA==
+"@fortawesome/fontawesome-free@^6.2.1":
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-free/-/fontawesome-free-6.2.1.tgz#344baf6ff9eaad7a73cff067d8c56bfc11ae5304"
+  integrity sha512-viouXhegu/TjkvYQoiRZK3aax69dGXxgEjpvZW81wIJdxm5Fnvp3VVIP4VHKqX4SvFw6qpmkILkD4RJWAdrt7A==
 
 "@npmcli/move-file@^1.0.1":
   version "1.0.1"


### PR DESCRIPTION
* Removes the import lines from stylesheets.scss & adds a single import line to application.js
* Upgrades the fontawesome node package so we can use FA 6 rather than 5. This gives us 400+ more available icons. See: https://fontawesome.com/v6/search?m=free