### PR TITLE
Allow advice pages to have associated activities

### DIFF
--- a/app/controllers/admin/advice_pages/activity_types_controller.rb
+++ b/app/controllers/admin/advice_pages/activity_types_controller.rb
@@ -1,0 +1,21 @@
+module Admin
+  module AdvicePages
+    class ActivityTypesController < AdminController
+      def show
+        @advice_page = AdvicePage.find(params[:advice_page_id])
+        @activity_categories_and_types = ActivityCategory.listed_with_activity_types
+        @positions = @advice_page.advice_page_activity_types.inject({}) do |positions, advice_page_activity_types|
+          positions[advice_page_activity_types.activity_type_id] = advive_page_activity_types.position
+          positions
+        end
+      end
+
+      def update
+        @advice_page = AdvicePage.find(params[:advice_page_id])
+        position_attributes = params.permit(activity_types: [:position, :activity_type_id]).fetch(:activity_types) { {} }
+        @advice_page.update_activity_type_positions!(position_attributes)
+        redirect_to admin_advice_pages_path, notice: 'Activity types updated'
+      end
+    end
+  end
+end

--- a/app/controllers/admin/advice_pages/activity_types_controller.rb
+++ b/app/controllers/admin/advice_pages/activity_types_controller.rb
@@ -5,7 +5,7 @@ module Admin
         @advice_page = AdvicePage.find(params[:advice_page_id])
         @activity_categories_and_types = ActivityCategory.listed_with_activity_types
         @positions = @advice_page.advice_page_activity_types.inject({}) do |positions, advice_page_activity_types|
-          positions[advice_page_activity_types.activity_type_id] = advive_page_activity_types.position
+          positions[advice_page_activity_types.activity_type_id] = advice_page_activity_types.position
           positions
         end
       end

--- a/app/models/advice_page.rb
+++ b/app/models/advice_page.rb
@@ -17,4 +17,16 @@ class AdvicePage < ApplicationRecord
   include TransifexSerialisable
 
   translates :learn_more, backend: :action_text
+
+  has_many :advice_page_activity_types
+  has_many :activity_types, through: :advice_page_activity_types
+
+  accepts_nested_attributes_for :advice_page_activity_types, reject_if: proc {|attributes| attributes['position'].blank? }
+
+  def update_activity_type_positions!(position_attributes)
+    transaction do
+      advice_page_activity_types.destroy_all
+      update!(advice_page_activity_types_attributes: position_attributes)
+    end
+  end
 end

--- a/app/models/advice_page_activity_type.rb
+++ b/app/models/advice_page_activity_type.rb
@@ -1,0 +1,6 @@
+class AdvicePageActivityType < ApplicationRecord
+  belongs_to :advice_page
+  belongs_to :activity_type
+
+  validates :activity_type, :advice_page, presence: true
+end

--- a/app/views/admin/advice_pages/activity_types/show.html.erb
+++ b/app/views/admin/advice_pages/activity_types/show.html.erb
@@ -1,0 +1,18 @@
+<h2>Recommended activities for the <%= @advice_page.key %> advice page</h2>
+
+<%= form_tag admin_advice_page_activity_types_path(@advice_page), method: :put do %>
+  <%= submit_tag 'Update associated activity types', class: 'btn btn-primary mb-3'%>
+  <% @activity_categories_and_types.each do |activity_category, activity_types| %>
+    <h3><%= activity_category.name %></h3>
+    <ul class="list-unstyled advice-page-activities">
+      <%- activity_types.each do |activity_type| %>
+        <li>
+          <%= number_field_tag "activity_types[#{activity_type.id}][position]", @positions[activity_type.id], min: 0, max: 99, step: 1 %>
+          <%= label_tag "activity_types[#{activity_type.id}][position]", activity_type.name %>
+          <%= hidden_field_tag  "activity_types[#{activity_type.id}][activity_type_id]", activity_type.id %>
+        </li>
+      <% end %>
+    </ul>
+  <% end %>
+  <%= submit_tag 'Update associated activity types', class: 'btn btn-primary'%>
+<% end %>

--- a/app/views/admin/advice_pages/index.html.erb
+++ b/app/views/admin/advice_pages/index.html.erb
@@ -1,6 +1,6 @@
 <% content_for :page_title, "Manage Advice Pages" %>
 
-<h1>Manage advice page configuration</h1>
+<h1>Manage advice pages</h1>
 
 <p>
  Use this page to manage the configuration of the new school advice pages.

--- a/app/views/admin/advice_pages/index.html.erb
+++ b/app/views/admin/advice_pages/index.html.erb
@@ -1,13 +1,17 @@
 <% content_for :page_title, "Manage Advice Pages" %>
 
-<h1>Manage advice pages</h1>
+<h1>Manage advice page configuration</h1>
+
+<p>
+ Use this page to manage the configuration of the new school advice pages.
+</p>
 
 <table class="table table-striped">
   <thead>
   <tr>
     <th>Key</th>
     <th>Restricted?</th>
-    <th></th>
+    <th>Manage</th>
   </tr>
   </thead>
   <tbody>
@@ -15,7 +19,10 @@
     <tr>
       <td><%= advice_page.key %></td>
       <td><%= y_n(advice_page.restricted) %></td>
-      <td><%= link_to 'Edit', edit_admin_advice_page_path(advice_page), class: 'btn'%></td>
+      <td>
+        <%= link_to 'Edit', edit_admin_advice_page_path(advice_page), class: 'btn'%>
+        <%= link_to "Activity types (#{advice_page.activity_types.count})", admin_advice_page_activity_types_path(advice_page), class: 'btn' %>
+      </td>
     </tr>
   <% end %>
   </tbody>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -307,7 +307,11 @@ Rails.application.routes.draw do
         resource :confirmation, only: [:create], controller: 'confirmation'
       end
     end
-    resources :advice_pages, only: [:index, :edit, :update]
+    resources :advice_pages, only: [:index, :edit, :update] do
+      scope module: :advice_pages do
+        resource :activity_types, only: [:show, :update]
+      end
+    end
     resources :case_studies
     resources :dcc_consents, only: [:index]
     post 'dcc_consents/:mpxn/withdraw', to: 'dcc_consents#withdraw', as: :withdraw_dcc_consent

--- a/db/migrate/20230105162523_create_advice_page_activity_type_join_table.rb
+++ b/db/migrate/20230105162523_create_advice_page_activity_type_join_table.rb
@@ -1,0 +1,9 @@
+class CreateAdvicePageActivityTypeJoinTable < ActiveRecord::Migration[6.0]
+  def change
+    create_table :advice_page_activity_types do |t|
+      t.belongs_to :advice_page
+      t.belongs_to :activity_type
+      t.integer :position
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_01_05_114127) do
+ActiveRecord::Schema.define(version: 2023_01_05_162523) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
@@ -144,6 +144,14 @@ ActiveRecord::Schema.define(version: 2023_01_05_114127) do
     t.string "summary"
     t.index ["active"], name: "index_activity_types_on_active"
     t.index ["activity_category_id"], name: "index_activity_types_on_activity_category_id"
+  end
+
+  create_table "advice_page_activity_types", force: :cascade do |t|
+    t.bigint "advice_page_id"
+    t.bigint "activity_type_id"
+    t.integer "position"
+    t.index ["activity_type_id"], name: "index_advice_page_activity_types_on_activity_type_id"
+    t.index ["advice_page_id"], name: "index_advice_page_activity_types_on_advice_page_id"
   end
 
   create_table "advice_pages", force: :cascade do |t|

--- a/spec/system/admin/advice_pages_spec.rb
+++ b/spec/system/admin/advice_pages_spec.rb
@@ -7,10 +7,12 @@ describe 'advice page management', type: :system do
 
   let!(:advice_page)   { create(:advice_page, key: 'baseload-summary') }
 
-  describe 'managing' do
+  before do
+    sign_in(admin)
+  end
 
+  describe 'managing the advice pages' do
     before do
-      sign_in(admin)
       visit admin_path
       click_on 'Advice Pages'
     end
@@ -36,6 +38,35 @@ describe 'advice page management', type: :system do
       expect(advice_page.learn_more.to_s).to include('english text here')
       expect(advice_page.learn_more_en.to_s).to include('english text here')
       expect(advice_page.learn_more_cy.to_s).to include('welsh text here')
+    end
+  end
+
+  describe 'managing associated activities' do
+    let!(:activity_category) { create(:activity_category)}
+    let!(:activity_type_1) { create(:activity_type, name: 'Turn off the lights', activity_category: activity_category)}
+    let!(:activity_type_2) { create(:activity_type, name: 'Turn down the heating', activity_category: activity_category)}
+
+    before do
+      visit admin_path
+      click_on 'Advice Pages'
+    end
+
+    it 'allows admin user to manage the activities' do
+      click_on 'Activity types (0)'
+
+      expect(page.find_field('Turn off the lights').value).to be_blank
+      expect(page.find_field('Turn down the heating').value).to be_blank
+
+      fill_in 'Turn down the heating', with: '1'
+
+      click_on 'Update associated activity type', match: :first
+      click_on 'Activity types'
+
+      expect(page.find_field('Turn off the lights').value).to be_blank
+      expect(page.find_field('Turn down the heating').value).to eq('1')
+
+      expect(advice_page.activity_types).to match_array([activity_type_2])
+      expect(advice_page.advice_page_activity_types.first.position).to eq(1)
     end
   end
 end


### PR DESCRIPTION
Updates the AdvicePage model to have an associated list of activity types.

Provides a simple admin interface for managing the activities, with a priority number. The interface is basic, but similar to what is used to manage similar relationships across the site.

This will be used to recommend activities from the advice page Insights tab.