### PR TITLE
3074 implement long term usage benchmark

### DIFF
--- a/app/components/school_comparison_component/school_comparison_component.html.erb
+++ b/app/components/school_comparison_component/school_comparison_component.html.erb
@@ -52,7 +52,7 @@
   <div class="col-md-4 justify-content-center <%= responsive_classes(:other_school) %>">
     <div>
       <h4 class="category-label">
-        <%= t('advice_pages.benchmarks.other') %>
+        <%= t('advice_pages.benchmarks.other_school') %>
       </h4>
       <p>
         &gt;<%= benchmark_value %>

--- a/app/controllers/schools/advice/advice_base_controller.rb
+++ b/app/controllers/schools/advice/advice_base_controller.rb
@@ -104,18 +104,7 @@ module Schools
       end
 
       def school_has_fuel_type?
-        case advice_page_fuel_type
-        when :gas
-          @school.has_gas?
-        when :electricity
-          @school.has_electricity?
-        when :storage_heater
-          @school.has_storage_heaters?
-        when :solar_pv
-          @school.has_solar_pv?
-        else
-          true
-        end
+        @advice_page.school_has_fuel_type?(@school)
       end
 
       def start_end_dates

--- a/app/controllers/schools/advice/base_long_term_controller.rb
+++ b/app/controllers/schools/advice/base_long_term_controller.rb
@@ -5,7 +5,7 @@ module Schools
         @analysis_dates = analysis_dates
         @annual_usage = usage_service.annual_usage
         @annual_usage_change_since_last_year = usage_service.annual_usage_change_since_last_year
-        @benchmarked_usage = benchmarked_usage(@annual_usage.kwh)
+        @benchmarked_usage = usage_service.benchmark_usage
       end
 
       def analysis
@@ -63,18 +63,6 @@ module Schools
       #for charts that use the last full week
       def last_full_week_end_date(end_date)
         end_date.prev_week.end_of_week - 1
-      end
-
-      def benchmarked_usage(annual_usage_kwh)
-        annual_usage_kwh_benchmark = usage_service.annual_usage_kwh(compare: :benchmark_school)
-        annual_usage_kwh_exemplar = usage_service.annual_usage_kwh(compare: :exemplar_school)
-
-        Schools::Comparison.new(
-          school_value: annual_usage_kwh,
-          benchmark_value: annual_usage_kwh_benchmark,
-          exemplar_value: annual_usage_kwh_exemplar,
-          unit: :kwh
-        )
       end
 
       def usage_service

--- a/app/controllers/schools/advice/total_energy_use_controller.rb
+++ b/app/controllers/schools/advice/total_energy_use_controller.rb
@@ -6,12 +6,12 @@ module Schools
 
         if can_benchmark_electricity?
           @electricity_annual_usage = electricity_usage_service.annual_usage
-          @electricity_benchmarked_usage = benchmarked_usage(electricity_usage_service, @electricity_annual_usage.kwh)
+          @electricity_benchmarked_usage = electricity_usage_service.benchmark_usage
         end
 
         if can_benchmark_gas?
           @gas_annual_usage = gas_usage_service.annual_usage
-          @gas_benchmarked_usage = benchmarked_usage(gas_usage_service, @gas_annual_usage.kwh)
+          @gas_benchmarked_usage = gas_usage_service.benchmark_usage
         end
       end
 
@@ -69,18 +69,6 @@ module Schools
 
       def analysis_end_date
         aggregate_meters.map { |meter| meter.amr_data.end_date }.min
-      end
-
-      def benchmarked_usage(usage_service, annual_usage_kwh)
-        annual_usage_kwh_benchmark = usage_service.annual_usage_kwh(compare: :benchmark_school)
-        annual_usage_kwh_exemplar = usage_service.annual_usage_kwh(compare: :exemplar_school)
-
-        Schools::Comparison.new(
-          school_value: annual_usage_kwh,
-          benchmark_value: annual_usage_kwh_benchmark,
-          exemplar_value: annual_usage_kwh_exemplar,
-          unit: :kwh
-        )
       end
 
       def gas_usage_service

--- a/app/models/advice_page.rb
+++ b/app/models/advice_page.rb
@@ -52,4 +52,22 @@ class AdvicePage < ApplicationRecord
       update!(advice_page_intervention_types_attributes: position_attributes)
     end
   end
+
+  #Check whether school has the fuel type for this advice page
+  #Defaults to treating unknown/nil fuel type as applicable to
+  #all schools
+  def school_has_fuel_type?(school, default_value: true)
+    case fuel_type&.to_sym
+    when :gas
+      school.has_gas?
+    when :electricity
+      school.has_electricity?
+    when :storage_heater
+      school.has_storage_heaters?
+    when :solar_pv
+      school.has_solar_pv?
+    else
+      default_value
+    end
+  end
 end

--- a/app/services/schools/advice/long_term_usage_service.rb
+++ b/app/services/schools/advice/long_term_usage_service.rb
@@ -41,6 +41,20 @@ module Schools
         meter_breakdown_service.calculate_breakdown
       end
 
+      def benchmark_usage
+        annual_usage_kwh = annual_usage.kwh
+        annual_usage_kwh_benchmark = annual_usage_kwh(compare: :benchmark_school)
+        annual_usage_kwh_exemplar = annual_usage_kwh(compare: :exemplar_school)
+
+        Schools::Comparison.new(
+          school_value: annual_usage_kwh,
+          benchmark_value: annual_usage_kwh_benchmark,
+          exemplar_value: annual_usage_kwh_exemplar,
+          unit: :kwh
+        )
+      end
+
+
       private
 
       def aggregate_meter

--- a/app/services/schools/advice_page_benchmarks/long_term_usage_benchmark_generator.rb
+++ b/app/services/schools/advice_page_benchmarks/long_term_usage_benchmark_generator.rb
@@ -9,7 +9,7 @@ module Schools
       private
 
       def usage_service
-        @usage_service ||= Schools::Advice::LongTermUsageService.new(@school, @aggregate_school, @advice_page.fuel_type)
+        @usage_service ||= Schools::Advice::LongTermUsageService.new(@school, @aggregate_school, advice_page_fuel_type)
       end
     end
   end

--- a/app/services/schools/advice_page_benchmarks/long_term_usage_benchmark_generator.rb
+++ b/app/services/schools/advice_page_benchmarks/long_term_usage_benchmark_generator.rb
@@ -1,0 +1,16 @@
+module Schools
+  module AdvicePageBenchmarks
+    class LongTermUsageBenchmarkGenerator < SchoolBenchmarkGenerator
+      def benchmark_school
+        return unless usage_service.enough_data?
+        usage_service.benchmark_usage.category
+      end
+
+      private
+
+      def usage_service
+        @usage_service ||= Schools::Advice::LongTermUsageService.new(@school, @aggregate_school, @advice_page.fuel_type)
+      end
+    end
+  end
+end

--- a/app/services/schools/advice_page_benchmarks/school_benchmark_generator.rb
+++ b/app/services/schools/advice_page_benchmarks/school_benchmark_generator.rb
@@ -10,8 +10,11 @@ module Schools
       def self.generator_for(advice_page:, school:, aggregate_school:)
         case advice_page.key.to_sym
         when :baseload
-          BaseloadBenchmarkGenerator.new(advice_page: advice_page, school: school, aggregate_school: aggregate_school)
+          BaseloadBenchmarkGenerator
+        when :electricity_long_term, :gas_long_term
+          LongTermUsageBenchmarkGenerator
         end
+        return generator_class.new(advice_page: advice_page, school: school, aggregate_school: aggregate_school)
       end
 
       def perform

--- a/config/locales/views/advice_pages/advice_pages.yml
+++ b/config/locales/views/advice_pages/advice_pages.yml
@@ -4,7 +4,7 @@ en:
     benchmarks:
       benchmark_school: Well managed
       exemplar_school: Exemplar
-      other: Improving
+      other_school: Improving
       your_school: Your school
     breadcrumbs:
       root: Advice

--- a/spec/services/schools/advice_page_benchmarks/long_term_usage_benchmark_generator_spec.rb
+++ b/spec/services/schools/advice_page_benchmarks/long_term_usage_benchmark_generator_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+RSpec.describe Schools::AdvicePageBenchmarks::LongTermUsageBenchmarkGenerator, type: :service do
+
+  let(:school)      { create(:school) }
+  let(:advice_page) { create(:advice_page, key: :electricity_long_term, fuel_type: :electricity) }
+  let(:aggregate_school) { double(:aggregate_school) }
+
+  let(:service)     { Schools::AdvicePageBenchmarks::LongTermUsageBenchmarkGenerator.new(advice_page: advice_page, school: school, aggregate_school: aggregate_school)}
+
+  context '#benchmark_school' do
+    let(:enough_data) { true }
+    let(:comparison) {
+      Schools::Comparison.new(
+        school_value: 42000.0,
+        benchmark_value: 45000.0,
+        exemplar_value: 30000.0,
+        unit: :kw
+      )
+    }
+    before(:each) do
+      allow_any_instance_of(Schools::Advice::LongTermUsageService).to receive(:enough_data?).and_return(enough_data)
+      allow_any_instance_of(Schools::Advice::LongTermUsageService).to receive(:benchmark_usage).and_return(comparison)
+    end
+
+    context 'not enough data' do
+      let(:enough_data) { false }
+      it 'does not benchmark' do
+        expect(service.benchmark_school).to be_nil
+      end
+    end
+    context 'with a comparison' do
+      it 'returns the comparison category' do
+        expect(service.benchmark_school).to eq :benchmark_school
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds an advice page benchmark for the long term usage pages

* Move method from `AdviceBaseController` to `AdvicePage` so there's a consistent approach to checking if school has right fuel type for page for benchmarks and display of pages
* Move method from `BaseLongTermController` to `LongTermUsageService` so that benchmark comparison is reusable
* Changes long term usage advice controllers to request benchmark comparison from service
* Ensure school has right fuel type before generating an advice page benchmark
* Adds new `LongTermUsageBenchmarkGenerator` to produce benchmark for index page, and adds it to the factory method in base class
* Ensure `SchoolComparisonComponent` and advice page index are using same translation keys
* Tests for the above

