### PR TITLE
Add country to school group and onboarding

### DIFF
--- a/app/controllers/admin/school_groups_controller.rb
+++ b/app/controllers/admin/school_groups_controller.rb
@@ -46,7 +46,8 @@ module Admin
 
     def school_group_params
       params.require(:school_group).permit(
-        :name, :description, :country,
+        :name, :description,
+        :default_country,
         :default_scoreboard_id,
         :default_template_calendar_id,
         :default_dark_sky_area_id,

--- a/app/controllers/admin/school_groups_controller.rb
+++ b/app/controllers/admin/school_groups_controller.rb
@@ -46,7 +46,8 @@ module Admin
 
     def school_group_params
       params.require(:school_group).permit(
-        :name, :description, :default_scoreboard_id,
+        :name, :description, :country,
+        :default_scoreboard_id,
         :default_template_calendar_id,
         :default_dark_sky_area_id,
         :default_solar_pv_tuos_area_id,

--- a/app/controllers/admin/school_onboardings/configuration_controller.rb
+++ b/app/controllers/admin/school_onboardings/configuration_controller.rb
@@ -11,7 +11,7 @@ module Admin
           @school_onboarding.weather_station = @school_onboarding.school_group.default_weather_station
           @school_onboarding.scoreboard = @school_onboarding.school_group.default_scoreboard
           @school_onboarding.default_chart_preference = @school_onboarding.school_group.default_chart_preference
-          @school_onboarding.country = @school_onboarding.school_group.country
+          @school_onboarding.country = @school_onboarding.school_group.default_country
         end
       end
 

--- a/app/controllers/admin/school_onboardings/configuration_controller.rb
+++ b/app/controllers/admin/school_onboardings/configuration_controller.rb
@@ -11,6 +11,7 @@ module Admin
           @school_onboarding.weather_station = @school_onboarding.school_group.default_weather_station
           @school_onboarding.scoreboard = @school_onboarding.school_group.default_scoreboard
           @school_onboarding.default_chart_preference = @school_onboarding.school_group.default_chart_preference
+          @school_onboarding.country = @school_onboarding.school_group.country
         end
       end
 
@@ -32,7 +33,8 @@ module Admin
           :dark_sky_area_id,
           :scoreboard_id,
           :weather_station_id,
-          :default_chart_preference
+          :default_chart_preference,
+          :country
         )
       end
     end

--- a/app/models/school_group.rb
+++ b/app/models/school_group.rb
@@ -65,7 +65,7 @@ class SchoolGroup < ApplicationRecord
   validates :name, presence: true
 
   enum default_chart_preference: [:default, :carbon, :usage, :cost]
-  enum country: School.countries
+  enum default_country: School.countries
 
   def has_visible_schools?
     schools.visible.any?

--- a/app/models/school_group.rb
+++ b/app/models/school_group.rb
@@ -65,6 +65,7 @@ class SchoolGroup < ApplicationRecord
   validates :name, presence: true
 
   enum default_chart_preference: [:default, :carbon, :usage, :cost]
+  enum country: School.countries
 
   def has_visible_schools?
     schools.visible.any?

--- a/app/models/school_onboarding.rb
+++ b/app/models/school_onboarding.rb
@@ -64,6 +64,7 @@ class SchoolOnboarding < ApplicationRecord
   scope :for_school_type, ->(school_type) { joins(:school).where(schools: { school_type: school_type }) }
 
   enum default_chart_preference: [:default, :carbon, :usage, :cost]
+  enum country: School.countries
 
   def has_event?(event_name)
     events.where(event: event_name).any?

--- a/app/views/admin/school_groups/_form.html.erb
+++ b/app/views/admin/school_groups/_form.html.erb
@@ -51,6 +51,11 @@
       </div>
 
       <div class="form-group">
+        <%= f.label :country, 'Default country' %>
+        <%= f.select :country, options_for_select(School.countries.map {|key, value| [key.titleize, key]}, @school_group.country), {include_blank: false}, { class: 'form-control' } %>
+      </div>
+
+      <div class="form-group">
         <label><%= t("admin.school_groups.default_chart_preference.form_group") %></label>
         <p class="small"><%= t("admin.school_groups.default_chart_preference.explanation") %></p>
         <% SchoolGroup.default_chart_preferences.keys.each do |preference| %>

--- a/app/views/admin/school_groups/_form.html.erb
+++ b/app/views/admin/school_groups/_form.html.erb
@@ -51,8 +51,8 @@
       </div>
 
       <div class="form-group">
-        <%= f.label :country, 'Default country' %>
-        <%= f.select :country, options_for_select(School.countries.map {|key, value| [key.titleize, key]}, @school_group.country), {include_blank: false}, { class: 'form-control' } %>
+        <%= f.label :default_country, 'Default country' %>
+§        <%= f.select :default_country, options_for_select(School.countries.map {|key, value| [key.titleize, key]}, @school_group.default_country), {include_blank: false}, { class: 'form-control' } %>
       </div>
 
       <div class="form-group">

--- a/app/views/admin/school_groups/_form.html.erb
+++ b/app/views/admin/school_groups/_form.html.erb
@@ -52,7 +52,7 @@
 
       <div class="form-group">
         <%= f.label :default_country, 'Default country' %>
-§        <%= f.select :default_country, options_for_select(School.countries.map {|key, value| [key.titleize, key]}, @school_group.default_country), {include_blank: false}, { class: 'form-control' } %>
+        <%= f.select :default_country, options_for_select(School.countries.map {|key, value| [key.titleize, key]}, @school_group.default_country), {include_blank: false}, { class: 'form-control' } %>
       </div>
 
       <div class="form-group">

--- a/app/views/admin/school_onboardings/configuration/edit.html.erb
+++ b/app/views/admin/school_onboardings/configuration/edit.html.erb
@@ -34,6 +34,12 @@
       <%= f.select :scoreboard_id, options_from_collection_for_select(Scoreboard.order(:name), 'id', 'name', (@school_onboarding.scoreboard.id if @school_onboarding.scoreboard)),{}, { class: 'form-control' }%>
     </div>
   </div>
+  <div class="form-row">
+    <div class="form-group col-md-6">
+      <%= f.label :country, 'Country' %>
+      <%= f.select :country, options_for_select(School.countries.map {|key, value| [key.titleize, key]}, @school_onboarding.country), {include_blank: false}, { class: 'form-control' } %>
+    </div>
+  </div>
 
   <div class="form-group">
     <label><%= t("admin.school_groups.default_chart_preference.form_group") %></label>

--- a/db/migrate/20230224111422_add_country_to_school_groups.rb
+++ b/db/migrate/20230224111422_add_country_to_school_groups.rb
@@ -1,0 +1,5 @@
+class AddCountryToSchoolGroups < ActiveRecord::Migration[6.0]
+  def change
+    add_column :school_groups, :country, :integer, default: 0, null: false
+  end
+end

--- a/db/migrate/20230224111422_add_country_to_school_groups.rb
+++ b/db/migrate/20230224111422_add_country_to_school_groups.rb
@@ -1,5 +1,0 @@
-class AddCountryToSchoolGroups < ActiveRecord::Migration[6.0]
-  def change
-    add_column :school_groups, :country, :integer, default: 0, null: false
-  end
-end

--- a/db/migrate/20230224111422_add_default_country_to_school_groups.rb
+++ b/db/migrate/20230224111422_add_default_country_to_school_groups.rb
@@ -1,0 +1,5 @@
+class AddDefaultCountryToSchoolGroups < ActiveRecord::Migration[6.0]
+  def change
+    add_column :school_groups, :default_country, :integer, default: 0, null: false
+  end
+end

--- a/db/migrate/20230224111633_add_country_to_school_onboardings.rb
+++ b/db/migrate/20230224111633_add_country_to_school_onboardings.rb
@@ -1,0 +1,5 @@
+class AddCountryToSchoolOnboardings < ActiveRecord::Migration[6.0]
+  def change
+    add_column :school_onboardings, :country, :integer, default: 0, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_02_08_104408) do
+ActiveRecord::Schema.define(version: 2023_02_24_111633) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
@@ -827,13 +827,13 @@ ActiveRecord::Schema.define(version: 2023_02_08_104408) do
     t.index ["replaced_by_id"], name: "index_global_meter_attributes_on_replaced_by_id"
   end
 
-  create_table "good_job_processes", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "good_job_processes", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.jsonb "state"
   end
 
-  create_table "good_job_settings", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "good_job_settings", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.text "key"
@@ -841,7 +841,7 @@ ActiveRecord::Schema.define(version: 2023_02_08_104408) do
     t.index ["key"], name: "index_good_job_settings_on_key", unique: true
   end
 
-  create_table "good_jobs", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "good_jobs", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.text "queue_name"
     t.integer "priority"
     t.jsonb "serialized_params"
@@ -1279,6 +1279,7 @@ ActiveRecord::Schema.define(version: 2023_02_08_104408) do
     t.boolean "public", default: true
     t.integer "default_chart_preference", default: 0, null: false
     t.bigint "default_issues_admin_user_id"
+    t.integer "country", default: 0, null: false
     t.index ["default_issues_admin_user_id"], name: "index_school_groups_on_default_issues_admin_user_id"
     t.index ["default_scoreboard_id"], name: "index_school_groups_on_default_scoreboard_id"
     t.index ["default_solar_pv_tuos_area_id"], name: "index_school_groups_on_default_solar_pv_tuos_area_id"
@@ -1332,6 +1333,7 @@ ActiveRecord::Schema.define(version: 2023_02_08_104408) do
     t.bigint "weather_station_id"
     t.boolean "school_will_be_public", default: true
     t.integer "default_chart_preference", default: 0, null: false
+    t.integer "country", default: 0, null: false
     t.index ["created_by_id"], name: "index_school_onboardings_on_created_by_id"
     t.index ["created_user_id"], name: "index_school_onboardings_on_created_user_id"
     t.index ["school_group_id"], name: "index_school_onboardings_on_school_group_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -827,13 +827,13 @@ ActiveRecord::Schema.define(version: 2023_02_24_111633) do
     t.index ["replaced_by_id"], name: "index_global_meter_attributes_on_replaced_by_id"
   end
 
-  create_table "good_job_processes", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "good_job_processes", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.jsonb "state"
   end
 
-  create_table "good_job_settings", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "good_job_settings", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.text "key"
@@ -841,7 +841,7 @@ ActiveRecord::Schema.define(version: 2023_02_24_111633) do
     t.index ["key"], name: "index_good_job_settings_on_key", unique: true
   end
 
-  create_table "good_jobs", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "good_jobs", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.text "queue_name"
     t.integer "priority"
     t.jsonb "serialized_params"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1279,7 +1279,7 @@ ActiveRecord::Schema.define(version: 2023_02_24_111633) do
     t.boolean "public", default: true
     t.integer "default_chart_preference", default: 0, null: false
     t.bigint "default_issues_admin_user_id"
-    t.integer "country", default: 0, null: false
+    t.integer "default_country", default: 0, null: false
     t.index ["default_issues_admin_user_id"], name: "index_school_groups_on_default_issues_admin_user_id"
     t.index ["default_scoreboard_id"], name: "index_school_groups_on_default_scoreboard_id"
     t.index ["default_solar_pv_tuos_area_id"], name: "index_school_groups_on_default_solar_pv_tuos_area_id"

--- a/spec/system/admin/school_groups_spec.rb
+++ b/spec/system/admin/school_groups_spec.rb
@@ -106,6 +106,7 @@ RSpec.describe 'school groups', :school_groups, type: :system, include_applicati
           select 'BANES and Frome', from: 'Default scoreboard'
           select 'BANES dark sky weather', from: 'Default Dark Sky Weather Data Feed Area'
           select 'Admin', from: 'Default issues admin user'
+          select 'Wales', from: 'Default country'
           choose 'Display chart data in kwh, where available'
           click_on 'Create School group'
         end
@@ -113,6 +114,7 @@ RSpec.describe 'school groups', :school_groups, type: :system, include_applicati
           expect(SchoolGroup.where(name: 'BANES').count).to eq(1)
         end
         it { expect(SchoolGroup.where(name: 'BANES').first.default_issues_admin_user).to eq(admin) }
+        it { expect(SchoolGroup.where(name: 'BANES').first.default_country).to eq("wales") }
       end
     end
 

--- a/spec/system/admin/school_onboarding_spec.rb
+++ b/spec/system/admin/school_onboarding_spec.rb
@@ -23,7 +23,8 @@ RSpec.describe "onboarding", :schools, type: :system do
       default_dark_sky_area: dark_sky_weather_area,
       default_weather_station: weather_station,
       default_scoreboard: scoreboard,
-      default_chart_preference: default_chart_preference
+      default_chart_preference: default_chart_preference,
+      default_country: 'wales'
     )
   end
 
@@ -61,6 +62,7 @@ RSpec.describe "onboarding", :schools, type: :system do
       expect(page).to have_select('Dark Sky Data Feed Area', selected: 'BANES dark sky weather')
       expect(page).to have_select('Weather Station', selected: 'BANES weather')
       expect(page).to have_select('Scoreboard', selected: 'BANES scoreboard')
+      expect(page).to have_select('Country', selected: 'Wales')
 
       click_on 'Next'
 
@@ -97,6 +99,7 @@ RSpec.describe "onboarding", :schools, type: :system do
       click_on 'Next'
 
       select 'Oxford calendar', from: 'Template calendar'
+      select 'Scotland', from: 'Country'
 
       choose('Display chart data in £, where available')
 
@@ -105,6 +108,7 @@ RSpec.describe "onboarding", :schools, type: :system do
       expect(onboarding.school_name).to eq('A new name')
       expect(onboarding.template_calendar).to eq(other_template_calendar)
       expect(onboarding.default_chart_preference).to eq "cost"
+      expect(onboarding.country).to eq "scotland"
     end
 
     context 'when completing onboarding as admin without consents' do


### PR DESCRIPTION
The onboarding process will send emails in multiple languages if the onboarding is for a school in Wales.

To support this, the onboarding has a country specified. The country is initially set according to a default country on the school group.

The country fields are implemented as enums, sharing the same values as the country field on the School model.
