### PR TITLE
Initial round of bug fixes for the baseload analysis

### DIFF
--- a/app/assets/stylesheets/advice_page.scss
+++ b/app/assets/stylesheets/advice_page.scss
@@ -6,4 +6,14 @@
   hr {
     margin-top: 50px;
   }
+
+  h4.chart-title {
+    font-weight: bold;
+    padding-bottom: 0px;
+  }
+
+  h5.chart-subtitle {
+    padding-top: 0px !important;
+    padding-bottom: 0px !important;
+  }
 }

--- a/app/assets/stylesheets/analysis.scss
+++ b/app/assets/stylesheets/analysis.scss
@@ -76,7 +76,7 @@ div.popover {
 }
 
 .table-with-totals {
-  tr:last-of-type  {
+  tbody tr:last-of-type  {
     @extend .table-success
   }
 }

--- a/app/controllers/concerns/advice_pages.rb
+++ b/app/controllers/concerns/advice_pages.rb
@@ -99,8 +99,7 @@ module AdvicePages
 
     baseload_service = Baseload::BaseloadCalculationService.new(meter_collection.aggregated_electricity_meters, end_of_previous_year)
     previous_year_baseload = baseload_service.average_baseload_kw
-    meter_breakdowns['Total'] = build_meter_breakdown_totals(meter_breakdowns, previous_year_baseload)
-
+    meter_breakdowns['All meters'] = build_meter_breakdown_totals(meter_breakdowns, previous_year_baseload)
     meter_breakdowns
   end
 

--- a/app/controllers/concerns/advice_pages.rb
+++ b/app/controllers/concerns/advice_pages.rb
@@ -1,12 +1,9 @@
 module AdvicePages
   extend ActiveSupport::Concern
 
-  def variation_rating(variation_percentage)
-    calculate_rating_from_range(0, 0.50, variation_percentage.abs)
-  end
-
   # from analytics: lib/dashboard/charting_and_reports/content_base.rb
   def calculate_rating_from_range(good_value, bad_value, actual_value)
+    actual_value = actual_value.abs
     [10.0 * [(actual_value - bad_value) / (good_value - bad_value), 0.0].max, 10.0].min.round(1)
   end
 
@@ -40,7 +37,7 @@ module AdvicePages
       percentage: variation.percentage,
       estimated_saving_£: saving.£,
       estimated_saving_co2: saving.co2,
-      variation_rating: variation_rating(variation.percentage)
+      variation_rating: calculate_rating_from_range(0, 0.50, variation.percentage)
     )
   end
 
@@ -51,7 +48,7 @@ module AdvicePages
       percent_intraday_variation: variation.percent_intraday_variation,
       estimated_saving_£: saving.£,
       estimated_saving_co2: saving.co2,
-      variation_rating: variation_rating(variation.percent_intraday_variation)
+      variation_rating: calculate_rating_from_range(0.1, 0.3, variation.percent_intraday_variation)
     )
   end
 

--- a/app/controllers/concerns/advice_pages.rb
+++ b/app/controllers/concerns/advice_pages.rb
@@ -15,16 +15,19 @@ module AdvicePages
       baseload_kw: breakdown.baseload_kw(mpan_mprn),
       baseload_cost_£: breakdown.baseload_cost_£(mpan_mprn),
       percentage_baseload: breakdown.percentage_baseload(mpan_mprn),
-      baseload_previous_year_kw: previous_year_baseload
+      baseload_previous_year_kw: previous_year_baseload,
+      baseload_change_kw: breakdown.baseload_kw(mpan_mprn) - previous_year_baseload
     )
   end
 
   def build_meter_breakdown_totals(breakdowns, previous_year_baseload)
+    baseload_kw = breakdowns.values.map(&:baseload_kw).sum
     OpenStruct.new(
-      baseload_kw: breakdowns.values.map(&:baseload_kw).sum,
+      baseload_kw: baseload_kw,
       baseload_cost_£: breakdowns.values.map(&:baseload_cost_£).sum,
       percentage_baseload: breakdowns.values.map(&:percentage_baseload).sum,
-      baseload_previous_year_kw: previous_year_baseload
+      baseload_previous_year_kw: previous_year_baseload,
+      baseload_change_kw: baseload_kw - previous_year_baseload
     )
   end
 

--- a/app/controllers/concerns/advice_pages.rb
+++ b/app/controllers/concerns/advice_pages.rb
@@ -50,19 +50,24 @@ module AdvicePages
     )
   end
 
+  def average_baseload_kw(meter_collection, end_date, period: :year)
+    baseload_service(meter_collection, end_date).average_baseload_kw(period: period)
+  end
+
+  def average_baseload_kw_benchmark(meter_collection, end_date, compare: :benchmark_school)
+    benchmark_service(meter_collection, end_date).average_baseload_kw(compare: compare)
+  end
+
   def baseload_usage(meter_collection, end_date)
-    baseload_service = Baseload::BaseloadCalculationService.new(meter_collection.aggregated_electricity_meters, end_date)
-    baseload_service.annual_baseload_usage
+    baseload_service(meter_collection, end_date).annual_baseload_usage
   end
 
   def benchmark_usage(meter_collection, end_date)
-    benchmark_service = Baseload::BaseloadBenchmarkingService.new(meter_collection, end_date)
-    benchmark_service.baseload_usage
+    benchmark_service(meter_collection, end_date).baseload_usage
   end
 
   def estimated_savings(meter_collection, end_date)
-    benchmark_service = Baseload::BaseloadBenchmarkingService.new(meter_collection, end_date)
-    benchmark_service.estimated_savings
+    benchmark_service(meter_collection, end_date).estimated_savings
   end
 
   def annual_average_baseloads(meter_collection, start_date, end_date)
@@ -133,5 +138,13 @@ module AdvicePages
       end
     end
     variation_by_meter
+  end
+
+  def baseload_service(meter_collection, end_date)
+    @baseload_service ||= Baseload::BaseloadCalculationService.new(meter_collection.aggregated_electricity_meters, end_date)
+  end
+
+  def benchmark_service(meter_collection, end_date)
+    @benchmark_service ||= Baseload::BaseloadBenchmarkingService.new(meter_collection, end_date)
   end
 end

--- a/app/controllers/concerns/advice_pages.rb
+++ b/app/controllers/concerns/advice_pages.rb
@@ -76,6 +76,7 @@ module AdvicePages
       baseload_service = Baseload::BaseloadCalculationService.new(meter_collection.aggregated_electricity_meters, end_of_year)
       {
         year: year,
+        baseload: baseload_service.average_baseload_kw(period: :year),
         baseload_usage: baseload_service.annual_baseload_usage
       }
     end

--- a/app/controllers/schools/advice/baseload_controller.rb
+++ b/app/controllers/schools/advice/baseload_controller.rb
@@ -19,14 +19,16 @@ module Schools
         @estimated_savings = estimated_savings(aggregate_school, @end_date)
         @annual_average_baseloads = annual_average_baseloads(aggregate_school, @start_date, @end_date)
 
-        @baseload_meter_breakdown = baseload_meter_breakdown(aggregate_school, @end_date)
-        @baseload_meter_breakdown_total = build_meter_breakdown_total(aggregate_school, @end_date)
+        if @multiple_meters
+          @baseload_meter_breakdown = baseload_meter_breakdown(aggregate_school, @end_date)
+          @baseload_meter_breakdown_total = build_meter_breakdown_total(aggregate_school, @end_date)
+        end
 
         @seasonal_variation = seasonal_variation(aggregate_school, @end_date)
-        @seasonal_variation_by_meter = seasonal_variation_by_meter(aggregate_school)
+        @seasonal_variation_by_meter = seasonal_variation_by_meter(aggregate_school) if @multiple_meters
 
         @intraweek_variation = intraweek_variation(aggregate_school, @end_date)
-        @intraweek_variation_by_meter = intraweek_variation_by_meter(aggregate_school)
+        @intraweek_variation_by_meter = intraweek_variation_by_meter(aggregate_school) if @multiple_meters
       end
 
       private

--- a/app/controllers/schools/advice/baseload_controller.rb
+++ b/app/controllers/schools/advice/baseload_controller.rb
@@ -18,7 +18,9 @@ module Schools
         @benchmark_usage = benchmark_usage(aggregate_school, @end_date)
         @estimated_savings = estimated_savings(aggregate_school, @end_date)
         @annual_average_baseloads = annual_average_baseloads(aggregate_school, @start_date, @end_date)
+
         @baseload_meter_breakdown = baseload_meter_breakdown(aggregate_school, @end_date)
+        @baseload_meter_breakdown_total = build_meter_breakdown_total(aggregate_school, @end_date)
 
         @seasonal_variation = seasonal_variation(aggregate_school, @end_date)
         @seasonal_variation_by_meter = seasonal_variation_by_meter(aggregate_school)

--- a/app/controllers/schools/advice/baseload_controller.rb
+++ b/app/controllers/schools/advice/baseload_controller.rb
@@ -11,6 +11,9 @@ module Schools
         @end_date = aggregate_school.aggregated_electricity_meters.amr_data.end_date
         @multiple_meters = @school.meters.electricity.count > 1
 
+        @average_baseload_kw = average_baseload_kw(aggregate_school, @end_date, period: :year)
+        @average_baseload_kw_benchmark = average_baseload_kw_benchmark(aggregate_school, @end_date, compare: :benchmark_school)
+
         @baseload_usage = baseload_usage(aggregate_school, @end_date)
         @benchmark_usage = benchmark_usage(aggregate_school, @end_date)
         @estimated_savings = estimated_savings(aggregate_school, @end_date)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -320,6 +320,10 @@ module ApplicationHelper
     !field.required? && field.structure.any? { |_k, v| v.required? }
   end
 
+  def format_unit(value, units)
+    FormatEnergyUnit.format(units, value, :html, false, true).html_safe
+  end
+
   def format_target(value, units)
     FormatEnergyUnit.format(units, value, :html, false, true, :target).html_safe
   end

--- a/app/models/meter.rb
+++ b/app/models/meter.rb
@@ -140,6 +140,10 @@ class Meter < ApplicationRecord
     return true if fuel_type == :electricity && zero_reading_days.count > 0
   end
 
+  def name_or_mpan_mprn
+    name.present? ? name : mpan_mprn
+  end
+
   def display_name
     name.present? ? "#{display_meter_mpan_mprn} (#{name})" : display_meter_mpan_mprn
   end

--- a/app/views/schools/advice/_advice_page.html.erb
+++ b/app/views/schools/advice/_advice_page.html.erb
@@ -15,6 +15,8 @@
   </div>
   <div class="col-md-9 col-lg-9 col-xl-10 advice-page-tabs">
     <%= render 'schools/advice/advice_tabs', school: school, advice_page: advice_page, tab: tab %>
-    <%= yield %>
+    <div class="mt-4" id="<%= advice_page.key %>-<%= tab %>">
+      <%= yield %>
+    </div>
   </div>
 </div>

--- a/app/views/schools/advice/baseload/_long_term_trends_table.html.erb
+++ b/app/views/schools/advice/baseload/_long_term_trends_table.html.erb
@@ -2,7 +2,7 @@
   <thead class="thead-dark">
     <tr>
       <th>Year</th>
-      <th class="text-right">Average annual consumption (kW)</th>
+      <th class="text-right">Average baseload (kW)</th>
       <th class="text-right">Average annual cost (£)</th>
       <th class="text-right">Average annual CO2 (kg)</th>
     </tr>

--- a/app/views/schools/advice/baseload/_long_term_trends_table.html.erb
+++ b/app/views/schools/advice/baseload/_long_term_trends_table.html.erb
@@ -1,10 +1,10 @@
 <table class="table table-sm">
   <thead class="thead-dark">
     <tr>
-      <th>Year</th>
-      <th class="text-right">Average baseload (kW)</th>
-      <th class="text-right">Average annual cost (£)</th>
-      <th class="text-right">Average annual CO2 (kg)</th>
+      <th><%= t('advice_pages.baseload.tables.columns.year') %></th>
+      <th class="text-right"><%= t('advice_pages.baseload.tables.columns.average_annual_baseload_kw') %></th>
+      <th class="text-right"><%= t('advice_pages.baseload.tables.columns.average_annual_baseload_gbp') %></th>
+      <th class="text-right"><%= t('advice_pages.baseload.tables.columns.average_annual_baseload_co2') %></th>
     </tr>
   </thead>
   <tbody>

--- a/app/views/schools/advice/baseload/_long_term_trends_table.html.erb
+++ b/app/views/schools/advice/baseload/_long_term_trends_table.html.erb
@@ -11,7 +11,7 @@
     <% annual_average_baseloads.each do |annual_average_baseload| %>
     <tr>
       <td><%= annual_average_baseload[:year] %></td>
-      <td class="text-right"><%= format_unit(annual_average_baseload[:baseload_usage].kwh, :kwh) %></td>
+      <td class="text-right"><%= format_unit(annual_average_baseload[:baseload], :kw) %></td>
       <td class="text-right"><%= format_unit(annual_average_baseload[:baseload_usage].£, :£) %></td>
       <td class="text-right"><%= format_unit(annual_average_baseload[:baseload_usage].co2, :co2) %></td>
     </tr>

--- a/app/views/schools/advice/baseload/_long_term_trends_table.html.erb
+++ b/app/views/schools/advice/baseload/_long_term_trends_table.html.erb
@@ -11,9 +11,9 @@
     <% annual_average_baseloads.each do |annual_average_baseload| %>
     <tr>
       <td><%= annual_average_baseload[:year] %></td>
-      <td class="text-right"><%= format_target(annual_average_baseload[:baseload_usage].kwh, :kwh) %></td>
-      <td class="text-right"><%= format_target(annual_average_baseload[:baseload_usage].£, :£) %></td>
-      <td class="text-right"><%= format_target(annual_average_baseload[:baseload_usage].co2, :co2) %></td>
+      <td class="text-right"><%= format_unit(annual_average_baseload[:baseload_usage].kwh, :kwh) %></td>
+      <td class="text-right"><%= format_unit(annual_average_baseload[:baseload_usage].£, :£) %></td>
+      <td class="text-right"><%= format_unit(annual_average_baseload[:baseload_usage].co2, :co2) %></td>
     </tr>
     <% end %>
   </tbody>

--- a/app/views/schools/advice/baseload/_meter_breakdown_table.html.erb
+++ b/app/views/schools/advice/baseload/_meter_breakdown_table.html.erb
@@ -11,12 +11,19 @@
   <tbody>
     <% baseload_meter_breakdown.each do |mpan_mprn, breakdown| %>
     <tr>
-      <td><%= mpan_mprn == "All meters" ? mpan_mprn: school.meters.find_by_mpan_mprn(mpan_mprn).name_or_mpan_mprn %></td>
-      <td class="text-right"><%= format_unit(breakdown.baseload_kw, :kwh) %></td>
+      <td><%= school.meters.find_by_mpan_mprn(mpan_mprn).name_or_mpan_mprn %></td>
+      <td class="text-right"><%= format_unit(breakdown.baseload_kw, :kw) %></td>
       <td class="text-right"><%= format_unit(breakdown.baseload_cost_£, :£) %></td>
       <td class="text-right"><%= format_unit(breakdown.baseload_change_kw, :kw) %></td>
       <td class="text-right"><%= format_unit(breakdown.percentage_baseload, :percent) %></td>
     </tr>
     <% end %>
+    <tr>
+      <td>All meters</td>
+      <td class="text-right"><%= format_unit(baseload_meter_breakdown_total.baseload_kw, :kw) %></td>
+      <td class="text-right"><%= format_unit(baseload_meter_breakdown_total.baseload_cost_£, :£) %></td>
+      <td class="text-right"><%= format_unit(baseload_meter_breakdown_total.baseload_change_kw, :kw) %></td>
+      <td class="text-right"><%= format_unit(baseload_meter_breakdown_total.percentage_baseload, :percent) %></td>
+    </tr>
   </tbody>
 </table>

--- a/app/views/schools/advice/baseload/_meter_breakdown_table.html.erb
+++ b/app/views/schools/advice/baseload/_meter_breakdown_table.html.erb
@@ -1,11 +1,11 @@
 <table class="table table-sm table-with-totals">
   <thead class="thead-dark">
     <tr>
-      <th>Meter</th>
-      <th class="text-right">Average baseload (kW)</th>
-      <th class="text-right">Average annual cost (£)</th>
-      <th class="text-right">Change since previous year (kW)</th>
-      <th class="text-right">% of total baseload</th>
+      <th><%= t('advice_pages.baseload.tables.columns.meter') %></th>
+      <th class="text-right"><%= t('advice_pages.baseload.tables.columns.average_annual_baseload_kw') %></th>
+      <th class="text-right"><%= t('advice_pages.baseload.tables.columns.average_annual_baseload_gbp') %></th>
+      <th class="text-right"><%= t('advice_pages.baseload.tables.columns.change_since_previous_year') %></th>
+      <th class="text-right"><%= t('advice_pages.baseload.tables.columns.percentage_of_total') %></th>
     </tr>
   </thead>
   <tbody>

--- a/app/views/schools/advice/baseload/_meter_breakdown_table.html.erb
+++ b/app/views/schools/advice/baseload/_meter_breakdown_table.html.erb
@@ -14,7 +14,7 @@
       <td><%= mpan_mprn %></td>
       <td class="text-right"><%= format_unit(breakdown.baseload_kw, :kwh) %></td>
       <td class="text-right"><%= format_unit(breakdown.baseload_cost_£, :£) %></td>
-      <td class="text-right"><%= format_unit(breakdown.baseload_previous_year_kw, :kw) %></td>
+      <td class="text-right"><%= format_unit(breakdown.baseload_change_kw, :kw) %></td>
       <td class="text-right"><%= format_unit(breakdown.percentage_baseload, :percent) %></td>
     </tr>
     <% end %>

--- a/app/views/schools/advice/baseload/_meter_breakdown_table.html.erb
+++ b/app/views/schools/advice/baseload/_meter_breakdown_table.html.erb
@@ -2,7 +2,7 @@
   <thead class="thead-dark">
     <tr>
       <th>Meter</th>
-      <th class="text-right">Average annual baseload (kW)</th>
+      <th class="text-right">Average baseload (kW)</th>
       <th class="text-right">Average annual cost (£)</th>
       <th class="text-right">Change since previous year (kW)</th>
       <th class="text-right">% of total baseload</th>

--- a/app/views/schools/advice/baseload/_meter_breakdown_table.html.erb
+++ b/app/views/schools/advice/baseload/_meter_breakdown_table.html.erb
@@ -11,7 +11,7 @@
   <tbody>
     <% baseload_meter_breakdown.each do |mpan_mprn, breakdown| %>
     <tr>
-      <td><%= mpan_mprn %></td>
+      <td><%= mpan_mprn == "All meters" ? mpan_mprn: school.meters.find_by_mpan_mprn(mpan_mprn).name_or_mpan_mprn %></td>
       <td class="text-right"><%= format_unit(breakdown.baseload_kw, :kwh) %></td>
       <td class="text-right"><%= format_unit(breakdown.baseload_cost_£, :£) %></td>
       <td class="text-right"><%= format_unit(breakdown.baseload_change_kw, :kw) %></td>

--- a/app/views/schools/advice/baseload/_meter_breakdown_table.html.erb
+++ b/app/views/schools/advice/baseload/_meter_breakdown_table.html.erb
@@ -19,7 +19,7 @@
     </tr>
     <% end %>
     <tr>
-      <td>All meters</td>
+      <td><%= t('advice_pages.baseload.tables.labels.all_meters') %></td>
       <td class="text-right"><%= format_unit(baseload_meter_breakdown_total.baseload_kw, :kw) %></td>
       <td class="text-right"><%= format_unit(baseload_meter_breakdown_total.baseload_cost_£, :£) %></td>
       <td class="text-right"><%= format_unit(baseload_meter_breakdown_total.baseload_change_kw, :kw) %></td>

--- a/app/views/schools/advice/baseload/_meter_breakdown_table.html.erb
+++ b/app/views/schools/advice/baseload/_meter_breakdown_table.html.erb
@@ -12,10 +12,10 @@
     <% baseload_meter_breakdown.each do |mpan_mprn, breakdown| %>
     <tr>
       <td><%= mpan_mprn %></td>
-      <td class="text-right"><%= format_target(breakdown.baseload_kw, :kwh) %></td>
-      <td class="text-right"><%= format_target(breakdown.baseload_cost_£, :£) %></td>
-      <td class="text-right"><%= format_target(breakdown.baseload_previous_year_kw, :kw) %></td>
-      <td class="text-right"><%= format_target(breakdown.percentage_baseload, :percent) %></td>
+      <td class="text-right"><%= format_unit(breakdown.baseload_kw, :kwh) %></td>
+      <td class="text-right"><%= format_unit(breakdown.baseload_cost_£, :£) %></td>
+      <td class="text-right"><%= format_unit(breakdown.baseload_previous_year_kw, :kw) %></td>
+      <td class="text-right"><%= format_unit(breakdown.percentage_baseload, :percent) %></td>
     </tr>
     <% end %>
   </tbody>

--- a/app/views/schools/advice/baseload/_seasonal_variation_breakdown_table.html.erb
+++ b/app/views/schools/advice/baseload/_seasonal_variation_breakdown_table.html.erb
@@ -15,11 +15,11 @@
     <tr>
       <td class="text-right"><%= mpan_mprn %></td>
       <td class="text-right"><%= format_rating(variation.variation_rating) %></td>
-      <td class="text-right"><%= format_target(variation.winter_kw, :kwh) %></td>
-      <td class="text-right"><%= format_target(variation.summer_kw, :kwh) %></td>
-      <td class="text-right"><%= format_target(variation.percentage, :percent) %></td>
-      <td class="text-right"><%= format_target(variation.estimated_saving_£, :£) %></td>
-      <td class="text-right"><%= format_target(variation.estimated_saving_co2, :kg) %></td>
+      <td class="text-right"><%= format_unit(variation.winter_kw, :kwh) %></td>
+      <td class="text-right"><%= format_unit(variation.summer_kw, :kwh) %></td>
+      <td class="text-right"><%= format_unit(variation.percentage, :percent) %></td>
+      <td class="text-right"><%= format_unit(variation.estimated_saving_£, :£) %></td>
+      <td class="text-right"><%= format_unit(variation.estimated_saving_co2, :kg) %></td>
     </tr>
     <% end %>
     <tr>

--- a/app/views/schools/advice/baseload/_seasonal_variation_breakdown_table.html.erb
+++ b/app/views/schools/advice/baseload/_seasonal_variation_breakdown_table.html.erb
@@ -1,4 +1,4 @@
-<table class="table table-sm">
+<table class="table table-sm table-with-totals">
   <thead class="thead-dark">
     <tr>
       <th class="text-right">Meter</th>
@@ -24,7 +24,7 @@
     <% end %>
     <tr>
       <td class="text-right">All meters</td>
-      <td class="text-right"><%= format_target(seasonal_variation.variation_rating, :r2) %></td>
+      <td class="text-right"><%= format_rating(seasonal_variation.variation_rating) %></td>
       <td class="text-right"><%= format_target(seasonal_variation.winter_kw, :kwh) %></td>
       <td class="text-right"><%= format_target(seasonal_variation.summer_kw, :kwh) %></td>
       <td class="text-right"><%= format_target(seasonal_variation.percentage, :percent) %></td>

--- a/app/views/schools/advice/baseload/_seasonal_variation_breakdown_table.html.erb
+++ b/app/views/schools/advice/baseload/_seasonal_variation_breakdown_table.html.erb
@@ -1,8 +1,8 @@
 <table class="table table-sm table-with-totals">
   <thead class="thead-dark">
     <tr>
-      <th class="text-right"><%= t('advice_pages.baseload.tables.columns.meter') %></th>
-      <th class="text-right"><%= t('advice_pages.baseload.tables.columns.assessment') %></th>
+      <th class="text-left"><%= t('advice_pages.baseload.tables.columns.meter') %></th>
+      <th class="text-left"><%= t('advice_pages.baseload.tables.columns.assessment') %></th>
       <th class="text-right"><%= t('advice_pages.baseload.tables.columns.baseload_in_winter') %></th>
       <th class="text-right"><%= t('advice_pages.baseload.tables.columns.baseload_in_summer') %></th>
       <th class="text-right"><%= t('advice_pages.baseload.tables.columns.percentage_difference') %></th>
@@ -13,8 +13,8 @@
   <tbody>
     <% seasonal_variation_by_meter.each do |mpan_mprn, variation| %>
     <tr>
-      <td class="text-right"><%= school.meters.find_by_mpan_mprn(mpan_mprn).name_or_mpan_mprn %></td>
-      <td class="text-right"><%= format_rating(variation.variation_rating) %></td>
+      <td class="text-left"><%= school.meters.find_by_mpan_mprn(mpan_mprn).name_or_mpan_mprn %></td>
+      <td class="text-left"><%= format_rating(variation.variation_rating) %></td>
       <td class="text-right"><%= format_unit(variation.winter_kw, :kw) %></td>
       <td class="text-right"><%= format_unit(variation.summer_kw, :kw) %></td>
       <td class="text-right"><%= format_unit(variation.percentage, :percent) %></td>
@@ -23,8 +23,8 @@
     </tr>
     <% end %>
     <tr>
-      <td class="text-right">All meters</td>
-      <td class="text-right"><%= format_rating(seasonal_variation.variation_rating) %></td>
+      <td class="text-left"><%= t('advice_pages.baseload.tables.labels.all_meters') %></td>
+      <td class="text-left"><%= format_rating(seasonal_variation.variation_rating) %></td>
       <td class="text-right"><%= format_target(seasonal_variation.winter_kw, :kwh) %></td>
       <td class="text-right"><%= format_target(seasonal_variation.summer_kw, :kwh) %></td>
       <td class="text-right"><%= format_target(seasonal_variation.percentage, :percent) %></td>

--- a/app/views/schools/advice/baseload/_seasonal_variation_breakdown_table.html.erb
+++ b/app/views/schools/advice/baseload/_seasonal_variation_breakdown_table.html.erb
@@ -1,13 +1,13 @@
 <table class="table table-sm table-with-totals">
   <thead class="thead-dark">
     <tr>
-      <th class="text-right">Meter</th>
-      <th class="text-right">Assessment</th>
-      <th class="text-right">Baseload in winter (kW)</th>
-      <th class="text-right">Baseload in summer (kW)</th>
-      <th class="text-right">Percentage difference (%)</th>
-      <th class="text-right">Potential saving (£)</th>
-      <th class="text-right">CO2 reduction (kg)</th>
+      <th class="text-right"><%= t('advice_pages.baseload.tables.columns.meter') %></th>
+      <th class="text-right"><%= t('advice_pages.baseload.tables.columns.assessment') %></th>
+      <th class="text-right"><%= t('advice_pages.baseload.tables.columns.baseload_in_winter') %></th>
+      <th class="text-right"><%= t('advice_pages.baseload.tables.columns.baseload_in_summer') %></th>
+      <th class="text-right"><%= t('advice_pages.baseload.tables.columns.percentage_difference') %></th>
+      <th class="text-right"><%= t('advice_pages.baseload.tables.columns.potential_saving_gbp') %></th>
+      <th class="text-right"><%= t('advice_pages.baseload.tables.columns.potential_saving_co2') %></th>
     </tr>
   </thead>
   <tbody>

--- a/app/views/schools/advice/baseload/_seasonal_variation_breakdown_table.html.erb
+++ b/app/views/schools/advice/baseload/_seasonal_variation_breakdown_table.html.erb
@@ -15,8 +15,8 @@
     <tr>
       <td class="text-right"><%= mpan_mprn %></td>
       <td class="text-right"><%= format_rating(variation.variation_rating) %></td>
-      <td class="text-right"><%= format_unit(variation.winter_kw, :kwh) %></td>
-      <td class="text-right"><%= format_unit(variation.summer_kw, :kwh) %></td>
+      <td class="text-right"><%= format_unit(variation.winter_kw, :kw) %></td>
+      <td class="text-right"><%= format_unit(variation.summer_kw, :kw) %></td>
       <td class="text-right"><%= format_unit(variation.percentage, :percent) %></td>
       <td class="text-right"><%= format_unit(variation.estimated_saving_£, :£) %></td>
       <td class="text-right"><%= format_unit(variation.estimated_saving_co2, :kg) %></td>

--- a/app/views/schools/advice/baseload/_seasonal_variation_breakdown_table.html.erb
+++ b/app/views/schools/advice/baseload/_seasonal_variation_breakdown_table.html.erb
@@ -13,7 +13,7 @@
   <tbody>
     <% seasonal_variation_by_meter.each do |mpan_mprn, variation| %>
     <tr>
-      <td class="text-right"><%= mpan_mprn %></td>
+      <td class="text-right"><%= school.meters.find_by_mpan_mprn(mpan_mprn).name_or_mpan_mprn %></td>
       <td class="text-right"><%= format_rating(variation.variation_rating) %></td>
       <td class="text-right"><%= format_unit(variation.winter_kw, :kw) %></td>
       <td class="text-right"><%= format_unit(variation.summer_kw, :kw) %></td>
@@ -23,7 +23,7 @@
     </tr>
     <% end %>
     <tr>
-      <td class="text-right">Whole school</td>
+      <td class="text-right">All meters</td>
       <td class="text-right"><%= format_target(seasonal_variation.variation_rating, :r2) %></td>
       <td class="text-right"><%= format_target(seasonal_variation.winter_kw, :kwh) %></td>
       <td class="text-right"><%= format_target(seasonal_variation.summer_kw, :kwh) %></td>

--- a/app/views/schools/advice/baseload/_seasonal_variation_breakdown_table.html.erb
+++ b/app/views/schools/advice/baseload/_seasonal_variation_breakdown_table.html.erb
@@ -1,4 +1,4 @@
-<table class="table table-sm table-with-totals">
+<table class="table table-sm">
   <thead class="thead-dark">
     <tr>
       <th class="text-right">Meter</th>
@@ -23,7 +23,7 @@
     </tr>
     <% end %>
     <tr>
-      <td class="text-right">Whole school, aggregated meters</td>
+      <td class="text-right">Whole school</td>
       <td class="text-right"><%= format_target(seasonal_variation.variation_rating, :r2) %></td>
       <td class="text-right"><%= format_target(seasonal_variation.winter_kw, :kwh) %></td>
       <td class="text-right"><%= format_target(seasonal_variation.summer_kw, :kwh) %></td>

--- a/app/views/schools/advice/baseload/_seasonal_variation_table.html.erb
+++ b/app/views/schools/advice/baseload/_seasonal_variation_table.html.erb
@@ -12,8 +12,8 @@
   <tbody>
     <tr>
       <td class="text-right"><%= format_rating(seasonal_variation.variation_rating) %></td>
-      <td class="text-right"><%= format_unit(seasonal_variation.winter_kw, :kwh) %></td>
-      <td class="text-right"><%= format_unit(seasonal_variation.summer_kw, :kwh) %></td>
+      <td class="text-right"><%= format_unit(seasonal_variation.winter_kw, :kw) %></td>
+      <td class="text-right"><%= format_unit(seasonal_variation.summer_kw, :kw) %></td>
       <td class="text-right"><%= format_unit(seasonal_variation.percentage, :r2) %></td>
       <td class="text-right"><%= format_unit(seasonal_variation.estimated_saving_£, :£) %></td>
       <td class="text-right"><%= format_unit(seasonal_variation.estimated_saving_co2, :kg) %></td>

--- a/app/views/schools/advice/baseload/_seasonal_variation_table.html.erb
+++ b/app/views/schools/advice/baseload/_seasonal_variation_table.html.erb
@@ -1,7 +1,7 @@
 <table class="table table-sm">
   <thead class="thead-dark">
     <tr>
-      <th class="text-right"><%= t('advice_pages.baseload.tables.columns.assessment') %></th>
+      <th class="text-left"><%= t('advice_pages.baseload.tables.columns.assessment') %></th>
       <th class="text-right"><%= t('advice_pages.baseload.tables.columns.baseload_in_winter') %></th>
       <th class="text-right"><%= t('advice_pages.baseload.tables.columns.baseload_in_summer') %></th>
       <th class="text-right"><%= t('advice_pages.baseload.tables.columns.percentage_difference') %></th>
@@ -11,7 +11,7 @@
   </thead>
   <tbody>
     <tr>
-      <td class="text-right"><%= format_rating(seasonal_variation.variation_rating) %></td>
+      <td class="text-left"><%= format_rating(seasonal_variation.variation_rating) %></td>
       <td class="text-right"><%= format_unit(seasonal_variation.winter_kw, :kw) %></td>
       <td class="text-right"><%= format_unit(seasonal_variation.summer_kw, :kw) %></td>
       <td class="text-right"><%= format_unit(seasonal_variation.percentage, :r2) %></td>

--- a/app/views/schools/advice/baseload/_seasonal_variation_table.html.erb
+++ b/app/views/schools/advice/baseload/_seasonal_variation_table.html.erb
@@ -12,11 +12,11 @@
   <tbody>
     <tr>
       <td class="text-right"><%= format_rating(seasonal_variation.variation_rating) %></td>
-      <td class="text-right"><%= format_target(seasonal_variation.winter_kw, :kwh) %></td>
-      <td class="text-right"><%= format_target(seasonal_variation.summer_kw, :kwh) %></td>
-      <td class="text-right"><%= format_target(seasonal_variation.percentage, :r2) %></td>
-      <td class="text-right"><%= format_target(seasonal_variation.estimated_saving_£, :£) %></td>
-      <td class="text-right"><%= format_target(seasonal_variation.estimated_saving_co2, :kg) %></td>
+      <td class="text-right"><%= format_unit(seasonal_variation.winter_kw, :kwh) %></td>
+      <td class="text-right"><%= format_unit(seasonal_variation.summer_kw, :kwh) %></td>
+      <td class="text-right"><%= format_unit(seasonal_variation.percentage, :r2) %></td>
+      <td class="text-right"><%= format_unit(seasonal_variation.estimated_saving_£, :£) %></td>
+      <td class="text-right"><%= format_unit(seasonal_variation.estimated_saving_co2, :kg) %></td>
     </tr>
   </tbody>
 </table>

--- a/app/views/schools/advice/baseload/_seasonal_variation_table.html.erb
+++ b/app/views/schools/advice/baseload/_seasonal_variation_table.html.erb
@@ -1,12 +1,12 @@
 <table class="table table-sm">
   <thead class="thead-dark">
     <tr>
-      <th class="text-right">Assessment</th>
-      <th class="text-right">Baseload in winter (kW)</th>
-      <th class="text-right">Baseload in summer (kW)</th>
-      <th class="text-right">Percentage difference (%)</th>
-      <th class="text-right">Potential saving (£)</th>
-      <th class="text-right">CO2 reduction (kg)</th>
+      <th class="text-right"><%= t('advice_pages.baseload.tables.columns.assessment') %></th>
+      <th class="text-right"><%= t('advice_pages.baseload.tables.columns.baseload_in_winter') %></th>
+      <th class="text-right"><%= t('advice_pages.baseload.tables.columns.baseload_in_summer') %></th>
+      <th class="text-right"><%= t('advice_pages.baseload.tables.columns.percentage_difference') %></th>
+      <th class="text-right"><%= t('advice_pages.baseload.tables.columns.potential_saving_gbp') %></th>
+      <th class="text-right"><%= t('advice_pages.baseload.tables.columns.potential_saving_co2') %></th>
     </tr>
   </thead>
   <tbody>

--- a/app/views/schools/advice/baseload/_weekday_variation_breakdown_table.html.erb
+++ b/app/views/schools/advice/baseload/_weekday_variation_breakdown_table.html.erb
@@ -1,13 +1,13 @@
 <table class="table table-sm table-with-totals">
   <thead class="thead-dark">
     <tr>
-      <th class="text-right">Meter</th>
-      <th class="text-right">Assessment</th>
-      <th class="text-right">Highest day baseload (kW)</th>
-      <th class="text-right">Lowest day baseload (kW)</th>
-      <th class="text-right">Percentage difference (%)</th>
-      <th class="text-right">Potential saving (£)</th>
-      <th class="text-right">CO2 reduction (kg)</th>
+      <th class="text-right"><%= t('advice_pages.baseload.tables.columns.meter') %></th>
+      <th class="text-right"><%= t('advice_pages.baseload.tables.columns.assessment') %></th>
+      <th class="text-right"><%= t('advice_pages.baseload.tables.columns.highest_day_baseload') %></th>
+      <th class="text-right"><%= t('advice_pages.baseload.tables.columns.lowest_day_baseload') %></th>
+      <th class="text-right"><%= t('advice_pages.baseload.tables.columns.percentage_difference') %></th>
+      <th class="text-right"><%= t('advice_pages.baseload.tables.columns.potential_saving_gbp') %></th>
+      <th class="text-right"><%= t('advice_pages.baseload.tables.columns.potential_saving_co2') %></th>
     </tr>
   </thead>
   <tbody>

--- a/app/views/schools/advice/baseload/_weekday_variation_breakdown_table.html.erb
+++ b/app/views/schools/advice/baseload/_weekday_variation_breakdown_table.html.erb
@@ -13,7 +13,7 @@
   <tbody>
     <% intraweek_variation_by_meter.each do |mpan_mprn, variation| %>
     <tr>
-      <td class="text-right"><%= mpan_mprn %></td>
+      <td class="text-right"><%= school.meters.find_by_mpan_mprn(mpan_mprn).name_or_mpan_mprn %></td>
       <td class="text-right"><%= format_rating(variation.variation_rating) %></td>
       <td class="text-right"><%= format_unit(variation.max_day_kw, :kw) %></td>
       <td class="text-right"><%= format_unit(variation.min_day_kw, :kw) %></td>
@@ -23,7 +23,7 @@
     </tr>
     <% end %>
     <tr>
-      <td class="text-right">Whole school</td>
+      <td class="text-right">All meters</td>
       <td class="text-right"><%= format_target(intraweek_variation.variation_rating, :r2) %></td>
       <td class="text-right"><%= format_target(intraweek_variation.max_day_kw, :kwh) %></td>
       <td class="text-right"><%= format_target(intraweek_variation.min_day_kw, :kwh) %></td>

--- a/app/views/schools/advice/baseload/_weekday_variation_breakdown_table.html.erb
+++ b/app/views/schools/advice/baseload/_weekday_variation_breakdown_table.html.erb
@@ -1,8 +1,8 @@
 <table class="table table-sm table-with-totals">
   <thead class="thead-dark">
     <tr>
-      <th class="text-right"><%= t('advice_pages.baseload.tables.columns.meter') %></th>
-      <th class="text-right"><%= t('advice_pages.baseload.tables.columns.assessment') %></th>
+      <th class="text-left"><%= t('advice_pages.baseload.tables.columns.meter') %></th>
+      <th class="text-left"><%= t('advice_pages.baseload.tables.columns.assessment') %></th>
       <th class="text-right"><%= t('advice_pages.baseload.tables.columns.highest_day_baseload') %></th>
       <th class="text-right"><%= t('advice_pages.baseload.tables.columns.lowest_day_baseload') %></th>
       <th class="text-right"><%= t('advice_pages.baseload.tables.columns.percentage_difference') %></th>
@@ -13,8 +13,8 @@
   <tbody>
     <% intraweek_variation_by_meter.each do |mpan_mprn, variation| %>
     <tr>
-      <td class="text-right"><%= school.meters.find_by_mpan_mprn(mpan_mprn).name_or_mpan_mprn %></td>
-      <td class="text-right"><%= format_rating(variation.variation_rating) %></td>
+      <td class="text-left"><%= school.meters.find_by_mpan_mprn(mpan_mprn).name_or_mpan_mprn %></td>
+      <td class="text-left"><%= format_rating(variation.variation_rating) %></td>
       <td class="text-right"><%= format_unit(variation.max_day_kw, :kw) %></td>
       <td class="text-right"><%= format_unit(variation.min_day_kw, :kw) %></td>
       <td class="text-right"><%= format_unit(variation.percent_intraday_variation, :percent) %></td>
@@ -23,8 +23,8 @@
     </tr>
     <% end %>
     <tr>
-      <td class="text-right">All meters</td>
-      <td class="text-right"><%= format_rating(intraweek_variation.variation_rating) %></td>
+      <td class="text-left"><%= t('advice_pages.baseload.tables.labels.all_meters') %></td>
+      <td class="text-left"><%= format_rating(intraweek_variation.variation_rating) %></td>
       <td class="text-right"><%= format_target(intraweek_variation.max_day_kw, :kwh) %></td>
       <td class="text-right"><%= format_target(intraweek_variation.min_day_kw, :kwh) %></td>
       <td class="text-right"><%= format_target(intraweek_variation.percent_intraday_variation, :percent) %></td>

--- a/app/views/schools/advice/baseload/_weekday_variation_breakdown_table.html.erb
+++ b/app/views/schools/advice/baseload/_weekday_variation_breakdown_table.html.erb
@@ -15,11 +15,11 @@
     <tr>
       <td class="text-right"><%= mpan_mprn %></td>
       <td class="text-right"><%= format_rating(variation.variation_rating) %></td>
-      <td class="text-right"><%= format_target(variation.max_day_kw, :kwh) %></td>
-      <td class="text-right"><%= format_target(variation.min_day_kw, :kwh) %></td>
-      <td class="text-right"><%= format_target(variation.percent_intraday_variation, :percent) %></td>
-      <td class="text-right"><%= format_target(variation.estimated_saving_£, :£) %></td>
-      <td class="text-right"><%= format_target(variation.estimated_saving_co2, :kg) %></td>
+      <td class="text-right"><%= format_unit(variation.max_day_kw, :kwh) %></td>
+      <td class="text-right"><%= format_unit(variation.min_day_kw, :kwh) %></td>
+      <td class="text-right"><%= format_unit(variation.percent_intraday_variation, :percent) %></td>
+      <td class="text-right"><%= format_unit(variation.estimated_saving_£, :£) %></td>
+      <td class="text-right"><%= format_unit(variation.estimated_saving_co2, :kg) %></td>
     </tr>
     <% end %>
     <tr>

--- a/app/views/schools/advice/baseload/_weekday_variation_breakdown_table.html.erb
+++ b/app/views/schools/advice/baseload/_weekday_variation_breakdown_table.html.erb
@@ -1,4 +1,4 @@
-<table class="table table-sm">
+<table class="table table-sm table-with-totals">
   <thead class="thead-dark">
     <tr>
       <th class="text-right">Meter</th>
@@ -24,7 +24,7 @@
     <% end %>
     <tr>
       <td class="text-right">All meters</td>
-      <td class="text-right"><%= format_target(intraweek_variation.variation_rating, :r2) %></td>
+      <td class="text-right"><%= format_rating(intraweek_variation.variation_rating) %></td>
       <td class="text-right"><%= format_target(intraweek_variation.max_day_kw, :kwh) %></td>
       <td class="text-right"><%= format_target(intraweek_variation.min_day_kw, :kwh) %></td>
       <td class="text-right"><%= format_target(intraweek_variation.percent_intraday_variation, :percent) %></td>

--- a/app/views/schools/advice/baseload/_weekday_variation_breakdown_table.html.erb
+++ b/app/views/schools/advice/baseload/_weekday_variation_breakdown_table.html.erb
@@ -1,4 +1,4 @@
-<table class="table table-sm table-with-totals">
+<table class="table table-sm">
   <thead class="thead-dark">
     <tr>
       <th class="text-right">Meter</th>
@@ -23,7 +23,7 @@
     </tr>
     <% end %>
     <tr>
-      <td class="text-right">Whole school, aggregated meters</td>
+      <td class="text-right">Whole school</td>
       <td class="text-right"><%= format_target(intraweek_variation.variation_rating, :r2) %></td>
       <td class="text-right"><%= format_target(intraweek_variation.max_day_kw, :kwh) %></td>
       <td class="text-right"><%= format_target(intraweek_variation.min_day_kw, :kwh) %></td>

--- a/app/views/schools/advice/baseload/_weekday_variation_breakdown_table.html.erb
+++ b/app/views/schools/advice/baseload/_weekday_variation_breakdown_table.html.erb
@@ -15,8 +15,8 @@
     <tr>
       <td class="text-right"><%= mpan_mprn %></td>
       <td class="text-right"><%= format_rating(variation.variation_rating) %></td>
-      <td class="text-right"><%= format_unit(variation.max_day_kw, :kwh) %></td>
-      <td class="text-right"><%= format_unit(variation.min_day_kw, :kwh) %></td>
+      <td class="text-right"><%= format_unit(variation.max_day_kw, :kw) %></td>
+      <td class="text-right"><%= format_unit(variation.min_day_kw, :kw) %></td>
       <td class="text-right"><%= format_unit(variation.percent_intraday_variation, :percent) %></td>
       <td class="text-right"><%= format_unit(variation.estimated_saving_£, :£) %></td>
       <td class="text-right"><%= format_unit(variation.estimated_saving_co2, :kg) %></td>

--- a/app/views/schools/advice/baseload/_weekday_variation_table.html.erb
+++ b/app/views/schools/advice/baseload/_weekday_variation_table.html.erb
@@ -1,12 +1,12 @@
 <table class="table table-sm">
   <thead class="thead-dark">
     <tr>
-      <th class="text-right">Assessment</th>
-      <th class="text-right">Highest day baseload (kW)</th>
-      <th class="text-right">Lowest day baseload (kW)</th>
-      <th class="text-right">Percentage difference (%)</th>
-      <th class="text-right">Potential saving (£)</th>
-      <th class="text-right">CO2 reduction (kg)</th>
+      <th class="text-right"><%= t('advice_pages.baseload.tables.columns.assessment') %></th>
+      <th class="text-right"><%= t('advice_pages.baseload.tables.columns.highest_day_baseload') %></th>
+      <th class="text-right"><%= t('advice_pages.baseload.tables.columns.lowest_day_baseload') %></th>
+      <th class="text-right"><%= t('advice_pages.baseload.tables.columns.percentage_difference') %></th>
+      <th class="text-right"><%= t('advice_pages.baseload.tables.columns.potential_saving_gbp') %></th>
+      <th class="text-right"><%= t('advice_pages.baseload.tables.columns.potential_saving_co2') %></th>
     </tr>
   </thead>
   <tbody>

--- a/app/views/schools/advice/baseload/_weekday_variation_table.html.erb
+++ b/app/views/schools/advice/baseload/_weekday_variation_table.html.erb
@@ -1,7 +1,7 @@
 <table class="table table-sm">
   <thead class="thead-dark">
     <tr>
-      <th class="text-right"><%= t('advice_pages.baseload.tables.columns.assessment') %></th>
+      <th class="text-left"><%= t('advice_pages.baseload.tables.columns.assessment') %></th>
       <th class="text-right"><%= t('advice_pages.baseload.tables.columns.highest_day_baseload') %></th>
       <th class="text-right"><%= t('advice_pages.baseload.tables.columns.lowest_day_baseload') %></th>
       <th class="text-right"><%= t('advice_pages.baseload.tables.columns.percentage_difference') %></th>
@@ -11,7 +11,7 @@
   </thead>
   <tbody>
     <tr>
-      <td class="text-right"><%= format_rating(intraweek_variation.variation_rating) %></td>
+      <td class="text-left"><%= format_rating(intraweek_variation.variation_rating) %></td>
       <td class="text-right"><%= format_unit(intraweek_variation.max_day_kw, :kw) %></td>
       <td class="text-right"><%= format_unit(intraweek_variation.min_day_kw, :kw) %></td>
       <td class="text-right"><%= format_unit(intraweek_variation.percent_intraday_variation, :percent) %></td>

--- a/app/views/schools/advice/baseload/_weekday_variation_table.html.erb
+++ b/app/views/schools/advice/baseload/_weekday_variation_table.html.erb
@@ -12,12 +12,11 @@
   <tbody>
     <tr>
       <td class="text-right"><%= format_rating(intraweek_variation.variation_rating) %></td>
-      <td class="text-right"><%= format_target(intraweek_variation.max_day_kw, :kwh) %></td>
-      <td class="text-right"><%= format_target(intraweek_variation.min_day_kw, :kwh) %></td>
-      <td class="text-right"><%= format_target(intraweek_variation.percent_intraday_variation, :r2) %></td>
-      <td class="text-right"><%= format_target(intraweek_variation.percent_intraday_variation, :percent) %></td>
-      <td class="text-right"><%= format_target(intraweek_variation.estimated_saving_£, :£) %></td>
-      <td class="text-right"><%= format_target(intraweek_variation.estimated_saving_co2, :kg) %></td>
+      <td class="text-right"><%= format_unit(intraweek_variation.max_day_kw, :kwh) %></td>
+      <td class="text-right"><%= format_unit(intraweek_variation.min_day_kw, :kwh) %></td>
+      <td class="text-right"><%= format_unit(intraweek_variation.percent_intraday_variation, :percent) %></td>
+      <td class="text-right"><%= format_unit(intraweek_variation.estimated_saving_£, :£) %></td>
+      <td class="text-right"><%= format_unit(intraweek_variation.estimated_saving_co2, :kg) %></td>
     </tr>
   </tbody>
 </table>

--- a/app/views/schools/advice/baseload/_weekday_variation_table.html.erb
+++ b/app/views/schools/advice/baseload/_weekday_variation_table.html.erb
@@ -12,8 +12,8 @@
   <tbody>
     <tr>
       <td class="text-right"><%= format_rating(intraweek_variation.variation_rating) %></td>
-      <td class="text-right"><%= format_unit(intraweek_variation.max_day_kw, :kwh) %></td>
-      <td class="text-right"><%= format_unit(intraweek_variation.min_day_kw, :kwh) %></td>
+      <td class="text-right"><%= format_unit(intraweek_variation.max_day_kw, :kw) %></td>
+      <td class="text-right"><%= format_unit(intraweek_variation.min_day_kw, :kw) %></td>
       <td class="text-right"><%= format_unit(intraweek_variation.percent_intraday_variation, :percent) %></td>
       <td class="text-right"><%= format_unit(intraweek_variation.estimated_saving_£, :£) %></td>
       <td class="text-right"><%= format_unit(intraweek_variation.estimated_saving_co2, :kg) %></td>

--- a/app/views/schools/advice/baseload/analysis.html.erb
+++ b/app/views/schools/advice/baseload/analysis.html.erb
@@ -77,7 +77,7 @@
     <p><%= t('advice_pages.baseload.analysis_meter_breakdown_intro') %></p>
     <p><%= t('advice_pages.baseload.analysis_meter_breakdown_table_description') %></p>
 
-    <%= render 'meter_breakdown_table', baseload_meter_breakdown: @baseload_meter_breakdown %>
+    <%= render 'meter_breakdown_table', school: @school, baseload_meter_breakdown: @baseload_meter_breakdown %>
 
   <% end %>
 
@@ -90,7 +90,7 @@
 
   <% if @multiple_meters %>
     <p><%= t('advice_pages.baseload.analysis_seasonal_variation_table_description') %></p>
-    <%= render 'seasonal_variation_breakdown_table', seasonal_variation: @seasonal_variation, seasonal_variation_by_meter: @seasonal_variation_by_meter %>
+    <%= render 'seasonal_variation_breakdown_table', school: @school, seasonal_variation: @seasonal_variation, seasonal_variation_by_meter: @seasonal_variation_by_meter %>
   <% else %>
     <%= render 'seasonal_variation_table', seasonal_variation: @seasonal_variation %>
   <% end %>
@@ -105,7 +105,7 @@
 
   <% if @multiple_meters %>
     <p><%= t('advice_pages.baseload.analysis_weekday_variation_table_description') %></p>
-    <%= render 'weekday_variation_breakdown_table', intraweek_variation: @intraweek_variation, intraweek_variation_by_meter: @intraweek_variation_by_meter %>
+    <%= render 'weekday_variation_breakdown_table', school: @school, intraweek_variation: @intraweek_variation, intraweek_variation_by_meter: @intraweek_variation_by_meter %>
   <% else %>
     <%= render 'weekday_variation_table', intraweek_variation: @intraweek_variation %>
   <% end %>

--- a/app/views/schools/advice/baseload/analysis.html.erb
+++ b/app/views/schools/advice/baseload/analysis.html.erb
@@ -21,14 +21,14 @@
 
   <%= render 'schools/advice/section_title', section_id: 'recent-trend', section_title: t('advice_pages.baseload.analysis_recent_trend_title') %>
 
-  <p><%= t('advice_pages.baseload.analysis_usage', baseload_usage: format_target(@baseload_usage.kwh, :kw), benchmark_usage: format_target(@benchmark_usage.kwh, :kw)) %></p>
+  <p><%= t('advice_pages.baseload.analysis_usage', baseload_usage: format_unit(@average_baseload_kw, :kw), benchmark_usage: format_unit(@average_baseload_kw_benchmark, :kw)) %></p>
 
   <% if advice_baseload_high?(@estimated_savings.£) %>
     <p><%= t('advice_pages.baseload.analysis_baseload_high') %></p>
-    <p><%= t('advice_pages.baseload.analysis_baseload_high_details_html', estimated_savings: format_target(@estimated_savings.£, :£)) %></p>
+    <p><%= t('advice_pages.baseload.analysis_baseload_high_details_html', estimated_savings: format_unit(@estimated_savings.£, :£)) %></p>
   <% else %>
     <p><%= t('advice_pages.baseload.analysis_baseload_low') %></p>
-    <p><%= t('advice_pages.baseload.analysis_baseload_low_details_html', estimated_savings: format_target(@estimated_savings.£.abs, :£)) %></p>
+    <p><%= t('advice_pages.baseload.analysis_baseload_low_details_html', estimated_savings: format_unit(@estimated_savings.£.abs, :£)) %></p>
   <% end %>
 
   <h4><%= t('advice_pages.baseload.analysis_electricity_baseload_chart_title') %></h4>

--- a/app/views/schools/advice/baseload/analysis.html.erb
+++ b/app/views/schools/advice/baseload/analysis.html.erb
@@ -77,7 +77,7 @@
     <p><%= t('advice_pages.baseload.analysis_meter_breakdown_intro') %></p>
     <p><%= t('advice_pages.baseload.analysis_meter_breakdown_table_description') %></p>
 
-    <%= render 'meter_breakdown_table', school: @school, baseload_meter_breakdown: @baseload_meter_breakdown %>
+    <%= render 'meter_breakdown_table', school: @school, baseload_meter_breakdown: @baseload_meter_breakdown, baseload_meter_breakdown_total: @baseload_meter_breakdown_total %>
 
   <% end %>
 

--- a/app/views/schools/advice/baseload/analysis.html.erb
+++ b/app/views/schools/advice/baseload/analysis.html.erb
@@ -31,8 +31,8 @@
     <p><%= t('advice_pages.baseload.analysis_baseload_low_details_html', estimated_savings: format_unit(@estimated_savings.£.abs, :£)) %></p>
   <% end %>
 
-  <h4><%= t('advice_pages.baseload.analysis_electricity_baseload_chart_title') %></h4>
-  <h5><%= t('advice_pages.baseload.analysis_electricity_baseload_chart_subtitle', start_month_year: month_year(@end_date - 1.year), end_month_year: month_year(@end_date)) %></h5>
+  <h4 class="chart-title"><%= t('advice_pages.baseload.analysis_electricity_baseload_chart_title') %></h4>
+  <h5 class="chart-subtitle"><%= t('advice_pages.baseload.analysis_electricity_baseload_chart_subtitle', start_month_year: month_year(@end_date - 1.year), end_month_year: month_year(@end_date)) %></h5>
 
   <div id="chart_wrapper_baseload_lastyear" class="chart-wrapper">
     <%= render 'shared/analysis_controls', chart_type: :baseload_lastyear, axis_controls: true, analysis_controls: true %>
@@ -57,8 +57,8 @@
 
   <%= render 'long_term_trends_table', annual_average_baseloads: @annual_average_baseloads %>
 
-  <h4><%= t('advice_pages.baseload.analysis_electricity_long_term_baseload_chart_title') %></h4>
-  <h5><%= t('advice_pages.baseload.analysis_electricity_long_term_baseload_chart_subtitle', start_month_year: month_year(@start_date), end_month_year: month_year(@end_date.last_month)) %></h5>
+  <h4 class="chart-title"><%= t('advice_pages.baseload.analysis_electricity_long_term_baseload_chart_title') %></h4>
+  <h5 class="chart-subtitle"><%= t('advice_pages.baseload.analysis_electricity_long_term_baseload_chart_subtitle', start_month_year: month_year(@start_date), end_month_year: month_year(@end_date.last_month)) %></h5>
 
   <div id="chart_wrapper_baseload_versus_benchmarks" class="chart-wrapper">
     <%= render 'shared/analysis_controls', chart_type: :baseload_versus_benchmarks, axis_controls: true, analysis_controls: true %>
@@ -109,6 +109,5 @@
   <% else %>
     <%= render 'weekday_variation_table', intraweek_variation: @intraweek_variation %>
   <% end %>
-
 
 <% end %>

--- a/config/locales/views/advice_pages/baseload.yml
+++ b/config/locales/views/advice_pages/baseload.yml
@@ -40,3 +40,20 @@ en:
       analysis_weekday_variation_title: Variation in baseload between days of week
       insights_title: What is baseload?
       page_title: Baseload analysis
+      tables:
+        columns:
+          assessment: Assessment
+          average_annual_baseload_co2: Average annual CO2 (kg)
+          average_annual_baseload_gbp: Average annual cost (£)
+          average_annual_baseload_kw: Average baseload (kW)
+          baseload_in_summer: Baseload in summer (kW)
+          baseload_in_winter: Baseload in winter (kW)
+          change_since_previous_year: Change since previous year (kW)
+          highest_day_baseload: Highest day baseload (kW)
+          lowest_day_baseload: Lowest day baseload (kW)
+          meter: Meter
+          percentage_difference: "% difference"
+          percentage_of_total: "% of total baseload"
+          potential_saving_co2: CO2 reduction (kg)
+          potential_saving_gbp: Potential saving (£)
+          year: Year

--- a/config/locales/views/advice_pages/baseload.yml
+++ b/config/locales/views/advice_pages/baseload.yml
@@ -36,16 +36,18 @@ en:
       analysis_usage: Your electricity baseload over the last 12 months was %{baseload_usage} kW. Other schools with a similar number of pupils have a baseload of %{benchmark_usage} kW.
       analysis_weekday_variation_intro_1: At a well-managed school the baseload should remain the same throughout the week, there should be no reason why the electricity consumption at midnight on a weekday should be higher than during the weekend.
       analysis_weekday_variation_intro_2: The most common cause of weekday variation is a high energy consuming appliance which is turned on on a Monday and off again on a Friday.
-      analysis_weekday_variation_table_description: The meter breakdown in the table below may help to identify where in the school, seasonal variation comes from.
+      analysis_weekday_variation_table_description: The meter breakdown in the table below may help to identify where in the school, daily variation variation comes from.
       analysis_weekday_variation_title: Variation in baseload between days of week
       insights_title: What is baseload?
       page_title: Baseload analysis
       tables:
+        labels:
+          all_meters: All meters
         columns:
           assessment: Assessment
           average_annual_baseload_co2: Average annual CO2 (kg)
           average_annual_baseload_gbp: Average annual cost (£)
-          average_annual_baseload_kw: Average baseload (kW)
+          average_annual_baseload_kw: Average annual baseload (kW)
           baseload_in_summer: Baseload in summer (kW)
           baseload_in_winter: Baseload in winter (kW)
           change_since_previous_year: Change since previous year (kW)

--- a/config/locales/views/advice_pages/baseload.yml
+++ b/config/locales/views/advice_pages/baseload.yml
@@ -41,8 +41,6 @@ en:
       insights_title: What is baseload?
       page_title: Baseload analysis
       tables:
-        labels:
-          all_meters: All meters
         columns:
           assessment: Assessment
           average_annual_baseload_co2: Average annual CO2 (kg)
@@ -59,3 +57,5 @@ en:
           potential_saving_co2: CO2 reduction (kg)
           potential_saving_gbp: Potential saving (£)
           year: Year
+        labels:
+          all_meters: All meters

--- a/spec/controllers/concerns/advice_pages_spec.rb
+++ b/spec/controllers/concerns/advice_pages_spec.rb
@@ -13,24 +13,26 @@ describe AdvicePages, type: :controller do
 
   let(:subject) { TestAdvicePagesController.new }
 
-  describe '.variation_rating' do
+  describe '.calculate_rating_from_range' do
+    let(:good) {0.0}
+    let(:bad)  {0.5}
     it 'shows 0% as 10.0' do
-      expect(subject.variation_rating(0)).to eq(10.0)
+      expect(subject.calculate_rating_from_range(good, bad, 0)).to eq(10.0)
     end
     it 'shows 10% as 8.0' do
-      expect(subject.variation_rating(0.1)).to eq(8.0)
+      expect(subject.calculate_rating_from_range(good, bad, 0.1)).to eq(8.0)
     end
-    it 'shows -10% as 10.0' do
-      expect(subject.variation_rating(-0.1)).to eq(8.0)
+    it 'shows -10% as 8.0' do
+      expect(subject.calculate_rating_from_range(good, bad, -0.1.abs)).to eq(8.0)
     end
     it 'shows 40% as 2.0' do
-      expect(subject.variation_rating(0.4)).to eq(2.0)
+      expect(subject.calculate_rating_from_range(good, bad, 0.4)).to eq(2.0)
     end
     it 'shows -40% as 2.0' do
-      expect(subject.variation_rating(0.4)).to eq(2.0)
+      expect(subject.calculate_rating_from_range(good, bad, -0.4)).to eq(2.0)
     end
     it 'shows 50% as 0.0' do
-      expect(subject.variation_rating(0.5)).to eq(0.0)
+      expect(subject.calculate_rating_from_range(good, bad, 0.5)).to eq(0.0)
     end
   end
 

--- a/spec/controllers/concerns/advice_pages_spec.rb
+++ b/spec/controllers/concerns/advice_pages_spec.rb
@@ -38,6 +38,7 @@ describe AdvicePages, type: :controller do
   let(:meter_collection) { double(:meter_collection, electricity_meters: electricity_meters, aggregated_electricity_meters: double(fuel_type: :electricity)) }
   let(:end_date) { Date.parse('20200101') }
   let(:usage) { 'usage' }
+  let(:average_baseload_kw) { 2.1 }
   let(:savings) { double(£: 1, co2: 2) }
 
   describe '.baseload_usage' do
@@ -72,6 +73,7 @@ describe AdvicePages, type: :controller do
     let(:end_date) { Date.parse('20210101')}
     before do
       allow_any_instance_of(Baseload::BaseloadCalculationService).to receive(:annual_baseload_usage).and_return(usage)
+      allow_any_instance_of(Baseload::BaseloadCalculationService).to receive(:average_baseload_kw).and_return(average_baseload_kw)
     end
     it 'returns usage by years' do
       result = subject.annual_average_baseloads(meter_collection, start_date, end_date)
@@ -96,8 +98,8 @@ describe AdvicePages, type: :controller do
     it 'returns usage by years' do
       result = subject.baseload_meter_breakdown(meter_collection, end_date)
 
-      expect(result['Total'].to_h.keys).to match_array([:baseload_kw, :baseload_cost_£, :percentage_baseload, :baseload_previous_year_kw])
-      expect(result['Total'].baseload_previous_year_kw).to eq(123.0)
+      expect(result['All meters'].to_h.keys).to match_array([:baseload_kw, :baseload_change_kw, :baseload_cost_£, :percentage_baseload, :baseload_previous_year_kw])
+      expect(result['All meters'].baseload_previous_year_kw).to eq(123.0)
     end
   end
 

--- a/spec/controllers/concerns/advice_pages_spec.rb
+++ b/spec/controllers/concerns/advice_pages_spec.rb
@@ -37,7 +37,7 @@ describe AdvicePages, type: :controller do
   let(:electricity_meters) { ['electricity-meter'] }
   let(:meter_collection) { double(:meter_collection, electricity_meters: electricity_meters, aggregated_electricity_meters: double(fuel_type: :electricity)) }
   let(:end_date) { Date.parse('20200101') }
-  let(:usage) { 'usage' }
+  let(:usage) { CombinedUsageMetric.new(£: 0, kwh: 0, co2: 0) }
   let(:average_baseload_kw) { 2.1 }
   let(:savings) { double(£: 1, co2: 2) }
 
@@ -88,18 +88,18 @@ describe AdvicePages, type: :controller do
   let(:breakdown) { double(meters: []) }
   let(:average_baseload_kw) { 123.0 }
 
-  describe '.baseload_meter_breakdown' do
+  describe '.build_meter_breakdown_total' do
     let(:start_date) { Date.parse('20190101')}
     let(:end_date) { Date.parse('20210101')}
     before do
       allow_any_instance_of(Baseload::BaseloadMeterBreakdownService).to receive(:calculate_breakdown).and_return(breakdown)
+      allow_any_instance_of(Baseload::BaseloadCalculationService).to receive(:annual_baseload_usage).and_return(usage)
       allow_any_instance_of(Baseload::BaseloadCalculationService).to receive(:average_baseload_kw).and_return(average_baseload_kw)
     end
     it 'returns usage by years' do
-      result = subject.baseload_meter_breakdown(meter_collection, end_date)
-
-      expect(result['All meters'].to_h.keys).to match_array([:baseload_kw, :baseload_change_kw, :baseload_cost_£, :percentage_baseload, :baseload_previous_year_kw])
-      expect(result['All meters'].baseload_previous_year_kw).to eq(123.0)
+      result = subject.build_meter_breakdown_total(meter_collection, end_date)
+      expect(result.to_h.keys).to match_array([:baseload_kw, :baseload_change_kw, :baseload_cost_£, :percentage_baseload, :baseload_previous_year_kw])
+      expect(result.baseload_previous_year_kw).to eq(123.0)
     end
   end
 

--- a/spec/system/schools/advice_pages/baseload_spec.rb
+++ b/spec/system/schools/advice_pages/baseload_spec.rb
@@ -81,6 +81,10 @@ RSpec.describe "baseload advice page", type: :system do
       end
 
       it 'shows analysis content' do
+
+        average_baseload_kw = 2.4
+        average_baseload_kw_benchmark = 2.1
+
         usage = double(kwh: 123.0, £: 456.0, co2: 789.0)
         savings = double(kwh: 11.0, £: 22.0, co2: 33.0)
         annual_average_baseload = {year: 2020, baseload_usage: usage}
@@ -89,6 +93,9 @@ RSpec.describe "baseload advice page", type: :system do
         seasonal_variation_by_meter = {}
         intraweek_variation = double(max_day_kw: 1, min_day_kw: 2, percent_intraday_variation: 3, estimated_saving_£: 4, estimated_saving_co2: 5, variation_rating: 6)
         intraweek_variation_by_meter = {}
+
+        allow_any_instance_of(Schools::Advice::BaseloadController).to receive(:average_baseload_kw).and_return(average_baseload_kw)
+        allow_any_instance_of(Schools::Advice::BaseloadController).to receive(:average_baseload_kw_benchmark).and_return(average_baseload_kw_benchmark)
 
         allow_any_instance_of(Schools::Advice::BaseloadController).to receive(:baseload_usage).and_return(usage)
         allow_any_instance_of(Schools::Advice::BaseloadController).to receive(:benchmark_usage).and_return(usage)
@@ -104,7 +111,7 @@ RSpec.describe "baseload advice page", type: :system do
         click_on 'Analysis'
         within '.advice-page-tabs' do
           expect(page).to have_content('Recent trend')
-          expect(page).to have_content('baseload over the last 12 months was 123 kW')
+          expect(page).to have_content('baseload over the last 12 months was 2.4 kW')
         end
       end
     end


### PR DESCRIPTION
* show average annual kw values for school and benchmark, not the kwh usage across the whole year
* cache the baseload services to take advantage of cached values
* fix formatting of weekly variation table (extra column showing `r2`?)
* add `format_unit` helper and use that rather than version used on school target report
* fix CSS for `table-with-totals`, so head row isn't selected
* fix padding around tab page content and chart title/sub-title
* fix long term trend table to show `kw` not `kwh` and update table columns and units used when formatting
* change "Whole school, aggregated meters" to "All meters"
* label meters according to their name, not just the mpan
* change meter breakdown table so last round isn't a sum. It should be the average usage for the whole school != the sum of the other averages
* fix the ratings assigned to seasonal and intraday variation, the existing alerts uses slightly different logic for different rating assessments

There are still other improvements to be done here, but these can be done in a separate PR:

* adding notices to call out key information
* fixing sorting of the tables with meter breakdown, they should be sorted by meter name by default