### PR TITLE
Add real links to advice index page tabs

### DIFF
--- a/app/helpers/advice_page_helper.rb
+++ b/app/helpers/advice_page_helper.rb
@@ -1,7 +1,7 @@
 # rubocop:disable Naming/AsciiIdentifiers
 module AdvicePageHelper
-  def advice_page_path(school, advice_page, tab = :insights)
-    polymorphic_path([tab, school, :advice, advice_page.key.to_sym])
+  def advice_page_path(school, advice_page, tab = :insights, params: {}, anchor: nil)
+    polymorphic_path([tab, school, :advice, advice_page.key.to_sym], params: params, anchor: anchor)
   end
 
   #Helper for the advice pages, passes a scope to the I18n.t API based on

--- a/app/models/alert.rb
+++ b/app/models/alert.rb
@@ -68,6 +68,10 @@ class Alert < ApplicationRecord
   scope :without_exclusions, -> { joins(:alert_type).joins('LEFT OUTER JOIN school_alert_type_exclusions ON school_alert_type_exclusions.school_id = alerts.school_id AND school_alert_type_exclusions.alert_type_id = alert_types.id').where(school_alert_type_exclusions: { school_id: nil }) }
   scope :displayable, -> { where(displayable: true) }
 
+  def advice_page
+    alert_type.advice_page
+  end
+
   def frequency
     alert_type.frequency
   end

--- a/app/models/alert_type.rb
+++ b/app/models/alert_type.rb
@@ -56,7 +56,7 @@ class AlertType < ApplicationRecord
   end
 
   def advice_page_tab_for_link_to
-    case link_to
+    case link_to.to_sym
     when :analysis_page
       :analysis
     when :learn_more_page

--- a/app/views/schools/advice/index/_alerts.html.erb
+++ b/app/views/schools/advice/index/_alerts.html.erb
@@ -7,9 +7,11 @@
           </div>
           <div class="col-md-11">
           <%= alert_content.send(content_field) %>
-            <div class="text-right">
-              <%= link_to t('advice_pages.index.alerts.view_analysis'), insights_school_advice_total_energy_use_path(@school), class: 'btn btn-rounded btn-fixed-width-10' %>
-            </div>
+            <% if alert_content.alert.advice_page.present? %>
+              <div class="text-right">
+                <%= link_to t('advice_pages.index.alerts.view_analysis'), advice_page_path(school, alert_content.alert.advice_page, alert_content.alert.alert_type.advice_page_tab_for_link_to, anchor: alert_content.alert.alert_type.link_to_section) %>
+              </div>
+            <% end %>
           </div>
         </div>
       <% end %>

--- a/app/views/schools/advice/index/_priority_table.html.erb
+++ b/app/views/schools/advice/index/_priority_table.html.erb
@@ -17,7 +17,11 @@
         </td>
         <td>
           <h4>
-            <%= priority.management_priorities_title %>
+            <% if priority.alert.advice_page.present? %>
+              <%= link_to priority.management_priorities_title, advice_page_path(school, priority.alert.advice_page, priority.alert.alert_type.advice_page_tab_for_link_to, anchor: priority.alert.alert_type.link_to_section) %>
+            <% else %>
+              <%= priority.management_priorities_title %>
+            <% end %>
           </h4>
         </td>
         <td>

--- a/spec/helpers/schools_helper_spec.rb
+++ b/spec/helpers/schools_helper_spec.rb
@@ -42,7 +42,7 @@ describe SchoolsHelper do
           let(:alert_type)   { create(:alert_type, advice_page: advice_page, link_to: :analysis_page, link_to_section: anchor) }
           it 'returns the expected path' do
             path = helper.find_out_more_path_from_alert_content(school, alert_content, params: params)
-            expect(path).to eq insights_school_advice_baseload_path(school, params: params, anchor: anchor)
+            expect(path).to eq analysis_school_advice_baseload_path(school, params: params, anchor: anchor)
           end
         end
       end
@@ -85,7 +85,7 @@ describe SchoolsHelper do
 
           it 'returns the expected path' do
             buttons = helper.dashboard_alert_buttons(school, alert_content)
-            expect(buttons.values.first).to eq insights_school_advice_baseload_path(school, anchor: anchor)
+            expect(buttons.values.first).to eq analysis_school_advice_baseload_path(school, anchor: anchor)
           end
         end
       end


### PR DESCRIPTION
Updates the list of priorities and recent alerts to link to the actual advice pages (and sections where configured).