### PR TITLE
Run i18n tasks earlier in build

### DIFF
--- a/.github/workflows/rubyonrails.yml
+++ b/.github/workflows/rubyonrails.yml
@@ -37,6 +37,9 @@ jobs:
       # Precompile assets
       - name: Precompile assets
         run: bundle exec rake assets:precompile
+      # Fail early if we have issues with translation keys
+      - name: Run i18n-tasks
+        run: bundle exec i18n-tasks health
       # Add or replace test runners here
       - name: Run tests
         run: bin/rake

--- a/.github/workflows/rubyonrails.yml
+++ b/.github/workflows/rubyonrails.yml
@@ -42,4 +42,4 @@ jobs:
         run: bundle exec i18n-tasks health
       # Add or replace test runners here
       - name: Run tests
-        run: bin/rake
+        run: bundle exec rspec --exclude-pattern "i18n_spec.rb"


### PR DESCRIPTION
We currently check status of i18n files whilst running the specs.

Proposing that we change the workflow to explicitly run the `i18n-tasks health` task before the specs so that they fail early, rather than at the end of the build.

At the moment I've left the rspec test in place, but this could possibly be removed now. In testing I've noticed that its takes up to 45 seconds to run the i18n-spec file so we probably don't want to run these checks twice.