### PR TITLE
Initial analysis page layout and first chart

### DIFF
--- a/app/controllers/schools/advice/advice_base_controller.rb
+++ b/app/controllers/schools/advice/advice_base_controller.rb
@@ -39,7 +39,7 @@ module Schools
       end
 
       def advice_page_end_date
-        @advice_page_end_date ||= AggregateSchoolService.analysis_date(aggregate_school, @advice_page.fuel_type)
+        @advice_page_end_date ||= AggregateSchoolService.analysis_date(aggregate_school, advice_page_fuel_type)
       end
 
       def set_tab_name
@@ -72,7 +72,7 @@ module Schools
       end
 
       def school_has_fuel_type?
-        case @advice_page.fuel_type.to_sym
+        case advice_page_fuel_type
         when :gas
           @school.has_gas?
         when :electricity
@@ -88,9 +88,33 @@ module Schools
 
       def start_end_dates
         {
-          earliest_reading:  aggregate_school.aggregate_meter(@advice_page.fuel_type.to_sym).amr_data.start_date,
-          last_reading:  aggregate_school.aggregate_meter(@advice_page.fuel_type.to_sym).amr_data.end_date,
+          earliest_reading:  analysis_start_date,
+          last_reading:  analysis_end_date,
         }
+      end
+
+      def advice_page_fuel_type
+        @advice_page.fuel_type.to_sym
+      end
+
+      def analysis_start_date
+        aggregate_school.aggregate_meter(advice_page_fuel_type).amr_data.start_date
+      end
+
+      def analysis_end_date
+        aggregate_school.aggregate_meter(advice_page_fuel_type).amr_data.end_date
+      end
+
+      def analysis_dates
+        start_date = analysis_start_date
+        end_date = analysis_end_date
+        OpenStruct.new(
+          start_date: start_date,
+          end_date: end_date,
+          one_years_data: one_years_data?(start_date, end_date),
+          recent_data: recent_data?(end_date),
+          months_analysed: months_analysed(start_date, end_date)
+        )
       end
 
       #Should return an object that conforms to interface described

--- a/app/controllers/schools/advice/baseload_controller.rb
+++ b/app/controllers/schools/advice/baseload_controller.rb
@@ -37,18 +37,6 @@ module Schools
 
       private
 
-      def analysis_dates
-        start_date = aggregate_school.aggregated_electricity_meters.amr_data.start_date
-        end_date = aggregate_school.aggregated_electricity_meters.amr_data.end_date
-        OpenStruct.new(
-          start_date: start_date,
-          end_date: end_date,
-          one_years_data: one_years_data?(start_date, end_date),
-          recent_data: recent_data?(end_date),
-          months_analysed: months_analysed(start_date, end_date)
-        )
-      end
-
       def current_baseload
         average_baseload_kw_last_year = baseload_service.average_baseload_kw(period: :year)
         average_baseload_kw_last_week = baseload_service.average_baseload_kw(period: :week)

--- a/app/controllers/schools/advice/electricity_intraday_controller.rb
+++ b/app/controllers/schools/advice/electricity_intraday_controller.rb
@@ -16,18 +16,6 @@ module Schools
         )
       end
 
-      def analysis_dates
-        start_date = aggregate_school.aggregated_electricity_meters.amr_data.start_date
-        end_date = aggregate_school.aggregated_electricity_meters.amr_data.end_date
-        OpenStruct.new(
-          start_date: start_date,
-          end_date: end_date,
-          one_years_data: one_years_data?(start_date, end_date),
-          recent_data: recent_data?(end_date),
-          months_analysed: months_analysed(start_date, end_date)
-        )
-      end
-
       def advice_page_key
         :electricity_intraday
       end

--- a/app/controllers/schools/advice/electricity_intraday_controller.rb
+++ b/app/controllers/schools/advice/electricity_intraday_controller.rb
@@ -5,9 +5,22 @@ module Schools
       end
 
       def analysis
+        @analysis_dates = analysis_dates
       end
 
       private
+
+      def analysis_dates
+        start_date = aggregate_school.aggregated_electricity_meters.amr_data.start_date
+        end_date = aggregate_school.aggregated_electricity_meters.amr_data.end_date
+        OpenStruct.new(
+          start_date: start_date,
+          end_date: end_date,
+          one_years_data: one_years_data?(start_date, end_date),
+          recent_data: recent_data?(end_date),
+          months_analysed: months_analysed(start_date, end_date)
+        )
+      end
 
       def advice_page_key
         :electricity_intraday

--- a/app/controllers/schools/advice/electricity_intraday_controller.rb
+++ b/app/controllers/schools/advice/electricity_intraday_controller.rb
@@ -10,6 +10,12 @@ module Schools
 
       private
 
+      def create_analysable
+        OpenStruct.new(
+          enough_data?: analysis_dates.one_years_data
+        )
+      end
+
       def analysis_dates
         start_date = aggregate_school.aggregated_electricity_meters.amr_data.start_date
         end_date = aggregate_school.aggregated_electricity_meters.amr_data.end_date

--- a/app/views/schools/advice/electricity_intraday/_analysis.html.erb
+++ b/app/views/schools/advice/electricity_intraday/_analysis.html.erb
@@ -53,7 +53,7 @@
 
 <%= component 'chart', chart_type: :intraday_line_school_last7days, school: @school do |c| %>
   <% c.with_title { t('advice_pages.electricity_intraday.analysis.charts.trends_chart_title') } %>
-  <% c.with_subtitle { t('advice_pages.electricity_intraday.analysis.charts.trends_chart_subtitle_html') } %>
+  <% c.with_subtitle { t('advice_pages.electricity_intraday.analysis.charts.trends_chart_subtitle_html', start_date: short_dates(@analysis_dates.end_date - 6.days), end_date: short_dates(@analysis_dates.end_date)) } %>
   <% c.with_footer do %>
     <p><%= t('advice_pages.electricity_intraday.analysis.charts.trends_chart_explanation') %></p>
   <% end %>

--- a/app/views/schools/advice/electricity_intraday/_analysis.html.erb
+++ b/app/views/schools/advice/electricity_intraday/_analysis.html.erb
@@ -1,0 +1,34 @@
+<p><%= t('advice_pages.electricity_intraday.analysis.summary') %></p>
+
+<p><%= t('advice_pages.electricity_intraday.analysis.sections') %></p>
+
+<ul>
+  <li><%= link_to(t('advice_pages.electricity_intraday.analysis.comparison.title'), '#comparison') %></li>
+  <li><%= link_to(t('advice_pages.electricity_intraday.analysis.schooldays.title'), '#schooldays') %></li>
+  <li><%= link_to(t('advice_pages.electricity_intraday.analysis.holidays.title'), '#holidays') %></li>
+  <li><%= link_to(t('advice_pages.electricity_intraday.analysis.weekends.title'), '#weekends') %></li>
+  <li><%= link_to(t('advice_pages.electricity_intraday.analysis.trends.title'), '#trends') %></li>
+</ul>
+
+<!--  SCHOOL COMPARISON -->
+<%= render 'schools/advice/section_title', section_id: 'comparison', section_title: t('advice_pages.electricity_intraday.analysis.comparison.title') %>
+
+<%= component 'chart', chart_type: :intraday_line_school_days_reduced_data_versus_benchmarks, school: @school do |c| %>
+  <% c.with_title { t('advice_pages.electricity_intraday.analysis.charts.comparison_chart_title', months_analysed: @analysis_dates.months_analysed) } %>
+  <% c.with_subtitle { t('advice_pages.electricity_intraday.analysis.charts.comparison_chart_subtitle_html', start_month_year: short_dates(@analysis_dates.one_years_data ? @analysis_dates.end_date - 1.year : @analysis_dates.start_date), end_month_year: short_dates(@analysis_dates.end_date)) } %>
+  <% c.with_footer do %>
+    <p><%= t('advice_pages.electricity_intraday.analysis.charts.comparison_chart_explanation_html') %></p>
+  <% end %>
+<% end %>
+
+<!--  SCHOOL DAYS -->
+<%= render 'schools/advice/section_title', section_id: 'schooldays', section_title: t('advice_pages.electricity_intraday.analysis.schooldays.title') %>
+
+<!--  HOLIDAYS -->
+<%= render 'schools/advice/section_title', section_id: 'holidays', section_title: t('advice_pages.electricity_intraday.analysis.holidays.title') %>
+
+<!--  WEEKDAYS -->
+<%= render 'schools/advice/section_title', section_id: 'weekends', section_title: t('advice_pages.electricity_intraday.analysis.weekends.title') %>
+
+<!--  RECENT TRENDS -->
+<%= render 'schools/advice/section_title', section_id: 'trends', section_title: t('advice_pages.electricity_intraday.analysis.trends.title') %>

--- a/app/views/schools/advice/electricity_intraday/_analysis.html.erb
+++ b/app/views/schools/advice/electricity_intraday/_analysis.html.erb
@@ -14,7 +14,7 @@
 <%= render 'schools/advice/section_title', section_id: 'comparison', section_title: t('advice_pages.electricity_intraday.analysis.comparison.title') %>
 
 <%= component 'chart', chart_type: :intraday_line_school_days_reduced_data_versus_benchmarks, school: @school do |c| %>
-  <% c.with_title { t('advice_pages.electricity_intraday.analysis.charts.comparison_chart_title', months_analysed: @analysis_dates.months_analysed) } %>
+  <% c.with_title { t('advice_pages.electricity_intraday.analysis.charts.comparison_chart_title') } %>
   <% c.with_subtitle { t('advice_pages.electricity_intraday.analysis.charts.comparison_chart_subtitle_html', start_month_year: short_dates(@analysis_dates.one_years_data ? @analysis_dates.end_date - 1.year : @analysis_dates.start_date), end_month_year: short_dates(@analysis_dates.end_date)) } %>
   <% c.with_footer do %>
     <p><%= t('advice_pages.electricity_intraday.analysis.charts.comparison_chart_explanation_html') %></p>
@@ -24,11 +24,37 @@
 <!--  SCHOOL DAYS -->
 <%= render 'schools/advice/section_title', section_id: 'schooldays', section_title: t('advice_pages.electricity_intraday.analysis.schooldays.title') %>
 
+<%= component 'chart', chart_type: :intraday_line_school_days_reduced_data, school: @school do |c| %>
+  <% c.with_title { t('advice_pages.electricity_intraday.analysis.charts.schooldays_chart_title') } %>
+  <% c.with_subtitle { t('advice_pages.electricity_intraday.analysis.charts.schooldays_chart_subtitle') } %>
+  <% c.with_footer do %>
+    <p><%= t('advice_pages.electricity_intraday.analysis.charts.schooldays_chart_explanation_html') %></p>
+  <% end %>
+<% end %>
+
 <!--  HOLIDAYS -->
 <%= render 'schools/advice/section_title', section_id: 'holidays', section_title: t('advice_pages.electricity_intraday.analysis.holidays.title') %>
 
-<!--  WEEKDAYS -->
+<%= component 'chart', chart_type: :intraday_line_holidays, school: @school do |c| %>
+  <% c.with_title { t('advice_pages.electricity_intraday.analysis.charts.holidays_chart_title') } %>
+  <% c.with_subtitle { t('advice_pages.electricity_intraday.analysis.charts.holidays_chart_subtitle') } %>
+<% end %>
+
+<!--  WEEKENDS -->
 <%= render 'schools/advice/section_title', section_id: 'weekends', section_title: t('advice_pages.electricity_intraday.analysis.weekends.title') %>
+
+<%= component 'chart', chart_type: :intraday_line_weekends, school: @school do |c| %>
+  <% c.with_title { t('advice_pages.electricity_intraday.analysis.charts.weekends_chart_title') } %>
+  <% c.with_subtitle { t('advice_pages.electricity_intraday.analysis.charts.weekends_chart_subtitle') } %>
+<% end %>
 
 <!--  RECENT TRENDS -->
 <%= render 'schools/advice/section_title', section_id: 'trends', section_title: t('advice_pages.electricity_intraday.analysis.trends.title') %>
+
+<%= component 'chart', chart_type: :intraday_line_school_last7days, school: @school do |c| %>
+  <% c.with_title { t('advice_pages.electricity_intraday.analysis.charts.trends_chart_title') } %>
+  <% c.with_subtitle { t('advice_pages.electricity_intraday.analysis.charts.trends_chart_subtitle_html') } %>
+  <% c.with_footer do %>
+    <p><%= t('advice_pages.electricity_intraday.analysis.charts.trends_chart_explanation') %></p>
+  <% end %>
+<% end %>

--- a/config/locales/views/advice_pages/electricity_intraday.yml
+++ b/config/locales/views/advice_pages/electricity_intraday.yml
@@ -3,7 +3,32 @@ en:
   advice_pages:
     electricity_intraday:
       analysis:
+        charts:
+          comparison_chart_explanation_html: |-
+            <p>
+              This chart allows you to see how your school’s electricity consumption compares with other energy efficient schools throughout the school day. A 'benchmark' school represents the 30.0% best ranked primary schools and 'exemplar' the 17.5% best primary schools.
+            </p>
+            <p>
+              This chart can be useful to observe where your school’s pattern of energy use differs from other schools. There might be anomalies like jumps in usage outside school hours which can’t be accounted for.
+            </p>
+            <p>
+              If your school has high consumption overnight, compared to the benchmark schools, this could indicate that you need to reduce your baseload. If consumption is mainly high during the middle of the day, this indicates you need to reduce your peak electricity use.
+            </p>
+          comparison_chart_subtitle_html: The chart below provides a comparison of your school's average consumption during school days between <span class="start-date">%{start_month_year}</span> and <span class="end-date">%{end_month_year}</span>, and includes a comparison with 'benchmark' and 'exemplar' schools.
+          comparison_chart_title: Electricity consumption during the school day over the last 12 months
+        sections: The following sections provide more background and analysis on your electricity baseload
+        summary: This section gives a more detailed analysis of how your school’s electricity use varies throughout the day. Comparisons are made between your school and benchmark and exemplar schools as well as between this year and the previous year for weekdays, weekends and holidays.
         title: Analysis
+        comparison:
+          title: How does your school compare?
+        schooldays:
+          title: School days
+        holidays:
+          title: Holidays
+        weekends:
+          title: Weekends
+        trends:
+          title: Recent trends
       insights:
         next_steps: Next steps
         title: Insights

--- a/config/locales/views/advice_pages/electricity_intraday.yml
+++ b/config/locales/views/advice_pages/electricity_intraday.yml
@@ -16,19 +16,35 @@ en:
             </p>
           comparison_chart_subtitle_html: The chart below provides a comparison of your school's average consumption during school days between <span class="start-date">%{start_month_year}</span> and <span class="end-date">%{end_month_year}</span>, and includes a comparison with 'benchmark' and 'exemplar' schools.
           comparison_chart_title: Electricity consumption during the school day over the last 12 months
+          holidays_chart_subtitle: The graph compares the average electricity consumption for your school during the school holidays over the last 2 years
+          holidays_chart_title: Daily variation in electricity use during school holidays
+          schooldays_chart_explanation_html: |-
+            <p>
+              This chart shows the peak electricity usage at the school (normally during the middle of the day) and the overnight electricity consumption.
+            </p>
+            <p>
+              It is useful in diagnosing what changes have happened over the last year which may have changed electricity consumption.
+            </p>
+          schooldays_chart_subtitle: The chart shows the average electricity consumption for your school during the school day over the last 2 years
+          schooldays_chart_title: Daily variation in electricity use during school days
+          trends_chart_explanation: You can use this type of graph to understand how the schools electricity usage changes over time. You can click on the legend to add or remove lines from the graph to make it clearer.
+          trends_chart_subtitle_html: The graph shows how the electricity consumption for your school varies during the day between <span class="start-date">%{start_date}</span> and <span class="end-date">%{end_date}</span>
+          trends_chart_title: Daily variation in electricity use over the last 7 days
+          weekends_chart_subtitle: The graph compares the average electricity consumption for your school during the weekend over the last 2 years
+          weekends_chart_title: Daily variation in electricity use over the weekends
+        comparison:
+          title: How does your school compare?
+        holidays:
+          title: Holidays
+        schooldays:
+          title: School days
         sections: The following sections provide more background and analysis on your electricity baseload
         summary: This section gives a more detailed analysis of how your school’s electricity use varies throughout the day. Comparisons are made between your school and benchmark and exemplar schools as well as between this year and the previous year for weekdays, weekends and holidays.
         title: Analysis
-        comparison:
-          title: How does your school compare?
-        schooldays:
-          title: School days
-        holidays:
-          title: Holidays
-        weekends:
-          title: Weekends
         trends:
           title: Recent trends
+        weekends:
+          title: Weekends
       insights:
         next_steps: Next steps
         title: Insights

--- a/spec/support/advice_pages_shared_contexts.rb
+++ b/spec/support/advice_pages_shared_contexts.rb
@@ -30,6 +30,7 @@ RSpec.shared_context "electricity advice page" do
     allow(amr_data).to receive(:end_date).and_return(end_date)
     allow(electricity_aggregate_meter).to receive(:fuel_type).and_return(:electricity)
     allow(electricity_aggregate_meter).to receive(:amr_data).and_return(amr_data)
+    allow(meter_collection).to receive(:aggregate_meter).with(:electricity).and_return(electricity_aggregate_meter)
     allow(meter_collection).to receive(:aggregated_electricity_meters).and_return(electricity_aggregate_meter)
     allow(meter_collection).to receive(:amr_data).and_return(amr_data)
     allow_any_instance_of(AggregateSchoolService).to receive(:aggregate_school).and_return(meter_collection)

--- a/spec/system/schools/advice_pages/electricity_intraday_spec.rb
+++ b/spec/system/schools/advice_pages/electricity_intraday_spec.rb
@@ -19,10 +19,32 @@ RSpec.describe "electricity intraday advice page", type: :system do
       before { click_on 'Insights' }
       it_behaves_like "an advice page tab", tab: "Insights"
     end
+
     context "clicking the 'Analysis' tab" do
-      before { click_on 'Analysis' }
+      let(:start_date)          { Date.parse('20190101')}
+      let(:end_date)            { Date.parse('20210101')}
+      let(:amr_data)            { double('amr-data', start_date: start_date, end_date: end_date) }
+      let(:aggregate_meter)     { double('aggregate_meter', amr_data: amr_data) }
+      let(:aggregate_school)    { double('meter-collection') }
+
+      before do
+        allow(aggregate_school).to receive(:aggregated_electricity_meters).and_return(aggregate_meter)
+        allow(aggregate_school).to receive(:aggregate_meter).and_return(aggregate_meter)
+        allow_any_instance_of(AggregateSchoolService).to receive(:aggregate_school).and_return(aggregate_school)
+        click_on 'Analysis'
+      end
+
       it_behaves_like "an advice page tab", tab: "Analysis"
+
+      it "shows titles" do
+        expect(page).to have_content("Electricity consumption during the school day over the last 12 months")
+      end
+
+      it "shows dates for 7 day period up to end date" do
+        expect(page).to have_content("graph shows how the electricity consumption for your school varies during the day between 26 Dec 2020 and 01 Jan 2021")
+      end
     end
+
     context "clicking the 'Learn More' tab" do
       before { click_on 'Learn More' }
       it_behaves_like "an advice page tab", tab: "Learn More"

--- a/spec/system/schools/advice_pages/electricity_intraday_spec.rb
+++ b/spec/system/schools/advice_pages/electricity_intraday_spec.rb
@@ -43,6 +43,13 @@ RSpec.describe "electricity intraday advice page", type: :system do
       it "shows dates for 7 day period up to end date" do
         expect(page).to have_content("graph shows how the electricity consumption for your school varies during the day between 26 Dec 2020 and 01 Jan 2021")
       end
+
+      context 'when not enough data' do
+        let(:start_date)          { end_date - 11.months }
+        it "shows message" do
+          expect(page).to have_content("Not enough data to run analysis")
+        end
+      end
     end
 
     context "clicking the 'Learn More' tab" do

--- a/spec/system/schools/advice_pages/electricity_intraday_spec.rb
+++ b/spec/system/schools/advice_pages/electricity_intraday_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 RSpec.describe "electricity intraday advice page", type: :system do
   let(:key) { 'electricity_intraday' }
   let(:expected_page_title) { "Electricity intraday usage analysis" }
+
   include_context "electricity advice page"
 
   context 'as school admin' do
@@ -21,16 +22,7 @@ RSpec.describe "electricity intraday advice page", type: :system do
     end
 
     context "clicking the 'Analysis' tab" do
-      let(:start_date)          { Date.parse('20190101')}
-      let(:end_date)            { Date.parse('20210101')}
-      let(:amr_data)            { double('amr-data', start_date: start_date, end_date: end_date) }
-      let(:aggregate_meter)     { double('aggregate_meter', amr_data: amr_data) }
-      let(:aggregate_school)    { double('meter-collection') }
-
       before do
-        allow(aggregate_school).to receive(:aggregated_electricity_meters).and_return(aggregate_meter)
-        allow(aggregate_school).to receive(:aggregate_meter).and_return(aggregate_meter)
-        allow_any_instance_of(AggregateSchoolService).to receive(:aggregate_school).and_return(aggregate_school)
         click_on 'Analysis'
       end
 
@@ -41,11 +33,13 @@ RSpec.describe "electricity intraday advice page", type: :system do
       end
 
       it "shows dates for 7 day period up to end date" do
-        expect(page).to have_content("graph shows how the electricity consumption for your school varies during the day between 26 Dec 2020 and 01 Jan 2021")
+        expected_start_date = (end_date - 6.days).to_s(:es_short)
+        expected_end_date = end_date.to_s(:es_short)
+        expect(page).to have_content("graph shows how the electricity consumption for your school varies during the day between #{expected_start_date} and #{expected_end_date}")
       end
 
       context 'when not enough data' do
-        let(:start_date)          { end_date - 11.months }
+        let(:start_date) { end_date - 11.months}
         it "shows message" do
           expect(page).to have_content("Not enough data to run analysis")
         end


### PR DESCRIPTION
This PR implements the analysis tab of the electricity intraday advice page, with charts and text.

It includes support for the Analysable checks for date ranges.

It also factors out some support methods into the AdviceBaseController for setting up analysis dates.
