### PR TITLE
Make issues admin user more visible

### DIFF
--- a/app/assets/stylesheets/nav.scss
+++ b/app/assets/stylesheets/nav.scss
@@ -53,6 +53,11 @@
     overflow-y: auto;
   }
 
+  .dropdown-menu.scrollable {
+    max-height: 85vh;
+    overflow-y: auto;
+  }
+
   .dropdown-item:hover {
     color: $dark;
   }
@@ -61,6 +66,7 @@
     border-color: rgb(255,255,255);
     margin: 6px;
   }
+
   .navbar-toggler-icon {
     width: 1em;
     height: 1.25em;

--- a/app/views/admin/school_groups/index.html.erb
+++ b/app/views/admin/school_groups/index.html.erb
@@ -7,6 +7,7 @@
     <thead>
       <tr>
         <th>Name</th>
+        <th class="d-none d-xl-block nowrap">Issues admin</th>
         <th title="Schools onboarding">Onboarding</th>
         <th title="Schools active (without data visible)">Active</th>
         <th title="Schools active (with data visible)" class='nowrap'>Data visible</small></th>
@@ -22,6 +23,15 @@
           <td><%= school_group.name %>
             <%= dashboard_message_icon(school_group) %>
           </td>
+          <td class="d-none d-xl-block">
+          <% if school_group.default_issues_admin_user %>
+            <span class="badge border badge-pill border-secondary font-weight-normal">
+              <%= link_to (school_group.default_issues_admin_user == current_user ? "You" : school_group.default_issues_admin_user.display_name),
+                polymorphic_path([:admin, Issue], user: school_group.default_issues_admin_user),
+                class: 'text-decoration-none' %>
+            </span>
+          <% end %>
+          </td>
           <td><%= school_group.school_onboardings.incomplete.count %></td>
           <td><%= school_group.schools.visible.count %></td>
           <td><%= school_group.schools.visible.data_enabled.count %></td>
@@ -32,6 +42,7 @@
       <% end %>
       <tr class="font-weight-bold">
         <td>All Energy Sparks Schools</td>
+        <td class="d-none d-xl-block"></td>
         <td><%= SchoolOnboarding.incomplete.count %></td>
         <td><%= School.visible.count %></td>
         <td><%= School.visible.data_enabled.count %></td>

--- a/app/views/admin/school_groups/show.html.erb
+++ b/app/views/admin/school_groups/show.html.erb
@@ -4,7 +4,20 @@
     <%= header_nav_link 'All school groups', admin_school_groups_url %>
   </div>
 </div>
-<p>Pupils in active schools: <span class="badge badge-success"><%= number_with_delimiter @school_group.schools.visible.map(&:number_of_pupils).compact.sum %></span></p>
+<div class="row pb-2">
+  <div class="col-lg-6">
+    Pupils in active schools: <span class="badge badge-success"><%= number_with_delimiter @school_group.schools.visible.map(&:number_of_pupils).compact.sum %>
+  </div>
+  <div class="col-lg-6 text-right">
+    <% if @school_group.default_issues_admin_user %>
+      <span class="badge border badge-pill border-secondary font-weight-normal">
+        <%= link_to "Default Issues Admin • " + (@school_group.default_issues_admin_user == current_user ? "You" : @school_group.default_issues_admin_user.display_name),
+          polymorphic_path([:admin, Issue], user: @school_group.default_issues_admin_user),
+          class: 'text-decoration-none' %>
+      </span>
+    <% end %>
+  </div>
+</div>
 <div class="row pb-2">
   <div class="col-lg-12">
     <div class="card-deck">

--- a/app/views/shared/_manage_school.html.erb
+++ b/app/views/shared/_manage_school.html.erb
@@ -1,6 +1,6 @@
 <li class="nav-item dropdown mt-2">
   <a class="nav-link dropdown-toggle" data-toggle="dropdown" id="manage_school" href="#" role="button" aria-haspopup="true" aria-expanded="false"><%= t('manage_school_menu.manage_school') %></a>
-  <div class="dropdown-menu" aria-labelledby="manage_school" id="manage_school_menu">
+  <div class="dropdown-menu scrollable" aria-labelledby="manage_school" id="manage_school_menu">
     <%= link_to t('manage_school_menu.edit_school_details'), edit_school_path(school), class: 'dropdown-item' %>
     <%= link_to t('manage_school_menu.edit_school_times'), edit_school_times_path(school), class: 'dropdown-item' if can? :manage_school_times, school %>
     <%= link_to t('manage_school_menu.your_school_estate'), edit_school_your_school_estate_path(school), class: 'dropdown-item' if EnergySparks::FeatureFlags.active?(:your_school_estates) %>
@@ -20,6 +20,7 @@
     <%= link_to t('manage_school_menu.manage_audits'), school_audits_path(school), class: 'dropdown-item' if can? :manage, Audit %>
     <%= link_to t('manage_school_menu.manage_partners'), admin_school_partners_path(school), class: 'dropdown-item' if can? :manage, SchoolPartner %>
     <%= link_to t('manage_school_menu.manage_cads'), school_cads_path(school), class: 'dropdown-item' if can? :manage, Cad %>
+    <%= link_to t('manage_school_menu.manage_school_group'), admin_school_group_path(school.school_group), class: 'dropdown-item' if school.school_group && can?(:manage, school.school_group) %>
     <%= link_to t('manage_school_menu.manage_issues'), admin_school_issues_path(school), class: 'dropdown-item' if can? :manage, Issue %>
     <%= link_to t('manage_school_menu.batch_reports'), school_reports_path(school), class: 'dropdown-item' if can? :view_content_reports, school %>
     <%= link_to t('manage_school_menu.review_targets'), school_school_targets_path(school), class: 'dropdown-item' if current_user.admin? && Targets::SchoolTargetService.targets_enabled?(school) && can?(:manage, SchoolTarget) && Targets::SchoolTargetService.new(school).enough_data? %>

--- a/config/locales/views/shared/shared.yml
+++ b/config/locales/views/shared/shared.yml
@@ -76,6 +76,7 @@ en:
     manage_meters: Manage meters
     manage_partners: Manage partners
     manage_school: Manage School
+    manage_school_group: Manage school group
     manage_tariffs: Manage tariffs
     manage_usage_estimate: Manage usage estimate
     manage_users: Manage users

--- a/spec/system/admin/school_groups_spec.rb
+++ b/spec/system/admin/school_groups_spec.rb
@@ -32,18 +32,18 @@ RSpec.describe 'school groups', :school_groups, type: :system, include_applicati
       end
 
       context "with multiple groups" do
-        let(:school_groups) { [create(:school_group), create(:school_group)] }
+        let(:school_groups) { [create(:school_group, default_issues_admin_user: create(:admin)), create(:school_group)] }
 
         it "displays totals for each group" do
           within('table') do
             school_groups.each do |school_group|
-              expect(page).to have_selector(:table_row, { "Name" => school_group.name, "Onboarding" => 1 , "Active" => 1, "Data visible" => 1, "Invisible" => 1, "Removed" => 1 })
+              expect(page).to have_selector(:table_row, { "Name" => school_group.name, "Issues admin" => school_group.default_issues_admin_user.try(:display_name) || "", "Onboarding" => 1 , "Active" => 1, "Data visible" => 1, "Invisible" => 1, "Removed" => 1 })
             end
           end
         end
         it "displays a grand total" do
           within('table') do
-            expect(page).to have_selector(:table_row, { "Name" => "All Energy Sparks Schools", "Onboarding" => 2 , "Active" => 2, "Data visible" => 2, "Invisible" => 2, "Removed" => 2 })
+            expect(page).to have_selector(:table_row, { "Name" => "All Energy Sparks Schools", "Issues admin" => "", "Onboarding" => 2 , "Active" => 2, "Data visible" => 2, "Invisible" => 2, "Removed" => 2 })
           end
         end
         it "has a link to manage school group" do

--- a/spec/system/admin/school_groups_spec.rb
+++ b/spec/system/admin/school_groups_spec.rb
@@ -117,7 +117,8 @@ RSpec.describe 'school groups', :school_groups, type: :system, include_applicati
     end
 
     describe "Viewing school group page" do
-      let!(:school_group) { create :school_group }
+      let!(:issues_admin) { }
+      let!(:school_group) { create :school_group, default_issues_admin_user: issues_admin }
       before do
         click_on 'Edit School Groups'
         within "table" do
@@ -136,6 +137,22 @@ RSpec.describe 'school groups', :school_groups, type: :system, include_applicati
         end
         it "displays pupils in active schools count" do
           expect(page).to have_content("Pupils in active schools: #{school_group.schools.visible.map(&:number_of_pupils).compact.sum}")
+        end
+
+        describe "with an issues admin" do
+          let(:issues_link) { polymorphic_path([:admin, Issue], user: issues_admin) }
+          let!(:setup_data) { issues_admin }
+          context "that is the same as the logged in user" do
+            let!(:issues_admin) { admin }
+            it { expect(page).to have_link("Default Issues Admin • You", href: issues_link) }
+          end
+          context "that is a different user" do
+            let!(:issues_admin) { create(:admin) }
+            it { expect(page).to have_link("Default Issues Admin • #{issues_admin.display_name}", href: issues_link) }
+          end
+          context "no issues admin user is set" do
+            it { expect(page).to_not have_link(href: issues_link) }
+          end
         end
       end
 

--- a/spec/system/schools/dashboard/manage_school_spec.rb
+++ b/spec/system/schools/dashboard/manage_school_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe "manage school", type: :system do
-  let(:school)             { create(:school) }
+  let(:school)             { create(:school, :with_school_group) }
   let!(:fuel_configuration) { Schools::FuelConfiguration.new(has_electricity: true, has_gas: true, has_storage_heaters: true)}
 
   before(:each) do
@@ -39,82 +39,79 @@ RSpec.describe "manage school", type: :system do
     end
   end
 
+  shared_examples "a manage school menu" do
+    it 'should have manage school menu' do
+      expect(page).to have_css("#manage_school")
+      within "#manage_school_menu" do
+        expect(page).to have_link("Edit school details")
+        expect(page).to have_link("Edit school times")
+        expect(page).to have_link("School calendar")
+        expect(page).to have_link("Manage users")
+        expect(page).to have_link("Manage alert contacts")
+        expect(page).to have_link("Manage meters")
+      end
+    end
+  end
+
+  shared_examples "a manage school menu displaying admin section" do
+    it 'shows extra manage menu items' do
+      expect(page).to have_css("#manage_school")
+      within "#manage_school_menu" do
+        expect(page).to have_link("School configuration")
+        expect(page).to have_link("Meter attributes")
+        expect(page).to have_link("Manage CADs")
+        expect(page).to have_link("Manage school group")
+        expect(page).to have_link("Manage issues")
+        expect(page).to have_link("Manage partners")
+        expect(page).to have_link("Batch reports")
+        expect(page).to have_link("Review targets")
+        expect(page).to have_link("Expert analysis")
+        expect(page).to have_link("Advice pages")
+        expect(page).to have_link("Remove school")
+      end
+    end
+  end
+
+  shared_examples "a manage school menu not displaying admin section" do
+    it 'does not shows extra manage menu items' do
+      expect(page).to have_css("#manage_school")
+      within "#manage_school_menu" do
+        expect(page).to_not have_link("School configuration")
+        expect(page).to_not have_link("Meter attributes")
+        expect(page).to_not have_link("Manage CADs")
+        expect(page).to_not have_link("Manage school group")
+        expect(page).to_not have_link("Manage issues")
+        expect(page).to_not have_link("Manage partners")
+        expect(page).to_not have_link("Batch reports")
+        expect(page).to_not have_link("Review targets")
+        expect(page).to_not have_link("Expert analysis")
+        expect(page).to_not have_link("Advice pages")
+        expect(page).to_not have_link("Remove school")
+      end
+    end
+  end
+
   context 'as school admin' do
     let(:user)  { create(:school_admin, school: school) }
-    it 'should have manage school menu' do
-      visit school_path(school)
-      expect(page).to have_css("#manage_school")
-      expect(page).to have_link("Edit school details")
-      expect(page).to have_link("Edit school times")
-      expect(page).to have_link("School calendar")
-      expect(page).to have_link("Manage users")
-      expect(page).to have_link("Manage alert contacts")
-      expect(page).to have_link("Manage meters")
-    end
-    it 'does not shows extra manage menu items' do
-      visit school_path(school)
-      expect(page).to have_css("#manage_school")
-      expect(page).to_not have_link("School configuration")
-      expect(page).to_not have_link("Meter attributes")
-      expect(page).to_not have_link("Manage CADs")
-      expect(page).to_not have_link("Manage partners")
-      expect(page).to_not have_link("Batch reports")
-      expect(page).to_not have_link("Expert analysis")
-      expect(page).to_not have_link("Remove school")
-    end
+    before { visit school_path(school) }
+    it_behaves_like "a manage school menu"
+    it_behaves_like "a manage school menu not displaying admin section"
   end
 
   context 'as group admin' do
     let(:school_group)  { create(:school_group) }
     let(:school)        { create(:school, school_group: school_group) }
     let(:user)          { create(:group_admin, school_group: school_group) }
-    it 'should have manage school menu' do
-      visit school_path(school)
-      expect(page).to have_css("#manage_school")
-      expect(page).to have_link("Edit school details")
-      expect(page).to have_link("Edit school times")
-      expect(page).to have_link("School calendar")
-      expect(page).to have_link("Manage users")
-      expect(page).to have_link("Manage alert contacts")
-      expect(page).to have_link("Manage meters")
-    end
-    it 'does not shows extra manage menu items' do
-      visit school_path(school)
-      expect(page).to have_css("#manage_school")
-      expect(page).to_not have_link("School configuration")
-      expect(page).to_not have_link("Meter attributes")
-      expect(page).to_not have_link("Manage CADs")
-      expect(page).to_not have_link("Manage partners")
-      expect(page).to_not have_link("Batch reports")
-      expect(page).to_not have_link("Expert analysis")
-      expect(page).to_not have_link("Remove school")
-    end
+    before { visit school_path(school) }
+    it_behaves_like "a manage school menu"
+    it_behaves_like "a manage school menu not displaying admin section"
   end
 
   context 'as admin' do
     let(:user)          { create(:admin) }
-
-    it 'should have manage school menu' do
-      visit school_path(school)
-      expect(page).to have_css("#manage_school")
-      expect(page).to have_link("Edit school details")
-      expect(page).to have_link("Edit school times")
-      expect(page).to have_link("School calendar")
-      expect(page).to have_link("Manage users")
-      expect(page).to have_link("Manage alert contacts")
-      expect(page).to have_link("Manage meters")
-    end
-
-    it 'shows extra manage menu items' do
-      visit school_path(school)
-      expect(page).to have_link("School configuration")
-      expect(page).to have_link("Meter attributes")
-      expect(page).to have_link("Manage CADs")
-      expect(page).to have_link("Manage partners")
-      expect(page).to have_link("Batch reports")
-      expect(page).to have_link("Expert analysis")
-      expect(page).to have_link("Remove school")
-    end
+    before { visit school_path(school) }
+    it_behaves_like "a manage school menu"
+    it_behaves_like "a manage school menu displaying admin section"
 
     it 'displays batch reports' do
       visit school_path(school)


### PR DESCRIPTION
- Displays default issues admin against school group & links to issues for user
- Adds school group to manage school menu & tidies spec. Also makes the menu scrollable as it was dropping down out of view.
- Adds issues admin to school group index page (if page is wide enough)