### PR TITLE
Integrate benchmarks into advice page index

### DIFF
--- a/app/assets/stylesheets/advice_page.scss
+++ b/app/assets/stylesheets/advice_page.scss
@@ -70,3 +70,16 @@
 .advice-table-caption {
   margin-bottom: 40px;
 }
+
+.advice-page-label {
+  padding-bottom: 0px;
+  padding-top: 10px;
+  font-weight: bold;
+}
+.advice-page-benchmark-label {
+  text-align: center !important;
+  color: white;
+  font-weight: bold;
+  padding-top: 10px;
+  padding-bottom: 10px;
+}

--- a/app/assets/stylesheets/colours.scss
+++ b/app/assets/stylesheets/colours.scss
@@ -68,3 +68,13 @@ $colours-light: (
 .advice-question-icon {
   color: $light-blue-links;
 }
+
+.bg-exemplar_school {
+  background-color: $green !important;
+}
+.bg-benchmark_school {
+  background-color: $light-orange !important;
+}
+.bg-other_school {
+  background-color: $bg-negative !important;
+}

--- a/app/controllers/schools/advice_controller.rb
+++ b/app/controllers/schools/advice_controller.rb
@@ -11,6 +11,7 @@ module Schools
     include DashboardPriorities
 
     def show
+      @advice_page_benchmarks = @school.advice_page_school_benchmarks
     end
 
     def priorities

--- a/app/views/schools/advice/index/_page_list.html.erb
+++ b/app/views/schools/advice/index/_page_list.html.erb
@@ -2,27 +2,36 @@
   <div class="col">
     <% if display_advice_page?(school, fuel_type) %>
       <div class="row mt-4">
-        <div class="col <%=fuel_type_background_class(fuel_type)%>">
+        <div class="col-2">
           <h4>
-            <span>
+            <span class="<%= fuel_type_class(fuel_type) %>">
               <%= fa_icon( fuel_type_icon(fuel_type) ) %>
             </span>
             <%= t("advice_pages.nav.sections.#{fuel_type}") %>
           </h4>
         </div>
+        <div class="col-10"></div>
       </div>
       <div class="row">
         <div class="col">
           <% sort_by_label(advice_pages.where(fuel_type: fuel_type)).each do |ap| %>
-            <div class="mt-2 row d-flex align-items-center" style="">
+            <div class="mt-3 row d-flex align-items-center">
               <div class="col-2">
-                <h5 style="padding-bottom: 0px;"><%= link_to translated_label(ap), advice_page_path(school, ap) %></h5>
+                <h5 class="advice-page-label"><%= link_to translated_label(ap), advice_page_path(school, ap) %></h5>
               </div>
               <div class="col">
                 <%= t("advice_pages.index.show.page_summary.#{ap.key}") %>
               </div>
-              <div class="col-2">
-              </div>
+              <% school_benchmark = advice_page_benchmarks.where(advice_page: ap).first %>
+              <% if school_benchmark.present? %>
+                <div class="col-2 bg-<%= school_benchmark.benchmarked_as %>">
+                  <div class="advice-page-benchmark-label">
+                    <%= t("advice_pages.benchmarks.#{school_benchmark.benchmarked_as}") %>
+                  </div>
+                </div>
+              <% else %>
+                <div class="col-2"></div>
+              <% end %>
             </div>
           <% end %>
         </div>

--- a/app/views/schools/advice/show.html.erb
+++ b/app/views/schools/advice/show.html.erb
@@ -8,5 +8,5 @@
       <% end %>
     </div>
   </div>
-  <%= render 'schools/advice/index/page_list', school: @school, advice_pages: @advice_pages %>
+  <%= render 'schools/advice/index/page_list', school: @school, advice_pages: @advice_pages, advice_page_benchmarks: @advice_page_benchmarks %>
 <% end %>


### PR DESCRIPTION
Adds the school advice page benchmarks into the index page

* Loads the benchmarks
* Where a benchmark is available, add a column with the appropriate label and background colour
* Further tweaks to page styling.