### PR TITLE
Electricity long term use insights

### DIFF
--- a/app/controllers/schools/advice/electricity_long_term_controller.rb
+++ b/app/controllers/schools/advice/electricity_long_term_controller.rb
@@ -2,6 +2,12 @@ module Schools
   module Advice
     class ElectricityLongTermController < AdviceBaseController
       def insights
+        @analysis_dates = analysis_dates
+        @annual_usage = usage_service.annual_usage
+        @vs_benchmark = usage_service.annual_usage_vs_benchmark(compare: :benchmark_school)
+        @vs_exemplar = usage_service.annual_usage_vs_benchmark(compare: :exemplar_school)
+        @annual_usage_change_since_last_year = usage_service.annual_usage_change_since_last_year
+        @benchmarked_usage = benchmarked_usage(@annual_usage.kwh)
       end
 
       def analysis
@@ -59,6 +65,18 @@ module Schools
       #for charts that use the last full week
       def last_full_week_end_date(end_date)
         end_date.prev_week.end_of_week - 1
+      end
+
+      def benchmarked_usage(annual_usage_kwh)
+        annual_usage_kwh_benchmark = usage_service.annual_usage_kwh(compare: :benchmark_school)
+        annual_usage_kwh_exemplar = usage_service.annual_usage_kwh(compare: :exemplar_school)
+
+        OpenStruct.new(
+          category: categorise_school_vs_benchmark(annual_usage_kwh, annual_usage_kwh_benchmark, annual_usage_kwh_exemplar),
+          annual_usage_kwh: annual_usage_kwh,
+          annual_usage_kwh_benchmark: annual_usage_kwh_benchmark,
+          annual_usage_kwh_exemplar: annual_usage_kwh_exemplar
+        )
       end
 
       def usage_service

--- a/app/services/schools/advice/long_term_usage_service.rb
+++ b/app/services/schools/advice/long_term_usage_service.rb
@@ -21,6 +21,14 @@ module Schools
         annual_usage_calculator.annual_usage
       end
 
+      def annual_usage_change_since_last_year
+        annual_usage_calculator.annual_usage_change_since_last_year
+      end
+
+      def annual_usage_kwh(compare: :benchmark_school)
+        annual_usage_benchmark.annual_electricity_usage_kwh(compare: compare)
+      end
+
       def annual_usage_vs_benchmark(compare: :benchmark_school)
         annual_usage_benchmark.annual_usage(compare: compare)
       end

--- a/app/views/schools/advice/baseload/_comparison.html.erb
+++ b/app/views/schools/advice/baseload/_comparison.html.erb
@@ -41,8 +41,8 @@
   </tbody>
 </table>
 
-<p>
-  <% if school.school_group.present? %>
+<% if school.school_group.present? %>
+  <p>
     <%= t('advice_pages.baseload.comparison.more_detail_html', link: benchmark_for_school_group_path(:baseload_per_pupil, school)) %>
-  <% end %>
-</p>
+  </p>
+<% end %>

--- a/app/views/schools/advice/baseload/_comparison.html.erb
+++ b/app/views/schools/advice/baseload/_comparison.html.erb
@@ -6,7 +6,7 @@
 
 <table class="table table-sm advice-table" id="comparison-baseload">
   <thead>
-    <th><%= t('advice_pages.baseload.comparison.tables.columns.category') %></th>
+    <th><%= t('advice_pages.tables.columns.category') %></th>
     <th class="text-right"><%= t('advice_pages.baseload.tables.columns.average_annual_baseload_kw') %></th>
     <th class="text-right"><%= t('advice_pages.baseload.comparison.tables.columns.your_baseload') %></th>
   </thead>

--- a/app/views/schools/advice/baseload/_current_baseload.html.erb
+++ b/app/views/schools/advice/baseload/_current_baseload.html.erb
@@ -2,7 +2,7 @@
 
 <table class="mt-2 table table-sm advice-table" id="current-baseload">
     <thead>
-      <th><%= t('advice_pages.baseload.current_baseload.tables.columns.period') %></th>
+      <th><%= t('advice_pages.tables.columns.period') %></th>
       <th class="text-right"><%= t('advice_pages.baseload.current_baseload.tables.columns.use') %></th>
       <th class="text-right"><%= t('advice_pages.baseload.current_baseload.tables.columns.percentage_change') %></th>
     </thead>

--- a/app/views/schools/advice/electricity_long_term/_analysis.html.erb
+++ b/app/views/schools/advice/electricity_long_term/_analysis.html.erb
@@ -13,7 +13,7 @@
 </ul>
 
 <%= render 'recent_trend', school: @school, analysis_dates: @analysis_dates, annual_usage: @annual_usage, vs_exemplar: @vs_exemplar, estimated_savings_vs_exemplar: @estimated_savings_vs_exemplar %>
-<%= render 'comparison', school: @school, analysis_dates: @analysis_dates, annual_usage: @annual_usage, vs_benchmark: @vs_benchmark, vs_exemplar: @vs_exemplar, estimated_savings_vs_exemplar: @estimated_savings_vs_exemplar, estimated_savings_vs_benchmark: @estimated_savings_vs_benchmark %>
+<%= render 'analysis_comparison', school: @school, analysis_dates: @analysis_dates, annual_usage: @annual_usage, vs_benchmark: @vs_benchmark, vs_exemplar: @vs_exemplar, estimated_savings_vs_exemplar: @estimated_savings_vs_exemplar, estimated_savings_vs_benchmark: @estimated_savings_vs_benchmark %>
 <%= render 'long_term_trend', school: @school, analysis_dates: @analysis_dates %>
 
 <% if @multiple_meters %>

--- a/app/views/schools/advice/electricity_long_term/_analysis_comparison.html.erb
+++ b/app/views/schools/advice/electricity_long_term/_analysis_comparison.html.erb
@@ -1,0 +1,17 @@
+<%= render 'schools/advice/section_title', section_id: 'comparison', section_title: t('advice_pages.electricity_long_term.analysis.comparison.title') %>
+
+<%= component 'chart', chart_type: :benchmark_electric_only_£, school: school do |c| %>
+  <% c.with_title { t('advice_pages.electricity_long_term.charts.benchmark.title') } %>
+  <% c.with_subtitle { t('advice_pages.electricity_long_term.charts.benchmark.subtitle', start_date: analysis_dates.one_year_before_end.to_s(:es_short), end_date: analysis_dates.end_date.to_s(:es_short)) } %>
+<% end %>
+
+<p>
+  <%= t('advice_pages.electricity_long_term.analysis.comparison.table_explanation', school_type: t('analytics.school_types.' + school.school_type)) %>
+</p>
+
+<%= render 'comparison_with_benchmark_table', annual_usage: annual_usage, vs_exemplar: vs_exemplar, vs_benchmark: vs_benchmark, estimated_savings_vs_exemplar: estimated_savings_vs_exemplar, estimated_savings_vs_benchmark: estimated_savings_vs_benchmark %>
+
+<%= component 'chart', chart_type: :group_by_week_electricity_versus_benchmark, school: school do |c| %>
+  <% c.with_title { t('advice_pages.electricity_long_term.charts.group_by_week_electricity_versus_benchmark.title') } %>
+  <% c.with_subtitle { t('advice_pages.electricity_long_term.charts.group_by_week_electricity_versus_benchmark.subtitle_html', start_date: analysis_dates.last_full_week_start_date.to_s(:es_short), end_date: analysis_dates.last_full_week_end_date.to_s(:es_short)) } %>
+<% end %>

--- a/app/views/schools/advice/electricity_long_term/_comparison.html.erb
+++ b/app/views/schools/advice/electricity_long_term/_comparison.html.erb
@@ -41,8 +41,8 @@
   </tbody>
 </table>
 
-<p>
-  <% if school.school_group.present? %>
+<% if school.school_group.present? %>
+  <p>
     <%= t('advice_pages.electricity_long_term.insights.comparison.more_detail_html', link: benchmark_for_school_group_path(:annual_electricity_costs_per_pupil, school)) %>
-  <% end %>
-</p>
+  </p>
+<% end %>

--- a/app/views/schools/advice/electricity_long_term/_comparison.html.erb
+++ b/app/views/schools/advice/electricity_long_term/_comparison.html.erb
@@ -1,17 +1,48 @@
-<%= render 'schools/advice/section_title', section_id: 'comparison', section_title: t('advice_pages.electricity_long_term.analysis.comparison.title') %>
-
-<%= component 'chart', chart_type: :benchmark_electric_only_£, school: school do |c| %>
-  <% c.with_title { t('advice_pages.electricity_long_term.charts.benchmark.title') } %>
-  <% c.with_subtitle { t('advice_pages.electricity_long_term.charts.benchmark.subtitle', start_date: analysis_dates.one_year_before_end.to_s(:es_short), end_date: analysis_dates.end_date.to_s(:es_short)) } %>
-<% end %>
+<%= render 'schools/advice/section_title', section_id: 'comparison', section_title: t('advice_pages.electricity_long_term.insights.comparison.title') %>
 
 <p>
-  <%= t('advice_pages.electricity_long_term.analysis.comparison.table_explanation', school_type: t('analytics.school_types.' + school.school_type)) %>
+  <%= t('advice_pages.electricity_long_term.insights.comparison.how_do_you_compare', school_type: t('analytics.school_types.' + school.school_type)) %>
 </p>
 
-<%= render 'comparison_with_benchmark_table', annual_usage: annual_usage, vs_exemplar: vs_exemplar, vs_benchmark: vs_benchmark, estimated_savings_vs_exemplar: estimated_savings_vs_exemplar, estimated_savings_vs_benchmark: estimated_savings_vs_benchmark %>
+<table class="table table-sm advice-table" id="comparison-long-term-usage">
+  <thead>
+    <th><%= t('advice_pages.tables.columns.category') %></th>
+    <th class="text-right"><%= t('advice_pages.electricity_long_term.tables.columns.annual_usage_kwh') %></th>
+    <th class="text-right"><%= t('advice_pages.electricity_long_term.tables.columns.your_usage') %></th>
+  </thead>
+  <tbody>
+    <tr class="<%= row_class_for_category(benchmarked_usage.category, :exemplar) %>">
+      <td><%= t('advice_pages.benchmarks.exemplar_school') %></td>
+      <td class="text-right"><%= format_unit(benchmarked_usage.annual_usage_kwh_exemplar, :kwh) %></td>
+      <td class="text-right">
+        <% if benchmarked_usage.category == :exemplar %>
+         <%= format_unit(benchmarked_usage.annual_usage_kwh, :kwh) %>
+        <% end %>
+      </td>
+    </tr>
+    <tr class="<%= row_class_for_category(benchmarked_usage.category, :benchmark) %>">
+      <td><%= t('advice_pages.benchmarks.benchmark_school') %></td>
+      <td class="text-right"><%= format_unit(benchmarked_usage.annual_usage_kwh_benchmark, :kwh) %></td>
+      <td class="text-right">
+        <% if benchmarked_usage.category == :benchmark %>
+         <%= format_unit(benchmarked_usage.annual_usage_kwh, :kwh) %>
+        <% end %>
+      </td>
+    </tr>
+    <tr class="<%= row_class_for_category(benchmarked_usage.category, :other, 'negative-row') %>">
+      <td><%= t('advice_pages.benchmarks.other') %></td>
+      <td class="text-right">><%= format_unit(benchmarked_usage.annual_usage_kwh_benchmark, :kwh) %></td>
+      <td class="text-right">
+        <% if benchmarked_usage.category == :other %>
+          <%= format_unit(benchmarked_usage.annual_usage_kwh, :kwh) %>
+        <% end %>
+      </td>
+    </tr>
+  </tbody>
+</table>
 
-<%= component 'chart', chart_type: :group_by_week_electricity_versus_benchmark, school: school do |c| %>
-  <% c.with_title { t('advice_pages.electricity_long_term.charts.group_by_week_electricity_versus_benchmark.title') } %>
-  <% c.with_subtitle { t('advice_pages.electricity_long_term.charts.group_by_week_electricity_versus_benchmark.subtitle_html', start_date: analysis_dates.last_full_week_start_date.to_s(:es_short), end_date: analysis_dates.last_full_week_end_date.to_s(:es_short)) } %>
-<% end %>
+<p>
+  <% if school.school_group.present? %>
+    <%= t('advice_pages.electricity_long_term.insights.comparison.more_detail_html', link: benchmark_for_school_group_path(:annual_electricity_costs_per_pupil, school)) %>
+  <% end %>
+</p>

--- a/app/views/schools/advice/electricity_long_term/_current_usage.html.erb
+++ b/app/views/schools/advice/electricity_long_term/_current_usage.html.erb
@@ -1,0 +1,30 @@
+<%= render 'schools/advice/section_title', section_id: 'current', section_title: t('advice_pages.electricity_long_term.insights.current_usage.title') %>
+
+<table class="table table-sm advice-table">
+  <thead class="thead-dark">
+    <th><%= t('advice_pages.tables.columns.period') %></th>
+    <th class="text-right"><%= t('advice_pages.electricity_long_term.tables.columns.annual_usage_kwh') %></th>
+    <th class="text-right"><%= t('advice_pages.electricity_long_term.tables.columns.annual_usage_co2') %></th>
+    <th class="text-right"><%= t('advice_pages.electricity_long_term.tables.columns.annual_usage_gbp') %></th>
+    <th class="text-right"><%= t('advice_pages.electricity_long_term.tables.columns.annual_change') %></th>
+  </thead>
+  <tbody>
+    <tr>
+      <td><%= t('advice_pages.electricity_long_term.insights.current_usage.last_year') %></td>
+      <td class="text-right"><%= format_unit(annual_usage.kwh, :kwh) %></td>
+      <td class="text-right"><%= format_unit(annual_usage.co2, :co2) %></td>
+      <td class="text-right"><%= format_unit(annual_usage.£, :£) %></td>
+      <td class="text-right">
+        <% if annual_usage_change_since_last_year.present? %>
+          <%= up_downify( format_unit(annual_usage_change_since_last_year.percent, :relative_percent, false) ) %>
+        <% else %>
+          -
+        <% end %>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<div class="text-right advice-table-caption">
+  <%= t('advice_pages.electricity_long_term.insights.current_usage.calculation_dates', start_date: I18n.l(analysis_dates.end_date, format: '%-d %B %Y'), end_date: I18n.l(analysis_dates.one_year_before_end, format: '%-d %B %Y')) %>.
+  <a href="<%= analysis_school_advice_electricity_long_term_path(school) %>"><%= t('advice_pages.electricity_long_term.insights.current_usage.review_our_analysis') %></a>
+</div>

--- a/app/views/schools/advice/electricity_long_term/_insights.html.erb
+++ b/app/views/schools/advice/electricity_long_term/_insights.html.erb
@@ -1,0 +1,3 @@
+  <%= render 'insights_intro', school: @school %>
+  <%= render 'current_usage', school: @school, analysis_dates: @analysis_dates, annual_usage: @annual_usage, annual_usage_change_since_last_year: @annual_usage_change_since_last_year %>
+  <%= render 'comparison', school: @school, benchmarked_usage: @benchmarked_usage %>

--- a/app/views/schools/advice/electricity_long_term/_insights_intro.html.erb
+++ b/app/views/schools/advice/electricity_long_term/_insights_intro.html.erb
@@ -1,0 +1,4 @@
+<%= component 'notice', status: :neutral do |c| %>
+  <% c.with_link { link_to t('advice_pages.electricity_long_term.what_is_long_term_use.link'), learn_more_school_advice_electricity_long_term_path(school) } %>
+  <%= t('advice_pages.electricity_long_term.what_is_long_term_use.text_html') %>
+<% end %>

--- a/config/locales/views/advice_pages/advice_pages.yml
+++ b/config/locales/views/advice_pages/advice_pages.yml
@@ -1,6 +1,10 @@
 ---
 en:
   advice_pages:
+    tables:
+      columns:
+        period: Period
+        category: Category
     benchmarks:
       benchmark_school: Well managed
       exemplar_school: Exemplar

--- a/config/locales/views/advice_pages/advice_pages.yml
+++ b/config/locales/views/advice_pages/advice_pages.yml
@@ -1,10 +1,6 @@
 ---
 en:
   advice_pages:
-    tables:
-      columns:
-        period: Period
-        category: Category
     benchmarks:
       benchmark_school: Well managed
       exemplar_school: Exemplar
@@ -57,3 +53,7 @@ en:
       title: Not enough data to run analysis
     show:
       title: Advice Pages
+    tables:
+      columns:
+        category: Category
+        period: Period

--- a/config/locales/views/advice_pages/baseload.yml
+++ b/config/locales/views/advice_pages/baseload.yml
@@ -51,18 +51,16 @@ en:
         more_detail_html: For more detail, <a href="%{link}">compare with other schools in your group</a>
         tables:
           columns:
-            category: Category
             your_baseload: Your baseload (kW)
         title: How do you compare?
       current_baseload:
-        calculation_dates: Calculation based on data from %{start_date} to %{end_date}
+        calculation_dates: Calculation based on usage between %{start_date} and %{end_date}
         last_week: Last week
         last_year: Last year
         review_our_analysis: Review our detailed analysis
         tables:
           columns:
             percentage_change: "% Change"
-            period: Period
             use: Average baseload (kW)
         title: Your current baseload
       insights:

--- a/config/locales/views/advice_pages/electricity_long_term.yml
+++ b/config/locales/views/advice_pages/electricity_long_term.yml
@@ -61,17 +61,17 @@ en:
           subtitle_html: This chart shows how your school’s electricity use compares against well managed and exemplar schools for each week between <span class='start-date'>%{start_date}</span> and <span class='end-date'>%{end_date}</span>
           title: Electricity use comparison with other schools over the last 12 months
       insights:
-        next_steps: To fully determine the causes of the changes in your electricity consumption you should review how consumption has changed month by month and look in more detail at how your baseload and peak electricity consumption have changed.
-        title: What do we mean by long term electricity use?
-        current_usage:
-          title: Your long term electricity use
-          calculation_dates: Calculation based on usage between %{start_date} and %{end_date}
-          last_year: Last year
-          review_our_analysis: Review our detailed analysis
         comparison:
           how_do_you_compare: How does your electricity use for the last 12 months compare to other %{school_type} schools on Energy Sparks, with a similar number of pupils?
           more_detail_html: For more detail, <a href="%{link}">compare with other schools in your group</a>
           title: How do you compare?
+        current_usage:
+          calculation_dates: Calculation based on usage between %{start_date} and %{end_date}
+          last_year: Last year
+          review_our_analysis: Review our detailed analysis
+          title: Your long term electricity use
+        next_steps: To fully determine the causes of the changes in your electricity consumption you should review how consumption has changed month by month and look in more detail at how your baseload and peak electricity consumption have changed.
+        title: What do we mean by long term electricity use?
       page_title: Long term changes in electricity consumption
       tables:
         columns:
@@ -86,11 +86,11 @@ en:
         labels:
           all_meters: All meters
       what_is_long_term_use:
-        text_html: |-
-            <p>
-            Tracking long term trends in your school's electricity use can help you to monitor your overall progress towards reducing your electricity costs and carbon emissions.
-            </p>
-            <p>
-            Viewing your electricity use over a whole year or more can help identify any seasonal variations in your usage and do forward planning.
-            </p>
         link: Learn more
+        text_html: |-
+          <p>
+          Tracking long term trends in your school's electricity use can help you to monitor your overall progress towards reducing your electricity costs and carbon emissions.
+          </p>
+          <p>
+          Viewing your electricity use over a whole year or more can help identify any seasonal variations in your usage and do forward planning.
+          </p>

--- a/config/locales/views/advice_pages/electricity_long_term.yml
+++ b/config/locales/views/advice_pages/electricity_long_term.yml
@@ -61,17 +61,36 @@ en:
           subtitle_html: This chart shows how your school’s electricity use compares against well managed and exemplar schools for each week between <span class='start-date'>%{start_date}</span> and <span class='end-date'>%{end_date}</span>
           title: Electricity use comparison with other schools over the last 12 months
       insights:
-        next_steps: Next steps
-        title: Insights
+        next_steps: To fully determine the causes of the changes in your electricity consumption you should review how consumption has changed month by month and look in more detail at how your baseload and peak electricity consumption have changed.
+        title: What do we mean by long term electricity use?
+        current_usage:
+          title: Your long term electricity use
+          calculation_dates: Calculation based on usage between %{start_date} and %{end_date}
+          last_year: Last year
+          review_our_analysis: Review our detailed analysis
+        comparison:
+          how_do_you_compare: How does your electricity use for the last 12 months compare to other %{school_type} schools on Energy Sparks, with a similar number of pupils?
+          more_detail_html: For more detail, <a href="%{link}">compare with other schools in your group</a>
+          title: How do you compare?
       page_title: Long term changes in electricity consumption
       tables:
         columns:
           annual_change: Annual change in usage
           annual_usage_co2: Annual co2 (kg/CO2)
           annual_usage_gbp: Annual cost (£)
-          annual_usage_kwh: Annual usage (kwh)
+          annual_usage_kwh: Annual usage (kWh)
           estimated_savings_gbp: Estimated saving (£)
           meter: Meter
           percent: Percent of total use
+          your_usage: Your usage (kWh)
         labels:
           all_meters: All meters
+      what_is_long_term_use:
+        text_html: |-
+            <p>
+            Tracking long term trends in your school's electricity use can help you to monitor your overall progress towards reducing your electricity costs and carbon emissions.
+            </p>
+            <p>
+            Viewing your electricity use over a whole year or more can help identify any seasonal variations in your usage and do forward planning.
+            </p>
+        link: Learn more

--- a/spec/system/schools/advice_pages/electricity_long_term_spec.rb
+++ b/spec/system/schools/advice_pages/electricity_long_term_spec.rb
@@ -27,6 +27,9 @@ RSpec.describe "electricity long term advice page", type: :system do
       allow_any_instance_of(Schools::Advice::LongTermUsageService).to receive(:estimated_savings).with(versus: :benchmark_school).and_return(annual_usage_vs_benchmark)
       allow_any_instance_of(Schools::Advice::LongTermUsageService).to receive(:estimated_savings).with(versus: :exemplar_school).and_return(annual_usage_vs_exemplar)
 
+      allow_any_instance_of(Schools::Advice::LongTermUsageService).to receive(:annual_usage_kwh).with(compare: :benchmark_school).and_return(annual_usage_vs_benchmark.kwh)
+      allow_any_instance_of(Schools::Advice::LongTermUsageService).to receive(:annual_usage_kwh).with(compare: :exemplar_school).and_return(annual_usage_vs_exemplar.kwh)
+
       sign_in(user)
       visit school_advice_electricity_long_term_path(school)
     end
@@ -34,8 +37,24 @@ RSpec.describe "electricity long term advice page", type: :system do
     it_behaves_like "an advice page tab", tab: "Insights"
 
     context "clicking the 'Insights' tab" do
-      before { click_on 'Insights' }
+      before do
+        click_on 'Insights'
+      end
+
       it_behaves_like "an advice page tab", tab: "Insights"
+      it 'includes expected sections' do
+        expect(page).to have_content("Tracking long term trends")
+        expect(page).to have_content(I18n.t('advice_pages.electricity_long_term.insights.current_usage.title'))
+        expect(page).to have_content(I18n.t('advice_pages.electricity_long_term.insights.comparison.title'))
+      end
+      it 'includes expected data' do
+        expect(page).to have_content("1,000")
+        expect(page).to have_content("£500")
+        expect(page).to have_content("1,500")
+
+        expect(page).to have_content("500")
+        expect(page).to have_content("800")
+      end
     end
     context "clicking the 'Analysis' tab" do
       before do


### PR DESCRIPTION
Implements the insights section for the electricity long term use page

- adds the introductory text in a notice
- adds table with summary of usage over last 12 months
- adds comparison with exemplar
- adds "next steps" text

Also tweaks a couple of keys used in the baseload yml so they're shared across advice pages