### PR TITLE
Revise ordering to reduce likelihood of tests flickering

### DIFF
--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -261,14 +261,14 @@ class School < ApplicationRecord
 
   def activities_in_academic_year(date)
     if (academic_year = academic_year_for(date))
-      return activities.between(academic_year.start_date, academic_year.end_date)
+      return activities.between(academic_year.start_date, academic_year.end_date).order(created_at: :asc)
     end
     []
   end
 
   def observations_in_academic_year(date)
     if (academic_year = academic_year_for(date))
-      return observations.between(academic_year.start_date, academic_year.end_date)
+      return observations.between(academic_year.start_date, academic_year.end_date).order(created_at: :asc)
     end
     []
   end

--- a/spec/models/intervention_type_spec.rb
+++ b/spec/models/intervention_type_spec.rb
@@ -42,7 +42,8 @@ describe 'InterventionType' do
       intervention_type_1 = create(:intervention_type, name: 'time')
       intervention_type_2 = create(:intervention_type, name: 'timing')
 
-      expect(InterventionType.search(query: 'timing', locale: 'en')).to eq([intervention_type_1, intervention_type_2])
+      #use match array here as the ordering isn't guaranteed?
+      expect(InterventionType.search(query: 'timing', locale: 'en')).to match_array([intervention_type_2, intervention_type_1])
     end
 
     it 'finds search content for different locales' do

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -703,7 +703,7 @@ describe School do
     let!(:intervention_type_2){ create :intervention_type }
     let!(:observation_1){ create :observation, :intervention, at: date_1, school: school, intervention_type: intervention_type_1 }
     let!(:observation_2){ create :observation, :intervention, at: date_2, school: school, intervention_type: intervention_type_2 }
-    let!(:observation_without_intervention_type) { create(:observation, :temperature, at: date_1, school: school) }
+    let!(:observation_without_intervention_type) { create(:observation, :temperature, at: date_1 + 1.day, school: school) }
 
     it 'finds observations from the academic year' do
       expect(school.observations_in_academic_year(academic_year.start_date + 2.months)).to eq([observation_1, observation_without_intervention_type])

--- a/spec/system/activity_types_spec.rb
+++ b/spec/system/activity_types_spec.rb
@@ -39,31 +39,39 @@ describe 'activity types', type: :system do
       expect(page).to have_content(activity_type_1.name)
     end
 
-    it 'paginates search results' do
-      Pagy::DEFAULT[:items] = 1
-      visit search_activity_types_path
-      fill_in 'query', with: 'activity'
-      click_on 'Search'
-
-      #possibly flickering as ordering might be different?
-      expect(page).to have_content(activity_type_1.name)
-      expect(page).not_to have_content(activity_type_2.name)
-
-      click_on 'Next'
-
-      expect(page).not_to have_content(activity_type_1.name)
-      expect(page).to have_content(activity_type_2.name)
-
-      # reset this to prevent problems with other tests..
-      Pagy::DEFAULT[:items] = 20
-    end
-
     it 'shows no results' do
       visit search_activity_types_path
       fill_in 'query', with: 'blah'
       click_on 'Search'
 
       expect(page).to have_content('No results found')
+    end
+
+    context 'when paginating' do
+      before :each do
+        Pagy::DEFAULT[:items] = 1
+        visit search_activity_types_path
+      end
+
+      after :each do
+        Pagy::DEFAULT[:items] = 20
+      end
+
+      it 'limits the search results' do
+        fill_in 'query', with: 'activity'
+        click_on 'Search'
+
+        #possibly flickering as ordering might be different?
+        #test could instead assert whether there is expect number of
+        #result rows, check for navigation, etc.
+        expect(page).to have_content(activity_type_1.name)
+        expect(page).not_to have_content(activity_type_2.name)
+
+        click_on 'Next'
+        expect(page).not_to have_content(activity_type_1.name)
+        expect(page).to have_content(activity_type_2.name)
+      end
+
     end
 
     context 'when filtering' do
@@ -74,9 +82,14 @@ describe 'activity types', type: :system do
       let!(:activity_type_1) { create(:activity_type, name: 'baz one', key_stages: [key_stage_1], subjects: [subject_1]) }
       let!(:activity_type_2) { create(:activity_type, name: 'baz two', key_stages: [key_stage_2], subjects: [subject_2]) }
 
-      context "visiting the seach page" do
+      context "visiting the search page" do
         before :each do
+          Pagy::DEFAULT[:items] = 20
           visit search_activity_types_path
+        end
+
+        after :each do
+          Pagy::DEFAULT[:items] = 20
         end
 
         it 'finds all with no filter' do


### PR DESCRIPTION
We have some flickering tests in the suite. This PR aims to fix a couple of them

* When returning activities and observations required in the academic year, order them by increasing creation date, rather than leaving the order undefined

* Revise the school spec to adjust `at` value for third intervention. Using the same value leaves us open to an ordering problem

* For the intervention type search use `match_array` rather than `eq` as we expect both results. I would normally expect the exact match to be first, but it's possible the postgres stemming ignores that, leaving us with two records that might end up having identical search rank. 