### PR TITLE
Advice index prototype

### DIFF
--- a/app/controllers/schools/advice_controller.rb
+++ b/app/controllers/schools/advice_controller.rb
@@ -6,8 +6,21 @@ module Schools
     before_action :load_advice_pages
 
     include SchoolAggregation
+    include DashboardAlerts
 
     def show
+      @management_priorities = @school.latest_management_priorities.by_priority.limit(site_settings.management_priorities_page_limit).map do |priority|
+        TemplateInterpolation.new(
+          priority.content_version,
+          with_objects: { find_out_more: priority.find_out_more },
+          proxy: [:colour]
+        ).interpolate(
+          :management_priorities_title,
+          with: priority.alert.template_variables
+        )
+      end
+
+      @dashboard_alerts = setup_alerts(@school.latest_dashboard_alerts.management_dashboard, :management_dashboard_title, limit: nil)
     end
 
     private

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -91,6 +91,11 @@ module ApplicationHelper
     end
   end
 
+  def status_for_alert_colour(colour)
+    return :unknown if colour.nil?
+    colour
+  end
+
   def class_for_alert_colour(colour)
     return class_for_alert_colour(:unknown) if colour.nil?
     case colour.to_sym

--- a/app/views/schools/advice/_alerts.html.erb
+++ b/app/views/schools/advice/_alerts.html.erb
@@ -1,0 +1,19 @@
+<% unless dashboard_alerts.empty? %>
+    <% dashboard_alerts.each do |alert_content|%>
+
+      <%= component 'notice', classes: 'mt-4', status: status_for_alert_colour(alert_content.colour) do |c| %>
+        <div class="row">
+          <div class="col-md-1 d-flex align-items-center">
+          <%= fa_icon( alert_icon(alert_content.alert, 'fa-3x') ) %>
+          </div>
+          <div class="col-md-11">
+          <%= alert_content.send(content_field) %>
+            <div class="text-right">
+              <%= link_to 'View analysis', insights_school_advice_total_energy_use_path(@school), class: 'btn btn-rounded btn-fixed-width-10' %>
+            </div>
+          </div>
+        </div>
+      <% end %>
+
+  <% end %>
+<% end %>

--- a/app/views/schools/advice/_list.html.erb
+++ b/app/views/schools/advice/_list.html.erb
@@ -1,0 +1,47 @@
+<div class="table-responsive-sm">
+  <table class="table table-borderless table-sm">
+    <thead>
+      <tr>
+        <th></th>
+        <th colspan="1"></th>
+        <th colspan="2">Annual Saving</th>
+        <th></th>
+      </tr>
+      <tr>
+        <th></th>
+        <th scope="col"></th>
+        <th scope="col">Cost</th>
+        <th scope="col">Co2 (kg/CO2)</th>
+        <th scope="col"></th>
+      </tr>
+    </thead>
+    <tbody>
+      <% management_priorities.each do |priority| %>
+        <tr>
+          <td>
+            <span class="<%=fuel_type_class(priority.find_out_more.alert.alert_type.fuel_type)%>">
+              <%= fa_icon fuel_type_icon(priority.find_out_more.alert.alert_type.fuel_type) %>
+            </span>
+          </td>
+          <td scope="row">
+            <%= link_to priority.management_priorities_title, advice_page_path(school, AdvicePage.first) %>
+          </td>
+          <td><%= priority.template_variables[:average_one_year_saving_gbp] %></td>
+          <td><%= priority.template_variables[:one_year_saving_co2] %><br></td>
+          <td>
+            <% if priority.find_out_more %>
+              <%= link_to 'View analysis', advice_page_path(school, AdvicePage.first), class: 'btn btn-rounded btn-fixed-width-10' %>
+            <% end %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+    <% if local_assigns[:show_more] %>
+      <tfoot>
+        <tr>
+          <td colspan="5" class="text-right"><%= link_to t('management.priorities.more_opportunities'), management_school_management_priorities_path(school)  %></td>
+        </tr>
+      </tfoot>
+    <% end %>
+  </table>
+</div>

--- a/app/views/schools/advice/_list.html.erb
+++ b/app/views/schools/advice/_list.html.erb
@@ -1,47 +1,56 @@
-<div class="table-responsive-sm">
-  <table class="table table-borderless table-sm">
-    <thead>
+<style>
+  td h4 {
+    padding-top: 0px;
+    padding-bottom: 0px;
+  }
+
+  td h4 a div.trix-content div {
+    font-size: inherit;
+  }
+</style>
+<table class="table table-borderless table-sorted advice-table" style="margin-top: 10px !important;">
+  <thead>
+    <tr>
+      <th>Fuel</th>
+      <th data-orderable="false"></th>
+      <th>Cost saving</th>
+      <th>Co2 reduction</th>
+      <!--
+      <th data-orderable="false"></th>
+      -->
+    </tr>
+  </thead>
+  <tbody id="priority">
+    <% management_priorities.each do |priority| %>
       <tr>
-        <th></th>
-        <th colspan="1"></th>
-        <th colspan="2">Annual Saving</th>
-        <th></th>
-      </tr>
-      <tr>
-        <th></th>
-        <th scope="col"></th>
-        <th scope="col">Cost</th>
-        <th scope="col">Co2 (kg/CO2)</th>
-        <th scope="col"></th>
-      </tr>
-    </thead>
-    <tbody>
-      <% management_priorities.each do |priority| %>
-        <tr>
-          <td>
-            <span class="<%=fuel_type_class(priority.find_out_more.alert.alert_type.fuel_type)%>">
-              <%= fa_icon fuel_type_icon(priority.find_out_more.alert.alert_type.fuel_type) %>
-            </span>
-          </td>
-          <td scope="row">
+        <td data-order="<%= priority.find_out_more.alert.alert_type.fuel_type %>">
+          <span class="<%=fuel_type_class(priority.find_out_more.alert.alert_type.fuel_type)%>">
+            <%= fa_icon alert_icon(priority.find_out_more.alert,'fa-2x') %>
+          </span>
+        </td>
+        <td>
+          <h4>
             <%= link_to priority.management_priorities_title, advice_page_path(school, AdvicePage.first) %>
-          </td>
-          <td><%= priority.template_variables[:average_one_year_saving_gbp] %></td>
-          <td><%= priority.template_variables[:one_year_saving_co2] %><br></td>
-          <td>
-            <% if priority.find_out_more %>
-              <%= link_to 'View analysis', advice_page_path(school, AdvicePage.first), class: 'btn btn-rounded btn-fixed-width-10' %>
-            <% end %>
-          </td>
-        </tr>
-      <% end %>
-    </tbody>
-    <% if local_assigns[:show_more] %>
-      <tfoot>
-        <tr>
-          <td colspan="5" class="text-right"><%= link_to t('management.priorities.more_opportunities'), management_school_management_priorities_path(school)  %></td>
-        </tr>
-      </tfoot>
+          </h4>
+        </td>
+        <td>
+          <h4>
+            <%= priority.template_variables[:average_one_year_saving_gbp] %>
+          </h4>
+        </td>
+        <td>
+            <h4>
+              <%= priority.template_variables[:one_year_saving_co2] %>
+            </h4>
+        </td>
+        <!--
+        <td>
+          <% if priority.find_out_more %>
+            <%= link_to 'View analysis', advice_page_path(school, AdvicePage.first), class: 'btn btn-rounded btn-fixed-width-10' %>
+          <% end %>
+        </td>
+        -->
+      </tr>
     <% end %>
-  </table>
-</div>
+  </tbody>
+</table>

--- a/app/views/schools/advice/_list.html.erb
+++ b/app/views/schools/advice/_list.html.erb
@@ -15,6 +15,7 @@
       <th data-orderable="false"></th>
       <th>Cost saving</th>
       <th>Co2 reduction</th>
+      <th>Delivery cost</th>
       <!--
       <th data-orderable="false"></th>
       -->
@@ -42,6 +43,11 @@
             <h4>
               <%= priority.template_variables[:one_year_saving_co2] %>
             </h4>
+        </td>
+        <td>
+          <h4>
+            <%= priority.template_variables[:average_capital_cost] %>
+          </h4>
         </td>
         <!--
         <td>

--- a/app/views/schools/advice/show.html.erb
+++ b/app/views/schools/advice/show.html.erb
@@ -11,14 +11,57 @@
   <div class="col-md-3 col-lg-3 col-xl-2 advice-page-nav">
     <%= render 'nav', school: @school, advice_pages: @advice_pages %>
   </div>
+
   <div class="col-md-9 col-lg-9 col-xl-10 advice-page-tabs">
-    <h2><%= component 'page_nav/collapse_button', display: 'inline' %> All pages</h2>
-    <% if @advice_pages.any? %>
-      <% @advice_pages.each do |advice_page| %>
-        <li><%= link_to advice_page.key, advice_page_path(@school, advice_page) %></li>
-      <% end %>
+    <ul class="nav nav-tabs locales">
+      <li class="nav-item d-md-none">
+        <%= component 'page_nav/collapse_button' %>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link active" href="<%= school_advice_path(@school) %>">
+          Priorities
+        </a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link" href="<%= school_advice_path(@school, alerts: true) %>">
+          Alerts
+        </a>
+      </li>
+    </ul>
+
+    <% if params[:alerts] %>
+      <div class="row mt-4">
+        <div class="col">
+          <%= component 'notice', status: :neutral do |c| %>
+            <p>
+              These are the latest alerts for your school.
+            </p>
+          <% end %>
+
+          <% if @dashboard_alerts %>
+            <%= render 'shared/dashboard_alerts', dashboard_alerts: @dashboard_alerts, school: @school, content_field: :management_dashboard_title, show_all: true %>
+          <% end %>
+        </div>
+      </div>
     <% else %>
-      <p>No advice pages</p>
+      <div class="row mt-4">
+        <div class="col">
+          <%= component 'notice', status: :neutral do |c| %>
+            <% c.with_link { link_to 'View energy use summary', insights_school_advice_total_energy_use_path(@school) } %>
+            <p>
+              Prioritise the following areas to help reduce your costs and
+              co2 emissions.
+            </p>
+            <p>
+              Used the links on the left to explore your energy usage data in more
+              detail
+            </p>
+          <% end %>
+          <%= render 'list', management_priorities: @management_priorities, school: @school %>
+        </div>
+      </div>
+
     <% end %>
+
   </div>
 </div>

--- a/app/views/schools/advice/show.html.erb
+++ b/app/views/schools/advice/show.html.erb
@@ -19,12 +19,17 @@
       </li>
       <li class="nav-item">
         <a class="nav-link active" href="<%= school_advice_path(@school) %>">
-          Priority areas
+          Overview
+        </a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link" href="<%= school_advice_path(@school, savings: true) %>">
+          Priority areas <span class="badge badge-secondary"><%= @management_priorities.count %></span>
         </a>
       </li>
       <li class="nav-item">
         <a class="nav-link" href="<%= school_advice_path(@school, alerts: true) %>">
-          Latest alerts
+          Recent alerts <span class="badge badge-secondary"><%= @dashboard_alerts.count %></span>
         </a>
       </li>
     </ul>
@@ -32,18 +37,17 @@
     <% if params[:alerts] %>
       <div class="row mt-4">
         <div class="col">
-          <h2>Latest alerts</h2>
+          <h2>Recent alerts</h2>
 
           <% if @dashboard_alerts %>
             <%= render 'alerts', dashboard_alerts: @dashboard_alerts, school: @school, content_field: :management_dashboard_title %>
           <% end %>
         </div>
       </div>
-
-    <% else %>
+    <% elsif params[:savings] %>
       <div class="row mt-4">
         <div class="col">
-          <h2>Prioritised cost savings</h2>
+          <h2>Priority areas</h2>
 
           <%= component 'notice', status: :neutral do |c| %>
             <% c.with_link { link_to 'View energy use summary', insights_school_advice_total_energy_use_path(@school) } %>
@@ -60,7 +64,53 @@
           <%= render 'list', management_priorities: @management_priorities, school: @school %>
         </div>
       </div>
+    <% else %>
 
+        <div class="row mt-4">
+          <div class="col">
+            <h2>Overview</h2>
+            <p>
+              We carry out a detailed analysis of your school energy data. You can
+              explore our analysis using the links below or in the navigation bar
+              on the left.
+            </p>
+            <p>
+              Every page provides recommended activities for both adults and pupils to help you
+              reduce your energy usage and carbon emissions.
+            </p>
+            <%= component 'notice', status: :neutral do |c| %>
+              <% c.with_link { link_to 'View priority areas', school_advice_path(@school, savings: true) } %>
+              <p>
+                Looking for suggestions of where to start first? Review our suggested priority areas and
+                your recent alerts.
+              </p>
+            <% end %>
+          </div>
+        </div>
+
+
+          <% AdvicePage.fuel_types.each do |fuel_type| %>
+          <div class="row mt-4">
+            <div class="col">
+              <h3>
+                <span class="<%=fuel_type_class(fuel_type.first)%>">
+                  <%= fa_icon( fuel_type_icon(fuel_type.first) ) %>
+                </span>
+                <%= t("advice_pages.nav.sections.#{fuel_type.first}") %>
+              </h3>
+              <% AdvicePage.where(fuel_type: fuel_type.first).order(:key).each do |ap| %>
+                <div class="mt-4 row d-flex align-items-center" style="">
+                  <div class="col">
+                    <h4><%= link_to t("advice_pages.nav.pages.#{ap.key}"), advice_page_path(@school, ap) %></h4>
+                  </div>
+                  <div class="col">
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam id bibendum mauris.
+                  </div>
+                </div>
+              <% end %>
+            </div>
+          </div>
+          <% end %>
     <% end %>
 
   </div>

--- a/app/views/schools/advice/show.html.erb
+++ b/app/views/schools/advice/show.html.erb
@@ -19,12 +19,12 @@
       </li>
       <li class="nav-item">
         <a class="nav-link active" href="<%= school_advice_path(@school) %>">
-          Priorities
+          Priority areas
         </a>
       </li>
       <li class="nav-item">
         <a class="nav-link" href="<%= school_advice_path(@school, alerts: true) %>">
-          Alerts
+          Latest alerts
         </a>
       </li>
     </ul>
@@ -32,20 +32,19 @@
     <% if params[:alerts] %>
       <div class="row mt-4">
         <div class="col">
-          <%= component 'notice', status: :neutral do |c| %>
-            <p>
-              These are the latest alerts for your school.
-            </p>
-          <% end %>
+          <h2>Latest alerts</h2>
 
           <% if @dashboard_alerts %>
-            <%= render 'shared/dashboard_alerts', dashboard_alerts: @dashboard_alerts, school: @school, content_field: :management_dashboard_title, show_all: true %>
+            <%= render 'alerts', dashboard_alerts: @dashboard_alerts, school: @school, content_field: :management_dashboard_title %>
           <% end %>
         </div>
       </div>
+
     <% else %>
       <div class="row mt-4">
         <div class="col">
+          <h2>Prioritised cost savings</h2>
+
           <%= component 'notice', status: :neutral do |c| %>
             <% c.with_link { link_to 'View energy use summary', insights_school_advice_total_energy_use_path(@school) } %>
             <p>
@@ -57,6 +56,7 @@
               detail
             </p>
           <% end %>
+
           <%= render 'list', management_priorities: @management_priorities, school: @school %>
         </div>
       </div>

--- a/config/locales/views/advice_pages/advice_pages.yml
+++ b/config/locales/views/advice_pages/advice_pages.yml
@@ -85,7 +85,7 @@ en:
       message: We don't currently have enough %{fuel_type} data in order to run this analysis for your school.
       title: Not enough data to run analysis
     show:
-      title: Advice Pages
+      title: Energy efficiency advice
     tables:
       columns:
         category: Category

--- a/spec/system/schools/advice_pages/advice_pages_spec.rb
+++ b/spec/system/schools/advice_pages/advice_pages_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe "advice pages", type: :system do
     end
     it 'shows the no fuel type page' do
       visit school_advice_path(school)
-      click_on key
+      click_on 'Total energy use'
       expect(page).to have_content('Unable to run requested analysis')
     end
   end
@@ -45,7 +45,7 @@ RSpec.describe "advice pages", type: :system do
     end
     it 'shows the not enough data page' do
       visit school_advice_path(school)
-      click_on key
+      click_on 'Total energy use'
       expect(page).to have_content('Not enough data to run analysis')
       expect(page).to_not have_content('Assuming we continue to regularly receive data')
     end
@@ -53,7 +53,7 @@ RSpec.describe "advice pages", type: :system do
       let(:data_available_from) { Date.today + 10 }
       it 'also includes the data' do
         visit school_advice_path(school)
-        click_on key
+        click_on 'Total energy use'
         expect(page).to have_content("Assuming we continue to regularly receive data we expect this analysis to be available after #{data_available_from.to_s(:es_short)}")
       end
     end
@@ -67,8 +67,8 @@ RSpec.describe "advice pages", type: :system do
     end
 
     it 'shows the advice pages index' do
-      expect(page).to have_content('Advice Pages')
-      expect(page).to have_link(key)
+      expect(page).to have_content('Energy efficiency advice')
+      expect(page).to have_link('Total energy use')
     end
 
     context 'when page is restricted' do
@@ -76,8 +76,8 @@ RSpec.describe "advice pages", type: :system do
         advice_page.update(restricted: true)
       end
       it 'does not show the restricted advice page' do
-        click_on key
-        expect(page).to have_content('Advice Pages')
+        click_on 'Total energy use'
+        expect(page).to have_content('Energy efficiency advice')
         expect(page).to have_content("Only an admin or staff user for this school can access this content")
       end
     end
@@ -94,8 +94,8 @@ RSpec.describe "advice pages", type: :system do
     end
 
     it 'shows the advice pages index' do
-      expect(page).to have_content('Advice Pages')
-      expect(page).to have_link(key)
+      expect(page).to have_content('Energy efficiency advice')
+      expect(page).to have_link('Total energy use')
     end
 
     context 'basic navigation checks' do
@@ -140,8 +140,7 @@ RSpec.describe "advice pages", type: :system do
         within '#manage_school_menu' do
           click_on 'Advice pages'
         end
-        expect(page).to have_content("Advice Pages")
-        expect(page).to have_content("All pages")
+        expect(page).to have_content("Energy efficiency advice")
       end
 
       it 'links from admin page' do


### PR DESCRIPTION
This is a rough prototype for a new advice index page. DO NOT MERGE

* Replaces index page with a list of prioritised areas, using existing management priorities
* Adds an alerts tab with existing content from school alerts

Links are all placeholders, just using this to get feedback on the UX before replacing this branch with a proper implementation.