### PR TITLE
Fix chart and routes on costs page

### DIFF
--- a/app/controllers/schools/advice/base_costs_controller.rb
+++ b/app/controllers/schools/advice/base_costs_controller.rb
@@ -19,6 +19,7 @@ module Schools
         @multiple_meters = costs_service.multiple_meters?
         @monthly_costs = costs_service.calculate_costs_for_latest_twelve_months
         @change_in_costs = costs_service.calculate_change_in_costs
+        @aggregate_meter_mpan_mprn = aggregate_meter_mpan_mprn
         if @multiple_meters
           @annual_costs_breakdown_by_meter = costs_service.annual_costs_breakdown_by_meter
           @aggregate_meter_adapter = aggregate_meter_adapter

--- a/app/controllers/schools/advice/gas_costs_controller.rb
+++ b/app/controllers/schools/advice/gas_costs_controller.rb
@@ -17,13 +17,13 @@ module Schools
         days_of_data = dates.end_date - dates.start_date
         case days_of_data
         when 1..13
-          @one_year_breakdown_chart = :gas_cost_1_year_accounting_breakdown_group_by_day
+          @one_year_breakdown_chart = :electricity_cost_1_year_accounting_breakdown_group_by_day
           @one_year_breakdown_chart_key = :cost_1_year_accounting_breakdown_group_by_day
         when 14..79
-          @one_year_breakdown_chart = :gas_cost_1_year_accounting_breakdown_group_by_week
+          @one_year_breakdown_chart = :electricity_cost_1_year_accounting_breakdown_group_by_week
           @one_year_breakdown_chart_key = :cost_1_year_accounting_breakdown_group_by_week
         else
-          @one_year_breakdown_chart = :gas_cost_1_year_accounting_breakdown
+          @one_year_breakdown_chart = :electricity_cost_1_year_accounting_breakdown
           @one_year_breakdown_chart_key = :cost_1_year_accounting_breakdown
         end
       end

--- a/app/views/schools/advice/gas_costs/_analysis.html.erb
+++ b/app/views/schools/advice/gas_costs/_analysis.html.erb
@@ -41,6 +41,7 @@
     one_year_breakdown_chart_key: @one_year_breakdown_chart_key,
     monthly_costs: @monthly_costs,
     change_in_costs: @change_in_costs,
+    aggregate_meter_mpan_mprn: @aggregate_meter_mpan_mprn,
     show_school_total: true %>
   <% if @analysis_dates.months_of_data > 23 %>
     <%= render 'cost_comparison', school: @school, analysis_dates: @analysis_dates %>

--- a/app/views/schools/advice/gas_costs/_cost_breakdown_by_charge.html.erb
+++ b/app/views/schools/advice/gas_costs/_cost_breakdown_by_charge.html.erb
@@ -6,7 +6,7 @@
   </p>
 <% end %>
 
-<%= component 'chart', chart_type: one_year_breakdown_chart, school: school do |c| %>
+<%= component 'chart', chart_type: one_year_breakdown_chart, school: school, chart_config: create_chart_config(school, one_year_breakdown_chart, aggregate_meter_mpan_mprn) do |c| %>
   <% c.with_title { advice_t("gas_costs.charts.#{one_year_breakdown_chart_key}.title") } %>
   <% c.with_subtitle { advice_t("gas_costs.charts.#{one_year_breakdown_chart_key}.subtitle_html", end_date: analysis_dates.end_date.to_s(:es_short)) } %>
 <% end %>

--- a/app/views/schools/advice/gas_costs/_meter_breakdown.html.erb
+++ b/app/views/schools/advice/gas_costs/_meter_breakdown.html.erb
@@ -1,6 +1,6 @@
 <%= render 'schools/advice/section_title', section_id: 'meter-breakdown', section_title: advice_t('gas_costs.analysis.meter_breakdown.title') %>
 
-<%= simple_form_for :school, url: meter_costs_school_advice_electricity_costs_path(school, format: :js), method: :get, remote: true do |f| %>
+<%= simple_form_for :school, url: meter_costs_school_advice_gas_costs_path(school, format: :js), method: :get, remote: true do |f| %>
   <div class="form-group">
     <label>
       <%= advice_t('gas_costs.analysis.meter_breakdown.select') %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -167,7 +167,7 @@ Rails.application.routes.draw do
               get :insights
               get :analysis
               get :learn_more
-              if page == :electricity_costs
+              if [:electricity_costs, :gas_costs].include?(page)
                 get :meter_costs
               end
             end


### PR DESCRIPTION
Fixes some issues with the gas costs page:

* Missing route and incorrect form target meant gas page was loading electricity data
* The existing advice page actually uses charts called `electricity_*` for both gas and electricity. Now using the right charts for gas and specifying mpan which is what triggers the charting framework to use the right data