### PR TITLE
Change find out more linking

### DIFF
--- a/app/controllers/management/management_priorities_controller.rb
+++ b/app/controllers/management/management_priorities_controller.rb
@@ -1,19 +1,12 @@
 module Management
   class ManagementPrioritiesController < ApplicationController
+    include DashboardPriorities
+
     load_and_authorize_resource :school
 
     def index
       authorize! :show_management_dash, @school
-      @management_priorities = @school.latest_management_priorities.by_priority.limit(site_settings.management_priorities_page_limit).map do |priority|
-        TemplateInterpolation.new(
-          priority.content_version,
-          with_objects: { find_out_more: priority.find_out_more },
-          proxy: [:colour]
-        ).interpolate(
-          :management_priorities_title,
-          with: priority.alert.template_variables
-        )
-      end
+      @management_priorities = setup_priorities(@school.latest_management_priorities, limit: site_settings.management_priorities_page_limit)
     end
   end
 end

--- a/app/helpers/schools_helper.rb
+++ b/app/helpers/schools_helper.rb
@@ -18,4 +18,8 @@ module SchoolsHelper
   def disabled_for_pseudo_meter?(meter)
     meter.pseudo && action_name == 'edit'
   end
+
+  def dashboard_alert_buttons(school, alert_content)
+    alert_content.find_out_more ? { t('schools.show.find_out_more') => school_find_out_more_path(school, alert_content.find_out_more) } : {}
+  end
 end

--- a/app/helpers/schools_helper.rb
+++ b/app/helpers/schools_helper.rb
@@ -19,22 +19,30 @@ module SchoolsHelper
     meter.pseudo && action_name == 'edit'
   end
 
+  def dashboard_alert_buttons(school, alert_content)
+    path = find_out_more_path_from_alert_content(school, alert_content)
+    return {} if path.nil?
+    { t('schools.show.find_out_more') => path }
+  end
+
+  #Switches between linking to the old find out more pages and the
+  #new advice pages.
+  def find_out_more_path_from_alert_content(school, alert_content)
+    if EnergySparks::FeatureFlags.active?(:replace_find_out_mores)
+      alert_type = alert_content.alert.alert_type
+      return nil unless alert_type.advice_page.present?
+      advice_page_path_from_alert_type(school, alert_type)
+    else
+      return nil unless alert_content.find_out_more.present?
+      school_find_out_more_path(school, alert_content.find_out_more)
+    end
+  end
+
   def advice_page_path_from_alert_type(school, alert_type)
     advice_page = alert_type.advice_page
     polymorphic_path(
       [alert_type.advice_page_tab_for_link_to, school, :advice, advice_page.key.to_sym],
       anchor: alert_type.link_to_section
     )
-  end
-
-  def dashboard_alert_buttons(school, alert_content)
-    if EnergySparks::FeatureFlags.active?(:replace_find_out_mores)
-      alert_type = alert_content.alert.alert_type
-      return {} unless alert_type.advice_page.present?
-      { t('schools.show.find_out_more') => advice_page_path_from_alert_type(school, alert_type) }
-    else
-      return {} unless alert_content.find_out_more.present?
-      { t('schools.show.find_out_more') => school_find_out_more_path(school, alert_content.find_out_more) }
-    end
   end
 end

--- a/app/helpers/schools_helper.rb
+++ b/app/helpers/schools_helper.rb
@@ -19,7 +19,22 @@ module SchoolsHelper
     meter.pseudo && action_name == 'edit'
   end
 
+  def advice_page_path_from_alert_type(school, alert_type)
+    advice_page = alert_type.advice_page
+    polymorphic_path(
+      [alert_type.advice_page_tab_for_link_to, school, :advice, advice_page.key.to_sym],
+      anchor: alert_type.link_to_section
+    )
+  end
+
   def dashboard_alert_buttons(school, alert_content)
-    alert_content.find_out_more ? { t('schools.show.find_out_more') => school_find_out_more_path(school, alert_content.find_out_more) } : {}
+    if EnergySparks::FeatureFlags.active?(:replace_find_out_mores)
+      alert_type = alert_content.alert.alert_type
+      return {} unless alert_type.advice_page.present?
+      { t('schools.show.find_out_more') => advice_page_path_from_alert_type(school, alert_type) }
+    else
+      return {} unless alert_content.find_out_more.present?
+      { t('schools.show.find_out_more') => school_find_out_more_path(school, alert_content.find_out_more) }
+    end
   end
 end

--- a/app/helpers/schools_helper.rb
+++ b/app/helpers/schools_helper.rb
@@ -27,22 +27,24 @@ module SchoolsHelper
 
   #Switches between linking to the old find out more pages and the
   #new advice pages.
-  def find_out_more_path_from_alert_content(school, alert_content)
+  def find_out_more_path_from_alert_content(school, alert_content, params: {}, mailer: false)
     if EnergySparks::FeatureFlags.active?(:replace_find_out_mores)
       alert_type = alert_content.alert.alert_type
       return nil unless alert_type.advice_page.present?
-      advice_page_path_from_alert_type(school, alert_type)
+      advice_page_path_from_alert_type(school, alert_type, params: params, mailer: mailer)
     else
       return nil unless alert_content.find_out_more.present?
-      school_find_out_more_path(school, alert_content.find_out_more)
+      school_find_out_more_path(school, alert_content.find_out_more, params: params)
     end
   end
 
-  def advice_page_path_from_alert_type(school, alert_type)
+  def advice_page_path_from_alert_type(school, alert_type, params: {}, mailer: false)
     advice_page = alert_type.advice_page
-    polymorphic_path(
-      [alert_type.advice_page_tab_for_link_to, school, :advice, advice_page.key.to_sym],
-      anchor: alert_type.link_to_section
-    )
+    path_segments = [alert_type.advice_page_tab_for_link_to, school, :advice, advice_page.key.to_sym]
+    if mailer
+      polymorphic_url(path_segments, params.merge(anchor: alert_type.link_to_section))
+    else
+      polymorphic_path(path_segments, params.merge(anchor: alert_type.link_to_section))
+    end
   end
 end

--- a/app/helpers/schools_helper.rb
+++ b/app/helpers/schools_helper.rb
@@ -34,7 +34,11 @@ module SchoolsHelper
       advice_page_path_from_alert_type(school, alert_type, params: params, mailer: mailer)
     else
       return nil unless alert_content.find_out_more.present?
-      school_find_out_more_path(school, alert_content.find_out_more, params: params)
+      if mailer
+        school_find_out_more_url(school, alert_content.find_out_more, params: params)
+      else
+        school_find_out_more_path(school, alert_content.find_out_more, params: params)
+      end
     end
   end
 

--- a/app/mailers/alert_mailer.rb
+++ b/app/mailers/alert_mailer.rb
@@ -1,6 +1,8 @@
 class AlertMailer < LocaleMailer
   include MailgunMailerHelper
+
   helper :application
+  helper :schools
 
   after_action :prevent_delivery_from_test
 

--- a/app/models/alert_type.rb
+++ b/app/models/alert_type.rb
@@ -55,6 +55,17 @@ class AlertType < ApplicationRecord
     fuel_type.humanize
   end
 
+  def advice_page_tab_for_link_to
+    case link_to
+    when :analysis_page
+      :analysis
+    when :learn_more_page
+      :learn_more
+    else
+      :insights
+    end
+  end
+
   def cleaned_template_variables
     # TODO: make the analytics code remove the £ sign
     class_name.constantize.front_end_template_variables.deep_transform_keys do |key|

--- a/app/models/find_out_more.rb
+++ b/app/models/find_out_more.rb
@@ -27,6 +27,10 @@ class FindOutMore < ApplicationRecord
   belongs_to :alert
   belongs_to :content_version, class_name: 'AlertTypeRatingContentVersion', foreign_key: :alert_type_rating_content_version_id
 
+  def alert_type
+    content_version.alert_type_rating.alert_type
+  end
+
   def activity_types
     content_version.alert_type_rating.ordered_activity_types
   end

--- a/app/views/alert_mailer/alert_email.html.erb
+++ b/app/views/alert_mailer/alert_email.html.erb
@@ -57,9 +57,10 @@
 
   <div class="row">
     <div class="col col-lg-4">
-      <% if alert_content.find_out_more %>
+      <% path = find_out_more_path_from_alert_content(@school, alert_content, params: weekly_alert_utm_parameters, mailer: true) %>
+      <% if path %>
         <p>
-          <%= link_to t('alert_mailer.alert_email.find_out_more'), school_find_out_more_url(@school, alert_content.find_out_more, params: weekly_alert_utm_parameters), class: 'btn btn-primary mt-2 mb-2'%>
+          <%= link_to t('alert_mailer.alert_email.find_out_more'), path, class: 'btn btn-primary mt-2 mb-2'%>
         </p>
       <% end %>
     </div>

--- a/app/views/management/management_priorities/_list.html.erb
+++ b/app/views/management/management_priorities/_list.html.erb
@@ -23,8 +23,9 @@
           <td><%= priority.template_variables[:one_year_saving_co2] %><br></td>
           <td><%= priority.template_variables[:average_capital_cost] %></td>
           <td>
-            <% if priority.find_out_more %>
-              <%= link_to t('management.priorities.find_out_more'), school_find_out_more_path(school, priority.find_out_more), class: 'btn btn-rounded btn-fixed-width-10' %>
+            <% path = find_out_more_path_from_alert_content(school, priority) %>
+            <% if path != nil %>
+              <%= link_to t('management.priorities.find_out_more'), path, class: 'btn btn-rounded btn-fixed-width-10' %>
             <% end %>
           </td>
         </tr>

--- a/app/views/pupils/schools/show.html.erb
+++ b/app/views/pupils/schools/show.html.erb
@@ -36,7 +36,7 @@
           colour: class_for_alert_colour(content.colour),
           icon: alert_icon(content.alert, 'fa-3x'),
           content: content.pupil_dashboard_title,
-          buttons: content.find_out_more ? { t('pupils.schools.show.find_out_more') => school_find_out_more_path(@school, content.find_out_more) } : {}
+          buttons: dashboard_alert_buttons(@school, content)
     %>
    <% end %>
 <% end %>

--- a/app/views/schools/find_out_more/show.html.erb
+++ b/app/views/schools/find_out_more/show.html.erb
@@ -3,6 +3,13 @@
 
 <h1 class="pt-4"><%= sanitize @content.find_out_more_title %></h1>
 
+<% if EnergySparks::FeatureFlags.active?(:replace_find_out_mores) %>
+  <div class="mb-2 alert alert-danger row">
+    Currently only admin users can view this page as the "REPLACE_FIND_OUT_MORES" feature is
+    active.
+  </div>
+<% end %>
+
 <div class="row">
   <% if @chart %>
     <div class="col">

--- a/app/views/shared/_dashboard_alerts.html.erb
+++ b/app/views/shared/_dashboard_alerts.html.erb
@@ -10,7 +10,7 @@
         colour: class_for_alert_colour(alert_content.colour),
         icon: alert_icon(alert_content.alert, 'fa-3x'),
         content: alert_content.send(content_field),
-        buttons: alert_content.find_out_more ? {t('for_schools.find_out_more') => school_find_out_more_path(school, alert_content.find_out_more)} : {}
+        buttons: dashboard_alert_buttons(@school, alert_content)
       %>
   <% end %>
   <% if dashboard_alerts.size > 1 && !local_assigns[:show_all] %>

--- a/config/locales/cy/views/pupils/pupils.yml
+++ b/config/locales/cy/views/pupils/pupils.yml
@@ -63,7 +63,6 @@ cy:
         complete_an_activity: Cwblha weithgaredd i sgorio pwyntiau ar Sbarcynni
         enter_temperatures: Rho dymereddau
         find_how_much_energy_used: Darganfod faint o ynni a ddefnyddiwyd
-        find_out_more: Dysgu rhagor&hellip;
         how_will_school_compare: Sut bydd dy ysgol yn cymharu? Byddi di'n gallu darganfod yn fuan!
         look_at_the_energy_use: Gad i ni edrych ar y data defnydd ynni ar gyfer dy ysgol
         measure_temperatures: Mesura dymhereddau ystafell ddosbarth i ddarganfod a ddylet ti droi'r gwres i lawr i arbed ynni

--- a/config/locales/views/pupils/pupils.yml
+++ b/config/locales/views/pupils/pupils.yml
@@ -64,7 +64,6 @@ en:
         complete_an_activity: Complete an activity to score points on Energy Sparks
         enter_temperatures: Enter temperatures
         find_how_much_energy_used: Find out how much energy has been used
-        find_out_more: Find out more&hellip;
         how_will_school_compare: How will your school compare? You'll soon be able to find out!
         look_at_the_energy_use: Let's look at the energy use data for your school
         measure_temperatures: Measure classroom temperatures to find out whether you should turn down the heating to save energy

--- a/config/locales/views/schools/schools.yml
+++ b/config/locales/views/schools/schools.yml
@@ -513,6 +513,7 @@ en:
       download_data: Download your data
       energy_bill_required: We need you to provide a recent energy bill for your school to confirm your meter numbers. This will help ensure that we can collect, process and display your school data.
       energy_saving_opportunities: Energy saving opportunities
+      find_out_more: Find out more
       find_training: Find training
       making_progress: Well done, you are making progress towards achieving your target to reduce your %{fuels} usage!
       more_information: More information

--- a/spec/controllers/schools/find_out_more_controller_spec.rb
+++ b/spec/controllers/schools/find_out_more_controller_spec.rb
@@ -1,0 +1,88 @@
+require 'rails_helper'
+
+RSpec.describe Schools::FindOutMoreController, type: :controller do
+
+  let(:school)    { create(:school) }
+  let(:user)      { create(:staff, school: school) }
+
+  let!(:alert_type_rating_content_version) do
+    create(:alert_type_rating_content_version, alert_type_rating: alert_type_rating)
+  end
+  let!(:alert_type_rating) do
+    create(
+      :alert_type_rating,
+      find_out_more_active: true
+    )
+  end
+  let!(:alert) do
+    create(:alert, :with_run,
+      alert_type: alert_type_rating.alert_type,
+      run_on: Time.zone.today, school: school,
+      rating: 9.0
+    )
+  end
+
+  let(:feature_flag)      { 'false' }
+
+  before do
+    Alerts::GenerateContent.new(school).perform
+  end
+
+  around do |example|
+    ClimateControl.modify FEATURE_FLAG_REPLACE_FIND_OUT_MORES: feature_flag do
+      example.run
+    end
+  end
+
+  context '#redirect_if_disabled_and_not_admin' do
+    context 'with feature active' do
+      let(:feature_flag)      { 'true' }
+
+      context 'for a guest' do
+        it 'redirects the user' do
+          get :show, params: { school_id: school.to_param, id: FindOutMore.first.to_param }
+          expect(response).to redirect_to(school_advice_path(school))
+        end
+      end
+
+      context 'for a staff user' do
+        before(:each) do
+          sign_in(user)
+        end
+        it 'redirects the user' do
+          get :show, params: { school_id: school.to_param, id: FindOutMore.first.to_param }
+          expect(response).to redirect_to(school_advice_path(school))
+        end
+        context 'and there is an advice page' do
+          let(:advice_page)  { create(:advice_page, key: :baseload) }
+          before(:each) do
+            alert_type_rating.alert_type.update(advice_page: advice_page)
+          end
+          it 'redirects to the page' do
+            get :show, params: { school_id: school.to_param, id: FindOutMore.first.to_param }
+            expect(response).to redirect_to(insights_school_advice_baseload_path(school))
+          end
+        end
+      end
+
+      context 'for an admin user' do
+        let(:user)   { create(:admin) }
+        before(:each) do
+          sign_in(user)
+        end
+        it 'does not redirect the user' do
+          get :show, params: { school_id: school.to_param, id: FindOutMore.first.to_param }
+          expect(response).to have_http_status(:success)
+        end
+      end
+
+    end
+
+    context 'with feature disabled' do
+      it 'displays the page' do
+        get :show, params: { school_id: school.to_param, id: FindOutMore.first.to_param }
+        expect(response).to have_http_status(:success)
+      end
+    end
+  end
+end

--- a/spec/helpers/schools_helper_spec.rb
+++ b/spec/helpers/schools_helper_spec.rb
@@ -3,20 +3,52 @@ require 'rails_helper'
 describe SchoolsHelper do
   let(:school)                    { create(:school) }
 
-  context '#dashboard_alert_buttons' do
-    let(:feature_flag)      { 'false' }
-    let(:alert_type)        { create(:alert_type) }
-    let!(:alert) do
-      create(:alert, :with_run,
-        alert_type: alert_type,
-        run_on: Time.zone.today, school: school,
-        rating: 9.0
-      )
+  let(:feature_flag)      { 'false' }
+  let(:alert_type)        { create(:alert_type) }
+  let!(:alert) do
+    create(:alert, :with_run,
+      alert_type: alert_type,
+      run_on: Time.zone.today, school: school,
+      rating: 9.0
+    )
+  end
+  let(:find_out_more)     { create(:find_out_more, alert: alert)}
+
+  let(:alert_content) { OpenStruct.new(alert: alert, find_out_more: find_out_more) }
+
+  context '#find_out_more_path_from_alert_content' do
+    around do |example|
+      ClimateControl.modify FEATURE_FLAG_REPLACE_FIND_OUT_MORES: feature_flag do
+        example.run
+      end
     end
-    let(:find_out_more)     { create(:find_out_more, alert: alert)}
+    context 'with feature on and advice path' do
+      let(:feature_flag) { 'true' }
+      let(:advice_page)  { create(:advice_page, key: :baseload) }
+      let(:alert_type)   { create(:alert_type, advice_page: advice_page) }
 
-    let(:alert_content) { OpenStruct.new(alert: alert, find_out_more: find_out_more) }
-
+      it 'returns expected path' do
+        path = helper.find_out_more_path_from_alert_content(school, alert_content)
+        expect(path).to eq insights_school_advice_baseload_path(school)
+      end
+      context 'and utm params' do
+        let(:params)   { {utm_medium: 'email'} }
+        it 'returns expected path' do
+          path = helper.find_out_more_path_from_alert_content(school, alert_content, params: params)
+          expect(path).to eq insights_school_advice_baseload_path(school, params: params)
+        end
+        context 'and link_to_content' do
+          let(:anchor) { 'some-section' }
+          let(:alert_type)   { create(:alert_type, advice_page: advice_page, link_to: :analysis_page, link_to_section: anchor) }
+          it 'returns the expected path' do
+            path = helper.find_out_more_path_from_alert_content(school, alert_content, params: params)
+            expect(path).to eq insights_school_advice_baseload_path(school, params: params, anchor: anchor)
+          end
+        end
+      end
+    end
+  end
+  context '#dashboard_alert_buttons' do
     around do |example|
       ClimateControl.modify FEATURE_FLAG_REPLACE_FIND_OUT_MORES: feature_flag do
         example.run
@@ -48,13 +80,13 @@ describe SchoolsHelper do
         end
 
         context 'and link_to_content' do
-          let(:alert_type)   { create(:alert_type, advice_page: advice_page, link_to: :analysis_page, link_to_section: 'some-section') }
+          let(:anchor) { 'some-section' }
+          let(:alert_type)   { create(:alert_type, advice_page: advice_page, link_to: :analysis_page, link_to_section: anchor) }
 
           it 'returns the expected path' do
             buttons = helper.dashboard_alert_buttons(school, alert_content)
-            expect(buttons.values.first).to eq insights_school_advice_baseload_path(school, anchor: 'some-section')
+            expect(buttons.values.first).to eq insights_school_advice_baseload_path(school, anchor: anchor)
           end
-
         end
       end
     end

--- a/spec/helpers/schools_helper_spec.rb
+++ b/spec/helpers/schools_helper_spec.rb
@@ -1,0 +1,62 @@
+require 'rails_helper'
+
+describe SchoolsHelper do
+  let(:school)                    { create(:school) }
+
+  context '#dashboard_alert_buttons' do
+    let(:feature_flag)      { 'false' }
+    let(:alert_type)        { create(:alert_type) }
+    let!(:alert) do
+      create(:alert, :with_run,
+        alert_type: alert_type,
+        run_on: Time.zone.today, school: school,
+        rating: 9.0
+      )
+    end
+    let(:find_out_more)     { create(:find_out_more, alert: alert)}
+
+    let(:alert_content) { OpenStruct.new(alert: alert, find_out_more: find_out_more) }
+
+    around do |example|
+      ClimateControl.modify FEATURE_FLAG_REPLACE_FIND_OUT_MORES: feature_flag do
+        example.run
+      end
+    end
+
+    context 'with feature off' do
+      it 'returns the expected path' do
+        buttons = helper.dashboard_alert_buttons(school, alert_content)
+        expect(buttons.values.first).to eq school_find_out_more_path(school, alert_content.find_out_more)
+      end
+    end
+
+    context 'with feature on' do
+      let(:feature_flag) { 'true' }
+      context 'and no advice page' do
+        it 'returns empty hash' do
+          buttons = helper.dashboard_alert_buttons(school, alert_content)
+          expect(buttons).to eq({})
+        end
+      end
+      context 'and advice page' do
+        let(:advice_page)  { create(:advice_page, key: :baseload) }
+        let(:alert_type)   { create(:alert_type, advice_page: advice_page) }
+
+        it 'returns the expected path' do
+          buttons = helper.dashboard_alert_buttons(school, alert_content)
+          expect(buttons.values.first).to eq insights_school_advice_baseload_path(school)
+        end
+
+        context 'and link_to_content' do
+          let(:alert_type)   { create(:alert_type, advice_page: advice_page, link_to: :analysis_page, link_to_section: 'some-section') }
+
+          it 'returns the expected path' do
+            buttons = helper.dashboard_alert_buttons(school, alert_content)
+            expect(buttons.values.first).to eq insights_school_advice_baseload_path(school, anchor: 'some-section')
+          end
+
+        end
+      end
+    end
+  end
+end

--- a/spec/services/alerts/generate_email_notifications_spec.rb
+++ b/spec/services/alerts/generate_email_notifications_spec.rb
@@ -20,7 +20,7 @@ describe Alerts::GenerateEmailNotifications do
   let(:alert_subscription_event_2) { AlertSubscriptionEvent.find_by!(content_version: content_version_2) }
 
   around do |example|
-    ClimateControl.modify SEND_AUTOMATED_EMAILS: 'true' do
+    ClimateControl.modify SEND_AUTOMATED_EMAILS: 'true', FEATURE_FLAG_REPLACE_FIND_OUT_MORES: 'false' do
       example.run
     end
   end


### PR DESCRIPTION
Changes whether the "find out more" pages are accessible to users. This is part of retiring that part of the application, replacing them with direct links to the new advice pages.

Uses a Feature Flag to control the behaviour change (`FEATURE_FLAG_REPLACE_FIND_OUT_MORES`)

The majority of the work is done in some new helper methods in the `SchoolsHelper`. This checks the status of the feature flag and then returns either the path to the find out more page (if its off) or the advice page (if there is one). I've added an rspec test which exercises the majority of the paths through this code.

The rest of the changes are then largely in the templates, which now call these methods.

Summary of changes:

* [x] Updates the find out more controller to redirect users to the corresponding advice page if there is one,  or the advice index as a fallback, rather than letting them view the find out more page. Admins can still view the content
* [x] Updates the display of alerts on the pupil and school dashboard to link to the corresponding advice page, rather than find out more
* [x] Changes links in the mgt priorities list on the dashboard, and the dedicated page (which will also later be removed)
* [x] Changes links in alert emails.
* [x] Some minor tidy up of i18n keys for "Find out more" link
