### PR TITLE
Add extra fields to alert type

### DIFF
--- a/app/models/advice_page.rb
+++ b/app/models/advice_page.rb
@@ -19,6 +19,7 @@ class AdvicePage < ApplicationRecord
 
   translates :learn_more, backend: :action_text
 
+  has_many :alert_types
   has_many :advice_page_activity_types
   has_many :activity_types, through: :advice_page_activity_types
 

--- a/app/models/alert_type.rb
+++ b/app/models/alert_type.rb
@@ -2,17 +2,25 @@
 #
 # Table name: alert_types
 #
+#  advice_page_id  :bigint(8)
 #  background      :boolean          default(FALSE)
 #  benchmark       :boolean          default(FALSE)
 #  class_name      :text
 #  frequency       :integer
 #  fuel_type       :integer
+#  group           :integer          default("advice"), not null
 #  has_ratings     :boolean          default(TRUE)
 #  id              :bigint(8)        not null, primary key
+#  link_to         :integer          default("insights_page"), not null
+#  link_to_section :string
 #  source          :integer          default("analytics"), not null
 #  sub_category    :integer
 #  title           :text
 #  user_restricted :boolean          default(FALSE), not null
+#
+# Indexes
+#
+#  index_alert_types_on_advice_page_id  (advice_page_id)
 #
 
 class AlertType < ApplicationRecord
@@ -30,6 +38,7 @@ class AlertType < ApplicationRecord
   enum sub_category: SUB_CATEGORIES
   enum frequency: [:termly, :weekly, :before_each_holiday]
   enum group: [:advice, :benchmarking, :change, :priority]
+  enum link_to: [:insights_page, :analysis_page, :learn_more_page]
 
   scope :electricity,   -> { where(fuel_type: :electricity) }
   scope :gas,           -> { where(fuel_type: :gas) }

--- a/app/models/alert_type.rb
+++ b/app/models/alert_type.rb
@@ -18,6 +18,8 @@
 class AlertType < ApplicationRecord
   SUB_CATEGORIES = [:hot_water, :heating, :baseload, :electricity_use, :solar_pv, :tariffs, :co2, :boiler_control, :overview, :storage_heaters].freeze
 
+  belongs_to :advice_page, optional: true
+
   has_many :alerts
 
   has_many :ratings, class_name: 'AlertTypeRating'
@@ -27,6 +29,7 @@ class AlertType < ApplicationRecord
   enum fuel_type: [:electricity, :gas, :storage_heater, :solar_pv], _suffix: :fuel_type
   enum sub_category: SUB_CATEGORIES
   enum frequency: [:termly, :weekly, :before_each_holiday]
+  enum group: [:advice, :benchmarking, :change, :priority]
 
   scope :electricity,   -> { where(fuel_type: :electricity) }
   scope :gas,           -> { where(fuel_type: :gas) }
@@ -34,7 +37,7 @@ class AlertType < ApplicationRecord
 
   scope :editable, -> { where.not(background: true) }
 
-  validates_presence_of :frequency, :title, :class_name, :source
+  validates_presence_of :frequency, :title, :class_name, :source, :group
 
   has_rich_text :description
 

--- a/app/models/school_group.rb
+++ b/app/models/school_group.rb
@@ -4,6 +4,7 @@
 #
 #  created_at                    :datetime         not null
 #  default_chart_preference      :integer          default("default"), not null
+#  default_country               :integer          default("england"), not null
 #  default_dark_sky_area_id      :bigint(8)
 #  default_issues_admin_user_id  :bigint(8)
 #  default_scoreboard_id         :bigint(8)

--- a/app/models/school_onboarding.rb
+++ b/app/models/school_onboarding.rb
@@ -3,6 +3,7 @@
 # Table name: school_onboardings
 #
 #  contact_email            :string           not null
+#  country                  :integer          default("england"), not null
 #  created_at               :datetime         not null
 #  created_by_id            :bigint(8)
 #  created_user_id          :bigint(8)

--- a/db/migrate/20230302122743_add_advice_page_and_group_to_alert_type.rb
+++ b/db/migrate/20230302122743_add_advice_page_and_group_to_alert_type.rb
@@ -1,6 +1,8 @@
 class AddAdvicePageAndGroupToAlertType < ActiveRecord::Migration[6.0]
   def change
     add_reference :alert_types, :advice_page, index: true
+    add_column :alert_types, :link_to, :integer, default: 0, null: false
+    add_column :alert_types, :link_to_section, :string, null: true
     add_column :alert_types, :group, :integer, default: 0, null: false
   end
 end

--- a/db/migrate/20230302122743_add_advice_page_and_group_to_alert_type.rb
+++ b/db/migrate/20230302122743_add_advice_page_and_group_to_alert_type.rb
@@ -1,0 +1,6 @@
+class AddAdvicePageAndGroupToAlertType < ActiveRecord::Migration[6.0]
+  def change
+    add_reference :alert_types, :advice_page, index: true
+    add_column :alert_types, :group, :integer, default: 0, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_02_24_111633) do
+ActiveRecord::Schema.define(version: 2023_03_02_122743) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
@@ -314,6 +314,9 @@ ActiveRecord::Schema.define(version: 2023_02_24_111633) do
     t.boolean "background", default: false
     t.boolean "benchmark", default: false
     t.boolean "user_restricted", default: false, null: false
+    t.bigint "advice_page_id"
+    t.integer "group", default: 0, null: false
+    t.index ["advice_page_id"], name: "index_alert_types_on_advice_page_id"
   end
 
   create_table "alerts", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -315,6 +315,8 @@ ActiveRecord::Schema.define(version: 2023_03_02_122743) do
     t.boolean "benchmark", default: false
     t.boolean "user_restricted", default: false, null: false
     t.bigint "advice_page_id"
+    t.integer "link_to", default: 0, null: false
+    t.string "link_to_section"
     t.integer "group", default: 0, null: false
     t.index ["advice_page_id"], name: "index_alert_types_on_advice_page_id"
   end

--- a/lib/tasks/deployment/20230302123836_assign_group_to_alert.rake
+++ b/lib/tasks/deployment/20230302123836_assign_group_to_alert.rake
@@ -1,0 +1,27 @@
+namespace :after_party do
+  desc 'Deployment task: assign_group_to_alert'
+  task assign_group_to_alert: :environment do
+    puts "Running deploy task 'assign_group_to_alert'"
+
+    #Add all the benchmarking alerts to benchmarking group
+    AlertType.analytics.where("class_name like ?", "%Benchmark").update_all(group: :benchmarking)
+
+    #Add all the comparison alerts and baseload change to the change detection group
+    AlertType.analytics.where("class_name like ?", "%Comparison%").update_all(group: :change)
+    AlertType.find_by_class_name("AlertChangeInElectricityBaseloadShortTerm").update!(group: :change)
+
+    #Add all the alerts focused on short term issues to priority group
+    AlertType.find_by_class_name("AlertElectricityUsageDuringCurrentHoliday").update!(group: :priority)
+    AlertType.find_by_class_name("AlertGasHeatingHotWaterOnDuringHoliday").update!(group: :priority)
+    AlertType.find_by_class_name("AlertStorageHeaterHeatingOnDuringHoliday").update!(group: :priority)
+    AlertType.find_by_class_name("AlertTurnHeatingOff").update!(group: :priority)
+    AlertType.find_by_class_name("AlertTurnHeatingOffStorageHeaters").update!(group: :priority)
+    AlertType.find_by_class_name("AlertImpendingHoliday").update!(group: :priority)
+    AlertType.find_by_class_name("AlertWeekendGasConsumptionShortTerm").update!(group: :priority)
+
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord
+      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+  end
+end

--- a/lib/tasks/deployment/20230302140543_assign_advice_page_to_alert_type.rake
+++ b/lib/tasks/deployment/20230302140543_assign_advice_page_to_alert_type.rake
@@ -1,0 +1,92 @@
+namespace :after_party do
+  desc 'Deployment task: assign_advice_page_to_alert_type'
+  task assign_advice_page_to_alert_type: :environment do
+    puts "Running deploy task 'assign_advice_page_to_alert_type'"
+
+    #Add AdvicePage to Alerts, for linking from dashboard alerts
+    ALERTS = {
+      "AlertHeatingComingOnTooEarly" => :baseload,
+      "AlertHeatingSensitivityAdvice" => :heating_control,
+      "AlertHotWaterEfficiency" => :hot_water,
+      "AlertOutOfHoursElectricityUsage" => :electricity_out_of_hours,
+      "AlertOutOfHoursGasUsage" => :gas_out_of_hours,
+      "AlertHotWaterInsulationAdvice" => :hot_water,
+      "AlertThermostaticControl" => :thermostatic,
+      "AlertElectricityMeterConsolidationOpportunity" => :electricity_costs,
+      "AlertGasMeterConsolidationOpportunity" => :gas_costs,
+      "AlertMeterASCLimit" => :electricity_costs,
+      "AlertStorageHeaterThermostatic" => :storage_heaters,
+      "AlertStorageHeaterOutOfHours" => :storage_heaters,
+      "AlertSolarPVBenefitEstimator" => :solar_pv,
+      "AlertElectricityLongTermTrend" => :electricity_long_term,
+      "AlertGasLongTermTrend" => :gas_long_term,
+      "AlertStorageHeatersLongTermTrend" => :storage_heaters,
+      "AlertOptimumStartAnalysis" => :heating_control,
+      "AlertChangeInElectricityBaseloadShortTerm" => :baseload,
+      "AlertWeekendGasConsumptionShortTerm" => :gas_out_of_hours,
+      "AlertSchoolWeekComparisonElectricity" => :electricity_recent_changes,
+      "AlertPreviousHolidayComparisonElectricity" => :electricity_out_of_hours,
+      "AlertPreviousYearHolidayComparisonElectricity" => :electricity_out_of_hours,
+      "AlertSchoolWeekComparisonGas" => :gas_recent_changes,
+      "AlertPreviousHolidayComparisonGas" => :gas_out_of_hours,
+      "AlertSeasonalBaseloadVariation" => :baseload,
+      "AlertIntraweekBaseloadVariation" => :baseload,
+      "AlertSeasonalHeatingSchoolDays" => :gas_out_of_hours,
+      "AlertSeasonalHeatingSchoolDaysStorageHeaters" => :storage_heaters,
+      "AlertElectricityUsageDuringCurrentHoliday" => :electricity_out_of_hours,
+      "AlertGasHeatingHotWaterOnDuringHoliday" => :gas_out_of_hours,
+      "AlertStorageHeaterHeatingOnDuringHoliday" => :storage_heaters,
+      "AlertTurnHeatingOff" => :heating_control,
+      "AlertTurnHeatingOffStorageHeaters" => :storage_heaters,
+      "AlertEnergyAnnualVersusBenchmark" => :total_energy_use,
+      "AlertElectricityAnnualVersusBenchmark" => :electricity_long_term,
+      "AlertElectricityBaseloadVersusBenchmark" => :baseload,
+      "AlertGasAnnualVersusBenchmark" => :gas_long_term,
+      "AlertElectricityPeakKWVersusBenchmark" => :electricity_intraday,
+      "AlertStorageHeaterAnnualVersusBenchmark" => :storage_heaters,
+      "AlertPreviousYearHolidayComparisonGas" => :gas_out_of_hours
+    }
+
+    ALERTS.each do |clazz, key|
+      advice_page = AdvicePage.find_by_key(key)
+      AlertType.where(class_name: clazz).update(advice_page: advice_page)
+    end
+
+    #Add advice page for analysis pages, to handle redirects
+    OLD_ANALYSIS_PAGES = {
+      "AdviceGasOutHours" => :gas_out_of_hours,
+      "AdviceBenchmark" => :total_energy_use,
+      "AdviceGasAnnual" => :gas_long_term,
+      "AdviceElectricityAnnual" => :electricity_long_term,
+      "AdviceElectricityOutHours" => :electricity_out_of_hours,
+      "AdviceElectricityLongTerm" => :electricity_long_term,
+      "AdviceElectricityRecent" => :electricity_recent_changes,
+      "AdviceGasLongTerm" => :gas_long_term,
+      "AdviceGasRecent" => :gas_recent_changes,
+      "AdviceGasBoilerMorningStart" => :heating_control,
+      "AdviceGasBoilerSeasonalControl" => :heating_control,
+      "AdviceGasHotWater" => :hot_water,
+      "AdviceEnergyTariffs" => :electricity_costs,
+      "AdviceElectricityIntraday" => :electricity_intraday,
+      "AdviceGasBoilerFrost" => :heating_control,
+      "AdviceStorageHeaters" => :storage_heaters,
+      "AdviceSolarPV" => :solar_pv,
+      "AdviceGasThermostaticControl" => :thermostatic,
+      "AdviceBaseload" => :baseload,
+      "AdviceGasCosts" => :gas_costs,
+      "AdviceElectricityCosts" => :electricity_costs,
+      "AdviceGasMeterBreakdownBase" => :gas_costs,
+      "AdviceElectricityMeterBreakdownBase" => :electricity_costs
+    }
+
+    OLD_ANALYSIS_PAGES.each do |clazz, key|
+      advice_page = AdvicePage.find_by_key(key)
+      AlertType.where(class_name: clazz).update(advice_page: advice_page)
+    end
+
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord
+      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+  end
+end


### PR DESCRIPTION
Adds some extra fields to `AlertType`:

* a reference to `AdvicePages` which will allow us to link alerts to their pages, as well as redirect users from the old analysis pages to the new versions
* a `group` attribute that will be used to categorise the alerts based on whether they are carrying out benchmarking of a school, reporting on short term changes, indicate some priority areas for attention, or are just general advice. This will allow us to improve the display and prioritisation of alert content on the advice page index
* a `link_to` property to indicate which tab of the advice page to link to, defaulting to insights
* a `link_to_section` property, to indicate a section of the insights or analysis page to link to

The last two are to allow admins to have some control over where to send users clicking on a dashboard alert.

Also includes: 

* an after party task to populate the group attribute
* an after party task to populate the advice page reference

The other changes will rely on admins editing the content.