### PR TITLE
2762 integrate the baseload advice page insights section

### DIFF
--- a/app/assets/stylesheets/advice_page.scss
+++ b/app/assets/stylesheets/advice_page.scss
@@ -32,6 +32,12 @@
   .icon {
     width: 10px;
   }
+  tr.positive-row {
+    border-left: 5px solid $green;
+  }
+  tr.negative-row {
+    border-left: 5px solid $new-red;
+  }
 }
 
 .advice-table-caption {

--- a/app/assets/stylesheets/advice_page.scss
+++ b/app/assets/stylesheets/advice_page.scss
@@ -17,3 +17,23 @@
     padding-bottom: 0px !important;
   }
 }
+
+.advice-table {
+  thead {
+    background-color: $dark-blue !important;
+    color: white;
+  }
+  .fa-arrow-circle-down {
+    color: $green;
+  }
+  .fa-arrow-circle-up {
+    color: $new-red;
+  }
+  .icon {
+    width: 10px;
+  }
+}
+
+.advice-table-caption {
+  margin-bottom: 40px;
+}

--- a/app/controllers/schools/advice/advice_base_controller.rb
+++ b/app/controllers/schools/advice/advice_base_controller.rb
@@ -10,6 +10,8 @@ module Schools
 
       include SchoolAggregation
 
+      before_action :check_aggregated_school_in_cache, only: [:insights, :analysis]
+
       def show
         redirect_to url_for([:insights, @school, :advice, advice_page_key])
       end

--- a/app/controllers/schools/advice/baseload_controller.rb
+++ b/app/controllers/schools/advice/baseload_controller.rb
@@ -1,6 +1,7 @@
 module Schools
   module Advice
     class BaseloadController < AdviceBaseController
+      include AdvicePageHelper
       def insights
         @start_date = aggregate_school.aggregated_electricity_meters.amr_data.start_date
         @end_date = aggregate_school.aggregated_electricity_meters.amr_data.end_date
@@ -10,12 +11,14 @@ module Schools
         @average_baseload_kw_last_week = baseload_service.average_baseload_kw(period: :week)
 
         @previous_year_average_baseload_kw = baseload_service.previous_period_average_baseload_kw(period: :year)
-        @percentage_change_year = (@average_baseload_kw_last_year - @previous_year_average_baseload_kw) / @average_baseload_kw_last_year
+        @percentage_change_year = relative_percent(@previous_year_average_baseload_kw, @average_baseload_kw_last_year)
+
         @previous_week_average_baseload_kw = baseload_service.previous_period_average_baseload_kw(period: :week)
-        @percentage_change_week = (@average_baseload_kw_last_week - @previous_week_average_baseload_kw) / @average_baseload_kw_last_year
+        @percentage_change_week = relative_percent(@previous_week_average_baseload_kw, @average_baseload_kw_last_week)
 
         @average_baseload_kw_benchmark = baseload_service.average_baseload_kw_benchmark(compare: :benchmark_school)
         @average_baseload_kw_exemplar = baseload_service.average_baseload_kw_benchmark(compare: :exemplar_school)
+        @category = categorise_school_vs_benchmark(@average_baseload_kw_last_year, @average_baseload_kw_benchmark, @average_baseload_kw_exemplar)
       end
 
       def analysis

--- a/app/controllers/schools/advice/baseload_controller.rb
+++ b/app/controllers/schools/advice/baseload_controller.rb
@@ -13,6 +13,9 @@ module Schools
         @percentage_change_year = (@average_baseload_kw_last_year - @previous_year_average_baseload_kw) / @average_baseload_kw_last_year
         @previous_week_average_baseload_kw = baseload_service.previous_period_average_baseload_kw(period: :week)
         @percentage_change_week = (@average_baseload_kw_last_week - @previous_week_average_baseload_kw) / @average_baseload_kw_last_year
+
+        @average_baseload_kw_benchmark = baseload_service.average_baseload_kw_benchmark(compare: :benchmark_school)
+        @average_baseload_kw_exemplar = baseload_service.average_baseload_kw_benchmark(compare: :exemplar_school)
       end
 
       def analysis

--- a/app/helpers/advice_page_helper.rb
+++ b/app/helpers/advice_page_helper.rb
@@ -22,4 +22,38 @@ module AdvicePageHelper
   def format_rating(rating)
     rating > 4 ? "Limited variation" : "Large variation"
   end
+
+  #link to a specific benchmark for a school group, falls back to the
+  #generic benchmark page if a school doesn't have a group
+  def benchmark_for_school_group_path(benchmark_type, school)
+    if school.school_group.present?
+      benchmark_path({ "benchmark_type" => benchmark_type, "benchmark[school_group_ids][]" => school.school_group.id })
+    else
+      benchmark_path({ "benchmark_type" => benchmark_type })
+    end
+  end
+
+  #categorise a school as being in the "exemplar", "benchmark" or "other" categories
+  #by comparing a numeric metric, e.g. their baseload, against expected values for
+  #the other categories
+  #
+  #returns a symbol: :exemplar, :benchmark, :other
+  def categorise_school_vs_benchmark(school, benchmark_school, exemplar_school)
+    return :other if school.nil? || benchmark_school.nil? || exemplar_school.nil?
+    if school <= exemplar_school
+      :exemplar
+    elsif school > exemplar_school &&
+          school <= benchmark_school
+      :benchmark
+    else
+      :other
+    end
+  end
+
+  #calculate relative % change of a current value from a base value
+  def relative_percent(base, current)
+    return 0.0 if base.nil? || current.nil? || base == current
+    return 0.0 if base == 0.0
+    (current - base) / base
+  end
 end

--- a/app/views/schools/advice/baseload/_comparison.html.erb
+++ b/app/views/schools/advice/baseload/_comparison.html.erb
@@ -4,44 +4,45 @@
   <%= t('advice_pages.baseload.comparison.how_do_you_compare', school_type: t('analytics.school_types.' + school.school_type)) %>
 </p>
 
-<table class="table table-sm advice-table">
-     <thead>
-       <th><%= t('advice_pages.baseload.comparison.tables.columns.category') %></th>
-       <th class="text-right"><%= t('advice_pages.baseload.tables.columns.average_annual_baseload_kw') %></th>
-       <th class="text-right"><%= t('advice_pages.baseload.comparison.tables.columns.your_baseload') %></th>
-     </thead>
-     <tbody>
-       <tr>
-         <td><%= t('advice_pages.benchmarks.exemplar_school') %></td>
-         <td class="text-right"><%= format_unit(average_baseload_kw_exemplar, :kw) %></td>
-         <td class="text-right">
-           <% if average_baseload_kw_last_year <= average_baseload_kw_exemplar %>
-            <%= format_unit(average_baseload_kw_last_year, :kw) %>
-           <% end %>
-         </td>
-       </tr>
-       <tr style="border-left: 5px solid #5cb85c;">
-         <td><%= t('advice_pages.benchmarks.benchmark_school') %></td>
-         <td class="text-right"><%= format_unit(average_baseload_kw_benchmark, :kw) %></td>
-         <td class="text-right">
-           <% if average_baseload_kw_last_year > average_baseload_kw_exemplar &&
-                 average_baseload_kw_last_year <= average_baseload_kw_benchmark %>
-            <%= format_unit(average_baseload_kw_last_year, :kw) %>
-           <% end %>
-         </td>
-       </tr>
-       <tr>
-         <td><%= t('advice_pages.benchmarks.other') %></td>
-         <td class="text-right">><%= format_unit(average_baseload_kw_benchmark, :kw) %></td>
-         <td class="text-right">
-           <% if average_baseload_kw_last_year > average_baseload_kw_benchmark %>
-            <%= format_unit(average_baseload_kw_last_year, :kw) %>
-           <% end %>
-         </td>
-       </tr>
-     </tbody>
+<table class="table table-sm advice-table" id="comparison-baseload">
+  <thead>
+    <th><%= t('advice_pages.baseload.comparison.tables.columns.category') %></th>
+    <th class="text-right"><%= t('advice_pages.baseload.tables.columns.average_annual_baseload_kw') %></th>
+    <th class="text-right"><%= t('advice_pages.baseload.comparison.tables.columns.your_baseload') %></th>
+  </thead>
+  <tbody>
+    <tr class="<%= 'positive-row' if category == :exemplar %>">
+      <td><%= t('advice_pages.benchmarks.exemplar_school') %></td>
+      <td class="text-right"><%= format_unit(average_baseload_kw_exemplar, :kw) %></td>
+      <td class="text-right">
+        <% if category == :exemplar %>
+         <%= format_unit(average_baseload_kw_last_year, :kw) %>
+        <% end %>
+      </td>
+    </tr>
+    <tr class="<%= 'positive-row' if category == :benchmark %>">
+      <td><%= t('advice_pages.benchmarks.benchmark_school') %></td>
+      <td class="text-right"><%= format_unit(average_baseload_kw_benchmark, :kw) %></td>
+      <td class="text-right">
+        <% if category == :benchmark %>
+         <%= format_unit(average_baseload_kw_last_year, :kw) %>
+        <% end %>
+      </td>
+    </tr>
+    <tr class="<%= 'negative-row' if category == :other %>">
+      <td><%= t('advice_pages.benchmarks.other') %></td>
+      <td class="text-right">><%= format_unit(average_baseload_kw_benchmark, :kw) %></td>
+      <td class="text-right">
+        <% if category == :other %>
+          <%= format_unit(average_baseload_kw_last_year, :kw) %>
+        <% end %>
+      </td>
+    </tr>
+  </tbody>
 </table>
 
 <p>
-  <%= t('advice_pages.baseload.comparison.more_detail_html', link: benchmark_path({"benchmark_type" => :baseload_per_pupil, "benchmark[school_group_ids][]" => school.school_group.id})) %>
+  <% if school.school_group.present? %>
+    <%= t('advice_pages.baseload.comparison.more_detail_html', link: benchmark_for_school_group_path(:baseload_per_pupil, school)) %>
+  <% end %>
 </p>

--- a/app/views/schools/advice/baseload/_comparison.html.erb
+++ b/app/views/schools/advice/baseload/_comparison.html.erb
@@ -1,1 +1,47 @@
-<h2 class="pt-4"><%= t('advice_pages.baseload.comparison_title') %></h2>
+<h2 class="pt-4"><%= t('advice_pages.baseload.comparison.title') %></h2>
+
+<p>
+  <%= t('advice_pages.baseload.comparison.how_do_you_compare', school_type: t('analytics.school_types.' + school.school_type)) %>
+</p>
+
+<table class="table table-sm advice-table">
+     <thead>
+       <th><%= t('advice_pages.baseload.comparison.tables.columns.category') %></th>
+       <th class="text-right"><%= t('advice_pages.baseload.tables.columns.average_annual_baseload_kw') %></th>
+       <th class="text-right"><%= t('advice_pages.baseload.comparison.tables.columns.your_baseload') %></th>
+     </thead>
+     <tbody>
+       <tr>
+         <td><%= t('advice_pages.benchmarks.exemplar_school') %></td>
+         <td class="text-right"><%= format_unit(average_baseload_kw_exemplar, :kw) %></td>
+         <td class="text-right">
+           <% if average_baseload_kw_last_year <= average_baseload_kw_exemplar %>
+            <%= format_unit(average_baseload_kw_last_year, :kw) %>
+           <% end %>
+         </td>
+       </tr>
+       <tr style="border-left: 5px solid #5cb85c;">
+         <td><%= t('advice_pages.benchmarks.benchmark_school') %></td>
+         <td class="text-right"><%= format_unit(average_baseload_kw_benchmark, :kw) %></td>
+         <td class="text-right">
+           <% if average_baseload_kw_last_year > average_baseload_kw_exemplar &&
+                 average_baseload_kw_last_year <= average_baseload_kw_benchmark %>
+            <%= format_unit(average_baseload_kw_last_year, :kw) %>
+           <% end %>
+         </td>
+       </tr>
+       <tr>
+         <td><%= t('advice_pages.benchmarks.other') %></td>
+         <td class="text-right">><%= format_unit(average_baseload_kw_benchmark, :kw) %></td>
+         <td class="text-right">
+           <% if average_baseload_kw_last_year > average_baseload_kw_benchmark %>
+            <%= format_unit(average_baseload_kw_last_year, :kw) %>
+           <% end %>
+         </td>
+       </tr>
+     </tbody>
+</table>
+
+<p>
+  <%= t('advice_pages.baseload.comparison.more_detail_html', link: benchmark_path({"benchmark_type" => :baseload_per_pupil, "benchmark[school_group_ids][]" => school.school_group.id})) %>
+</p>

--- a/app/views/schools/advice/baseload/_comparison.html.erb
+++ b/app/views/schools/advice/baseload/_comparison.html.erb
@@ -1,0 +1,1 @@
+<h2 class="pt-4"><%= t('advice_pages.baseload.comparison_title') %></h2>

--- a/app/views/schools/advice/baseload/_current_baseload.html.erb
+++ b/app/views/schools/advice/baseload/_current_baseload.html.erb
@@ -2,9 +2,9 @@
 
 <table class="mt-2 table table-sm advice-table">
     <thead>
-      <th><%= t('advice_pages.baseload.current_baseload.table.columns.period') %></th>
-      <th class="text-right"><%= t('advice_pages.baseload.current_baseload.table.columns.use') %></th>
-      <th class="text-right"><%= t('advice_pages.baseload.current_baseload.table.columns.percentage_change') %></th>
+      <th><%= t('advice_pages.baseload.current_baseload.tables.columns.period') %></th>
+      <th class="text-right"><%= t('advice_pages.baseload.current_baseload.tables.columns.use') %></th>
+      <th class="text-right"><%= t('advice_pages.baseload.current_baseload.tables.columns.percentage_change') %></th>
     </thead>
     <tbody>
       <tr>

--- a/app/views/schools/advice/baseload/_current_baseload.html.erb
+++ b/app/views/schools/advice/baseload/_current_baseload.html.erb
@@ -1,6 +1,6 @@
 <h2 class="pt-4"><%= t('advice_pages.baseload.current_baseload.title') %></h2>
 
-<table class="mt-2 table table-sm advice-table">
+<table class="mt-2 table table-sm advice-table" id="current-baseload">
     <thead>
       <th><%= t('advice_pages.baseload.current_baseload.tables.columns.period') %></th>
       <th class="text-right"><%= t('advice_pages.baseload.current_baseload.tables.columns.use') %></th>
@@ -10,12 +10,16 @@
       <tr>
         <td><%= t('advice_pages.baseload.current_baseload.last_week') %></td>
         <td class="text-right"><%= format_unit(average_baseload_kw_last_week, :kw) %></td>
-        <td class="text-right"><%= up_downify( format_unit(percentage_change_week, :relative_percent)) %></td>
+        <td class="text-right">
+          <%= up_downify( format_unit(percentage_change_week, :relative_percent)) %>
+        </td>
       </tr>
       <tr>
         <td><%= t('advice_pages.baseload.current_baseload.last_year') %></td>
         <td class="text-right"><%= format_unit(average_baseload_kw_last_year, :kw) %></td>
-        <td class="text-right"><%= up_downify( format_unit(percentage_change_year, :relative_percent)) %></td>
+        <td class="text-right">
+          <%= up_downify( format_unit(percentage_change_year, :relative_percent)) %>
+        </td>
       </tr>
     </tbody>
 </table>

--- a/app/views/schools/advice/baseload/_current_baseload.html.erb
+++ b/app/views/schools/advice/baseload/_current_baseload.html.erb
@@ -1,0 +1,25 @@
+<h2 class="pt-4"><%= t('advice_pages.baseload.current_baseload.title') %></h2>
+
+<table class="mt-2 table table-sm advice-table">
+    <thead>
+      <th><%= t('advice_pages.baseload.current_baseload.table.columns.period') %></th>
+      <th class="text-right"><%= t('advice_pages.baseload.current_baseload.table.columns.use') %></th>
+      <th class="text-right"><%= t('advice_pages.baseload.current_baseload.table.columns.percentage_change') %></th>
+    </thead>
+    <tbody>
+      <tr>
+        <td><%= t('advice_pages.baseload.current_baseload.last_week') %></td>
+        <td class="text-right"><%= format_unit(average_baseload_kw_last_week, :kw) %></td>
+        <td class="text-right"><%= up_downify( format_unit(percentage_change_week, :relative_percent)) %></td>
+      </tr>
+      <tr>
+        <td><%= t('advice_pages.baseload.current_baseload.last_year') %></td>
+        <td class="text-right"><%= format_unit(average_baseload_kw_last_year, :kw) %></td>
+        <td class="text-right"><%= up_downify( format_unit(percentage_change_year, :relative_percent)) %></td>
+      </tr>
+    </tbody>
+</table>
+<div class="text-right advice-table-caption">
+  <%= t('advice_pages.baseload.current_baseload.calculation_dates', start_date: I18n.l(start_date, format: '%B %Y'), end_date: I18n.l(end_date, format: '%B %Y')) %>.
+  <a href="<%= analysis_school_advice_baseload_path(school) %>"><%= t('advice_pages.baseload.current_baseload.review_our_analysis') %></a>
+</div>

--- a/app/views/schools/advice/baseload/_what_is_baseload.html.erb
+++ b/app/views/schools/advice/baseload/_what_is_baseload.html.erb
@@ -1,0 +1,6 @@
+<div class="p-4 bg-light" style="border-left: 5px solid #93e1f6;">
+  <%= t('advice_pages.baseload.what_is_baseload_html') %>
+  <div class="text-right">
+    <a href="<%= learn_more_school_advice_baseload_path(school) %>"><%= t('advice_pages.baseload.what_is_baseload_link') %></a>
+  </div>
+</div>

--- a/app/views/schools/advice/baseload/insights.html.erb
+++ b/app/views/schools/advice/baseload/insights.html.erb
@@ -1,3 +1,9 @@
 <%= render 'schools/advice/advice_page', school: @school, advice_pages: @advice_pages, advice_page: @advice_page, tab: @tab do %>
   <h2><%= t('advice_pages.baseload.insights_title') %></h2>
+
+  <%= render 'what_is_baseload', school: @school %>
+  <%= render 'current_baseload', school: @school, start_date: @start_date, end_date: @end_date,
+  average_baseload_kw_last_week: @average_baseload_kw_last_week, average_baseload_kw_last_year: @average_baseload_kw_last_year, percentage_change_year: @percentage_change_year, percentage_change_week: @percentage_change_week %>
+  <%= render 'comparison', school: @school %>
+
 <% end %>

--- a/app/views/schools/advice/baseload/insights.html.erb
+++ b/app/views/schools/advice/baseload/insights.html.erb
@@ -6,6 +6,6 @@
   <%= render 'current_baseload', school: @school, start_date: @start_date, end_date: @end_date,
   average_baseload_kw_last_week: @average_baseload_kw_last_week, average_baseload_kw_last_year: @average_baseload_kw_last_year, percentage_change_year: @percentage_change_year, percentage_change_week: @percentage_change_week %>
 
-  <%= render 'comparison', school: @school, average_baseload_kw_last_year: @average_baseload_kw_last_year, average_baseload_kw_benchmark: @average_baseload_kw_benchmark, average_baseload_kw_exemplar: @average_baseload_kw_exemplar %>
+  <%= render 'comparison', school: @school, category: @category, average_baseload_kw_last_year: @average_baseload_kw_last_year, average_baseload_kw_benchmark: @average_baseload_kw_benchmark, average_baseload_kw_exemplar: @average_baseload_kw_exemplar %>
 
 <% end %>

--- a/app/views/schools/advice/baseload/insights.html.erb
+++ b/app/views/schools/advice/baseload/insights.html.erb
@@ -2,8 +2,10 @@
   <h2><%= t('advice_pages.baseload.insights_title') %></h2>
 
   <%= render 'what_is_baseload', school: @school %>
+
   <%= render 'current_baseload', school: @school, start_date: @start_date, end_date: @end_date,
   average_baseload_kw_last_week: @average_baseload_kw_last_week, average_baseload_kw_last_year: @average_baseload_kw_last_year, percentage_change_year: @percentage_change_year, percentage_change_week: @percentage_change_week %>
-  <%= render 'comparison', school: @school %>
+
+  <%= render 'comparison', school: @school, average_baseload_kw_last_year: @average_baseload_kw_last_year, average_baseload_kw_benchmark: @average_baseload_kw_benchmark, average_baseload_kw_exemplar: @average_baseload_kw_exemplar %>
 
 <% end %>

--- a/config/locales/views/advice_pages/advice_pages.yml
+++ b/config/locales/views/advice_pages/advice_pages.yml
@@ -1,6 +1,10 @@
 ---
 en:
   advice_pages:
+    benchmarks:
+      benchmark_school: Well managed
+      exemplar_school: Exemplar
+      other: Improving
     breadcrumbs:
       root: Advice
     nav:

--- a/config/locales/views/advice_pages/baseload.yml
+++ b/config/locales/views/advice_pages/baseload.yml
@@ -41,37 +41,26 @@ en:
       analysis_weekday_variation_intro_2: The most common cause of weekday variation is a high energy consuming appliance which is turned on on a Monday and off again on a Friday.
       analysis_weekday_variation_table_description: The meter breakdown in the table below may help to identify where in the school, daily variation variation comes from.
       analysis_weekday_variation_title: Variation in baseload between days of week
-      insights_title: What is baseload?
-      what_is_baseload_html: |-
-        <p>
-          Electricity baseload is the electricity needed to provide power to appliances that keep running at all times.
-        </p>
-        <p>
-          It can be the fastest way of reducing a school's energy costs and reducing its carbon footprint.
-        </p>
-        <p>
-          For each 1kW reduction in baseload, the school will save 8,760 kWh.
-        </p>
-      what_is_baseload_link: Learn more
-      current_baseload:
-        title: Your current baseload
-        review_our_analysis: Review our detailed analysis
-        calculation_dates: Calculation based on data from %{start_date} to %{end_date}
-        last_week: Last week
-        last_year: Last year
-        tables:
-          columns:
-            period: Period
-            use: Average baseload (kW)
-            percentage_change: "% Change"
       comparison:
-        title: How do you compare?
         how_do_you_compare: How does your baseload compare to other %{school_type} schools on Energy Sparks, with a similar number of pupils?
         more_detail_html: For more detail, <a href="%{link}">compare with other schools in your group</a>
         tables:
           columns:
             category: Category
             your_baseload: Your baseload (kW)
+        title: How do you compare?
+      current_baseload:
+        calculation_dates: Calculation based on data from %{start_date} to %{end_date}
+        last_week: Last week
+        last_year: Last year
+        review_our_analysis: Review our detailed analysis
+        tables:
+          columns:
+            percentage_change: "% Change"
+            period: Period
+            use: Average baseload (kW)
+        title: Your current baseload
+      insights_title: What is baseload?
       page_title: Baseload analysis
       tables:
         columns:
@@ -92,3 +81,14 @@ en:
           year: Year
         labels:
           all_meters: All meters
+      what_is_baseload_html: |-
+        <p>
+          Electricity baseload is the electricity needed to provide power to appliances that keep running at all times.
+        </p>
+        <p>
+          It can be the fastest way of reducing a school's energy costs and reducing its carbon footprint.
+        </p>
+        <p>
+          For each 1kW reduction in baseload, the school will save 8,760 kWh.
+        </p>
+      what_is_baseload_link: Learn more

--- a/config/locales/views/advice_pages/baseload.yml
+++ b/config/locales/views/advice_pages/baseload.yml
@@ -39,6 +39,30 @@ en:
       analysis_weekday_variation_table_description: The meter breakdown in the table below may help to identify where in the school, daily variation variation comes from.
       analysis_weekday_variation_title: Variation in baseload between days of week
       insights_title: What is baseload?
+      what_is_baseload_html: |-
+        <p>
+          Electricity baseload is the electricity needed to provide power to appliances that keep running at all times.
+        </p>
+        <p>
+          It can be the fastest way of reducing a school's energy costs and reducing its carbon footprint.
+        </p>
+        <p>
+          For each 1kW reduction in baseload, the school will save 8,760 kWh.
+        </p>
+      what_is_baseload_link: Learn more
+      current_baseload:
+        title: Your current baseload
+        review_our_analysis: Review our detailed analysis
+        calculation_dates: Calculation based on data from %{start_date} to %{end_date}
+        last_week: Last week
+        last_year: Last year
+        table:
+          columns:
+            period: Period
+            use: Use (kW)
+            percentage_change: "% Change"
+      current_baseload_title:
+      comparison_title: How do you compare?
       page_title: Baseload analysis
       tables:
         columns:

--- a/config/locales/views/advice_pages/baseload.yml
+++ b/config/locales/views/advice_pages/baseload.yml
@@ -59,7 +59,7 @@ en:
         tables:
           columns:
             period: Period
-            use: Use (kW)
+            use: Average baseload (kW)
             percentage_change: "% Change"
       comparison:
         title: How do you compare?

--- a/config/locales/views/advice_pages/baseload.yml
+++ b/config/locales/views/advice_pages/baseload.yml
@@ -56,13 +56,19 @@ en:
         calculation_dates: Calculation based on data from %{start_date} to %{end_date}
         last_week: Last week
         last_year: Last year
-        table:
+        tables:
           columns:
             period: Period
             use: Use (kW)
             percentage_change: "% Change"
-      current_baseload_title:
-      comparison_title: How do you compare?
+      comparison:
+        title: How do you compare?
+        how_do_you_compare: How does your baseload compare to other %{school_type} schools on Energy Sparks, with a similar number of pupils?
+        more_detail_html: For more detail, <a href="%{link}">compare with other schools in your group</a>
+        tables:
+          columns:
+            category: Category
+            your_baseload: Your baseload (kW)
       page_title: Baseload analysis
       tables:
         columns:

--- a/spec/services/schools/advice/baseload_service_spec.rb
+++ b/spec/services/schools/advice/baseload_service_spec.rb
@@ -51,13 +51,13 @@ RSpec.describe Schools::Advice::BaseloadService, type: :service do
     end
   end
 
-  describe '#previous_year_average_baseload_kw' do
+  describe '#previous_period_average_baseload_kw' do
     before do
       allow_any_instance_of(Baseload::BaseloadCalculationService).to receive(:average_baseload_kw).and_return(average_baseload_kw)
     end
 
     it 'returns the baseload' do
-      expect(service.previous_year_average_baseload_kw).to eq average_baseload_kw
+      expect(service.previous_period_average_baseload_kw).to eq average_baseload_kw
     end
   end
 

--- a/spec/system/schools/advice_pages/baseload_spec.rb
+++ b/spec/system/schools/advice_pages/baseload_spec.rb
@@ -39,23 +39,18 @@ RSpec.describe "baseload advice page", type: :system do
 
     it 'shows the advice pages index' do
       expect(page).to have_content('Advice Pages')
-      expect(page).to have_link(key)
+      within '.advice-page-nav' do
+        expect(page).to have_content("Baseload")
+      end
     end
 
-    context 'when viewing the page' do
-
+    context 'when viewing the insights page' do
       before(:each) do
         click_on key
       end
 
       it 'shows the page title' do
         expect(page).to have_content(expected_page_title)
-      end
-
-      it 'shows a link to the page in the nav bar' do
-        within '.advice-page-nav' do
-          expect(page).to have_content("Baseload")
-        end
       end
 
       it 'shows tabs for insights, analysis, learn more' do
@@ -80,6 +75,10 @@ RSpec.describe "baseload advice page", type: :system do
         within '.advice-page-tabs' do
           expect(page).to have_content(advice_page.learn_more.body.to_html)
         end
+      end
+
+      it 'shows the definition of baseload' do
+        expect(page).to have_content("Electricity baseload is the electricity needed to provide power to appliances")
       end
     end
 

--- a/spec/system/schools/advice_pages/baseload_spec.rb
+++ b/spec/system/schools/advice_pages/baseload_spec.rb
@@ -1,11 +1,11 @@
 require 'rails_helper'
 
-RSpec.describe "baseload advice page", type: :system do
+RSpec.describe "Baseload advice page", type: :system do
 
   let!(:advice_page) { create(:advice_page, key: key, restricted: false) }
   let(:key) { 'baseload' }
 
-  let(:school) { create(:school) }
+  let(:school) { create(:school, school_group: create(:school_group)) }
   let!(:fuel_configuration) { Schools::FuelConfiguration.new(has_electricity: true, has_gas: true, has_storage_heaters: true)}
 
   let(:start_date)  { Date.new(2019,12,31)}
@@ -29,7 +29,7 @@ RSpec.describe "baseload advice page", type: :system do
 
   let(:expected_page_title) { "Baseload analysis" }
 
-  context 'as school admin' do
+  context 'as a school admin' do
     let(:user)  { create(:school_admin, school: school) }
 
     before do
@@ -37,16 +37,23 @@ RSpec.describe "baseload advice page", type: :system do
       visit school_advice_path(school)
     end
 
-    it 'shows the advice pages index' do
+    it 'the advice pages index has a link to the page in the navbar' do
       expect(page).to have_content('Advice Pages')
       within '.advice-page-nav' do
         expect(page).to have_content("Baseload")
       end
     end
 
-    context 'when viewing the insights page' do
+    context 'when viewing the learn more page' do
       before(:each) do
-        click_on key
+        visit learn_more_school_advice_baseload_path(school)
+      end
+
+      it 'shows the learn more content' do
+        click_on 'Learn More'
+        within '.advice-page-tabs' do
+          expect(page).to have_content(advice_page.learn_more.body.to_html)
+        end
       end
 
       it 'shows the page title' do
@@ -68,17 +75,6 @@ RSpec.describe "baseload advice page", type: :system do
           expect(page).to have_link('Advice')
           expect(page).to have_text(key.humanize)
         end
-      end
-
-      it 'shows the learn more content' do
-        click_on 'Learn More'
-        within '.advice-page-tabs' do
-          expect(page).to have_content(advice_page.learn_more.body.to_html)
-        end
-      end
-
-      it 'shows the definition of baseload' do
-        expect(page).to have_content("Electricity baseload is the electricity needed to provide power to appliances")
       end
     end
 
@@ -127,14 +123,65 @@ RSpec.describe "baseload advice page", type: :system do
       end
     end
 
-    context 'when page is restricted' do
-      before do
-        advice_page.update(restricted: true)
+    context 'when viewing the insights' do
+      let(:average_baseload_last_year_kw) {2.1}
+      let(:average_baseload_last_week_kw) {2.2}
+
+
+      let(:average_baseload_kw_exemplar) {1.1}
+      let(:average_baseload_kw_benchmark) {2.4}
+
+      let(:previous_year_average_baseload_kw) { 2.0 }
+      let(:previous_week_average_baseload_kw) { 1.9 }
+
+      before(:each) do
+        #current baseload
+        allow_any_instance_of(Schools::Advice::BaseloadService).to receive(:average_baseload_kw).with(period: :year).and_return average_baseload_last_year_kw
+        allow_any_instance_of(Schools::Advice::BaseloadService).to receive(:average_baseload_kw).with(period: :week).and_return average_baseload_last_week_kw
+
+        allow_any_instance_of(Schools::Advice::BaseloadService).to receive(:previous_period_average_baseload_kw).with(period: :year).and_return previous_year_average_baseload_kw
+        allow_any_instance_of(Schools::Advice::BaseloadService).to receive(:previous_period_average_baseload_kw).with(period: :week).and_return previous_week_average_baseload_kw
+
+        #comparison
+        allow_any_instance_of(Schools::Advice::BaseloadService).to receive(:average_baseload_kw_benchmark).with(compare: :benchmark_school).and_return average_baseload_kw_benchmark
+        allow_any_instance_of(Schools::Advice::BaseloadService).to receive(:average_baseload_kw_benchmark).with(compare: :exemplar_school).and_return average_baseload_kw_exemplar
+
         visit insights_school_advice_baseload_path(school)
       end
-      it 'shows the restricted advice page' do
-        expect(page).to have_content(expected_page_title)
+
+      it 'shows the definition of baseload' do
+        expect(page).to have_content("Electricity baseload is the electricity needed to provide power to appliances")
       end
+
+      it 'shows the current baseload section' do
+        expect(page).to have_content("Your current baseload")
+        #check within table
+        within '#current-baseload' do
+          expect(page).to have_content("2.1")
+          expect(page).to have_content("2.2")
+        end
+      end
+
+      it 'shows the comparison section' do
+        expect(page).to have_content("How do you compare?")
+        #check within table
+        within '#comparison-baseload' do
+          expect(page).to have_content("1.1")
+          expect(page).to have_content("2.4")
+        end
+        expect(page).to have_content("compare with other schools in your group")
+      end
+
+      context 'when the page has been restricted' do
+        before do
+          advice_page.update(restricted: true)
+          visit insights_school_advice_baseload_path(school)
+        end
+        it 'still shows the analysis' do
+          expect(page).to have_content(expected_page_title)
+        end
+      end
+
     end
   end
 end


### PR DESCRIPTION
Implements the initial version of the baseload insights section:

- add definition
- add current baseload
- add comparison
- link to benchmark comparison for school

TODO:

- [x] tidy up code
- [x] add specs
- [x] fix up highlighting on comparison table

Further work to be done in other PRs to handle limited data.