### PR TITLE
Onboarding emails have subject and body in 2 languages if Welsh enabled

### DIFF
--- a/app/mailers/locale_mailer.rb
+++ b/app/mailers/locale_mailer.rb
@@ -16,15 +16,23 @@ class LocaleMailer < ApplicationMailer
     users.select {|u| u.preferred_locale.to_sym == locale.to_sym}
   end
 
+  def for_each_locale(locales)
+    locales.map { |locale| I18n.with_locale(locale) { yield } }
+  end
+
   # send with locale if preferred locales are enabled
   def make_bootstrap_mail(*args)
-    I18n.with_locale(active_locale) do
+    I18n.with_locale(active_locale(locale_param)) do
       super(*args)
     end
   end
 
-  def active_locale
-    EnergySparks::FeatureFlags.active?(:emails_with_preferred_locale) ? locale_param : :en
+  def active_locale(locale)
+    EnergySparks::FeatureFlags.active?(:emails_with_preferred_locale) ? locale : :en
+  end
+
+  def active_locales(locales)
+    EnergySparks::FeatureFlags.active?(:emails_with_preferred_locale) ? locales : [:en]
   end
 
   def locale_param

--- a/app/mailers/onboarding_mailer.rb
+++ b/app/mailers/onboarding_mailer.rb
@@ -1,28 +1,12 @@
-class OnboardingMailer < ApplicationMailer
+class OnboardingMailer < LocaleMailer
   helper :application
-
-  def get_locales(school_onboarding)
-    EnergySparks::FeatureFlags.active?(:emails_with_preferred_locale) ? school_onboarding.email_locales : [:en]
-  end
-
-  def for_locales(locales)
-    locales.map { |locale| I18n.with_locale(locale) { yield } }
-  end
 
   def onboarding_email
     @school_onboarding = params[:school_onboarding]
     @title = @school_onboarding.school_name
-
-    locales = get_locales(@school_onboarding)
-
-    @body = for_locales(locales) do
-      render :onboarding_email_content, layout: nil
-    end.join("<hr>")
-
-    @subject = for_locales(locales) do
-      default_i18n_subject
-    end.join(" / ")
-
+    locales = active_locales(@school_onboarding.email_locales)
+    @body = for_each_locale(locales) { render :onboarding_email_content, layout: nil }.join("<hr>")
+    @subject = for_each_locale(locales) { default_i18n_subject }.join(" / ")
     make_bootstrap_mail(to: @school_onboarding.contact_email, subject: @subject)
   end
 
@@ -38,7 +22,10 @@ class OnboardingMailer < ApplicationMailer
   def reminder_email
     @school_onboarding = params[:school_onboarding]
     @title = @school_onboarding.school_name
-    make_bootstrap_mail(to: @school_onboarding.contact_email)
+    locales = active_locales(@school_onboarding.email_locales)
+    @body = for_each_locale(locales) { render :reminder_email_content, layout: nil }.join("<hr>")
+    @subject = for_each_locale(locales) { default_i18n_subject }.join(" / ")
+    make_bootstrap_mail(to: @school_onboarding.contact_email, subject: @subject)
   end
 
   def activation_email

--- a/app/mailers/onboarding_mailer.rb
+++ b/app/mailers/onboarding_mailer.rb
@@ -1,10 +1,25 @@
 class OnboardingMailer < ApplicationMailer
   helper :application
 
+  def for_locales(locales)
+    locales.map { |locale| I18n.with_locale(locale) { yield } }
+  end
+
   def onboarding_email
     @school_onboarding = params[:school_onboarding]
     @title = @school_onboarding.school_name
-    make_bootstrap_mail(to: @school_onboarding.contact_email)
+
+    locales = @school_onboarding.email_locales
+
+    @body = for_locales(locales) do
+      render :onboarding_email_content, layout: nil
+    end.join("<hr>")
+
+    @subject = for_locales(locales) do
+      default_i18n_subject
+    end.join(" / ")
+
+    make_bootstrap_mail(to: @school_onboarding.contact_email, subject: @subject)
   end
 
   def completion_email

--- a/app/mailers/onboarding_mailer.rb
+++ b/app/mailers/onboarding_mailer.rb
@@ -1,6 +1,10 @@
 class OnboardingMailer < ApplicationMailer
   helper :application
 
+  def get_locales(school_onboarding)
+    EnergySparks::FeatureFlags.active?(:emails_with_preferred_locale) ? school_onboarding.email_locales : [:en]
+  end
+
   def for_locales(locales)
     locales.map { |locale| I18n.with_locale(locale) { yield } }
   end
@@ -9,7 +13,7 @@ class OnboardingMailer < ApplicationMailer
     @school_onboarding = params[:school_onboarding]
     @title = @school_onboarding.school_name
 
-    locales = @school_onboarding.email_locales
+    locales = get_locales(@school_onboarding)
 
     @body = for_locales(locales) do
       render :onboarding_email_content, layout: nil

--- a/app/models/school_onboarding.rb
+++ b/app/models/school_onboarding.rb
@@ -115,6 +115,10 @@ class SchoolOnboarding < ApplicationRecord
     pupil_account_created?
   end
 
+  def email_locales
+    country == 'wales' ? [:en, :cy] : [:en]
+  end
+
   def to_param
     uuid
   end

--- a/app/views/onboarding_mailer/onboarding_email.html.erb
+++ b/app/views/onboarding_mailer/onboarding_email.html.erb
@@ -1,15 +1,1 @@
-<h1 class="mb-3"><%= t('onboarding_mailer.onboarding_email.title') %></h1>
-
-<p>
-  <%= t('onboarding_mailer.onboarding_email.paragraph_1_html', school_name: @school_onboarding.school_name) %>
-</p>
-<p>
-  <%= t('onboarding_mailer.onboarding_email.paragraph_2') %>
-</p>
-<p>
-  <%= t('onboarding_mailer.onboarding_email.paragraph_3') %>
-<p>
-
-<%= link_to t('onboarding_mailer.onboarding_email.set_up_your_school_on_energy_sparks'), onboarding_url(@school_onboarding), class: 'btn btn-primary mb-3 mt-3'%>
-
-<p class="small"><%= t('onboarding_mailer.onboarding_email.the_energy_sparks_team') %><p>
+<%= @body.html_safe %>

--- a/app/views/onboarding_mailer/onboarding_email_content.html.erb
+++ b/app/views/onboarding_mailer/onboarding_email_content.html.erb
@@ -1,0 +1,15 @@
+<h1 class="mb-3"><%= t('onboarding_mailer.onboarding_email.title') %></h1>
+
+<p>
+  <%= t('onboarding_mailer.onboarding_email.paragraph_1_html', school_name: @school_onboarding.school_name) %>
+</p>
+<p>
+  <%= t('onboarding_mailer.onboarding_email.paragraph_2') %>
+</p>
+<p>
+  <%= t('onboarding_mailer.onboarding_email.paragraph_3') %>
+<p>
+
+<%= link_to t('onboarding_mailer.onboarding_email.set_up_your_school_on_energy_sparks'), onboarding_url(@school_onboarding), class: 'btn btn-primary mb-3 mt-3'%>
+
+<p class="small"><%= t('onboarding_mailer.onboarding_email.the_energy_sparks_team') %><p>

--- a/app/views/onboarding_mailer/reminder_email.html.erb
+++ b/app/views/onboarding_mailer/reminder_email.html.erb
@@ -1,8 +1,1 @@
-<h1 class="mb-3"><%= t('onboarding_mailer.reminder_email.title') %></h1>
-
-<p><%= t('onboarding_mailer.reminder_email.paragraph_1_html', school_name: @school_onboarding.school_name) %></p>
-<p><%= t('onboarding_mailer.reminder_email.paragraph_2') %><p>
-
-<%= link_to t('onboarding_mailer.reminder_email.paragraph_3'), onboarding_url(@school_onboarding), class: 'btn btn-primary mb-3 mt-3'%>
-
-<p class="small"><%= t('onboarding_mailer.reminder_email.the_energy_sparks_team') %><p>
+<%= @body.html_safe %>

--- a/app/views/onboarding_mailer/reminder_email_content.html.erb
+++ b/app/views/onboarding_mailer/reminder_email_content.html.erb
@@ -1,0 +1,8 @@
+<h1 class="mb-3"><%= t('onboarding_mailer.reminder_email.title') %></h1>
+
+<p><%= t('onboarding_mailer.reminder_email.paragraph_1_html', school_name: @school_onboarding.school_name) %></p>
+<p><%= t('onboarding_mailer.reminder_email.paragraph_2') %><p>
+
+<%= link_to t('onboarding_mailer.reminder_email.paragraph_3'), onboarding_url(@school_onboarding), class: 'btn btn-primary mb-3 mt-3'%>
+
+<p class="small"><%= t('onboarding_mailer.reminder_email.the_energy_sparks_team') %><p>

--- a/config/locales/cy/mailers/mailer.yml
+++ b/config/locales/cy/mailers/mailer.yml
@@ -45,6 +45,10 @@ cy:
       subject: "Mae %{school} bellach yn fyw ar Sbarcynni"
     onboarding_email:
       subject: Sefydlwch eich ysgol ar Sbarcynni
+      paragraph_1_html: Welsh here for %{school_name} ...
+      paragraph_2: Para 2 Welsh here...
+      paragraph_3: Para 3 Welsh here...
+      title: Sefydlwch eich ysgol ar Sbarcynni
     reminder_email:
       subject: Peidiwch ag anghofio sefydlu eich ysgol ar Sbarcynni
     welcome_email:

--- a/config/locales/cy/mailers/mailer.yml
+++ b/config/locales/cy/mailers/mailer.yml
@@ -45,12 +45,11 @@ cy:
       subject: "Mae %{school} bellach yn fyw ar Sbarcynni"
     onboarding_email:
       subject: Sefydlwch eich ysgol ar Sbarcynni
-      paragraph_1_html: Welsh here for %{school_name} ...
-      paragraph_2: Para 2 Welsh here...
-      paragraph_3: Para 3 Welsh here...
+      set_up_your_school_on_energy_sparks: Sefydlwch eich ysgol ar Sbarcynni
       title: Sefydlwch eich ysgol ar Sbarcynni
     reminder_email:
       subject: Peidiwch ag anghofio sefydlu eich ysgol ar Sbarcynni
+      title: Peidiwch ag anghofio sefydlu eich ysgol ar Sbarcynni
     welcome_email:
       subject: Croeso i Sbarcynni
   target_mailer:

--- a/spec/mailers/onboarding_mailer_spec.rb
+++ b/spec/mailers/onboarding_mailer_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe OnboardingMailer do
         end
       end
     end
-    context 'when locale emails disabled' do
+    context 'when locale emails enabled' do
       let(:enable_locale_emails) { 'true' }
       it 'sends the onboarding email in both languages' do
         OnboardingMailer.with(emails: ['test@blah.com'], school_onboarding: school_onboarding).onboarding_email.deliver_now

--- a/spec/mailers/onboarding_mailer_spec.rb
+++ b/spec/mailers/onboarding_mailer_spec.rb
@@ -23,9 +23,11 @@ RSpec.describe OnboardingMailer do
         I18n.t('onboarding_mailer.onboarding_email').except(:subject).values.each do |email_content|
           expect(email.body.to_s).to include(email_content.gsub('%{school_name}', school.name))
         end
+        expect(email.body.to_s).to include("http://localhost/school_setup/")
         I18n.t('onboarding_mailer.onboarding_email', locale: :cy).except(:subject).values.each do |email_content|
           expect(email.body.to_s).not_to include(email_content.gsub('%{school_name}', school.name))
         end
+        expect(email.body.to_s).not_to include("http://cy.localhost/school_setup/")
       end
     end
     context 'when locale emails enabled' do
@@ -37,9 +39,11 @@ RSpec.describe OnboardingMailer do
         I18n.t('onboarding_mailer.onboarding_email').except(:subject).values.each do |email_content|
           expect(email.body.to_s).to include(email_content.gsub('%{school_name}', school.name))
         end
+        expect(email.body.to_s).to include("http://localhost/school_setup/")
         I18n.t('onboarding_mailer.onboarding_email', locale: :cy).except(:subject).values.each do |email_content|
           expect(email.body.to_s).to include(email_content.gsub('%{school_name}', school.name))
         end
+        expect(email.body.to_s).to include("http://cy.localhost/school_setup/")
       end
     end
   end

--- a/spec/mailers/onboarding_mailer_spec.rb
+++ b/spec/mailers/onboarding_mailer_spec.rb
@@ -68,9 +68,11 @@ RSpec.describe OnboardingMailer do
         I18n.t('onboarding_mailer.reminder_email').except(:subject).values.each do |email_content|
           expect(ActionController::Base.helpers.sanitize(email.body.to_s)).to include(email_content.gsub('%{school_name}', school.name))
         end
+        expect(email.body.to_s).to include("http://localhost/school_setup/")
         I18n.t('onboarding_mailer.reminder_email', locale: :cy).except(:subject).values.each do |email_content|
           expect(ActionController::Base.helpers.sanitize(email.body.to_s)).not_to include(email_content.gsub('%{school_name}', school.name))
         end
+        expect(email.body.to_s).not_to include("http://cy.localhost/school_setup/")
       end
     end
     context 'when locale emails enabled' do
@@ -82,9 +84,11 @@ RSpec.describe OnboardingMailer do
         I18n.t('onboarding_mailer.reminder_email').except(:subject).values.each do |email_content|
           expect(ActionController::Base.helpers.sanitize(email.body.to_s)).to include(email_content.gsub('%{school_name}', school.name))
         end
+        expect(email.body.to_s).to include("http://localhost/school_setup/")
         I18n.t('onboarding_mailer.reminder_email', locale: :cy).except(:subject).values.each do |email_content|
           expect(ActionController::Base.helpers.sanitize(email.body.to_s)).to include(email_content.gsub('%{school_name}', school.name))
         end
+        expect(email.body.to_s).to include("http://cy.localhost/school_setup/")
       end
     end
   end

--- a/spec/mailers/onboarding_mailer_spec.rb
+++ b/spec/mailers/onboarding_mailer_spec.rb
@@ -3,15 +3,43 @@ require 'rails_helper'
 RSpec.describe OnboardingMailer do
   let(:school){ create(:school, name: 'Test School') }
   let(:user){ create(:onboarding_user, school: school) }
-  let(:school_onboarding) { create(:school_onboarding, school_name: 'Test School', created_by: user, school: school) }
+  let(:school_onboarding) { create(:school_onboarding, school_name: 'Test School', created_by: user, school: school, country: 'wales') }
+  let(:enable_locale_emails) { 'false' }
+
+  around do |example|
+    ClimateControl.modify FEATURE_FLAG_EMAILS_WITH_PREFERRED_LOCALE: enable_locale_emails do
+      ClimateControl.modify WELSH_APPLICATION_HOST: 'cy.localhost' do
+        example.run
+      end
+    end
+  end
 
   describe '#onboarding_email' do
-    it 'sends the onboarding email' do
-      OnboardingMailer.with(emails: ['test@blah.com'], school_onboarding: school_onboarding).onboarding_email.deliver_now
-      email = ActionMailer::Base.deliveries.last
-      expect(email.subject).to eq(I18n.t('onboarding_mailer.onboarding_email.subject'))
-      I18n.t('onboarding_mailer.onboarding_email').except(:subject).values.each do |email_content|
-        expect(email.body.to_s).to include(email_content.gsub('%{school_name}', school.name))
+    context 'when locale emails disabled' do
+      it 'sends the onboarding email in english only' do
+        OnboardingMailer.with(emails: ['test@blah.com'], school_onboarding: school_onboarding).onboarding_email.deliver_now
+        email = ActionMailer::Base.deliveries.last
+        expect(email.subject).to eq(I18n.t('onboarding_mailer.onboarding_email.subject'))
+        I18n.t('onboarding_mailer.onboarding_email').except(:subject).values.each do |email_content|
+          expect(email.body.to_s).to include(email_content.gsub('%{school_name}', school.name))
+        end
+        I18n.t('onboarding_mailer.onboarding_email', locale: :cy).except(:subject).values.each do |email_content|
+          expect(email.body.to_s).not_to include(email_content.gsub('%{school_name}', school.name))
+        end
+      end
+    end
+    context 'when locale emails disabled' do
+      let(:enable_locale_emails) { 'true' }
+      it 'sends the onboarding email in both languages' do
+        OnboardingMailer.with(emails: ['test@blah.com'], school_onboarding: school_onboarding).onboarding_email.deliver_now
+        email = ActionMailer::Base.deliveries.last
+        expect(email.subject).to eq(I18n.t('onboarding_mailer.onboarding_email.subject') + " / " + I18n.t('onboarding_mailer.onboarding_email.subject', locale: :cy))
+        I18n.t('onboarding_mailer.onboarding_email').except(:subject).values.each do |email_content|
+          expect(email.body.to_s).to include(email_content.gsub('%{school_name}', school.name))
+        end
+        I18n.t('onboarding_mailer.onboarding_email', locale: :cy).except(:subject).values.each do |email_content|
+          expect(email.body.to_s).to include(email_content.gsub('%{school_name}', school.name))
+        end
       end
     end
   end

--- a/spec/models/school_onboarding_spec.rb
+++ b/spec/models/school_onboarding_spec.rb
@@ -37,6 +37,18 @@ describe SchoolOnboarding, type: :model do
     end
   end
 
+  describe ".email_locales" do
+    it "only en for england" do
+      expect(SchoolOnboarding.new(country: 'england').email_locales).to eq([:en])
+    end
+    it "only en for scotland" do
+      expect(SchoolOnboarding.new(country: 'scotland').email_locales).to eq([:en])
+    end
+    it "en and cy for wales" do
+      expect(SchoolOnboarding.new(country: 'wales').email_locales).to eq([:en, :cy])
+    end
+  end
+
   describe ".incomplete" do
     context "when there is an onboarding with no events" do
       let!(:incomplete) { create :school_onboarding }


### PR DESCRIPTION
During onboarding, we don't yet have users set up in the system, so we don't know what their preferred language is. If the onboarding is for a Welsh school, then we will send emails in both languages - the subject line and body will contain the English and Welsh text (though the overall layout, headers etc will be the English ones).
