### PR TITLE
Remove comparison with benchmark chart from gas long term page

### DIFF
--- a/app/views/schools/advice/gas_long_term/_analysis_comparison.html.erb
+++ b/app/views/schools/advice/gas_long_term/_analysis_comparison.html.erb
@@ -10,8 +10,3 @@
 </p>
 
 <%= render 'comparison_with_benchmark_table', annual_usage: annual_usage, vs_exemplar: vs_exemplar, vs_benchmark: vs_benchmark, estimated_savings_vs_exemplar: estimated_savings_vs_exemplar, estimated_savings_vs_benchmark: estimated_savings_vs_benchmark %>
-
-<%= component 'chart', chart_type: :group_by_week_gas_versus_benchmark, school: school do |c| %>
-  <% c.with_title { t('advice_pages.gas_long_term.charts.group_by_week_gas_versus_benchmark.title') } %>
-  <% c.with_subtitle { t('advice_pages.gas_long_term.charts.group_by_week_gas_versus_benchmark.subtitle_html', start_date: analysis_dates.last_full_week_start_date.to_s(:es_short), end_date: analysis_dates.last_full_week_end_date.to_s(:es_short)) } %>
-<% end %>

--- a/config/locales/views/advice_pages/gas_long_term.yml
+++ b/config/locales/views/advice_pages/gas_long_term.yml
@@ -56,9 +56,6 @@ en:
           header: Each bar represents a whole week and the split between holiday, weekend and school day open and closed consumption for that week. It highlights how gas consumption generally increases in the winter and is lower in the summer.
           subtitle: This chart gives the breakdown of gas consumption between school day open and closed, holidays and weekends for every week of data for your school
           title: Gas consumption by week for the last few years
-        group_by_week_gas_versus_benchmark:
-          subtitle_html: This chart shows how your school’s gas use compares against well managed and exemplar schools for each week between <span class='start-date'>%{start_date}</span> and <span class='end-date'>%{end_date}</span>
-          title: Gas use comparison with other schools over the last 12 months
       insights:
         comparison:
           how_do_you_compare: How does your gas use for the last 12 months compare to other %{school_type} schools on Energy Sparks, with a similar number of pupils?

--- a/spec/system/schools/advice_pages/gas_long_term_spec.rb
+++ b/spec/system/schools/advice_pages/gas_long_term_spec.rb
@@ -71,7 +71,6 @@ RSpec.describe "gas long term advice page", type: :system do
       end
       it 'includes expected charts' do
         expect(page).to have_css('#chart_wrapper_group_by_week_gas')
-        expect(page).to have_css('#chart_wrapper_group_by_week_gas_versus_benchmark')
         expect(page).to have_css('#chart_wrapper_group_by_week_gas_unlimited')
 
         #not enough data for these


### PR DESCRIPTION
The benchmarking data for the long term trend chart is not robust enough for display on the chart. So removing this for now.