### PR TITLE
Implement total energy use page

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ gem 'pg_search'
 gem 'calculate_in_group'
 
 # Dashboard analytics
-gem 'energy-sparks_analytics', git: 'https://github.com/Energy-Sparks/energy-sparks_analytics.git', tag: '2.4.9'
+gem 'energy-sparks_analytics', git: 'https://github.com/Energy-Sparks/energy-sparks_analytics.git', tag: '2.4.10'
 #gem 'energy-sparks_analytics', git: 'https://github.com/Energy-Sparks/energy-sparks_analytics.git', branch: 'aws-eb-test'
 #gem 'energy-sparks_analytics', path: '../energy-sparks_analytics'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/Energy-Sparks/energy-sparks_analytics.git
-  revision: 206d1d171d81497280dbde9ea9a44c8b8b3905f0
-  tag: 2.4.9
+  revision: 5dee5d812354987404f8c4c46401240941218229
+  tag: 2.4.10
   specs:
     energy-sparks_analytics (1.2.1)
       activesupport (~> 6.0.0)

--- a/app/controllers/schools/advice/advice_base_controller.rb
+++ b/app/controllers/schools/advice/advice_base_controller.rb
@@ -97,7 +97,7 @@ module Schools
         when :solar_pv
           @school.has_solar_pv?
         else
-          false
+          true
         end
       end
 
@@ -109,7 +109,7 @@ module Schools
       end
 
       def advice_page_fuel_type
-        @advice_page.fuel_type.to_sym
+        @advice_page.fuel_type&.to_sym
       end
 
       def analysis_start_date

--- a/app/controllers/schools/advice/advice_base_controller.rb
+++ b/app/controllers/schools/advice/advice_base_controller.rb
@@ -38,7 +38,7 @@ module Schools
       private
 
       def set_insights_next_steps
-        @advice_page_insights_next_steps = t("advice_pages.#{@advice_page.key}.insights.next_steps")
+        @advice_page_insights_next_steps = if_exists('insights.next_steps')
       end
 
       def set_page_title
@@ -46,7 +46,14 @@ module Schools
       end
 
       def set_page_subtitle
-        @advice_page_subtitle = t("advice_pages.#{@advice_page.key}.#{action_name}.title")
+        @advice_page_subtitle = if_exists("#{action_name}.title")
+      end
+
+      def if_exists(key)
+        full_key = "advice_pages.#{@advice_page.key}.#{key}"
+        if I18n.exists?(full_key, I18n.locale)
+          t(full_key)
+        end
       end
 
       def set_data_warning

--- a/app/controllers/schools/advice/advice_base_controller.rb
+++ b/app/controllers/schools/advice/advice_base_controller.rb
@@ -141,6 +141,7 @@ module Schools
           last_full_week_start_date: last_full_week_start_date(end_date),
           last_full_week_end_date: last_full_week_end_date(end_date),
           recent_data: recent_data?(end_date),
+          months_of_data: months_between(start_date, end_date),
           months_analysed: months_analysed(start_date, end_date)
         )
       end

--- a/app/controllers/schools/advice/base_long_term_controller.rb
+++ b/app/controllers/schools/advice/base_long_term_controller.rb
@@ -4,8 +4,6 @@ module Schools
       def insights
         @analysis_dates = analysis_dates
         @annual_usage = usage_service.annual_usage
-        @vs_benchmark = usage_service.annual_usage_vs_benchmark(compare: :benchmark_school)
-        @vs_exemplar = usage_service.annual_usage_vs_benchmark(compare: :exemplar_school)
         @annual_usage_change_since_last_year = usage_service.annual_usage_change_since_last_year
         @benchmarked_usage = benchmarked_usage(@annual_usage.kwh)
       end

--- a/app/controllers/schools/advice/total_energy_use_controller.rb
+++ b/app/controllers/schools/advice/total_energy_use_controller.rb
@@ -3,6 +3,16 @@ module Schools
     class TotalEnergyUseController < AdviceBaseController
       def insights
         @overview_data = Schools::ManagementTableService.new(@school).management_data
+
+        if @school.has_electricity? && electricity_usage_service.enough_data?
+          @electricity_annual_usage = electricity_usage_service.annual_usage
+          @electricity_benchmarked_usage = benchmarked_usage(electricity_usage_service, @electricity_annual_usage.kwh)
+        end
+
+        if @school.has_gas? && gas_usage_service.enough_data?
+          @gas_annual_usage = gas_usage_service.annual_usage
+          @gas_benchmarked_usage = benchmarked_usage(gas_usage_service, @gas_annual_usage.kwh)
+        end
       end
 
       def analysis
@@ -25,6 +35,30 @@ module Schools
 
       def analysis_end_date
         aggregate_meters.map { |meter| meter.amr_data.end_date }.min
+      end
+
+      def benchmarked_usage(usage_service, annual_usage_kwh)
+        annual_usage_kwh_benchmark = usage_service.annual_usage_kwh(compare: :benchmark_school)
+        annual_usage_kwh_exemplar = usage_service.annual_usage_kwh(compare: :exemplar_school)
+
+        OpenStruct.new(
+          category: categorise_school_vs_benchmark(annual_usage_kwh, annual_usage_kwh_benchmark, annual_usage_kwh_exemplar),
+          annual_usage_kwh: annual_usage_kwh,
+          annual_usage_kwh_benchmark: annual_usage_kwh_benchmark,
+          annual_usage_kwh_exemplar: annual_usage_kwh_exemplar
+        )
+      end
+
+      def gas_usage_service
+        @gas_usage_service ||= usage_service(:gas)
+      end
+
+      def electricity_usage_service
+        @electricity_usage_service ||= usage_service(:electricity)
+      end
+
+      def usage_service(fuel_type)
+        Schools::Advice::LongTermUsageService.new(@school, aggregate_school, fuel_type)
       end
     end
   end

--- a/app/controllers/schools/advice/total_energy_use_controller.rb
+++ b/app/controllers/schools/advice/total_energy_use_controller.rb
@@ -6,6 +6,7 @@ module Schools
 
       def analysis
         @analysis_dates = analysis_dates
+        puts @analysis_dates.inspect
       end
 
       private
@@ -19,7 +20,7 @@ module Schools
       end
 
       def analysis_start_date
-        analysis_end_date - 1.year
+        aggregate_meters.map { |meter| meter.amr_data.start_date }.max
       end
 
       def analysis_end_date

--- a/app/controllers/schools/advice/total_energy_use_controller.rb
+++ b/app/controllers/schools/advice/total_energy_use_controller.rb
@@ -2,11 +2,11 @@ module Schools
   module Advice
     class TotalEnergyUseController < AdviceBaseController
       def insights
+        @overview_data = Schools::ManagementTableService.new(@school).management_data
       end
 
       def analysis
         @analysis_dates = analysis_dates
-        puts @analysis_dates.inspect
       end
 
       private

--- a/app/controllers/schools/advice/total_energy_use_controller.rb
+++ b/app/controllers/schools/advice/total_energy_use_controller.rb
@@ -18,6 +18,22 @@ module Schools
       def analysis
         @analysis_dates = analysis_dates
         @benchmark_chart = benchmark_chart
+
+        if can_benchmark_electricity?
+          @electricity_annual_usage = electricity_usage_service.annual_usage
+          @electricity_vs_benchmark = electricity_usage_service.annual_usage_vs_benchmark(compare: :benchmark_school)
+          @electricity_vs_exemplar = electricity_usage_service.annual_usage_vs_benchmark(compare: :exemplar_school)
+          @electricity_estimated_savings_vs_exemplar = electricity_usage_service.estimated_savings(versus: :exemplar_school)
+          @electricity_estimated_savings_vs_benchmark = electricity_usage_service.estimated_savings(versus: :benchmark_school)
+        end
+
+        if can_benchmark_gas?
+          @gas_annual_usage = gas_usage_service.annual_usage
+          @gas_vs_benchmark = gas_usage_service.annual_usage_vs_benchmark(compare: :benchmark_school)
+          @gas_vs_exemplar = gas_usage_service.annual_usage_vs_benchmark(compare: :exemplar_school)
+          @gas_estimated_savings_vs_exemplar = gas_usage_service.estimated_savings(versus: :exemplar_school)
+          @gas_estimated_savings_vs_benchmark = gas_usage_service.estimated_savings(versus: :benchmark_school)
+        end
       end
 
       private

--- a/app/controllers/schools/advice/total_energy_use_controller.rb
+++ b/app/controllers/schools/advice/total_energy_use_controller.rb
@@ -4,12 +4,12 @@ module Schools
       def insights
         @overview_data = Schools::ManagementTableService.new(@school).management_data
 
-        if @school.has_electricity? && electricity_usage_service.enough_data?
+        if can_benchmark_electricity?
           @electricity_annual_usage = electricity_usage_service.annual_usage
           @electricity_benchmarked_usage = benchmarked_usage(electricity_usage_service, @electricity_annual_usage.kwh)
         end
 
-        if @school.has_gas? && gas_usage_service.enough_data?
+        if can_benchmark_gas?
           @gas_annual_usage = gas_usage_service.annual_usage
           @gas_benchmarked_usage = benchmarked_usage(gas_usage_service, @gas_annual_usage.kwh)
         end
@@ -17,9 +17,25 @@ module Schools
 
       def analysis
         @analysis_dates = analysis_dates
+        @benchmark_chart = benchmark_chart
       end
 
       private
+
+      def can_benchmark_electricity?
+        @school.has_electricity? && electricity_usage_service.enough_data?
+      end
+
+      def can_benchmark_gas?
+        @school.has_gas? && gas_usage_service.enough_data?
+      end
+
+      def benchmark_chart
+        return :benchmark_one_year if can_benchmark_gas? && can_benchmark_electricity?
+        return :benchmark_electric_only_one_year_kwh if can_benchmark_electricity?
+        return :benchmark_gas_only_one_year_kwh if can_benchmark_gas?
+        nil
+      end
 
       def advice_page_key
         :total_energy_use

--- a/app/controllers/schools/advice/total_energy_use_controller.rb
+++ b/app/controllers/schools/advice/total_energy_use_controller.rb
@@ -5,12 +5,25 @@ module Schools
       end
 
       def analysis
+        @analysis_dates = analysis_dates
       end
 
       private
 
       def advice_page_key
         :total_energy_use
+      end
+
+      def aggregate_meters
+        [aggregate_school.aggregated_electricity_meters, aggregate_school.aggregated_heat_meters].compact
+      end
+
+      def analysis_start_date
+        analysis_end_date - 1.year
+      end
+
+      def analysis_end_date
+        aggregate_meters.map { |meter| meter.amr_data.end_date }.min
       end
     end
   end

--- a/app/helpers/advice_page_helper.rb
+++ b/app/helpers/advice_page_helper.rb
@@ -5,11 +5,10 @@ module AdvicePageHelper
   end
 
   #Helper for the advice pages, passes a scope to the I18n.t API based on
-  #our naming convention and page keys. Will only work on advice pages,
-  #and only for keys that are part of a page. Generic templates need to use
-  #the default helper.
+  #our naming convention and page keys. Will only work on advice pages
+  #content, e.g advice_pages.*
   def advice_t(key, **vars)
-    I18n.t(key, vars.merge(scope: [:advice_pages, @advice_page.key.to_sym])).html_safe
+    I18n.t(key, vars.merge(scope: [:advice_pages])).html_safe
   end
 
   def chart_start_month_year(date = Time.zone.today)

--- a/app/views/management/schools/_overview_data.html.erb
+++ b/app/views/management/schools/_overview_data.html.erb
@@ -8,7 +8,9 @@
         <th class="text-right"><%= t('schools.show.use_kwh') %></th>
         <th class="text-right"><%= t('schools.show.co2_kg') %></th>
         <th class="text-right"><%= t('schools.show.cost_£') %></th>
-        <th class="text-right"><%= t('schools.show.potential_savings') %></th>
+        <% if local_assigns[:show_savings].nil? || local_assigns[:shows_savings] == true %>
+          <th class="text-right"><%= t('schools.show.potential_savings') %></th>
+        <% end %>
         <th class="text-right"><%= t('schools.show.percentage_change') %></th>
       </tr>
     </thead>
@@ -27,7 +29,9 @@
           <td class="text-right <%= data.message_class %>"><%= data.usage %></td>
           <td class="text-right <%= data.message_class %>"><%= data.co2 %></td>
           <td class="text-right <%= data.message_class %>"><%= data.cost %></td>
-          <td class="text-right <%= data.message_class %>"><%= data.savings %></td>
+          <% if local_assigns[:show_savings].nil? || local_assigns[:shows_savings] == true %>
+            <td class="text-right <%= data.message_class %>"><%= data.savings %></td>
+          <% end %>
           <td class="text-right"><%= up_downify(data.change) %></td>
         <% else %>
           <td class="text-center <%= data.message_class %>" colspan='5'><%= data.message %></td>

--- a/app/views/management/schools/_overview_data.html.erb
+++ b/app/views/management/schools/_overview_data.html.erb
@@ -1,4 +1,4 @@
-<div class="table-responsive-sm">
+<div class="table-responsive-sm" id='management-overview-table'>
   <table class="table management-overview">
     <thead class="thead-dark">
       <tr>

--- a/app/views/schools/advice/advice_base/analysis.html.erb
+++ b/app/views/schools/advice/advice_base/analysis.html.erb
@@ -1,6 +1,8 @@
 <%= render 'schools/advice/advice_page', school: @school, advice_pages: @advice_pages, advice_page: @advice_page, tab: @tab, data_warning: @data_warning do %>
 
-  <h2><%= @advice_page_subtitle %></h2>
+  <% if @advice_page_subtitle.present? %>
+    <h2><%= @advice_page_subtitle %></h2>
+  <% end %>
 
   <%= render 'analysis' %>
 <% end %>

--- a/app/views/schools/advice/advice_base/insights.html.erb
+++ b/app/views/schools/advice/advice_base/insights.html.erb
@@ -1,11 +1,16 @@
 <%= render 'schools/advice/advice_page', school: @school, advice_pages: @advice_pages, advice_page: @advice_page, tab: @tab, data_warning: @data_warning do %>
 
-  <h2><%= @advice_page_subtitle %></h2>
+  <% if @advice_page_subtitle.present? %>
+    <h2><%= @advice_page_subtitle %></h2>
+  <% end %>
 
   <%= render 'insights' %>
 
   <%= render 'schools/advice/section_title', section_id: 'recommendations', section_title: t('advice_pages.insights.recommendations.title') %>
-  <p><%= @advice_page_insights_next_steps %></p>
+
+  <% if @advice_page_insights_next_steps.present? %>
+    <p><%= @advice_page_insights_next_steps %></p>
+  <% end %>
 
   <%= component 'recommendations', recommendations: @activity_types, title: t("advice_pages.insights.recommendations.activities_title"), classes: 'pb-4' %>
 

--- a/app/views/schools/advice/electricity_long_term/_comparison.html.erb
+++ b/app/views/schools/advice/electricity_long_term/_comparison.html.erb
@@ -4,42 +4,7 @@
   <%= t('advice_pages.electricity_long_term.insights.comparison.how_do_you_compare', school_type: t('analytics.school_types.' + school.school_type)) %>
 </p>
 
-<table class="table table-sm advice-table" id="comparison-long-term-usage">
-  <thead>
-    <th><%= t('advice_pages.tables.columns.category') %></th>
-    <th class="text-right"><%= t('advice_pages.electricity_long_term.tables.columns.annual_usage_kwh') %></th>
-    <th class="text-right"><%= t('advice_pages.electricity_long_term.tables.columns.your_usage') %></th>
-  </thead>
-  <tbody>
-    <tr class="<%= row_class_for_category(benchmarked_usage.category, :exemplar) %>">
-      <td><%= t('advice_pages.benchmarks.exemplar_school') %></td>
-      <td class="text-right"><%= format_unit(benchmarked_usage.annual_usage_kwh_exemplar, :kwh) %></td>
-      <td class="text-right">
-        <% if benchmarked_usage.category == :exemplar %>
-         <%= format_unit(benchmarked_usage.annual_usage_kwh, :kwh) %>
-        <% end %>
-      </td>
-    </tr>
-    <tr class="<%= row_class_for_category(benchmarked_usage.category, :benchmark) %>">
-      <td><%= t('advice_pages.benchmarks.benchmark_school') %></td>
-      <td class="text-right"><%= format_unit(benchmarked_usage.annual_usage_kwh_benchmark, :kwh) %></td>
-      <td class="text-right">
-        <% if benchmarked_usage.category == :benchmark %>
-         <%= format_unit(benchmarked_usage.annual_usage_kwh, :kwh) %>
-        <% end %>
-      </td>
-    </tr>
-    <tr class="<%= row_class_for_category(benchmarked_usage.category, :other, 'negative-row') %>">
-      <td><%= t('advice_pages.benchmarks.other') %></td>
-      <td class="text-right">><%= format_unit(benchmarked_usage.annual_usage_kwh_benchmark, :kwh) %></td>
-      <td class="text-right">
-        <% if benchmarked_usage.category == :other %>
-          <%= format_unit(benchmarked_usage.annual_usage_kwh, :kwh) %>
-        <% end %>
-      </td>
-    </tr>
-  </tbody>
-</table>
+<%= render 'insights_benchmark_table', benchmarked_usage: benchmarked_usage %>
 
 <% if school.school_group.present? %>
   <p>

--- a/app/views/schools/advice/electricity_long_term/_insights_benchmark_table.html.erb
+++ b/app/views/schools/advice/electricity_long_term/_insights_benchmark_table.html.erb
@@ -1,0 +1,36 @@
+<table class="table table-sm advice-table" id="electricity-comparison-long-term-usage">
+  <thead>
+    <th><%= t('advice_pages.tables.columns.category') %></th>
+    <th class="text-right"><%= t('advice_pages.electricity_long_term.tables.columns.annual_usage_kwh') %></th>
+    <th class="text-right"><%= t('advice_pages.electricity_long_term.tables.columns.your_usage') %></th>
+  </thead>
+  <tbody>
+    <tr class="<%= row_class_for_category(benchmarked_usage.category, :exemplar) %>">
+      <td><%= t('advice_pages.benchmarks.exemplar_school') %></td>
+      <td class="text-right"><%= format_unit(benchmarked_usage.annual_usage_kwh_exemplar, :kwh) %></td>
+      <td class="text-right">
+        <% if benchmarked_usage.category == :exemplar %>
+         <%= format_unit(benchmarked_usage.annual_usage_kwh, :kwh) %>
+        <% end %>
+      </td>
+    </tr>
+    <tr class="<%= row_class_for_category(benchmarked_usage.category, :benchmark) %>">
+      <td><%= t('advice_pages.benchmarks.benchmark_school') %></td>
+      <td class="text-right"><%= format_unit(benchmarked_usage.annual_usage_kwh_benchmark, :kwh) %></td>
+      <td class="text-right">
+        <% if benchmarked_usage.category == :benchmark %>
+         <%= format_unit(benchmarked_usage.annual_usage_kwh, :kwh) %>
+        <% end %>
+      </td>
+    </tr>
+    <tr class="<%= row_class_for_category(benchmarked_usage.category, :other, 'negative-row') %>">
+      <td><%= t('advice_pages.benchmarks.other') %></td>
+      <td class="text-right">><%= format_unit(benchmarked_usage.annual_usage_kwh_benchmark, :kwh) %></td>
+      <td class="text-right">
+        <% if benchmarked_usage.category == :other %>
+          <%= format_unit(benchmarked_usage.annual_usage_kwh, :kwh) %>
+        <% end %>
+      </td>
+    </tr>
+  </tbody>
+</table>

--- a/app/views/schools/advice/gas_long_term/_comparison.html.erb
+++ b/app/views/schools/advice/gas_long_term/_comparison.html.erb
@@ -4,42 +4,7 @@
   <%= t('advice_pages.gas_long_term.insights.comparison.how_do_you_compare', school_type: t('analytics.school_types.' + school.school_type)) %>
 </p>
 
-<table class="table table-sm advice-table" id="comparison-long-term-usage">
-  <thead>
-    <th><%= t('advice_pages.tables.columns.category') %></th>
-    <th class="text-right"><%= t('advice_pages.gas_long_term.tables.columns.annual_usage_kwh') %></th>
-    <th class="text-right"><%= t('advice_pages.gas_long_term.tables.columns.your_usage') %></th>
-  </thead>
-  <tbody>
-    <tr class="<%= row_class_for_category(benchmarked_usage.category, :exemplar) %>">
-      <td><%= t('advice_pages.benchmarks.exemplar_school') %></td>
-      <td class="text-right"><%= format_unit(benchmarked_usage.annual_usage_kwh_exemplar, :kwh) %></td>
-      <td class="text-right">
-        <% if benchmarked_usage.category == :exemplar %>
-         <%= format_unit(benchmarked_usage.annual_usage_kwh, :kwh) %>
-        <% end %>
-      </td>
-    </tr>
-    <tr class="<%= row_class_for_category(benchmarked_usage.category, :benchmark) %>">
-      <td><%= t('advice_pages.benchmarks.benchmark_school') %></td>
-      <td class="text-right"><%= format_unit(benchmarked_usage.annual_usage_kwh_benchmark, :kwh) %></td>
-      <td class="text-right">
-        <% if benchmarked_usage.category == :benchmark %>
-         <%= format_unit(benchmarked_usage.annual_usage_kwh, :kwh) %>
-        <% end %>
-      </td>
-    </tr>
-    <tr class="<%= row_class_for_category(benchmarked_usage.category, :other, 'negative-row') %>">
-      <td><%= t('advice_pages.benchmarks.other') %></td>
-      <td class="text-right">><%= format_unit(benchmarked_usage.annual_usage_kwh_benchmark, :kwh) %></td>
-      <td class="text-right">
-        <% if benchmarked_usage.category == :other %>
-          <%= format_unit(benchmarked_usage.annual_usage_kwh, :kwh) %>
-        <% end %>
-      </td>
-    </tr>
-  </tbody>
-</table>
+<%= render 'insights_benchmark_table', benchmarked_usage: benchmarked_usage %>
 
 <% if school.school_group.present? %>
   <p>

--- a/app/views/schools/advice/gas_long_term/_insights_benchmark_table.html.erb
+++ b/app/views/schools/advice/gas_long_term/_insights_benchmark_table.html.erb
@@ -1,0 +1,36 @@
+<table class="table table-sm advice-table" id="gas-comparison-long-term-usage">
+  <thead>
+    <th><%= t('advice_pages.tables.columns.category') %></th>
+    <th class="text-right"><%= t('advice_pages.gas_long_term.tables.columns.annual_usage_kwh') %></th>
+    <th class="text-right"><%= t('advice_pages.gas_long_term.tables.columns.your_usage') %></th>
+  </thead>
+  <tbody>
+    <tr class="<%= row_class_for_category(benchmarked_usage.category, :exemplar) %>">
+      <td><%= t('advice_pages.benchmarks.exemplar_school') %></td>
+      <td class="text-right"><%= format_unit(benchmarked_usage.annual_usage_kwh_exemplar, :kwh) %></td>
+      <td class="text-right">
+        <% if benchmarked_usage.category == :exemplar %>
+         <%= format_unit(benchmarked_usage.annual_usage_kwh, :kwh) %>
+        <% end %>
+      </td>
+    </tr>
+    <tr class="<%= row_class_for_category(benchmarked_usage.category, :benchmark) %>">
+      <td><%= t('advice_pages.benchmarks.benchmark_school') %></td>
+      <td class="text-right"><%= format_unit(benchmarked_usage.annual_usage_kwh_benchmark, :kwh) %></td>
+      <td class="text-right">
+        <% if benchmarked_usage.category == :benchmark %>
+         <%= format_unit(benchmarked_usage.annual_usage_kwh, :kwh) %>
+        <% end %>
+      </td>
+    </tr>
+    <tr class="<%= row_class_for_category(benchmarked_usage.category, :other, 'negative-row') %>">
+      <td><%= t('advice_pages.benchmarks.other') %></td>
+      <td class="text-right">><%= format_unit(benchmarked_usage.annual_usage_kwh_benchmark, :kwh) %></td>
+      <td class="text-right">
+        <% if benchmarked_usage.category == :other %>
+          <%= format_unit(benchmarked_usage.annual_usage_kwh, :kwh) %>
+        <% end %>
+      </td>
+    </tr>
+  </tbody>
+</table>

--- a/app/views/schools/advice/total_energy_use/_analysis.html.erb
+++ b/app/views/schools/advice/total_energy_use/_analysis.html.erb
@@ -1,22 +1,22 @@
-<p><%= advice_t('analysis.summary') %></p>
+<p><%= advice_t('total_energy_use.analysis.summary') %></p>
 
 <ul>
-  <li><%= link_to(advice_t('analysis.comparison.title'), '#comparison') %></li>
+  <li><%= link_to(advice_t('total_energy_use.analysis.comparison.title'), '#comparison') %></li>
   <% if @analysis_dates.months_of_data > 23 %>
-    <li><%= link_to(advice_t('analysis.long_term_trend.title'), '#long-term-trend') %></li>
+    <li><%= link_to(advice_t('total_energy_use.analysis.long_term_trend.title'), '#long-term-trend') %></li>
   <% end %>
 </ul>
 
 <% if @benchmark_chart.present? %>
-  <%= render 'schools/advice/section_title', section_id: 'comparison', section_title: advice_t('analysis.comparison.title') %>
+  <%= render 'schools/advice/section_title', section_id: 'comparison', section_title: advice_t('total_energy_use.analysis.comparison.title') %>
 
   <%= component 'chart', chart_type: @benchmark_chart, analysis_controls: false, school: @school do |c| %>
-    <% c.with_title { advice_t('charts.benchmark_one_year.title') } %>
+    <% c.with_title { advice_t('total_energy_use.charts.benchmark_one_year.title') } %>
     <% c.with_subtitle do %>
-      <%= advice_t('charts.benchmark_one_year.subtitle', start_date: @analysis_dates.one_year_before_end.to_s(:es_short), end_date: @analysis_dates.end_date.to_s(:es_short)) %>
+      <%= advice_t('total_energy_use.charts.benchmark_one_year.subtitle', start_date: @analysis_dates.one_year_before_end.to_s(:es_short), end_date: @analysis_dates.end_date.to_s(:es_short)) %>
     <% end %>
     <% c.with_footer do %>
-      <%= advice_t('charts.benchmark_one_year.footer') %>
+      <%= advice_t('total_energy_use.charts.benchmark_one_year.footer') %>
     <% end %>
   <% end %>
 
@@ -41,12 +41,12 @@
 <% end %>
 
 <% if @analysis_dates.months_of_data > 23 %>
-  <%= render 'schools/advice/section_title', section_id: 'long-term-trend', section_title: advice_t('analysis.long_term_trend.title') %>
+  <%= render 'schools/advice/section_title', section_id: 'long-term-trend', section_title: advice_t('total_energy_use.analysis.long_term_trend.title') %>
 
   <%= component 'chart', chart_type: :stacked_all_years, school: @school do |c| %>
-    <% c.with_title { advice_t('charts.stacked_all_years.title') } %>
+    <% c.with_title { advice_t('total_energy_use.charts.stacked_all_years.title') } %>
     <% c.with_subtitle do %>
-      <%= advice_t('charts.stacked_all_years.subtitle') %>
+      <%= advice_t('total_energy_use.charts.stacked_all_years.subtitle') %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/views/schools/advice/total_energy_use/_analysis.html.erb
+++ b/app/views/schools/advice/total_energy_use/_analysis.html.erb
@@ -1,1 +1,8 @@
-<p><%= advice_t('advice_pages.total_energy_use.analysis.summary') %></p>
+<p><%= advice_t('analysis.summary') %></p>
+
+<%= component 'chart', chart_type: :benchmark, school: @school do |c| %>
+  <% c.with_title { advice_t('charts.benchmark.title') } %>
+  <% c.with_subtitle do %>
+    <%= advice_t('charts.benchmark.subtitle_html', start_date: @analysis_dates.one_year_before_end.to_s(:es_short), end_date: @analysis_dates.end_date.to_s(:es_short)) %>
+  <% end %>
+<% end %>

--- a/app/views/schools/advice/total_energy_use/_analysis.html.erb
+++ b/app/views/schools/advice/total_energy_use/_analysis.html.erb
@@ -1,8 +1,31 @@
 <p><%= advice_t('analysis.summary') %></p>
 
-<%= component 'chart', chart_type: :benchmark, school: @school do |c| %>
-  <% c.with_title { advice_t('charts.benchmark.title') } %>
+<ul>
+  <li><%= link_to(advice_t('analysis.comparison.title'), '#comparison') %></li>
+  <% if @analysis_dates.months_of_data > 23 %>
+    <li><%= link_to(advice_t('analysis.long_term_trend.title'), '#long-term-trend') %></li>
+  <% end %>
+</ul>
+
+<%= render 'schools/advice/section_title', section_id: 'comparison', section_title: advice_t('analysis.comparison.title') %>
+
+<%= component 'chart', chart_type: :benchmark_one_year, analysis_controls: false, school: @school do |c| %>
+  <% c.with_title { advice_t('charts.benchmark_one_year.title') } %>
   <% c.with_subtitle do %>
-    <%= advice_t('charts.benchmark.subtitle_html', start_date: @analysis_dates.one_year_before_end.to_s(:es_short), end_date: @analysis_dates.end_date.to_s(:es_short)) %>
+    <%= advice_t('charts.benchmark_one_year.subtitle', start_date: @analysis_dates.one_year_before_end.to_s(:es_short), end_date: @analysis_dates.end_date.to_s(:es_short)) %>
+  <% end %>
+  <% c.with_footer do %>
+    <%= advice_t('charts.benchmark_one_year.footer') %>
+  <% end %>
+<% end %>
+
+<% if @analysis_dates.months_of_data > 23 %>
+  <%= render 'schools/advice/section_title', section_id: 'long-term-trend', section_title: advice_t('analysis.long_term_trend.title') %>
+
+  <%= component 'chart', chart_type: :stacked_all_years, school: @school do |c| %>
+    <% c.with_title { advice_t('charts.stacked_all_years.title') } %>
+    <% c.with_subtitle do %>
+      <%= advice_t('charts.stacked_all_years.subtitle') %>
+    <% end %>
   <% end %>
 <% end %>

--- a/app/views/schools/advice/total_energy_use/_analysis.html.erb
+++ b/app/views/schools/advice/total_energy_use/_analysis.html.erb
@@ -19,6 +19,25 @@
       <%= advice_t('charts.benchmark_one_year.footer') %>
     <% end %>
   <% end %>
+
+  <% if @electricity_annual_usage %>
+    <h3><%= t('common.electricity') %></h3>
+    <p>
+      <%= t('advice_pages.electricity_long_term.analysis.comparison.table_explanation', school_type: t('analytics.school_types.' + @school.school_type).downcase) %>
+    </p>
+
+    <%= render 'schools/advice/electricity_long_term/comparison_with_benchmark_table', annual_usage: @electricity_annual_usage, vs_exemplar: @electricity_vs_exemplar, vs_benchmark: @electricity_vs_benchmark, estimated_savings_vs_exemplar: @electricity_estimated_savings_vs_exemplar, estimated_savings_vs_benchmark: @electricity_estimated_savings_vs_benchmark %>
+  <% end %>
+
+  <% if @gas_annual_usage %>
+    <h3><%= t('common.gas') %></h3>
+    <p>
+      <%= t('advice_pages.gas_long_term.analysis.comparison.table_explanation', school_type: t('analytics.school_types.' + @school.school_type).downcase) %>
+    </p>
+
+    <%= render 'schools/advice/gas_long_term/comparison_with_benchmark_table', annual_usage: @gas_annual_usage, vs_exemplar: @gas_vs_exemplar, vs_benchmark: @gas_vs_benchmark, estimated_savings_vs_exemplar: @gas_estimated_savings_vs_exemplar, estimated_savings_vs_benchmark: @gas_estimated_savings_vs_benchmark %>
+  <% end %>
+
 <% end %>
 
 <% if @analysis_dates.months_of_data > 23 %>

--- a/app/views/schools/advice/total_energy_use/_analysis.html.erb
+++ b/app/views/schools/advice/total_energy_use/_analysis.html.erb
@@ -7,15 +7,17 @@
   <% end %>
 </ul>
 
-<%= render 'schools/advice/section_title', section_id: 'comparison', section_title: advice_t('analysis.comparison.title') %>
+<% if @benchmark_chart.present? %>
+  <%= render 'schools/advice/section_title', section_id: 'comparison', section_title: advice_t('analysis.comparison.title') %>
 
-<%= component 'chart', chart_type: :benchmark_one_year, analysis_controls: false, school: @school do |c| %>
-  <% c.with_title { advice_t('charts.benchmark_one_year.title') } %>
-  <% c.with_subtitle do %>
-    <%= advice_t('charts.benchmark_one_year.subtitle', start_date: @analysis_dates.one_year_before_end.to_s(:es_short), end_date: @analysis_dates.end_date.to_s(:es_short)) %>
-  <% end %>
-  <% c.with_footer do %>
-    <%= advice_t('charts.benchmark_one_year.footer') %>
+  <%= component 'chart', chart_type: @benchmark_chart, analysis_controls: false, school: @school do |c| %>
+    <% c.with_title { advice_t('charts.benchmark_one_year.title') } %>
+    <% c.with_subtitle do %>
+      <%= advice_t('charts.benchmark_one_year.subtitle', start_date: @analysis_dates.one_year_before_end.to_s(:es_short), end_date: @analysis_dates.end_date.to_s(:es_short)) %>
+    <% end %>
+    <% c.with_footer do %>
+      <%= advice_t('charts.benchmark_one_year.footer') %>
+    <% end %>
   <% end %>
 <% end %>
 

--- a/app/views/schools/advice/total_energy_use/_analysis.html.erb
+++ b/app/views/schools/advice/total_energy_use/_analysis.html.erb
@@ -1,0 +1,1 @@
+<p><%= advice_t('advice_pages.total_energy_use.analysis.summary') %></p>

--- a/app/views/schools/advice/total_energy_use/_insights.html.erb
+++ b/app/views/schools/advice/total_energy_use/_insights.html.erb
@@ -1,9 +1,9 @@
 <%= component 'notice', status: :neutral do |c| %>
-  <% c.with_link { link_to advice_t('insights.intro.link'), learn_more_school_advice_total_energy_use_path(@school) } %>
-  <%= advice_t('insights.intro.text') %>
+  <% c.with_link { link_to advice_t('total_energy_use.insights.intro.link'), learn_more_school_advice_total_energy_use_path(@school) } %>
+  <%= advice_t('total_energy_use.insights.intro.text') %>
 <% end %>
 
-<%= render 'schools/advice/section_title', section_id: 'energy-use', section_title: advice_t('insights.energy_use.title') %>
+<%= render 'schools/advice/section_title', section_id: 'energy-use', section_title: advice_t('total_energy_use.insights.energy_use.title') %>
 
 <% if @overview_data %>
   <%= render 'management/schools/overview_data', overview_data: @overview_data, show_savings: false %>
@@ -13,11 +13,11 @@
   </div>
 <% end %>
 
-<%= render 'schools/advice/section_title', section_id: 'comparison', section_title: advice_t('insights.comparison.title') %>
+<%= render 'schools/advice/section_title', section_id: 'comparison', section_title: advice_t('total_energy_use.insights.comparison.title') %>
 
 <% if @electricity_benchmarked_usage.present? || @gas_benchmarked_usage.present? %>
   <p>
-    <%= advice_t('insights.comparison.how_do_you_compare', school_type: t('analytics.school_types.' + @school.school_type).downcase) %>
+    <%= advice_t('total_energy_use.insights.comparison.how_do_you_compare', school_type: t('analytics.school_types.' + @school.school_type).downcase) %>
   </p>
 
   <% if @electricity_benchmarked_usage.present? %>
@@ -35,6 +35,6 @@
 
 <% if @school.school_group.present? %>
   <p>
-    <%= advice_t('insights.comparison.more_detail_html', link: benchmark_for_school_group_path(:annual_energy_costs_per_pupil, @school)) %>
+    <%= advice_t('total_energy_use.insights.comparison.more_detail_html', link: benchmark_for_school_group_path(:annual_energy_costs_per_pupil, @school)) %>
   </p>
 <% end %>

--- a/app/views/schools/advice/total_energy_use/_insights.html.erb
+++ b/app/views/schools/advice/total_energy_use/_insights.html.erb
@@ -15,6 +15,24 @@
 
 <%= render 'schools/advice/section_title', section_id: 'comparison', section_title: advice_t('insights.comparison.title') %>
 
+<% if @electricity_benchmarked_usage.present? || @gas_benchmarked_usage.present? %>
+  <p>
+    <%= advice_t('insights.comparison.how_do_you_compare', school_type: t('analytics.school_types.' + @school.school_type).downcase) %>
+  </p>
+
+  <% if @electricity_benchmarked_usage.present? %>
+    <h3><%= t('common.electricity') %></h3>
+
+    <%= render 'schools/advice/electricity_long_term/insights_benchmark_table', school: @school, benchmarked_usage: @electricity_benchmarked_usage %>
+  <% end %>
+
+  <% if @gas_benchmarked_usage.present? %>
+    <h3><%= t('common.gas') %></h3>
+
+    <%= render 'schools/advice/gas_long_term/insights_benchmark_table', school: @school, benchmarked_usage: @gas_benchmarked_usage %>
+  <% end %>
+<% end %>
+
 <% if @school.school_group.present? %>
   <p>
     <%= advice_t('insights.comparison.more_detail_html', link: benchmark_for_school_group_path(:annual_energy_costs_per_pupil, @school)) %>

--- a/app/views/schools/advice/total_energy_use/_insights.html.erb
+++ b/app/views/schools/advice/total_energy_use/_insights.html.erb
@@ -1,0 +1,22 @@
+<%= component 'notice', status: :neutral do |c| %>
+  <% c.with_link { link_to advice_t('insights.intro.link'), learn_more_school_advice_total_energy_use_path(@school) } %>
+  <%= advice_t('insights.intro.text') %>
+<% end %>
+
+<%= render 'schools/advice/section_title', section_id: 'energy-use', section_title: advice_t('insights.energy_use.title') %>
+
+<% if @overview_data %>
+  <%= render 'management/schools/overview_data', overview_data: @overview_data, show_savings: false %>
+  <div class="text-right management-overview-caption">
+    <%= @overview_data.date_ranges %>
+    <%= link_to_help_for_feature :management_summary_overview, title: "#{t('schools.show.more_information')} #{fa_icon('info-circle')}".html_safe %>
+  </div>
+<% end %>
+
+<%= render 'schools/advice/section_title', section_id: 'comparison', section_title: advice_t('insights.comparison.title') %>
+
+<% if @school.school_group.present? %>
+  <p>
+    <%= advice_t('insights.comparison.more_detail_html', link: benchmark_for_school_group_path(:annual_energy_costs_per_pupil, @school)) %>
+  </p>
+<% end %>

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -141,6 +141,9 @@ ignore_unused:
   - 'advice_pages.baseload.analysis.charts.long_term_baseload_meter_chart_title'
   - 'advice_pages.heating_control.analysis.meter_breakdown.chart_subtitle_html'
   - 'advice_pages.heating_control.analysis.meter_breakdown.chart_title'
+  - 'advice_pages.*.analysis.title'
+  - 'advice_pages.*.insights.title'
+  - 'advice_pages.*.insights.next_steps'
 # - '{devise,kaminari,will_paginate}.*'
 # - 'simple_form.{yes,no}'
 # - 'simple_form.{placeholders,hints,labels}.*'
@@ -173,3 +176,7 @@ ignore_unused:
 #
 # <%# I18n::Tasks.add_scanner 'I18n::Tasks::Scanners::PatternMapper',
 #       patterns: [['\bSpree\.t[( ]\s*%{key}', 'spree.%{key}']] %>
+ <% I18n::Tasks.add_scanner 'I18n::Tasks::Scanners::PatternMapper',
+       patterns: [
+         ['\badvice_t[( ]\s*%{key}', 'advice_pages.%{key}']
+       ] %>

--- a/config/locales/views/advice_pages/heating_control.yml
+++ b/config/locales/views/advice_pages/heating_control.yml
@@ -50,7 +50,6 @@ en:
         controls:
           average_start_time: Our analysis shows that recently the average start time for your heating was %{time}.
           title: Your heating controls
-        next_steps: Review your heating times.
         title: What do we mean by heating control?
         view_our_analysis_html: <a href="%{href}">View our analysis</a>
         warm_weather:

--- a/config/locales/views/advice_pages/total_energy_use.yml
+++ b/config/locales/views/advice_pages/total_energy_use.yml
@@ -4,5 +4,9 @@ en:
     total_energy_use:
       analysis:
         summary: This section gives a more detailed analysis of how your school’s energy consumption compares with other schools.
+      charts:
+        benchmark:
+          subtitle_html: This chart shows how your school’s energy use compared against well managed and exemplar schools between <span class='start-date'>%{start_date}</span> and <span class='end-date'>%{end_date}</span>
+          title: Annual energy use comparison with other schools
       insights:
       page_title: Energy usage summary

--- a/config/locales/views/advice_pages/total_energy_use.yml
+++ b/config/locales/views/advice_pages/total_energy_use.yml
@@ -3,10 +3,24 @@ en:
   advice_pages:
     total_energy_use:
       analysis:
+        comparison:
+          title: Comparison with other schools
+        long_term_trend:
+          title: Long term trend
         summary: This section gives a more detailed analysis of how your school’s energy consumption compares with other schools.
       charts:
-        benchmark:
-          subtitle_html: This chart shows how your school’s energy use compared against well managed and exemplar schools between <span class='start-date'>%{start_date}</span> and <span class='end-date'>%{end_date}</span>
+        benchmark_one_year:
+          footer: |-
+            <p>
+            Whether you have old or new school buildings, good energy management and best practice in operation can save significant amounts of energy. With good management an old building can use significantly less energy than a poorly managed new building. Improving controls, upgrading to more efficient lighting and other measures are applicable to all school buildings.
+            </p>
+            <p>
+            Monetary values for well managed and exemplar schools are converted using your school's tariffs.
+            </p>
+          subtitle: This chart shows how your school’s energy use compared against well managed and exemplar schools between %{start_date} and %{end_date}
           title: Annual energy use comparison with other schools
+        stacked_all_years:
+          subtitle: This chart summarises the gas and electricity consumption for all the full years of data for your school
+          title: Change in energy consumption for last few years
       insights:
       page_title: Energy usage summary

--- a/config/locales/views/advice_pages/total_energy_use.yml
+++ b/config/locales/views/advice_pages/total_energy_use.yml
@@ -3,8 +3,6 @@ en:
   advice_pages:
     total_energy_use:
       analysis:
-        title: Analysis
+        summary: This section gives a more detailed analysis of how your school’s energy consumption compares with other schools.
       insights:
-        next_steps: Next steps
-        title: Insights
-      page_title: Total energy use
+      page_title: Energy usage summary

--- a/config/locales/views/advice_pages/total_energy_use.yml
+++ b/config/locales/views/advice_pages/total_energy_use.yml
@@ -23,4 +23,12 @@ en:
           subtitle: This chart summarises the gas and electricity consumption for all the full years of data for your school
           title: Change in energy consumption for last few years
       insights:
+        comparison:
+          more_detail_html: For more detail, <a href="%{link}">compare with other schools in your group</a>
+          title: How do you compare?
+        energy_use:
+          title: Your school’s energy use
+        intro:
+          link: Learn more
+          text: Looking at the big picture of energy consumption for your school can help get started on investigating and reducing energy use.
       page_title: Energy usage summary

--- a/config/locales/views/advice_pages/total_energy_use.yml
+++ b/config/locales/views/advice_pages/total_energy_use.yml
@@ -24,6 +24,7 @@ en:
           title: Change in energy consumption for last few years
       insights:
         comparison:
+          how_do_you_compare: How does your energy use for the last 12 months compare to other %{school_type} schools on Energy Sparks with a similar number of pupils?
           more_detail_html: For more detail, <a href="%{link}">compare with other schools in your group</a>
           title: How do you compare?
         energy_use:

--- a/spec/system/schools/advice_pages/advice_pages_spec.rb
+++ b/spec/system/schools/advice_pages/advice_pages_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "advice pages", type: :system do
 
   let(:key) { 'total_energy_use' }
   let(:learn_more) { 'here is some more explanation' }
-  let(:expected_page_title) { "Total energy use" }
+  let(:expected_page_title) { "Energy usage summary" }
 
   let!(:advice_page) { create(:advice_page, key: key, restricted: false, learn_more: learn_more) }
 
@@ -15,9 +15,7 @@ RSpec.describe "advice pages", type: :system do
       allow_any_instance_of(Schools::Advice::AdviceBaseController).to receive(:learn_more).and_raise(StandardError.new('testing..'))
     end
     it 'shows the error page' do
-      visit school_advice_path(school)
-      click_on key
-      click_on 'Learn More'
+      visit learn_more_school_advice_total_energy_use_path(school)
       expect(page).to have_content('Sorry, something has gone wrong')
       expect(page).to have_content('We encountered an error attempting to generate your analysis')
     end
@@ -73,11 +71,6 @@ RSpec.describe "advice pages", type: :system do
       expect(page).to have_link(key)
     end
 
-    it 'shows the advice page' do
-      click_on key
-      expect(page).to have_content(expected_page_title)
-    end
-
     context 'when page is restricted' do
       before do
         advice_page.update(restricted: true)
@@ -105,67 +98,68 @@ RSpec.describe "advice pages", type: :system do
       expect(page).to have_link(key)
     end
 
-    it 'shows the advice page' do
-      click_on key
-      expect(page).to have_content(expected_page_title)
-    end
-
-    it 'shows the nav bar' do
-      click_on key
-      within '.advice-page-nav' do
-        expect(page).to have_content("Advice")
+    context 'basic navigation checks' do
+      before(:each) do
+        visit learn_more_school_advice_total_energy_use_path(school)
       end
-    end
 
-    it 'shows tabs for insights, analysis, learn more' do
-      click_on key
-      within '.advice-page-tabs' do
-        expect(page).to have_link('Insights')
-        expect(page).to have_link('Analysis')
-        expect(page).to have_link('Learn More')
-      end
-    end
-
-    it 'shows breadcrumb' do
-      click_on key
-      within '.advice-page-breadcrumb' do
-        expect(page).to have_link('Schools')
-        expect(page).to have_link(school.name)
-        expect(page).to have_link('Advice')
-        expect(page).to have_text(key.humanize)
-      end
-    end
-
-    it 'shows learn more content' do
-      click_on key
-      click_on 'Learn More'
-      within '.advice-page-tabs' do
-        expect(page).to have_content(learn_more)
-      end
-    end
-
-    it 'links to advice pages from manage school menu' do
-      within '#manage_school_menu' do
-        click_on 'Advice pages'
-      end
-      expect(page).to have_content("Advice Pages")
-      expect(page).to have_content("All pages")
-    end
-
-    it 'links from admin page' do
-      visit admin_path
-      click_on 'Advice Pages'
-      expect(page).to have_content('Manage advice pages')
-    end
-
-    context 'when page is restricted' do
-      before do
-        advice_page.update(restricted: true)
-      end
-      it 'shows the restricted advice page' do
-        click_on key
+      it 'shows the advice page' do
         expect(page).to have_content(expected_page_title)
       end
+
+      it 'shows the nav bar' do
+        within '.advice-page-nav' do
+          expect(page).to have_content("Advice")
+        end
+      end
+
+      it 'shows tabs for insights, analysis, learn more' do
+        within '.advice-page-tabs' do
+          expect(page).to have_link('Insights')
+          expect(page).to have_link('Analysis')
+          expect(page).to have_link('Learn More')
+        end
+      end
+
+      it 'shows breadcrumb' do
+        within '.advice-page-breadcrumb' do
+          expect(page).to have_link('Schools')
+          expect(page).to have_link(school.name)
+          expect(page).to have_link('Advice')
+          expect(page).to have_text(expected_page_title)
+        end
+      end
+
+      it 'shows learn more content' do
+        within '.advice-page-tabs' do
+          expect(page).to have_content(learn_more)
+        end
+      end
+
+      it 'links to advice pages from manage school menu' do
+        within '#manage_school_menu' do
+          click_on 'Advice pages'
+        end
+        expect(page).to have_content("Advice Pages")
+        expect(page).to have_content("All pages")
+      end
+
+      it 'links from admin page' do
+        visit admin_path
+        click_on 'Advice Pages'
+        expect(page).to have_content('Manage advice pages')
+      end
+
+      context 'when page is restricted' do
+        before do
+          advice_page.update(restricted: true)
+        end
+        it 'shows the restricted advice page' do
+          refresh
+          expect(page).to have_content(expected_page_title)
+        end
+      end
+
     end
   end
 end

--- a/spec/system/schools/advice_pages/total_energy_use_spec.rb
+++ b/spec/system/schools/advice_pages/total_energy_use_spec.rb
@@ -7,8 +7,29 @@ RSpec.describe "total energy use advice page", type: :system do
 
   context 'as school admin' do
     let(:user)  { create(:school_admin, school: school) }
+    let(:gas_aggregate_meter)   { double('gas-aggregated-meter')}
+
+    let(:management_data) {
+      Tables::SummaryTableData.new({ electricity: { year: { :percent_change => 0.11050 }, workweek: { :percent_change => -0.0923132131 } } })
+    }
+
+    let(:enough_data)  { true }
+    let(:annual_usage) { CombinedUsageMetric.new(kwh: 1000, £: 500, co2: 1500) }
+    let(:annual_usage_vs_benchmark) { CombinedUsageMetric.new(kwh: 800, £: 400, co2: 1300) }
+    let(:annual_usage_vs_exemplar) { CombinedUsageMetric.new(kwh: 500, £: 300, co2: 1000) }
 
     before do
+      allow(gas_aggregate_meter).to receive(:amr_data).and_return(amr_data)
+      allow(meter_collection).to receive(:aggregated_heat_meters).and_return(gas_aggregate_meter)
+
+      allow_any_instance_of(Schools::ManagementTableService).to receive(:management_data).and_return(management_data)
+      allow_any_instance_of(Schools::Advice::LongTermUsageService).to receive_messages(
+        enough_data?: enough_data,
+        annual_usage: annual_usage
+      )
+      allow_any_instance_of(Schools::Advice::LongTermUsageService).to receive(:annual_usage_kwh).with(compare: :benchmark_school).and_return(annual_usage_vs_benchmark.kwh)
+      allow_any_instance_of(Schools::Advice::LongTermUsageService).to receive(:annual_usage_kwh).with(compare: :exemplar_school).and_return(annual_usage_vs_exemplar.kwh)
+
       sign_in(user)
       visit school_advice_total_energy_use_path(school)
     end
@@ -18,10 +39,40 @@ RSpec.describe "total energy use advice page", type: :system do
     context "clicking the 'Insights' tab" do
       before { click_on 'Insights' }
       it_behaves_like "an advice page tab", tab: "Insights"
+
+      it 'has expected content' do
+        expect(page).to have_content(I18n.t('advice_pages.total_energy_use.insights.intro.text'))
+        expect(page).to have_css('#management-overview-table')
+        expect(page).to have_content("How does your energy use for the last 12 months compare to other primary schools")
+      end
     end
     context "clicking the 'Analysis' tab" do
-      before { click_on 'Analysis' }
-      it_behaves_like "an advice page tab", tab: "Analysis"
+      context 'with default data' do
+        before { click_on 'Analysis' }
+        it_behaves_like "an advice page tab", tab: "Analysis"
+        it 'has expected content' do
+          expect(page).to have_content(I18n.t('advice_pages.total_energy_use.analysis.comparison.title'))
+          #only one year of data in mocked out data
+          expect(page).to_not have_css('#long-term-trend')
+        end
+        it 'has expected charts' do
+          expect(page).to have_css('#chart_wrapper_benchmark_one_year')
+          #only one year of data in mocked out data
+          expect(page).to_not have_css('#chart_wrapper_stacked_all_years')
+        end
+      end
+      context 'with more data' do
+        before { click_on 'Analysis' }
+        let(:start_date) { end_date - 2.years}
+        it 'has expected content' do
+          expect(page).to have_content(I18n.t('advice_pages.total_energy_use.analysis.comparison.title'))
+          expect(page).to have_css('#long-term-trend')
+        end
+        it 'has expected charts' do
+          expect(page).to have_css('#chart_wrapper_benchmark_one_year')
+          expect(page).to have_css('#chart_wrapper_stacked_all_years')
+        end
+      end
     end
     context "clicking the 'Learn More' tab" do
       before { click_on 'Learn More' }

--- a/spec/system/schools/advice_pages/total_energy_use_spec.rb
+++ b/spec/system/schools/advice_pages/total_energy_use_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe "total energy use advice page", type: :system do
   let(:key) { 'total_energy_use' }
-  let(:expected_page_title) { "Total energy use" }
+  let(:expected_page_title) { "Energy usage summary" }
   include_context "electricity advice page"
 
   context 'as school admin' do

--- a/spec/system/schools/advice_pages/total_energy_use_spec.rb
+++ b/spec/system/schools/advice_pages/total_energy_use_spec.rb
@@ -18,6 +18,14 @@ RSpec.describe "total energy use advice page", type: :system do
     let(:annual_usage_vs_benchmark) { CombinedUsageMetric.new(kwh: 800, £: 400, co2: 1300) }
     let(:annual_usage_vs_exemplar) { CombinedUsageMetric.new(kwh: 500, £: 300, co2: 1000) }
 
+    let(:annual_usage) { CombinedUsageMetric.new(kwh: 1000, £: 500, co2: 1500) }
+    let(:annual_usage_vs_benchmark) { CombinedUsageMetric.new(kwh: 800, £: 400, co2: 1300) }
+    let(:annual_usage_vs_exemplar) { CombinedUsageMetric.new(kwh: 500, £: 300, co2: 1000) }
+
+    let(:savings_vs_benchmark) { CombinedUsageMetric.new(kwh: 200, £: 100, co2: 200) }
+    let(:savings_vs_exemplar) { CombinedUsageMetric.new(kwh: 500, £: 200, co2: 500) }
+
+
     before do
       allow(gas_aggregate_meter).to receive(:amr_data).and_return(amr_data)
       allow(meter_collection).to receive(:aggregated_heat_meters).and_return(gas_aggregate_meter)
@@ -29,6 +37,12 @@ RSpec.describe "total energy use advice page", type: :system do
       )
       allow_any_instance_of(Schools::Advice::LongTermUsageService).to receive(:annual_usage_kwh).with(compare: :benchmark_school).and_return(annual_usage_vs_benchmark.kwh)
       allow_any_instance_of(Schools::Advice::LongTermUsageService).to receive(:annual_usage_kwh).with(compare: :exemplar_school).and_return(annual_usage_vs_exemplar.kwh)
+
+      allow_any_instance_of(Schools::Advice::LongTermUsageService).to receive(:annual_usage_vs_benchmark).with(compare: :benchmark_school).and_return(annual_usage_vs_benchmark)
+      allow_any_instance_of(Schools::Advice::LongTermUsageService).to receive(:annual_usage_vs_benchmark).with(compare: :exemplar_school).and_return(annual_usage_vs_exemplar)
+
+      allow_any_instance_of(Schools::Advice::LongTermUsageService).to receive(:estimated_savings).with(versus: :benchmark_school).and_return(annual_usage_vs_benchmark)
+      allow_any_instance_of(Schools::Advice::LongTermUsageService).to receive(:estimated_savings).with(versus: :exemplar_school).and_return(annual_usage_vs_exemplar)
 
       sign_in(user)
       visit school_advice_total_energy_use_path(school)


### PR DESCRIPTION
Adds the Total Energy Use page

This page has a combination of information from other sources, so there's some reuse of partials, etc.

* Updates advice base controller to allow subtitles and "next steps" to be optional
* Removes some unneeded variables in the long term controller (spotted while testing)
* Incorporates the table from the school dashboard, so reuses partial and existing code. Partial has been updated to allow cost saving to be hidden
* Extracts partials for the tables from electricity/gas long term analysis so they can be reused

Page uses the new advice page translation helper (`advice_t`) to reduce length of keys. However I found that this was tripping up `i18n-tasks`, so I have also:

* revised the helper to require passing in the page key, e.g. `total_energy_use` rather than relying on instance variable
* added an i18n pattern matcher for the `advice_t` function so that it can figure out the full key.

Felt it was better to compromise a bit on the helper, to have i18n as a safety net.