### PR TITLE
Update js to handle fields within chart section

### DIFF
--- a/app/assets/javascripts/usage_charts.js
+++ b/app/assets/javascripts/usage_charts.js
@@ -15,9 +15,9 @@ $(document).ready(function() {
       chartConfig.mpan_mprn = meter;
     }
 
-    var series_breakdown = $(chartDiv).find("input[name='series_breakdown']").val();
-    if (series_breakdown) {
-      chartConfig.series_breakdown = series_breakdown;
+    var seriesBreakdown = $(chartDiv).find("input[name='series_breakdown']").val();
+    if (seriesBreakdown) {
+      chartConfig.series_breakdown = seriesBreakdown;
     }
 
     chartConfig.date_ranges = getDateRanges(chartDiv);
@@ -46,13 +46,13 @@ $(document).ready(function() {
     }
 
     // maintain this order of range addition to match input order to chart order
-    var second_date = $(chartDiv).find("input[name='second-date-picker']").val();
-    if(second_date){
-      addRange(second_date, dateRanges, rangeExtension);
+    var secondDate = $(chartDiv).find("input[name='second-date-picker']").val();
+    if(secondDate){
+      addRange(secondDate, dateRanges, rangeExtension);
     }
 
-    var first_date = $(chartDiv).find("input[name='first-date-picker']").val();
-    addRange(first_date, dateRanges, rangeExtension);
+    var firstDate = $(chartDiv).find("input[name='first-date-picker']").val();
+    addRange(firstDate, dateRanges, rangeExtension);
 
     return dateRanges;
   }


### PR DESCRIPTION
This is a PR to update the javascript that displays usage charts so that multiple charts can be displayed on the same page.

Previously, the usage js functions relied on element ids (#period, #supply etc) to fetch arguments from the page markup and render charts. The PR changes to using named elements within a specified section of the page so that the chart, config and form settings can appear multiple times.

Duplicate ids shouldn't really be rendered in the page (not valid html) but that could be cleaned up in a separate PR if necessary (possibly using prefixes for any form tag input elements).