### PR TITLE
Add extra columns to school issue list

### DIFF
--- a/app/assets/stylesheets/base.scss
+++ b/app/assets/stylesheets/base.scss
@@ -149,6 +149,19 @@ th.fixed-width-150 {
   min-width: 150px;
 }
 
+.table td.fit {
+  white-space: nowrap;
+  width: 1px;
+}
+
+.table td.overflow {
+  white-space: nowrap;
+  text-overflow:ellipsis;
+  overflow: hidden;
+  max-width:1px;
+}
+
+
 div.meter-attributes {
   kbd {
     color: black;

--- a/app/models/meter.rb
+++ b/app/models/meter.rb
@@ -155,7 +155,10 @@ class Meter < ApplicationRecord
   end
 
   def display_mpan_mprn_name
-    name.present? ? "#{mpan_mprn} - #{name}" : mpan_mprn
+    output = mpan_mprn.to_s
+    output += " - #{name}" if name.present?
+    output += " - #{data_source.name}" if data_source
+    output
   end
 
   def school_meter_attributes

--- a/app/views/admin/data_sources/show.html.erb
+++ b/app/views/admin/data_sources/show.html.erb
@@ -45,7 +45,7 @@
 <div class="tab-content" id="data-source-content">
   <div class="tab-pane fade show active" id="issues" role="tabpanel" aria-labelledby="issues-tab">
     <% if @data_source.issues.status_open.any? %>
-      <%= render 'admin/issues/issues_list', issues: @data_source.issues.status_open, show_issueable: false %>
+      <%= render 'admin/issues/issues_list', issues: @data_source.issues.status_open, issueable_type: 'Data source' %>
     <% else %>
       <div class="bg-light p-2">No issues for <%= @data_source.name %>.</div>
     <% end %>

--- a/app/views/admin/data_sources/show.html.erb
+++ b/app/views/admin/data_sources/show.html.erb
@@ -38,14 +38,14 @@
 
 <ul class="nav nav-tabs url-aware" id="data-source-tabs" role="tablist">
   <li class="nav-item">
-    <a class="nav-link active" id="issues-tab" data-toggle="tab" href="#issues" role="tab" aria-controls="issues-content" aria-selected="true">Issues <span class="badge badge-secondary"><%= @data_source.issues.status_open.count %></span></a>
+    <a class="nav-link active" id="issues-tab" data-toggle="tab" href="#issues" role="tab" aria-controls="issues-content" aria-selected="true">Issues <span class="badge badge-secondary"><%= @data_source.issues.count %></span></a>
   </li>
 </ul>
 
 <div class="tab-content" id="data-source-content">
   <div class="tab-pane fade show active" id="issues" role="tabpanel" aria-labelledby="issues-tab">
-    <% if @data_source.issues.status_open.any? %>
-      <%= render 'admin/issues/issues_list', issues: @data_source.issues.status_open, issueable_type: 'Data source' %>
+    <% if @data_source.issues.any? %>
+      <%= render 'admin/issues/issues_list', issues: @data_source.issues, issueable_type: 'Data source' %>
     <% else %>
       <div class="bg-light p-2">No issues for <%= @data_source.name %>.</div>
     <% end %>

--- a/app/views/admin/issues/_issue.html.erb
+++ b/app/views/admin/issues/_issue.html.erb
@@ -1,4 +1,4 @@
-<% expand = (@issueable || local_assigns[:single]) unless local_assigns[:expand] %>
+<% expand = ((issue.status_open? && @issueable) || local_assigns[:single]) unless local_assigns[:expand] %>
 <div class="row pb-2">
   <div class="admin-issue <%= issue.issue_type %> col-md-12 rounded">
     <h4>

--- a/app/views/admin/issues/_issues_list.html.erb
+++ b/app/views/admin/issues/_issues_list.html.erb
@@ -18,7 +18,7 @@
         <td class="fit"><%= render 'admin/issues/issueable', issueable: issue.try(:issueable) %></td>
         <td width="100%" class="overflow">
           <%= render 'admin/issues/pinned', issue: issue %>
-          <%= issue.title %><br />
+          <span title="<%= issue.title %>" data-toggle="tooltip"><%= issue.title %></span><br />
           <%= render 'admin/issues/meters', issue: issue %>
         </td>
         <td class="fit"><%= render 'admin/issues/fuel_type', issue: issue %></td>

--- a/app/views/admin/issues/_issues_list.html.erb
+++ b/app/views/admin/issues/_issues_list.html.erb
@@ -1,8 +1,10 @@
-<table class="table table-sorted" style="width: 100%">
+<table class="table table-sorted">
   <thead>
     <tr>
       <th class="no-sort"></th>
+      <th><%= local_assigns[:issueable_type] || 'Issue for' %></th>
       <th>Title</th>
+      <th>Fuel</th>
       <th class="nowrap">Assigned to</th>
       <th>Status</th>
       <th>Updated</th>
@@ -12,19 +14,20 @@
   <tbody>
     <% issues.by_priority_order.each do |issue| %>
       <tr class="bg-light admin-issue">
-        <td class="<%= issue.issue_type %>"><%= issue_type_icon(issue.issue_type) %></td>
-        <td class="nowrap"><%= issue.title %> <%= render 'admin/issues/pinned', issue: issue %>
-        <% if show_issueable %>
-          <br /><%= render 'admin/issues/issueable', issueable: issue.try(:issueable) %>
-        <% end %>
-        <%= render 'admin/issues/fuel_type', issue: issue %>
-        <%= render 'admin/issues/meters', issue: issue %>
+        <td class="fit issue-type <%= issue.issue_type %>"><%= issue_type_icon(issue.issue_type) %></td>
+        <td class="fit"><%= render 'admin/issues/issueable', issueable: issue.try(:issueable) %></td>
+        <td width="100%" class="overflow">
+          <%= render 'admin/issues/pinned', issue: issue %>
+          <%= issue.title %><br />
+          <%= render 'admin/issues/meters', issue: issue %>
         </td>
-        <td><%= render 'admin/issues/owned_by', issue: issue %></td>
-        <td><%= render 'admin/issues/status', issue: issue %></td>
-        <td data-order="<%= issue.updated_at %>"><div class="badge badge-pill bg-white text-dark font-weight-normal nowrap"><%= nice_date_times_today(issue.updated_at) %></div></td>
-        <td class="nowrap text-right">
+        <td class="fit"><%= render 'admin/issues/fuel_type', issue: issue %></td>
+        <td class="fit"><%= render 'admin/issues/owned_by', issue: issue %></td>
+        <td class="fit"><%= render 'admin/issues/status', issue: issue %></td>
+        <td class="fit" data-order="<%= issue.updated_at %>"><div class="badge badge-pill bg-white text-dark font-weight-normal nowrap"><%= nice_date_times_today(issue.updated_at) %></div></td>
+        <td class="fit nowrap text-right">
           <%= link_to 'View', polymorphic_path([:admin, issue.issueable, issue]), class: "btn btn-sm" %>
+          <%= link_to 'Edit', edit_polymorphic_path([:admin, @issueable, issue]), class: 'btn btn-info btn-sm' %>
         </td>
       </tr>
     <% end %>

--- a/app/views/admin/issues/_meters.html.erb
+++ b/app/views/admin/issues/_meters.html.erb
@@ -1,7 +1,7 @@
 <% if issue.meters %>
   <% issue.meters.each do |meter| %>
     <span class="badge badge-light border border-dark">
-      <%= link_to("#{fa_icon(fuel_type_icon(meter.meter_type))} #{meter.mpan_mprn}".html_safe, school_meter_path(meter.school, meter), title: meter.name, data: { toggle: 'tooltip'}, class: 'text-decoration-none') %>
+      <%= link_to("#{fa_icon(fuel_type_icon(meter.meter_type))} #{meter.mpan_mprn}".html_safe, school_meter_path(meter.school, meter), title: meter.display_mpan_mprn_name, data: { toggle: 'tooltip'}, class: 'text-decoration-none') %>
     </span>
   <% end %>
 <% end %>

--- a/app/views/admin/issues/index.html.erb
+++ b/app/views/admin/issues/index.html.erb
@@ -45,7 +45,7 @@
       <% end %>
     </div>
   <% else %>
-    <%= render 'issues_list', issues: @issues, show_issueable: true %>
+    <%= render 'issues_list', issues: @issues %>
   <% end %>
   <%= render "shared/pagy_footer" %>
 <% else %>

--- a/app/views/admin/school_groups/_schools_tabs.html.erb
+++ b/app/views/admin/school_groups/_schools_tabs.html.erb
@@ -9,9 +9,9 @@
     <a class="nav-link" id="removed-tab" data-toggle="tab" href="#removed" role="tab" aria-controls="removed-content" aria-selected="true">Removed</a>
   </li>
   <li class="nav-item">
-    <a class="nav-link" id="school-group-issues-tab" data-toggle="tab" href="#school-group-issues" role="tab" aria-controls="school-group-issues-content" aria-selected="true">School Group Issues <span class="badge badge-secondary"><%= @school_group.issues.status_open.count %></span></a>
+    <a class="nav-link" id="school-group-issues-tab" data-toggle="tab" href="#school-group-issues" role="tab" aria-controls="school-group-issues-content" aria-selected="true">School Group Issues <span class="badge badge-secondary"><%= @school_group.issues.count %></span></a>
   </li>
   <li class="nav-item">
-    <a class="nav-link" id="school-issues-tab" data-toggle="tab" href="#school-issues" role="tab" aria-controls="issues-content" aria-selected="true">School Issues <span class="badge badge-secondary"><%= @school_group.school_issues.status_open.count %></span></a>
+    <a class="nav-link" id="school-issues-tab" data-toggle="tab" href="#school-issues" role="tab" aria-controls="issues-content" aria-selected="true">School Issues <span class="badge badge-secondary"><%= @school_group.school_issues.count %></span></a>
   </li>
 </ul>

--- a/app/views/admin/school_groups/show.html.erb
+++ b/app/views/admin/school_groups/show.html.erb
@@ -68,16 +68,16 @@
     <% end %>
   </div>
   <div class="tab-pane fade" id="school-group-issues" role="tabpanel" aria-labelledby="school-group-issues-tab">
-    <% if @school_group.issues.status_open.any? %>
-      <%= render 'admin/issues/issues_list', issues: @school_group.issues.status_open, issueable_type: 'Group' %>
+    <% if @school_group.issues.any? %>
+      <%= render 'admin/issues/issues_list', issues: @school_group.issues, issueable_type: 'Group' %>
     <% else %>
       <div class="bg-light p-2">No school group issues for <%= @school_group.name %>.</div>
     <% end %>
     <%= render 'admin/issues/new_issues_links', issueable: @school_group %>
   </div>
   <div class="tab-pane fade" id="school-issues" role="tabpanel" aria-labelledby="school-issues-tab">
-    <% if @school_group.school_issues.status_open.any? %>
-      <%= render 'admin/issues/issues_list', issues: @school_group.school_issues.status_open, issueable_type: 'School' %>
+    <% if @school_group.school_issues.any? %>
+      <%= render 'admin/issues/issues_list', issues: @school_group.school_issues, issueable_type: 'School' %>
     <% else %>
       <div class="bg-light p-2">No school issues for <%= @school_group.name %>.</div>
     <% end %>

--- a/app/views/admin/school_groups/show.html.erb
+++ b/app/views/admin/school_groups/show.html.erb
@@ -69,7 +69,7 @@
   </div>
   <div class="tab-pane fade" id="school-group-issues" role="tabpanel" aria-labelledby="school-group-issues-tab">
     <% if @school_group.issues.status_open.any? %>
-      <%= render 'admin/issues/issues_list', issues: @school_group.issues.status_open, show_issueable: false %>
+      <%= render 'admin/issues/issues_list', issues: @school_group.issues.status_open, issueable_type: 'Group' %>
     <% else %>
       <div class="bg-light p-2">No school group issues for <%= @school_group.name %>.</div>
     <% end %>
@@ -77,7 +77,7 @@
   </div>
   <div class="tab-pane fade" id="school-issues" role="tabpanel" aria-labelledby="school-issues-tab">
     <% if @school_group.school_issues.status_open.any? %>
-      <%= render 'admin/issues/issues_list', issues: @school_group.school_issues.status_open, show_issueable: true %>
+      <%= render 'admin/issues/issues_list', issues: @school_group.school_issues.status_open, issueable_type: 'School' %>
     <% else %>
       <div class="bg-light p-2">No school issues for <%= @school_group.name %>.</div>
     <% end %>

--- a/app/views/schools/meters/show.html.erb
+++ b/app/views/schools/meters/show.html.erb
@@ -1,6 +1,6 @@
 <div class="d-flex justify-content-between align-items-center">
   <h1>
-    <%= meter_name = @meter.name.present? ? @meter.name : t('schools.meters.show.meter') %>
+    <% meter_name = @meter.name.present? ? @meter.name : t('schools.meters.show.meter') %>
     <%= t('schools.meters.show.title', meter_name: meter_name, meter_mpan_mprn: @meter.mpan_mprn) %>
   </h1>
   <div class="h5">

--- a/spec/system/admin/data_sources_spec.rb
+++ b/spec/system/admin/data_sources_spec.rb
@@ -154,7 +154,7 @@ RSpec.describe 'Data Sources admin', :school_groups, type: :system, include_appl
             it { expect(page).to have_content("Data source was successfully deleted") }
           end
           describe "Issues tab" do
-            context "when there are open issues for the data source" do
+            context "when there are issues for the data source" do
               let(:admin) { create(:admin) }
               let(:issue) { create(:issue, issue_type: :issue, status: :open, updated_by: admin, issueable: existing_data_source, fuel_type: :gas, pinned: true) }
               let(:setup_data) { issue }
@@ -164,7 +164,7 @@ RSpec.describe 'Data Sources admin', :school_groups, type: :system, include_appl
               it "lists issue in issues tab" do
                 within '#issues' do
                   expect(page).to have_content issue.title
-                  expect(page).to_not have_content issue.issueable.name
+                  expect(page).to have_content issue.issueable.name
                   expect(page).to have_content issue.fuel_type.capitalize
                   expect(page).to have_content nice_date_times_today(issue.updated_at)
                   expect(page).to have_link("View", href: polymorphic_path([:admin, existing_data_source, issue]))

--- a/spec/system/admin/school_groups_spec.rb
+++ b/spec/system/admin/school_groups_spec.rb
@@ -329,7 +329,7 @@ RSpec.describe 'school groups', :school_groups, type: :system, include_applicati
       end
 
       describe "School Group Issues tab" do
-        context "when there are open issues for the school group" do
+        context "when there are issues for the school group" do
           let!(:issue) { create(:issue, issue_type: :issue, status: :open, updated_by: admin, issueable: school_group, fuel_type: :gas, pinned: true) }
           let!(:setup_data) { issue }
           it "displays a count of school group issues" do
@@ -338,10 +338,11 @@ RSpec.describe 'school groups', :school_groups, type: :system, include_applicati
           it "lists issue in issues tab" do
             within '#school-group-issues' do
               expect(page).to have_content issue.title
-              expect(page).to_not have_content issue.issueable.name
+              expect(page).to have_content issue.issueable.name
               expect(page).to have_content issue.fuel_type.capitalize
               expect(page).to have_content nice_date_times_today(issue.updated_at)
               expect(page).to have_link("View", href: polymorphic_path([:admin, school_group, issue]))
+              expect(page).to have_link("Edit", href: edit_polymorphic_path([:admin, issue]))
               expect(page).to have_css("i[class*='fa-thumbtack']")
             end
           end
@@ -356,7 +357,7 @@ RSpec.describe 'school groups', :school_groups, type: :system, include_applicati
       end
 
       describe "School Issues tab" do
-        context "when there are open issues for schools in the school group" do
+        context "when there are issues for schools in the school group" do
           let!(:school) { create(:school, school_group: school_group)}
           let!(:issue) { create(:issue, issue_type: :issue, status: :open, updated_by: admin, issueable: school, fuel_type: :gas, pinned: true) }
           let!(:setup_data) { issue }
@@ -370,6 +371,7 @@ RSpec.describe 'school groups', :school_groups, type: :system, include_applicati
               expect(page).to have_content issue.fuel_type.capitalize
               expect(page).to have_content nice_date_times_today(issue.updated_at)
               expect(page).to have_link("View", href: polymorphic_path([:admin, school, issue]))
+              expect(page).to have_link("Edit", href: edit_polymorphic_path([:admin, issue]))
               expect(page).to have_css("i[class*='fa-thumbtack']")
             end
           end


### PR DESCRIPTION
Revises the list of "Issues" on the manage school group page so that there are separate sortable columns for:
* school name
* fuel type

The trello card also specifies adding a data source column, but I'm not sure this makes sense with the model we have, as an issue can have multiple meters and each can have a data source. So an issue could have multiple data sources effectively, which would not work well with a sortable column.
So where meters are listed under the issue title, I've added a tooltip to also show the meter data source. This links through to the meter, where the data source can be accessed.

Also as part of this ticket, the issues lists for school and school group now include both open and closed issues.