### PR TITLE
Handle missing user_return_to in session during redirects

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -15,9 +15,9 @@ class ApplicationController < ActionController::Base
     if EnergySparks::FeatureFlags.active?(:redirect_to_preferred_locale)
       subdomain = ApplicationController.helpers.subdomain_for(user.preferred_locale)
       I18n.locale = user.preferred_locale
-      root_url(subdomain: subdomain) + (session[:user_return_to][1..-1] || '')
+      root_url(subdomain: subdomain).chomp('/') + session.fetch(:user_return_to, '/')
     else
-      session[:user_return_to] || root_url
+      session.fetch(:user_return_to, root_url)
     end
   end
 

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -1,0 +1,36 @@
+require "rails_helper"
+
+RSpec.describe ApplicationController, type: :controller do
+
+  let(:user) { create(:user) }
+
+  describe "#after_sign_in_path_for" do
+    it "redirects to the root path" do
+      expect(subject.after_sign_in_path_for(user)).to eq('http://test.host/')
+    end
+
+    it "uses the return to url" do
+      allow_any_instance_of(ApplicationController).to receive(:session).and_return({user_return_to: '/blah'})
+      expect(subject.after_sign_in_path_for(user)).to eq('http://test.host/blah')
+    end
+
+    context 'when redirecting to prefered locale' do
+      let(:user) { create(:user, preferred_locale: :cy) }
+
+      around do |example|
+        ClimateControl.modify FEATURE_FLAG_REDIRECT_TO_PREFERRED_LOCALE: 'true' do
+          example.run
+        end
+      end
+
+      it "redirects to the root path for locale" do
+        expect(subject.after_sign_in_path_for(user)).to eq('http://cy.test.host/')
+      end
+
+      it "uses the return to url and locale subdomain" do
+        allow_any_instance_of(ApplicationController).to receive(:session).and_return({user_return_to: '/blah'})
+        expect(subject.after_sign_in_path_for(user)).to eq('http://cy.test.host/blah')
+      end
+    end
+  end
+end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe ApplicationController, type: :controller do
 
     it "uses the return to url" do
       allow_any_instance_of(ApplicationController).to receive(:session).and_return({user_return_to: '/blah'})
-      expect(subject.after_sign_in_path_for(user)).to eq('http://test.host/blah')
+      expect(subject.after_sign_in_path_for(user)).to eq('/blah')
     end
 
     context 'when redirecting to prefered locale' do


### PR DESCRIPTION
Error during login when trying to redirect to a locale subdomain, and the session[:user_return_to] was not set.