### PR TITLE
Revise recent onboarding report

### DIFF
--- a/app/controllers/admin/school_onboardings_controller.rb
+++ b/app/controllers/admin/school_onboardings_controller.rb
@@ -17,7 +17,7 @@ module Admin
     end
 
     def completed
-      @completed_schools = @school_onboardings.complete.order(:updated_at)
+      @completed_schools = @school_onboardings.complete.order(updated_at: :desc)
     end
 
     def create

--- a/app/models/school_onboarding.rb
+++ b/app/models/school_onboarding.rb
@@ -127,4 +127,19 @@ class SchoolOnboarding < ApplicationRecord
   def page_anchor
     school_group.slug if school_group
   end
+
+  def onboarding_completed_on
+    events.onboarding_complete.minimum(:created_at)
+  end
+
+  def first_made_data_enabled
+    events.onboarding_data_enabled.minimum(:created_at)
+  end
+
+  def days_until_data_enabled
+    return nil unless complete?
+    data_enabled_on = first_made_data_enabled
+    return nil unless data_enabled_on.present?
+    (data_enabled_on.to_date - onboarding_completed_on.to_date).to_i
+  end
 end

--- a/app/views/admin/school_onboardings/completed.html.erb
+++ b/app/views/admin/school_onboardings/completed.html.erb
@@ -1,4 +1,4 @@
-.<h1>Schools recently onboarded</h1>
+<h1>Schools recently onboarded</h1>
 
 <table class="table table-sorted table-sm">
   <thead>
@@ -7,7 +7,7 @@
       <th>School group</th>
       <th>School name</th>
       <th>Contact email</th>
-      <th>Onboarded Completed</th>
+      <th>Onboarding Completed</th>
       <th>Data Enabled?</th>
       <th>Data Enabled On</th>
       <th>Days Until Enabled</th>

--- a/app/views/admin/school_onboardings/completed.html.erb
+++ b/app/views/admin/school_onboardings/completed.html.erb
@@ -1,4 +1,4 @@
-<h1>Schools recently onboarded</h1>
+.<h1>Schools recently onboarded</h1>
 
 <table class="table table-sorted table-sm">
   <thead>
@@ -7,7 +7,10 @@
       <th>School group</th>
       <th>School name</th>
       <th>Contact email</th>
-      <th>Onboarded at event</th>
+      <th>Onboarded Completed</th>
+      <th>Data Enabled?</th>
+      <th>Data Enabled On</th>
+      <th>Days Until Enabled</th>
     </tr>
   </thead>
   <tbody>
@@ -17,7 +20,10 @@
         <td><%= link_to onboarding.school.school_group.name, admin_school_group_path(onboarding.school.school_group) if onboarding.school.school_group.present? %> </td>
         <td><%= link_to onboarding.school_name, school_path(onboarding.school) %></td>
         <td><%= onboarding.contact_email %></td>
-        <td data-order="<%= onboarding.events.maximum(:created_at) %>"><%= nice_date_times(onboarding.events.maximum(:created_at)) %></td>
+        <td data-order="<%= onboarding.onboarding_completed_on %>"><%= nice_date_times(onboarding.onboarding_completed_on) %></td>
+        <td><%= onboarding.school.data_enabled %></td>
+        <td data-order="<%= onboarding.first_made_data_enabled %>"><%= nice_date_times(onboarding.first_made_data_enabled) %></td>
+        <td><%= onboarding.days_until_data_enabled %></td>
       </tr>
     <% end %>
   </tbody>


### PR DESCRIPTION
Revises the admin recent onboarding report:

* Order so most recent first
* Change "Onboarding event" column to be date-time when onboarding completed, not last event date
* Add column for whether school is data enabled
* Add column for date-time when school was data enabled
* Calculate number of days between onboarding completed and data being enabled

Pushed most of the logic into the SchoolOnboarding model.
