### PR TITLE
Created chart component and replaced charts on baseload analysis

### DIFF
--- a/app/components/chart_component.html.erb
+++ b/app/components/chart_component.html.erb
@@ -3,5 +3,5 @@
 
 <div id="chart_wrapper_<%= chart_type %>" class="chart-wrapper">
   <%= render 'shared/analysis_controls', chart_type: chart_type, axis_controls: true, analysis_controls: analysis_controls %>
-  <%= chart_tag(school, chart_type, no_zoom: no_zoom, wrap: false, chart_config: chart_config) %>
+  <%= chart_tag(school, chart_type, no_zoom: no_zoom, wrap: false, html_class: html_class, chart_config: chart_config) %>
 </div>

--- a/app/components/chart_component.html.erb
+++ b/app/components/chart_component.html.erb
@@ -6,15 +6,11 @@
   <h5 class="chart-subtitle"><%= subtitle %></h5>
 <% end %>
 
-<% if header %>
-  <p><%= header %></p>
-<% end %>
+<%= header %>
 
 <div id="chart_wrapper_<%= chart_type %>" class="chart-wrapper">
   <%= render 'shared/analysis_controls', chart_type: chart_type, axis_controls: true, analysis_controls: analysis_controls %>
   <%= chart_tag(school, chart_type, no_zoom: no_zoom, wrap: false, html_class: html_class, chart_config: chart_config) %>
 </div>
 
-<% if footer %>
-  <p><%= footer %></p>
-<% end %>
+<%= footer %>

--- a/app/components/chart_component.html.erb
+++ b/app/components/chart_component.html.erb
@@ -1,16 +1,28 @@
-<% if title %>
-  <h4 id="chart-section-<%= chart_type %>" class="chart-title"><%= title %></h4>
+<% if valid_config? %>
+
+  <% if title %>
+    <h4 id="chart-section-<%= chart_type %>" class="chart-title"><%= title %></h4>
+  <% end %>
+
+  <% if subtitle %>
+    <h5 class="chart-subtitle"><%= subtitle %></h5>
+  <% end %>
+
+  <%= header %>
+
+  <div id="chart_wrapper_<%= chart_type %>" class="chart-wrapper">
+    <%= render 'shared/analysis_controls', chart_type: chart_type, axis_controls: true, analysis_controls: analysis_controls %>
+    <%= chart_tag(school, chart_type, no_zoom: no_zoom, wrap: false, html_class: html_class, chart_config: chart_config) %>
+  </div>
+
+  <%= footer %>
+
+<% else %>
+
+  <div class="padded-row">
+    <div class="bg-negative-light">
+      <p>The chart can't be displayed - please check the configuration</p>
+    </div>
+  </div>
+
 <% end %>
-
-<% if subtitle %>
-  <h5 class="chart-subtitle"><%= subtitle %></h5>
-<% end %>
-
-<%= header %>
-
-<div id="chart_wrapper_<%= chart_type %>" class="chart-wrapper">
-  <%= render 'shared/analysis_controls', chart_type: chart_type, axis_controls: true, analysis_controls: analysis_controls %>
-  <%= chart_tag(school, chart_type, no_zoom: no_zoom, wrap: false, html_class: html_class, chart_config: chart_config) %>
-</div>
-
-<%= footer %>

--- a/app/components/chart_component.html.erb
+++ b/app/components/chart_component.html.erb
@@ -1,5 +1,5 @@
 <% if title %>
-  <h4 class="chart-title"><%= title %></h4>
+  <h4 id="chart_<%= chart_type %>_title" class="chart-title"><%= title %></h4>
 <% end %>
 
 <% if subtitle %>

--- a/app/components/chart_component.html.erb
+++ b/app/components/chart_component.html.erb
@@ -1,5 +1,10 @@
-<h4 class="chart-title"><%= title %></h4>
-<h5 class="chart-subtitle"><%= subtitle %></h5>
+<% if title %>
+  <h4 class="chart-title"><%= title %></h4>
+<% end %>
+
+<% if subtitle %>
+  <h5 class="chart-subtitle"><%= subtitle %></h5>
+<% end %>
 
 <% if header %>
   <p><%= header %></p>

--- a/app/components/chart_component.html.erb
+++ b/app/components/chart_component.html.erb
@@ -1,5 +1,5 @@
 <% if title %>
-  <h4 id="chart_<%= chart_type %>_title" class="chart-title"><%= title %></h4>
+  <h4 id="chart-section-<%= chart_type %>" class="chart-title"><%= title %></h4>
 <% end %>
 
 <% if subtitle %>

--- a/app/components/chart_component.html.erb
+++ b/app/components/chart_component.html.erb
@@ -1,7 +1,15 @@
 <h4 class="chart-title"><%= title %></h4>
 <h5 class="chart-subtitle"><%= subtitle %></h5>
 
+<% if header %>
+  <p><%= header %></p>
+<% end %>
+
 <div id="chart_wrapper_<%= chart_type %>" class="chart-wrapper">
   <%= render 'shared/analysis_controls', chart_type: chart_type, axis_controls: true, analysis_controls: analysis_controls %>
   <%= chart_tag(school, chart_type, no_zoom: no_zoom, wrap: false, html_class: html_class, chart_config: chart_config) %>
 </div>
+
+<% if footer %>
+  <p><%= footer %></p>
+<% end %>

--- a/app/components/chart_component.html.erb
+++ b/app/components/chart_component.html.erb
@@ -1,0 +1,7 @@
+<h4 class="chart-title"><%= title %></h4>
+<h5 class="chart-subtitle"><%= subtitle %></h5>
+
+<div id="chart_wrapper_<%= chart_type %>" class="chart-wrapper">
+  <%= render 'shared/analysis_controls', chart_type: chart_type, axis_controls: true, analysis_controls: analysis_controls %>
+  <%= chart_tag(school, chart_type, no_zoom: no_zoom, wrap: false, chart_config: chart_config) %>
+</div>

--- a/app/components/chart_component.rb
+++ b/app/components/chart_component.rb
@@ -6,16 +6,26 @@ class ChartComponent < ViewComponent::Base
   renders_one :header
   renders_one :footer
 
-  attr_reader :school, :chart_type, :chart_config, :analysis_controls, :no_zoom, :html_class
+  attr_reader :school, :chart_type, :analysis_controls, :no_zoom, :html_class
 
   include ChartHelper
 
   def initialize(chart_type: '', school: nil, chart_config: nil, analysis_controls: true, no_zoom: false, html_class: 'analysis-chart')
     @chart_type = chart_type
     @school = school
-    @chart_config = chart_config || create_chart_config(@school, @chart_type)
+    @chart_config = chart_config
     @analysis_controls = analysis_controls
     @no_zoom = no_zoom
     @html_class = html_class
+  end
+
+  def chart_config
+    @chart_config ||= create_chart_config(@school, @chart_type)
+  rescue StandardError
+    nil
+  end
+
+  def valid_config?
+    !chart_config.nil?
   end
 end

--- a/app/components/chart_component.rb
+++ b/app/components/chart_component.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class ChartComponent < ViewComponent::Base
+  attr_reader :school, :title, :subtitle, :chart_type, :chart_config, :analysis_controls, :no_zoom
+
+  include ChartHelper
+
+  def initialize(chart_type: '', school: nil, title: '', subtitle: '', chart_config: {}, analysis_controls: false, no_zoom: true)
+    @chart_type = chart_type
+    @school = school
+    @title = title
+    @subtitle = subtitle
+    @chart_config = chart_config
+    @analysis_controls = analysis_controls
+    @no_zoom = no_zoom
+  end
+end

--- a/app/components/chart_component.rb
+++ b/app/components/chart_component.rb
@@ -10,7 +10,7 @@ class ChartComponent < ViewComponent::Base
 
   include ChartHelper
 
-  def initialize(chart_type: '', school: nil, chart_config: nil, analysis_controls: true, no_zoom: false, html_class: 'analysis-chart')
+  def initialize(chart_type:, school:, chart_config: nil, analysis_controls: true, no_zoom: false, html_class: 'analysis-chart')
     @chart_type = chart_type
     @school = school
     @chart_config = chart_config

--- a/app/components/chart_component.rb
+++ b/app/components/chart_component.rb
@@ -10,10 +10,10 @@ class ChartComponent < ViewComponent::Base
 
   include ChartHelper
 
-  def initialize(chart_type: '', school: nil, chart_config: {}, analysis_controls: false, no_zoom: true, html_class: 'analysis-chart')
+  def initialize(chart_type: '', school: nil, chart_config: nil, analysis_controls: false, no_zoom: true, html_class: 'analysis-chart')
     @chart_type = chart_type
     @school = school
-    @chart_config = chart_config
+    @chart_config = chart_config || create_chart_config(@school, @chart_type)
     @analysis_controls = analysis_controls
     @no_zoom = no_zoom
     @html_class = html_class

--- a/app/components/chart_component.rb
+++ b/app/components/chart_component.rb
@@ -10,7 +10,7 @@ class ChartComponent < ViewComponent::Base
 
   include ChartHelper
 
-  def initialize(chart_type: '', school: nil, chart_config: nil, analysis_controls: false, no_zoom: true, html_class: 'analysis-chart')
+  def initialize(chart_type: '', school: nil, chart_config: nil, analysis_controls: true, no_zoom: false, html_class: 'analysis-chart')
     @chart_type = chart_type
     @school = school
     @chart_config = chart_config || create_chart_config(@school, @chart_type)

--- a/app/components/chart_component.rb
+++ b/app/components/chart_component.rb
@@ -1,18 +1,18 @@
 # frozen_string_literal: true
 
 class ChartComponent < ViewComponent::Base
+  renders_one :title
+  renders_one :subtitle
   renders_one :header
   renders_one :footer
 
-  attr_reader :school, :title, :subtitle, :chart_type, :chart_config, :analysis_controls, :no_zoom, :html_class
+  attr_reader :school, :chart_type, :chart_config, :analysis_controls, :no_zoom, :html_class
 
   include ChartHelper
 
-  def initialize(chart_type: '', school: nil, title: '', subtitle: '', chart_config: {}, analysis_controls: false, no_zoom: true, html_class: 'analysis-chart')
+  def initialize(chart_type: '', school: nil, chart_config: {}, analysis_controls: false, no_zoom: true, html_class: 'analysis-chart')
     @chart_type = chart_type
     @school = school
-    @title = title
-    @subtitle = subtitle
     @chart_config = chart_config
     @analysis_controls = analysis_controls
     @no_zoom = no_zoom

--- a/app/components/chart_component.rb
+++ b/app/components/chart_component.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 class ChartComponent < ViewComponent::Base
+  renders_one :header
+  renders_one :footer
+
   attr_reader :school, :title, :subtitle, :chart_type, :chart_config, :analysis_controls, :no_zoom, :html_class
 
   include ChartHelper

--- a/app/components/chart_component.rb
+++ b/app/components/chart_component.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
 class ChartComponent < ViewComponent::Base
-  attr_reader :school, :title, :subtitle, :chart_type, :chart_config, :analysis_controls, :no_zoom
+  attr_reader :school, :title, :subtitle, :chart_type, :chart_config, :analysis_controls, :no_zoom, :html_class
 
   include ChartHelper
 
-  def initialize(chart_type: '', school: nil, title: '', subtitle: '', chart_config: {}, analysis_controls: false, no_zoom: true)
+  def initialize(chart_type: '', school: nil, title: '', subtitle: '', chart_config: {}, analysis_controls: false, no_zoom: true, html_class: 'analysis-chart')
     @chart_type = chart_type
     @school = school
     @title = title
@@ -13,5 +13,6 @@ class ChartComponent < ViewComponent::Base
     @chart_config = chart_config
     @analysis_controls = analysis_controls
     @no_zoom = no_zoom
+    @html_class = html_class
   end
 end

--- a/app/views/schools/advice/baseload/_analysis.html.erb
+++ b/app/views/schools/advice/baseload/_analysis.html.erb
@@ -50,7 +50,7 @@
   <%= render(ChartComponent.new(chart_type: :baseload_versus_benchmarks, school: @school)) do |c| %>
     <% c.with_title { t('advice_pages.baseload.analysis.charts.long_term_baseload_chart_title') } %>
     <% c.with_subtitle { t('advice_pages.baseload.analysis.charts.long_term_baseload_chart_subtitle', start_month_year: month_year(@analysis_dates.start_date), end_month_year: month_year(@analysis_dates.end_date.last_month)) } %>
-    <% c.with_footer { raw("<p>t('advice_pages.baseload.analysis.charts.long_term_baseload_chart_explanation')</p>") } %>
+    <% c.with_footer { raw("<p>#{t('advice_pages.baseload.analysis.charts.long_term_baseload_chart_explanation')}</p>") } %>
   <% end %>
 
   <!--  METER BREAKDOWN TABLE -->

--- a/app/views/schools/advice/baseload/_analysis.html.erb
+++ b/app/views/schools/advice/baseload/_analysis.html.erb
@@ -29,7 +29,7 @@
   <%= render(ChartComponent.new(chart_type: :baseload_lastyear, school: @school)) do |c| %>
     <% c.with_title { t('advice_pages.baseload.analysis.charts.baseload_chart_title', months_analysed: @analysis_dates.months_analysed) } %>
     <% c.with_subtitle { t('advice_pages.baseload.analysis.charts.baseload_chart_subtitle', start_month_year: month_year(@analysis_dates.one_years_data ? @analysis_dates.end_date - 1.year : @analysis_dates.start_date), end_month_year: month_year(@analysis_dates.end_date)) } %>
-    <% c.with_footer { t('advice_pages.baseload.analysis.charts.baseload_chart_explanation') } %>
+    <% c.with_footer { raw("<p>#{t('advice_pages.baseload.analysis.charts.baseload_chart_explanation')}</p>") } %>
   <% end %>
 
   <% if @multiple_meters %>
@@ -50,7 +50,7 @@
   <%= render(ChartComponent.new(chart_type: :baseload_versus_benchmarks, school: @school)) do |c| %>
     <% c.with_title { t('advice_pages.baseload.analysis.charts.long_term_baseload_chart_title') } %>
     <% c.with_subtitle { t('advice_pages.baseload.analysis.charts.long_term_baseload_chart_subtitle', start_month_year: month_year(@analysis_dates.start_date), end_month_year: month_year(@analysis_dates.end_date.last_month)) } %>
-    <% c.with_footer { t('advice_pages.baseload.analysis.charts.long_term_baseload_chart_explanation') } %>
+    <% c.with_footer { raw("<p>t('advice_pages.baseload.analysis.charts.long_term_baseload_chart_explanation')</p>") } %>
   <% end %>
 
   <!--  METER BREAKDOWN TABLE -->

--- a/app/views/schools/advice/baseload/_analysis.html.erb
+++ b/app/views/schools/advice/baseload/_analysis.html.erb
@@ -26,7 +26,7 @@
 
   <%= render 'assessment', estimated_savings_vs_benchmark: @estimated_savings_vs_benchmark, estimated_savings_vs_exemplar: @estimated_savings_vs_exemplar %>
 
-  <%= render(ChartComponent.new(chart_type: :baseload_lastyear, school: @school, chart_config: create_chart_config(@school, :baseload_lastyear))) do |c| %>
+  <%= render(ChartComponent.new(chart_type: :baseload_lastyear, school: @school)) do |c| %>
     <% c.with_title { t('advice_pages.baseload.analysis.charts.baseload_chart_title', months_analysed: @analysis_dates.months_analysed) } %>
     <% c.with_subtitle { t('advice_pages.baseload.analysis.charts.baseload_chart_subtitle', start_month_year: month_year(@analysis_dates.one_years_data ? @analysis_dates.end_date - 1.year : @analysis_dates.start_date), end_month_year: month_year(@analysis_dates.end_date)) } %>
     <% c.with_footer { t('advice_pages.baseload.analysis.charts.baseload_chart_explanation') } %>
@@ -47,7 +47,7 @@
 
   <%= render 'long_term_trends_table', annual_average_baseloads: @annual_average_baseloads %>
 
-  <%= render(ChartComponent.new(chart_type: :baseload_versus_benchmarks, school: @school, chart_config: create_chart_config(@school, :baseload_versus_benchmarks))) do |c| %>
+  <%= render(ChartComponent.new(chart_type: :baseload_versus_benchmarks, school: @school)) do |c| %>
     <% c.with_title { t('advice_pages.baseload.analysis.charts.long_term_baseload_chart_title') } %>
     <% c.with_subtitle { t('advice_pages.baseload.analysis.charts.long_term_baseload_chart_subtitle', start_month_year: month_year(@analysis_dates.start_date), end_month_year: month_year(@analysis_dates.end_date.last_month)) } %>
     <% c.with_footer { t('advice_pages.baseload.analysis.charts.long_term_baseload_chart_explanation') } %>

--- a/app/views/schools/advice/baseload/_analysis.html.erb
+++ b/app/views/schools/advice/baseload/_analysis.html.erb
@@ -29,7 +29,9 @@
   <%= render(ChartComponent.new(chart_type: :baseload_lastyear, school: @school)) do |c| %>
     <% c.with_title { t('advice_pages.baseload.analysis.charts.baseload_chart_title', months_analysed: @analysis_dates.months_analysed) } %>
     <% c.with_subtitle { t('advice_pages.baseload.analysis.charts.baseload_chart_subtitle', start_month_year: month_year(@analysis_dates.one_years_data ? @analysis_dates.end_date - 1.year : @analysis_dates.start_date), end_month_year: month_year(@analysis_dates.end_date)) } %>
-    <% c.with_footer { raw("<p>#{t('advice_pages.baseload.analysis.charts.baseload_chart_explanation')}</p>") } %>
+    <% c.with_footer do %>
+      <p><%= t('advice_pages.baseload.analysis.charts.baseload_chart_explanation') %></p>
+    <% end %>
   <% end %>
 
   <% if @multiple_meters %>
@@ -50,7 +52,9 @@
   <%= render(ChartComponent.new(chart_type: :baseload_versus_benchmarks, school: @school)) do |c| %>
     <% c.with_title { t('advice_pages.baseload.analysis.charts.long_term_baseload_chart_title') } %>
     <% c.with_subtitle { t('advice_pages.baseload.analysis.charts.long_term_baseload_chart_subtitle', start_month_year: month_year(@analysis_dates.start_date), end_month_year: month_year(@analysis_dates.end_date.last_month)) } %>
-    <% c.with_footer { raw("<p>#{t('advice_pages.baseload.analysis.charts.long_term_baseload_chart_explanation')}</p>") } %>
+    <% c.with_footer do %>
+      <p><%= t('advice_pages.baseload.analysis.charts.long_term_baseload_chart_explanation') %></p>
+    <% end %>
   <% end %>
 
   <!--  METER BREAKDOWN TABLE -->

--- a/app/views/schools/advice/baseload/_analysis.html.erb
+++ b/app/views/schools/advice/baseload/_analysis.html.erb
@@ -26,13 +26,13 @@
 
   <%= render 'assessment', estimated_savings_vs_benchmark: @estimated_savings_vs_benchmark, estimated_savings_vs_exemplar: @estimated_savings_vs_exemplar %>
 
-  <h4 class="chart-title"><%= t('advice_pages.baseload.analysis.charts.baseload_chart_title', months_analysed: @analysis_dates.months_analysed) %></h4>
-  <h5 class="chart-subtitle"><%= t('advice_pages.baseload.analysis.charts.baseload_chart_subtitle', start_month_year: month_year(@analysis_dates.one_years_data ? @analysis_dates.end_date - 1.year : @analysis_dates.start_date), end_month_year: month_year(@analysis_dates.end_date)) %></h5>
-
-  <div id="chart_wrapper_baseload_lastyear" class="chart-wrapper">
-    <%= render 'shared/analysis_controls', chart_type: :baseload_lastyear, axis_controls: true, analysis_controls: true %>
-    <%= chart_tag(@school, :baseload_lastyear, no_zoom: true, wrap: false, chart_config: create_chart_config(@school, :baseload_lastyear, nil)) %>
-  </div>
+  <%= render(ChartComponent.new(
+    chart_type: :baseload_lastyear,
+    school: @school,
+    title: t('advice_pages.baseload.analysis.charts.baseload_chart_title', months_analysed: @analysis_dates.months_analysed),
+    subtitle: t('advice_pages.baseload.analysis.charts.baseload_chart_subtitle', start_month_year: month_year(@analysis_dates.one_years_data ? @analysis_dates.end_date - 1.year : @analysis_dates.start_date), end_month_year: month_year(@analysis_dates.end_date)),
+    chart_config: create_chart_config(@school, :baseload_lastyear, nil)))
+  %>
 
   <p><%= t('advice_pages.baseload.analysis.charts.baseload_chart_explanation') %></p>
 

--- a/app/views/schools/advice/baseload/_analysis.html.erb
+++ b/app/views/schools/advice/baseload/_analysis.html.erb
@@ -26,15 +26,11 @@
 
   <%= render 'assessment', estimated_savings_vs_benchmark: @estimated_savings_vs_benchmark, estimated_savings_vs_exemplar: @estimated_savings_vs_exemplar %>
 
-  <%= render(ChartComponent.new(
-    chart_type: :baseload_lastyear,
-    school: @school,
-    title: t('advice_pages.baseload.analysis.charts.baseload_chart_title', months_analysed: @analysis_dates.months_analysed),
-    subtitle: t('advice_pages.baseload.analysis.charts.baseload_chart_subtitle', start_month_year: month_year(@analysis_dates.one_years_data ? @analysis_dates.end_date - 1.year : @analysis_dates.start_date), end_month_year: month_year(@analysis_dates.end_date)),
-    chart_config: create_chart_config(@school, :baseload_lastyear)))
-  %>
-
-  <p><%= t('advice_pages.baseload.analysis.charts.baseload_chart_explanation') %></p>
+  <%= render(ChartComponent.new(chart_type: :baseload_lastyear, school: @school, chart_config: create_chart_config(@school, :baseload_lastyear))) do |c| %>
+    <% c.with_title { t('advice_pages.baseload.analysis.charts.baseload_chart_title', months_analysed: @analysis_dates.months_analysed) } %>
+    <% c.with_subtitle { t('advice_pages.baseload.analysis.charts.baseload_chart_subtitle', start_month_year: month_year(@analysis_dates.one_years_data ? @analysis_dates.end_date - 1.year : @analysis_dates.start_date), end_month_year: month_year(@analysis_dates.end_date)) } %>
+    <% c.with_footer { t('advice_pages.baseload.analysis.charts.baseload_chart_explanation') } %>
+  <% end %>
 
   <% if @multiple_meters %>
     <p><%= t('advice_pages.baseload.analysis.multiple_meters_suggestion_html', link: link_to(t('advice_pages.baseload.analysis.meter_breakdown.link_text'), '#meter-breakdown')) %></p>
@@ -51,16 +47,11 @@
 
   <%= render 'long_term_trends_table', annual_average_baseloads: @annual_average_baseloads %>
 
-  <%= render(ChartComponent.new(
-    chart_type: :baseload_versus_benchmarks,
-    school: @school,
-    title: t('advice_pages.baseload.analysis.charts.long_term_baseload_chart_title'),
-    subtitle: t('advice_pages.baseload.analysis.charts.long_term_baseload_chart_subtitle', start_month_year: month_year(@analysis_dates.start_date), end_month_year: month_year(@analysis_dates.end_date.last_month)),
-    chart_config: create_chart_config(@school, :baseload_versus_benchmarks)))
-  %>
-
-  <p><%= t('advice_pages.baseload.analysis.charts.long_term_baseload_chart_explanation') %></p>
-
+  <%= render(ChartComponent.new(chart_type: :baseload_versus_benchmarks, school: @school, chart_config: create_chart_config(@school, :baseload_versus_benchmarks))) do |c| %>
+    <% c.with_title { t('advice_pages.baseload.analysis.charts.long_term_baseload_chart_title') } %>
+    <% c.with_subtitle { t('advice_pages.baseload.analysis.charts.long_term_baseload_chart_subtitle', start_month_year: month_year(@analysis_dates.start_date), end_month_year: month_year(@analysis_dates.end_date.last_month)) } %>
+    <% c.with_footer { t('advice_pages.baseload.analysis.charts.long_term_baseload_chart_explanation') } %>
+  <% end %>
 
   <!--  METER BREAKDOWN TABLE -->
 

--- a/app/views/schools/advice/baseload/_analysis.html.erb
+++ b/app/views/schools/advice/baseload/_analysis.html.erb
@@ -31,7 +31,7 @@
     school: @school,
     title: t('advice_pages.baseload.analysis.charts.baseload_chart_title', months_analysed: @analysis_dates.months_analysed),
     subtitle: t('advice_pages.baseload.analysis.charts.baseload_chart_subtitle', start_month_year: month_year(@analysis_dates.one_years_data ? @analysis_dates.end_date - 1.year : @analysis_dates.start_date), end_month_year: month_year(@analysis_dates.end_date)),
-    chart_config: create_chart_config(@school, :baseload_lastyear, nil)))
+    chart_config: create_chart_config(@school, :baseload_lastyear)))
   %>
 
   <p><%= t('advice_pages.baseload.analysis.charts.baseload_chart_explanation') %></p>
@@ -51,13 +51,13 @@
 
   <%= render 'long_term_trends_table', annual_average_baseloads: @annual_average_baseloads %>
 
-  <h4 class="chart-title"><%= t('advice_pages.baseload.analysis.charts.long_term_baseload_chart_title') %></h4>
-  <h5 class="chart-subtitle"><%= t('advice_pages.baseload.analysis.charts.long_term_baseload_chart_subtitle', start_month_year: month_year(@analysis_dates.start_date), end_month_year: month_year(@analysis_dates.end_date.last_month)) %></h5>
-
-  <div id="chart_wrapper_baseload_versus_benchmarks" class="chart-wrapper">
-    <%= render 'shared/analysis_controls', chart_type: :baseload_versus_benchmarks, axis_controls: true, analysis_controls: true %>
-    <%= chart_tag(@school, :baseload_versus_benchmarks, no_zoom: true, wrap: false, chart_config: create_chart_config(@school, :baseload_versus_benchmarks, nil)) %>
-  </div>
+  <%= render(ChartComponent.new(
+    chart_type: :baseload_versus_benchmarks,
+    school: @school,
+    title: t('advice_pages.baseload.analysis.charts.long_term_baseload_chart_title'),
+    subtitle: t('advice_pages.baseload.analysis.charts.long_term_baseload_chart_subtitle', start_month_year: month_year(@analysis_dates.start_date), end_month_year: month_year(@analysis_dates.end_date.last_month)),
+    chart_config: create_chart_config(@school, :baseload_versus_benchmarks)))
+  %>
 
   <p><%= t('advice_pages.baseload.analysis.charts.long_term_baseload_chart_explanation') %></p>
 

--- a/app/views/schools/advice/baseload/_meter_breakdown_charts.html.erb
+++ b/app/views/schools/advice/baseload/_meter_breakdown_charts.html.erb
@@ -13,10 +13,5 @@
     </div>
   <% end %>
 
-  <%= render(ChartComponent.new(
-    chart_type: :baseload,
-    school: school,
-    html_class: 'usage-chart',
-    chart_config: create_chart_config(school, :baseload, meters.first.mpan_mprn)))
-  %>
+  <%= render(ChartComponent.new(chart_type: :baseload, school: school, html_class: 'usage-chart', chart_config: create_chart_config(school, :baseload, meters.first.mpan_mprn))) %>
 </div>

--- a/app/views/schools/advice/baseload/_meter_breakdown_charts.html.erb
+++ b/app/views/schools/advice/baseload/_meter_breakdown_charts.html.erb
@@ -13,10 +13,10 @@
     </div>
   <% end %>
 
-  <div class="row">
-    <div class="col-md-12 chart-wrapper" id="chart_wrapper_baseload">
-      <%= render 'shared/analysis_controls', chart_type: :baseload, axis_controls: true, analysis_controls: true %>
-      <%= chart_tag(school, :baseload, no_zoom: true, wrap: false, html_class: 'usage-chart', chart_config: create_chart_config(school, :baseload, @meters.first.mpan_mprn)) %>
-    </div>
-  </div>
+  <%= render(ChartComponent.new(
+    chart_type: :baseload,
+    school: school,
+    html_class: 'usage-chart',
+    chart_config: create_chart_config(school, :baseload, meters.first.mpan_mprn)))
+  %>
 </div>

--- a/spec/components/chart_component_spec.rb
+++ b/spec/components/chart_component_spec.rb
@@ -23,14 +23,14 @@ RSpec.describe ChartComponent, type: :component, include_url_helpers: true do
       render_inline ChartComponent.new(**params) do |c|
         c.with_title    { "I'm a title" }
         c.with_subtitle { "I'm a subtitle" }
-        c.with_header   { "I'm a header" }
-        c.with_footer   { "I'm a footer" }
+        c.with_header   { "<strong>I'm a header</strong>".html_safe }
+        c.with_footer   { "<small>I'm a footer</small>".html_safe }
       end
     end
     it { expect(html).to have_selector("h4", text: "I'm a title") }
     it { expect(html).to have_selector("h4", id: "chart_baseload_title") }
     it { expect(html).to have_selector("h5", text: "I'm a subtitle") }
-    it { expect(html).to have_selector("p", text: "I'm a header") }
-    it { expect(html).to have_selector("p", text: "I'm a footer") }
+    it { expect(html).to have_selector("strong", text: "I'm a header") }
+    it { expect(html).to have_selector("small", text: "I'm a footer") }
   end
 end

--- a/spec/components/chart_component_spec.rb
+++ b/spec/components/chart_component_spec.rb
@@ -4,15 +4,25 @@ require "rails_helper"
 
 RSpec.describe ChartComponent, type: :component, include_url_helpers: true do
   let(:school) { create(:school) }
-  let(:html) { render_inline(ChartComponent.new(**params)) }
   let(:chart_type) { :baseload }
-  let(:all_params) { { school: school, chart_type: chart_type, title: 'Title text', subtitle: 'Subtitle text', html_class: 'usage-chart' } }
+  let(:params) { { school: school, chart_type: chart_type, title: 'Title text', subtitle: 'Subtitle text', html_class: 'usage-chart' } }
 
   context "with all params" do
-    let(:params) { all_params }
+    let(:html) { render_inline(ChartComponent.new(**params)) }
     it { expect(html).to have_selector("h4", text: "Title text") }
     it { expect(html).to have_selector("h5", text: "Subtitle text") }
     it { expect(html).to have_selector("div", id: "chart_wrapper_baseload") }
     it { expect(html).to have_selector("div", class: "usage-chart") }
+  end
+
+  context "with header and footer slots" do
+    let(:html) do
+      render_inline ChartComponent.new(**params) do |c|
+        c.with_header { "I'm a header" }
+        c.with_footer { "I'm a footer" }
+      end
+    end
+    it { expect(html).to have_selector("p", text: "I'm a header") }
+    it { expect(html).to have_selector("p", text: "I'm a footer") }
   end
 end

--- a/spec/components/chart_component_spec.rb
+++ b/spec/components/chart_component_spec.rb
@@ -9,8 +9,13 @@ RSpec.describe ChartComponent, type: :component, include_url_helpers: true do
 
   context "with all params" do
     let(:html) { render_inline(ChartComponent.new(**params)) }
+
     it { expect(html).to have_selector("div", id: "chart_wrapper_baseload") }
     it { expect(html).to have_selector("div", class: "usage-chart") }
+
+    it 'sets up chart config data attribute' do
+      expect(html).to have_selector("div", id: 'chart_baseload') { |d| JSON.parse(d['data-chart-config'])['type'] == 'baseload' }
+    end
   end
 
   context "with title, subtitle, header and footer slots" do
@@ -23,6 +28,7 @@ RSpec.describe ChartComponent, type: :component, include_url_helpers: true do
       end
     end
     it { expect(html).to have_selector("h4", text: "I'm a title") }
+    it { expect(html).to have_selector("h4", id: "chart_baseload_title") }
     it { expect(html).to have_selector("h5", text: "I'm a subtitle") }
     it { expect(html).to have_selector("p", text: "I'm a header") }
     it { expect(html).to have_selector("p", text: "I'm a footer") }

--- a/spec/components/chart_component_spec.rb
+++ b/spec/components/chart_component_spec.rb
@@ -6,12 +6,13 @@ RSpec.describe ChartComponent, type: :component, include_url_helpers: true do
   let(:school) { create(:school) }
   let(:html) { render_inline(ChartComponent.new(**params)) }
   let(:chart_type) { :baseload }
-  let(:all_params) { { school: school, chart_type: chart_type, title: 'Title text', subtitle: 'Subtitle text' } }
+  let(:all_params) { { school: school, chart_type: chart_type, title: 'Title text', subtitle: 'Subtitle text', html_class: 'usage-chart' } }
 
   context "with all params" do
     let(:params) { all_params }
     it { expect(html).to have_selector("h4", text: "Title text") }
     it { expect(html).to have_selector("h5", text: "Subtitle text") }
     it { expect(html).to have_selector("div", id: "chart_wrapper_baseload") }
+    it { expect(html).to have_selector("div", class: "usage-chart") }
   end
 end

--- a/spec/components/chart_component_spec.rb
+++ b/spec/components/chart_component_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe ChartComponent, type: :component, include_url_helpers: true do
       end
     end
     it { expect(html).to have_selector("h4", text: "I'm a title") }
-    it { expect(html).to have_selector("h4", id: "chart_baseload_title") }
+    it { expect(html).to have_selector("h4", id: "chart-section-baseload") }
     it { expect(html).to have_selector("h5", text: "I'm a subtitle") }
     it { expect(html).to have_selector("strong", text: "I'm a header") }
     it { expect(html).to have_selector("small", text: "I'm a footer") }

--- a/spec/components/chart_component_spec.rb
+++ b/spec/components/chart_component_spec.rb
@@ -20,8 +20,8 @@ RSpec.describe ChartComponent, type: :component, include_url_helpers: true do
     end
   end
 
-  context "with no params" do
-    let(:html) { render_inline(ChartComponent.new) }
+  context "with bad chart type" do
+    let(:html) { render_inline(ChartComponent.new(school: school, chart_type: 'wibble')) }
 
     it 'shows an error message' do
       expect(html).to have_text("The chart can't be displayed")

--- a/spec/components/chart_component_spec.rb
+++ b/spec/components/chart_component_spec.rb
@@ -20,6 +20,14 @@ RSpec.describe ChartComponent, type: :component, include_url_helpers: true do
     end
   end
 
+  context "with no params" do
+    let(:html) { render_inline(ChartComponent.new) }
+
+    it 'shows an error message' do
+      expect(html).to have_text("The chart can't be displayed")
+    end
+  end
+
   context "with title, subtitle, header and footer slots" do
     let(:html) do
       render_inline ChartComponent.new(**params) do |c|

--- a/spec/components/chart_component_spec.rb
+++ b/spec/components/chart_component_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ChartComponent, type: :component, include_url_helpers: true do
+  let(:school) { create(:school) }
+  let(:html) { render_inline(ChartComponent.new(**params)) }
+  let(:chart_type) { :baseload }
+  let(:all_params) { { school: school, chart_type: chart_type, title: 'Title text', subtitle: 'Subtitle text' } }
+
+  context "with all params" do
+    let(:params) { all_params }
+    it { expect(html).to have_selector("h4", text: "Title text") }
+    it { expect(html).to have_selector("h5", text: "Subtitle text") }
+    it { expect(html).to have_selector("div", id: "chart_wrapper_baseload") }
+  end
+end

--- a/spec/components/chart_component_spec.rb
+++ b/spec/components/chart_component_spec.rb
@@ -10,6 +10,8 @@ RSpec.describe ChartComponent, type: :component, include_url_helpers: true do
   context "with all params" do
     let(:html) { render_inline(ChartComponent.new(**params)) }
 
+    it { expect(html).not_to have_selector("h4") }
+    it { expect(html).not_to have_selector("h5") }
     it { expect(html).to have_selector("div", id: "chart_wrapper_baseload") }
     it { expect(html).to have_selector("div", class: "usage-chart") }
 

--- a/spec/components/chart_component_spec.rb
+++ b/spec/components/chart_component_spec.rb
@@ -5,23 +5,25 @@ require "rails_helper"
 RSpec.describe ChartComponent, type: :component, include_url_helpers: true do
   let(:school) { create(:school) }
   let(:chart_type) { :baseload }
-  let(:params) { { school: school, chart_type: chart_type, title: 'Title text', subtitle: 'Subtitle text', html_class: 'usage-chart' } }
+  let(:params) { { school: school, chart_type: chart_type, html_class: 'usage-chart' } }
 
   context "with all params" do
     let(:html) { render_inline(ChartComponent.new(**params)) }
-    it { expect(html).to have_selector("h4", text: "Title text") }
-    it { expect(html).to have_selector("h5", text: "Subtitle text") }
     it { expect(html).to have_selector("div", id: "chart_wrapper_baseload") }
     it { expect(html).to have_selector("div", class: "usage-chart") }
   end
 
-  context "with header and footer slots" do
+  context "with title, subtitle, header and footer slots" do
     let(:html) do
       render_inline ChartComponent.new(**params) do |c|
-        c.with_header { "I'm a header" }
-        c.with_footer { "I'm a footer" }
+        c.with_title    { "I'm a title" }
+        c.with_subtitle { "I'm a subtitle" }
+        c.with_header   { "I'm a header" }
+        c.with_footer   { "I'm a footer" }
       end
     end
+    it { expect(html).to have_selector("h4", text: "I'm a title") }
+    it { expect(html).to have_selector("h5", text: "I'm a subtitle") }
     it { expect(html).to have_selector("p", text: "I'm a header") }
     it { expect(html).to have_selector("p", text: "I'm a footer") }
   end


### PR DESCRIPTION
A chart component allows charts to be added to a page, specifying a chart type, school, and chart config.

Some other parameters (analysis controls, zoom, html class) can also be provided.

The title, subtitle, header and footer text can be optionally added - implemented as slots.

The title tag has an id to enable linking to that specific chart.
