### PR TITLE
Sorting of meter tables

### DIFF
--- a/app/helpers/advice_page_helper.rb
+++ b/app/helpers/advice_page_helper.rb
@@ -1,3 +1,4 @@
+# rubocop:disable Naming/AsciiIdentifiers
 module AdvicePageHelper
   def advice_page_path(school, advice_page, tab = :insights)
     polymorphic_path([tab, school, :advice, advice_page.key.to_sym])
@@ -85,4 +86,13 @@ module AdvicePageHelper
       annual_usage_breakdown.school_day_closed.send(unit) +
       annual_usage_breakdown.community.send(unit)
   end
+
+  def meters_by_estimated_saving(meters)
+    meters.sort_by {|_, v| -v.estimated_saving_£ }
+  end
+
+  def meters_by_percentage_baseload(meters)
+    meters.sort_by {|_, v| -v.percentage_baseload }
+  end
 end
+# rubocop:enable Naming/AsciiIdentifiers

--- a/app/views/schools/advice/baseload/_meter_breakdown_table.html.erb
+++ b/app/views/schools/advice/baseload/_meter_breakdown_table.html.erb
@@ -9,7 +9,7 @@
     </tr>
   </thead>
   <tbody>
-    <% baseload_meter_breakdown.each do |mpan_mprn, breakdown| %>
+    <% meters_by_percentage_baseload(baseload_meter_breakdown).each do |mpan_mprn, breakdown| %>
     <tr>
       <td><%= breakdown.meter.present? ? breakdown.meter.name_or_mpan_mprn : mpan_mprn %></td>
       <td class="text-right"><%= format_unit(breakdown.baseload_kw, :kw) %></td>

--- a/app/views/schools/advice/baseload/_seasonal_variation_breakdown_table.html.erb
+++ b/app/views/schools/advice/baseload/_seasonal_variation_breakdown_table.html.erb
@@ -11,7 +11,7 @@
     </tr>
   </thead>
   <tbody>
-    <% seasonal_variation_by_meter.each do |mpan_mprn, variation| %>
+    <% meters_by_estimated_saving(seasonal_variation_by_meter).each do |mpan_mprn, variation| %>
     <tr>
       <td class="text-left"><%= variation.meter.present? ? variation.meter.name_or_mpan_mprn : mpan_mprn %></td>
       <td class="text-left"><%= format_rating(variation.variation_rating) %></td>

--- a/app/views/schools/advice/baseload/_weekday_variation_breakdown_table.html.erb
+++ b/app/views/schools/advice/baseload/_weekday_variation_breakdown_table.html.erb
@@ -11,7 +11,7 @@
     </tr>
   </thead>
   <tbody>
-    <% intraweek_variation_by_meter.each do |mpan_mprn, variation| %>
+    <% meters_by_estimated_saving(intraweek_variation_by_meter).each do |mpan_mprn, variation| %>
     <tr>
       <td class="text-left"><%= variation.meter.present? ? variation.meter.name_or_mpan_mprn : mpan_mprn %></td>
       <td class="text-left"><%= format_rating(variation.variation_rating) %></td>


### PR DESCRIPTION
Change default sort order for tables on baseload analysis:

- meter breakdown sorted by % baseload (desc)
- seasonal and intraday variation sorted by estimated saving (desc)