### PR TITLE
2863 error handling for advice page controllers

### DIFF
--- a/app/controllers/schools/advice/advice_base_controller.rb
+++ b/app/controllers/schools/advice/advice_base_controller.rb
@@ -12,6 +12,11 @@ module Schools
 
       before_action :check_aggregated_school_in_cache, only: [:insights, :analysis]
 
+      rescue_from StandardError do |exception|
+        Rollbar.error(exception)
+        render 'error'
+      end
+
       def show
         redirect_to url_for([:insights, @school, :advice, advice_page_key])
       end

--- a/app/controllers/schools/advice/advice_base_controller.rb
+++ b/app/controllers/schools/advice/advice_base_controller.rb
@@ -13,7 +13,7 @@ module Schools
       before_action :check_aggregated_school_in_cache, only: [:insights, :analysis]
 
       rescue_from StandardError do |exception|
-        Rollbar.error(exception)
+        Rollbar.error(exception, advice_page: advice_page_key, school: @school.name, school_id: @school.id)
         render 'error'
       end
 

--- a/app/controllers/schools/advice_controller.rb
+++ b/app/controllers/schools/advice_controller.rb
@@ -13,7 +13,7 @@ module Schools
     private
 
     def load_advice_pages
-      @advice_pages = AdvicePage.all
+      @advice_pages = AdvicePage.all.by_key
     end
   end
 end

--- a/app/views/schools/advice/advice_base/error.html.erb
+++ b/app/views/schools/advice/advice_base/error.html.erb
@@ -1,0 +1,18 @@
+<div class="advice-page-breadcrumb">
+  <%= render(BreadcrumbsComponent.new) do |c| %>
+    <% c.with_school(@school) %>
+    <% c.with_items([{ name: t('advice_pages.breadcrumbs.root'), href: school_advice_path(@school) }]) %>
+  <% end %>
+</div>
+
+<h1><%= t('advice_pages.show.title') %></h1>
+
+<div class="row">
+  <div class="col-md-3 col-lg-3 col-xl-2 advice-page-nav">
+    <%= render 'schools/advice/nav', school: @school, advice_pages: @advice_pages %>
+  </div>
+  <div class="col-md-9 col-lg-9 col-xl-10 advice-page-tabs">
+    <h2><%= render(PageNavComponent::CollapseButton.new(display: 'inline')) %><%= t('advice_pages.error.title') %></h2>
+    <p><%= t('advice_pages.error.message') %></p>
+  </div>
+</div>

--- a/config/locales/views/advice_pages/advice_pages.yml
+++ b/config/locales/views/advice_pages/advice_pages.yml
@@ -7,6 +7,9 @@ en:
       other: Improving
     breadcrumbs:
       root: Advice
+    error:
+      message: We encountered an error attempting to generate your analysis. The Energy Sparks team have been notified of the problem.
+      title: Error
     nav:
       carbon:
         name: Carbon

--- a/config/locales/views/advice_pages/advice_pages.yml
+++ b/config/locales/views/advice_pages/advice_pages.yml
@@ -9,7 +9,7 @@ en:
       root: Advice
     error:
       message: We encountered an error attempting to generate your analysis. The Energy Sparks team have been notified of the problem.
-      title: Error
+      title: Sorry, something has gone wrong
     nav:
       carbon:
         name: Carbon

--- a/spec/system/schools/advice_pages/advice_pages_spec.rb
+++ b/spec/system/schools/advice_pages/advice_pages_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe "advice pages", type: :system do
       visit school_advice_path(school)
       click_on key
       click_on 'Learn More'
-      expect(page).to have_content('Error')
+      expect(page).to have_content('Sorry, something has gone wrong')
       expect(page).to have_content('We encountered an error attempting to generate your analysis')
     end
   end

--- a/spec/system/schools/advice_pages/advice_pages_spec.rb
+++ b/spec/system/schools/advice_pages/advice_pages_spec.rb
@@ -11,6 +11,19 @@ RSpec.describe "advice pages", type: :system do
 
   let(:expected_page_title) { "Total energy use" }
 
+  context 'when error occurs' do
+    before do
+      allow_any_instance_of(Schools::Advice::AdviceBaseController).to receive(:learn_more).and_raise(StandardError.new('testing..'))
+    end
+    it 'shows the error page' do
+      visit school_advice_path(school)
+      click_on key
+      click_on 'Learn More'
+      expect(page).to have_content('Error')
+      expect(page).to have_content('We encountered an error attempting to generate your analysis')
+    end
+  end
+
   context 'as non-logged in user' do
 
     before do


### PR DESCRIPTION
When an error occurs in the advice pages, we rescue the exception in the advice pages base class, log it to Rollbar, and show a styled error page (which includes the usual advice page navigation).
