### PR TITLE
Recent Progress Page Review Fixes

### DIFF
--- a/app/controllers/schools/advice/electricity_recent_changes_controller.rb
+++ b/app/controllers/schools/advice/electricity_recent_changes_controller.rb
@@ -22,8 +22,8 @@ module Schools
 
       def change
         Usage::CombinedUsageMetricComparison.new(
-          last_week.combined_usage_metric,
-          previous_week.combined_usage_metric
+          previous_week.combined_usage_metric,
+          last_week.combined_usage_metric
         ).compare
       end
 

--- a/app/controllers/schools/advice/gas_recent_changes_controller.rb
+++ b/app/controllers/schools/advice/gas_recent_changes_controller.rb
@@ -22,8 +22,8 @@ module Schools
 
       def change
         Usage::CombinedUsageMetricComparison.new(
-          last_week.combined_usage_metric,
-          previous_week.combined_usage_metric
+          previous_week.combined_usage_metric,
+          last_week.combined_usage_metric
         ).compare
       end
 

--- a/app/views/schools/advice/electricity_recent_changes/_insights.html.erb
+++ b/app/views/schools/advice/electricity_recent_changes/_insights.html.erb
@@ -5,4 +5,4 @@
 <%= render 'schools/advice/section_title', section_id: 'your_recent_electricity_use', section_title: t('advice_pages.electricity_recent_changes.insights.your_recent_electricity_use.title') %>
 <%= render 'your_recent_electricity_use_table' %>
 <%= render 'schools/advice/section_title', section_id: 'how_do_you_compare', section_title: t('advice_pages.electricity_recent_changes.insights.how_do_you_compare.title') %>
-<%= t('advice_pages.electricity_recent_changes.insights.how_do_you_compare.summary_html', comparison_link: benchmark_path(benchmark_type: :change_in_electricity_consumption_recent_school_weeks, benchmark: { school_group_ids: [@school.school_group_id] })) %>
+<%= t('advice_pages.electricity_recent_changes.insights.how_do_you_compare.summary_html', comparison_link: benchmark_for_school_group_path(:change_in_electricity_consumption_recent_school_weeks, @school)) %>

--- a/app/views/schools/advice/electricity_recent_changes/_insights.html.erb
+++ b/app/views/schools/advice/electricity_recent_changes/_insights.html.erb
@@ -5,4 +5,4 @@
 <%= render 'schools/advice/section_title', section_id: 'your_recent_electricity_use', section_title: t('advice_pages.electricity_recent_changes.insights.your_recent_electricity_use.title') %>
 <%= render 'your_recent_electricity_use_table' %>
 <%= render 'schools/advice/section_title', section_id: 'how_do_you_compare', section_title: t('advice_pages.electricity_recent_changes.insights.how_do_you_compare.title') %>
-<%= t('advice_pages.electricity_recent_changes.insights.how_do_you_compare.summary_html', comparison_link: benchmark_path(benchmark_type: :change_in_electricity_consumption_recent_school_weeks)) %>
+<%= t('advice_pages.electricity_recent_changes.insights.how_do_you_compare.summary_html', comparison_link: benchmark_path(benchmark_type: :change_in_electricity_consumption_recent_school_weeks, benchmark: { school_group_ids: [@school.school_group_id] })) %>

--- a/app/views/schools/advice/electricity_recent_changes/_your_recent_electricity_use_table.html.erb
+++ b/app/views/schools/advice/electricity_recent_changes/_your_recent_electricity_use_table.html.erb
@@ -6,12 +6,12 @@
     <th class="text-right"><%= t('co2') %></th>
   </thead>
   <%= render 'your_recent_electricity_use_table_row',
-      combined_usage_metric: @recent_usage.last_week.combined_usage_metric,
-      period: @recent_usage.last_week.date_range.map { |d| d.to_s(:es_short) }.join(' - ')
-  %>
-  <%= render 'your_recent_electricity_use_table_row',
       combined_usage_metric: @recent_usage.previous_week.combined_usage_metric,
       period: @recent_usage.previous_week.date_range.map { |d| d.to_s(:es_short) }.join(' - ')
+  %>
+  <%= render 'your_recent_electricity_use_table_row',
+      combined_usage_metric: @recent_usage.last_week.combined_usage_metric,
+      period: @recent_usage.last_week.date_range.map { |d| d.to_s(:es_short) }.join(' - ')
   %>
   <%= render 'your_recent_electricity_use_table_row',
       combined_usage_metric: @recent_usage.change,

--- a/app/views/schools/advice/electricity_recent_changes/_your_recent_electricity_use_table.html.erb
+++ b/app/views/schools/advice/electricity_recent_changes/_your_recent_electricity_use_table.html.erb
@@ -18,3 +18,6 @@
       period: t('advice_pages.electricity_recent_changes.insights.your_recent_electricity_use.table.change')
   %>
 </table>
+<div class="text-right advice-table-caption">
+  <%= t('advice_pages.tables.notice.two_significant_figures') %>
+</div>

--- a/app/views/schools/advice/gas_recent_changes/_insights.html.erb
+++ b/app/views/schools/advice/gas_recent_changes/_insights.html.erb
@@ -5,5 +5,5 @@
 <%= render 'schools/advice/section_title', section_id: 'your_recent_gas_use', section_title: t('advice_pages.gas_recent_changes.insights.your_recent_gas_use.title') %>
 <%= render 'your_recent_gas_use_table' %>
 <%= render 'schools/advice/section_title', section_id: 'how_do_you_compare', section_title: t('advice_pages.gas_recent_changes.insights.how_do_you_compare.title') %>
-<%= t('advice_pages.gas_recent_changes.insights.how_do_you_compare.summary_html', comparison_link: benchmark_path(benchmark_type: :change_in_gas_consumption_recent_school_weeks, benchmark: { school_group_ids: [@school.school_group_id] })) %>
+<%= t('advice_pages.gas_recent_changes.insights.how_do_you_compare.summary_html', comparison_link: benchmark_for_school_group_path(:change_in_gas_consumption_recent_school_weeks, @school)) %>
 

--- a/app/views/schools/advice/gas_recent_changes/_insights.html.erb
+++ b/app/views/schools/advice/gas_recent_changes/_insights.html.erb
@@ -5,5 +5,5 @@
 <%= render 'schools/advice/section_title', section_id: 'your_recent_gas_use', section_title: t('advice_pages.gas_recent_changes.insights.your_recent_gas_use.title') %>
 <%= render 'your_recent_gas_use_table' %>
 <%= render 'schools/advice/section_title', section_id: 'how_do_you_compare', section_title: t('advice_pages.gas_recent_changes.insights.how_do_you_compare.title') %>
-<%= t('advice_pages.gas_recent_changes.insights.how_do_you_compare.summary_html', comparison_link: benchmark_path(benchmark_type: :change_in_gas_consumption_recent_school_weeks)) %>
+<%= t('advice_pages.gas_recent_changes.insights.how_do_you_compare.summary_html', comparison_link: benchmark_path(benchmark_type: :change_in_gas_consumption_recent_school_weeks, benchmark: { school_group_ids: [@school.school_group_id] })) %>
 

--- a/app/views/schools/advice/gas_recent_changes/_your_recent_gas_use_table.html.erb
+++ b/app/views/schools/advice/gas_recent_changes/_your_recent_gas_use_table.html.erb
@@ -18,3 +18,6 @@
       period: t('advice_pages.gas_recent_changes.insights.your_recent_gas_use.table.change')
   %>
 </table>
+<div class="text-right advice-table-caption">
+  <%= t('advice_pages.tables.notice.two_significant_figures') %>
+</div>

--- a/app/views/schools/advice/gas_recent_changes/_your_recent_gas_use_table.html.erb
+++ b/app/views/schools/advice/gas_recent_changes/_your_recent_gas_use_table.html.erb
@@ -6,12 +6,12 @@
     <th class="text-right"><%= t('co2') %></th>
   </thead>
   <%= render 'your_recent_gas_use_table_row',
-      combined_usage_metric: @recent_usage.last_week.combined_usage_metric,
-      period: @recent_usage.last_week.date_range.map { |d| d.to_s(:es_short) }.join(' - ')
-  %>
-  <%= render 'your_recent_gas_use_table_row',
       combined_usage_metric: @recent_usage.previous_week.combined_usage_metric,
       period: @recent_usage.previous_week.date_range.map { |d| d.to_s(:es_short) }.join(' - ')
+  %>
+  <%= render 'your_recent_gas_use_table_row',
+      combined_usage_metric: @recent_usage.last_week.combined_usage_metric,
+      period: @recent_usage.last_week.date_range.map { |d| d.to_s(:es_short) }.join(' - ')
   %>
   <%= render 'your_recent_gas_use_table_row',
       combined_usage_metric: @recent_usage.change,

--- a/config/locales/views/advice_pages/advice_pages.yml
+++ b/config/locales/views/advice_pages/advice_pages.yml
@@ -61,3 +61,5 @@ en:
         period: Period
       labels:
         partial: "(partial)"
+      notice:
+        two_significant_figures: Data in this table are presented to 2 significant figures.

--- a/config/locales/views/advice_pages/gas_recent_changes.yml
+++ b/config/locales/views/advice_pages/gas_recent_changes.yml
@@ -31,7 +31,7 @@ en:
           title: How do you compare?
         link: Learn more
         next_steps: Try to ensure that you understand the causes of any significant changes in your gas consumption.
-        summary: This page makes note of whether your gas use has increased or decreased recently.  Monitoring recent changes to your energy use can help you to assess the impacts of changes you have made, or quickly identify problems.
+        summary: This page makes note of whether your gas use has increased or decreased recently.  Monitoring recent changes to your energy use can help you to assess the impacts of changes you have made, or quickly identify problems
         title: What do we mean by recent changes?
         your_recent_gas_use:
           table:


### PR DESCRIPTION
This PR covers a few updates & fixes raised during the review of the new Recent Changes Page:

- [x] Fix school comparison link on insights page to link to comparison for school group (missing param?)
- [x] Reorder table to go from oldest, to most recent with change at the bottom
- [x] Check calculation on recent changes, should be most recent minus least recent
- [x] Add a note re: rounding
- [x] Insights tab, definition - remove double full stop at end.