### PR TITLE
2761 further baseload advice page analysis

### DIFF
--- a/app/assets/stylesheets/advice_page.scss
+++ b/app/assets/stylesheets/advice_page.scss
@@ -1,5 +1,5 @@
 .advice-page {
   h1, h2, h3, h4, h5 {
-    scroll-margin-top: 100px
+    scroll-margin-top: 100px;
   }
 }

--- a/app/assets/stylesheets/advice_page.scss
+++ b/app/assets/stylesheets/advice_page.scss
@@ -1,4 +1,4 @@
-.advice-page {
+.advice-page-tabs {
   h1, h2, h3, h4, h5 {
     scroll-margin-top: 100px;
   }

--- a/app/assets/stylesheets/advice_page.scss
+++ b/app/assets/stylesheets/advice_page.scss
@@ -1,0 +1,5 @@
+.advice-page {
+  h1, h2, h3, h4, h5 {
+    scroll-margin-top: 100px
+  }
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -51,3 +51,4 @@
 @import "live_data";
 @import "activations";
 @import "toggler";
+@import "advice_page";

--- a/app/controllers/schools/advice/baseload_controller.rb
+++ b/app/controllers/schools/advice/baseload_controller.rb
@@ -17,6 +17,7 @@ module Schools
         @estimated_savings = benchmark_service.estimated_savings
 
         @chart_name = :baseload_lastyear
+        @multiple_meters = @school.meters.electricity.count > 1
       end
 
       private

--- a/app/helpers/advice_page_helper.rb
+++ b/app/helpers/advice_page_helper.rb
@@ -3,6 +3,18 @@ module AdvicePageHelper
     polymorphic_path([tab, school, :advice, advice_page.key.to_sym])
   end
 
+  def chart_start_month_year(date = Time.zone.today)
+    month_year(date.last_month - 1.year)
+  end
+
+  def chart_end_month_year(date = Time.zone.today)
+    month_year(date.last_month)
+  end
+
+  def month_year(date)
+    I18n.t('date.month_names')[date.month] + " " + date.year.to_s
+  end
+
   def advice_baseload_high?(val)
     val > 0.0
   end

--- a/app/views/schools/advice/_advice_page.html.erb
+++ b/app/views/schools/advice/_advice_page.html.erb
@@ -1,22 +1,20 @@
-<div class="advice-page">
-  <h1><%= "Advice page: #{advice_page.key.humanize}" %></h1>
+<h1><%= "Advice page: #{advice_page.key.humanize}" %></h1>
 
-  <div class="advice-page-breadcrumb">
-    <%= render(BreadcrumbsComponent.new) do |c| %>
-      <% c.with_school(school) %>
-      <% c.with_items([ { name: "Advice", href: school_advice_path(school) },
-                        { name: advice_page.key.humanize, href: advice_page_path(school, advice_page) },
-                      ]) %>
-    <% end %>
+<div class="advice-page-breadcrumb">
+  <%= render(BreadcrumbsComponent.new) do |c| %>
+    <% c.with_school(school) %>
+    <% c.with_items([ { name: "Advice", href: school_advice_path(school) },
+                      { name: advice_page.key.humanize, href: advice_page_path(school, advice_page) },
+                    ]) %>
+  <% end %>
+</div>
+
+<div class="row">
+  <div class="col-md-2 advice-page-nav">
+    <%= render 'schools/advice/nav', school: school, advice_pages: advice_pages %>
   </div>
-
-  <div class="row">
-    <div class="col-md-2 advice-page-nav">
-      <%= render 'schools/advice/nav', school: school, advice_pages: advice_pages %>
-    </div>
-    <div class="col-md-10 advice-page-tabs">
-      <%= render 'schools/advice/advice_tabs', school: school, advice_page: advice_page, tab: tab %>
-      <%= yield %>
-    </div>
+  <div class="col-md-10 advice-page-tabs">
+    <%= render 'schools/advice/advice_tabs', school: school, advice_page: advice_page, tab: tab %>
+    <%= yield %>
   </div>
 </div>

--- a/app/views/schools/advice/_advice_page.html.erb
+++ b/app/views/schools/advice/_advice_page.html.erb
@@ -1,5 +1,3 @@
-<h1><%= "Advice page: #{advice_page.key.humanize}" %></h1>
-
 <div class="advice-page-breadcrumb">
   <%= render(BreadcrumbsComponent.new) do |c| %>
     <% c.with_school(school) %>
@@ -14,6 +12,7 @@
     <%= render 'schools/advice/nav', school: school, advice_pages: advice_pages %>
   </div>
   <div class="col-md-10 advice-page-tabs">
+    <h1><%= "#{advice_page.key.humanize} analysis and advice" %></h1>
     <%= render 'schools/advice/advice_tabs', school: school, advice_page: advice_page, tab: tab %>
     <%= yield %>
   </div>

--- a/app/views/schools/advice/_advice_page.html.erb
+++ b/app/views/schools/advice/_advice_page.html.erb
@@ -12,7 +12,7 @@
     <%= render 'schools/advice/nav', school: school, advice_pages: advice_pages %>
   </div>
   <div class="col-md-10 advice-page-tabs">
-    <h1><%= "#{advice_page.key.humanize} analysis and advice" %></h1>
+    <h1><%= "#{advice_page.key.humanize} #{t('advice_pages.analysis_and_advice')}" %></h1>
     <%= render 'schools/advice/advice_tabs', school: school, advice_page: advice_page, tab: tab %>
     <%= yield %>
   </div>

--- a/app/views/schools/advice/_advice_page.html.erb
+++ b/app/views/schools/advice/_advice_page.html.erb
@@ -1,20 +1,22 @@
-<h1><%= "Advice page: #{advice_page.key.humanize}" %></h1>
+<div class="advice-page">
+  <h1><%= "Advice page: #{advice_page.key.humanize}" %></h1>
 
-<div class="advice-page-breadcrumb">
-  <%= render(BreadcrumbsComponent.new) do |c| %>
-    <% c.with_school(school) %>
-    <% c.with_items([ { name: "Advice", href: school_advice_path(school) },
-                      { name: advice_page.key.humanize, href: advice_page_path(school, advice_page) },
-                    ]) %>
-  <% end %>
-</div>
-
-<div class="row">
-  <div class="col-md-2 advice-page-nav">
-    <%= render 'schools/advice/nav', school: school, advice_pages: advice_pages %>
+  <div class="advice-page-breadcrumb">
+    <%= render(BreadcrumbsComponent.new) do |c| %>
+      <% c.with_school(school) %>
+      <% c.with_items([ { name: "Advice", href: school_advice_path(school) },
+                        { name: advice_page.key.humanize, href: advice_page_path(school, advice_page) },
+                      ]) %>
+    <% end %>
   </div>
-  <div class="col-md-10 advice-page-tabs">
-    <%= render 'schools/advice/advice_tabs', school: school, advice_page: advice_page, tab: tab %>
-    <%= yield %>
+
+  <div class="row">
+    <div class="col-md-2 advice-page-nav">
+      <%= render 'schools/advice/nav', school: school, advice_pages: advice_pages %>
+    </div>
+    <div class="col-md-10 advice-page-tabs">
+      <%= render 'schools/advice/advice_tabs', school: school, advice_page: advice_page, tab: tab %>
+      <%= yield %>
+    </div>
   </div>
 </div>

--- a/app/views/schools/advice/_section_title.html.erb
+++ b/app/views/schools/advice/_section_title.html.erb
@@ -1,0 +1,12 @@
+<hr>
+
+<div class="d-flex justify-content-between align-items-top">
+  <div>
+    <h2 id="<%= section_id %>" class="scrollable"><%= section_title %></h2>
+  </div>
+  <div>
+    <%= link_to "#" do %>
+      <%= t('common.back_to_top') %> <i class="fa fa-arrow-up" data-toggle="tooltip" title="<%= t('common.back_to_top') %>"></i>
+    <% end %>
+  </div>
+</div>

--- a/app/views/schools/advice/baseload/analysis.html.erb
+++ b/app/views/schools/advice/baseload/analysis.html.erb
@@ -4,9 +4,17 @@
 
   <p><%= t('advice_pages.baseload.analysis_summary') %></p>
 
-  <%= t('advice_pages.baseload.analysis_sections_html') %>
+  <p><%= t('advice_pages.baseload.analysis_sections') %></p>
 
-  <h2><%= t('advice_pages.baseload.analysis_recent_trend') %></h2>
+  <ul>
+    <li><%= link_to(t('advice_pages.baseload.analysis_recent_trend_title'), '#recent-trend') %></li>
+    <li><%= link_to(t('advice_pages.baseload.analysis_long_term_trends_title'), '#long-term-trends') %></li>
+    <li><%= link_to(t('advice_pages.baseload.analysis_meter_breakdown_title'), '#meter-breakdown') %></li>
+    <li><%= link_to(t('advice_pages.baseload.analysis_seasonal_variation_title'), '#seasonal-variation') %></li>
+    <li><%= link_to(t('advice_pages.baseload.analysis_weekday_variation_title'), '#weekday-variation') %></li>
+  </ul>
+
+  <h2 id="recent-trend" class="scrollable"><%= t('advice_pages.baseload.analysis_recent_trend_title') %></h2>
 
   <p><%= t('advice_pages.baseload.analysis_usage', baseload_usage: format_target(@baseload_usage.kwh, :kw), benchmark_usage: format_target(@benchmark_usage.kwh, :kw)) %></p>
 
@@ -20,18 +28,24 @@
 
   <h3><%= t('advice_pages.baseload.analysis_electricity_baseload_chart_title') %></h3>
 
-  <h4><%= t('advice_pages.baseload.analysis_electricity_baseload_chart_subtitle') %></h4>
+  <h4><%= t('advice_pages.baseload.analysis_electricity_baseload_chart_subtitle', start_month_year: chart_start_month_year, end_month_year: chart_end_month_year) %></h4>
 
   <%= chart_tag(@school, @chart_name) %>
 
   <p><%= t('advice_pages.baseload.analysis_electricity_baseload_chart_explanation') %></p>
 
-  <h2><%= t('advice_pages.baseload.analysis_long_term_trends') %></h2>
+  <% if !@multiple_meters %>
+    <p><%= t('advice_pages.baseload.analysis_multiple_meters_suggestion_html', link: link_to(t('advice_pages.baseload.analysis_meter_breakdown'), '#meter-breakdown')) %></p>
+  <% end %>
 
-  <h2><%= t('advice_pages.baseload.analysis_meter_breakdown') %></h2>
+  <%= t('advice_pages.baseload.analysis_baseload_chart_considerations_html') %>
 
-  <h2><%= t('advice_pages.baseload.analysis_seasonal_variation') %></h2>
+  <h2 id="long-term-trends"><%= t('advice_pages.baseload.analysis_long_term_trends_title') %></h2>
 
-  <h2><%= t('advice_pages.baseload.analysis_weekday_variation') %></h2>
+  <h2 id="meter-breakdown"><%= t('advice_pages.baseload.analysis_meter_breakdown_title') %></h2>
+
+  <h2 id="seasonal-variation"><%= t('advice_pages.baseload.analysis_seasonal_variation_title') %></h2>
+
+  <h2 id="weekday-variation"><%= t('advice_pages.baseload.analysis_weekday_variation_title') %></h2>
 
 <% end %>

--- a/app/views/schools/advice/baseload/analysis.html.erb
+++ b/app/views/schools/advice/baseload/analysis.html.erb
@@ -14,7 +14,7 @@
     <li><%= link_to(t('advice_pages.baseload.analysis_weekday_variation_title'), '#weekday-variation') %></li>
   </ul>
 
-  <h2 id="recent-trend" class="scrollable"><%= t('advice_pages.baseload.analysis_recent_trend_title') %></h2>
+  <%= render 'schools/advice/section_title', section_id: 'recent-trend', section_title: t('advice_pages.baseload.analysis_recent_trend_title') %>
 
   <p><%= t('advice_pages.baseload.analysis_usage', baseload_usage: format_target(@baseload_usage.kwh, :kw), benchmark_usage: format_target(@benchmark_usage.kwh, :kw)) %></p>
 
@@ -40,12 +40,12 @@
 
   <%= t('advice_pages.baseload.analysis_baseload_chart_considerations_html') %>
 
-  <h2 id="long-term-trends"><%= t('advice_pages.baseload.analysis_long_term_trends_title') %></h2>
+  <%= render 'schools/advice/section_title', section_id: 'long-term-trends', section_title: t('advice_pages.baseload.analysis_long_term_trends_title') %>
 
-  <h2 id="meter-breakdown"><%= t('advice_pages.baseload.analysis_meter_breakdown_title') %></h2>
+  <%= render 'schools/advice/section_title', section_id: 'meter-breakdown', section_title: t('advice_pages.baseload.analysis_meter_breakdown_title') %>
 
-  <h2 id="seasonal-variation"><%= t('advice_pages.baseload.analysis_seasonal_variation_title') %></h2>
+  <%= render 'schools/advice/section_title', section_id: 'seasonal-variation', section_title: t('advice_pages.baseload.analysis_seasonal_variation_title') %>
 
-  <h2 id="weekday-variation"><%= t('advice_pages.baseload.analysis_weekday_variation_title') %></h2>
+  <%= render 'schools/advice/section_title', section_id: 'weekday-variation', section_title: t('advice_pages.baseload.analysis_weekday_variation_title') %>
 
 <% end %>

--- a/config/locales/common.yml
+++ b/config/locales/common.yml
@@ -3,6 +3,7 @@ en:
   co2: CO2
   common:
     application: Energy Sparks
+    back_to_top: Back to top
     bar_charts: Bar charts
     confirm: Are you sure?
     data: data

--- a/config/locales/views/advice_pages/advice_pages.yml
+++ b/config/locales/views/advice_pages/advice_pages.yml
@@ -1,6 +1,7 @@
 ---
 en:
   advice_pages:
+    analysis_and_advice: analysis and advice
     baseload:
       analysis_baseload_chart_considerations_html: |-
         <p>Consider the following things when observing this chart:</p>

--- a/config/locales/views/advice_pages/advice_pages.yml
+++ b/config/locales/views/advice_pages/advice_pages.yml
@@ -2,15 +2,15 @@
 en:
   advice_pages:
     baseload:
-      analysis_baseload_high: Your baseload is high.
-      analysis_baseload_high_details_html: If you matched the baseload of other schools of the same size you would save %{estimated_savings}.
-      analysis_baseload_low: Your baseload is low.
-      analysis_baseload_low_details_html: Your school's baseload is low, which is good and as a result you are saving %{estimated_savings} per year versus the average of other schools of a similar size.
       analysis_baseload_chart_considerations_html: |-
         <p>Consider the following things when observing this chart:</p>
         <ul>
           <li>If your baseload has changed, for example suddenly increasing or decreasing, you should be able to track down and explain the cause of this change. Consider whether the school has recently purchased new equipment. A very large decrease over the summer holidays is good, it shows that appliances and equipment have been switched off. Perhaps fridges and freezers in the kitchen were emptied or consolidated. Consider how significant that drop is - if caused by switching off fridges and freezers, they might be inefficient enough to require replacement. Think about whether your school can replicate that decrease for other holidays, or even weekends.</li>
         </ul>
+      analysis_baseload_high: Your baseload is high.
+      analysis_baseload_high_details_html: If you matched the baseload of other schools of the same size you would save %{estimated_savings}.
+      analysis_baseload_low: Your baseload is low.
+      analysis_baseload_low_details_html: Your school's baseload is low, which is good and as a result you are saving %{estimated_savings} per year versus the average of other schools of a similar size.
       analysis_electricity_baseload_chart_explanation: Each point on this chart represents the average over the hours a school is closed on that day. You can click on a point in the chart and it will drill down to show you the usage on that day. Ideally, there should be little variation between different days and seasons.
       analysis_electricity_baseload_chart_subtitle: This chart shows the electricity baseload for your school between %{start_month_year} and %{end_month_year}.
       analysis_electricity_baseload_chart_title: Electricity baseload for the last 12 months

--- a/config/locales/views/advice_pages/advice_pages.yml
+++ b/config/locales/views/advice_pages/advice_pages.yml
@@ -6,23 +6,23 @@ en:
       analysis_baseload_high_details_html: If you matched the baseload of other schools of the same size you would save %{estimated_savings}.
       analysis_baseload_low: Your baseload is low.
       analysis_baseload_low_details_html: Your school's baseload is low, which is good and as a result you are saving %{estimated_savings} per year versus the average of other schools of a similar size.
-      analysis_electricity_baseload_chart_explanation: Each point on this chart represents the average over the hours a school is closed on that day. You can click on a point in the chart and it will drill down to show you the usage on that day. Ideally, there should be little variation between different days and seasons.
-      analysis_electricity_baseload_chart_subtitle: This chart shows the electricity baseload for your school between Month Year and Month Year for every day of the last year.
-      analysis_electricity_baseload_chart_title: Electricity baseload for the last 12 months
-      analysis_long_term_trends: Long term trends
-      analysis_meter_breakdown: Baseload breakdown by meter
-      analysis_recent_trend: Recent trend
-      analysis_seasonal_variation: Seasonal variation
-      analysis_sections_html: |-
-        <p>The following sections provide more background and analysis on your electricity baseload</p>
+      analysis_baseload_chart_considerations_html: |-
+        <p>Consider the following things when observing this chart:</p>
         <ul>
-          <li>Recent trend</li>
-          <li>Seasonal and weekday variation</li>
-          <li>Long term trends</li>
-          <li>Baseload breakdown by meter</li>
+          <li>If your baseload has changed, for example suddenly increasing or decreasing, you should be able to track down and explain the cause of this change. Consider whether the school has recently purchased new equipment. A very large decrease over the summer holidays is good, it shows that appliances and equipment have been switched off. Perhaps fridges and freezers in the kitchen were emptied or consolidated. Consider how significant that drop is - if caused by switching off fridges and freezers, they might be inefficient enough to require replacement. Think about whether your school can replicate that decrease for other holidays, or even weekends.</li>
         </ul>
+      analysis_electricity_baseload_chart_explanation: Each point on this chart represents the average over the hours a school is closed on that day. You can click on a point in the chart and it will drill down to show you the usage on that day. Ideally, there should be little variation between different days and seasons.
+      analysis_electricity_baseload_chart_subtitle: This chart shows the electricity baseload for your school between %{start_month_year} and %{end_month_year}.
+      analysis_electricity_baseload_chart_title: Electricity baseload for the last 12 months
+      analysis_long_term_trends_title: Long term trends
+      analysis_meter_breakdown: meter breakdown
+      analysis_meter_breakdown_title: Baseload breakdown by meter
+      analysis_multiple_meters_suggestion_html: If you notice unusual changes or very high baseload, you might be able to narrow down what is causing it by looking at the %{link} below.
+      analysis_recent_trend_title: Recent trend
+      analysis_seasonal_variation_title: Seasonal variation
+      analysis_sections: The following sections provide more background and analysis on your electricity baseload
       analysis_summary: This section gives a more detailed analysis of your school’s electricity baseload and some things to look out for.
       analysis_title: Baseload Analysis
       analysis_usage: Your electricity baseload over the last 12 months was %{baseload_usage} kW. Other schools with a similar number of pupils have a baseload of %{benchmark_usage} kW.
-      analysis_weekday_variation: Weekday variation
+      analysis_weekday_variation_title: Variation in baseload between days of week
       insights_title: What is baseload?

--- a/spec/helpers/advice_page_helper_spec.rb
+++ b/spec/helpers/advice_page_helper_spec.rb
@@ -18,6 +18,18 @@ describe AdvicePageHelper do
     end
   end
 
+  describe '.chart_start_month_year' do
+    it 'returns month and year' do
+      expect(helper.chart_start_month_year(Date.parse('20210101'))).to eq('December 2019')
+    end
+  end
+
+  describe '.chart_end_month_year' do
+    it 'returns month and year' do
+      expect(helper.chart_end_month_year(Date.parse('20210101'))).to eq('December 2020')
+    end
+  end
+
   describe '.advice_page_path' do
 
     it 'returns path to insights by default' do

--- a/spec/system/schools/advice_pages_spec.rb
+++ b/spec/system/schools/advice_pages_spec.rb
@@ -89,6 +89,25 @@ RSpec.describe "advice page", type: :system do
       end
     end
 
+    it 'shows analysis content' do
+      annual_baseload_usage = double(kwh: 123.0, £: 1.0, co2: 1.0)
+      baseload_usage = double(kwh: 1.0, £: 1.0, co2: 1.0)
+      estimated_savings = double(kwh: 1.0, £: 1.0, co2: 1.0)
+
+      baseload_calculation_service = double(annual_baseload_usage: annual_baseload_usage)
+      allow(Baseload::BaseloadCalculationService).to receive(:new).and_return(baseload_calculation_service)
+
+      benchmark_calculation_service = double(baseload_usage: baseload_usage, estimated_savings: estimated_savings)
+      allow(Baseload::BaseloadBenchmarkingService).to receive(:new).and_return(benchmark_calculation_service)
+
+      click_on key
+      click_on 'Analysis'
+      within '.advice-page-tabs' do
+        expect(page).to have_content('Recent trend')
+        expect(page).to have_content('baseload over the last 12 months was 123 kW')
+      end
+    end
+
     context 'when page is restricted' do
       before do
         advice_page_baseload.update(restricted: true)

--- a/spec/system/schools/advice_pages_spec.rb
+++ b/spec/system/schools/advice_pages_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe "advice page", type: :system do
 
     it 'shows the advice page' do
       click_on key
-      expect(page).to have_content("Advice page: #{key.humanize}")
+      expect(page).to have_content("#{key.humanize} analysis and advice")
     end
 
     context 'when page is restricted' do
@@ -52,7 +52,7 @@ RSpec.describe "advice page", type: :system do
 
     it 'shows the advice page' do
       click_on key
-      expect(page).to have_content("Advice page: #{key.humanize}")
+      expect(page).to have_content("#{key.humanize} analysis and advice")
     end
 
     it 'shows the nav bar' do
@@ -114,7 +114,7 @@ RSpec.describe "advice page", type: :system do
       end
       it 'shows the restricted advice page' do
         click_on key
-        expect(page).to have_content("Advice page: #{key.humanize}")
+        expect(page).to have_content("#{key.humanize} analysis and advice")
       end
     end
   end


### PR DESCRIPTION
This PR expands on the analysis page template:

- clickable table of contents at the top
- scroll top adjustment for the section titles in the advice pages
- month/year text for the chart description
- test that the analysis tab renders
- move the page title to sit with the content tabs
- add back-to-top links for each section


![es-advice](https://user-images.githubusercontent.com/227935/212363425-14b753e1-b27e-49ab-b68b-e9b4c008df0e.png)
