### PR TITLE
Add notes about partial years to long term trend table

### DIFF
--- a/app/helpers/advice_page_helper.rb
+++ b/app/helpers/advice_page_helper.rb
@@ -15,6 +15,15 @@ module AdvicePageHelper
     I18n.t('date.month_names')[date.month] + " " + date.year.to_s
   end
 
+  def partial_year_note(year, amr_start_date, amr_end_date)
+    if year == amr_start_date.year && (amr_start_date > Date.new(year, 1, 1))
+      return I18n.t('advice_pages.tables.labels.partial')
+    end
+    if year == amr_end_date.year && amr_end_date < Date.new(year, 12, 31)
+      return I18n.t('advice_pages.tables.labels.partial')
+    end
+  end
+
   def advice_baseload_high?(estimated_savings_vs_benchmark)
     estimated_savings_vs_benchmark > 0.0
   end

--- a/app/helpers/advice_page_helper.rb
+++ b/app/helpers/advice_page_helper.rb
@@ -17,10 +17,11 @@ module AdvicePageHelper
 
   def partial_year_note(year, amr_start_date, amr_end_date)
     if year == amr_start_date.year && (amr_start_date > Date.new(year, 1, 1))
-      return I18n.t('advice_pages.tables.labels.partial')
-    end
-    if year == amr_end_date.year && amr_end_date < Date.new(year, 12, 31)
-      return I18n.t('advice_pages.tables.labels.partial')
+      I18n.t('advice_pages.tables.labels.partial')
+    elsif year == amr_end_date.year && amr_end_date < Date.new(year, 12, 31)
+      I18n.t('advice_pages.tables.labels.partial')
+    else
+      ''
     end
   end
 

--- a/app/views/schools/advice/baseload/_analysis.html.erb
+++ b/app/views/schools/advice/baseload/_analysis.html.erb
@@ -47,7 +47,7 @@
   <p><%= t('advice_pages.baseload.analysis.long_term_trends.intro') %></p>
   <p><%= t('advice_pages.baseload.analysis.long_term_trends.table_description') %></p>
 
-  <%= render 'long_term_trends_table', annual_average_baseloads: @annual_average_baseloads %>
+  <%= render 'long_term_trends_table', school: @school, annual_average_baseloads: @annual_average_baseloads, analysis_dates: @analysis_dates %>
 
   <%= component 'chart', chart_type: :baseload_versus_benchmarks, school: @school do |c| %>
     <% c.with_title { t('advice_pages.baseload.analysis.charts.long_term_baseload_chart_title') } %>

--- a/app/views/schools/advice/baseload/_long_term_trends_table.html.erb
+++ b/app/views/schools/advice/baseload/_long_term_trends_table.html.erb
@@ -10,7 +10,10 @@
   <tbody>
     <% annual_average_baseloads.each do |annual_average_baseload| %>
     <tr>
-      <td><%= annual_average_baseload[:year] %></td>
+      <td>
+        <%= annual_average_baseload[:year] %>
+        <%= partial_year_note(annual_average_baseload[:year], analysis_dates.start_date, analysis_dates.end_date) %>
+      </td>
       <td class="text-right"><%= format_unit(annual_average_baseload[:baseload], :kw) %></td>
       <td class="text-right"><%= format_unit(annual_average_baseload[:baseload_usage].£, :£) %></td>
       <td class="text-right"><%= format_unit(annual_average_baseload[:baseload_usage].co2, :co2) %></td>
@@ -18,3 +21,6 @@
     <% end %>
   </tbody>
 </table>
+<div class="text-right advice-table-caption">
+  <%= t('advice_pages.baseload.current_baseload.calculation_dates', start_date: I18n.l(analysis_dates.start_date, format: '%-d %B %Y'), end_date: I18n.l(analysis_dates.end_date, format: '%-d %B %Y')) %>
+</div>

--- a/config/locales/views/advice_pages/advice_pages.yml
+++ b/config/locales/views/advice_pages/advice_pages.yml
@@ -57,4 +57,4 @@ en:
         category: Category
         period: Period
       labels:
-        partial: (partial)
+        partial: "(partial)"

--- a/config/locales/views/advice_pages/advice_pages.yml
+++ b/config/locales/views/advice_pages/advice_pages.yml
@@ -56,3 +56,5 @@ en:
       columns:
         category: Category
         period: Period
+      labels:
+        partial: (partial)


### PR DESCRIPTION
Adds a "(partial") note next to years with limited data. Extracted the logic into a helper so it can potentially be reused elsewhere/