### PR TITLE
Update alert type management forms

### DIFF
--- a/app/controllers/admin/alert_types_controller.rb
+++ b/app/controllers/admin/alert_types_controller.rb
@@ -25,7 +25,7 @@ module Admin
   private
 
     def alert_type_params
-      params.require(:alert_type).permit(:title, :description, :frequency)
+      params.require(:alert_type).permit(:title, :description, :frequency, :group, :advice_page_id, :link_to, :link_to_section)
     end
   end
 end

--- a/app/models/advice_page.rb
+++ b/app/models/advice_page.rb
@@ -34,6 +34,10 @@ class AdvicePage < ApplicationRecord
 
   enum fuel_type: [:electricity, :gas, :storage_heater, :solar_pv]
 
+  def label
+    key.humanize
+  end
+
   def update_activity_type_positions!(position_attributes)
     transaction do
       advice_page_activity_types.destroy_all

--- a/app/views/admin/alert_types/_table.html.erb
+++ b/app/views/admin/alert_types/_table.html.erb
@@ -1,18 +1,32 @@
-<table class="table table-striped">
+<table class="table table-sorted">
   <thead>
     <tr>
-      <th>Title</th>
       <th>Fuel</th>
-      <th>Frequency</th>
-      <th></th>
+      <th>Title</th>
+      <th>Advice Page</th>
+      <% if local_assigns[:show_full] %>
+        <th>Group</th>
+        <th>Email Frequency</th>
+      <% end %>
+      <th data-orderable="false"></th>
     </tr>
   </thead>
   <tbody>
     <% alert_types.each do |alert_type| %>
       <tr>
-        <td><%= link_to alert_type.title, admin_alert_type_path(alert_type) %></td>
         <td><%= alert_type.display_fuel_type %></td>
-        <td><%= alert_type.frequency %></td>
+        <td><%= link_to alert_type.title, admin_alert_type_path(alert_type) %></td>
+        <td>
+          <% if alert_type.advice_page.present? %>
+            <%= link_to alert_type.advice_page.key, edit_admin_advice_page_path(alert_type.advice_page) %>
+          <% else %>
+            none
+          <% end %>
+        </td>
+        <% if local_assigns[:show_full] %>
+          <td><%= alert_type.group %></td>
+          <td><%= alert_type.frequency %></td>
+        <% end %>
         <td><%= link_to 'Manage', admin_alert_type_path(alert_type), class: 'btn btn-primary btn-sm'%></td>
       </tr>
     <% end %>

--- a/app/views/admin/alert_types/_table.html.erb
+++ b/app/views/admin/alert_types/_table.html.erb
@@ -18,7 +18,7 @@
         <td><%= link_to alert_type.title, admin_alert_type_path(alert_type) %></td>
         <td>
           <% if alert_type.advice_page.present? %>
-            <%= link_to alert_type.advice_page.key, edit_admin_advice_page_path(alert_type.advice_page) %>
+            <%= link_to alert_type.advice_page.label, edit_admin_advice_page_path(alert_type.advice_page) %>
           <% else %>
             none
           <% end %>

--- a/app/views/admin/alert_types/edit.html.erb
+++ b/app/views/admin/alert_types/edit.html.erb
@@ -2,10 +2,32 @@
 
 <%= simple_form_for(@alert_type, url: admin_alert_type_path(@alert_type)) do |f| %>
   <%= f.input :title, as: :string %>
-  <%= f.label 'Description', for: :description %>
+  <%= f.label 'Description (for internal use)', for: :description %>
   <%= f.rich_text_area :description %>
-  <%= f.input :frequency, as: :radio_buttons, collection: AlertType.frequencies.keys, label_method: :humanize %>
+  <%= f.input :frequency, as: :radio_buttons, collection: AlertType.frequencies.keys, label_method: :humanize, label: 'Email frequency' %>
 
-  <%= f.submit class: 'btn btn-success' %>
-  <%= link_to 'Cancel', admin_alert_type_path(@alert_type), class: 'btn btn-warning' %>
+  <div class="form-group">
+    <%= f.label 'Group', for: :group %>
+    <%= f.select :group, options_for_select(AlertType.groups.map {|key, value| [key.titleize, key]}, f.object.group), {include_blank: false}, { class: 'form-control' } %>
+  </div>
+
+  <div class="form-group">
+    <%= f.label 'Advice Page', for: :advice_page_id %>
+    <%= f.select :advice_page_id, options_from_collection_for_select(AdvicePage.all, 'id', 'label', f.object.advice_page_id), {include_blank: 'none'}, { class: 'form-control' } %>
+  </div>
+
+  <div class="form-group">
+    <%= f.label 'Link to', for: :link_to %>
+    <%= f.select :link_to, options_for_select(AlertType.link_tos.map {|key, value| [key.titleize, key]}, f.object.group), {include_blank: false}, { class: 'form-control' } %>
+  </div>
+
+  <div class="form-group">
+    <%= f.input :link_to_section, as: :string %>
+    <small>Optional: provide a specific section of the selected analysis page to which users will be sent</small>
+  </div>
+
+  <div class="form-group mt-4">
+    <%= f.submit class: 'btn btn-success' %>
+    <%= link_to 'Cancel', admin_alert_type_path(@alert_type), class: 'btn btn-warning' %>
+  </div>
 <% end %>

--- a/app/views/admin/alert_types/index.html.erb
+++ b/app/views/admin/alert_types/index.html.erb
@@ -1,7 +1,5 @@
 <h1>Alert type management</h1>
 
-<p><%= link_to 'Admin page', admin_path %></p>
-
 <ul class="nav nav-pills">
   <li class="nav-item">
     <a class="nav-link disabled" href="#">Jump to</a>
@@ -17,17 +15,16 @@
   <a name="Standard"> </a>
 </div>
 <h2>Standard</h2>
-<%= render 'table', alert_types: @standard_alert_types %>
+<%= render 'table', alert_types: @standard_alert_types, show_full: true %>
 
 <div class="nav-anchor">
   <a name="System"> </a>
 </div>
 <h2>System</h2>
-<%= render 'table', alert_types: @system_alert_types %>
+<%= render 'table', alert_types: @system_alert_types, show_full: true %>
 
 <div class="nav-anchor">
   <a name="Analysis"> </a>
 </div>
-<h2>Analysis</h2>
+<h2>Old Analysis Pages</h2>
 <%= render 'table', alert_types: @analysis_alert_types %>
-

--- a/app/views/admin/alert_types/show.html.erb
+++ b/app/views/admin/alert_types/show.html.erb
@@ -1,6 +1,6 @@
 <h1><%= @alert_type.title %></h1>
 
-<p><%= link_to 'Admin page', admin_path %>, <%= link_to 'All alert types', admin_alert_types_path %></p>
+<p><%= link_to 'All alert types', admin_alert_types_path %></p>
 
 <%= render 'nav', alert_type: @alert_type %>
 
@@ -8,15 +8,46 @@
   <dt class="col-md-2">Fuel</dt>
   <dd class="col-md-10"><%= @alert_type.display_fuel_type %></dd>
 
+  <dt class="col-md-2">Sub category</dt>
+  <dd class="col-md-10"><%= @alert_type.sub_category ? @alert_type.sub_category.to_s.capitalize : 'Not set' %></dd>
+
+  <dt class="col-md-2">Group</dt>
+  <dd class="col-md-10"><%= @alert_type.group&.humanize %></dd>
+
   <dt class="col-md-2">Frequency</dt>
   <dd class="col-md-10"><%= @alert_type.frequency.humanize %></dd>
 
-  <dt class="col-md-2">Sub category</dt>
-  <dd class="col-md-10"><%= @alert_type.sub_category ? @alert_type.sub_category.to_s.capitalize : 'Not set' %></dd>
+  <dt class="col-md-2">Advice Page</dt>
+  <dd class="col-md-10">
+    <% if @alert_type.advice_page.present? %>
+      <%= link_to @alert_type.advice_page.label, edit_admin_advice_page_path(@alert_type.advice_page) %>
+    <% else %>
+      none
+    <% end %>
+  </dd>
+
+  <dt class="col-md-2">Link to</dt>
+  <dd class="col-md-10">
+    <% if @alert_type.advice_page.present? %>
+      <%= @alert_type.link_to.humanize %>
+      <% if @alert_type.link_to_section.present? %>
+        (#<%= @alert_type.link_to_section %>)
+      <% end %>
+    <% else %>
+      N/A
+    <% end %>
+  </dd>
+
+
+  <dt class="col-md-2">Class</dt>
+  <dd class="col-md-10"><%= @alert_type.class_name %></dd>
+
 </dl>
 
-<h2>Description</h2>
-<%= @alert_type.description %>
+<% if @alert_type.description.present? %>
+  <h2>Description</h2>
+  <%= @alert_type.description %>
+<% end %>
 
 <p>
   <%= link_to 'Edit', edit_admin_alert_type_path(@alert_type), class: 'btn btn-small btn-primary' %>


### PR DESCRIPTION
Updates the admin pages for managing Alert Types

* Tidy up the index page to make tables sortable, add in the extra fields
* Add extra fields for the overview tab of individual alert types
* Update the form to allow admin to set group, advice page, link to, etc.