### PR TITLE
Test link from admin pages and sort index by key

### DIFF
--- a/app/controllers/admin/advice_pages_controller.rb
+++ b/app/controllers/admin/advice_pages_controller.rb
@@ -4,6 +4,7 @@ module Admin
     load_and_authorize_resource
 
     def index
+      @advice_pages = @advice_pages.by_key
     end
 
     def edit

--- a/app/models/advice_page.rb
+++ b/app/models/advice_page.rb
@@ -28,6 +28,8 @@ class AdvicePage < ApplicationRecord
 
   accepts_nested_attributes_for :advice_page_intervention_types, reject_if: proc {|attributes| attributes['position'].blank? }
 
+  scope :by_key, -> { order(key: :asc) }
+
   def update_activity_type_positions!(position_attributes)
     transaction do
       advice_page_activity_types.destroy_all

--- a/spec/system/schools/advice_pages/advice_pages_spec.rb
+++ b/spec/system/schools/advice_pages/advice_pages_spec.rb
@@ -101,6 +101,12 @@ RSpec.describe "advice pages", type: :system do
       expect(page).to have_content("All pages")
     end
 
+    it 'links from admin page' do
+      visit admin_path
+      click_on 'Advice Pages'
+      expect(page).to have_content('Manage advice pages')
+    end
+
     context 'when page is restricted' do
       before do
         advice_page.update(restricted: true)


### PR DESCRIPTION
There was already a link from the admin pages to the advice page management, so this PR just adds a test (and also ensures that the index page list is sorted).