### PR TITLE
Out of Hours Usage Pages Review Fixes

### DIFF
--- a/app/views/schools/advice/electricity_out_of_hours/_analysis.html.erb
+++ b/app/views/schools/advice/electricity_out_of_hours/_analysis.html.erb
@@ -14,13 +14,6 @@
 
 <%= render 'schools/advice/section_title', section_id: 'last_twelve_months', section_title: t('advice_pages.electricity_out_of_hours.analysis.last_twelve_months.title') %>
 
-<% if @annual_usage_breakdown.community.present? %>
-  <p><%= t('advice_pages.electricity_out_of_hours.analysis.last_twelve_months.community_use_html',
-    community_kwh: format_unit(@annual_usage_breakdown.community.kwh, :kwh),
-    community_gbp: format_unit(@annual_usage_breakdown.community.£, :£),
-    community_co2: format_unit(@annual_usage_breakdown.community.co2, :co2) ) %></p>
-<% end %>
-
 <%= component 'chart', chart_type: :daytype_breakdown_electricity_tolerant, school: @school do |c| %>
   <% c.with_title do %>
     <%= t('advice_pages.electricity_out_of_hours.analysis.usage_by_day_of_week.daytype_breakdown_electricity_tolerant_chart.title') %>

--- a/app/views/schools/advice/electricity_out_of_hours/_insights_table.html.erb
+++ b/app/views/schools/advice/electricity_out_of_hours/_insights_table.html.erb
@@ -12,7 +12,7 @@
         <%= format_unit(@annual_usage_breakdown&.potential_savings(versus: :exemplar_school)&.kwh, :kwh) %>
       </td>
       <td class="text-right">
-        <%= format_unit(@annual_usage_breakdown&.total&.kwh, :kwh) %>
+        <%= format_unit(@annual_usage_breakdown&.out_of_hours&.kwh, :kwh) %>
       </td>
     <tr>
 </table>

--- a/app/views/schools/advice/gas_out_of_hours/_analysis.html.erb
+++ b/app/views/schools/advice/gas_out_of_hours/_analysis.html.erb
@@ -14,13 +14,6 @@
 
 <%= render 'schools/advice/section_title', section_id: 'last_twelve_months', section_title: t('advice_pages.gas_out_of_hours.analysis.last_twelve_months.title') %>
 
-<% if @annual_usage_breakdown.community.present? %>
-  <p><%= t('advice_pages.gas_out_of_hours.analysis.last_twelve_months.community_use_html',
-    community_kwh: format_unit(@annual_usage_breakdown.community.kwh, :kwh),
-    community_gbp: format_unit(@annual_usage_breakdown.community.£, :£),
-    community_co2: format_unit(@annual_usage_breakdown.community.co2, :co2) ) %></p>
-<% end %>
-
 <%= component 'chart', chart_type: :daytype_breakdown_gas_tolerant, school: @school do |c| %>
   <% c.with_title do %>
     <%= t('advice_pages.gas_out_of_hours.analysis.usage_by_day_of_week.daytype_breakdown_gas_tolerant_chart.title') %>

--- a/app/views/schools/advice/gas_out_of_hours/_insights_table.html.erb
+++ b/app/views/schools/advice/gas_out_of_hours/_insights_table.html.erb
@@ -12,7 +12,7 @@
         <%= format_unit(@annual_usage_breakdown&.potential_savings(versus: :exemplar_school)&.kwh, :kwh) %>
       </td>
       <td class="text-right">
-        <%= format_unit(@annual_usage_breakdown&.total&.kwh, :kwh) %>
+        <%= format_unit(@annual_usage_breakdown&.out_of_hours&.kwh, :kwh) %>
       </td>
     <tr>
 </table>

--- a/config/locales/views/advice_pages/electricity_out_of_hours.yml
+++ b/config/locales/views/advice_pages/electricity_out_of_hours.yml
@@ -4,7 +4,6 @@ en:
     electricity_out_of_hours:
       analysis:
         last_twelve_months:
-          community_use_html: Your school has identified that there is community use of the school outside of school hours. Over the last year, %{community_kwh} kWh of electricity has been used during these times which will have cost %{community_gbp} and caused %{community_co2} kg/co2 to be emitted.
           table:
             co2_kg: kg/co2
             gbp_at_current_tariff: "£ (at current tariff)"

--- a/config/locales/views/advice_pages/gas_out_of_hours.yml
+++ b/config/locales/views/advice_pages/gas_out_of_hours.yml
@@ -4,7 +4,6 @@ en:
     gas_out_of_hours:
       analysis:
         last_twelve_months:
-          community_use_html: Your school has identified that there is community use of the school outside of school hours. Over the last year, %{community_kwh} kWh of gas has been used during these times which will have cost %{community_gbp} and caused %{community_co2} to be emitted.
           table:
             co2_kg: kg/co2
             gbp_at_current_tariff: "£ (at current tariff)"


### PR DESCRIPTION
This PR adds some fixes & updates to the out of hours pages following review:

- [x] Gas/electricity page insights tab, table - check the data in "Your kWh" column. This should be the out of hours consumption, I think we have total consumption in here.
- [x] Remove paragraph on analysis page which starts with "Your school has identified". The community use figures are summarised below anyway.