### PR TITLE
Revise hot water analysis

### DIFF
--- a/app/controllers/schools/advice/hot_water_controller.rb
+++ b/app/controllers/schools/advice/hot_water_controller.rb
@@ -34,7 +34,11 @@ module Schools
       end
 
       def gas_hot_water
-        @gas_hot_water ||= gas_hot_water_service.create_model
+        @gas_hot_water ||= build_gas_hot_water_model
+      end
+
+      def build_gas_hot_water_model
+        gas_hot_water_service.create_model
       end
 
       def gas_hot_water_service

--- a/app/controllers/schools/advice/hot_water_controller.rb
+++ b/app/controllers/schools/advice/hot_water_controller.rb
@@ -1,22 +1,40 @@
 module Schools
   module Advice
     class HotWaterController < AdviceBaseController
+      before_action   :gas_hot_water
+      before_action   :check_can_run_analysis, only: [:insights, :analysis]
+
       def insights
-        @gas_hot_water = build_gas_hot_water
       end
 
       def analysis
-        @gas_hot_water = build_gas_hot_water
       end
 
       private
+
+      def check_can_run_analysis
+        @has_swimming_pool = has_swimming_pool?
+        render :not_relevant and return if not_relevant?
+      end
+
+      def not_relevant?
+        has_swimming_pool? || minimal_use_of_gas?
+      end
+
+      def minimal_use_of_gas?
+        @gas_hot_water.investment_choices.existing_gas.efficiency > 1.0
+      end
+
+      def has_swimming_pool?
+        @school.has_swimming_pool?
+      end
 
       def create_analysable
         gas_hot_water_service
       end
 
-      def build_gas_hot_water
-        gas_hot_water_service.create_model
+      def gas_hot_water
+        @gas_hot_water ||= gas_hot_water_service.create_model
       end
 
       def gas_hot_water_service

--- a/app/views/schools/advice/hot_water/_analysis.html.erb
+++ b/app/views/schools/advice/hot_water/_analysis.html.erb
@@ -29,7 +29,31 @@
 
 <%= t('advice_pages.hot_water.analysis.hot_water_efficiency_improvement_options_table_footer_html') %>
 
-<strong><%= t('advice_pages.hot_water.analysis.improved_boiler_control_title') %></strong>
+<% if @gas_hot_water.investment_choices.point_of_use_electric.saving_£ > @gas_hot_water.investment_choices.gas_better_control.saving_£ &&
+     @gas_hot_water.investment_choices.point_of_use_electric.saving_co2 > @gas_hot_water.investment_choices.gas_better_control.saving_co2 %>
+     <p>
+       <%= t('advice_pages.hot_water.analysis.options.point_of_use_best') %>
+     </p>
+<% elsif @gas_hot_water.investment_choices.point_of_use_electric.saving_£ < @gas_hot_water.investment_choices.gas_better_control.saving_£ &&
+     @gas_hot_water.investment_choices.point_of_use_electric.annual_£ > @gas_hot_water.investment_choices.existing_gas.annual_£ &&
+     @gas_hot_water.investment_choices.point_of_use_electric.saving_co2 > @gas_hot_water.investment_choices.gas_better_control.saving_co2 %>
+     <p>
+       <%= t('advice_pages.hot_water.analysis.options.point_of_use_co2_saving') %>
+     </p>
+<% elsif @gas_hot_water.investment_choices.point_of_use_electric.saving_£ < @gas_hot_water.investment_choices.gas_better_control.saving_£ &&
+  @gas_hot_water.investment_choices.point_of_use_electric.annual_£ < @gas_hot_water.investment_choices.existing_gas.annual_£ &&
+  @gas_hot_water.investment_choices.point_of_use_electric.saving_co2 > @gas_hot_water.investment_choices.gas_better_control.saving_co2 %>
+    <p>
+       <%= t('advice_pages.hot_water.analysis.options.point_of_use_larger_co2_benefit') %>
+    </p>
+<% elsif @gas_hot_water.investment_choices.point_of_use_electric.saving_£ < @gas_hot_water.investment_choices.gas_better_control.saving_£ &&
+  @gas_hot_water.investment_choices.point_of_use_electric.saving_co2 < @gas_hot_water.investment_choices.gas_better_control.saving_co2 %>
+    <p>
+       <%= t('advice_pages.hot_water.analysis.options.point_of_use_not_worthwhile') %>
+    </p>
+<% end %>
+
+<p><strong><%= t('advice_pages.hot_water.analysis.improved_boiler_control_title') %></strong></p>
 <%= t('advice_pages.hot_water.analysis.improved_boiler_control_content_html',
       gas_better_control_saving_gbp: format_unit(@gas_hot_water.investment_choices.gas_better_control.saving_£, :£),
       gas_better_control_saving_co2: format_unit(@gas_hot_water.investment_choices.gas_better_control.saving_co2, :co2),
@@ -37,7 +61,7 @@
   )
 %>
 
-<strong><%= t('advice_pages.hot_water.analysis.point_of_use_electric_heater_title') %></strong>
+<p><strong><%= t('advice_pages.hot_water.analysis.point_of_use_electric_heater_title') %></strong></p>
 <%= t('advice_pages.hot_water.analysis.point_of_use_electric_heater_content_html',
        point_of_use_electric_saving_gbp: format_unit(@gas_hot_water.investment_choices.point_of_use_electric.saving_£, :£),
        point_of_use_electric_saving_co2: format_unit(@gas_hot_water.investment_choices.point_of_use_electric.saving_co2, :co2),

--- a/app/views/schools/advice/hot_water/_analysis_table.html.erb
+++ b/app/views/schools/advice/hot_water/_analysis_table.html.erb
@@ -1,16 +1,26 @@
 <table class="table table-sm">
   <thead class="thead-dark">
-    <th><%= t('advice_pages.hot_water.analysis.table.columns.choice') %></th>
-    <th class="text-right"><%= t('advice_pages.hot_water.analysis.table.columns.annual_kwh') %></th>
-    <th class="text-right"><%= t('advice_pages.hot_water.analysis.table.columns.annual_cost_gbp') %></th>
-    <th class="text-right"><%= t('advice_pages.hot_water.analysis.table.columns.annual_co2_kg') %></th>
-    <th class="text-right"><%= t('advice_pages.hot_water.analysis.table.columns.efficiency') %></th>
-    <th class="text-right"><%= t('advice_pages.hot_water.analysis.table.columns.saving_gbp') %></th>
-    <th class="text-right"><%= t('advice_pages.hot_water.analysis.table.columns.saving_gbp_percent') %></th>
-    <th class="text-right"><%= t('advice_pages.hot_water.analysis.table.columns.saving_co2') %></th>
-    <th class="text-right"><%= t('advice_pages.hot_water.analysis.table.columns.saving_co2_percent') %></th>
-    <th class="text-right"><%= t('advice_pages.hot_water.analysis.table.columns.capital_cost') %></th>
-    <th class="text-right"><%= t('advice_pages.hot_water.analysis.table.columns.payback_years') %></th>
+    <tr>
+      <th></th>
+      <th colspan="3"><%= t('advice_pages.hot_water.analysis.table.columns.annual') %></th>
+      <th></th>
+      <th colspan="4"><%= t('advice_pages.hot_water.analysis.table.columns.saving') %></th>
+      <th class="text-right"><%= t('advice_pages.hot_water.analysis.table.columns.capital_cost') %></th>
+      <th class="text-right"><%= t('advice_pages.hot_water.analysis.table.columns.payback') %></th>
+    </tr>
+    <tr>
+      <th><%= t('advice_pages.hot_water.analysis.table.columns.choice') %></th>
+      <th class="text-right"><%= t('advice_pages.hot_water.analysis.table.columns.annual_kwh') %></th>
+      <th class="text-right"><%= t('advice_pages.hot_water.analysis.table.columns.annual_cost_gbp') %></th>
+      <th class="text-right"><%= t('advice_pages.hot_water.analysis.table.columns.annual_co2_kg') %></th>
+      <th class="text-right"><%= t('advice_pages.hot_water.analysis.table.columns.efficiency') %></th>
+      <th class="text-right"><%= t('advice_pages.hot_water.analysis.table.columns.saving_gbp') %></th>
+      <th class="text-right"><%= t('advice_pages.hot_water.analysis.table.columns.saving_gbp_percent') %></th>
+      <th class="text-right"><%= t('advice_pages.hot_water.analysis.table.columns.saving_co2') %></th>
+      <th class="text-right"><%= t('advice_pages.hot_water.analysis.table.columns.saving_co2_percent') %></th>
+      <th class="text-right"><%= t('advice_pages.hot_water.analysis.table.columns.capital_cost_gbp') %></th>
+      <th class="text-right"><%= t('advice_pages.hot_water.analysis.table.columns.payback_years') %></th>
+    </tr>
   </thead>
   <tbody>
     <tr>

--- a/app/views/schools/advice/hot_water/_insights.html.erb
+++ b/app/views/schools/advice/hot_water/_insights.html.erb
@@ -4,6 +4,7 @@
 <%= render 'schools/advice/section_title', section_id: 'your_hot_water_use', section_title: 'Your hot water use' %>
 <p><%= t('advice_pages.hot_water.insights.circulatory_gas_based_hot_water') %></p>
 <p><%= t('advice_pages.hot_water.insights.we_estimate_your_hot_water_efficiency_to_be_html', efficiency_percent: format_unit(@gas_hot_water.investment_choices.existing_gas.efficiency, :percent)) %></p>
+
 <p>
   <%= t('advice_pages.hot_water.insights.improving_the_way_html',
          gas_better_control_saving_kwh_percent: format_unit(@gas_hot_water.investment_choices.gas_better_control.saving_kwh_percent, :percent),

--- a/app/views/schools/advice/hot_water/not_relevant.html.erb
+++ b/app/views/schools/advice/hot_water/not_relevant.html.erb
@@ -1,0 +1,11 @@
+<%= render 'schools/advice/advice_page', school: @school, advice_pages: @advice_pages, advice_page: @advice_page, tab: @tab, data_warning: @data_warning do %>
+
+  <% if @has_swimming_pool %>
+    <h2><%= advice_t('hot_water.not_relevant.swimming_pool.title') %></h2>
+    <%= advice_t('hot_water.not_relevant.swimming_pool.reason') %>
+  <% else %>
+    <h2><%= advice_t('hot_water.not_relevant.other_reasons.title') %></h2>
+    <%= advice_t('hot_water.not_relevant.other_reasons.reason') %>
+  <% end %>
+
+<% end %>

--- a/config/locales/views/advice_pages/hot_water.yml
+++ b/config/locales/views/advice_pages/hot_water.yml
@@ -122,7 +122,7 @@ en:
               <li>our preliminary analysis shows that it is unlikely your school uses a significant amount of gas to heat hot water</li>
               <li>you may already follow our advice and have switched off your hot water during the holidays. Well done!</li>
             </ul>
-          title: Unable to perform analysis
+          title: Unable to perform hot water analysis
         swimming_pool:
           reason: |-
             <p>

--- a/config/locales/views/advice_pages/hot_water.yml
+++ b/config/locales/views/advice_pages/hot_water.yml
@@ -73,10 +73,7 @@ en:
         circulatory_gas_based_hot_water: Circulatory gas-based hot water systems in schools are generally very inefficient, averaging about 15%
         for_more_detail_html: For more detail, <a href='%{link}'>compare with other schools in your group</a>
         how_do_you_compare: How do you compare?
-        improving_the_way_html: |-
-          Improving the way that you control your hot water could reduce your annual gas consumption by %{gas_better_control_saving_kwh_percent}
-          or you could investigate replacing your current hot water system with point of use electric heaters which would save
-          %{gas_point_of_use_electric_saving_kwh_percent}
+        improving_the_way_html: If you followed our recommendations to improve the way that you control your hot water, you could reduce your annual gas consumption for hot water by %{gas_better_control_saving_kwh_percent}. Or you could investigate replacing your current hot water system with point of use electric heaters.
         next_steps_html: |-
           To reduce the amount of energy used to heat water in your school:
           <ul>

--- a/config/locales/views/advice_pages/hot_water.yml
+++ b/config/locales/views/advice_pages/hot_water.yml
@@ -31,6 +31,11 @@ en:
         introduction_html: |-
           <p>This section gives a more detailed analysis of how to improve the efficiency of your school’s hot water system.</p>
           <p>The following sections provide more background and analysis on your hot water efficiency including:</p>
+        options:
+          point_of_use_best: Our analysis is showing that for your school, investing in point of use electric heaters would be the best option.
+          point_of_use_co2_saving: Our analysis is showing that for your school, investing in point of use electric heaters would cost more money to run than your current setup. However, it would reduce your CO2 emissions by more.
+          point_of_use_larger_co2_benefit: Our analysis is showing that for your school, investing in point of use electric heaters would save less money each year than improving your boiler control. However, it would reduce your CO2 emissions by more.
+          point_of_use_not_worthwhile: Our analysis is showing that for your school, investing in point of use electric heaters would be unlikely to be the best option.
         point_of_use_electric_heater_content_html: |-
           <p>This option often leads to the largest savings but for most schools it does require a significant capital investment.</p>
           <p>

--- a/config/locales/views/advice_pages/hot_water.yml
+++ b/config/locales/views/advice_pages/hot_water.yml
@@ -41,17 +41,21 @@ en:
         summary_notice: 'Note: if your school has a gas heated swimming pool, it is more difficult for us to assess efficiency.'
         table:
           columns:
-            annual_co2_kg: Annual CO2/kg
-            annual_cost_gbp: Annual Cost £
-            annual_kwh: Annual kWh
+            annual: Annual use
+            annual_co2_kg: CO2/kg
+            annual_cost_gbp: "£"
+            annual_kwh: kWh
             capital_cost: Capital Cost
+            capital_cost_gbp: "£"
             choice: Choice
             efficiency: Efficiency
-            payback_years: Payback (years)
-            saving_co2: Saving CO2
-            saving_co2_percent: Saving CO2 percent
-            saving_gbp: Saving £
-            saving_gbp_percent: Saving £ percent
+            payback: Payback
+            payback_years: Years
+            saving: Annual saving
+            saving_co2: CO2/kg
+            saving_co2_percent: "%"
+            saving_gbp: Cost
+            saving_gbp_percent: "%"
           rows:
             current_setup: Current setup
             improved_boiler_control: Improved boiler control

--- a/config/locales/views/advice_pages/hot_water.yml
+++ b/config/locales/views/advice_pages/hot_water.yml
@@ -106,4 +106,22 @@ en:
           Adjust your boiler settings to ensure that you are only heating water when it is needed.
         title: What do we mean by hot water gas use?
         we_estimate_your_hot_water_efficiency_to_be_html: We estimate your hot water efficiency to be %{efficiency_percent}
+      not_relevant:
+        other_reasons:
+          reason: |-
+            <p>We cannot generate a hot water gas use analysis for your school.</p>
+            <p>This could be for a number of reasons:</p>
+            <ul>
+              <li>we do not have enough gas consumption data for your school to perform the analysis, in which case you could try checking again after the next summer holidays</li>
+              <li>our preliminary analysis shows that it is unlikely your school uses a significant amount of gas to heat hot water</li>
+              <li>you may already follow our advice and have switched off your hot water during the holidays. Well done!</li>
+            </ul>
+          title: Unable to perform analysis
+        swimming_pool:
+          reason: |-
+            <p>
+            You've told us that your school has a swimming pool. Because of this we cannot accurately
+            estimate how much gas you use for hot water.
+            </p>
+          title: Unable to perform hot water analysis
       page_title: Hot water usage analysis

--- a/spec/system/schools/advice_pages/hot_water_spec.rb
+++ b/spec/system/schools/advice_pages/hot_water_spec.rb
@@ -94,6 +94,32 @@ RSpec.describe "hot water advice page", type: :system do
 
     it_behaves_like "an advice page tab", tab: "Insights"
 
+    context "when school has a pool" do
+      before do
+        allow_any_instance_of(Schools::Advice::HotWaterController).to receive_messages(
+          has_swimming_pool?: true
+        )
+        click_on 'Insights'
+      end
+      it 'shows not relevant page' do
+        expect(page).to have_content(I18n.t('advice_pages.hot_water.not_relevant.swimming_pool.title'))
+        expect(page).to have_content('pool')
+      end
+    end
+
+    context "when efficiency is too high" do
+      before do
+        allow_any_instance_of(Schools::Advice::HotWaterController).to receive_messages(
+          has_swimming_pool?: false,
+          minimal_use_of_gas?: true
+        )
+        click_on 'Insights'
+      end
+      it 'shows not relevant page' do
+        expect(page).to have_content(I18n.t('advice_pages.hot_water.not_relevant.other_reasons.title'))
+      end
+    end
+
     context "clicking the 'Insights' tab" do
       before { click_on 'Insights' }
       it_behaves_like "an advice page tab", tab: "Insights"
@@ -104,6 +130,7 @@ RSpec.describe "hot water advice page", type: :system do
         expect(page).to have_content('70,000') # 69_893  annual efficiency kwh total
         expect(page).to have_content('£2,100') # 2096    annual efficiency £ total
       end
+
     end
 
     context "clicking the 'Analysis' tab" do

--- a/spec/system/schools/advice_pages/hot_water_spec.rb
+++ b/spec/system/schools/advice_pages/hot_water_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "hot water advice page", type: :system do
       allow_any_instance_of(Schools::Advice::HotWaterController).to receive_messages(
         {
           create_analysable: OpenStruct.new(enough_data?: true),
-          build_gas_hot_water: OpenStruct.new(
+          build_gas_hot_water_model: OpenStruct.new(
             investment_choices: OpenStruct.new(
               existing_gas: OpenStruct.new(
                 annual_co2: 14_677.565516249997,


### PR DESCRIPTION
Revises the hot water advice page

* [x] Don't show the analysis or insights when a school has a swimming pool. Controller will now push user to a different page
* [x] Similarly, hide content if the estimated efficiency is >100%. Suggests we don't have enough data or our results are inaccurate
* [x] Revise table format on analysis page to better format the columns and labels
* [x] Revise insights tab text
* [x] Revise analysis page assessment of options, to include some interpretation based on the table data. (This may need to get revised later, so have left the logic in the template)
* [x] Add specs for not relevant checks
