### PR TITLE
Implement advice index page benchmarking framework

### DIFF
--- a/app/controllers/schools/advice/baseload_controller.rb
+++ b/app/controllers/schools/advice/baseload_controller.rb
@@ -4,7 +4,7 @@ module Schools
       def insights
         @analysis_dates = analysis_dates
         @current_baseload = current_baseload
-        @benchmarked_baseload = benchmark_baseload(current_baseload.average_baseload_kw_last_year)
+        @benchmarked_baseload = baseload_service.benchmark_baseload
       end
 
       def analysis
@@ -63,18 +63,6 @@ module Schools
           average_baseload_kw_last_year: average_baseload_kw_last_year,
           percentage_change_year: relative_percent(previous_year_average_baseload_kw, average_baseload_kw_last_year),
           percentage_change_week: relative_percent(previous_week_average_baseload_kw, average_baseload_kw_last_week)
-        )
-      end
-
-      def benchmark_baseload(average_baseload_kw_last_year)
-        average_baseload_kw_benchmark = baseload_service.average_baseload_kw_benchmark(compare: :benchmark_school)
-        average_baseload_kw_exemplar = baseload_service.average_baseload_kw_benchmark(compare: :exemplar_school)
-
-        Schools::Comparison.new(
-          school_value: average_baseload_kw_last_year,
-          benchmark_value: average_baseload_kw_benchmark,
-          exemplar_value: average_baseload_kw_exemplar,
-          unit: :kw
         )
       end
 

--- a/app/models/advice_page.rb
+++ b/app/models/advice_page.rb
@@ -25,6 +25,7 @@ class AdvicePage < ApplicationRecord
 
   has_many :advice_page_intervention_types
   has_many :intervention_types, through: :advice_page_intervention_types
+  has_many :advice_page_school_benchmarks
 
   accepts_nested_attributes_for :advice_page_activity_types, reject_if: proc {|attributes| attributes['position'].blank? }
 

--- a/app/models/advice_page_school_benchmark.rb
+++ b/app/models/advice_page_school_benchmark.rb
@@ -22,5 +22,5 @@
 class AdvicePageSchoolBenchmark < ApplicationRecord
   belongs_to :school, inverse_of: :advice_page_school_benchmarks
   belongs_to :advice_page, inverse_of: :advice_page_school_benchmarks
-  enum benchmarked_as: [:improving, :well_managed, :exemplar]
+  enum benchmarked_as: [:other_school, :benchmark_school, :exemplar_school]
 end

--- a/app/models/advice_page_school_benchmark.rb
+++ b/app/models/advice_page_school_benchmark.rb
@@ -1,0 +1,26 @@
+# == Schema Information
+#
+# Table name: advice_page_school_benchmarks
+#
+#  advice_page_id :bigint(8)        not null
+#  benchmarked_as :integer          default("improving"), not null
+#  created_at     :datetime         not null
+#  id             :bigint(8)        not null, primary key
+#  school_id      :bigint(8)        not null
+#  updated_at     :datetime         not null
+#
+# Indexes
+#
+#  index_advice_page_school_benchmarks_on_advice_page_id  (advice_page_id)
+#  index_advice_page_school_benchmarks_on_school_id       (school_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (advice_page_id => advice_pages.id) ON DELETE => cascade
+#  fk_rails_...  (school_id => schools.id) ON DELETE => cascade
+#
+class AdvicePageSchoolBenchmark < ApplicationRecord
+  belongs_to :school, inverse_of: :advice_page_school_benchmarks
+  belongs_to :advice_page, inverse_of: :advice_page_school_benchmarks
+  enum benchmarked_as: [:improving, :well_managed, :exemplar]
+end

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -138,6 +138,8 @@ class School < ApplicationRecord
   has_many :school_alert_type_exclusions, dependent: :destroy
   has_many :school_batch_runs
 
+  has_many :advice_page_school_benchmarks
+
   belongs_to :calendar, optional: true
   belongs_to :template_calendar, optional: true, class_name: 'Calendar'
 

--- a/app/services/schools/advice/baseload_service.rb
+++ b/app/services/schools/advice/baseload_service.rb
@@ -143,7 +143,6 @@ module Schools
         )
       end
 
-
       private
 
       def asof_date

--- a/app/services/schools/advice/baseload_service.rb
+++ b/app/services/schools/advice/baseload_service.rb
@@ -130,6 +130,20 @@ module Schools
         end
       end
 
+      def benchmark_baseload
+        average_baseload_kw_last_year = average_baseload_kw(period: :year)
+        average_baseload_kw_benchmark = average_baseload_kw_benchmark(compare: :benchmark_school)
+        average_baseload_kw_exemplar = average_baseload_kw_benchmark(compare: :exemplar_school)
+
+        Schools::Comparison.new(
+          school_value: average_baseload_kw_last_year,
+          benchmark_value: average_baseload_kw_benchmark,
+          exemplar_value: average_baseload_kw_exemplar,
+          unit: :kw
+        )
+      end
+
+
       private
 
       def asof_date

--- a/app/services/schools/advice_page_benchmarks/baseload_benchmark_generator.rb
+++ b/app/services/schools/advice_page_benchmarks/baseload_benchmark_generator.rb
@@ -2,9 +2,8 @@ module Schools
   module AdvicePageBenchmarks
     class BaseloadBenchmarkGenerator < SchoolBenchmarkGenerator
       def benchmark_school
-        return nil unless baseload_service.enough_data?
-        comparison = baseload_service.benchmark_baseload
-        return comparison.category
+        return unless baseload_service.enough_data?
+        baseload_service.benchmark_baseload.category
       end
 
       private

--- a/app/services/schools/advice_page_benchmarks/baseload_benchmark_generator.rb
+++ b/app/services/schools/advice_page_benchmarks/baseload_benchmark_generator.rb
@@ -1,0 +1,17 @@
+module Schools
+  module AdvicePageBenchmarks
+    class BaseloadBenchmarkGenerator < SchoolBenchmarkGenerator
+      def benchmark_school
+        return nil unless baseload_service.enough_data?
+        comparison = baseload_service.benchmark_baseload
+        return comparison.category
+      end
+
+      private
+
+      def baseload_service
+        @baseload_service ||= Schools::Advice::BaseloadService.new(@school, @aggregate_school)
+      end
+    end
+  end
+end

--- a/app/services/schools/advice_page_benchmarks/school_benchmark_generator.rb
+++ b/app/services/schools/advice_page_benchmarks/school_benchmark_generator.rb
@@ -1,0 +1,32 @@
+module Schools
+  module AdvicePageBenchmarks
+    class SchoolBenchmarkGenerator
+      def initialize(advice_page:, school:, aggregate_school:)
+        @advice_page = advice_page
+        @school = school
+        @aggregate_school = aggregate_school
+      end
+
+      def perform
+        begin
+          benchmarked_as = benchmark_school
+          @school_benchmark = @school.advice_page_school_benchmarks.find_or_create_by(advice_page: @advice_page)
+          if benchmarked_as.nil?
+            @school_benchmark.destroy
+            return nil
+          end
+          @school_benchmark.update!(benchmarked_as: benchmarked_as)
+          @school_benchmark
+        rescue => e
+          Rollbar.error(e, scope: :advice_page_benchmarks, school_id: @school.id, school: @school.name, advice_page: @advice_page.key)
+        end
+      end
+
+      protected
+
+      def benchmark_school
+        nil
+      end
+    end
+  end
+end

--- a/app/services/schools/advice_page_benchmarks/school_benchmark_generator.rb
+++ b/app/services/schools/advice_page_benchmarks/school_benchmark_generator.rb
@@ -7,6 +7,13 @@ module Schools
         @aggregate_school = aggregate_school
       end
 
+      def self.generator_for(advice_page:, school:, aggregate_school:)
+        case advice_page.key.to_sym
+        when :baseload
+          BaseloadBenchmarkGenerator.new(advice_page: advice_page, school: school, aggregate_school: aggregate_school)
+        end
+      end
+
       def perform
         begin
           benchmarked_as = benchmark_school

--- a/db/migrate/20230314141937_create_advice_page_school_benchmarks.rb
+++ b/db/migrate/20230314141937_create_advice_page_school_benchmarks.rb
@@ -1,0 +1,10 @@
+class CreateAdvicePageSchoolBenchmarks < ActiveRecord::Migration[6.0]
+  def change
+    create_table :advice_page_school_benchmarks do |t|
+      t.references :school, null: false, foreign_key: {on_delete: :cascade}
+      t.references :advice_page, null: false, foreign_key: {on_delete: :cascade}
+      t.integer :benchmarked_as, default: 0, null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_03_02_122743) do
+ActiveRecord::Schema.define(version: 2023_03_14_141937) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
@@ -160,6 +160,16 @@ ActiveRecord::Schema.define(version: 2023_03_02_122743) do
     t.integer "position"
     t.index ["advice_page_id"], name: "index_advice_page_intervention_types_on_advice_page_id"
     t.index ["intervention_type_id"], name: "index_advice_page_intervention_types_on_intervention_type_id"
+  end
+
+  create_table "advice_page_school_benchmarks", force: :cascade do |t|
+    t.bigint "school_id", null: false
+    t.bigint "advice_page_id", null: false
+    t.integer "benchmarked_as", default: 0, null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["advice_page_id"], name: "index_advice_page_school_benchmarks_on_advice_page_id"
+    t.index ["school_id"], name: "index_advice_page_school_benchmarks_on_school_id"
   end
 
   create_table "advice_pages", force: :cascade do |t|
@@ -1805,6 +1815,8 @@ ActiveRecord::Schema.define(version: 2023_03_02_122743) do
   add_foreign_key "activity_type_topics", "activity_types", on_delete: :cascade
   add_foreign_key "activity_type_topics", "topics", on_delete: :restrict
   add_foreign_key "activity_types", "activity_categories"
+  add_foreign_key "advice_page_school_benchmarks", "advice_pages", on_delete: :cascade
+  add_foreign_key "advice_page_school_benchmarks", "schools", on_delete: :cascade
   add_foreign_key "alert_errors", "alert_generation_runs", on_delete: :cascade
   add_foreign_key "alert_errors", "alert_types", on_delete: :cascade
   add_foreign_key "alert_generation_runs", "schools", on_delete: :cascade

--- a/spec/factories/advice_page_school_benchmarks.rb
+++ b/spec/factories/advice_page_school_benchmarks.rb
@@ -1,0 +1,4 @@
+FactoryBot.define do
+  factory :advice_page_school_benchmark do
+  end
+end

--- a/spec/models/advice_page_school_benchmark_spec.rb
+++ b/spec/models/advice_page_school_benchmark_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe AdvicePageSchoolBenchmark, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/services/schools/advice_page_benchmarks/baseload_benchmark_generator_spec.rb
+++ b/spec/services/schools/advice_page_benchmarks/baseload_benchmark_generator_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+RSpec.describe Schools::AdvicePageBenchmarks::BaseloadBenchmarkGenerator, type: :service do
+
+  let(:school)      { create(:school) }
+  let(:advice_page) { create(:advice_page, key: :baseload) }
+  let(:aggregate_school) { double(:aggregate_school) }
+
+  let(:service)     { Schools::AdvicePageBenchmarks::BaseloadBenchmarkGenerator.new(advice_page: advice_page, school: school, aggregate_school: aggregate_school)}
+
+  context '#benchmark_school' do
+    let(:enough_data) { true }
+    let(:comparison) {
+      Schools::Comparison.new(
+        school_value: 10.0,
+        benchmark_value: 15.0,
+        exemplar_value: 8.0,
+        unit: :kw
+      )
+    }
+    before(:each) do
+      allow_any_instance_of(Schools::Advice::BaseloadService).to receive(:enough_data?).and_return(enough_data)
+      allow_any_instance_of(Schools::Advice::BaseloadService).to receive(:benchmark_baseload).and_return(comparison)
+    end
+
+    context 'not enough data' do
+      let(:enough_data) { false }
+      it 'does not benchmark' do
+        expect(service.benchmark_school).to be_nil
+      end
+    end
+    context 'with a comparison' do
+      it 'returns the comparison category' do
+        expect(service.benchmark_school).to eq :benchmark_school
+      end
+    end
+  end
+end

--- a/spec/services/schools/advice_page_benchmarks/school_benchmark_generator_spec.rb
+++ b/spec/services/schools/advice_page_benchmarks/school_benchmark_generator_spec.rb
@@ -1,0 +1,64 @@
+require 'rails_helper'
+RSpec.describe Schools::AdvicePageBenchmarks::SchoolBenchmarkGenerator, type: :service do
+
+  let(:school)      { create(:school) }
+  let(:advice_page) { create(:advice_page, key: :baseload) }
+  let(:aggregate_school) { double(:aggregate_school) }
+
+  let(:service)     { Schools::AdvicePageBenchmarks::SchoolBenchmarkGenerator.new(advice_page: advice_page, school: school, aggregate_school: aggregate_school)}
+
+  context '#perform' do
+    let(:result)      { service.perform }
+
+    context 'when an error occurs' do
+      before(:each) do
+        allow(service).to receive(:benchmark_school).and_raise
+      end
+      it 'logs rollbar' do
+        expect(Rollbar).to receive(:error)
+        service.perform
+      end
+    end
+    context 'with no benchmark' do
+      it 'doesnt create record if benchmarked_as is nil' do
+        expect(result).to be_nil
+        expect(AdvicePageSchoolBenchmark.count).to eq 0
+      end
+      context 'and a benchmark is generated' do
+        before(:each) do
+          allow(service).to receive(:benchmark_school).and_return(:exemplar)
+        end
+        it 'creates benchmark' do
+          expect(result).to_not be_nil
+          expect(result.advice_page).to eq advice_page
+          expect(result.school).to eq school
+          expect(result.benchmarked_as).to eq "exemplar"
+        end
+      end
+    end
+    context 'with existing benchmark' do
+      let!(:benchmark) { create(:advice_page_school_benchmark, school: school, advice_page: advice_page, benchmarked_as: :improving)}
+
+      before(:each) do
+        school.reload
+      end
+
+      context 'and a benchmark is generated' do
+        before(:each) do
+          allow(service).to receive(:benchmark_school).and_return(:exemplar)
+        end
+        it 'updates the benchmark' do
+          expect(result).to eq benchmark
+          benchmark.reload
+          expect(benchmark.benchmarked_as).to eq "exemplar"
+        end
+      end
+      context 'and benchmark is nil' do
+        it 'removes the benchmark' do
+          expect(result).to eq nil
+          expect(AdvicePageSchoolBenchmark.count).to eq 0
+        end
+      end
+    end
+  end
+end

--- a/spec/services/schools/advice_page_benchmarks/school_benchmark_generator_spec.rb
+++ b/spec/services/schools/advice_page_benchmarks/school_benchmark_generator_spec.rb
@@ -26,18 +26,18 @@ RSpec.describe Schools::AdvicePageBenchmarks::SchoolBenchmarkGenerator, type: :s
       end
       context 'and a benchmark is generated' do
         before(:each) do
-          allow(service).to receive(:benchmark_school).and_return(:exemplar)
+          allow(service).to receive(:benchmark_school).and_return(:exemplar_school)
         end
         it 'creates benchmark' do
           expect(result).to_not be_nil
           expect(result.advice_page).to eq advice_page
           expect(result.school).to eq school
-          expect(result.benchmarked_as).to eq "exemplar"
+          expect(result.benchmarked_as).to eq "exemplar_school"
         end
       end
     end
     context 'with existing benchmark' do
-      let!(:benchmark) { create(:advice_page_school_benchmark, school: school, advice_page: advice_page, benchmarked_as: :improving)}
+      let!(:benchmark) { create(:advice_page_school_benchmark, school: school, advice_page: advice_page, benchmarked_as: :other_school)}
 
       before(:each) do
         school.reload
@@ -45,12 +45,12 @@ RSpec.describe Schools::AdvicePageBenchmarks::SchoolBenchmarkGenerator, type: :s
 
       context 'and a benchmark is generated' do
         before(:each) do
-          allow(service).to receive(:benchmark_school).and_return(:exemplar)
+          allow(service).to receive(:benchmark_school).and_return(:exemplar_school)
         end
         it 'updates the benchmark' do
           expect(result).to eq benchmark
           benchmark.reload
-          expect(benchmark.benchmarked_as).to eq "exemplar"
+          expect(benchmark.benchmarked_as).to eq "exemplar_school"
         end
       end
       context 'and benchmark is nil' do

--- a/spec/system/schools/advice_pages/baseload_spec.rb
+++ b/spec/system/schools/advice_pages/baseload_spec.rb
@@ -127,6 +127,14 @@ RSpec.describe "Baseload advice page", type: :system do
       let(:previous_year_average_baseload_kw) { 2.0 }
       let(:previous_week_average_baseload_kw) { 1.9 }
 
+      let(:comparison) {
+        Schools::Comparison.new(
+          school_value: average_baseload_last_year_kw,
+          benchmark_value: average_baseload_kw_benchmark,
+          exemplar_value: average_baseload_kw_exemplar,
+          unit: :kw
+        )
+      }
       before(:each) do
         #current baseload
         allow_any_instance_of(Schools::Advice::BaseloadService).to receive(:average_baseload_kw).with(period: :year).and_return average_baseload_last_year_kw
@@ -136,9 +144,7 @@ RSpec.describe "Baseload advice page", type: :system do
         allow_any_instance_of(Schools::Advice::BaseloadService).to receive(:previous_period_average_baseload_kw).with(period: :week).and_return previous_week_average_baseload_kw
 
         #comparison
-        allow_any_instance_of(Schools::Advice::BaseloadService).to receive(:average_baseload_kw_benchmark).with(compare: :benchmark_school).and_return average_baseload_kw_benchmark
-        allow_any_instance_of(Schools::Advice::BaseloadService).to receive(:average_baseload_kw_benchmark).with(compare: :exemplar_school).and_return average_baseload_kw_exemplar
-
+        allow_any_instance_of(Schools::Advice::BaseloadService).to receive(:benchmark_baseload).and_return comparison
         visit insights_school_advice_baseload_path(school)
       end
 


### PR DESCRIPTION
An initial PR a small framework for generating the benchmark school comparisons to be shown on the advice index page.

For each of the advice pages, we will aim to generate a comparison of that schools data against a "benchmark" or "exemplar" school. E.g. a comparison of their current baseload against what we consider to be good values.

We will generate each of these benchmarks, for each school, every day.

This initial PR covers:

* Added a new model `AdvicePageSchoolBenchmark` which holds the relationship between a page and a school, along with the result of the benchmark
* A base class `SchoolBenchmarkGenerator` which can be extended to implement the benchmarks for each page. The base class just handles creating/updating/removing the above model, but delegates to sub-classes to perform the actual benchmarking
* An initial benchmark implementation for the baseload page
* The above class reuses existing code. This has been moved from the baseload controller to the `BaseloadService` so that it can be called by the generator. This ensures that the advice page and the generator are using the same logic
* I've written tests for the new classes, and updated the existing specs for the baseload controller, service and page to reflect the refactoring

Next step is to add this benchmarking framework to the nightly job.