### PR TITLE
Use locale mailer and yield block to send locale-specific emails

### DIFF
--- a/app/controllers/onboarding/consent_controller.rb
+++ b/app/controllers/onboarding/consent_controller.rb
@@ -14,7 +14,7 @@ module Onboarding
       @consent_grant = ConsentGrant.new(school_onboarding_consent_params.merge(user: current_user, school: @school_onboarding.school, ip_address: current_ip_address))
       if @consent_grant.save
         @school_onboarding.events.create!(event: :permission_given)
-        ConsentGrantMailer.with(consent_grant: @consent_grant).email_consent.deliver_now
+        ConsentGrantMailer.with_user_locales(users: [@consent_grant.user.email], consent_grant: @consent_grant) { |mailer| mailer.email_consent.deliver_now }
         redirect_to onboarding_users_path(@school_onboarding)
       else
         render :show

--- a/app/controllers/onboarding/consent_controller.rb
+++ b/app/controllers/onboarding/consent_controller.rb
@@ -14,7 +14,7 @@ module Onboarding
       @consent_grant = ConsentGrant.new(school_onboarding_consent_params.merge(user: current_user, school: @school_onboarding.school, ip_address: current_ip_address))
       if @consent_grant.save
         @school_onboarding.events.create!(event: :permission_given)
-        ConsentGrantMailer.with_user_locales(users: [@consent_grant.user.email], consent_grant: @consent_grant) { |mailer| mailer.email_consent.deliver_now }
+        ConsentGrantMailer.with_user_locales(users: [@consent_grant.user], consent_grant: @consent_grant) { |mailer| mailer.email_consent.deliver_now }
         redirect_to onboarding_users_path(@school_onboarding)
       else
         render :show

--- a/app/controllers/schools/consents_controller.rb
+++ b/app/controllers/schools/consents_controller.rb
@@ -10,7 +10,7 @@ module Schools
     def create
       @consent_grant = ConsentGrant.new(school_consent_params.merge(user: current_user, school: @school, ip_address: current_ip_address))
       if @consent_grant.save
-        ConsentGrantMailer.with(consent_grant: @consent_grant).email_consent.deliver_now
+        ConsentGrantMailer.with_user_locales(users: [@consent_grant.user.email], consent_grant: @consent_grant) { |mailer| mailer.email_consent.deliver_now }
         redirect_to root_path(@school)
       else
         render :show

--- a/app/controllers/schools/consents_controller.rb
+++ b/app/controllers/schools/consents_controller.rb
@@ -10,7 +10,7 @@ module Schools
     def create
       @consent_grant = ConsentGrant.new(school_consent_params.merge(user: current_user, school: @school, ip_address: current_ip_address))
       if @consent_grant.save
-        ConsentGrantMailer.with_user_locales(users: [@consent_grant.user.email], consent_grant: @consent_grant) { |mailer| mailer.email_consent.deliver_now }
+        ConsentGrantMailer.with_user_locales(users: [@consent_grant.user], consent_grant: @consent_grant) { |mailer| mailer.email_consent.deliver_now }
         redirect_to root_path(@school)
       else
         render :show

--- a/app/mailers/alert_mailer.rb
+++ b/app/mailers/alert_mailer.rb
@@ -13,7 +13,7 @@ class AlertMailer < LocaleMailer
     @target_prompt = params[:target_prompt]
     @title = @school.name
 
-    email = make_bootstrap_mail(to: @email_address, subject: I18n.t('alert_mailer.alert_email.subject', locale: active_locale))
+    email = make_bootstrap_mail(to: @email_address)
     add_mg_email_tag(email, 'alerts')
   end
 

--- a/app/mailers/alert_mailer.rb
+++ b/app/mailers/alert_mailer.rb
@@ -1,4 +1,4 @@
-class AlertMailer < ApplicationMailer
+class AlertMailer < LocaleMailer
   include MailgunMailerHelper
   helper :application
 
@@ -13,7 +13,7 @@ class AlertMailer < ApplicationMailer
     @target_prompt = params[:target_prompt]
     @title = @school.name
 
-    email = make_bootstrap_mail(to: @email_address, subject: I18n.t('alert_mailer.alert_email.subject'))
+    email = make_bootstrap_mail(to: @email_address, subject: I18n.t('alert_mailer.alert_email.subject', locale: active_locale))
     add_mg_email_tag(email, 'alerts')
   end
 

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -4,6 +4,13 @@ class ApplicationMailer < ActionMailer::Base
 
   before_action :set_title
 
+  # send with locale if preferred locales are enabled
+  def make_bootstrap_mail_for_locale(*args)
+    I18n.with_locale(active_locale) do
+      make_bootstrap_mail(*args)
+    end
+  end
+
   # ensure that emails are all in English for the moment
   def make_bootstrap_mail_en(*args)
     I18n.with_locale(:en) do
@@ -21,5 +28,18 @@ class ApplicationMailer < ActionMailer::Base
 
   def set_title
     @title = params[:title] || ""
+  end
+
+  def email_addresses_for_locale(users)
+    locale = params[:locale]
+    users.select {|u| u.preferred_locale.to_sym == locale.to_sym}.map(&:email)
+  end
+
+  def active_locale
+    if EnergySparks::FeatureFlags.active?(:emails_with_preferred_locale)
+      params[:locale] || :en
+    else
+      :en
+    end
   end
 end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -4,13 +4,6 @@ class ApplicationMailer < ActionMailer::Base
 
   before_action :set_title
 
-  # send with locale if preferred locales are enabled
-  def make_bootstrap_mail_for_locale(*args)
-    I18n.with_locale(active_locale) do
-      make_bootstrap_mail(*args)
-    end
-  end
-
   # ensure that emails are all in English for the moment
   def make_bootstrap_mail_en(*args)
     I18n.with_locale(:en) do
@@ -28,18 +21,5 @@ class ApplicationMailer < ActionMailer::Base
 
   def set_title
     @title = params[:title] || ""
-  end
-
-  def email_addresses_for_locale(users)
-    locale = params[:locale]
-    users.select {|u| u.preferred_locale.to_sym == locale.to_sym}.map(&:email)
-  end
-
-  def active_locale
-    if EnergySparks::FeatureFlags.active?(:emails_with_preferred_locale)
-      params[:locale] || :en
-    else
-      :en
-    end
   end
 end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -22,4 +22,8 @@ class ApplicationMailer < ActionMailer::Base
   def set_title
     @title = params[:title] || ""
   end
+
+  def user_emails(users)
+    users.map(&:email)
+  end
 end

--- a/app/mailers/bill_request_mailer.rb
+++ b/app/mailers/bill_request_mailer.rb
@@ -1,10 +1,10 @@
-class BillRequestMailer < ApplicationMailer
+class BillRequestMailer < LocaleMailer
   def request_bill
     @school = params[:school]
     @title = @school.name
     @electricity_meters = params[:electricity_meters]
     @gas_meters = params[:gas_meters]
-    make_bootstrap_mail_en(to: params[:emails])
+    make_bootstrap_mail(to: user_emails(params[:users]))
   end
 
   def notify_admin

--- a/app/mailers/consent_grant_mailer.rb
+++ b/app/mailers/consent_grant_mailer.rb
@@ -1,7 +1,7 @@
-class ConsentGrantMailer < ApplicationMailer
+class ConsentGrantMailer < LocaleMailer
   def email_consent
     @consent_grant = params[:consent_grant]
     @title = @consent_grant.school.name
-    make_bootstrap_mail_en(to: @consent_grant.user.email)
+    make_bootstrap_mail(to: user_emails(params[:users]))
   end
 end

--- a/app/mailers/consent_request_mailer.rb
+++ b/app/mailers/consent_request_mailer.rb
@@ -2,6 +2,7 @@ class ConsentRequestMailer < ApplicationMailer
   def request_consent
     @school = params[:school]
     @title = @school.name
-    make_bootstrap_mail_en(to: params[:emails])
+    email_addressess = email_addresses_for_locale(params[:users])
+    make_bootstrap_mail_for_locale(to: email_addressess) if email_addressess.any?
   end
 end

--- a/app/mailers/consent_request_mailer.rb
+++ b/app/mailers/consent_request_mailer.rb
@@ -1,8 +1,8 @@
-class ConsentRequestMailer < ApplicationMailer
+class ConsentRequestMailer < LocaleMailer
   def request_consent
     @school = params[:school]
     @title = @school.name
     email_addressess = email_addresses_for_locale(params[:users])
-    make_bootstrap_mail_for_locale(to: email_addressess) if email_addressess.any?
+    make_bootstrap_mail(to: email_addressess) if email_addressess.any?
   end
 end

--- a/app/mailers/consent_request_mailer.rb
+++ b/app/mailers/consent_request_mailer.rb
@@ -2,7 +2,7 @@ class ConsentRequestMailer < LocaleMailer
   def request_consent
     @school = params[:school]
     @title = @school.name
-    email_addressess = email_addresses_for_locale(params[:users])
-    make_bootstrap_mail(to: email_addressess) if email_addressess.any?
+    emails = user_emails(params[:users])
+    make_bootstrap_mail(to: emails)
   end
 end

--- a/app/mailers/consent_request_mailer.rb
+++ b/app/mailers/consent_request_mailer.rb
@@ -2,7 +2,6 @@ class ConsentRequestMailer < LocaleMailer
   def request_consent
     @school = params[:school]
     @title = @school.name
-    emails = user_emails(params[:users])
-    make_bootstrap_mail(to: emails)
+    make_bootstrap_mail(to: user_emails(params[:users]))
   end
 end

--- a/app/mailers/locale_mailer.rb
+++ b/app/mailers/locale_mailer.rb
@@ -1,0 +1,8 @@
+class LocaleMailer
+  def self.with(params)
+    mailer_class = params.delete(:mailer)
+    I18n.available_locales.each do |locale|
+      yield mailer_class.with(params.merge(locale: locale))
+    end
+  end
+end

--- a/app/mailers/locale_mailer.rb
+++ b/app/mailers/locale_mailer.rb
@@ -1,8 +1,26 @@
-class LocaleMailer
-  def self.with(params)
-    mailer_class = params.delete(:mailer)
+class LocaleMailer < ApplicationMailer
+  def self.with_locales(params)
     I18n.available_locales.each do |locale|
-      yield mailer_class.with(params.merge(locale: locale))
+      yield self.with(params.merge(locale: locale))
     end
+  end
+
+  # send with locale if preferred locales are enabled
+  def make_bootstrap_mail(*args)
+    I18n.with_locale(active_locale) do
+      super(*args)
+    end
+  end
+
+  def email_addresses_for_locale(users)
+    users.select {|u| u.preferred_locale.to_sym == locale.to_sym}.map(&:email)
+  end
+
+  def active_locale
+    EnergySparks::FeatureFlags.active?(:emails_with_preferred_locale) ? locale : :en
+  end
+
+  def locale
+    params[:locale] || :en
   end
 end

--- a/app/mailers/locale_mailer.rb
+++ b/app/mailers/locale_mailer.rb
@@ -8,6 +8,10 @@ class LocaleMailer < ApplicationMailer
     end
   end
 
+  def self.with_contact_locale(contact:, **args)
+    yield self.with(**args, school: contact.school, email_address: contact.email_address, locale: contact.preferred_locale)
+  end
+
   def self.users_for_locale(users, locale)
     users.select {|u| u.preferred_locale.to_sym == locale.to_sym}
   end

--- a/app/mailers/target_mailer.rb
+++ b/app/mailers/target_mailer.rb
@@ -1,21 +1,21 @@
-class TargetMailer < ApplicationMailer
+class TargetMailer < LocaleMailer
   helper :application
 
   def first_target
     @school = params[:school]
-    @to = params[:to]
+    @to = user_emails(params[:users])
     make_bootstrap_mail(to: @to)
   end
 
   def first_target_reminder
     @school = params[:school]
-    @to = params[:to]
+    @to = user_emails(params[:users])
     make_bootstrap_mail(to: @to)
   end
 
   def review_target
     @school = params[:school]
-    @to = params[:to]
+    @to = user_emails(params[:users])
     make_bootstrap_mail(to: @to)
   end
 

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -49,4 +49,8 @@ class Contact < ApplicationRecord
     self.email_address = user.email
     self.staff_role = user.staff_role
   end
+
+  def preferred_locale
+    user ? user.preferred_locale : :en
+  end
 end

--- a/app/services/alerts/generate_email_notifications.rb
+++ b/app/services/alerts/generate_email_notifications.rb
@@ -9,7 +9,7 @@ module Alerts
       events.group_by(&:contact).each do |contact, contact_events|
         email = Email.create!(contact: contact)
         target_prompt = include_target_prompt_in_email?(contact.school)
-        AlertMailer.with(email_address: contact.email_address, events: contact_events, school: contact.school, target_prompt: target_prompt).alert_email.deliver_now
+        AlertMailer.with_contact_locale(contact: contact, events: contact_events, target_prompt: target_prompt) { |mailer| mailer.alert_email.deliver_now }
         contact_events.each {|event| event.update!(status: :sent, email: email) }
         email.update(sent_at: Time.now.utc)
       end

--- a/app/services/schools/bill_request_service.rb
+++ b/app/services/schools/bill_request_service.rb
@@ -13,7 +13,7 @@ module Schools
     def request_documentation!(users, meters = [])
       electricity_meters = meters.select(&:electricity?)
       gas_meters = meters.select(&:gas?)
-      BillRequestMailer.with(emails: users.map(&:email), school: @school, electricity_meters: electricity_meters, gas_meters: gas_meters).request_bill.deliver_now
+      BillRequestMailer.with_user_locales(users: users, school: @school, electricity_meters: electricity_meters, gas_meters: gas_meters) { |mailer| mailer.request_bill.deliver_now }
       @school.update!(bill_requested: true)
     end
   end

--- a/app/services/schools/consent_request_service.rb
+++ b/app/services/schools/consent_request_service.rb
@@ -10,7 +10,7 @@ module Schools
     end
 
     def request_consent!(users)
-      ConsentRequestMailer.with(emails: users.map(&:email), school: @school).request_consent.deliver_now
+      LocaleMailer.with(mailer: ConsentRequestMailer, users: users, school: @school) { |mailer| mailer.request_consent.deliver_now }
     end
   end
 end

--- a/app/services/schools/consent_request_service.rb
+++ b/app/services/schools/consent_request_service.rb
@@ -10,7 +10,7 @@ module Schools
     end
 
     def request_consent!(users)
-      LocaleMailer.with(mailer: ConsentRequestMailer, users: users, school: @school) { |mailer| mailer.request_consent.deliver_now }
+      ConsentRequestMailer.with_locales(users: users, school: @school) { |mailer| mailer.request_consent.deliver_now }
     end
   end
 end

--- a/app/services/schools/consent_request_service.rb
+++ b/app/services/schools/consent_request_service.rb
@@ -10,7 +10,7 @@ module Schools
     end
 
     def request_consent!(users)
-      ConsentRequestMailer.with_locales(users: users, school: @school) { |mailer| mailer.request_consent.deliver_now }
+      ConsentRequestMailer.with_user_locales(users: users, school: @school) { |mailer| mailer.request_consent.deliver_now }
     end
   end
 end

--- a/app/services/targets/target_mailer_service.rb
+++ b/app/services/targets/target_mailer_service.rb
@@ -17,9 +17,9 @@ module Targets
 
     def invite_schools_to_set_first_target
       list_schools.each do |school|
-        to = to(school)
-        if to.any?
-          TargetMailer.with(to: to, school: school).first_target.deliver_now
+        users = users(school)
+        if users.any?
+          TargetMailer.with_user_locales(users: users, school: school) { |mailer| mailer.first_target.deliver_now }
           school.school_target_events.create(event: :first_target_sent)
         end
       end
@@ -27,9 +27,9 @@ module Targets
 
     def remind_schools_to_set_first_target
       list_schools_requiring_reminder.each do |school|
-        to = to(school)
-        if to.any?
-          TargetMailer.with(to: to, school: school).first_target_reminder.deliver_now
+        users = users(school)
+        if users.any?
+          TargetMailer.with_user_locales(users: users, school: school) { |mailer| mailer.first_target_reminder.deliver_now }
           school.school_target_events.create(event: :first_target_reminder_sent)
         end
       end
@@ -37,9 +37,9 @@ module Targets
 
     def invite_schools_to_review_target
       list_schools_requiring_review.each do |school|
-        to = to(school)
-        if to.any?
-          TargetMailer.with(to: to, school: school).review_target.deliver_now
+        users = users(school)
+        if users.any?
+          TargetMailer.with_user_locales(users: users, school: school) { |mailer| mailer.review_target.deliver_now }
           school.school_target_events.create(event: :review_target_sent)
         end
       end
@@ -53,9 +53,8 @@ module Targets
       end
     end
 
-    def to(school)
-      users = school.all_adult_school_users.to_a
-      users.uniq.map(&:email)
+    def users(school)
+      school.all_adult_school_users.uniq
     end
 
     def reject_for_reminder?(school)

--- a/config/locales/cy/mailers/mailer.yml
+++ b/config/locales/cy/mailers/mailer.yml
@@ -2,7 +2,7 @@
 cy:
   alert_mailer:
     alert_email:
-      subject: welsh alert..
+      subject: Energy Sparks rhybuddion
   bill_request_mailer:
     request_bill:
       description: "Mae Sbarcynni angen i chi ddarparu bil ynni diweddar ar gyfer eich ysgol i gadarnhau rhifau eich mesurydd ac awdurdod Energy Sparks i gasglu, prosesu ac arddangos y data ar gyfer y mesuryddion hynny."

--- a/config/locales/cy/mailers/mailer.yml
+++ b/config/locales/cy/mailers/mailer.yml
@@ -1,5 +1,8 @@
 ---
 cy:
+  alert_mailer:
+    alert_email:
+      subject: welsh alert..
   bill_request_mailer:
     request_bill:
       description: "Mae Sbarcynni angen i chi ddarparu bil ynni diweddar ar gyfer eich ysgol i gadarnhau rhifau eich mesurydd ac awdurdod Energy Sparks i gasglu, prosesu ac arddangos y data ar gyfer y mesuryddion hynny."

--- a/spec/mailers/alert_mailer_spec.rb
+++ b/spec/mailers/alert_mailer_spec.rb
@@ -20,5 +20,25 @@ RSpec.describe AlertMailer do
       AlertMailer.with(email_address: email_address, school: school, events: []).alert_email.deliver_now
       expect(ActionMailer::Base.deliveries.count).to eql 0
     end
+
+    it 'uses locale if specified and enabled' do
+      ClimateControl.modify FEATURE_FLAG_EMAILS_WITH_PREFERRED_LOCALE: 'true' do
+        ClimateControl.modify SEND_AUTOMATED_EMAILS: 'true' do
+          AlertMailer.with(email_address: email_address, school: school, events: [], locale: :cy).alert_email.deliver_now
+        end
+      end
+      email = ActionMailer::Base.deliveries.last
+      expect(email.subject).to eql "welsh alert.."
+    end
+
+    it 'uses default locale if specified but disabled' do
+      ClimateControl.modify FEATURE_FLAG_EMAILS_WITH_PREFERRED_LOCALE: 'false' do
+        ClimateControl.modify SEND_AUTOMATED_EMAILS: 'true' do
+          AlertMailer.with(email_address: email_address, school: school, events: [], locale: :cy).alert_email.deliver_now
+        end
+      end
+      email = ActionMailer::Base.deliveries.last
+      expect(email.subject).to eql "Energy Sparks alerts"
+    end
   end
 end

--- a/spec/mailers/alert_mailer_spec.rb
+++ b/spec/mailers/alert_mailer_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe AlertMailer do
         end
       end
       email = ActionMailer::Base.deliveries.last
-      expect(email.subject).to eql "welsh alert.."
+      expect(email.subject).to eql "Energy Sparks rhybuddion"
     end
 
     it 'uses default locale if specified but disabled' do
@@ -39,6 +39,20 @@ RSpec.describe AlertMailer do
       end
       email = ActionMailer::Base.deliveries.last
       expect(email.subject).to eql "Energy Sparks alerts"
+    end
+  end
+
+  describe '#with_contact_locale' do
+    let(:user) { create(:user, preferred_locale: :cy) }
+    let(:contact) { create(:contact_with_name_email, school: school, user: user) }
+    it 'uses locale from contact' do
+      ClimateControl.modify FEATURE_FLAG_EMAILS_WITH_PREFERRED_LOCALE: 'true' do
+        ClimateControl.modify SEND_AUTOMATED_EMAILS: 'true' do
+          AlertMailer.with_contact_locale(contact: contact, events: []) { |mailer| mailer.alert_email.deliver_now }
+        end
+      end
+      email = ActionMailer::Base.deliveries.last
+      expect(email.subject).to eql "Energy Sparks rhybuddion"
     end
   end
 end

--- a/spec/mailers/bill_request_mailer_spec.rb
+++ b/spec/mailers/bill_request_mailer_spec.rb
@@ -2,43 +2,40 @@ require 'rails_helper'
 
 RSpec.describe BillRequestMailer do
 
+  let(:user) { create(:user, preferred_locale: :cy) }
   let(:school) { create(:school, name: 'Test School') }
   let(:electricity_meter) { create(:electricity_meter) }
   let(:gas_meter) { create(:gas_meter) }
 
-  describe '#email_consent' do
-
-    context 'when locale is cy' do
-
-      let(:cy_translations) do
-        {
-          bill_request_mailer:
-            {
-              request_bill:
-                {
-                  subject: "Welsh subject line should not be used (yet)",
-                  description: "Welsh description should not be used (yet)",
-                }
-            }
-        }
+  around do |example|
+    ClimateControl.modify SEND_AUTOMATED_EMAILS: 'true' do
+      ClimateControl.modify FEATURE_FLAG_EMAILS_WITH_PREFERRED_LOCALE: enable_locale_emails do
+        example.run
       end
+    end
+  end
 
-      before do
-        I18n.locale = 'cy'
-        I18n.backend.store_translations("cy", cy_translations)
+  before :each do
+    BillRequestMailer.with_user_locales(users: [user], school: school, electricity_meters: [electricity_meter], gas_meters: [gas_meter]) { |mailer| mailer.request_bill.deliver_now }
+    @email = ActionMailer::Base.deliveries.last
+  end
+
+  context 'when locale emails disabled' do
+    let(:enable_locale_emails) { 'false' }
+    describe '#request_bill' do
+      it 'sends an email with en strings' do
+        expect(@email.subject).to eql ("Please upload a recent energy bill to Energy Sparks")
+        expect(@email.body.to_s).to include("Please upload an energy bill for Test School")
       end
+    end
+  end
 
-      after do
-        I18n.locale = 'en'
-      end
-
-      it 'sends an email with en strings even if I18n is cy' do
-        ClimateControl.modify SEND_AUTOMATED_EMAILS: 'true' do
-          BillRequestMailer.with(emails: ['test@blah.com'], school: school, electricity_meters: [electricity_meter], gas_meters: [gas_meter]).request_bill.deliver_now
-        end
-        email = ActionMailer::Base.deliveries.last
-        expect(email.subject).to eql ("Please upload a recent energy bill to Energy Sparks")
-        expect(email.body.to_s).to include("Please upload an energy bill for Test School")
+  context 'when locale emails enabled' do
+    let(:enable_locale_emails) { 'true' }
+    describe '#request_bill' do
+      it 'sends an email with en strings' do
+        expect(@email.subject).to eql ("Uwchlwythwch fil ynni diweddar i Sbarcynni")
+        expect(@email.body.to_s).to include("Uwchlwythwch fil ynni ar gyfer Test School")
       end
     end
   end

--- a/spec/mailers/consent_grant_mailer_spec.rb
+++ b/spec/mailers/consent_grant_mailer_spec.rb
@@ -2,43 +2,39 @@ require 'rails_helper'
 
 RSpec.describe ConsentGrantMailer do
 
-  let(:user) { create(:user) }
+  let(:user) { create(:user, preferred_locale: :cy) }
   let(:school) { create(:school, name: 'Test School') }
   let(:consent_grant) { create(:consent_grant, user: user, school: school) }
 
-  describe '#email_consent' do
-
-    context 'when locale is cy' do
-
-      let(:cy_translations) do
-        {
-          consent_grant_mailer:
-            {
-              email_consent:
-                {
-                  subject: "Welsh subject line should not be used (yet)",
-                  message_1: "Welsh message_1 for %{school_name} should not be used (yet)"
-                }
-            }
-        }
+  around do |example|
+    ClimateControl.modify SEND_AUTOMATED_EMAILS: 'true' do
+      ClimateControl.modify FEATURE_FLAG_EMAILS_WITH_PREFERRED_LOCALE: enable_locale_emails do
+        example.run
       end
+    end
+  end
 
-      before do
-        I18n.locale = 'cy'
-        I18n.backend.store_translations("cy", cy_translations)
+  before :each do
+    ConsentGrantMailer.with_user_locales(users: [user], consent_grant: consent_grant) { |mailer| mailer.email_consent.deliver_now }
+    @email = ActionMailer::Base.deliveries.last
+  end
+
+  context 'when locale emails disabled' do
+    let(:enable_locale_emails) { 'false' }
+    describe '#email_consent' do
+      it 'sends an email with en strings' do
+        expect(@email.subject).to eql ("Your grant of consent to Energy Sparks")
+        expect(@email.body.to_s).to include("Thank you for granting permission for Energy Sparks to access data for Test School")
       end
+    end
+  end
 
-      after do
-        I18n.locale = 'en'
-      end
-
-      it 'sends an email with en strings even if I18n is cy' do
-        ClimateControl.modify SEND_AUTOMATED_EMAILS: 'true' do
-          ConsentGrantMailer.with(consent_grant: consent_grant).email_consent.deliver_now
-        end
-        email = ActionMailer::Base.deliveries.last
-        expect(email.subject).to eql ("Your grant of consent to Energy Sparks")
-        expect(email.body.to_s).to include("Thank you for granting permission for Energy Sparks to access data for Test School")
+  context 'when locale emails enabled' do
+    let(:enable_locale_emails) { 'true' }
+    describe '#email_consent' do
+      it 'sends an email with cy strings' do
+        expect(@email.subject).to eql ("Eich caniatâd i Sbarcynni")
+        expect(ActionController::Base.helpers.sanitize(@email.body.to_s)).to include("Diolch am roi caniatâd i Sbarcynni gael mynediad at ddata ar gyfer Test School")
       end
     end
   end

--- a/spec/mailers/consent_request_mailer_spec.rb
+++ b/spec/mailers/consent_request_mailer_spec.rb
@@ -2,43 +2,38 @@ require 'rails_helper'
 
 RSpec.describe ConsentRequestMailer do
 
+  let(:user) { create(:user, preferred_locale: :cy) }
   let(:school) { create(:school, name: 'Test School') }
-  let(:email_address) { 'blah@blah.com' }
-  let(:user) { create(:user, email: email_address) }
 
-  describe '#request_consent' do
-
-    context 'when locale is cy' do
-
-      let(:cy_translations) do
-        {
-          consent_request_mailer:
-            {
-              request_consent:
-                {
-                  subject: "Welsh subject line should not be used (yet)",
-                  description: "Welsh description for %{school_name} should not be used (yet)"
-                }
-            }
-        }
+  around do |example|
+    ClimateControl.modify SEND_AUTOMATED_EMAILS: 'true' do
+      ClimateControl.modify FEATURE_FLAG_EMAILS_WITH_PREFERRED_LOCALE: enable_locale_emails do
+        example.run
       end
+    end
+  end
 
-      before do
-        I18n.locale = 'cy'
-        I18n.backend.store_translations("cy", cy_translations)
+  before :each do
+    ConsentRequestMailer.with_user_locales(users: [user], school: school) { |mailer| mailer.request_consent.deliver_now }
+    @email = ActionMailer::Base.deliveries.last
+  end
+
+  context 'when locale emails disabled' do
+    let(:enable_locale_emails) { 'false' }
+    describe '#request_consent' do
+      it 'sends an email with en strings' do
+        expect(@email.subject).to eql ("We need permission to access your school's energy data")
+        expect(@email.body.to_s).to include("Please provide permission for Energy Sparks to access data for Test School")
       end
+    end
+  end
 
-      after do
-        I18n.locale = 'en'
-      end
-
-      it 'sends an email with en strings even if I18n is cy' do
-        ClimateControl.modify SEND_AUTOMATED_EMAILS: 'true' do
-          ConsentRequestMailer.with(users: [user], school: school).request_consent.deliver_now
-        end
-        email = ActionMailer::Base.deliveries.last
-        expect(email.subject).to eql ("We need permission to access your school's energy data")
-        expect(email.body.to_s).to include("Please provide permission for Energy Sparks to access data for Test School")
+  context 'when locale emails enabled' do
+    let(:enable_locale_emails) { 'true' }
+    describe '#request_consent' do
+      it 'sends an email with cy strings' do
+        expect(@email.subject).to eql ("Mae angen caniatâd arnom i gael mynediad at ddata ynni eich ysgol")
+        expect(ActionController::Base.helpers.sanitize(@email.body.to_s)).to include("Rhowch ganiatâd i Energy Sparks gael mynediad at ddata ar gyfer Test School")
       end
     end
   end

--- a/spec/mailers/consent_request_mailer_spec.rb
+++ b/spec/mailers/consent_request_mailer_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe ConsentRequestMailer do
 
   let(:school) { create(:school, name: 'Test School') }
   let(:email_address) { 'blah@blah.com' }
+  let(:user) { create(:user, email: email_address) }
 
   describe '#request_consent' do
 
@@ -33,7 +34,7 @@ RSpec.describe ConsentRequestMailer do
 
       it 'sends an email with en strings even if I18n is cy' do
         ClimateControl.modify SEND_AUTOMATED_EMAILS: 'true' do
-          ConsentRequestMailer.with(emails: [email_address], school: school).request_consent.deliver_now
+          ConsentRequestMailer.with(users: [user], school: school).request_consent.deliver_now
         end
         email = ActionMailer::Base.deliveries.last
         expect(email.subject).to eql ("We need permission to access your school's energy data")

--- a/spec/mailers/previews/bill_request_mailer_preview.rb
+++ b/spec/mailers/previews/bill_request_mailer_preview.rb
@@ -1,6 +1,6 @@
 class BillRequestMailerPreview < ActionMailer::Preview
   def request_bill
-    BillRequestMailer.with(emails: ['test@blah.com'], school: School.first, electricity_meters: [Meter.electricity.first], gas_meters: [Meter.gas.first]).request_bill
+    BillRequestMailer.with(users: School.first.users, school: School.first, electricity_meters: [Meter.electricity.first], gas_meters: [Meter.gas.first]).request_bill
   end
   def notify_admin
     BillRequestMailer.with(school: School.first, consent_document: ConsentDocument.first, updated: false).notify_admin

--- a/spec/mailers/previews/consent_grant_mailer_preview.rb
+++ b/spec/mailers/previews/consent_grant_mailer_preview.rb
@@ -1,5 +1,5 @@
 class ConsentGrantMailerPreview < ActionMailer::Preview
   def email_consent
-    ConsentGrantMailer.with(consent_grant: ConsentGrant.first).email_consent
+    ConsentGrantMailer.with(users: [ConsentGrant.first.user], consent_grant: ConsentGrant.first).email_consent
   end
 end

--- a/spec/mailers/previews/consent_request_mailer_preview.rb
+++ b/spec/mailers/previews/consent_request_mailer_preview.rb
@@ -1,5 +1,5 @@
 class ConsentRequestMailerPreview < ActionMailer::Preview
   def request_consent
-    ConsentRequestMailer.with(school: School.first, emails: 'test@blah.com').request_consent
+    ConsentRequestMailer.with(school: School.first, users: School.first.users).request_consent
   end
 end

--- a/spec/mailers/previews/target_mailer_preview.rb
+++ b/spec/mailers/previews/target_mailer_preview.rb
@@ -1,13 +1,13 @@
 class TargetMailerPreview < ActionMailer::Preview
   def first_target
-    TargetMailer.with(to: 'test@blah.com', school: School.first).first_target
+    TargetMailer.with(users: School.first.users, school: School.first).first_target
   end
 
   def first_target_reminder
-    TargetMailer.with(to: 'test@blah.com', school: School.first).first_target_reminder
+    TargetMailer.with(users: School.first.users, school: School.first).first_target_reminder
   end
 
   def review_target
-    TargetMailer.with(to: 'test@blah.com', school: SchoolTarget.last.school).review_target
+    TargetMailer.with(users: School.first.users, school: SchoolTarget.last.school).review_target
   end
 end

--- a/spec/services/schools/bill_request_service_spec.rb
+++ b/spec/services/schools/bill_request_service_spec.rb
@@ -56,30 +56,49 @@ RSpec.describe Schools::BillRequestService do
     end
 
     context 'when formatting email' do
-        before(:each) do
-          service.request_documentation!([school_admin])
-          @email = ActionMailer::Base.deliveries.last
-        end
+      before(:each) do
+        service.request_documentation!([school_admin])
+        @email = ActionMailer::Base.deliveries.last
+      end
 
-        it 'should send to the correct users' do
-          expect(@email.to).to match_array([school_admin.email])
-        end
+      it 'should send to the correct users' do
+        expect(@email.to).to match_array([school_admin.email])
+      end
 
-        it 'should have the expected subject line' do
-          expect(@email.subject).to eql("Please upload a recent energy bill to Energy Sparks")
-        end
+      it 'should have the expected subject line' do
+        expect(@email.subject).to eql("Please upload a recent energy bill to Energy Sparks")
+      end
 
-        it 'should include the school name' do
-          email_body = @email.body.to_s
-          expect(email_body).to include(school.name)
-        end
+      it 'should include the school name' do
+        email_body = @email.body.to_s
+        expect(email_body).to include(school.name)
+      end
 
-        it 'should include a link to the upload a bill page' do
-          email_body = @email.body.to_s
-          node = Capybara::Node::Simple.new(email_body)
-          expect(node).to have_link('Upload your bill')
-        end
+      it 'should include a link to the upload a bill page' do
+        email_body = @email.body.to_s
+        node = Capybara::Node::Simple.new(email_body)
+        expect(node).to have_link('Upload your bill')
+      end
 
+    end
+
+    context 'when user has a locale' do
+
+      around do |example|
+        ClimateControl.modify FEATURE_FLAG_EMAILS_WITH_PREFERRED_LOCALE: 'true' do
+          example.run
+        end
+      end
+
+      before(:each) do
+        school_admin.update(preferred_locale: :cy)
+        service.request_documentation!([school_admin])
+        @email = ActionMailer::Base.deliveries.last
+      end
+
+      it 'should have the expected subject line' do
+        expect(@email.subject).to eql("Uwchlwythwch fil ynni diweddar i Sbarcynni")
+      end
     end
 
     context 'with mpans' do

--- a/spec/services/schools/consent_request_service_spec.rb
+++ b/spec/services/schools/consent_request_service_spec.rb
@@ -72,5 +72,31 @@ RSpec.describe Schools::ConsentRequestService do
         end
       end
     end
+
+    context 'when formatting multiple emails' do
+      let!(:preferred_locale) { :cy }
+      let!(:staff)            { create(:staff, school: school) }
+
+      it 'should generate 2 emails' do
+        expect { service.request_consent!([school_admin, staff])
+        }.to change(ActionMailer::Base.deliveries, :count).from(0).to(2)
+      end
+
+      context 'when locales are different' do
+        before :each do
+          service.request_consent!([school_admin, staff])
+        end
+
+        it 'email should have cy subject line' do
+          email = ActionMailer::Base.deliveries.last
+          expect(email.subject).to eql("Mae angen caniatâd arnom i gael mynediad at ddata ynni eich ysgol")
+        end
+
+        it 'email should have en subject line' do
+          email = ActionMailer::Base.deliveries.last(2).first
+          expect(email.subject).to eql("We need permission to access your school's energy data")
+        end
+      end
+    end
   end
 end

--- a/spec/services/schools/consent_request_service_spec.rb
+++ b/spec/services/schools/consent_request_service_spec.rb
@@ -2,8 +2,15 @@ require 'rails_helper'
 
 RSpec.describe Schools::ConsentRequestService do
 
+  let!(:preferred_locale) { :en }
   let!(:school)           { create(:school) }
   let!(:service)          { Schools::ConsentRequestService.new(school) }
+
+  around do |example|
+    ClimateControl.modify FEATURE_FLAG_EMAILS_WITH_PREFERRED_LOCALE: 'true' do
+      example.run
+    end
+  end
 
   context 'listing users' do
 
@@ -14,9 +21,9 @@ RSpec.describe Schools::ConsentRequestService do
     end
 
     context 'with users' do
-      let!(:school_admin)     { create(:school_admin, school: school)}
-      let!(:staff)            { create(:staff, school: school)}
-      let!(:pupil)            { create(:pupil, school: school)}
+      let!(:school_admin) { create(:school_admin, school: school) }
+      let!(:staff)        { create(:staff, school: school) }
+      let!(:pupil)        { create(:pupil, school: school) }
 
       it 'should return only staff and school admins' do
         expect(service.users).to match_array([staff, school_admin])
@@ -26,40 +33,44 @@ RSpec.describe Schools::ConsentRequestService do
   end
 
   context '#request_consent!' do
-    let!(:school_admin)     { create(:school_admin, school: school)}
+    let!(:school_admin) { create(:school_admin, school: school, preferred_locale: preferred_locale) }
 
     it 'should generate an email' do
-      expect{
-        service.request_consent!([school_admin])
+      expect { service.request_consent!([school_admin])
       }.to change(ActionMailer::Base.deliveries, :count).from(0).to(1)
     end
 
     context 'when formatting email' do
-        before(:each) do
-          service.request_consent!([school_admin])
-          @email = ActionMailer::Base.deliveries.last
-        end
+      before(:each) do
+        service.request_consent!([school_admin])
+        @email = ActionMailer::Base.deliveries.last
+      end
 
-        it 'should send to the correct users' do
-          expect(@email.to).to match_array([school_admin.email])
-        end
+      it 'should send to the correct users' do
+        expect(@email.to).to match_array([school_admin.email])
+      end
 
+      it 'should have the expected subject line' do
+        expect(@email.subject).to eql("We need permission to access your school's energy data")
+      end
+
+      it 'should include the school name' do
+        email_body = @email.body.to_s
+        expect(email_body).to include(school.name)
+      end
+
+      it 'should include a link to the give consent page' do
+        email_body = @email.body.to_s
+        node = Capybara::Node::Simple.new(email_body.to_s)
+        expect(node).to have_link('Give consent')
+      end
+
+      context 'when preferred locale is cy' do
+        let!(:preferred_locale) { :cy }
         it 'should have the expected subject line' do
-          expect(@email.subject).to eql("We need permission to access your school's energy data")
+          expect(@email.subject).to eql("Mae angen caniatâd arnom i gael mynediad at ddata ynni eich ysgol")
         end
-
-        it 'should include the school name' do
-          email_body = @email.body.to_s
-          expect(email_body).to include(school.name)
-        end
-
-        it 'should include a link to the give consent page' do
-          email_body = @email.body.to_s
-          node = Capybara::Node::Simple.new(email_body.to_s)
-          expect(node).to have_link('Give consent')
-        end
-
+      end
     end
-
   end
 end


### PR DESCRIPTION
Emails should be sent with a users preferred locale.

This PR introduces a LocaleMailer base class, extended by the mailers that need to be locale aware. A constructor method allow the mailers to be constructed with a collection of users, which are split into groups by preferred locale, and sent with the appropriate i18n locale. Another constructor allows mailers to be created for a Contact, to support the alert emailers (though Contacts will eventually all have Users, so this constructor will be removed).

The PR covers the mailers for Alerts, BillRequests, ConsentGrants, ConsentRequests, and Targets.

The Devise emails and Onboarding emails will be covered in separate PRs.
