### PR TITLE
Create notice view component

### DIFF
--- a/app/assets/stylesheets/advice_page.scss
+++ b/app/assets/stylesheets/advice_page.scss
@@ -43,16 +43,3 @@
 .advice-table-caption {
   margin-bottom: 40px;
 }
-
-.advice-page-notice {
-  background-color: #f8f9fa !important;
-  &.negative {
-    border-left: 5px solid $new-red;
-  }
-  &.positive {
-    border-left: 5px solid $green;
-  }
-  &.neutral {
-    border-left: 5px solid $electric-light;
-  }
-}

--- a/app/components/notice_component.html.erb
+++ b/app/components/notice_component.html.erb
@@ -1,0 +1,6 @@
+<div class="p-4 advice-page-notice neutral">
+  <%= content %>
+  <div class="text-right">
+    <%= link_to link_name, href %>
+  </div>
+</div>

--- a/app/components/notice_component.html.erb
+++ b/app/components/notice_component.html.erb
@@ -1,6 +1,8 @@
-<div class="p-4 advice-page-notice neutral">
+<div class="p-4 page-notice<%= classes %>">
   <%= content %>
-  <div class="text-right">
-    <%= link_to link_name, href %>
-  </div>
+  <% if link %>
+    <div class="text-right">
+      <%= link %>
+    </div>
+  <% end %>
 </div>

--- a/app/components/notice_component.rb
+++ b/app/components/notice_component.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class NoticeComponent < ViewComponent::Base
+  attr_reader :status, :classes, :link_name, :href
+
+  def initialize(status:, classes: nil, link_name: nil, href: nil)
+    @status = status
+    @classes = classes
+    @link_name = link_name
+    @href = href
+  end
+end

--- a/app/components/notice_component.rb
+++ b/app/components/notice_component.rb
@@ -1,12 +1,33 @@
 # frozen_string_literal: true
 
 class NoticeComponent < ViewComponent::Base
-  attr_reader :status, :classes, :link_name, :href
+  renders_one :link
 
-  def initialize(status:, classes: nil, link_name: nil, href: nil)
-    @status = status
+  def initialize(status:, classes: nil)
     @classes = classes
-    @link_name = link_name
-    @href = href
+    @status = status
+    validate
+  end
+
+  def validate
+    raise ArgumentError.new(self.class.status_error) unless self.class.statuses.include?(@status.to_sym)
+  end
+
+  def classes
+    classes = " #{@status}"
+    classes += " #{@classes}" if @classes
+    classes
+  end
+
+  def render?
+    content
+  end
+
+  def self.statuses
+    [:positive, :negative, :neutral]
+  end
+
+  def self.status_error
+    "Status must be: " + self.statuses.to_sentence(last_word_connector: ' or ')
   end
 end

--- a/app/components/notice_component.scss
+++ b/app/components/notice_component.scss
@@ -1,0 +1,12 @@
+.page-notice {
+  background-color: #f8f9fa !important;
+  &.negative {
+    border-left: 5px solid $new-red;
+  }
+  &.positive {
+    border-left: 5px solid $green;
+  }
+  &.neutral {
+    border-left: 5px solid $electric-light;
+  }
+}

--- a/app/components/notice_component.scss
+++ b/app/components/notice_component.scss
@@ -1,5 +1,5 @@
 .page-notice {
-  background-color: #f8f9fa !important;
+  background-color: $light !important;
   &.negative {
     border-left: 5px solid $new-red;
   }

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -431,7 +431,7 @@ module ApplicationHelper
   end
 
   def component(name, *args, **kwargs, &block)
-    component = "#{name.to_s.camelize}Component".constantize
+    component = name.to_s.sub(%r{(/|$)}, '_component\1').camelize.constantize
     render(component.new(*args, **kwargs), &block)
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -429,4 +429,9 @@ module ApplicationHelper
   def text_with_icon(text, icon)
     (icon ? "#{fa_icon(icon)} #{text}" : text).html_safe
   end
+
+  def component(name, *args, **kwargs, &block)
+    component = "#{name.to_s.camelize}Component".constantize
+    render(component.new(*args, **kwargs), &block)
+  end
 end

--- a/app/views/schools/advice/_advice_page.html.erb
+++ b/app/views/schools/advice/_advice_page.html.erb
@@ -1,7 +1,7 @@
 <% content_for :page_title, "#{t("advice_pages.#{advice_page.key}.page_title")} | #{school.name}" %>
 
 <div class="advice-page-breadcrumb">
-  <%= render(BreadcrumbsComponent.new) do |c| %>
+  <%= component 'breadcrumbs' do |c| %>
     <% c.with_school(school) %>
     <% c.with_items([ { name: t('advice_pages.breadcrumbs.root'), href: school_advice_path(school) },
                       { name: t("advice_pages.nav.sections.#{advice_page.fuel_type}"), visible: advice_page.fuel_type },

--- a/app/views/schools/advice/_advice_tabs.html.erb
+++ b/app/views/schools/advice/_advice_tabs.html.erb
@@ -1,6 +1,6 @@
 <ul class="nav nav-tabs locales">
   <li class="nav-item d-md-none">
-    <%= component 'page_nav::collapse_button' %>
+    <%= component 'page_nav/collapse_button' %>
   </li>
   <li class="nav-item">
     <a class="nav-link <%= 'active' if tab == :insights %>" href="<%= advice_page_path(school, advice_page, :insights) %>">

--- a/app/views/schools/advice/_advice_tabs.html.erb
+++ b/app/views/schools/advice/_advice_tabs.html.erb
@@ -1,6 +1,6 @@
 <ul class="nav nav-tabs locales">
   <li class="nav-item d-md-none">
-    <%= render(PageNavComponent::CollapseButton.new) %>
+    <%= component 'page_nav::collapse_button' %>
   </li>
   <li class="nav-item">
     <a class="nav-link <%= 'active' if tab == :insights %>" href="<%= advice_page_path(school, advice_page, :insights) %>">

--- a/app/views/schools/advice/_data_warning.html.erb
+++ b/app/views/schools/advice/_data_warning.html.erb
@@ -1,3 +1,3 @@
-<div class="p-4 advice-page-notice negative">
-  <p><%= t('advice_pages.error.data_warning', fuel_type: fuel_type) %></p>
-</div>
+<%= component 'notice', status: :negative do |c| %>
+  <%= t('advice_pages.error.data_warning', fuel_type: fuel_type) %>
+<% end %>

--- a/app/views/schools/advice/_nav.html.erb
+++ b/app/views/schools/advice/_nav.html.erb
@@ -1,4 +1,4 @@
-<%= render(PageNavComponent.new(name: t('advice_pages.nav.name'), icon: 'home', href: school_advice_path(@school), options: { match_controller: true })) do |c| %>
+<%= component 'page_nav', name: t('advice_pages.nav.name'), icon: 'home', href: school_advice_path(@school), options: { match_controller: true } do |c| %>
   <% c.with_section do |s| %>
     <% s.with_item(name: t('advice_pages.nav.pages.total_energy_use'), href: school_advice_total_energy_use_path(@school)) %>
   <% end %>

--- a/app/views/schools/advice/advice_base/error.html.erb
+++ b/app/views/schools/advice/advice_base/error.html.erb
@@ -12,7 +12,7 @@
     <%= render 'schools/advice/nav', school: @school, advice_pages: @advice_pages %>
   </div>
   <div class="col-md-9 col-lg-9 col-xl-10 advice-page-tabs">
-    <h2><%= component 'page_nav::collapse_button', display: 'inline' %><%= t('advice_pages.error.title') %></h2>
+    <h2><%= component 'page_nav/collapse_button', display: 'inline' %><%= t('advice_pages.error.title') %></h2>
     <p><%= t('advice_pages.error.message') %></p>
   </div>
 </div>

--- a/app/views/schools/advice/advice_base/error.html.erb
+++ b/app/views/schools/advice/advice_base/error.html.erb
@@ -1,5 +1,5 @@
 <div class="advice-page-breadcrumb">
-  <%= render(BreadcrumbsComponent.new) do |c| %>
+  <%= component 'breadcrumbs' do |c| %>
     <% c.with_school(@school) %>
     <% c.with_items([{ name: t('advice_pages.breadcrumbs.root'), href: school_advice_path(@school) }]) %>
   <% end %>
@@ -12,7 +12,7 @@
     <%= render 'schools/advice/nav', school: @school, advice_pages: @advice_pages %>
   </div>
   <div class="col-md-9 col-lg-9 col-xl-10 advice-page-tabs">
-    <h2><%= render(PageNavComponent::CollapseButton.new(display: 'inline')) %><%= t('advice_pages.error.title') %></h2>
+    <h2><%= component 'page_nav::collapse_button', display: 'inline' %><%= t('advice_pages.error.title') %></h2>
     <p><%= t('advice_pages.error.message') %></p>
   </div>
 </div>

--- a/app/views/schools/advice/advice_base/insights.html.erb
+++ b/app/views/schools/advice/advice_base/insights.html.erb
@@ -7,7 +7,7 @@
   <%= render 'schools/advice/section_title', section_id: 'recommendations', section_title: t('advice_pages.insights.recommendations.title') %>
   <p><%= t("advice_pages.#{@advice_page.key}.insights.next_steps") %></p>
 
-  <%= render(RecommendationsComponent.new(recommendations: @activity_types, title: t("advice_pages.insights.recommendations.activities_title"), classes: 'pb-4')) %>
+  <%= component 'recommendations', recommendations: @activity_types, title: t("advice_pages.insights.recommendations.activities_title"), classes: 'pb-4' %>
 
-  <%= render(RecommendationsComponent.new(recommendations: @intervention_types, title: t("advice_pages.insights.recommendations.actions_title"), classes: 'pb-4')) %>
+  <%= component 'recommendations', recommendations: @intervention_types, title: t("advice_pages.insights.recommendations.actions_title"), classes: 'pb-4' %>
 <% end %>

--- a/app/views/schools/advice/baseload/_assessment.html.erb
+++ b/app/views/schools/advice/baseload/_assessment.html.erb
@@ -1,16 +1,14 @@
 <% if advice_baseload_high?(estimated_savings_vs_benchmark.£) %>
-  <div class="p-4 advice-page-notice negative">
+  <%= component 'notice', status: :negative do %>
     <p><%= t('advice_pages.baseload.analysis.baseload_high') %></p>
     <p><%= t('advice_pages.baseload.analysis.baseload_high_details_html', estimated_savings: format_unit(estimated_savings_vs_benchmark.£, :£)) %></p>
-  </div>
+  <% end %>
 <% else %>
-  <div class="p-4 advice-page-notice positive">
+  <%= component 'notice', status: :positive do %>
     <p><%= t('advice_pages.baseload.analysis.baseload_low') %></p>
     <p><%= t('advice_pages.baseload.analysis.baseload_low_details_html', estimated_savings: format_unit(estimated_savings_vs_benchmark.£.abs, :£)) %></p>
-    <p>
     <% if estimated_savings_vs_exemplar.£ > 0.0 %>
-      <%= t('advice_pages.baseload.analysis.baseload_low_extra_savings_html', estimated_savings: format_unit(estimated_savings_vs_exemplar.£, :£)) %>
-    <% end %>
-    </p>
-  </div>
+      <p><%= t('advice_pages.baseload.analysis.baseload_low_extra_savings_html', estimated_savings: format_unit(estimated_savings_vs_exemplar.£, :£)) %>
+    <% end %></p>
+  <% end %>
 <% end %>

--- a/app/views/schools/advice/baseload/_what_is_baseload.html.erb
+++ b/app/views/schools/advice/baseload/_what_is_baseload.html.erb
@@ -1,6 +1,4 @@
-<%= render(NoticeComponent.new(
-    status: 'neutral',
-    link_name: t('advice_pages.baseload.what_is_baseload_link'),
-    href: learn_more_school_advice_baseload_path(school))) do %>
+<%= component 'notice', status: :neutral do |c| %>
+  <% c.with_link { link_to t('advice_pages.baseload.what_is_baseload_link'), learn_more_school_advice_baseload_path(school) } %>
   <%= t('advice_pages.baseload.what_is_baseload_html') %>
 <% end %>

--- a/app/views/schools/advice/baseload/_what_is_baseload.html.erb
+++ b/app/views/schools/advice/baseload/_what_is_baseload.html.erb
@@ -1,6 +1,6 @@
-<div class="p-4 advice-page-notice neutral">
+<%= render(NoticeComponent.new(
+    status: 'neutral',
+    link_name: t('advice_pages.baseload.what_is_baseload_link'),
+    href: learn_more_school_advice_baseload_path(school))) do %>
   <%= t('advice_pages.baseload.what_is_baseload_html') %>
-  <div class="text-right">
-    <a href="<%= learn_more_school_advice_baseload_path(school) %>"><%= t('advice_pages.baseload.what_is_baseload_link') %></a>
-  </div>
-</div>
+<% end %>

--- a/app/views/schools/advice/show.html.erb
+++ b/app/views/schools/advice/show.html.erb
@@ -1,5 +1,5 @@
 <div class="advice-page-breadcrumb">
-  <%= render(BreadcrumbsComponent.new) do |c| %>
+  <%= component 'breadcrumbs' do |c| %>
     <% c.with_school(@school) %>
     <% c.with_items([{ name: t('advice_pages.breadcrumbs.root'), href: school_advice_path(@school) }]) %>
   <% end %>
@@ -12,7 +12,7 @@
     <%= render 'nav', school: @school, advice_pages: @advice_pages %>
   </div>
   <div class="col-md-9 col-lg-9 col-xl-10 advice-page-tabs">
-    <h2><%= render(PageNavComponent::CollapseButton.new(display: 'inline')) %> All pages</h2>
+    <h2><%= component 'page_nav::collapse_button', display: 'inline' %> All pages</h2>
     <% if @advice_pages.any? %>
       <% @advice_pages.each do |advice_page| %>
         <li><%= link_to advice_page.key, advice_page_path(@school, advice_page) %></li>

--- a/app/views/schools/advice/show.html.erb
+++ b/app/views/schools/advice/show.html.erb
@@ -12,7 +12,7 @@
     <%= render 'nav', school: @school, advice_pages: @advice_pages %>
   </div>
   <div class="col-md-9 col-lg-9 col-xl-10 advice-page-tabs">
-    <h2><%= component 'page_nav::collapse_button', display: 'inline' %> All pages</h2>
+    <h2><%= component 'page_nav/collapse_button', display: 'inline' %> All pages</h2>
     <% if @advice_pages.any? %>
       <% @advice_pages.each do |advice_page| %>
         <li><%= link_to advice_page.key, advice_page_path(@school, advice_page) %></li>

--- a/spec/components/notice_component_spec.rb
+++ b/spec/components/notice_component_spec.rb
@@ -1,15 +1,60 @@
 # frozen_string_literal: true
-
 require "rails_helper"
+include ActionView::Helpers::UrlHelper
 
-RSpec.describe NoticeComponent, type: :component do
-  pending "add some examples to (or delete) #{__FILE__}"
+RSpec.describe NoticeComponent, type: :component, include_application_helper: true do
+  let(:all_params) { { status: :neutral, classes: 'extra-classes' } }
+  let(:params) { all_params }
+  let(:content) { "<p>Content</p>" }
+  let(:link) { link_to 'Link text', 'href' }
 
-  # it "renders something useful" do
-  #   expect(
-  #     render_inline(described_class.new(attr: "value")) { "Hello, components!" }.css("p").to_html
-  #   ).to include(
-  #     "Hello, components!"
-  #   )
-  # end
+  context "with all params" do
+    let(:html) do
+      render_inline(NoticeComponent.new(**params)) do |c|
+        c.with_link { link }
+        content
+      end
+    end
+    it "has the status class" do
+      expect(html).to have_css('div.page-notice.neutral')
+    end
+    it "has additional classes" do
+      expect(html).to have_css('div.page-notice.extra-classes')
+    end
+    it { expect(html).to have_link("Link text", href: 'href') }
+    it { expect(html).to have_text(content) }
+
+    context "with unrecognised status" do
+      let(:params) { all_params.update(status: :unrecognised) }
+      it { expect { html }.to raise_error(ArgumentError, 'Status must be: positive, negative or neutral') }
+    end
+
+    context "with recognised statuses" do
+      [:positive, :negative, :neutral].each do |status|
+        let(:params) { all_params.update(status: status) }
+        it "should recognise #{status}" do
+          expect { html }.to_not raise_error
+        end
+      end
+    end
+  end
+
+  context "with no link" do
+    let(:html) do
+      render_inline(NoticeComponent.new(**params)) do |c|
+        content
+      end
+    end
+    it { expect(html).to have_text(content) }
+    it { expect(html).to_not have_link("Link text", href: 'href') }
+  end
+
+  context "with no content" do
+    let(:html) do
+      render_inline(NoticeComponent.new(**params)) do |c|
+        c.with_link { link }
+      end
+    end
+    it { expect(html.to_html).to be_blank }
+  end
 end

--- a/spec/components/notice_component_spec.rb
+++ b/spec/components/notice_component_spec.rb
@@ -1,12 +1,11 @@
 # frozen_string_literal: true
 require "rails_helper"
-include ActionView::Helpers::UrlHelper
 
 RSpec.describe NoticeComponent, type: :component, include_application_helper: true do
   let(:all_params) { { status: :neutral, classes: 'extra-classes' } }
   let(:params) { all_params }
   let(:content) { "<p>Content</p>" }
-  let(:link) { link_to 'Link text', 'href' }
+  let(:link) { ActionController::Base.helpers.link_to 'Link text', 'href' }
 
   context "with all params" do
     let(:html) do

--- a/spec/components/notice_component_spec.rb
+++ b/spec/components/notice_component_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe NoticeComponent, type: :component do
+  pending "add some examples to (or delete) #{__FILE__}"
+
+  # it "renders something useful" do
+  #   expect(
+  #     render_inline(described_class.new(attr: "value")) { "Hello, components!" }.css("p").to_html
+  #   ).to include(
+  #     "Hello, components!"
+  #   )
+  # end
+end


### PR DESCRIPTION
This PR implements the Notice Component and moves existing notices over to use the component.
As part of this, I've created a new components helper, so you are able to write the following (which I think reads better):

`<%= component 'notice', status: :negative do |c| %>
`
Rather than:
`<%= render(NoticeComponent.new(status: :negative)) do |c| %>`

Happy to move other components over to using it as part of this PR if all ok.