### PR TITLE
Integrate advice page benchmarks into content batch

### DIFF
--- a/app/services/content_batch.rb
+++ b/app/services/content_batch.rb
@@ -67,6 +67,11 @@ class ContentBatch
       Targets::GenerateProgressService.new(school, aggregate_school).generate!
 
       @logger.info "Generated target data"
+
+      # Generate advice page benchmarks
+      Schools::AdvicePageBenchmarks::GenerateBenchmarks.new(school: school, aggregate_school: aggregate_school).generate!
+      @logger.info "Generated advice page benchmarks"
+
     rescue StandardError => e
       @logger.error "There was an error for #{school.name} - #{e.message}"
       Rollbar.error(e, job: :content_batch, school_id: school.id, school: school.name)

--- a/app/services/schools/advice_page_benchmarks/generate_benchmarks.rb
+++ b/app/services/schools/advice_page_benchmarks/generate_benchmarks.rb
@@ -1,0 +1,17 @@
+module Schools
+  module AdvicePageBenchmarks
+    class GenerateBenchmarks
+      def initialize(school:, aggregate_school:)
+        @school = school
+        @aggregate_school = aggregate_school
+      end
+
+      def generate!
+        AdvicePage.all.each do |advice_page|
+          generator = SchoolBenchmarkGenerator.generator_for(advice_page: advice_page, school: @school, aggregate_school: @aggregate_school)
+          generator.perform if generator.present?
+        end
+      end
+    end
+  end
+end

--- a/spec/services/content_batch_spec.rb
+++ b/spec/services/content_batch_spec.rb
@@ -25,4 +25,16 @@ describe ContentBatch do
       expect(school_target.report_last_generated).to_not be_nil
     end
   end
+
+  context 'it should run advice page benchmarks' do
+    let(:stub)    { double('generator') }
+    before(:each) do
+      expect(Schools::AdvicePageBenchmarks::GenerateBenchmarks).to receive(:new).with(school: school_1, aggregate_school: anything).and_return(stub)
+      expect(Schools::AdvicePageBenchmarks::GenerateBenchmarks).to receive(:new).with(school: school_2, aggregate_school: anything).and_return(stub)
+      expect(stub).to receive(:generate!).twice
+    end
+    it 'runs the benchmarks' do
+      ContentBatch.new.generate
+    end
+  end
 end

--- a/spec/services/schools/advice_page_benchmarks/generate_benchmarks_spec.rb
+++ b/spec/services/schools/advice_page_benchmarks/generate_benchmarks_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+RSpec.describe Schools::AdvicePageBenchmarks::GenerateBenchmarks, type: :service do
+
+  let(:advice_page_1) { create(:advice_page, key: :baseload) }
+  let(:advice_page_2) { create(:advice_page, key: :electricity_out_of_hours) }
+
+  let(:school)        { create(:school) }
+  let(:aggregate_school) { double(:aggregate_school) }
+
+  let(:service)       { Schools::AdvicePageBenchmarks::GenerateBenchmarks.new(school: school, aggregate_school: aggregate_school)}
+
+  let(:generator)     { double('generator') }
+
+  context '#generate!' do
+    before(:each) do
+      expect(Schools::AdvicePageBenchmarks::SchoolBenchmarkGenerator).to receive(:generator_for).with(advice_page: advice_page_1, school: school, aggregate_school: aggregate_school).and_return(generator)
+      expect(Schools::AdvicePageBenchmarks::SchoolBenchmarkGenerator).to receive(:generator_for).with(advice_page: advice_page_2, school: school, aggregate_school: aggregate_school).and_return(generator)
+      expect(generator).to receive(:perform).twice
+    end
+    it 'should process all pages' do
+      service.generate!
+    end
+  end
+end


### PR DESCRIPTION
Integrates advice page benchmark generation into the content batch.

* Adds new service to generate the benchmarks for all pages
* Adds the service to the content batch
* Specs for the above
