### PR TITLE
Factor out default url options and test from bill request email

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,6 @@
 class ApplicationController < ActionController::Base
+  include DefaultUrlOptionsHelper
+
   protect_from_forgery with: :exception
   around_action :switch_locale
   before_action :authenticate_user!
@@ -23,14 +25,6 @@ class ApplicationController < ActionController::Base
   def switch_locale(&action)
     locale = LocaleFinder.new(params, request).locale
     I18n.with_locale(locale, &action)
-  end
-
-  def default_url_options
-    if Rails.env.production?
-      { host: I18n.locale == :cy ? ENV['WELSH_APPLICATION_HOST'] : ENV['APPLICATION_HOST'] }
-    else
-      super
-    end
   end
 
   def route_not_found

--- a/app/helpers/default_url_options_helper.rb
+++ b/app/helpers/default_url_options_helper.rb
@@ -1,0 +1,6 @@
+module DefaultUrlOptionsHelper
+  def default_url_options
+    host = I18n.locale == :cy ? ENV['WELSH_APPLICATION_HOST'] : ENV['APPLICATION_HOST']
+    host ? { host: host } : super
+  end
+end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,6 @@
 class ApplicationMailer < ActionMailer::Base
+  include DefaultUrlOptionsHelper
+
   default from: 'Energy Sparks <hello@energysparks.uk>'
   layout 'mailer'
 
@@ -8,14 +10,6 @@ class ApplicationMailer < ActionMailer::Base
   def make_bootstrap_mail_en(*args)
     I18n.with_locale(:en) do
       make_bootstrap_mail(*args)
-    end
-  end
-
-  def default_url_options
-    if Rails.env.production?
-      { host: I18n.locale == :cy ? ENV['WELSH_APPLICATION_HOST'] : ENV['APPLICATION_HOST'] }
-    else
-      super
     end
   end
 

--- a/app/mailers/energy_sparks_devise_mailer.rb
+++ b/app/mailers/energy_sparks_devise_mailer.rb
@@ -1,17 +1,10 @@
 class EnergySparksDeviseMailer < Devise::Mailer
   helper :application
   include Devise::Controllers::UrlHelpers
+  include DefaultUrlOptionsHelper
   default template_path: 'devise/mailer'
 
   layout 'mailer'
-
-  def default_url_options
-    if Rails.env.production?
-      { host: I18n.locale == :cy ? ENV['WELSH_APPLICATION_HOST'] : ENV['APPLICATION_HOST'] }
-    else
-      super
-    end
-  end
 
   protected
 

--- a/app/mailers/energy_sparks_devise_mailer.rb
+++ b/app/mailers/energy_sparks_devise_mailer.rb
@@ -11,10 +11,16 @@ class EnergySparksDeviseMailer < Devise::Mailer
   def devise_mail(record, action, opts = {}, &block)
     @title = t(:title, scope: [:devise, :mailer, action], default: "")
     initialize_from_record(record)
-    if Rails.env.test?
-      mail headers_for(action, opts), &block
-    else
-      make_bootstrap_mail headers_for(action, opts), &block
+    I18n.with_locale(active_locale(record.preferred_locale)) do
+      if Rails.env.test?
+        mail headers_for(action, opts), &block
+      else
+        make_bootstrap_mail headers_for(action, opts), &block
+      end
     end
+  end
+
+  def active_locale(locale)
+    EnergySparks::FeatureFlags.active?(:emails_with_preferred_locale) ? locale : :en
   end
 end

--- a/spec/mailers/bill_request_mailer_spec.rb
+++ b/spec/mailers/bill_request_mailer_spec.rb
@@ -10,7 +10,9 @@ RSpec.describe BillRequestMailer do
   around do |example|
     ClimateControl.modify SEND_AUTOMATED_EMAILS: 'true' do
       ClimateControl.modify FEATURE_FLAG_EMAILS_WITH_PREFERRED_LOCALE: enable_locale_emails do
-        example.run
+        ClimateControl.modify WELSH_APPLICATION_HOST: 'cy.localhost' do
+          example.run
+        end
       end
     end
   end
@@ -26,6 +28,7 @@ RSpec.describe BillRequestMailer do
       it 'sends an email with en strings' do
         expect(@email.subject).to eql ("Please upload a recent energy bill to Energy Sparks")
         expect(@email.body.to_s).to include("Please upload an energy bill for Test School")
+        expect(@email.body.to_s).to include("http://localhost/schools/test-school/consent_documents")
       end
     end
   end
@@ -36,6 +39,7 @@ RSpec.describe BillRequestMailer do
       it 'sends an email with en strings' do
         expect(@email.subject).to eql ("Uwchlwythwch fil ynni diweddar i Sbarcynni")
         expect(@email.body.to_s).to include("Uwchlwythwch fil ynni ar gyfer Test School")
+        expect(@email.body.to_s).to include("http://cy.localhost/schools/test-school/consent_documents")
       end
     end
   end

--- a/spec/system/password_reset_spec.rb
+++ b/spec/system/password_reset_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+describe 'password reset' do
+
+  let!(:user) { create(:user, email: "test@test.com", preferred_locale: :cy) }
+
+  around do |example|
+    ClimateControl.modify SEND_AUTOMATED_EMAILS: 'true' do
+      ClimateControl.modify FEATURE_FLAG_EMAILS_WITH_PREFERRED_LOCALE: enable_locale_emails do
+        ClimateControl.modify WELSH_APPLICATION_HOST: 'cy.localhost' do
+          example.run
+        end
+      end
+    end
+  end
+
+  context 'when using default domain' do
+    before :each do
+      visit new_user_session_path
+      click_link 'Forgot your password'
+      fill_in "user_email", with: "test@test.com"
+      click_button 'Send me reset password instructions'
+    end
+
+    context 'with locales not enabled' do
+      let(:enable_locale_emails) { 'false' }
+      it 'links to non-locale specific site' do
+        email = ActionMailer::Base.deliveries.last
+        expect(email.body).to include("http://localhost/users/password/edit?reset_password_token=")
+      end
+    end
+
+    context 'with locales enabled' do
+      let(:enable_locale_emails) { 'true' }
+      it 'links to non-locale specific site' do
+        email = ActionMailer::Base.deliveries.last
+        expect(email.body).to include("http://cy.localhost/users/password/edit?reset_password_token=")
+      end
+    end
+  end
+end


### PR DESCRIPTION
When emails are sent using a specific locale, the links in the email should use the same locale subdomain.

The functionality to format links is in the url helpers, but call a default_url_options helper method which can override to supply a specific host, dependent on locale.

If no host names are available in the APPLICATION_HOST or WELSH_APPLICATION_HOST env vars, we just use the default url options.
