### PR TITLE
Implement dynamic chart date ranges for subtitles

### DIFF
--- a/app/assets/javascripts/analysis.js
+++ b/app/assets/javascripts/analysis.js
@@ -1,5 +1,32 @@
 "use strict";
 
+function updateDynamicTitles(titleWrapper, chartData) {
+  var titleH3 = titleWrapper.find('h3');
+  var titleH5 = titleWrapper.find('h5');
+
+  titleH3.text(chartData.title);
+  if (chartData.subtitle) {
+    titleH5.text(chartData.subtitle);
+  } else {
+    if (chartData.drilldown_available) {
+      titleH5.text(chartData.explore_message);
+    } else {
+      titleH5.text('');
+    }
+  }
+}
+
+function updateDatesInSubtitles(subTitleElement, chartData) {
+  if (chartData.subtitle_start_date) {
+    var startDateElement = $(subTitleElement).find('.start-date');
+    startDateElement.text(chartData.subtitle_start_date);
+  }
+  if (chartData.subtitle_end_date) {
+    var endDateElement = $(subTitleElement).find('.end-date');
+    endDateElement.text(chartData.subtitle_end_date);
+  }
+}
+
 function chartFailure(chart, title) {
   var $standardErrorMessage = document.getElementById('chart-error').textContent
   var $chartDiv = $(chart.renderTo);
@@ -22,27 +49,16 @@ function chartSuccess(chartConfig, chartData, chart) {
   var noAdvice = chartConfig.no_advice;
 
   var $chartWrapper = $chartDiv.parents('.chart-wrapper');
-  var titleH3 = $chartWrapper.find('h3');
-  var titleH5 = $chartWrapper.find('h5');
 
-  //move elements in component within chart-wrapper
-  //ignore h5 that has a chart-subtitle
-
-  //add extra support for chart title/subtitle discovery
-  //find them within a custom div
-  //look within the subtitle for start/end dates
-  //if we have the dates in the response, then substitute them in.
-
-  titleH3.text(chartData.title);
-
-  if (chartData.subtitle) {
-    titleH5.text(chartData.subtitle);
-  } else {
-    if (chartData.drilldown_available) {
-      titleH5.text(chartData.explore_message);
-    } else {
-      titleH5.text('');
-    }
+  //supports dynamic title elements, in which whole content is replaced
+  if ($chartWrapper.find('div.dynamic-titles').length) {
+    var $titleWrapper = $( $chartWrapper.find('div.dynamic-titles')[0] );
+    updateDynamicTitles($titleWrapper, chartData);
+  }
+  //supports injecting start/end dates from JSON response
+  if ($chartWrapper.find('.chart-subtitle').length) {
+    var $subTitle = $( $chartWrapper.find('.chart-subtitle')[0] );
+    updateDatesInSubtitles($subTitle, chartData);
   }
 
   if (! noAdvice) {

--- a/app/assets/javascripts/analysis.js
+++ b/app/assets/javascripts/analysis.js
@@ -25,6 +25,14 @@ function chartSuccess(chartConfig, chartData, chart) {
   var titleH3 = $chartWrapper.find('h3');
   var titleH5 = $chartWrapper.find('h5');
 
+  //move elements in component within chart-wrapper
+  //ignore h5 that has a chart-subtitle
+
+  //add extra support for chart title/subtitle discovery
+  //find them within a custom div
+  //look within the subtitle for start/end dates
+  //if we have the dates in the response, then substitute them in.
+
   titleH3.text(chartData.title);
 
   if (chartData.subtitle) {

--- a/app/assets/javascripts/analysis.js
+++ b/app/assets/javascripts/analysis.js
@@ -7,12 +7,10 @@ function updateDynamicTitles(titleWrapper, chartData) {
   titleH3.text(chartData.title);
   if (chartData.subtitle) {
     titleH5.text(chartData.subtitle);
+  } else if (chartData.drilldown_available) {
+    titleH5.text(chartData.explore_message);
   } else {
-    if (chartData.drilldown_available) {
-      titleH5.text(chartData.explore_message);
-    } else {
-      titleH5.text('');
-    }
+    titleH5.text('');
   }
 }
 

--- a/app/components/chart_component.html.erb
+++ b/app/components/chart_component.html.erb
@@ -1,16 +1,17 @@
 <% if valid_config? %>
 
-  <% if title %>
-    <h4 id="chart-section-<%= chart_type %>" class="chart-title"><%= title %></h4>
-  <% end %>
-
-  <% if subtitle %>
-    <h5 class="chart-subtitle"><%= subtitle %></h5>
-  <% end %>
-
-  <%= header %>
-
   <div id="chart_wrapper_<%= chart_type %>" class="chart-wrapper">
+
+    <% if title %>
+      <h4 id="chart-section-<%= chart_type %>" class="chart-title"><%= title %></h4>
+    <% end %>
+
+    <% if subtitle %>
+      <h5 class="chart-subtitle"><%= subtitle %></h5>
+    <% end %>
+
+    <%= header %>
+
     <%= render 'shared/analysis_controls', chart_type: chart_type, axis_controls: true, analysis_controls: analysis_controls %>
     <%= chart_tag(school, chart_type, no_zoom: no_zoom, wrap: false, html_class: html_class, chart_config: chart_config) %>
   </div>

--- a/app/models/chart_data_values.rb
+++ b/app/models/chart_data_values.rb
@@ -45,7 +45,6 @@ class ChartDataValues
       @y2_chart_type      = chart[:y2_chart_type]
       @annotations        = []
       @y2_axis_label = '' # Set later
-      puts transformations.inspect
       @transformations = transformations
       @allowed_operations = allowed_operations
       @drilldown_available = drilldown_available

--- a/app/models/chart_data_values.rb
+++ b/app/models/chart_data_values.rb
@@ -30,7 +30,7 @@ class ChartDataValues
       @title              = chart[:title]
       @subtitle           = chart[:subtitle]
       @x_axis_categories  = translate_categories_for(chart[:x_axis])
-      @x_axis_ranges      = chart[:x_axis_ranges] # Not actually used but range of actual dates
+      @x_axis_ranges      = chart[:x_axis_ranges]
       @x_max_value        = chart[:x_max_value]
       @x_min_value        = chart[:x_min_value]
       @chart1_type        = chart[:chart1_type]
@@ -45,6 +45,7 @@ class ChartDataValues
       @y2_chart_type      = chart[:y2_chart_type]
       @annotations        = []
       @y2_axis_label = '' # Set later
+      puts transformations.inspect
       @transformations = transformations
       @allowed_operations = allowed_operations
       @drilldown_available = drilldown_available
@@ -183,11 +184,25 @@ class ChartDataValues
       :y1_axis_choices,
       :explore_message,
       :pinch_and_zoom_message,
-      :click_and_drag_message
+      :click_and_drag_message,
+      :subtitle_start_date,
+      :subtitle_end_date
     ].inject({}) do |json, field|
       json[field] = output.public_send(field)
       json
     end
+  end
+
+  def subtitle_start_date
+    transformations_empty_or_only_move? ? format_subtitle_date(@x_axis_ranges.first.first) : nil
+  end
+
+  def subtitle_end_date
+    transformations_empty_or_only_move? ? format_subtitle_date(@x_axis_ranges.last.last) : nil
+  end
+
+  def format_subtitle_date(date)
+    date.to_s(:es_short)
   end
 
   def translated_series_item_for(series_key_as_string)
@@ -492,5 +507,14 @@ private
 
   def y2_is_rating?(y2_data_title)
     y2_data_title.casecmp('rating').zero?
+  end
+
+  def transformations_empty_or_only_move?
+    return true if @transformations.empty?
+    return true if @transformations.length == 1 && transformation_type(@transformations[0]) == :move
+  end
+
+  def transformation_type(transformation)
+    transformation.first
   end
 end

--- a/app/models/chart_data_values.rb
+++ b/app/models/chart_data_values.rb
@@ -193,10 +193,12 @@ class ChartDataValues
   end
 
   def subtitle_start_date
+    return nil unless @x_axis_ranges.present? && !@x_axis_ranges.empty?
     transformations_empty_or_only_move? ? format_subtitle_date(@x_axis_ranges.first.first) : nil
   end
 
   def subtitle_end_date
+    return nil unless @x_axis_ranges.present? && !@x_axis_ranges.empty?
     transformations_empty_or_only_move? ? format_subtitle_date(@x_axis_ranges.last.last) : nil
   end
 
@@ -509,7 +511,7 @@ private
   end
 
   def transformations_empty_or_only_move?
-    return true if @transformations.empty?
+    return true if @transformations.nil? || @transformations.empty?
     return true if @transformations.length == 1 && transformation_type(@transformations[0]) == :move
   end
 

--- a/app/models/chart_data_values.rb
+++ b/app/models/chart_data_values.rb
@@ -193,13 +193,13 @@ class ChartDataValues
   end
 
   def subtitle_start_date
-    return nil unless x_axis_ranges_present?
-    transformations_empty_or_only_move? ? format_subtitle_date(@x_axis_ranges.first.first) : nil
+    return nil unless x_axis_ranges_present? && transformations_empty_or_only_move?
+    format_subtitle_date(@x_axis_ranges.first.first)
   end
 
   def subtitle_end_date
-    return nil unless x_axis_ranges_present?
-    transformations_empty_or_only_move? ? format_subtitle_date(@x_axis_ranges.last.last) : nil
+    return nil unless x_axis_ranges_present? && transformations_empty_or_only_move?
+    format_subtitle_date(@x_axis_ranges.last.last)
   end
 
   def format_subtitle_date(date)
@@ -517,6 +517,7 @@ private
   def transformations_empty_or_only_move?
     return true if @transformations.nil? || @transformations.empty?
     return true if @transformations.length == 1 && transformation_type(@transformations[0]) == :move
+    false
   end
 
   def transformation_type(transformation)

--- a/app/models/chart_data_values.rb
+++ b/app/models/chart_data_values.rb
@@ -193,12 +193,12 @@ class ChartDataValues
   end
 
   def subtitle_start_date
-    return nil unless @x_axis_ranges.present? && !@x_axis_ranges.empty?
+    return nil unless x_axis_ranges_present?
     transformations_empty_or_only_move? ? format_subtitle_date(@x_axis_ranges.first.first) : nil
   end
 
   def subtitle_end_date
-    return nil unless @x_axis_ranges.present? && !@x_axis_ranges.empty?
+    return nil unless x_axis_ranges_present?
     transformations_empty_or_only_move? ? format_subtitle_date(@x_axis_ranges.last.last) : nil
   end
 
@@ -508,6 +508,10 @@ private
 
   def y2_is_rating?(y2_data_title)
     y2_data_title.casecmp('rating').zero?
+  end
+
+  def x_axis_ranges_present?
+    @x_axis_ranges.present? && !@x_axis_ranges.empty?
   end
 
   def transformations_empty_or_only_move?

--- a/app/views/admin/analysis/generic_chart_template.html.erb
+++ b/app/views/admin/analysis/generic_chart_template.html.erb
@@ -18,7 +18,9 @@ with <%= @school.number_of_pupils %> pupils and a floor area of <%= @school.floo
     <hr class="analysis"/>
   <% end %>
   <div id="chart_wrapper_<%= chart %>" class="chart-wrapper">
-    <h3 class="analysis">Loading: <%= chart.to_s.humanize %></h3>
+    <div class="dynamic-titles">
+      <h3 class="analysis">Loading: <%= chart.to_s.humanize %></h3>
+    </div>
     <div class="advice-header"></div>
     <%= render 'shared/analysis_controls', chart_type: chart.to_s, axis_controls: true, analysis_controls: true %>
     <%= chart_tag(@school, chart.to_s, chart_config: @chart_config, wrap: false, show_advice: true) %>

--- a/app/views/pupils/analysis/show.html.erb
+++ b/app/views/pupils/analysis/show.html.erb
@@ -6,7 +6,7 @@
 </div>
 
 <div id="chart_wrapper_<%= @chart_type %>" class="pt-3 chart-wrapper">
-  <div class="pupil-chart-titles">
+  <div class="pupil-chart-titles dynamic-titles">
       <h3></h3>
       <h5></h5>
   </div>

--- a/app/views/schools/advice/baseload/_analysis.html.erb
+++ b/app/views/schools/advice/baseload/_analysis.html.erb
@@ -28,7 +28,7 @@
 
   <%= render(ChartComponent.new(chart_type: :baseload_lastyear, school: @school)) do |c| %>
     <% c.with_title { t('advice_pages.baseload.analysis.charts.baseload_chart_title', months_analysed: @analysis_dates.months_analysed) } %>
-    <% c.with_subtitle { t('advice_pages.baseload.analysis.charts.baseload_chart_subtitle', start_month_year: month_year(@analysis_dates.one_years_data ? @analysis_dates.end_date - 1.year : @analysis_dates.start_date), end_month_year: month_year(@analysis_dates.end_date)) } %>
+    <% c.with_subtitle { t('advice_pages.baseload.analysis.charts.baseload_chart_subtitle_html', start_month_year: short_dates(@analysis_dates.one_years_data ? @analysis_dates.end_date - 1.year : @analysis_dates.start_date), end_month_year: short_dates(@analysis_dates.end_date)) } %>
     <% c.with_footer do %>
       <p><%= t('advice_pages.baseload.analysis.charts.baseload_chart_explanation') %></p>
     <% end %>
@@ -51,7 +51,7 @@
 
   <%= render(ChartComponent.new(chart_type: :baseload_versus_benchmarks, school: @school)) do |c| %>
     <% c.with_title { t('advice_pages.baseload.analysis.charts.long_term_baseload_chart_title') } %>
-    <% c.with_subtitle { t('advice_pages.baseload.analysis.charts.long_term_baseload_chart_subtitle', start_month_year: month_year(@analysis_dates.start_date), end_month_year: month_year(@analysis_dates.end_date.last_month)) } %>
+    <% c.with_subtitle { t('advice_pages.baseload.analysis.charts.long_term_baseload_chart_subtitle_html', start_month_year: short_dates(@analysis_dates.start_date), end_month_year: short_dates(@analysis_dates.end_date.last_month)) } %>
     <% c.with_footer do %>
       <p><%= t('advice_pages.baseload.analysis.charts.long_term_baseload_chart_explanation') %></p>
     <% end %>

--- a/app/views/schools/analysis/_chart_name.html.erb
+++ b/app/views/schools/analysis/_chart_name.html.erb
@@ -1,5 +1,7 @@
 <div id="chart_wrapper_<%= content %>" class="pt-3 chart-wrapper">
   <%= render 'shared/analysis_controls', chart_type: content, axis_controls: true, analysis_controls: true %>
-  <h5 class="text-center"></h5>
+  <div class="dynamic-titles">
+    <h5 class="text-center"></h5>
+  </div>
   <%= chart_tag(school, content, no_zoom: true, wrap: false, chart_config: create_chart_config(school, content, mpan_mprn)) %>
 </div>

--- a/config/locales/views/advice_pages/baseload.yml
+++ b/config/locales/views/advice_pages/baseload.yml
@@ -15,10 +15,10 @@ en:
               <li>If your baseload has changed, for example suddenly increasing or decreasing, you should be able to track down and explain the cause of this change. Consider whether the school has recently purchased new equipment. A very large decrease over the summer holidays is good, it shows that appliances and equipment have been switched off. Perhaps fridges and freezers in the kitchen were emptied or consolidated. Consider how significant that drop is - if caused by switching off fridges and freezers, they might be inefficient enough to require replacement. Think about whether your school can replicate that decrease for other holidays, or even weekends.</li>
             </ul>
           baseload_chart_explanation: Each point on this chart represents the average over the hours a school is closed on that day. You can click on a point in the chart and it will drill down to show you the usage on that day. Ideally, there should be little variation between different days and seasons.
-          baseload_chart_subtitle: This chart shows the electricity baseload for your school between %{start_month_year} and %{end_month_year}.
+          baseload_chart_subtitle_html: This chart shows the electricity baseload for your school between <span class="start-date">%{start_month_year}</span> and <span class="end-date">%{end_month_year}</span>.
           baseload_chart_title: Electricity baseload for the last %{months_analysed} months
           long_term_baseload_chart_explanation: You can click on the chart to drill down to individual days and work out at what times of day and year your school is doing either better or worse than these schools.
-          long_term_baseload_chart_subtitle: This chart shows the long term trend in your school’s baseload between %{start_month_year} and %{end_month_year}, and includes a comparison with 'benchmark' and 'exemplar' schools
+          long_term_baseload_chart_subtitle_html: This chart shows the long term trend in your school’s baseload between <span class="start-date">%{start_month_year}</span> and <span class="end-date">%{end_month_year}</span>, and includes a comparison with 'benchmark' and 'exemplar' schools
           long_term_baseload_chart_title: Long term baseload comparison with benchmark and exemplar schools
           long_term_baseload_meter_chart_subtitle: Electricity baseload from %{month_year_start} to %{month_year_end} for %{meter}
           long_term_baseload_meter_chart_title: Long term trends in your electricity baseload for a single meter

--- a/spec/models/chart_data_values_spec.rb
+++ b/spec/models/chart_data_values_spec.rb
@@ -168,4 +168,19 @@ describe ChartDataValues do
       expect(chart_data_values.send(:scatter_series_data_for, [6,2,5,4,3,0,1])).to eq([["Sunday", 6], ["Monday", 2], ["Tuesday", 5], ["Wednesday", 4], ["Thursday", 3], ["Friday", 0], ["Saturday", 1]])
     end
   end
+
+  context 'sub-title dates' do
+    context 'with no transformations' do
+      it 'includes the chart date range'
+    end
+    context 'with drill down' do
+      it 'does not include the chart date range'
+    end
+    context 'with drill down and move' do
+      it 'does not include the chart date range'
+    end
+    context 'with move back' do
+      it 'includes the chart date range'
+    end
+  end
 end

--- a/spec/models/chart_data_values_spec.rb
+++ b/spec/models/chart_data_values_spec.rb
@@ -1,80 +1,94 @@
 require 'rails_helper'
 
-EXAMPLE_CONFIG = {
-    title: "Comparison of last 2 weeks gas consumption - adjusted for outside temperature £7.70",
-    x_axis: %w[Sunday Monday Tuesday Wednesday Thursday Friday Saturday],
-    x_axis_ranges: [[Date.parse('Sun, 28 Apr 2019'), Date.parse('Sun, 28 Apr 2019')]],
-    x_data: { "Energy:Sun21Apr19-Sat27Apr19" => [], "Energy:Sun28Apr19-Sat04May19" => [] },
-    chart1_type: :column,
-    chart1_subtype: nil,
-    y_axis_label: "£",
-    config_name: :teachers_landing_page_gas,
-    configuration: {}
-  }.freeze
-
 describe ChartDataValues do
+
+  let(:chart) { :management_dashboard_group_by_week_electricity }
+  let(:chart_type)  { :column }
+  let(:config) {
+    {
+      title: "Comparison of last 2 weeks gas consumption - adjusted for outside temperature £7.70",
+      x_axis: %w[Sunday Monday Tuesday Wednesday Thursday Friday Saturday],
+      x_axis_ranges: [[Date.parse('Sun, 28 Apr 2019'), Date.parse('Sun, 28 Apr 2019')]],
+      x_data: { "Energy:Sun21Apr19-Sat27Apr19" => [], "Energy:Sun28Apr19-Sat04May19" => [] },
+      chart1_type: chart_type,
+      chart1_subtype: nil,
+      y_axis_label: "£",
+      config_name: chart,
+      configuration: {}
+    }
+  }
+  let(:transformations) { [] }
+  let(:allowed_operations) { {} }
+  let(:drilldown_available) { false }
+  let(:parent_timescale_description) { nil }
+  let(:y1_axis_choices) { [] }
+
+  let(:chart_data_values)  { ChartDataValues.new(config, chart, transformations: transformations, allowed_operations: allowed_operations, drilldown_available: drilldown_available, parent_timescale_description: parent_timescale_description, y1_axis_choices: y1_axis_choices).process }
+
   it 'handles labels properly' do
-    chart_data_values = ChartDataValues.new(EXAMPLE_CONFIG, :teachers_landing_page_gas).process
     expect(chart_data_values.series_data.first[:name]).to eq "Sun 21 Apr 19 - Sat 27 Apr 19"
     expect(chart_data_values.series_data.second[:name]).to eq "Sun 28 Apr 19 - Sat 04 May 19"
     expect(chart_data_values.x_axis_categories).to eq %w[Sunday Monday Tuesday Wednesday Thursday Friday Saturday]
   end
 
-  it 'sets the colours for gas dashboard and pupil analysis charts' do
-    chart_data_values = ChartDataValues.new(EXAMPLE_CONFIG, :calendar_picker_gas_day_example_comparison_chart).process
-    expect(chart_data_values.series_data.first[:color]).to eq ChartDataValues::DARK_GAS
+  context 'when setting colours' do
+    context 'for gas dashboard and pupil analysis charts' do
+      let(:chart) { :calendar_picker_gas_day_example_comparison_chart }
+      it 'sets the right colours' do
+        expect(chart_data_values.series_data.first[:color]).to eq ChartDataValues::DARK_GAS
+      end
+    end
+    context 'for electricity dashboard and pupil analysis charts' do
+      let(:chart) { :calendar_picker_electricity_day_example_comparison_chart }
+      it 'sets the right colours' do
+        expect(chart_data_values.series_data.first[:color]).to eq ChartDataValues::DARK_ELECTRICITY
+      end
+    end
+    context 'for electricity line charts' do
+      let(:chart) { :calendar_picker_electricity_day_example_comparison_chart }
+      let(:chart_type)  { :line }
+      it 'sets the right colours' do
+        expect(chart_data_values.series_data.first[:color]).to eq ChartDataValues::DARK_ELECTRICITY
+      end
+    end
+    context 'for gas line charts' do
+      let(:chart) { :calendar_picker_gas_day_example_comparison_chart }
+      let(:chart_type)  { :line }
+      it 'sets the right colours' do
+        expect(chart_data_values.series_data.first[:color]).to eq ChartDataValues::DARK_GAS
+      end
+    end
+    it 'works out the best colour when label matches' do
+      label = chart_data_values.colour_lookup.keys.first
+      colour = chart_data_values.colour_lookup[label]
+      expect(ChartDataValues.new({}, :a).work_out_best_colour(label)).to eq(colour)
+    end
+    it 'works out the best colour when label includes one of the keys' do
+      colour_key = chart_data_values.colour_lookup.keys.first
+      label = "AB#{colour_key}C"
+      colour = chart_data_values.colour_lookup[colour_key]
+      expect(ChartDataValues.new({}, :a).work_out_best_colour(label)).to eq(colour)
+    end
+    it 'does not re-use included colours' do
+      colour_key = chart_data_values.colour_lookup.keys.first
+      label = "AB#{colour_key}C"
+      colour = chart_data_values.colour_lookup[colour_key]
+      cdv = ChartDataValues.new({}, :a)
+      expect(cdv.work_out_best_colour(label)).to eq(colour)
+      expect(cdv.work_out_best_colour(label)).to eq(nil)
+    end
   end
 
-  it 'sets the colours for electricity dashboard and pupil analysis charts' do
-    chart_data_values = ChartDataValues.new(EXAMPLE_CONFIG, :calendar_picker_electricity_day_example_comparison_chart).process
-    expect(chart_data_values.series_data.first[:color]).to eq ChartDataValues::DARK_ELECTRICITY
-  end
-
-  it 'sets the colours for electricity line charts' do
-    chart_data_values = ChartDataValues.new(EXAMPLE_CONFIG.merge(chart1_type: :line), :calendar_picker_electricity_day_example_comparison_chart).process
-    expect(chart_data_values.series_data.first[:color]).to eq ChartDataValues::DARK_ELECTRICITY
-  end
-
-  it 'sets the colours for gas line charts' do
-    chart_data_values = ChartDataValues.new(EXAMPLE_CONFIG.merge(chart1_type: :line), :calendar_picker_gas_day_example_comparison_chart).process
-    expect(chart_data_values.series_data.first[:color]).to eq ChartDataValues::DARK_GAS
-  end
-
-  it 'works out the best colour when label matches' do
-    chart_data_values = ChartDataValues.new(EXAMPLE_CONFIG, :teachers_landing_page_gas).process
-    label = chart_data_values.send(:colour_lookup).keys.first
-    colour = chart_data_values.send(:colour_lookup)[label]
-
-    expect(ChartDataValues.new({}, :a).work_out_best_colour(label)).to eq(colour)
-  end
-
-  it 'works out the best colour when label includes one of the keys' do
-    chart_data_values = ChartDataValues.new(EXAMPLE_CONFIG, :teachers_landing_page_gas).process
-    colour_key = chart_data_values.send(:colour_lookup).keys.first
-    label = "AB#{colour_key}C"
-    colour = chart_data_values.send(:colour_lookup)[colour_key]
-    expect(ChartDataValues.new({}, :a).work_out_best_colour(label)).to eq(colour)
-  end
-
-  it 'does not re-use included colours' do
-    chart_data_values = ChartDataValues.new(EXAMPLE_CONFIG, :teachers_landing_page_gas).process
-    colour_key = chart_data_values.send(:colour_lookup).keys.first
-    label = "AB#{colour_key}C"
-    colour = chart_data_values.send(:colour_lookup)[colour_key]
-    cdv = ChartDataValues.new({}, :a)
-    expect(cdv.work_out_best_colour(label)).to eq(colour)
-    expect(cdv.work_out_best_colour(label)).to eq(nil)
-  end
-
-  it 'includes y-axis choices' do
-    y1_axis_choices = [:kwh, :£]
-    chart_data_values = ChartDataValues.new(EXAMPLE_CONFIG.merge(chart1_type: :line), :calendar_picker_gas_day_example_comparison_chart, y1_axis_choices: y1_axis_choices).process
-    expect(chart_data_values.y1_axis_choices).to eql y1_axis_choices
+  context 'with limited y-axis choices' do
+    let(:y1_axis_choices) { [:kwh, :£] }
+    let(:chart_type) { :line }
+    let(:chart) { :calendar_picker_gas_day_example_comparison_chart }
+    it 'sets the choices' do
+      expect(chart_data_values.y1_axis_choices).to eql y1_axis_choices
+    end
   end
 
   describe '#series_translation_key_lookup' do
-    chart_data_values = ChartDataValues.new(EXAMPLE_CONFIG, :teachers_landing_page_gas).process
-
     it 'returns a hash matching series text keys to translation key values' do
       expect(chart_data_values.series_translation_key_lookup).to eq(
         { "Degree Days" => "degree_days", "Temperature" => "temperature", "School Day Closed" => "school_day_closed", "School Day Open" => "school_day_open", "Holiday" => "holiday", "Weekend" => "weekend", "Storage heater charge (school day)" => "storage_heater_charge", "Hot Water Usage" => "useful_hot_water_usage", "Wasted Hot Water Usage" => "wasted_hot_water_usage", "solar pv (consumed onsite)" => "solar_pv", "Solar Irradiance" => "solar_irradiance", "Carbon Intensity of Electricity Grid (kg/kWh)" => "gridcarbon", "Carbon Intensity of Gas (kg/kWh)" => "gascarbon", "Heating on in cold weather" => "heating_day", "Hot Water (& Kitchen)" => "non_heating_day", "Heating on in warm weather" => "heating_day_warm_weather", "electricity" => "electricity", "gas" => "gas", "storage heaters" => "storage_heaters", "Predicted Heat" => "predicted_heat", "Target degree days" => "target_degree_days", "CUSUM" => "cusum", "BASELOAD" => "baseload", "Peak (kW)" => "peak_kw", "Heating On School Days" => "school_day_heating", "Heating On Holidays" => "holiday_heating", "Heating On Weekends" => "weekend_heating", "Hot water/kitchen only On School Days" => "school_day_hot_water_kitchen", "Hot water/kitchen only On Holidays" => "holiday_hot_water_kitchen", "Hot water/kitchen only On Weekends" => "weekend_hot_water_kitchen", "Boiler Off" => "boiler_off", "Energy" => "none", "Exemplar School" => "exemplar_school", "Benchmark (Good) School" => "benchmark_school", "Community" => "community", "Community Baseload" => "community_baseload", "Electricity consumed from solar pv" => "electricity_consumed_from_solar_pv", "Exported solar electricity (not consumed onsite)" => "exported_solar_electricity", "Electricity consumed from mains" => "electricity_consumed_from_mains"}
@@ -87,8 +101,6 @@ describe ChartDataValues do
   end
 
   describe '#translated_series_item_for' do
-    chart_data_values = ChartDataValues.new(EXAMPLE_CONFIG, :teachers_landing_page_gas).process
-
     it 'returns a translation key for a series given string' do
       I18n.t('analytics.series_data_manager.series_name').each do |key, value|
         expect(chart_data_values.translated_series_item_for(I18n.t("analytics.series_data_manager.series_name.#{key}"))).to eq(value)
@@ -101,16 +113,12 @@ describe ChartDataValues do
   end
 
   describe '#wrap_label_as_html' do
-    chart_data_values = ChartDataValues.new(EXAMPLE_CONFIG, :teachers_landing_page_gas).process
-
     it 'adds line breaks tags to break up a given label and wraps it in a span' do
       expect(chart_data_values.send(:wrap_label_as_html, 'Degree Days')).to eq('<span>Degree<br />Days</span>')
     end
   end
 
   describe '#label_point_and_max_for' do
-    chart_data_values = ChartDataValues.new(EXAMPLE_CONFIG, :teachers_landing_page_gas).process
-
     it 'returns the label, point format, and max value (if needed) for a given y2 data title' do
       expect(chart_data_values.send(:label_point_and_max_for, Series::Temperature::TEMPERATURE)).to eq(['°C', '{point.y:.2f} °C',])
       expect(chart_data_values.send(:label_point_and_max_for, 'Temperature')).to eq(['°C', '{point.y:.2f} °C',])
@@ -130,8 +138,6 @@ describe ChartDataValues do
   end
 
   describe '#colour_lookup' do
-    chart_data_values = ChartDataValues.new(EXAMPLE_CONFIG, :teachers_landing_page_gas).process
-
     it 'returns a hash with colours assigned to chart series names' do
       expect(chart_data_values.colour_lookup).to eq(
         {"Degree Days" => "#232b49", "Temperature" => "#232b49", "School Day Closed" => "#3bc0f0", "School Day Open" => "#5cb85c", "Holiday" => "#ff4500", "Weekend" => "#ffac21", "Heating on in cold weather" => "#3bc0f0", "Hot Water (& Kitchen)" => "#5cb85c", "Hot Water Usage" => "#3bc0f0", "Wasted Hot Water Usage" => "#ff4500", "Solar PV (consumed onsite)" => "#ffac21", "Electricity" => "#02B8FF", "Gas" => "#FFB138", "Storage heaters" => "#501e74", "£" => "#232B49", "Electricity consumed from solar pv" => "#5cb85c", "translation missing: en.analytics.series_data_manager.series_name.Electricity consumed from mains" => "#02B8FF", "translation missing: en.analytics.series_data_manager.series_name.Exported solar electricity (not consumed onsite)" => "#FCB43A", "Solar irradiance (brightness of sunshine)" => "#FFB138", "Rating" => "#232b49"}
@@ -140,7 +146,6 @@ describe ChartDataValues do
   end
 
   describe '#trendline?' do
-    chart_data_values = ChartDataValues.new(EXAMPLE_CONFIG, :teachers_landing_page_gas).process
     it 'returns true if the data type starts with trendline' do
       expect(chart_data_values.send(:trendline?, :"trendline_heating_occupied_all_days =-138.9T + 2684, r2 = 0.64, n=138")).to be_truthy
       expect(chart_data_values.send(:trendline?, "trendline_heating_occupied_all_days =-138.9T + 2684, r2 = 0.64, n=138")).to be_truthy
@@ -152,7 +157,6 @@ describe ChartDataValues do
   end
 
   describe '#reduced_trendline_series_data_for' do
-    chart_data_values = ChartDataValues.new(EXAMPLE_CONFIG, :teachers_landing_page_gas).process
     it 'merges elements of the x_axis with corresponding data elements replacing all but the maximum and minimum values with nil' do
       # Trendline data needs to be reduced to maximum and minimum values only to reliably plot
       # a non-breaking straight line between two points.
@@ -162,7 +166,6 @@ describe ChartDataValues do
   end
 
   describe '#scatter_series_data_for' do
-    chart_data_values = ChartDataValues.new(EXAMPLE_CONFIG, :teachers_landing_page_gas).process
     it 'merges elements of the x_axis with corresponding data elements' do
       expect(chart_data_values.send(:scatter_series_data_for, [0,1,2,3,4,5,6])).to eq([["Sunday", 0], ["Monday", 1], ["Tuesday", 2], ["Wednesday", 3], ["Thursday", 4], ["Friday", 5], ["Saturday", 6]])
       expect(chart_data_values.send(:scatter_series_data_for, [6,2,5,4,3,0,1])).to eq([["Sunday", 6], ["Monday", 2], ["Tuesday", 5], ["Wednesday", 4], ["Thursday", 3], ["Friday", 0], ["Saturday", 1]])

--- a/spec/models/chart_data_values_spec.rb
+++ b/spec/models/chart_data_values_spec.rb
@@ -4,11 +4,12 @@ describe ChartDataValues do
 
   let(:chart) { :management_dashboard_group_by_week_electricity }
   let(:chart_type)  { :column }
+  let(:x_axis_ranges) { [[Date.parse('Sun, 28 Apr 2019'), Date.parse('Sun, 28 Apr 2019')]] }
   let(:config) {
     {
       title: "Comparison of last 2 weeks gas consumption - adjusted for outside temperature £7.70",
       x_axis: %w[Sunday Monday Tuesday Wednesday Thursday Friday Saturday],
-      x_axis_ranges: [[Date.parse('Sun, 28 Apr 2019'), Date.parse('Sun, 28 Apr 2019')]],
+      x_axis_ranges: x_axis_ranges,
       x_data: { "Energy:Sun21Apr19-Sat27Apr19" => [], "Energy:Sun28Apr19-Sat04May19" => [] },
       chart1_type: chart_type,
       chart1_subtype: nil,
@@ -173,17 +174,41 @@ describe ChartDataValues do
   end
 
   context 'sub-title dates' do
+    let(:x_axis_ranges) { [[Date.new(2023,1,31), Date.new(2023,2,4)]] }
+
     context 'with no transformations' do
-      it 'includes the chart date range'
+      it 'includes the chart date range' do
+        expect(chart_data_values.subtitle_start_date).to eq "31 Jan 2023"
+        expect(chart_data_values.subtitle_end_date).to eq "04 Feb 2023"
+      end
     end
     context 'with drill down' do
-      it 'does not include the chart date range'
+      let(:transformations) { [[:drilldown, 293]] }
+      it 'does not include the chart date range' do
+        expect(chart_data_values.subtitle_start_date).to be_nil
+        expect(chart_data_values.subtitle_end_date).to be_nil
+      end
     end
-    context 'with drill down and move' do
-      it 'does not include the chart date range'
+    context 'with move then drill down' do
+      let(:transformations) { [[:move, -2], [:drilldown, 141]] }
+      it 'does not include the chart date range' do
+        expect(chart_data_values.subtitle_start_date).to be_nil
+        expect(chart_data_values.subtitle_end_date).to be_nil
+      end
+    end
+    context 'with drill down then move' do
+      let(:transformations) { [[:drilldown, 1], [:move, -1]] }
+      it 'does not include the chart date range' do
+        expect(chart_data_values.subtitle_start_date).to be_nil
+        expect(chart_data_values.subtitle_end_date).to be_nil
+      end
     end
     context 'with move back' do
-      it 'includes the chart date range'
+      let(:transformations) { [[:move, 1]] }
+      it 'includes the chart date range' do
+        expect(chart_data_values.subtitle_start_date).to eq "31 Jan 2023"
+        expect(chart_data_values.subtitle_end_date).to eq "04 Feb 2023"
+      end
     end
   end
 end


### PR DESCRIPTION
Our existing chart templates and javascript support dynamically changing the chart titles and subtitles. This is currently used:

- on the pupil charts. Here the title changes as you drill down, and some of the subtitles change to reflect the dates being viewed
- on the existing analysis pages, which have subtitles that change to reflect the date range being viewed
- some admin only pages which have both dynamic titles and subtitles

The text injected into those charts is generated by the analytics.

On the new advice pages we don't (currently) want to dynamically change the whole title and subtitle, but we do want to ensure that dates in the subtitles update as a user moves forward and backward on a chart.

This PR does several things:

- refactors the existing templates and JS code so that dynamically replaced titles (h3) and subtitles (h5) are scoped within a div (`.dynamic-titles`). This preserves the existing behaviour, while allowing new behaviour to be added to other elements
- changes the ChartComponent template so that the chart title, subtitle and header are within the `chart_wrapper`. This makes it easier to find and manipulate those elements
- extends the `ChartDataValues` class to dynamically add start and end dates to the JSON returned to the browser. These should reflect the "top-level" range that the user is viewing. This code uses the existing date ranges supplied by the analytics. The dates are only added/changed when the user moves forward and backwards at the top-level of the chart, and not if they zoom in and then move forward/backward.
- adds support in the Javascript to find and dynamically update `.start-date` and `.end-date` spans within a `.chart-subtitle` element, if that information is in the JSON
- changes the baseload template and YAML files to use this new feature. This required changing date formats and adding HTML to the translation key.

The intention is that we'll use this on all chart subtitles to allow them to be dynamically changed.

We may need to do some additional work to provide default dates when pages first load, but this can be done in a separate PR, or as part of building the specific pages.