### PR TITLE
Prevent content disappearing under the top nav

### DIFF
--- a/app/controllers/schools/advice/advice_base_controller.rb
+++ b/app/controllers/schools/advice/advice_base_controller.rb
@@ -1,6 +1,8 @@
 module Schools
   module Advice
     class AdviceBaseController < ApplicationController
+      before_action :header_fix_enabled
+
       load_and_authorize_resource :school
       skip_before_action :authenticate_user!
 


### PR DESCRIPTION
Please can we try this out for the advice section? It stops content disappearing under the top nav. It's in place in other sections (transport, issues, data sources... etc).