### PR TITLE
Declare label var

### DIFF
--- a/app/assets/javascripts/analysis.js
+++ b/app/assets/javascripts/analysis.js
@@ -290,7 +290,7 @@ function enableAxisControls(chartContainer, chartData) {
         } else {
           $(this).prop('disabled', true);
         }
-        label = $("label[for='" + $(this).attr("id") + "']");
+        var label = $("label[for='" + $(this).attr("id") + "']");
         if(label) {
           if ($(label).text() == chartData.y_axis_label) {
             $(this).prop('checked', true);


### PR DESCRIPTION
Testing some of the charts I was getting a Javascript error about an undeclared variable.

Tweaked the javascript to add `var label` and everything seems OK now. Am unsure why this isn't causing problems elsewhere, but it might depend on the specific chart and the available axis choices.

This should be safe to merge.