### PR TITLE
Compare pages - Implement 'your group' tab

### DIFF
--- a/app/controllers/compare_controller.rb
+++ b/app/controllers/compare_controller.rb
@@ -9,6 +9,7 @@ class CompareController < ApplicationController
 
   # filters
   def group
+    params[:school_types] ||= School.school_types.keys
   end
 
   def categories
@@ -18,7 +19,7 @@ class CompareController < ApplicationController
   end
 
   # pick benchmark
-  def benchmark
+  def benchmarks
   end
 
   # display results

--- a/app/controllers/compare_controller.rb
+++ b/app/controllers/compare_controller.rb
@@ -1,6 +1,6 @@
 class CompareController < ApplicationController
-  skip_before_action :authenticate_user!
   before_action :header_fix_enabled
+  skip_before_action :authenticate_user!
 
   before_action :get_school_group
   before_action :redirect_unless_school_group, only: [:group]

--- a/app/controllers/compare_controller.rb
+++ b/app/controllers/compare_controller.rb
@@ -1,6 +1,9 @@
 class CompareController < ApplicationController
-  before_action :header_fix_enabled
   skip_before_action :authenticate_user!
+  before_action :header_fix_enabled
+
+  before_action :get_school_group
+  before_action :redirect_unless_school_group, only: [:group]
 
   # before_action :latest_benchmark_run, only: [:results]
 
@@ -20,5 +23,15 @@ class CompareController < ApplicationController
 
   # display results
   def results
+  end
+
+  private
+
+  def get_school_group
+    @school_group = current_user.try(:default_school_group)
+  end
+
+  def redirect_unless_school_group
+    redirect_to categories_compare_url unless @school_group
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -138,8 +138,11 @@ class User < ApplicationRecord
   end
 
   def school_group_name
-    return school.school_group.name if school && school.school_group
-    return school_group.name if school_group
+    default_school_group.try(:name)
+  end
+
+  def default_school_group
+    school.try(:school_group) || school_group
   end
 
   def self.new_pupil(school, attributes)

--- a/app/views/compare/_header.html.erb
+++ b/app/views/compare/_header.html.erb
@@ -11,3 +11,5 @@
     </div>
   </div>
 </div>
+
+<%= render 'tabs', tab: controller.action_name %>

--- a/app/views/compare/_header.html.erb
+++ b/app/views/compare/_header.html.erb
@@ -1,15 +1,19 @@
+<% content_for :page_title, t('compare.title') %>
+
 <h1><%= t('compare.title') %></h1>
 
-<div class="container">
-  <div class="row">
-    <div class="col-md">
-      <p><%= t("compare.#{controller.action_name}.intro") %></p>
-      <p><%= t("compare.options", schools_count: 'X', benchmarks_count: 'Y') %></p>
-    </div>
-    <div class="col-md">
-      <%= t("compare.summary_html") %>
-    </div>
+<div class="row">
+  <div class="col-md">
+    <p><%= t("compare.#{controller.action_name}.intro") %></p>
+    <p><%= t("compare.options", schools_count: 'X', benchmarks_count: 'Y') %></p>
+  </div>
+  <div class="col-md">
+    <%= t("compare.summary_html") %>
   </div>
 </div>
 
-<%= render 'tabs', tab: controller.action_name %>
+<div class="row">
+  <div class="col">
+    <%= render 'tabs', tab: controller.action_name %>
+  </div>
+</div>

--- a/app/views/compare/_tabs.html.erb
+++ b/app/views/compare/_tabs.html.erb
@@ -1,0 +1,17 @@
+<ul class="nav nav-tabs locales">
+  <li class="nav-item">
+    <a class="nav-link <%= 'active' if tab == 'group' %>" href="<%= group_compare_path %>">
+      <%= t('compare.group.tab') %>
+    </a>
+  </li>
+  <li class="nav-item">
+    <a class="nav-link <%= 'active' if tab == 'categories' %>" href="<%= categories_compare_path %>">
+      <%= t('compare.categories.tab') %>
+    </a>
+  </li>
+  <li class="nav-item">
+    <a class="nav-link <%= 'active' if tab == 'groups' %>" href="<%= groups_compare_path %>">
+    <%= t('compare.groups.tab') %>
+    </a>
+  </li>
+</ul>

--- a/app/views/compare/_tabs.html.erb
+++ b/app/views/compare/_tabs.html.erb
@@ -1,17 +1,13 @@
 <ul class="nav nav-tabs locales">
+  <% if @school_group %>
+    <li class="nav-item">
+      <a class="nav-link <%= 'active' if tab == 'group' %>" href="<%= group_compare_path %>"><%= t('compare.group.tab') %></a>
+    </li>
+  <% end %>
   <li class="nav-item">
-    <a class="nav-link <%= 'active' if tab == 'group' %>" href="<%= group_compare_path %>">
-      <%= t('compare.group.tab') %>
-    </a>
+    <a class="nav-link <%= 'active' if tab == 'categories' %>" href="<%= categories_compare_path %>"><%= t('compare.categories.tab') %></a>
   </li>
   <li class="nav-item">
-    <a class="nav-link <%= 'active' if tab == 'categories' %>" href="<%= categories_compare_path %>">
-      <%= t('compare.categories.tab') %>
-    </a>
-  </li>
-  <li class="nav-item">
-    <a class="nav-link <%= 'active' if tab == 'groups' %>" href="<%= groups_compare_path %>">
-    <%= t('compare.groups.tab') %>
-    </a>
+    <a class="nav-link <%= 'active' if tab == 'groups' %>" href="<%= groups_compare_path %>"><%= t('compare.groups.tab') %></a>
   </li>
 </ul>

--- a/app/views/compare/categories.html.erb
+++ b/app/views/compare/categories.html.erb
@@ -1,0 +1,1 @@
+<%= render 'header' %>

--- a/app/views/compare/group.html.erb
+++ b/app/views/compare/group.html.erb
@@ -1,1 +1,5 @@
 <%= render 'header' %>
+
+<% School.school_types.keys.each do |school_type| %>
+  <%= School.human_enum_name(:school_type, school_type) %>
+<% end %>

--- a/app/views/compare/group.html.erb
+++ b/app/views/compare/group.html.erb
@@ -1,5 +1,29 @@
 <%= render 'header' %>
 
-<% School.school_types.keys.each do |school_type| %>
-  <%= School.human_enum_name(:school_type, school_type) %>
-<% end %>
+<div class="row">
+  <div class="col">
+    <h4 class='my-2'><%= t('compare.group.title', name: @school_group.name) %></h4>
+  </div>
+</div>
+
+<div class="row">
+  <div class="col-md bg-light ml-3 p-3 rounded border">
+    <div class="smaller"><%= t('compare.limit_by_school_type') %></div>
+    <%= form_tag benchmarks_compare_path, method: :get do %>
+      <div class="nowrap ensure-one-checked">
+        <% School.school_types.keys.each do |school_type| %>
+          <%= check_box_tag('school_types[]', school_type, (params[:school_types] ||= []).include?(school_type), id: school_type, class: "badge-toggle-secondary") %>
+          <%= label_tag school_type, t('common.school_types.' + school_type),
+              data: {
+                toggle: "tooltip",
+                placement: "bottom",
+                delay: { "show": 500, "hide": 100 }},
+              title: "Select at least one" %>
+        <% end %>
+      </div>
+      <div class="pt-2">
+        <%= submit_tag 'Compare schools', class: 'btn btn-sm' %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/compare/groups.html.erb
+++ b/app/views/compare/groups.html.erb
@@ -1,0 +1,1 @@
+<%= render 'header' %>

--- a/app/views/home/_school_details.html.erb
+++ b/app/views/home/_school_details.html.erb
@@ -21,7 +21,7 @@
               <td><%= link_to school.name, school_path(school) %></td>
               <td><%= school.postcode %></td>
               <td><%= school.number_of_pupils %></td>
-              <td><%= t('analytics.school_types.' + school.school_type) %></td>
+              <td><%= t('common.school_types.' + school.school_type) %></td>
               <td class="text-right"><%= school.percentage_free_school_meals %></td>
             </tr>
           <% end %>

--- a/app/views/home/_school_types.html.erb
+++ b/app/views/home/_school_types.html.erb
@@ -12,7 +12,7 @@
       <tbody>
         <% @report.school_types.keys.sort.each do |type| %>
           <tr>
-            <td><%= t('analytics.school_types.' + type) %></td>
+            <td><%= t('common.school_types.' + type) %></td>
             <td class="text-right"><%= report.school_types[type] %></td>
           </tr>
         <% end %>

--- a/app/views/schools/_details_form.html.erb
+++ b/app/views/schools/_details_form.html.erb
@@ -51,7 +51,7 @@
   <% School.school_types.keys.each do |school_type| %>
     <div class="form-check form-check-inline">
       <%= f.radio_button :school_type, school_type, class: "form-check-input" %>
-      <%= f.label "school_type_#{school_type.to_sym}", t("school_types.#{school_type}", default: school_type.humanize),  class: "form-check-label" %>
+      <%= f.label "school_type_#{school_type.to_sym}", t("common.school_types.#{school_type}", default: school_type.humanize),  class: "form-check-label" %>
     </div>
   <% end %>
 </div>

--- a/app/views/schools/advice/_how_have_we_analysed_your_data.html.erb
+++ b/app/views/schools/advice/_how_have_we_analysed_your_data.html.erb
@@ -42,7 +42,7 @@
     </tr>
     <tr>
       <td class="text-left"><%= t('advice_pages.how_have_we_analysed_your_data.school_characteristics_table.rows.type') %></td>
-      <td><%= t("analytics.school_types.#{@school.school_type}") %></td>
+      <td><%= t("common.school_types.#{@school.school_type}") %></td>
     </tr>
   </tbody>
 </table>

--- a/app/views/schools/advice/baseload/_comparison.html.erb
+++ b/app/views/schools/advice/baseload/_comparison.html.erb
@@ -1,7 +1,7 @@
 <%= render 'schools/advice/section_title', section_id: 'comparison', section_title: t('advice_pages.baseload.comparison.title') %>
 
 <p>
-  <%= t('advice_pages.baseload.comparison.how_do_you_compare', school_type: t('analytics.school_types.' + school.school_type)) %>
+  <%= t('advice_pages.baseload.comparison.how_do_you_compare', school_type: t('common.school_types.' + school.school_type)) %>
 </p>
 
 <div class="col">

--- a/app/views/schools/advice/electricity_intraday/_analysis.html.erb
+++ b/app/views/schools/advice/electricity_intraday/_analysis.html.erb
@@ -17,7 +17,7 @@
   <% c.with_title { t('advice_pages.electricity_intraday.analysis.charts.comparison_chart_title') } %>
   <% c.with_subtitle { t('advice_pages.electricity_intraday.analysis.charts.comparison_chart_subtitle_html', start_month_year: short_dates(@analysis_dates.one_years_data ? @analysis_dates.end_date - 1.year : @analysis_dates.start_date), end_month_year: short_dates(@analysis_dates.end_date)) } %>
   <% c.with_footer do %>
-    <p><%= t('advice_pages.electricity_intraday.analysis.charts.comparison_chart_explanation_html', school_type: t('analytics.school_types.' + @school.school_type).downcase) %></p>
+    <p><%= t('advice_pages.electricity_intraday.analysis.charts.comparison_chart_explanation_html', school_type: t('common.school_types.' + @school.school_type).downcase) %></p>
   <% end %>
 <% end %>
 

--- a/app/views/schools/advice/electricity_long_term/_analysis_comparison.html.erb
+++ b/app/views/schools/advice/electricity_long_term/_analysis_comparison.html.erb
@@ -6,7 +6,7 @@
 <% end %>
 
 <p>
-  <%= t('advice_pages.electricity_long_term.analysis.comparison.table_explanation', school_type: t('analytics.school_types.' + school.school_type)) %>
+  <%= t('advice_pages.electricity_long_term.analysis.comparison.table_explanation', school_type: t('common.school_types.' + school.school_type)) %>
 </p>
 
 <%= render 'comparison_with_benchmark_table', annual_usage: annual_usage, vs_exemplar: vs_exemplar, vs_benchmark: vs_benchmark, estimated_savings_vs_exemplar: estimated_savings_vs_exemplar, estimated_savings_vs_benchmark: estimated_savings_vs_benchmark %>

--- a/app/views/schools/advice/electricity_long_term/_comparison.html.erb
+++ b/app/views/schools/advice/electricity_long_term/_comparison.html.erb
@@ -1,7 +1,7 @@
 <%= render 'schools/advice/section_title', section_id: 'comparison', section_title: t('advice_pages.electricity_long_term.insights.comparison.title') %>
 
 <p>
-  <%= t('advice_pages.electricity_long_term.insights.comparison.how_do_you_compare', school_type: t('analytics.school_types.' + school.school_type)) %>
+  <%= t('advice_pages.electricity_long_term.insights.comparison.how_do_you_compare', school_type: t('common.school_types.' + school.school_type)) %>
 </p>
 
 

--- a/app/views/schools/advice/electricity_out_of_hours/_insights.html.erb
+++ b/app/views/schools/advice/electricity_out_of_hours/_insights.html.erb
@@ -15,7 +15,7 @@
 <%= render 'schools/advice/section_title', section_id: 'current', section_title: t('advice_pages.electricity_out_of_hours.insights.comparison.title') %>
 
 <p>
-  <%= t('advice_pages.electricity_out_of_hours.insights.comparison.how_do_you_compare', school_type: t('analytics.school_types.' + @school.school_type).downcase) %>
+  <%= t('advice_pages.electricity_out_of_hours.insights.comparison.how_do_you_compare', school_type: t('common.school_types.' + @school.school_type).downcase) %>
 </p>
 
 <%= render 'insights_table' %>

--- a/app/views/schools/advice/gas_long_term/_analysis_comparison.html.erb
+++ b/app/views/schools/advice/gas_long_term/_analysis_comparison.html.erb
@@ -6,7 +6,7 @@
 <% end %>
 
 <p>
-  <%= t('advice_pages.gas_long_term.analysis.comparison.table_explanation', school_type: t('analytics.school_types.' + school.school_type)) %>
+  <%= t('advice_pages.gas_long_term.analysis.comparison.table_explanation', school_type: t('common.school_types.' + school.school_type)) %>
 </p>
 
 <%= render 'comparison_with_benchmark_table', annual_usage: annual_usage, vs_exemplar: vs_exemplar, vs_benchmark: vs_benchmark, estimated_savings_vs_exemplar: estimated_savings_vs_exemplar, estimated_savings_vs_benchmark: estimated_savings_vs_benchmark %>

--- a/app/views/schools/advice/gas_long_term/_comparison.html.erb
+++ b/app/views/schools/advice/gas_long_term/_comparison.html.erb
@@ -1,7 +1,7 @@
 <%= render 'schools/advice/section_title', section_id: 'comparison', section_title: t('advice_pages.gas_long_term.insights.comparison.title') %>
 
 <p>
-  <%= t('advice_pages.gas_long_term.insights.comparison.how_do_you_compare', school_type: t('analytics.school_types.' + school.school_type)) %>
+  <%= t('advice_pages.gas_long_term.insights.comparison.how_do_you_compare', school_type: t('common.school_types.' + school.school_type)) %>
 </p>
 
 <div class="col">

--- a/app/views/schools/advice/gas_out_of_hours/_insights.html.erb
+++ b/app/views/schools/advice/gas_out_of_hours/_insights.html.erb
@@ -15,7 +15,7 @@
   <%= render 'schools/advice/section_title', section_id: 'current', section_title: t('advice_pages.gas_out_of_hours.insights.comparison.title') %>
 
   <p>
-    <%= t('advice_pages.gas_out_of_hours.insights.comparison.how_do_you_compare', school_type: t('analytics.school_types.' + @school.school_type).downcase) %>
+    <%= t('advice_pages.gas_out_of_hours.insights.comparison.how_do_you_compare', school_type: t('common.school_types.' + @school.school_type).downcase) %>
   </p>
 
   <%= render 'insights_table' %>

--- a/app/views/schools/advice/total_energy_use/_analysis.html.erb
+++ b/app/views/schools/advice/total_energy_use/_analysis.html.erb
@@ -23,7 +23,7 @@
   <% if @electricity_annual_usage %>
     <h3><%= t('common.electricity') %></h3>
     <p>
-      <%= t('advice_pages.electricity_long_term.analysis.comparison.table_explanation', school_type: t('analytics.school_types.' + @school.school_type).downcase) %>
+      <%= t('advice_pages.electricity_long_term.analysis.comparison.table_explanation', school_type: t('common.school_types.' + @school.school_type).downcase) %>
     </p>
 
     <%= render 'schools/advice/electricity_long_term/comparison_with_benchmark_table', annual_usage: @electricity_annual_usage, vs_exemplar: @electricity_vs_exemplar, vs_benchmark: @electricity_vs_benchmark, estimated_savings_vs_exemplar: @electricity_estimated_savings_vs_exemplar, estimated_savings_vs_benchmark: @electricity_estimated_savings_vs_benchmark %>
@@ -33,7 +33,7 @@
   <% if @gas_annual_usage %>
     <h3><%= t('common.gas') %></h3>
     <p>
-      <%= t('advice_pages.gas_long_term.analysis.comparison.table_explanation', school_type: t('analytics.school_types.' + @school.school_type).downcase) %>
+      <%= t('advice_pages.gas_long_term.analysis.comparison.table_explanation', school_type: t('common.school_types.' + @school.school_type).downcase) %>
     </p>
 
     <%= render 'schools/advice/gas_long_term/comparison_with_benchmark_table', annual_usage: @gas_annual_usage, vs_exemplar: @gas_vs_exemplar, vs_benchmark: @gas_vs_benchmark, estimated_savings_vs_exemplar: @gas_estimated_savings_vs_exemplar, estimated_savings_vs_benchmark: @gas_estimated_savings_vs_benchmark %>

--- a/app/views/schools/advice/total_energy_use/_insights.html.erb
+++ b/app/views/schools/advice/total_energy_use/_insights.html.erb
@@ -14,7 +14,7 @@
 
 <% if @electricity_benchmarked_usage.present? || @gas_benchmarked_usage.present? %>
   <p>
-    <%= advice_t('total_energy_use.insights.comparison.how_do_you_compare', school_type: t('analytics.school_types.' + @school.school_type).downcase) %>
+    <%= advice_t('total_energy_use.insights.comparison.how_do_you_compare', school_type: t('common.school_types.' + @school.school_type).downcase) %>
   </p>
 
   <% if @electricity_benchmarked_usage.present? %>

--- a/config/locales/activerecord.yml
+++ b/config/locales/activerecord.yml
@@ -41,14 +41,6 @@ en:
         percentage_free_school_meals: Percentage of pupils eligible for free school meals at any time during the past 6 years
         postcode: Postcode
         public: Public
-        school_type:
-          infant: Infant
-          junior: Junior
-          middle: Middle
-          mixed_primary_and_secondary: 'Mixed: Primary and Secondary'
-          primary: Primary
-          secondary: Secondary
-          special: Special
         serves_dinners: Our school serves school dinners on site
         urn: Unique Reference Number
         website: Website

--- a/config/locales/activerecord.yml
+++ b/config/locales/activerecord.yml
@@ -41,6 +41,14 @@ en:
         percentage_free_school_meals: Percentage of pupils eligible for free school meals at any time during the past 6 years
         postcode: Postcode
         public: Public
+        school_type:
+          infant: Infant
+          junior: Junior
+          middle: Middle
+          mixed_primary_and_secondary: 'Mixed: Primary and Secondary'
+          primary: Primary
+          secondary: Secondary
+          special: Special
         serves_dinners: Our school serves school dinners on site
         urn: Unique Reference Number
         website: Website

--- a/config/locales/common.yml
+++ b/config/locales/common.yml
@@ -52,6 +52,14 @@ en:
     pie_charts: Pie charts
     privacy_policy: privacy policy
     school: School
+    school_types:
+      infant: Infant
+      junior: Junior
+      middle: Middle
+      mixed_primary_and_secondary: 'Mixed: Primary and Secondary'
+      primary: Primary
+      secondary: Secondary
+      special: Special
     solar_pv: Solar PV
     storage_heater: Storage heater
     storage_heaters: Storage heaters
@@ -62,6 +70,4 @@ en:
         other: "%{count} minutes"
   kw: kW
   kwh: kWh
-  school_types:
-    mixed_primary_and_secondary: 'Mixed: Primary and Secondary'
   "£": "£"

--- a/config/locales/cy/activerecord.yml
+++ b/config/locales/cy/activerecord.yml
@@ -44,14 +44,6 @@ cy:
         serves_dinners: Mae ein hysgol yn gweini cinio ysgol ar y safle
         urn: Cyfeirnod Unigryw
         website: Gwefan
-        school_type:
-          infant: Babanod
-          junior: Iau
-          middle: Canol
-          mixed_primary_and_secondary: 'Cymysg: Cynradd ac Uwchradd'
-          primary: Cynradd
-          secondary: Uwchradd
-          special: Arbennig
       transport_survey_response:
         id: Rhif adnabod
         journey_minutes: Munudau taith

--- a/config/locales/cy/activerecord.yml
+++ b/config/locales/cy/activerecord.yml
@@ -44,6 +44,14 @@ cy:
         serves_dinners: Mae ein hysgol yn gweini cinio ysgol ar y safle
         urn: Cyfeirnod Unigryw
         website: Gwefan
+        school_type:
+          infant: Babanod
+          junior: Iau
+          middle: Canol
+          mixed_primary_and_secondary: 'Cymysg: Cynradd ac Uwchradd'
+          primary: Cynradd
+          secondary: Uwchradd
+          special: Arbennig
       transport_survey_response:
         id: Rhif adnabod
         journey_minutes: Munudau taith

--- a/config/locales/cy/common.yml
+++ b/config/locales/cy/common.yml
@@ -50,6 +50,14 @@ cy:
     school: Ysgol
     storage_heater: Stôr-wresogydd
     storage_heaters: Stôr-wresogyddion
+    school_types:
+      infant: Babanod
+      junior: Iau
+      middle: Canol
+      mixed_primary_and_secondary: 'Cymysg: Cynradd ac Uwchradd'
+      primary: Cynradd
+      secondary: Uwchradd
+      special: Arbennig
     terms_and_conditions: telerau ac amodau
     units:
       minutes:
@@ -58,6 +66,4 @@ cy:
         many: "%{count} o funudau"
         other: "%{count} o funudau"
   kwh: kWh
-  school_types:
-    mixed_primary_and_secondary: 'Cymysg: Cynradd ac Uwchradd'
   "£": "£"

--- a/config/locales/views/compare/compare.yml
+++ b/config/locales/views/compare/compare.yml
@@ -3,10 +3,13 @@ en:
   compare:
     categories:
       intro: View how schools within the same MAT or local authority area compare across a range of energy performance benchmarks
+      tab: Choose categories
     group:
       intro: View how schools within the same MAT or local authority area compare across a range of energy performance benchmarks
+      tab: Your group
     groups:
       intro: View how schools within the same MAT or local authority area compare across a range of energy performance benchmarks
+      tab: Choose groups
     options: Use options below to compare %{schools_count} schools against %{benchmarks_count} benchmarks
     summary_html: |
       <ul>

--- a/config/locales/views/compare/compare.yml
+++ b/config/locales/views/compare/compare.yml
@@ -7,9 +7,11 @@ en:
     group:
       intro: View how schools within the same MAT or local authority area compare across a range of energy performance benchmarks
       tab: Your group
+      title: Compare all schools within %{name}
     groups:
       intro: View how schools within the same MAT or local authority area compare across a range of energy performance benchmarks
       tab: Choose groups
+    limit_by_school_type: 'Limit results to include schools of type:'
     options: Use options below to compare %{schools_count} schools against %{benchmarks_count} benchmarks
     summary_html: |
       <ul>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -51,7 +51,7 @@ Rails.application.routes.draw do
   resource :compare, controller: 'compare' do
     collection do
       get :index, to: "compare#group"
-      get :group, :categories, :groups, :benchmark, :results
+      get :group, :categories, :groups, :benchmarks, :results
     end
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -23,6 +23,34 @@ describe User do
     expect(user.school_name).to eq('Big School')
   end
 
+  describe "#default_school_group" do
+    let(:school) { }
+    let(:school_group) { }
+    let(:user) { create(:user, school_group: school_group, school: school) }
+    subject(:default_school_group) { user.default_school_group }
+
+    context "User has school with a school group" do
+      let(:school) { create(:school, :with_school_group) }
+      it { expect(default_school_group).to eq(school.school_group) }
+    end
+    context "User doesn't have school but has a school group" do
+      let(:school_group) { create(:school_group) }
+      it { expect(default_school_group).to eq(school_group) }
+    end
+    context "User has school with no school group but has group" do
+      let(:school) { create(:school) }
+      let(:school_group) { create(:school_group) }
+      it { expect(default_school_group).to eq(school_group) }
+    end
+    context "User has school with no school group and no group" do
+      let(:school) { create(:school) }
+      it { expect(default_school_group).to be_nil }
+    end
+    context "User has no school or school group" do
+      it { expect(default_school_group).to be_nil }
+    end
+  end
+
   it 'returns school group name' do
     user = create(:user)
     expect(user.school_group_name).to be_nil

--- a/spec/system/compare_spec.rb
+++ b/spec/system/compare_spec.rb
@@ -2,10 +2,23 @@ require 'rails_helper'
 
 describe 'compare pages', type: :system do
 
-  shared_examples "a compare search header" do
+  shared_examples "a compare search header" do |intro: |
     it "has standard header information" do
       expect(page).to have_content "School Comparison Tool"
       expect(page).to have_content "Identify examples of best practice"
+      expect(page).to have_content intro
+    end
+  end
+
+  shared_examples "a compare search filter page" do |tab: |
+    it "has tabbed navigation" do
+      expect(page).to have_link("Your group", href: '/compare/group')
+      expect(page).to have_link("Choose categories")
+      expect(page).to have_link("Choose groups")
+    end
+
+    it "#{tab} tab is selected" do
+      expect(page).to have_css("a.nav-link.active", text: tab)
     end
   end
 
@@ -13,10 +26,28 @@ describe 'compare pages', type: :system do
     visit compare_path
   end
 
-  it_behaves_like "a compare search header"
+  it_behaves_like "a compare search header", intro: "View how schools within the same MAT"
+  it_behaves_like "a compare search filter page", tab: 'Your group'
 
-  it "has group search intro" do
-    expect(page).to have_content "View how schools within the same MAT"
+  context "'Your group' filter page" do
+    before { click_on 'Your group' }
+
+    it_behaves_like "a compare search header", intro: "View how schools within the same MAT"
+    it_behaves_like "a compare search filter page", tab: 'Your group'
+
   end
 
+  context "'Categories' filter page" do
+    before { click_on 'Choose categories' }
+
+    it_behaves_like "a compare search header", intro: "View how schools within the same MAT"
+    it_behaves_like "a compare search filter page", tab: 'Choose categories'
+  end
+
+  context "'Groups' filter page" do
+    before { click_on 'Choose groups' }
+
+    it_behaves_like "a compare search header", intro: "View how schools within the same MAT"
+    it_behaves_like "a compare search filter page", tab: 'Choose groups'
+  end
 end

--- a/spec/system/compare_spec.rb
+++ b/spec/system/compare_spec.rb
@@ -27,8 +27,7 @@ shared_examples "a compare search filter page" do |tab:, show_your_group_tab:tru
   end
 end
 
-describe 'compare pages', type: :system do
-
+describe 'compare pages', :compare, type: :system do
   before do
     sign_in(user) if user
     visit compare_path
@@ -45,6 +44,16 @@ describe 'compare pages', type: :system do
 
       it_behaves_like "a compare search header", intro: "View how schools within the same MAT"
       it_behaves_like "a compare search filter page", tab: 'Your group'
+      it { expect(page).to have_content "Compare all schools within #{user.school_group_name}" }
+
+      context "search filter" do
+        it 'has a checked checkbox for each school type' do
+          School.school_types.keys.each do |school_type|
+            expect(page).to have_checked_field(I18n.t("common.school_types.#{school_type}"))
+          end
+        end
+        it { expect(page).to have_button "Compare schools" }
+      end
     end
 
     context "'Categories' filter page" do

--- a/spec/system/compare_spec.rb
+++ b/spec/system/compare_spec.rb
@@ -1,53 +1,79 @@
 require 'rails_helper'
 
+shared_examples "a compare search header" do |intro: |
+  it "has standard header information" do
+    expect(page).to have_content "School Comparison Tool"
+    expect(page).to have_content "Identify examples of best practice"
+    expect(page).to have_content intro
+  end
+end
+
+shared_examples "a compare search filter page" do |tab:, show_your_group_tab:true|
+  it "has standard tabs" do
+    expect(page).to have_link("Choose categories", href: '/compare/categories')
+    expect(page).to have_link("Choose groups", href: '/compare/groups')
+  end
+
+  it "has 'Your group' tab", if: show_your_group_tab do
+    expect(page).to have_link("Your group", href: '/compare/group')
+  end
+
+  it "doesn't have 'Your group' tab", unless: show_your_group_tab do
+    expect(page).to_not have_link("Your group", href: '/compare/group')
+  end
+
+  it "#{tab} tab is selected" do
+    expect(page).to have_css("a.nav-link.active", text: tab)
+  end
+end
+
 describe 'compare pages', type: :system do
 
-  shared_examples "a compare search header" do |intro: |
-    it "has standard header information" do
-      expect(page).to have_content "School Comparison Tool"
-      expect(page).to have_content "Identify examples of best practice"
-      expect(page).to have_content intro
-    end
-  end
-
-  shared_examples "a compare search filter page" do |tab: |
-    it "has tabbed navigation" do
-      expect(page).to have_link("Your group", href: '/compare/group')
-      expect(page).to have_link("Choose categories")
-      expect(page).to have_link("Choose groups")
-    end
-
-    it "#{tab} tab is selected" do
-      expect(page).to have_css("a.nav-link.active", text: tab)
-    end
-  end
-
   before do
+    sign_in(user) if user
     visit compare_path
   end
 
-  it_behaves_like "a compare search header", intro: "View how schools within the same MAT"
-  it_behaves_like "a compare search filter page", tab: 'Your group'
-
-  context "'Your group' filter page" do
-    before { click_on 'Your group' }
+  context "Logged in user with school group" do
+    let(:user) { create(:user, school_group: create(:school_group)) }
 
     it_behaves_like "a compare search header", intro: "View how schools within the same MAT"
     it_behaves_like "a compare search filter page", tab: 'Your group'
 
+    context "'Your group' filter page" do
+      before { click_on 'Your group' }
+
+      it_behaves_like "a compare search header", intro: "View how schools within the same MAT"
+      it_behaves_like "a compare search filter page", tab: 'Your group'
+    end
+
+    context "'Categories' filter page" do
+      before { click_on 'Choose categories' }
+
+      it_behaves_like "a compare search header", intro: "View how schools within the same MAT"
+      it_behaves_like "a compare search filter page", tab: 'Choose categories'
+    end
+
+    context "'Groups' filter page" do
+      before { click_on 'Choose groups' }
+
+      it_behaves_like "a compare search header", intro: "View how schools within the same MAT"
+      it_behaves_like "a compare search filter page", tab: 'Choose groups'
+    end
   end
 
-  context "'Categories' filter page" do
-    before { click_on 'Choose categories' }
+  context "Logged in user withought school group" do
+    let(:user) { create(:admin) }
 
     it_behaves_like "a compare search header", intro: "View how schools within the same MAT"
-    it_behaves_like "a compare search filter page", tab: 'Choose categories'
+    it_behaves_like "a compare search filter page", tab: 'Choose categories', show_your_group_tab: false
   end
 
-  context "'Groups' filter page" do
-    before { click_on 'Choose groups' }
+  context "Logged out user" do
+    let(:user) {}
 
     it_behaves_like "a compare search header", intro: "View how schools within the same MAT"
-    it_behaves_like "a compare search filter page", tab: 'Choose groups'
+    it_behaves_like "a compare search filter page", tab: 'Choose categories', show_your_group_tab: false
   end
+
 end

--- a/spec/system/compare_spec.rb
+++ b/spec/system/compare_spec.rb
@@ -71,7 +71,7 @@ describe 'compare pages', :compare, type: :system do
     end
   end
 
-  context "Logged in user withought school group" do
+  context "Logged in user without school group" do
     let(:user) { create(:admin) }
 
     it_behaves_like "a compare search header", intro: "View how schools within the same MAT"


### PR DESCRIPTION
Implements the 'Your group' tab for the new compare pages.

NB: I have moved the analytics.school_types.* key to common.school_types.* (and removed another key in root called school_types.mixed_primary_and_secondary and changed code accordingly)