### PR TITLE
Added preferred locale field to contact form

### DIFF
--- a/app/controllers/schools/contacts_controller.rb
+++ b/app/controllers/schools/contacts_controller.rb
@@ -50,7 +50,8 @@ private
       :mobile_phone_number,
       :name,
       :user_id,
-      :staff_role_id
+      :staff_role_id,
+      user_attributes: [:id, :preferred_locale]
     )
   end
 

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -39,6 +39,8 @@ class Contact < ApplicationRecord
   validates_uniqueness_of :email_address, scope: :school_id, unless: ->(contact) { contact.email_address.blank? }
   validates_uniqueness_of :mobile_phone_number, scope: :school_id, unless: ->(contact) { contact.mobile_phone_number.blank? }
 
+  accepts_nested_attributes_for :user
+
   def display_name
     name
   end

--- a/app/views/schools/contacts/_form.html.erb
+++ b/app/views/schools/contacts/_form.html.erb
@@ -1,16 +1,20 @@
+<%= render 'shared/errors', subject: f.object, subject_name: 'Contact' %>
 
 <%= f.input :user_id, as: :hidden %>
 <%= f.input :name, as: :string, readonly: f.object.user.present?, label: t('schools.contacts.form.labels.name') %>
 
-
 <% if f.object.user.nil? %>
   <%= f.input :staff_role_id, label: t('schools.contacts.form.labels.role'), collection: StaffRole.translated_names_and_ids %>
-
   <p><%= t('schools.contacts.form.enter_at_least_one_method_message') %></p>
 <% end %>
 
 <%= f.input :email_address, as: :email, readonly: f.object.user.present?, label: t('schools.contacts.form.labels.email') %>
 <%= f.input :mobile_phone_number, as: :string, label: t('schools.contacts.form.labels.mobile_phone_number') %>
 
-<%= f.submit submit, class: 'btn btn-primary' %>
+<% if f.object.user %>
+  <%= f.simple_fields_for :user do |p| %>
+    <%= p.input :preferred_locale, label: t('schools.users.form.preferred_locale'), required: :false, collection: I18n.available_locales.map { |locale| [I18n.t("languages.#{locale}"), locale] }, selected: f.object.preferred_locale, prompt: '', hint: t('schools.users.form.preferred_locale_hint') %>
+  <% end %>
+<% end %>
 
+<%= f.submit submit, class: 'btn btn-primary' %>

--- a/app/views/schools/contacts/index.html.erb
+++ b/app/views/schools/contacts/index.html.erb
@@ -30,6 +30,7 @@
         <th><%= t('schools.contacts.index.role') %></th>
         <th><%= t('schools.contacts.index.mobile_phone_number') %></th>
         <th><%= t('schools.contacts.index.email_address') %></th>
+        <th><%= t('schools.users.form.preferred_locale') %></th>
         <th><%= t('schools.contacts.index.actions') %></th>
       </tr>
     </thead>
@@ -40,6 +41,7 @@
           <td><%= contact.staff_role.try(:translated_title) %></td>
           <td><%= contact.mobile_phone_number %></td>
           <td><%= contact.email_address %></td>
+          <td><%= I18n.t("languages.#{contact.preferred_locale}") %></td>
           <td>
             <div class="btn-group">
               <%= link_to t('common.labels.edit'), edit_school_contact_path(@school, contact), class: 'btn btn-warning' %>

--- a/spec/system/schools/dashboard/manage_school_alert_contacts_spec.rb
+++ b/spec/system/schools/dashboard/manage_school_alert_contacts_spec.rb
@@ -59,7 +59,8 @@ RSpec.describe "manage school alert contacts", type: :system do
   end
 
   context 'as admin' do
-    let(:user)          { create(:admin) }
+    let(:user)                  { create(:admin) }
+    let!(:alertable_user) { create(:staff, school: school) }
     it 'should be able to visit the alert contacts page and enter a new contact' do
       visit school_contacts_path(school)
       expect(page.current_path).to eq(school_contacts_path(school))
@@ -81,6 +82,25 @@ RSpec.describe "manage school alert contacts", type: :system do
       expect(page.current_path).to eq(school_contacts_path(school))
       expect(page).not_to have_content("Professor Yaffle")
       expect(page).to have_content("Prof Yaffle")
+    end
+
+    it 'should be able to create and edit a new contact for a user' do
+      visit school_contacts_path(school)
+      click_on "Next"
+      fill_in 'Mobile phone number', with: '078912345678'
+      select 'Welsh', from: 'Preferred language'
+      click_on "Enable alert"
+      expect(page.current_path).to eq(school_contacts_path(school))
+      alertable_user.reload
+      expect(alertable_user.contacts.first.mobile_phone_number).to eq('078912345678')
+      expect(alertable_user.preferred_locale).to eq('cy')
+      click_on "Edit"
+      fill_in 'Mobile phone number', with: '01122333444'
+      select 'English', from: 'Preferred language'
+      click_on "Update details"
+      alertable_user.reload
+      expect(alertable_user.contacts.first.mobile_phone_number).to eq('01122333444')
+      expect(alertable_user.preferred_locale).to eq('en')
     end
   end
 end


### PR DESCRIPTION
When a contact has an associated user, the contact form should include a preferred language field, which reflects the preferred locale set on the user.

The language should be changeable from the contact form, and applied to the user.

If the contact doesn't have a user, then we don't show the preferred locale field.