### PR TITLE
Downgrade sass-rails and sprockets

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,7 +33,7 @@ gem 'statsample', git: 'https://github.com/Energy-Sparks/statsample', tag: '2.1.
 
 # Assets
 gem 'jquery-rails' # Use jquery as the JavaScript library
-gem 'sass-rails'# Use SCSS for stylesheets
+#gem 'sass-rails'# Use SCSS for stylesheets
 gem 'uglifier' # Use Uglifier as compressor for JavaScript assets
 gem 'bootstrap4-datetime-picker-rails' # For tempus dominus date picker
 gem 'momentjs-rails'
@@ -164,3 +164,6 @@ group :test do
   gem 'shoulda-matchers'
   gem 'timecop'
 end
+
+gem 'sprockets', '3.7.2'
+gem 'sass-rails', '5.1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -557,8 +557,17 @@ GEM
       sexp_processor (~> 4.16)
     rubyvis (0.6.1)
     rubyzip (1.3.0)
-    sass-rails (6.0.0)
-      sassc-rails (~> 2.1, >= 2.1.1)
+    sass (3.7.4)
+      sass-listen (~> 4.0.0)
+    sass-listen (4.0.0)
+      rb-fsevent (~> 0.9, >= 0.9.4)
+      rb-inotify (~> 0.9, >= 0.9.7)
+    sass-rails (5.1.0)
+      railties (>= 5.2.0)
+      sass (~> 3.1)
+      sprockets (>= 2.8, < 4.0)
+      sprockets-rails (>= 2.0, < 4.0)
+      tilt (>= 1.1, < 3)
     sassc (2.4.0)
       ffi (~> 1.9)
     sassc-rails (2.1.2)
@@ -596,7 +605,7 @@ GEM
       sys-uname (~> 1.0.2)
     spreadsheet (1.3.0)
       ruby-ole
-    sprockets (4.0.3)
+    sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sprockets-rails (3.4.2)
@@ -747,13 +756,14 @@ DEPENDENCIES
   rubocop-performance (= 1.8.0)
   rubocop-rails (= 2.8.0)
   rubocop-rspec
-  sass-rails
+  sass-rails (= 5.1.0)
   scout_apm
   selenium-webdriver
   shoulda-matchers
   simple_form
   simplecov
   sitemap_generator
+  sprockets (= 3.7.2)
   stateful_enum (= 0.6.0)
   statsample!
   terminal-notifier


### PR DESCRIPTION
Downgrade sass-rails and sprockets gems to avoid segfaults.

See:

https://github.com/sass/sassc-ruby/issues/207#issuecomment-1058148376