### PR TITLE
Allow relative links

### DIFF
--- a/app/assets/javascripts/trix_customisations.js
+++ b/app/assets/javascripts/trix_customisations.js
@@ -24,5 +24,5 @@ addEventListener("trix-initialize", event => {
   const { toolbarElement } = event.target
   const inputElement = toolbarElement.querySelector("input[name=href]")
   inputElement.type = "text"
-  inputElement.pattern = "(https?://|/).+"
+  inputElement.pattern = "(https?://|/|\.\./).+"
 })


### PR DESCRIPTION
Change the validation for links to properly support relative paths.

Required to support links to other analysis pages and page sections from the advice page editor.
