### PR TITLE
Implement gas cost advice page

### DIFF
--- a/app/controllers/schools/advice/base_costs_controller.rb
+++ b/app/controllers/schools/advice/base_costs_controller.rb
@@ -1,0 +1,82 @@
+module Schools
+  module Advice
+    class BaseCostsController < AdviceBaseController
+      protect_from_forgery except: :meter_costs
+
+      before_action :set_tariff_coverage, only: [:insights, :analysis]
+      before_action :set_next_steps, only: [:insights]
+      before_action :set_one_year_breakdown_chart, only: [:analysis, :meter_costs]
+      before_action :set_meters, only: [:analysis]
+
+      def insights
+        @annual_costs = costs_service.annual_costs
+        @monthly_costs = costs_service.calculate_costs_for_latest_twelve_months
+        @change_in_costs = costs_service.calculate_change_in_costs
+      end
+
+      def analysis
+        @annual_costs = costs_service.annual_costs
+        @multiple_meters = costs_service.multiple_meters?
+        @monthly_costs = costs_service.calculate_costs_for_latest_twelve_months
+        @change_in_costs = costs_service.calculate_change_in_costs
+        if @multiple_meters
+          @annual_costs_breakdown_by_meter = costs_service.annual_costs_breakdown_by_meter
+          @aggregate_meter_adapter = aggregate_meter_adapter
+          @options_for_meter_select = options_for_meter_select
+        end
+        @analysis_dates = analysis_dates
+      end
+
+      def meter_costs
+        if params[:mpan_mprn] == aggregate_meter_mpan_mprn
+          @mpan_mprn = aggregate_meter_mpan_mprn
+          @label = aggregate_meter_label
+          @monthly_costs = costs_service.calculate_costs_for_latest_twelve_months
+          @change_in_costs = costs_service.calculate_change_in_costs
+        else
+          meter = @school.meters.find_by_mpan_mprn(params[:mpan_mprn])
+          @mpan_mprn = params[:mpan_mprn]
+          @label = meter.name_or_mpan_mprn
+          analytics_meter = costs_service.analytics_meter_for_mpan(@mpan_mprn)
+          @monthly_costs = costs_service.calculate_costs_for_latest_twelve_months(analytics_meter)
+          @change_in_costs = costs_service.calculate_change_in_costs(analytics_meter)
+        end
+        @analysis_dates = analysis_dates
+        respond_to do |format|
+          format.js
+        end
+      end
+
+      private
+
+      def set_tariff_coverage
+        @complete_tariff_coverage = costs_service.complete_tariff_coverage?
+        @periods_with_missing_tariffs = costs_service.periods_with_missing_tariffs
+      end
+
+      def set_next_steps
+        @advice_page_insights_next_steps = @complete_tariff_coverage ? nil : I18n.t("advice_pages.#{advice_page_key}.insights.next_steps_html", link: school_user_tariffs_path(@school)).html_safe
+      end
+
+      def aggregate_meter_label
+        I18n.t("advice_pages.#{advice_page_key}.analysis.meter_breakdown.whole_school")
+      end
+
+      def aggregate_meter_mpan_mprn
+        aggregate_meter.mpan_mprn.to_s
+      end
+
+      def aggregate_meter_adapter
+        OpenStruct.new(mpan_mprn: aggregate_meter_mpan_mprn, name_or_mpan_mprn: aggregate_meter_label)
+      end
+
+      def options_for_meter_select
+        [aggregate_meter_adapter] + @meters.sort_by(&:name_or_mpan_mprn)
+      end
+
+      def costs_service
+        Schools::Advice::CostsService.new(@school, aggregate_school, advice_page_fuel_type)
+      end
+    end
+  end
+end

--- a/app/controllers/schools/advice/electricity_costs_controller.rb
+++ b/app/controllers/schools/advice/electricity_costs_controller.rb
@@ -1,63 +1,14 @@
 module Schools
   module Advice
-    class ElectricityCostsController < AdviceBaseController
-      protect_from_forgery except: :meter_costs
-
-      before_action :set_tariff_coverage, only: [:insights, :analysis]
-      before_action :set_next_steps, only: [:insights]
-      before_action :set_one_year_breakdown_chart, only: [:analysis, :meter_costs]
-
-      def insights
-        @annual_costs = costs_service.annual_costs
-        @monthly_costs = costs_service.calculate_costs_for_latest_twelve_months
-        @change_in_costs = costs_service.calculate_change_in_costs
-      end
-
-      def analysis
-        @meters = @school.meters.active.electricity
-        @annual_costs = costs_service.annual_costs
-        @multiple_meters = costs_service.multiple_meters?
-
-        @monthly_costs = costs_service.calculate_costs_for_latest_twelve_months
-        @change_in_costs = costs_service.calculate_change_in_costs
-
-        if @multiple_meters
-          @annual_costs_breakdown_by_meter = costs_service.annual_costs_breakdown_by_meter
-          @aggregate_meter_adapter = aggregate_meter_adapter
-          @options_for_meter_select = options_for_meter_select
-        end
-        @analysis_dates = analysis_dates
-      end
-
-      def meter_costs
-        if params[:mpan_mprn] == aggregate_meter_mpan_mprn
-          @mpan_mprn = aggregate_meter_mpan_mprn
-          @label = aggregate_meter_label
-          @monthly_costs = costs_service.calculate_costs_for_latest_twelve_months
-          @change_in_costs = costs_service.calculate_change_in_costs
-        else
-          meter = @school.meters.find_by_mpan_mprn(params[:mpan_mprn])
-          @mpan_mprn = params[:mpan_mprn]
-          @label = meter.name_or_mpan_mprn
-          analytics_meter = costs_service.analytics_meter_for_mpan(@mpan_mprn)
-          @monthly_costs = costs_service.calculate_costs_for_latest_twelve_months(analytics_meter)
-          @change_in_costs = costs_service.calculate_change_in_costs(analytics_meter)
-        end
-        @analysis_dates = analysis_dates
-        respond_to do |format|
-          format.js
-        end
-      end
-
+    class ElectricityCostsController < BaseCostsController
       private
 
-      def set_tariff_coverage
-        @complete_tariff_coverage = costs_service.complete_tariff_coverage?
-        @periods_with_missing_tariffs = costs_service.periods_with_missing_tariffs
+      def set_meters
+        @meters = @school.meters.active.electricity
       end
 
-      def set_next_steps
-        @advice_page_insights_next_steps = @complete_tariff_coverage ? nil : I18n.t('advice_pages.electricity_costs.insights.next_steps_html', link: school_user_tariffs_path(@school)).html_safe
+      def aggregate_meter
+        aggregate_school.aggregated_electricity_meters
       end
 
       def set_one_year_breakdown_chart
@@ -76,32 +27,12 @@ module Schools
         end
       end
 
-      def aggregate_meter_label
-        I18n.t('advice_pages.electricity_costs.analysis.meter_breakdown.whole_school')
-      end
-
-      def aggregate_meter_mpan_mprn
-        aggregate_school.aggregated_electricity_meters.mpan_mprn.to_s
-      end
-
-      def aggregate_meter_adapter
-        OpenStruct.new(mpan_mprn: aggregate_meter_mpan_mprn, name_or_mpan_mprn: aggregate_meter_label)
-      end
-
-      def options_for_meter_select
-        [aggregate_meter_adapter] + @meters.sort_by(&:name_or_mpan_mprn)
-      end
-
       def advice_page_key
         :electricity_costs
       end
 
       def advice_page_fuel_type
         :electricity
-      end
-
-      def costs_service
-        Schools::Advice::CostsService.new(@school, aggregate_school, :electricity)
       end
     end
   end

--- a/app/controllers/schools/advice/gas_costs_controller.rb
+++ b/app/controllers/schools/advice/gas_costs_controller.rb
@@ -1,16 +1,39 @@
 module Schools
   module Advice
-    class GasCostsController < AdviceBaseController
-      def insights
-      end
-
-      def analysis
-      end
-
+    class GasCostsController < BaseCostsController
       private
+
+      def set_meters
+        @meters = @school.meters.active.gas
+      end
+
+      def aggregate_meter
+        aggregate_school.aggregated_heat_meters
+      end
+
+      #FIXME keep to current, or change over?
+      def set_one_year_breakdown_chart
+        dates = analysis_dates
+        days_of_data = dates.end_date - dates.start_date
+        case days_of_data
+        when 1..13
+          @one_year_breakdown_chart = :gas_cost_1_year_accounting_breakdown_group_by_day
+          @one_year_breakdown_chart_key = :cost_1_year_accounting_breakdown_group_by_day
+        when 14..79
+          @one_year_breakdown_chart = :gas_cost_1_year_accounting_breakdown_group_by_week
+          @one_year_breakdown_chart_key = :cost_1_year_accounting_breakdown_group_by_week
+        else
+          @one_year_breakdown_chart = :gas_cost_1_year_accounting_breakdown
+          @one_year_breakdown_chart_key = :cost_1_year_accounting_breakdown
+        end
+      end
 
       def advice_page_key
         :gas_costs
+      end
+
+      def advice_page_fuel_type
+        :gas
       end
     end
   end

--- a/app/views/schools/advice/electricity_costs/_meter_breakdown.html.erb
+++ b/app/views/schools/advice/electricity_costs/_meter_breakdown.html.erb
@@ -1,12 +1,12 @@
 <%= render 'schools/advice/section_title', section_id: 'meter-breakdown', section_title: advice_t('electricity_costs.analysis.meter_breakdown.title') %>
 
 <%= simple_form_for :school, url: meter_costs_school_advice_electricity_costs_path(school, format: :js), method: :get, remote: true do |f| %>
-    <div class="form-group">
-      <label>
-        <%= advice_t('electricity_costs.analysis.meter_breakdown.select') %>
-      </label>
-      <%= select_tag :mpan_mprn, options_from_collection_for_select(options_for_meter_select, :mpan_mprn, :name_or_mpan_mprn, nil), class: "form-control", onchange: "$(this.form).submit();" %>
-    </div>
+  <div class="form-group">
+    <label>
+      <%= advice_t('electricity_costs.analysis.meter_breakdown.select') %>
+    </label>
+    <%= select_tag :mpan_mprn, options_from_collection_for_select(options_for_meter_select, :mpan_mprn, :name_or_mpan_mprn, nil), class: "form-control", onchange: "$(this.form).submit();" %>
+  </div>
 <% end %>
 
 <div id="meter-costs">

--- a/app/views/schools/advice/gas_costs/_analysis.html.erb
+++ b/app/views/schools/advice/gas_costs/_analysis.html.erb
@@ -1,0 +1,48 @@
+<%= render 'tariff_note', school: @school, analysis_dates: @analysis_dates, complete_tariff_coverage: @complete_tariff_coverage, periods_with_missing_tariffs: @periods_with_missing_tariffs %>
+
+<% if @multiple_meters || @analysis_dates.months_of_data > 23 %>
+  <p><%= advice_t('gas_costs.analysis.summary') %></p>
+<% end %>
+
+<% if @multiple_meters %>
+  <ul>
+    <li>
+      <%= link_to(advice_t('gas_costs.analysis.cost_breakdown_by_meter.title', period: format_unit(@annual_costs.days/365.0, :years)), '#cost-breakdown-by-meter') %>
+    </li>
+    <li><%= link_to(advice_t('gas_costs.analysis.meter_breakdown.title'), '#meter-breakdown') %></li>
+  </ul>
+<% else %>
+  <ul>
+    <% if @analysis_dates.months_of_data > 23 %>
+      <li><%= link_to( advice_t('gas_costs.analysis.cost_breakdown_by_charge.title', period: format_unit(@annual_costs.days/365.0, :years)), '#cost-breakdown-by-charge') %></li>
+      <li><%= link_to(advice_t('gas_costs.analysis.comparison.title'), '#comparison') %></li>
+    <% end %>
+  </ul>
+<% end %>
+
+<% if @multiple_meters %>
+  <%= render 'cost_breakdown_by_meter', school: @school, analysis_dates: @analysis_dates, annual_costs: @annual_costs, annual_costs_breakdown_by_meter: @annual_costs_breakdown_by_meter %>
+  <%= render 'meter_breakdown',
+    school: @school,
+    options_for_meter_select: @options_for_meter_select,
+    default_meter: @aggregate_meter_adapter.mpan_mprn,
+    default_meter_label: @aggregate_meter_adapter.name_or_mpan_mprn,
+    analysis_dates: @analysis_dates,
+    one_year_breakdown_chart: @one_year_breakdown_chart,
+    one_year_breakdown_chart_key: @one_year_breakdown_chart_key,
+    monthly_costs: @monthly_costs,
+    change_in_costs: @change_in_costs %>
+<% else %>
+  <%= render 'cost_breakdown_by_charge',
+    school: @school,
+    analysis_dates: @analysis_dates,
+    annual_costs: @annual_costs,
+    one_year_breakdown_chart: @one_year_breakdown_chart,
+    one_year_breakdown_chart_key: @one_year_breakdown_chart_key,
+    monthly_costs: @monthly_costs,
+    change_in_costs: @change_in_costs,
+    show_school_total: true %>
+  <% if @analysis_dates.months_of_data > 23 %>
+    <%= render 'cost_comparison', school: @school, analysis_dates: @analysis_dates %>
+  <% end %>
+<% end %>

--- a/app/views/schools/advice/gas_costs/_cost_breakdown_by_charge.html.erb
+++ b/app/views/schools/advice/gas_costs/_cost_breakdown_by_charge.html.erb
@@ -1,0 +1,14 @@
+<%= render 'schools/advice/section_title', section_id: 'cost-breakdown-by-charge', section_title: advice_t('gas_costs.analysis.cost_breakdown_by_charge.title', period: format_unit(annual_costs.days/365.0, :years)) %>
+
+<% if local_assigns[:show_school_total] == true %>
+  <p>
+    <%= advice_t('gas_costs.analysis.cost_breakdown_by_meter.whole_school', cost: format_unit(annual_costs.£, :£), period: format_unit(annual_costs.days/365.0, :years)) %>
+  </p>
+<% end %>
+
+<%= component 'chart', chart_type: one_year_breakdown_chart, school: school do |c| %>
+  <% c.with_title { advice_t("gas_costs.charts.#{one_year_breakdown_chart_key}.title") } %>
+  <% c.with_subtitle { advice_t("gas_costs.charts.#{one_year_breakdown_chart_key}.subtitle_html", end_date: analysis_dates.end_date.to_s(:es_short)) } %>
+<% end %>
+
+<%= component 'meter_costs_table', monthly_costs: monthly_costs, change_in_costs: change_in_costs %>

--- a/app/views/schools/advice/gas_costs/_cost_breakdown_by_meter.html.erb
+++ b/app/views/schools/advice/gas_costs/_cost_breakdown_by_meter.html.erb
@@ -1,0 +1,24 @@
+<%= render 'schools/advice/section_title', section_id: 'cost-breakdown-by-meter', section_title: advice_t('gas_costs.analysis.cost_breakdown_by_meter.title', period: format_unit(annual_costs.days/365.0, :years)) %>
+
+<p>
+  <%= advice_t('gas_costs.analysis.cost_breakdown_by_meter.intro', period: format_unit(annual_costs.days/365.0, :years)) %>
+</p>
+
+<table class="table table-sm advice-table table-with-totals">
+  <thead>
+    <th class="text-left"><%= advice_t('gas_costs.tables.columns.meter') %></th>
+    <th class="text-right"><%= advice_t('gas_costs.tables.columns.cost') %></th>
+  </thead>
+  <tbody>
+    <% annual_costs_breakdown_by_meter.sort{|a,b| a[0].name_or_mpan_mprn <=> b[0].name_or_mpan_mprn }.each do |meter, cost| %>
+      <tr>
+        <td class="text-left"><%= meter.name_or_mpan_mprn %></td>
+        <td class="text-right"><%= FormatEnergyUnit.format_pounds(:£, cost.£, :text, :approx_accountant, true) %></td>
+      </tr>
+    <% end %>
+    <tr>
+      <td class="text-left"><%= advice_t('gas_costs.tables.labels.total') %></td>
+      <td class="text-right"><%= FormatEnergyUnit.format_pounds(:£, annual_costs.£, :text, :approx_accountant, true) %></td>
+    </tr>
+  </tbody>
+</table>

--- a/app/views/schools/advice/gas_costs/_cost_comparison.html.erb
+++ b/app/views/schools/advice/gas_costs/_cost_comparison.html.erb
@@ -1,0 +1,6 @@
+<%= render 'schools/advice/section_title', section_id: 'comparison', section_title: advice_t('gas_costs.analysis.comparison.title') %>
+
+<%= component 'chart', chart_type: :electricity_cost_comparison_last_2_years_accounting, school: school do |c| %>
+  <% c.with_title { advice_t('gas_costs.charts.cost_comparison_last_2_years_accounting.title') } %>
+  <% c.with_subtitle { advice_t('gas_costs.charts.cost_comparison_last_2_years_accounting.subtitle_html', end_date: analysis_dates.end_date.to_s(:es_short)) } %>
+<% end %>

--- a/app/views/schools/advice/gas_costs/_insights.html.erb
+++ b/app/views/schools/advice/gas_costs/_insights.html.erb
@@ -1,0 +1,14 @@
+<%= component 'notice', status: :neutral do |c| %>
+  <% c.with_link { link_to t('advice_pages.gas_costs.insights.link'), learn_more_school_advice_electricity_costs_path(@school) } %>
+  <%= t('advice_pages.gas_costs.insights.intro_html') %>
+<% end %>
+
+<%= render 'schools/advice/section_title', section_id: 'current-costs', section_title: t('advice_pages.gas_costs.insights.current_costs.title') %>
+
+<%= render 'tariff_note', school: @school, analysis_dates: @analysis_dates, complete_tariff_coverage: @complete_tariff_coverage, periods_with_missing_tariffs: @periods_with_missing_tariffs %>
+
+<p>
+  <%= advice_t('gas_costs.analysis.cost_breakdown_by_meter.whole_school', cost: format_unit(@annual_costs.£, :£), period: format_unit(@annual_costs.days/365.0, :years)) %>
+</p>
+
+<%= component 'meter_costs_table', monthly_costs: @monthly_costs, change_in_costs: @change_in_costs %>

--- a/app/views/schools/advice/gas_costs/_meter.html.erb
+++ b/app/views/schools/advice/gas_costs/_meter.html.erb
@@ -1,0 +1,13 @@
+<%= component 'chart', chart_type: one_year_breakdown_chart, analysis_controls: true, school: school, chart_config: create_chart_config(school, one_year_breakdown_chart, mpan_mprn) do |c| %>
+  <% c.with_title { advice_t("gas_costs.charts.#{one_year_breakdown_chart_key}.meter_title", meter: label) } %>
+  <% c.with_subtitle { advice_t("gas_costs.charts.#{one_year_breakdown_chart_key}.meter_subtitle_html", end_date: analysis_dates.end_date.to_s(:es_short)) } %>
+<% end %>
+
+<%= component 'meter_costs_table', monthly_costs: monthly_costs, change_in_costs: change_in_costs %>
+
+<% if analysis_dates.months_of_data > 23 %>
+  <%= component 'chart', chart_type: :electricity_cost_comparison_last_2_years_accounting, analysis_controls: true, school: school, chart_config: create_chart_config(school, :electricity_cost_comparison_last_2_years_accounting, mpan_mprn) do |c| %>
+    <% c.with_title { advice_t('gas_costs.charts.cost_comparison_last_2_years_accounting.meter_title', meter: label) } %>
+    <% c.with_subtitle { advice_t('gas_costs.charts.cost_comparison_last_2_years_accounting.subtitle_html', end_date: analysis_dates.end_date.to_s(:es_short)) } %>
+  <% end %>
+<% end %>

--- a/app/views/schools/advice/gas_costs/_meter_breakdown.html.erb
+++ b/app/views/schools/advice/gas_costs/_meter_breakdown.html.erb
@@ -1,12 +1,12 @@
 <%= render 'schools/advice/section_title', section_id: 'meter-breakdown', section_title: advice_t('gas_costs.analysis.meter_breakdown.title') %>
 
 <%= simple_form_for :school, url: meter_costs_school_advice_electricity_costs_path(school, format: :js), method: :get, remote: true do |f| %>
-    <div class="form-group">
-      <label>
-        <%= advice_t('gas_costs.analysis.meter_breakdown.select') %>
-      </label>
-      <%= select_tag :mpan_mprn, options_from_collection_for_select(options_for_meter_select, :mpan_mprn, :name_or_mpan_mprn, nil), class: "form-control", onchange: "$(this.form).submit();" %>
-    </div>
+  <div class="form-group">
+    <label>
+      <%= advice_t('gas_costs.analysis.meter_breakdown.select') %>
+    </label>
+    <%= select_tag :mpan_mprn, options_from_collection_for_select(options_for_meter_select, :mpan_mprn, :name_or_mpan_mprn, nil), class: "form-control", onchange: "$(this.form).submit();" %>
+  </div>
 <% end %>
 
 <div id="meter-costs">

--- a/app/views/schools/advice/gas_costs/_meter_breakdown.html.erb
+++ b/app/views/schools/advice/gas_costs/_meter_breakdown.html.erb
@@ -1,0 +1,22 @@
+<%= render 'schools/advice/section_title', section_id: 'meter-breakdown', section_title: advice_t('gas_costs.analysis.meter_breakdown.title') %>
+
+<%= simple_form_for :school, url: meter_costs_school_advice_electricity_costs_path(school, format: :js), method: :get, remote: true do |f| %>
+    <div class="form-group">
+      <label>
+        <%= advice_t('gas_costs.analysis.meter_breakdown.select') %>
+      </label>
+      <%= select_tag :mpan_mprn, options_from_collection_for_select(options_for_meter_select, :mpan_mprn, :name_or_mpan_mprn, nil), class: "form-control", onchange: "$(this.form).submit();" %>
+    </div>
+<% end %>
+
+<div id="meter-costs">
+  <%= render 'meter',
+    mpan_mprn: default_meter,
+    label: default_meter_label,
+    school: school,
+    analysis_dates: analysis_dates,
+    one_year_breakdown_chart: one_year_breakdown_chart,
+    one_year_breakdown_chart_key: one_year_breakdown_chart_key,
+    monthly_costs: monthly_costs,
+    change_in_costs: change_in_costs %>
+</div>

--- a/app/views/schools/advice/gas_costs/_tariff_note.html.erb
+++ b/app/views/schools/advice/gas_costs/_tariff_note.html.erb
@@ -1,0 +1,12 @@
+<% if complete_tariff_coverage %>
+  <%= component 'notice', status: :neutral, classes: 'mb-2' do |c| %>
+    <%= advice_t('gas_costs.analysis.tariff_note.good_estimate') %>
+  <% end %>
+<% else %>
+  <%= component 'notice', status: :negative, classes: 'mb-2' do |c| %>
+    <% c.with_link { link_to advice_t('gas_costs.analysis.tariff_note.manage_tariffs'), school_user_tariffs_path(school) } %>
+    <p>
+      <%= advice_t('gas_costs.analysis.tariff_note.poor_estimate', period_start_and_end: @periods_with_missing_tariffs.map{|range| [range[0].to_s(:es_short), range[1].to_s(:es_short)].to_sentence }.join(",")) %>
+    </p>
+  <% end %>
+<% end %>

--- a/app/views/schools/advice/gas_costs/meter_costs.js.erb
+++ b/app/views/schools/advice/gas_costs/meter_costs.js.erb
@@ -1,0 +1,2 @@
+$("#meter-costs").html("<%= escape_javascript(render 'meter', mpan_mprn: @mpan_mprn, label: @label, school: @school, analysis_dates: @analysis_dates, one_year_breakdown_chart: @one_year_breakdown_chart, one_year_breakdown_chart_key: @one_year_breakdown_chart_key, monthly_costs: @monthly_costs, change_in_costs: @change_in_costs) %>");
+processAnalysisCharts();

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -145,6 +145,7 @@ ignore_unused:
   - 'advice_pages.*.insights.title'
   - 'advice_pages.*.insights.next_steps'
   - 'advice_pages.electricity_costs.charts.cost_1_year_accounting_breakdown*'
+  - 'advice_pages.gas_costs.charts.cost_1_year_accounting_breakdown*'
 # - '{devise,kaminari,will_paginate}.*'
 # - 'simple_form.{yes,no}'
 # - 'simple_form.{placeholders,hints,labels}.*'

--- a/config/locales/views/advice_pages/gas_costs.yml
+++ b/config/locales/views/advice_pages/gas_costs.yml
@@ -3,8 +3,58 @@ en:
   advice_pages:
     gas_costs:
       analysis:
-        title: Analysis
+        comparison:
+          title: Cost comparison for last 2 years
+        cost_breakdown_by_charge:
+          title: Cost breakdown by charge for the last %{period}
+        cost_breakdown_by_meter:
+          intro: The following table summarises the total cost associated with each meter for the last %{period}
+          title: Total cost for the last %{period}
+          whole_school: We estimate your total gas cost over the last %{period} to be %{cost}.
+        meter_breakdown:
+          select: Select an option to view costs for the whole school or a specific meter
+          title: Cost breakdown
+          whole_school: Whole school
+        summary: The following sections provide more background and analysis on your gas costs
+        tariff_note:
+          good_estimate: The information below provides a good estimate of your annual costs for this meter based on meter tariff information which has been provided to Energy Sparks.
+          manage_tariffs: Manage tariffs
+          poor_estimate: Energy Sparks currently doesn't have a complete record of your real tariffs and is using default tariffs between %{period_start_and_end}. This means the costs on this page won't be accurate.
+      charts:
+        cost_1_year_accounting_breakdown:
+          meter_subtitle_html: This chart shows the bill components for the 12 months ending on <span class='end-date'>%{end_date}</span>
+          meter_title: Gas cost components for the last year for %{meter}
+          subtitle_html: This chart shows the bill components for the 12 months ending on <span class='end-date'>%{end_date}</span> for the whole school
+          title: Gas cost components for the last year
+        cost_1_year_accounting_breakdown_group_by_day:
+          meter_subtitle_html: This chart shows the bill components for the period ending on <span class='end-date'>%{end_date}</span>
+          meter_title: Gas cost components for the last two weeks for %{meter}
+          subtitle_html: This chart shows the bill components for the period ending on <span class='end-date'>%{end_date}</span> for the whole school
+          title: Gas cost components for the last two weeks
+        cost_1_year_accounting_breakdown_group_by_week:
+          meter_subtitle_html: This chart shows the bill components for the period ending on <span class='end-date'>%{end_date}</span>
+          meter_title: Gas cost components for the last few weeks for %{meter}
+          subtitle_html: This chart shows the bill components for the period ending on <span class='end-date'>%{end_date}</span> for the whole school
+          title: Gas cost components for the last few weeks
+        cost_comparison_last_2_years_accounting:
+          meter_title: Gas cost comparison for last 2 years for %{meter}
+          subtitle_html: This chart compares your monthly consumption for the 12 months ending on <span class='end-date'>%{end_date}</span> and the previous 12 months
+          title: Gas cost comparison for last 2 years
       insights:
-        next_steps: Next steps
-        title: Insights
+        current_costs:
+          title: Your current costs
+        intro_html: |-
+          <p>Your gas bill is broken down into a variety of different charges.
+          </p>
+          <p>
+          Understanding these charges can help you reduce your costs and may help with bill validation.
+          </p>
+        link: Learn more
+        next_steps_html: To get a better estimate of your costs, <a href="%{link}">update your tariff information</a>
       page_title: Gas cost analysis
+      tables:
+        columns:
+          cost: Cost (£)
+          meter: Meter
+        labels:
+          total: Total

--- a/spec/system/schools/advice_pages/gas_costs_spec.rb
+++ b/spec/system/schools/advice_pages/gas_costs_spec.rb
@@ -8,7 +8,38 @@ RSpec.describe "gas costs advice page", type: :system do
   context 'as school admin' do
     let(:user)  { create(:school_admin, school: school) }
 
+    let(:complete_tariff_coverage) { false }
+    let(:multiple_meters) { false }
+    let(:period_start)  { Date.today.beginning_of_year }
+    let(:periods_with_missing_tariffs) { [[period_start, period_start + 1.month]] }
+    let(:annual_costs)  { OpenStruct.new(£: 1000, days: 365) }
+    let(:annual_costs_breakdown_by_meter) { Hash.new }
+    let(:beginning_of_month)  { Date.today.beginning_of_month }
+    let(:costs_for_latest_twelve_months) {
+      { beginning_of_month => Costs::MeterMonth.new(
+        month_start_date: beginning_of_month,
+        start_date: beginning_of_month,
+        end_date: beginning_of_month.end_of_month,
+        bill_component_costs: {}
+      )}
+    }
+    let(:change_in_costs) {
+      {beginning_of_month => nil}
+    }
+
     before do
+      allow(gas_aggregate_meter).to receive(:mpan_mprn).and_return("999999")
+
+      allow_any_instance_of(Schools::Advice::CostsService).to receive_messages(
+        complete_tariff_coverage?: complete_tariff_coverage,
+        periods_with_missing_tariffs: periods_with_missing_tariffs,
+        annual_costs: annual_costs,
+        multiple_meters?: multiple_meters,
+        annual_costs_breakdown_by_meter: annual_costs_breakdown_by_meter,
+        calculate_costs_for_latest_twelve_months: costs_for_latest_twelve_months,
+        calculate_change_in_costs: change_in_costs
+      )
+
       sign_in(user)
       visit school_advice_gas_costs_path(school)
     end
@@ -18,10 +49,69 @@ RSpec.describe "gas costs advice page", type: :system do
     context "clicking the 'Insights' tab" do
       before { click_on 'Insights' }
       it_behaves_like "an advice page tab", tab: "Insights"
+
+      it 'has the intro' do
+        expect(page).to have_content("Your gas bill is broken down into a variety of different charges")
+      end
+      it 'displays a brief summary of total cost' do
+        expect(page).to have_content("We estimate your total gas cost over the last 12 months to be £1,000")
+      end
+      context 'and incomplete tariffs' do
+        it 'displays warning about incomplete tariffs' do
+          expect(page).to have_content("Energy Sparks currently doesn't have a complete record of your real tariffs")
+        end
+      end
+      context 'and complete tariffs' do
+        let(:complete_tariff_coverage) { true }
+        it 'does not display warning about incomplete tariffs' do
+          expect(page).to_not have_content("Energy Sparks currently doesn't have a complete record of your real tariffs")
+          expect(page).to have_content("The information below provides a good estimate of your annual costs")
+        end
+      end
+
     end
     context "clicking the 'Analysis' tab" do
       before { click_on 'Analysis' }
       it_behaves_like "an advice page tab", tab: "Analysis"
+
+      context 'with single meter' do
+        it 'displays a brief summary of total cost' do
+          expect(page).to_not have_content(I18n.t('advice_pages.gas_costs.analysis.cost_breakdown_by_meter.title'))
+          expect(page).to have_content("We estimate your total gas cost over the last 12 months to be £1,000")
+        end
+        context 'and incomplete tariffs' do
+          it 'displays warning about incomplete tariffs' do
+            expect(page).to have_content("Energy Sparks currently doesn't have a complete record of your real tariffs")
+          end
+        end
+        context 'and complete tariffs' do
+          let(:complete_tariff_coverage) { true }
+          it 'does not display warning about incomplete tariffs' do
+            expect(page).to_not have_content("Energy Sparks currently doesn't have a complete record of your real tariffs")
+            expect(page).to have_content("The information below provides a good estimate of your annual costs")
+          end
+        end
+        it 'with only 12 months data' do
+          expect(page).to have_css('#chart_wrapper_gas_cost_1_year_accounting_breakdown')
+          expect(page).to_not have_css('#chart_wrapper_gas_cost_comparison_last_2_years_accounting')
+        end
+      end
+      context 'with multiple meters' do
+        let(:multiple_meters) { true }
+        before(:each) do
+          allow_any_instance_of(Schools::Advice::CostsService).to receive_messages(
+            annual_costs_breakdown_by_meter: annual_costs_breakdown_by_meter
+          )
+        end
+        it 'does not display a brief summary of total cost' do
+          expect(page).to_not have_content("We estimate your total gas cost over the last 12 months to be £1,000")
+        end
+        it 'displays table' do
+          expect(page).to have_content("Total cost for the last 12 months")
+          expect(page).to have_content('Whole school')
+        end
+      end
+
     end
     context "clicking the 'Learn More' tab" do
       before { click_on 'Learn More' }


### PR DESCRIPTION
Implements the gas costs advice page.

* Extracts code from electricity costs controller to create a common base class to be used for gas and electricity controllers
* Copies over the templates, specs and translation text for the gas page, adjusting values/keys as required

