### PR TITLE
Remove chart subtitle for intraday chart plus cosmetic fixes

### DIFF
--- a/app/views/schools/advice/electricity_intraday/_analysis.html.erb
+++ b/app/views/schools/advice/electricity_intraday/_analysis.html.erb
@@ -17,7 +17,7 @@
   <% c.with_title { t('advice_pages.electricity_intraday.analysis.charts.comparison_chart_title') } %>
   <% c.with_subtitle { t('advice_pages.electricity_intraday.analysis.charts.comparison_chart_subtitle_html', start_month_year: short_dates(@analysis_dates.one_years_data ? @analysis_dates.end_date - 1.year : @analysis_dates.start_date), end_month_year: short_dates(@analysis_dates.end_date)) } %>
   <% c.with_footer do %>
-    <p><%= t('advice_pages.electricity_intraday.analysis.charts.comparison_chart_explanation_html') %></p>
+    <p><%= t('advice_pages.electricity_intraday.analysis.charts.comparison_chart_explanation_html', school_type: t('analytics.school_types.' + @school.school_type).downcase) %></p>
   <% end %>
 <% end %>
 

--- a/app/views/schools/advice/electricity_intraday/_analysis.html.erb
+++ b/app/views/schools/advice/electricity_intraday/_analysis.html.erb
@@ -53,7 +53,7 @@
 
 <%= component 'chart', chart_type: :intraday_line_school_last7days, school: @school do |c| %>
   <% c.with_title { t('advice_pages.electricity_intraday.analysis.charts.trends_chart_title') } %>
-  <% c.with_subtitle { t('advice_pages.electricity_intraday.analysis.charts.trends_chart_subtitle_html', start_date: short_dates(@analysis_dates.end_date - 6.days), end_date: short_dates(@analysis_dates.end_date)) } %>
+  <% c.with_subtitle { t('advice_pages.electricity_intraday.analysis.charts.trends_chart_subtitle') } %>
   <% c.with_footer do %>
     <p><%= t('advice_pages.electricity_intraday.analysis.charts.trends_chart_explanation') %></p>
   <% end %>

--- a/config/locales/views/advice_pages/electricity_intraday.yml
+++ b/config/locales/views/advice_pages/electricity_intraday.yml
@@ -6,7 +6,7 @@ en:
         charts:
           comparison_chart_explanation_html: |-
             <p>
-              This chart allows you to see how your school’s electricity consumption compares with other energy efficient schools throughout the school day. A 'benchmark' school represents the 30.0% best ranked primary schools and 'exemplar' the 17.5% best primary schools.
+              This chart allows you to see how your school’s electricity consumption compares with other energy efficient schools throughout the school day. A 'benchmark' school represents the 30.0% best ranked %{school_type} schools and 'exemplar' the 17.5% best %{school_type} schools.
             </p>
             <p>
               This chart can be useful to observe where your school’s pattern of energy use differs from other schools. There might be anomalies like jumps in usage outside school hours which can’t be accounted for.
@@ -15,7 +15,7 @@ en:
               If your school has high consumption overnight, compared to the benchmark schools, this could indicate that you need to reduce your baseload. If consumption is mainly high during the middle of the day, this indicates you need to reduce your peak electricity use.
             </p>
           comparison_chart_subtitle_html: The chart below provides a comparison of your school's average consumption during school days between <span class="start-date">%{start_month_year}</span> and <span class="end-date">%{end_month_year}</span>, and includes a comparison with 'benchmark' and 'exemplar' schools.
-          comparison_chart_title: Electricity consumption during the school day over the last 12 months
+          comparison_chart_title: Your school day electricity consumption over the last 12 months
           holidays_chart_subtitle: The graph compares the average electricity consumption for your school during the school holidays over the last 2 years
           holidays_chart_title: Daily variation in electricity use during school holidays
           schooldays_chart_explanation_html: |-

--- a/config/locales/views/advice_pages/electricity_intraday.yml
+++ b/config/locales/views/advice_pages/electricity_intraday.yml
@@ -28,7 +28,7 @@ en:
           schooldays_chart_subtitle: The chart shows the average electricity consumption for your school during the school day over the last 2 years
           schooldays_chart_title: Daily variation in electricity use during school days
           trends_chart_explanation: You can use this type of graph to understand how the schools electricity usage changes over time. You can click on the legend to add or remove lines from the graph to make it clearer.
-          trends_chart_subtitle_html: The graph shows how the electricity consumption for your school varies during the day between <span class="start-date">%{start_date}</span> and <span class="end-date">%{end_date}</span>
+          trends_chart_subtitle: The graph shows how the electricity consumption for your school varies during the day over the last week
           trends_chart_title: Daily variation in electricity use over the last 7 days
           weekends_chart_subtitle: The graph compares the average electricity consumption for your school during the weekend over the last 2 years
           weekends_chart_title: Daily variation in electricity use over the weekends

--- a/spec/system/schools/advice_pages/electricity_intraday_spec.rb
+++ b/spec/system/schools/advice_pages/electricity_intraday_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe "electricity intraday advice page", type: :system do
       it_behaves_like "an advice page tab", tab: "Analysis"
 
       it "shows titles" do
-        expect(page).to have_content("Electricity consumption during the school day over the last 12 months")
+        expect(page).to have_content(I18n.t('advice_pages.electricity_intraday.analysis.comparison.title'))
       end
 
       it "shows the expected charts" do

--- a/spec/system/schools/advice_pages/electricity_intraday_spec.rb
+++ b/spec/system/schools/advice_pages/electricity_intraday_spec.rb
@@ -45,10 +45,12 @@ RSpec.describe "electricity intraday advice page", type: :system do
         expect(page).to have_content("Electricity consumption during the school day over the last 12 months")
       end
 
-      it "shows dates for 7 day period up to end date" do
-        expected_start_date = (end_date - 6.days).to_s(:es_short)
-        expected_end_date = end_date.to_s(:es_short)
-        expect(page).to have_content("graph shows how the electricity consumption for your school varies during the day between #{expected_start_date} and #{expected_end_date}")
+      it "shows the expected charts" do
+        expect(page).to have_css('#chart_wrapper_intraday_line_school_days_reduced_data_versus_benchmarks')
+        expect(page).to have_css('#chart_wrapper_intraday_line_school_days_reduced_data')
+        expect(page).to have_css('#chart_wrapper_intraday_line_holidays')
+        expect(page).to have_css('#chart_wrapper_intraday_line_weekends')
+        expect(page).to have_css('#chart_wrapper_intraday_line_school_last7days')
       end
 
       context 'when not enough data' do


### PR DESCRIPTION
* Removes the dynamic dates in the subtitle for an intraday chart.
* Revises title of first chart
* Parameterise description of benchmark schools using school type.
* Improved the rspec to check the right charts are on the page.

The chart framework doesn't return the correct date range for intraday charts. Am unclear how to fix that currently without potentially impacting other code. Because in this case the chart date ranges are clearly labelled as series, I've removed the dates on the chart for now. 
