### PR TITLE
Implement thermostatic benchmark

### DIFF
--- a/app/classes/schools/comparison.rb
+++ b/app/classes/schools/comparison.rb
@@ -2,11 +2,12 @@ module Schools
   class Comparison
     attr_reader :school_value, :benchmark_value, :exemplar_value, :unit
 
-    def initialize(school_value:, benchmark_value:, exemplar_value:, unit:)
+    def initialize(school_value:, benchmark_value:, exemplar_value:, unit:, low_is_good: true)
       @school_value = school_value
       @benchmark_value = benchmark_value
       @exemplar_value = exemplar_value
       @unit = unit
+      @low_is_good = low_is_good
     end
 
     def valid?
@@ -21,13 +22,24 @@ module Schools
 
     def categorise_school
       return :other_school if @school_value.nil? || @benchmark_value.nil? || @exemplar_value.nil?
-      if @school_value <= @exemplar_value
+      if exemplar_school?
         :exemplar_school
-      elsif @school_value > @exemplar_value &&
-            @school_value <= @benchmark_value
+      elsif benchmark_school?
         :benchmark_school
       else
         :other_school
+      end
+    end
+
+    def exemplar_school?
+      @low_is_good ? @school_value <= @exemplar_value : @school_value >= @exemplar_value
+    end
+
+    def benchmark_school?
+      if @low_is_good
+        @school_value > @exemplar_value && @school_value <= @benchmark_value
+      else
+        @school_value < @exemplar_value && @school_value >= @benchmark_value
       end
     end
   end

--- a/app/controllers/schools/advice/thermostatic_control_controller.rb
+++ b/app/controllers/schools/advice/thermostatic_control_controller.rb
@@ -2,25 +2,21 @@ module Schools
   module Advice
     class ThermostaticControlController < AdviceBaseController
       def insights
-        @heating_thermostatic_analysis = build_heating_thermostatic_analysis
+        @heating_thermostatic_analysis = thermostatic_analysis_service.thermostatic_analysis
       end
 
       def analysis
-        @heating_thermostatic_analysis = build_heating_thermostatic_analysis
+        @heating_thermostatic_analysis = thermostatic_analysis_service.thermostatic_analysis
       end
 
       private
 
+      def thermostatic_analysis_service
+        @thermostatic_analysis_service ||= Schools::Advice::ThermostaticAnalysisService.new(@school, aggregate_school)
+      end
+
       def create_analysable
-        heating_thermostatic_analysis_service
-      end
-
-      def build_heating_thermostatic_analysis
-        heating_thermostatic_analysis_service.create_model
-      end
-
-      def heating_thermostatic_analysis_service
-        @heating_thermostatic_analysis_service ||= Heating::HeatingThermostaticAnalysisService.new(meter_collection: aggregate_school)
+        thermostatic_analysis_service
       end
 
       def set_insights_next_steps

--- a/app/controllers/schools/advice/thermostatic_control_controller.rb
+++ b/app/controllers/schools/advice/thermostatic_control_controller.rb
@@ -3,6 +3,7 @@ module Schools
     class ThermostaticControlController < AdviceBaseController
       def insights
         @heating_thermostatic_analysis = thermostatic_analysis_service.thermostatic_analysis
+        @benchmark_thermostatic_control = thermostatic_analysis_service.benchmark_thermostatic_control
       end
 
       def analysis

--- a/app/helpers/advice_page_helper.rb
+++ b/app/helpers/advice_page_helper.rb
@@ -143,7 +143,7 @@ module AdvicePageHelper
   end
 
   def notice_status_for(rating_value)
-    rating_value > 4 ? :positive : :negative
+    rating_value > 6 ? :positive : :negative
   end
 
   def warm_weather_on_days_status(days)

--- a/app/services/schools/advice/thermostatic_analysis_service.rb
+++ b/app/services/schools/advice/thermostatic_analysis_service.rb
@@ -20,7 +20,20 @@ module Schools
         build_thermostatic_analysis_model
       end
 
+      #Benchmark schools using their r2 value.
+      #See HeatingModel.r2_statistics for an example of grading r2 values
+      def benchmark_thermostatic_control
+        Schools::Comparison.new(
+          school_value: thermostatic_analysis.r2,
+          benchmark_value: 0.6,
+          exemplar_value: 0.8,
+          unit: :r2,
+          low_is_good: false
+        )
+      end
+
       private
+
 
       def build_thermostatic_analysis_model
         thermostatic_analysis_service.create_model

--- a/app/services/schools/advice/thermostatic_analysis_service.rb
+++ b/app/services/schools/advice/thermostatic_analysis_service.rb
@@ -3,6 +3,9 @@ module Schools
     class ThermostaticAnalysisService
       include AnalysableMixin
 
+      EXEMPLAR_R2_VALUE = 0.8
+      BENCHMARK_R2_VALUE = 0.6
+
       def initialize(school, meter_collection)
         @school = school
         @meter_collection = meter_collection
@@ -25,8 +28,8 @@ module Schools
       def benchmark_thermostatic_control
         Schools::Comparison.new(
           school_value: thermostatic_analysis.r2,
-          benchmark_value: 0.6,
-          exemplar_value: 0.8,
+          benchmark_value: BENCHMARK_R2_VALUE,
+          exemplar_value: EXEMPLAR_R2_VALUE,
           unit: :r2,
           low_is_good: false
         )

--- a/app/services/schools/advice/thermostatic_analysis_service.rb
+++ b/app/services/schools/advice/thermostatic_analysis_service.rb
@@ -1,0 +1,34 @@
+module Schools
+  module Advice
+    class ThermostaticAnalysisService
+      include AnalysableMixin
+
+      def initialize(school, meter_collection)
+        @school = school
+        @meter_collection = meter_collection
+      end
+
+      def enough_data?
+        thermostatic_analysis_service.enough_data?
+      end
+
+      def data_available_from
+        thermostatic_analysis_service.data_available_from
+      end
+
+      def thermostatic_analysis
+        build_thermostatic_analysis_model
+      end
+
+      private
+
+      def build_thermostatic_analysis_model
+        thermostatic_analysis_service.create_model
+      end
+
+      def thermostatic_analysis_service
+        @thermostatic_analysis_service ||= Heating::HeatingThermostaticAnalysisService.new(meter_collection: @meter_collection)
+      end
+    end
+  end
+end

--- a/app/services/schools/advice_page_benchmarks/school_benchmark_generator.rb
+++ b/app/services/schools/advice_page_benchmarks/school_benchmark_generator.rb
@@ -17,6 +17,8 @@ module Schools
                             OutOfHoursUsageBenchmarkGenerator
                           when :electricity_intraday
                             PeakUsageBenchmarkGenerator
+                          when :thermostatic_control
+                            ThermostaticControlBenchmarkGenerator
                           end
         return nil unless generator_class.present?
         generator_class.new(advice_page: advice_page, school: school, aggregate_school: aggregate_school)

--- a/app/services/schools/advice_page_benchmarks/thermostatic_control_benchmark_generator.rb
+++ b/app/services/schools/advice_page_benchmarks/thermostatic_control_benchmark_generator.rb
@@ -1,0 +1,16 @@
+module Schools
+  module AdvicePageBenchmarks
+    class ThermostaticControlBenchmarkGenerator < SchoolBenchmarkGenerator
+      def benchmark_school
+        return unless thermostatic_analysis_service.enough_data?
+        thermostatic_analysis_service.benchmark_thermostatic_control.category
+      end
+
+      private
+
+      def thermostatic_analysis_service
+        @thermostatic_analysis_service ||= Schools::Advice::ThermostaticAnalysisService.new(@school, @aggregate_school)
+      end
+    end
+  end
+end

--- a/app/views/schools/advice/thermostatic_control/_insights.html.erb
+++ b/app/views/schools/advice/thermostatic_control/_insights.html.erb
@@ -3,19 +3,19 @@
   <%= t('advice_pages.thermostatic_control.insights.advice_html') %>
 <% end %>
 
-<%= render 'schools/advice/section_title', section_id: 'your_thermostatic_control', section_title: t('advice_pages.thermostatic_control.insights.your_thermostatic_control.title') %>
-
-<% rating_value = AnalyseHeatingAndHotWater::HeatingModel.find_r2_rating(@heating_thermostatic_analysis.r2, :rating_value) %>
-<%= component 'notice', status: notice_status_for(rating_value) do |c| %>
-  <%=
-    t('advice_pages.thermostatic_control.insights.thermostatic_control_r2_notice_html',
-      r2_rating_adjective: AnalyseHeatingAndHotWater::HeatingModel.r2_rating_adjective(@heating_thermostatic_analysis.r2),
-      r2: @heating_thermostatic_analysis.r2.round(2),
-      average_schools_r2: AnalyseHeatingAndHotWater::HeatingModel.average_schools_r2
-    )
-  %>
-<% end %>
-
 <%= render 'schools/advice/section_title', section_id: 'how_do_you_compare', section_title: t('advice_pages.thermostatic_control.insights.how_do_you_compare.title') %>
+
+<%=
+  t('advice_pages.thermostatic_control.insights.thermostatic_control_r2_notice_html',
+    r2_rating_adjective: AnalyseHeatingAndHotWater::HeatingModel.r2_rating_adjective(@heating_thermostatic_analysis.r2),
+    r2: @heating_thermostatic_analysis.r2.round(2),
+    average_schools_r2: AnalyseHeatingAndHotWater::HeatingModel.average_schools_r2
+  )
+%>
+
+<div class="col">
+  <%= component 'school_comparison', id: 'comparison-thermostatic', comparison: @benchmark_thermostatic_control do |c| %>
+  <% end %>
+</div>
 
 <%= t('advice_pages.thermostatic_control.insights.for_more_detail_html', link: benchmark_for_school_group_path(:thermostatic_control, @school)) %>

--- a/app/views/schools/advice/thermostatic_control/_insights.html.erb
+++ b/app/views/schools/advice/thermostatic_control/_insights.html.erb
@@ -14,8 +14,7 @@
 %>
 
 <div class="col">
-  <%= component 'school_comparison', id: 'comparison-thermostatic', comparison: @benchmark_thermostatic_control do |c| %>
-  <% end %>
+  <%= component 'school_comparison', id: 'comparison-thermostatic', comparison: @benchmark_thermostatic_control %>
 </div>
 
 <%= t('advice_pages.thermostatic_control.insights.for_more_detail_html', link: benchmark_for_school_group_path(:thermostatic_control, @school)) %>

--- a/config/locales/views/advice_pages/advice_pages.yml
+++ b/config/locales/views/advice_pages/advice_pages.yml
@@ -68,7 +68,7 @@ en:
         hot_water: Hot water
         solar_pv: Solar PV
         storage_heaters: Storage heaters
-        thermostatic_control: Thermostatic
+        thermostatic_control: Thermostatic control
         total_energy_use: Total energy use
       sections:
         electricity: Electricity

--- a/config/locales/views/advice_pages/thermostatic_control.yml
+++ b/config/locales/views/advice_pages/thermostatic_control.yml
@@ -47,8 +47,8 @@ en:
         your_schools_R2_value: Your school's R² value is %{r2} which is %{r2_rating_adjective}.
       insights:
         advice_html: |-
-          <p>We call this page an advanced page because there are some complex themes involved and it might take a user some time to work through the explanations.</p>
           <p>A building with good thermostatic control means that the colder it is outside the higher the gas consumption for heating.</p>
+          <p>This is an advanced page because there are some complex themes involved and it might take a user some time to work through the explanations.</p>
         for_more_detail_html: For more detail, <a href='%{link}'>compare with other schools in your group</a>
         how_do_you_compare:
           title: How do you compare?
@@ -63,7 +63,7 @@ en:
         thermostatic_control_r2_notice_html: |-
           <p>Your thermostatic control is %{r2}, which is %{r2_rating_adjective}</p>
           <p>The average value for schools is %{average_schools_r2} and a perfect value is 1.0. The lower the value below 1.0, the worse the school's thermostatic control.</p>
-        title: What do we mean by advanced thermostatic control?
+        title: What is thermostatic control?
         your_thermostatic_control:
           title: Your thermostatic control
-      page_title: Advanced thermostatic control analysis
+      page_title: Thermostatic control analysis

--- a/config/locales/views/advice_pages/thermostatic_control.yml
+++ b/config/locales/views/advice_pages/thermostatic_control.yml
@@ -64,6 +64,4 @@ en:
           <p>Your thermostatic control is %{r2}, which is %{r2_rating_adjective}</p>
           <p>The average value for schools is %{average_schools_r2} and a perfect value is 1.0. The lower the value below 1.0, the worse the school's thermostatic control.</p>
         title: What is thermostatic control?
-        your_thermostatic_control:
-          title: Your thermostatic control
       page_title: Thermostatic control analysis

--- a/spec/services/schools/advice_page_benchmarks/thermostatic_control_benchmark_generator_spec.rb
+++ b/spec/services/schools/advice_page_benchmarks/thermostatic_control_benchmark_generator_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+RSpec.describe Schools::AdvicePageBenchmarks::ThermostaticControlBenchmarkGenerator, type: :service do
+
+  let(:school)      { create(:school) }
+  let(:advice_page) { create(:advice_page, key: :thermostatic, fuel_type: :gas) }
+  let(:aggregate_school) { double(:aggregate_school) }
+
+  let(:service)     { Schools::AdvicePageBenchmarks::ThermostaticControlBenchmarkGenerator.new(advice_page: advice_page, school: school, aggregate_school: aggregate_school)}
+
+  context '#benchmark_school' do
+    let(:enough_data) { true }
+    let(:comparison) {
+      Schools::Comparison.new(
+        school_value: 0.75,
+        benchmark_value: 0.6,
+        exemplar_value: 0.8,
+        unit: :r2,
+        low_is_good: false
+      )
+    }
+    before(:each) do
+      allow_any_instance_of(Schools::Advice::ThermostaticAnalysisService).to receive(:enough_data?).and_return(enough_data)
+      allow_any_instance_of(Schools::Advice::ThermostaticAnalysisService).to receive(:benchmark_thermostatic_control).and_return(comparison)
+    end
+
+    context 'not enough data' do
+      let(:enough_data) { false }
+      it 'does not benchmark' do
+        expect(service.benchmark_school).to be_nil
+      end
+    end
+    context 'with a comparison' do
+      it 'returns the comparison category' do
+        expect(service.benchmark_school).to eq :benchmark_school
+      end
+    end
+  end
+end

--- a/spec/system/schools/advice_pages/thermostatic_control_spec.rb
+++ b/spec/system/schools/advice_pages/thermostatic_control_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe "thermostatic control advice page", type: :system do
   let(:key) { 'thermostatic_control' }
-  let(:expected_page_title) { "Advanced thermostatic control analysis" }
+  let(:expected_page_title) { "Thermostatic control analysis" }
   include_context "gas advice page"
 
   context 'as school admin' do
@@ -37,8 +37,7 @@ RSpec.describe "thermostatic control advice page", type: :system do
       it_behaves_like "an advice page tab", tab: "Insights"
 
       it 'shows expected content' do
-        expect(page).to have_content('What do we mean by advanced thermostatic control?')
-        expect(page).to have_content('Your thermostatic control')
+        expect(page).to have_content('What is thermostatic control?')
         expect(page).to have_content('How do you compare?')
         expect(page).to have_content('Your thermostatic control is 0.67, which is about average')
       end

--- a/spec/system/schools/advice_pages/thermostatic_control_spec.rb
+++ b/spec/system/schools/advice_pages/thermostatic_control_spec.rb
@@ -11,10 +11,10 @@ RSpec.describe "thermostatic control advice page", type: :system do
     before do
       sign_in(user)
 
-      allow_any_instance_of(Schools::Advice::ThermostaticControlController).to receive_messages(
+      allow_any_instance_of(Schools::Advice::ThermostaticAnalysisService).to receive_messages(
         {
-          create_analysable: OpenStruct.new(enough_data?: true),
-          build_heating_thermostatic_analysis: OpenStruct.new(
+          enough_data?: true,
+          thermostatic_analysis: OpenStruct.new(
             r2: 0.6743665142232793,
             insulation_hotwater_heat_loss_estimate_kwh: 193_133.95130872616,
             insulation_hotwater_heat_loss_estimate_£: 5794.0185392617805,


### PR DESCRIPTION
Implements the school comparison component and advice page benchmark for the thermostatic control page

* Extract some common code into a new `ThermostaticAnalysisService` to be shared by controller and benchmark
* Add the benchmark comparison, which is a simple comparison of r2 values
* Update `Schools::Comparison` to accept a parameter to indicate whether high or low in ranges is good. (So far in all other cases we have been aiming for schools to, e.g. reduce consumption, but here they need to increase r2)
* Implement the benchmark for the advice page index

I've also slightly simplified the insights page as there was duplication between the "What is your baseload" and comparison section. So these have been combined. I've also aligned the page title better with the navbar.