### PR TITLE
Out of hours usage page changes

### DIFF
--- a/app/views/schools/advice/electricity_out_of_hours/_analysis.html.erb
+++ b/app/views/schools/advice/electricity_out_of_hours/_analysis.html.erb
@@ -13,13 +13,13 @@
 </ul>
 
 <%= render 'schools/advice/section_title', section_id: 'last_twelve_months', section_title: t('advice_pages.electricity_out_of_hours.analysis.last_twelve_months.title') %>
-<% if @school.school_times.community_use.any? %>
-  <p><%= t('advice_pages.electricity_out_of_hours.analysis.last_twelve_months.community_use') %></p>
+
+<% if @annual_usage_breakdown.community.present? %>
+  <p><%= t('advice_pages.electricity_out_of_hours.analysis.last_twelve_months.community_use_html',
+    community_kwh: format_unit(@annual_usage_breakdown.community.kwh, :kwh),
+    community_gbp: format_unit(@annual_usage_breakdown.community.£, :£),
+    community_co2: format_unit(@annual_usage_breakdown.community.co2, :co2) ) %></p>
 <% end %>
-
-<p><%= t('advice_pages.electricity_out_of_hours.analysis.last_twelve_months.table_introduction') %></p>
-
-<%= render 'analysis_table' %>
 
 <%= component 'chart', chart_type: :daytype_breakdown_electricity_tolerant, school: @school do |c| %>
   <% c.with_title do %>
@@ -27,9 +27,11 @@
   <% end %>
 
   <% c.with_subtitle { t('advice_pages.electricity_out_of_hours.analysis.usage_by_day_of_week.daytype_breakdown_electricity_tolerant_chart.subtitle_html', start_month_year: short_dates(@analysis_dates.one_years_data ? @analysis_dates.end_date - 1.year : @analysis_dates.start_date), end_month_year: short_dates(@analysis_dates.end_date)) } %>
-
-
 <% end %>
+
+<p><%= t('advice_pages.electricity_out_of_hours.analysis.last_twelve_months.table_introduction') %></p>
+
+<%= render 'analysis_table' %>
 
 <%= render 'schools/advice/section_title', section_id: 'usage_by_day_of_week', section_title: t('advice_pages.electricity_out_of_hours.analysis.usage_by_day_of_week.title') %>
 <%= component 'chart', chart_type: :electricity_by_day_of_week_tolerant, school: @school do |c| %>
@@ -41,6 +43,3 @@
     <%= t('advice_pages.electricity_out_of_hours.analysis.usage_by_day_of_week.electricity_by_day_of_week_tolerant_chart.footer') %>
   <% end %>
 <% end %>
-
-
-

--- a/app/views/schools/advice/electricity_out_of_hours/_analysis_table.html.erb
+++ b/app/views/schools/advice/electricity_out_of_hours/_analysis_table.html.erb
@@ -2,7 +2,7 @@
   <thead class="thead-dark">
     <tr>
       <th class="text-left-">
-        <%= t('advice_pages.electricity_out_of_hours.analysis.last_twelve_months.table.time_of_day') %>
+        <%= t('advice_pages.electricity_out_of_hours.analysis.last_twelve_months.table.time_of_use') %>
       </th>
       <th class="text-right">
         <%= t('kwh') %>

--- a/app/views/schools/advice/electricity_out_of_hours/_insights.html.erb
+++ b/app/views/schools/advice/electricity_out_of_hours/_insights.html.erb
@@ -12,8 +12,16 @@
     )
   %>
 
-<%= render 'schools/advice/section_title', section_id: 'current', section_title: t('advice_pages.electricity_out_of_hours.insights.how_do_you_compare_title') %>
-<%= t('advice_pages.electricity_out_of_hours.insights.how_do_you_compare_one_html', school_type: I18n.t("analytics.school_types.#{@school&.school_type}").downcase) %>
+<%= render 'schools/advice/section_title', section_id: 'current', section_title: t('advice_pages.electricity_out_of_hours.insights.comparison.title') %>
+
+<p>
+  <%= t('advice_pages.electricity_out_of_hours.insights.comparison.how_do_you_compare', school_type: t('analytics.school_types.' + @school.school_type).downcase) %>
+</p>
+
 <%= render 'insights_table' %>
 
-<%= t('advice_pages.electricity_out_of_hours.insights.how_do_you_compare_two_html') %>
+<% if @school.school_group.present? %>
+  <p>
+    <%= t('advice_pages.electricity_out_of_hours.insights.comparison.more_detail_html', link: benchmark_for_school_group_path(:annual_electricity_out_of_hours_use, @school)) %>
+  </p>
+<% end %>

--- a/app/views/schools/advice/electricity_out_of_hours/_insights_table.html.erb
+++ b/app/views/schools/advice/electricity_out_of_hours/_insights_table.html.erb
@@ -1,12 +1,12 @@
 <table class="mt-2 table table-sm advice-table">
     <thead>
-      <th><%= t('advice_pages.electricity_out_of_hours.insights.how_do_you_compare.table.category') %></th>
+      <th><%= t('advice_pages.tables.columns.category') %></th>
       <th class="text-right"><%= t('kwh') %></th>
       <th class="text-right"><%= t('advice_pages.electricity_out_of_hours.insights.how_do_you_compare.table.your_kwh') %></th>
     </thead>
     <tr>
       <td>
-        <%= t('advice_pages.electricity_out_of_hours.insights.how_do_you_compare.table.exemplar_school') %>
+        <%= t('advice_pages.benchmarks.exemplar_school') %>
       </td>
       <td class="text-right">
         <%= format_unit(@annual_usage_breakdown&.potential_savings(versus: :exemplar_school)&.kwh, :kwh) %>

--- a/app/views/schools/advice/gas_out_of_hours/_analysis.html.erb
+++ b/app/views/schools/advice/gas_out_of_hours/_analysis.html.erb
@@ -13,13 +13,13 @@
 </ul>
 
 <%= render 'schools/advice/section_title', section_id: 'last_twelve_months', section_title: t('advice_pages.gas_out_of_hours.analysis.last_twelve_months.title') %>
-<% if @school.school_times.community_use.any? %>
-  <p><%= t('advice_pages.gas_out_of_hours.analysis.last_twelve_months.community_use') %></p>
+
+<% if @annual_usage_breakdown.community.present? %>
+  <p><%= t('advice_pages.gas_out_of_hours.analysis.last_twelve_months.community_use_html',
+    community_kwh: format_unit(@annual_usage_breakdown.community.kwh, :kwh),
+    community_gbp: format_unit(@annual_usage_breakdown.community.£, :£),
+    community_co2: format_unit(@annual_usage_breakdown.community.co2, :co2) ) %></p>
 <% end %>
-
-<p><%= t('advice_pages.gas_out_of_hours.analysis.last_twelve_months.table_introduction') %></p>
-
-<%= render 'analysis_table' %>
 
 <%= component 'chart', chart_type: :daytype_breakdown_gas_tolerant, school: @school do |c| %>
   <% c.with_title do %>
@@ -28,6 +28,10 @@
 
   <% c.with_subtitle { t('advice_pages.gas_out_of_hours.analysis.usage_by_day_of_week.daytype_breakdown_gas_tolerant_chart.subtitle_html', start_month_year: short_dates(@analysis_dates.one_years_data ? @analysis_dates.end_date - 1.year : @analysis_dates.start_date), end_month_year: short_dates(@analysis_dates.end_date)) } %>
 <% end %>
+
+<p><%= t('advice_pages.gas_out_of_hours.analysis.last_twelve_months.table_introduction') %></p>
+
+<%= render 'analysis_table' %>
 
 <%= render 'schools/advice/section_title', section_id: 'usage_by_day_of_week', section_title: t('advice_pages.gas_out_of_hours.analysis.usage_by_day_of_week.title') %>
 
@@ -61,4 +65,3 @@
     insights_school_advice_boiler_control_path: insights_school_advice_boiler_control_path(@school)) %>
   <% end %>
 <% end %>
-

--- a/app/views/schools/advice/gas_out_of_hours/_analysis_table.html.erb
+++ b/app/views/schools/advice/gas_out_of_hours/_analysis_table.html.erb
@@ -2,7 +2,7 @@
   <thead class="thead-dark">
     <tr>
       <th class="text-left-">
-        <%= t('advice_pages.gas_out_of_hours.analysis.last_twelve_months.table.time_of_day') %>
+        <%= t('advice_pages.gas_out_of_hours.analysis.last_twelve_months.table.time_of_use') %>
       </th>
       <th class="text-right">
         <%= t('kwh') %>

--- a/app/views/schools/advice/gas_out_of_hours/_insights.html.erb
+++ b/app/views/schools/advice/gas_out_of_hours/_insights.html.erb
@@ -12,9 +12,16 @@
     )
   %>
 
-<%= render 'schools/advice/section_title', section_id: 'current', section_title: t('advice_pages.gas_out_of_hours.insights.how_do_you_compare_title') %>
-<%= t('advice_pages.gas_out_of_hours.insights.how_do_you_compare_one_html') %>
+  <%= render 'schools/advice/section_title', section_id: 'current', section_title: t('advice_pages.gas_out_of_hours.insights.comparison.title') %>
 
-<%= render 'insights_table' %>
+  <p>
+    <%= t('advice_pages.gas_out_of_hours.insights.comparison.how_do_you_compare', school_type: t('analytics.school_types.' + @school.school_type).downcase) %>
+  </p>
 
-<%= t('advice_pages.gas_out_of_hours.insights.how_do_you_compare_two_html') %>
+  <%= render 'insights_table' %>
+
+  <% if @school.school_group.present? %>
+    <p>
+      <%= t('advice_pages.gas_out_of_hours.insights.comparison.more_detail_html', link: benchmark_for_school_group_path(:annual_gas_out_of_hours_use, @school)) %>
+    </p>
+  <% end %>

--- a/app/views/schools/advice/gas_out_of_hours/_insights_table.html.erb
+++ b/app/views/schools/advice/gas_out_of_hours/_insights_table.html.erb
@@ -1,12 +1,12 @@
 <table class="mt-2 table table-sm advice-table">
     <thead>
-      <th><%= t('advice_pages.gas_out_of_hours.insights.how_do_you_compare.table.category') %></th>
+      <th><%= t('advice_pages.tables.columns.category') %></th>
       <th class="text-right"><%= t('kwh') %></th>
       <th class="text-right"><%= t('advice_pages.gas_out_of_hours.insights.how_do_you_compare.table.your_kwh') %></th>
     </thead>
     <tr>
       <td>
-        <%= t('advice_pages.gas_out_of_hours.insights.how_do_you_compare.table.exemplar_school') %>
+        <%= t('advice_pages.benchmarks.exemplar_school') %>
       </td>
       <td class="text-right">
         <%= format_unit(@annual_usage_breakdown&.potential_savings(versus: :exemplar_school)&.kwh, :kwh) %>

--- a/config/locales/views/advice_pages/electricity_out_of_hours.yml
+++ b/config/locales/views/advice_pages/electricity_out_of_hours.yml
@@ -25,13 +25,13 @@ en:
             title: Electricity use by day of the week
           title: Usage by day of week
       insights:
+        comparison:
+          how_do_you_compare: How does your electricity usage out of school hours compare to other %{school_type} schools on Energy Sparks, with a similar number of pupils?
+          more_detail_html: For more detail, <a href="%{link}">compare with other schools in your group</a>
+          title: How do you compare?
         how_do_you_compare:
           table:
             your_kwh: Your kWh
-        comparison:
-          title: How do you compare?
-          how_do_you_compare: How does your electricity usage out of school hours compare to other %{school_type} schools on Energy Sparks, with a similar number of pupils?
-          more_detail_html: For more detail, <a href="%{link}">compare with other schools in your group</a>
         next_steps: Make sure you switch off lights and electrical equipment on a daily basis and do a more thorough check before weekends and holidays.
         title: What is out of hours usage?
         what_is_out_of_hours_usage_html: |-

--- a/config/locales/views/advice_pages/electricity_out_of_hours.yml
+++ b/config/locales/views/advice_pages/electricity_out_of_hours.yml
@@ -4,12 +4,12 @@ en:
     electricity_out_of_hours:
       analysis:
         last_twelve_months:
-          community_use: Your school has identified that there is community use of the school outside of school hours. Over the last year, {community_kwh} of electricity has been used during these times which will have cost {community_gbp} and caused {community_co2} to be emitted.
+          community_use_html: Your school has identified that there is community use of the school outside of school hours. Over the last year, %{community_kwh} kWh of electricity has been used during these times which will have cost %{community_gbp} and caused %{community_co2} kg/co2 to be emitted.
           table:
-            co2_kg: CO2 kg
+            co2_kg: kg/co2
             gbp_at_current_tariff: "£ (at current tariff)"
             percent: Percent
-            time_of_day: Time of day
+            time_of_use: Time of use
             total: Total
           table_introduction: The table below shows how much electricity has been used when the school is open and closed on a school day as well as during weekends and holidays.
           title: Last 12 months

--- a/config/locales/views/advice_pages/electricity_out_of_hours.yml
+++ b/config/locales/views/advice_pages/electricity_out_of_hours.yml
@@ -27,13 +27,12 @@ en:
       insights:
         how_do_you_compare:
           table:
-            category: Category
-            exemplar_school: Exemplar
             your_kwh: Your kWh
-        how_do_you_compare_one_html: "<p>How does your out of hours usage compare to other %{school_type} schools on Energy Sparks, with a similar number of pupils?</p>"
-        how_do_you_compare_title: How do you compare?
-        how_do_you_compare_two_html: "<p>For more detail, compare with other schools in your group</p>"
-        next_steps: Next steps
+        comparison:
+          title: How do you compare?
+          how_do_you_compare: How does your electricity usage out of school hours compare to other %{school_type} schools on Energy Sparks, with a similar number of pupils?
+          more_detail_html: For more detail, <a href="%{link}">compare with other schools in your group</a>
+        next_steps: Make sure you switch off lights and electrical equipment on a daily basis and do a more thorough check before weekends and holidays.
         title: What is out of hours usage?
         what_is_out_of_hours_usage_html: |-
           <p>

--- a/config/locales/views/advice_pages/gas_out_of_hours.yml
+++ b/config/locales/views/advice_pages/gas_out_of_hours.yml
@@ -46,12 +46,11 @@ en:
       insights:
         how_do_you_compare:
           table:
-            category: Category
-            exemplar_school: Exemplar
             your_kwh: Your kWh
-        how_do_you_compare_one_html: "<p>How does your out of hours gas use compare to other schools on Energy Sparks, with a similar number of pupils?</p>"
-        how_do_you_compare_title: How do you compare?
-        how_do_you_compare_two_html: "<p>For more detail, compare with other schools in your group</p>"
+        comparison:
+          title: How do you compare?
+          how_do_you_compare: How does your gas usage out of school hours compare to other %{school_type} schools on Energy Sparks, with a similar number of pupils?
+          more_detail_html: For more detail, <a href="%{link}">compare with other schools in your group</a>
         next_steps: Make sure that your heating is set to only heat the school when it needs to be warm. Heating and hot water can be switched off for evenings, weekends and holidays and heating should not come on too early in the mornings. Use a checklist of energy saving tasks to be completed before holidays.
         title: What is out of hours usage?
         what_is_out_of_hours_usage_html: |-

--- a/config/locales/views/advice_pages/gas_out_of_hours.yml
+++ b/config/locales/views/advice_pages/gas_out_of_hours.yml
@@ -4,12 +4,12 @@ en:
     gas_out_of_hours:
       analysis:
         last_twelve_months:
-          community_use: Your school has identified that there is community use of the school outside of school hours. Over the last year, {community_kwh} of gas has been used during these times which will have cost {community_gbp} and caused {community_co2} to be emitted.
+          community_use_html: Your school has identified that there is community use of the school outside of school hours. Over the last year, %{community_kwh} kWh of gas has been used during these times which will have cost %{community_gbp} and caused %{community_co2} to be emitted.
           table:
-            co2_kg: CO2 kg
+            co2_kg: kg/co2
             gbp_at_current_tariff: "£ (at current tariff)"
             percent: Percent
-            time_of_day: Time of day
+            time_of_use: Time of use
             total: Total
           table_introduction: The table below shows how much gas has been used when the school is open and closed on a school day as well as during weekends and holidays.
           title: Last 12 months

--- a/config/locales/views/advice_pages/gas_out_of_hours.yml
+++ b/config/locales/views/advice_pages/gas_out_of_hours.yml
@@ -44,13 +44,13 @@ en:
           subtitle: Another cause of high out of hours gas use is having central heating timings which cause the heating to be on for too long during a school day.
           title: Gas use through the school day
       insights:
+        comparison:
+          how_do_you_compare: How does your gas usage out of school hours compare to other %{school_type} schools on Energy Sparks, with a similar number of pupils?
+          more_detail_html: For more detail, <a href="%{link}">compare with other schools in your group</a>
+          title: How do you compare?
         how_do_you_compare:
           table:
             your_kwh: Your kWh
-        comparison:
-          title: How do you compare?
-          how_do_you_compare: How does your gas usage out of school hours compare to other %{school_type} schools on Energy Sparks, with a similar number of pupils?
-          more_detail_html: For more detail, <a href="%{link}">compare with other schools in your group</a>
         next_steps: Make sure that your heating is set to only heat the school when it needs to be warm. Heating and hot water can be switched off for evenings, weekends and holidays and heating should not come on too early in the mornings. Use a checklist of energy saving tasks to be completed before holidays.
         title: What is out of hours usage?
         what_is_out_of_hours_usage_html: |-


### PR DESCRIPTION
* The community use section wasn't working (no variables injected into the page templates)
* Reworked YAML slightly to structure into named sections rather than "one"/"two" paragraphs
* Add missing links to the school comparison pages
* Move the table below the pie chart