### PR TITLE
Add checks for fuel type and enough data to advice base controller

### DIFF
--- a/app/controllers/schools/advice/advice_base_controller.rb
+++ b/app/controllers/schools/advice/advice_base_controller.rb
@@ -11,6 +11,7 @@ module Schools
       before_action :load_advice_page, only: [:insights, :analysis, :learn_more]
       before_action :check_authorisation, only: [:insights, :analysis, :learn_more]
       before_action :load_recommendations, only: [:insights]
+      before_action :check_has_fuel_type, only: [:insights, :analysis]
       before_action :check_can_run_analysis, only: [:insights, :analysis]
       before_action :set_data_warning, only: [:insights, :analysis]
 
@@ -55,14 +56,15 @@ module Schools
         end
       end
 
+      def check_has_fuel_type
+        render('no_fuel_type', status: :bad_request) and return unless school_has_fuel_type?
+        true
+      end
+
       #Checks that the analysis can be run.
       #Enforces check that school has the necessary fuel type
       #and provides hook for controllers to plug in custom checks
       def check_can_run_analysis
-        unless school_has_fuel_type?
-          render 'no_fuel_type', status: :bad_request
-          return #avoid chance of double render error
-        end
         @analysable = create_analysable
         if @analysable.present? && !@analysable.enough_data?
           render 'not_enough_data'

--- a/app/controllers/schools/advice/advice_base_controller.rb
+++ b/app/controllers/schools/advice/advice_base_controller.rb
@@ -55,8 +55,41 @@ module Schools
         end
       end
 
+      #Checks that the analysis can be run.
+      #Enforces check that school has the necessary fuel type
+      #and provides hook for controllers to plug in custom checks
       def check_can_run_analysis
-        true
+        unless school_has_fuel_type?
+          render 'no_fuel_type'
+          return #avoid chance of double render error
+        end
+        @analysable = create_analysable
+        if @analysable.present? && !@analysable.enough_data?
+          render 'not_enough_data'
+        end
+      end
+
+      def school_has_fuel_type?
+        case @advice_page.fuel_type.to_sym
+        when :gas
+          @school.has_gas?
+        when :electricity
+          @school.has_electricity?
+        when :storage_heater
+          @school.has_storage_heaters?
+        when :solar_pv
+          @school.has_solar_pv?
+        else
+          false
+        end
+      end
+
+      #Should return an object that conforms to interface described
+      #by the AnalysableMixin. Will be used to determine whether
+      #there's enough data and, optionally, identify when we think there
+      #will be enough data.
+      def create_analysable
+        nil
       end
 
       def load_recommendations

--- a/app/controllers/schools/advice/advice_base_controller.rb
+++ b/app/controllers/schools/advice/advice_base_controller.rb
@@ -60,7 +60,7 @@ module Schools
       #and provides hook for controllers to plug in custom checks
       def check_can_run_analysis
         unless school_has_fuel_type?
-          render 'no_fuel_type'
+          render 'no_fuel_type', status: :bad_request
           return #avoid chance of double render error
         end
         @analysable = create_analysable

--- a/app/views/schools/advice/_nav.html.erb
+++ b/app/views/schools/advice/_nav.html.erb
@@ -23,7 +23,7 @@
   <% c.with_section(name: t('advice_pages.nav.sections.storage_heater'), icon: 'window-maximize', classes: 'bg-storage-light', visible: @school.has_storage_heaters?) do |s| %>
     <% s.with_item(name: t('advice_pages.nav.pages.storage_heaters'), href: school_advice_storage_heaters_path(@school)) %>
   <% end %>
-  <% c.with_section(name: t('advice_pages.nav.sections.solar'), icon: 'sun', classes: 'bg-solar-light', visible: @school.has_solar_pv?) do |s| %>
+  <% c.with_section(name: t('advice_pages.nav.sections.solar_pv'), icon: 'sun', classes: 'bg-solar-light', visible: @school.has_solar_pv?) do |s| %>
     <% s.with_item(name: t('advice_pages.nav.pages.solar_pv'), href: school_advice_solar_pv_path(@school)) %>
   <% end %>
 <% end %>

--- a/app/views/schools/advice/advice_base/error.html.erb
+++ b/app/views/schools/advice/advice_base/error.html.erb
@@ -1,18 +1,4 @@
-<div class="advice-page-breadcrumb">
-  <%= component 'breadcrumbs' do |c| %>
-    <% c.with_school(@school) %>
-    <% c.with_items([{ name: t('advice_pages.breadcrumbs.root'), href: school_advice_path(@school) }]) %>
-  <% end %>
-</div>
-
-<h1><%= t('advice_pages.show.title') %></h1>
-
-<div class="row">
-  <div class="col-md-3 col-lg-3 col-xl-2 advice-page-nav">
-    <%= render 'schools/advice/nav', school: @school, advice_pages: @advice_pages %>
-  </div>
-  <div class="col-md-9 col-lg-9 col-xl-10 advice-page-tabs">
+<%= render 'schools/advice/advice_page', school: @school, advice_pages: @advice_pages, advice_page: @advice_page, tab: @tab, data_warning: @data_warning do %>
     <h2><%= component 'page_nav/collapse_button', display: 'inline' %><%= t('advice_pages.error.title') %></h2>
     <p><%= t('advice_pages.error.message') %></p>
-  </div>
-</div>
+<% end %>

--- a/app/views/schools/advice/advice_base/error.html.erb
+++ b/app/views/schools/advice/advice_base/error.html.erb
@@ -1,4 +1,4 @@
-<%= render 'schools/advice/advice_page', school: @school, advice_pages: @advice_pages, advice_page: @advice_page, tab: @tab, data_warning: @data_warning do %>
+<%= render 'schools/advice/advice_page', school: @school, advice_pages: @advice_pages, advice_page: @advice_page, tab: @tab, data_warning: nil do %>
     <h2><%= component 'page_nav/collapse_button', display: 'inline' %><%= t('advice_pages.error.title') %></h2>
     <p><%= t('advice_pages.error.message') %></p>
 <% end %>

--- a/app/views/schools/advice/advice_base/no_fuel_type.html.erb
+++ b/app/views/schools/advice/advice_base/no_fuel_type.html.erb
@@ -1,0 +1,9 @@
+<%= render 'schools/advice/advice_page', school: @school, advice_pages: @advice_pages, advice_page: @advice_page, tab: @tab, data_warning: nil do %>
+    <h2>
+      <%= component 'page_nav/collapse_button', display: 'inline' %>
+      <%= t('advice_pages.no_fuel_type.title') %>
+    </h2>
+    <p>
+      <%= t('advice_pages.no_fuel_type.message', fuel_type: @advice_page.fuel_type) %>
+    </p>
+<% end %>

--- a/app/views/schools/advice/advice_base/not_enough_data.html.erb
+++ b/app/views/schools/advice/advice_base/not_enough_data.html.erb
@@ -1,0 +1,17 @@
+<%= render 'schools/advice/advice_page', school: @school, advice_pages: @advice_pages, advice_page: @advice_page, tab: @tab, data_warning: nil do %>
+    <h2>
+      <%= component 'page_nav/collapse_button', display: 'inline' %>
+      <%= t('advice_pages.not_enough_data.title') %>
+    </h2>
+    <p>
+      <%= t('advice_pages.not_enough_data.message', fuel_type: @advice_page.fuel_type) %>
+    </p>
+    <% if @analysable.available_from.present? %>
+      <p>
+        <%= t('advice_pages.not_enough_data.available_from', available_from: @analysable.available_from.to_s(:es_short)) %>
+      </p>
+    <% end %>
+    <p>
+      <%= t('advice_pages.not_enough_data.learn_more_html', learn_more_link: "learn_more") %>
+    </p>
+<% end %>

--- a/config/locales/views/advice_pages/advice_pages.yml
+++ b/config/locales/views/advice_pages/advice_pages.yml
@@ -7,14 +7,6 @@ en:
       other: Improving
     breadcrumbs:
       root: Advice
-    no_fuel_type:
-      title: Unable to run requested analysis
-      message: We don't currently have %{fuel_type} data for your school, so are unable to run this analysis
-    not_enough_data:
-      title: Not enough data to run analysis
-      message: We don't currently have enough %{fuel_type} data in order to run this analysis for your school.
-      available_from: Assuming we continue to regularly receive data we expect this analysis to be available after %{available_from}.
-      learn_more_html: In the meantime you can <a href="%{learn_more_link}">learn more</a> about this topic.
     error:
       data_warning: We have not received data for your %{fuel_type} usage for over thirty days. As a result your analysis will be out of date and may not reflect recent changes in your school.
       message: We encountered an error attempting to generate your analysis. The Energy Sparks team have been notified of the problem.
@@ -49,6 +41,14 @@ en:
         gas: Gas
         solar_pv: Solar
         storage_heater: Storage Heaters
+    no_fuel_type:
+      message: We don't currently have %{fuel_type} data for your school, so are unable to run this analysis
+      title: Unable to run requested analysis
     no_recent_data: no recent data
+    not_enough_data:
+      available_from: Assuming we continue to regularly receive data we expect this analysis to be available after %{available_from}.
+      learn_more_html: In the meantime you can <a href="%{learn_more_link}">learn more</a> about this topic.
+      message: We don't currently have enough %{fuel_type} data in order to run this analysis for your school.
+      title: Not enough data to run analysis
     show:
       title: Advice Pages

--- a/config/locales/views/advice_pages/advice_pages.yml
+++ b/config/locales/views/advice_pages/advice_pages.yml
@@ -7,6 +7,14 @@ en:
       other: Improving
     breadcrumbs:
       root: Advice
+    no_fuel_type:
+      title: Unable to run requested analysis
+      message: We don't currently have %{fuel_type} data for your school, so are unable to run this analysis
+    not_enough_data:
+      title: Not enough data to run analysis
+      message: We don't currently have enough %{fuel_type} data in order to run this analysis for your school.
+      available_from: Assuming we continue to regularly receive data we expect this analysis to be available after %{available_from}.
+      learn_more_html: In the meantime you can <a href="%{learn_more_link}">learn more</a> about this topic.
     error:
       data_warning: We have not received data for your %{fuel_type} usage for over thirty days. As a result your analysis will be out of date and may not reflect recent changes in your school.
       message: We encountered an error attempting to generate your analysis. The Energy Sparks team have been notified of the problem.

--- a/config/locales/views/advice_pages/advice_pages.yml
+++ b/config/locales/views/advice_pages/advice_pages.yml
@@ -47,7 +47,7 @@ en:
       sections:
         electricity: Electricity
         gas: Gas
-        solar: Solar
+        solar_pv: Solar
         storage_heater: Storage Heaters
     no_recent_data: no recent data
     show:

--- a/spec/factories/advice_pages.rb
+++ b/spec/factories/advice_pages.rb
@@ -2,5 +2,6 @@ FactoryBot.define do
   factory :advice_page do
     sequence(:key)        {|n| "Advice Page #{n}"}
     sequence(:learn_more) {|n| "Learn more #{n}"}
+    fuel_type { "electricity" }
   end
 end

--- a/spec/support/advice_pages_shared_contexts.rb
+++ b/spec/support/advice_pages_shared_contexts.rb
@@ -39,20 +39,74 @@ end
 RSpec.shared_context "gas advice page" do
   let(:fuel_type) { :gas }
   include_context "advice page base"
-  # creating page with no fuel type for now as this breaks gas pages. Assume other context is required.
-  let!(:advice_page) { create(:advice_page, key: key, restricted: false, learn_more: learn_more_content) }
+
+  let!(:advice_page) { create(:advice_page, key: key, restricted: false, fuel_type: fuel_type, learn_more: learn_more_content) }
+
+  let(:start_date)  { Date.today - 365}
+  let(:end_date)    { Date.today - 1}
+  let(:amr_data)    { double('amr-data') }
+
+  let(:gas_aggregate_meter)   { double('gas-aggregated-meter')}
+  let(:meter_collection)              { double('meter-collection', heater_meters: []) }
+
+  before do
+    school.configuration.update!(fuel_configuration: fuel_configuration)
+    allow(amr_data).to receive(:start_date).and_return(start_date)
+    allow(amr_data).to receive(:end_date).and_return(end_date)
+    allow(gas_aggregate_meter).to receive(:fuel_type).and_return(:gas)
+    allow(gas_aggregate_meter).to receive(:amr_data).and_return(amr_data)
+    allow(meter_collection).to receive(:aggregated_heat_meters).and_return(gas_aggregate_meter)
+    allow(meter_collection).to receive(:amr_data).and_return(amr_data)
+    allow_any_instance_of(AggregateSchoolService).to receive(:aggregate_school).and_return(meter_collection)
+  end
 end
 
 RSpec.shared_context "solar advice page" do
-  let(:fuel_type) { :solar }
+  let(:fuel_type) { :solar_pv }
   include_context "advice page base"
-  # creating page with no fuel type for now as this breaks solar pages. Assume other context is required.
-  let!(:advice_page) { create(:advice_page, key: key, restricted: false, learn_more: learn_more_content) }
+  let!(:advice_page) { create(:advice_page, key: key, restricted: false, fuel_type: fuel_type, learn_more: learn_more_content) }
+
+  let(:start_date)  { Date.today - 365}
+  let(:end_date)    { Date.today - 1}
+  let(:amr_data)    { double('amr-data') }
+
+  let(:electricity_aggregate_meter)   { double('electricity-aggregated-meter')}
+  let(:meter_collection)              { double('meter-collection', electricity_meters: []) }
+
+  before do
+    school.configuration.update!(fuel_configuration: fuel_configuration)
+    allow(amr_data).to receive(:start_date).and_return(start_date)
+    allow(amr_data).to receive(:end_date).and_return(end_date)
+    allow(electricity_aggregate_meter).to receive(:fuel_type).and_return(:electricity)
+    allow(electricity_aggregate_meter).to receive(:amr_data).and_return(amr_data)
+    allow(meter_collection).to receive(:aggregated_electricity_meters).and_return(electricity_aggregate_meter)
+    allow(meter_collection).to receive(:amr_data).and_return(amr_data)
+    allow_any_instance_of(AggregateSchoolService).to receive(:aggregate_school).and_return(meter_collection)
+  end
 end
 
 RSpec.shared_context "storage advice page" do
-  let(:fuel_type) { :storage }
+  let(:fuel_type) { :storage_heater }
   include_context "advice page base"
-  # creating page with no fuel type for now as this breaks storage pages. Assume other context is required.
-  let!(:advice_page) { create(:advice_page, key: key, restricted: false, learn_more: learn_more_content) }
+  let(:fuel_type) { :solar_pv }
+  include_context "advice page base"
+  let!(:advice_page) { create(:advice_page, key: key, restricted: false, fuel_type: fuel_type, learn_more: learn_more_content) }
+
+  let(:start_date)  { Date.today - 365}
+  let(:end_date)    { Date.today - 1}
+  let(:amr_data)    { double('amr-data') }
+
+  let(:electricity_aggregate_meter)   { double('electricity-aggregated-meter')}
+  let(:meter_collection)              { double('meter-collection', electricity_meters: []) }
+
+  before do
+    school.configuration.update!(fuel_configuration: fuel_configuration)
+    allow(amr_data).to receive(:start_date).and_return(start_date)
+    allow(amr_data).to receive(:end_date).and_return(end_date)
+    allow(electricity_aggregate_meter).to receive(:fuel_type).and_return(:electricity)
+    allow(electricity_aggregate_meter).to receive(:amr_data).and_return(amr_data)
+    allow(meter_collection).to receive(:aggregated_electricity_meters).and_return(electricity_aggregate_meter)
+    allow(meter_collection).to receive(:amr_data).and_return(amr_data)
+    allow_any_instance_of(AggregateSchoolService).to receive(:aggregate_school).and_return(meter_collection)
+  end
 end

--- a/spec/system/schools/advice_pages/advice_pages_spec.rb
+++ b/spec/system/schools/advice_pages/advice_pages_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe "advice pages", type: :system do
 
-  include_context "advice page base"
+  include_context "electricity advice page"
 
   let(:key) { 'total_energy_use' }
   let(:learn_more) { 'here is some more explanation' }

--- a/spec/system/schools/advice_pages/advice_pages_spec.rb
+++ b/spec/system/schools/advice_pages/advice_pages_spec.rb
@@ -2,14 +2,13 @@ require 'rails_helper'
 
 RSpec.describe "advice pages", type: :system do
 
-  let(:school) { create(:school) }
+  include_context "advice page base"
 
   let(:key) { 'total_energy_use' }
   let(:learn_more) { 'here is some more explanation' }
+  let(:expected_page_title) { "Total energy use" }
 
   let!(:advice_page) { create(:advice_page, key: key, restricted: false, learn_more: learn_more) }
-
-  let(:expected_page_title) { "Total energy use" }
 
   context 'when error occurs' do
     before do
@@ -23,6 +22,45 @@ RSpec.describe "advice pages", type: :system do
       expect(page).to have_content('We encountered an error attempting to generate your analysis')
     end
   end
+
+  context 'when school doesnt have fuel type' do
+    before do
+      allow_any_instance_of(Schools::Advice::AdviceBaseController).to receive(:school_has_fuel_type?).and_return(false)
+    end
+    it 'shows the no fuel type page' do
+      visit school_advice_path(school)
+      click_on key
+      expect(page).to have_content('Unable to run requested analysis')
+    end
+  end
+
+  context 'when school doesnt have enough data' do
+    let(:available_from)  { nil }
+    let(:analysable) {
+      OpenStruct.new(
+        enough_data?: false,
+        available_from: available_from
+      )
+    }
+    before do
+      allow_any_instance_of(Schools::Advice::AdviceBaseController).to receive(:create_analysable).and_return(analysable)
+    end
+    it 'shows the not enough data page' do
+      visit school_advice_path(school)
+      click_on key
+      expect(page).to have_content('Not enough data to run analysis')
+      expect(page).to_not have_content('Assuming we continue to regularly receive data')
+    end
+    context 'and we can estimate a date' do
+      let(:available_from) { Date.today + 10 }
+      it 'also includes the data' do
+        visit school_advice_path(school)
+        click_on key
+        expect(page).to have_content("Assuming we continue to regularly receive data we expect this analysis to be available after #{available_from.to_s(:es_short)}")
+      end
+    end
+  end
+
 
   context 'as non-logged in user' do
 

--- a/spec/system/schools/advice_pages/total_energy_use_spec.rb
+++ b/spec/system/schools/advice_pages/total_energy_use_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe "total energy use advice page", type: :system do
   let(:key) { 'total_energy_use' }
   let(:expected_page_title) { "Total energy use" }
-  include_context "advice page"
+  include_context "electricity advice page"
 
   context 'as school admin' do
     let(:user)  { create(:school_admin, school: school) }


### PR DESCRIPTION
Enforces a consistent approach for checking whether we have the right data available to run some analysis across all the advice page controllers.

This PR changes the base class so that:

- if a school doesn't have the right fuel type, we render a custom error page. This is only likely to happen if all the meters for a specific fuel type has been disabled, but a user has previously bookmarked a url. Ensures we provide a more helpful message
- if we can't run the analysis because we don't have enough data, then we render a custom error page which will ideally indicate when the analysis will be available
- improves the existing custom error handling to preserve the page tabs as these should have already been set in the request cycle. The error page also now returns a 500 status code

Individual page controllers can implement `create_analysable` and return an object that conforms to the `Analysable` mixin from the analytics package. The mixin will return a boolean to indicate if there is `enough_data?` and optionally a date when the analysis should be available from its `available_from` method.

From its `create_analysable` method, a specific page controller might:

- return a custom object or an OpenStruct that implement the right methods (see the advice page spec)
- create a service from the analytics which already implements Analysable and return that as a means of doing the check
- if could even check the `@tab` variable and return different objects for the different tabs if there are different data requirements

This should hopefully simplify this type of error checking. 

We might want to later allow for some more customised messages for individual "not enough data" pages, but this should be easier to add later. E.g. by adding additional content managed field to the AdvicePage model.