### PR TITLE
Implement heating control benchmark

### DIFF
--- a/app/controllers/schools/advice/heating_control_controller.rb
+++ b/app/controllers/schools/advice/heating_control_controller.rb
@@ -9,6 +9,7 @@ module Schools
         if @enough_data_for_seasonal_analysis
           @seasonal_analysis = heating_control_service.seasonal_analysis
           @warm_weather_on_days_rating = heating_control_service.warm_weather_on_days_rating
+          @benchmark_warm_weather_days = heating_control_service.benchmark_warm_weather_days
         end
       end
 

--- a/app/controllers/schools/advice/heating_control_controller.rb
+++ b/app/controllers/schools/advice/heating_control_controller.rb
@@ -6,7 +6,10 @@ module Schools
         @estimated_savings = heating_control_service.estimated_savings
         @percentage_of_annual_gas = heating_control_service.percentage_of_annual_gas
         @enough_data_for_seasonal_analysis = heating_control_service.enough_data_for_seasonal_analysis?
-        @seasonal_analysis = heating_control_service.seasonal_analysis
+        if @enough_data_for_seasonal_analysis
+          @seasonal_analysis = heating_control_service.seasonal_analysis
+          @warm_weather_on_days_rating = heating_control_service.warm_weather_on_days_rating
+        end
       end
 
       def analysis
@@ -15,8 +18,11 @@ module Schools
         @estimated_savings = heating_control_service.estimated_savings
         @percentage_of_annual_gas = heating_control_service.percentage_of_annual_gas
 
-        @seasonal_analysis = heating_control_service.seasonal_analysis
         @enough_data_for_seasonal_analysis = heating_control_service.enough_data_for_seasonal_analysis?
+        if @enough_data_for_seasonal_analysis
+          @seasonal_analysis = heating_control_service.seasonal_analysis
+          @warm_weather_on_days_rating = heating_control_service.warm_weather_on_days_rating
+        end
 
         @multiple_meters = heating_control_service.multiple_meters?
         if @multiple_meters

--- a/app/helpers/advice_page_helper.rb
+++ b/app/helpers/advice_page_helper.rb
@@ -127,27 +127,16 @@ module AdvicePageHelper
     end
   end
 
-  def warm_weather_on_days_rating(days)
-    range = {
-      0..6     => :excellent,
-      6..11    => :good,
-      12..16   => :above_average,
-      17..24   => :poor,
-      25..365  => :very_poor
-    }
-    range.select { |k, _v| k.cover?(days.to_i) }.values.first
-  end
-
-  def warm_weather_on_days_adjective(days)
-    I18nHelper.adjective(warm_weather_on_days_rating(days))
+  def warm_weather_on_days_adjective(rating)
+    I18nHelper.adjective(rating)
   end
 
   def notice_status_for(rating_value)
     rating_value > 6 ? :positive : :negative
   end
 
-  def warm_weather_on_days_status(days)
-    if [:excellent, :good].include?(warm_weather_on_days_rating(days))
+  def warm_weather_on_days_status(rating)
+    if [:excellent, :good].include?(rating)
       :positive
     else
       :negative

--- a/app/services/schools/advice/heating_control_service.rb
+++ b/app/services/schools/advice/heating_control_service.rb
@@ -3,6 +3,15 @@ module Schools
     class HeatingControlService
       include AnalysableMixin
 
+      #number of days heating on in warm weather => rating
+      WARM_WEATHER_DAYS_RATING = {
+        0..6     => :excellent,
+        6..11    => :good,
+        12..16   => :above_average,
+        17..24   => :poor,
+        25..365  => :very_poor
+      }.freeze
+
       def initialize(school, meter_collection)
         @school = school
         @meter_collection = meter_collection
@@ -62,7 +71,15 @@ module Schools
         seasonal_analysis_service.enough_data?
       end
 
+      def warm_weather_on_days_rating
+        WARM_WEATHER_DAYS_RATING.select { |k, _v| k.cover?(days_when_heating_on_warm_weather) }.values.first
+      end
+
       private
+
+      def days_when_heating_on_warm_weather
+        seasonal_analysis.heating_on_in_warm_weather_days.to_i
+      end
 
       def heat_meters
         @heat_meters ||= @meter_collection.heat_meters

--- a/app/services/schools/advice/heating_control_service.rb
+++ b/app/services/schools/advice/heating_control_service.rb
@@ -5,7 +5,7 @@ module Schools
 
       #number of days heating on in warm weather => rating
       WARM_WEATHER_DAYS_RATING = {
-        0..6     => :excellent,
+        0..5     => :excellent,
         6..11    => :good,
         12..16   => :above_average,
         17..24   => :poor,

--- a/app/services/schools/advice/heating_control_service.rb
+++ b/app/services/schools/advice/heating_control_service.rb
@@ -12,6 +12,9 @@ module Schools
         25..365  => :very_poor
       }.freeze
 
+      EXEMPLAR_WARM_WEATHER_DAYS = 6
+      BENCHMARK_WARM_WEATHER_DAYS = 11
+
       def initialize(school, meter_collection)
         @school = school
         @meter_collection = meter_collection
@@ -73,6 +76,15 @@ module Schools
 
       def warm_weather_on_days_rating
         WARM_WEATHER_DAYS_RATING.select { |k, _v| k.cover?(days_when_heating_on_warm_weather) }.values.first
+      end
+
+      def benchmark_warm_weather_days
+        Schools::Comparison.new(
+          school_value: days_when_heating_on_warm_weather,
+          benchmark_value: BENCHMARK_WARM_WEATHER_DAYS,
+          exemplar_value: EXEMPLAR_WARM_WEATHER_DAYS,
+          unit: :days
+        )
       end
 
       private

--- a/app/services/schools/advice_page_benchmarks/heating_control_benchmark_generator.rb
+++ b/app/services/schools/advice_page_benchmarks/heating_control_benchmark_generator.rb
@@ -1,0 +1,16 @@
+module Schools
+  module AdvicePageBenchmarks
+    class HeatingControlBenchmarkGenerator < SchoolBenchmarkGenerator
+      def benchmark_school
+        return unless heating_control_service.enough_data_for_seasonal_analysis?
+        heating_control_service.benchmark_warm_weather_days.category
+      end
+
+      private
+
+      def heating_control_service
+        @heating_control_service ||= Schools::Advice::HeatingControlService.new(@school, @aggregate_school)
+      end
+    end
+  end
+end

--- a/app/views/schools/advice/heating_control/_analysis.html.erb
+++ b/app/views/schools/advice/heating_control/_analysis.html.erb
@@ -24,5 +24,5 @@
 <% end %>
 
 <% if @enough_data_for_seasonal_analysis %>
-  <%= render 'seasonal_control', school: @school, analysis_dates: @analysis_dates, seasonal_analysis: @seasonal_analysis %>
+  <%= render 'seasonal_control', school: @school, analysis_dates: @analysis_dates, seasonal_analysis: @seasonal_analysis, warm_weather_on_days_rating: @warm_weather_on_days_rating %>
 <% end %>

--- a/app/views/schools/advice/heating_control/_comparison.html.erb
+++ b/app/views/schools/advice/heating_control/_comparison.html.erb
@@ -1,18 +1,33 @@
 <%= render 'schools/advice/section_title', section_id: 'comparison', section_title: t('advice_pages.heating_control.insights.comparison.title') %>
 
-<p>
-  <%= t('advice_pages.heating_control.insights.comparison.more_detail_html') %>
-</p>
+<% if @benchmark_warm_weather_days %>
+  <p>
+    <%= t('advice_pages.heating_control.insights.comparison.intro') %>
+  </p>
+  <div class="col">
+    <%= component 'school_comparison', id: 'comparison-warm-weather-days', comparison: @benchmark_warm_weather_days do |c| %>
+      <% c.with_callout_footer { advice_t('heating_control.insights.comparison.callout_footer') } %>
+    <% end %>
+  </div>
+<% end %>
 
-<ul>
-  <li>
-    <a href="<%= benchmark_for_school_group_path(:heating_coming_on_too_early, school) %>">
-      <%= t('advice_pages.heating_control.insights.comparison.start_time_comparison_link') %>
-    </a>
-  </li>
-  <li>
-    <a href="<%= benchmark_for_school_group_path(:heating_in_warm_weather, school) %>">
-      <%= t('advice_pages.heating_control.insights.comparison.heating_on_comparison_link') %>
-    </a>
-  </li>
-</ul>
+<div class="row">
+  <div class="col">
+  <p>
+    <%= t('advice_pages.heating_control.insights.comparison.more_detail_html') %>
+  </p>
+
+  <ul>
+    <li>
+      <a href="<%= benchmark_for_school_group_path(:heating_in_warm_weather, school) %>">
+        <%= t('advice_pages.heating_control.insights.comparison.heating_on_comparison_link') %>
+      </a>
+    </li>
+    <li>
+      <a href="<%= benchmark_for_school_group_path(:heating_coming_on_too_early, school) %>">
+        <%= t('advice_pages.heating_control.insights.comparison.start_time_comparison_link') %>
+      </a>
+    </li>
+  </ul>
+  </div>
+</div>

--- a/app/views/schools/advice/heating_control/_insights.html.erb
+++ b/app/views/schools/advice/heating_control/_insights.html.erb
@@ -21,7 +21,7 @@
 <% if @enough_data_for_seasonal_analysis %>
   <%= render 'schools/advice/section_title', section_id: 'comparison', section_title: t('advice_pages.heating_control.insights.warm_weather.title') %>
 
-  <%= render 'warm_weather_notice', seasonal_analysis: @seasonal_analysis %>
+  <%= render 'warm_weather_notice', seasonal_analysis: @seasonal_analysis, warm_weather_on_days_rating: @warm_weather_on_days_rating %>
 
   <%= render 'warm_weather_benefits', seasonal_analysis: @seasonal_analysis %>
 

--- a/app/views/schools/advice/heating_control/_insights.html.erb
+++ b/app/views/schools/advice/heating_control/_insights.html.erb
@@ -31,5 +31,5 @@
 <% end %>
 
 <% if @school.school_group.present? %>
-  <%= render 'comparison', school: @school %>
+  <%= render 'comparison', school: @school, benchmark_warm_weather_days: @benchmark_warm_weather_days %>
 <% end %>

--- a/app/views/schools/advice/heating_control/_seasonal_control.html.erb
+++ b/app/views/schools/advice/heating_control/_seasonal_control.html.erb
@@ -1,6 +1,6 @@
 <%= render 'schools/advice/section_title', section_id: 'seasonal-control', section_title: t('advice_pages.heating_control.analysis.seasonal_control.title') %>
 
-<%= render 'warm_weather_notice', seasonal_analysis: seasonal_analysis %>
+<%= render 'warm_weather_notice', seasonal_analysis: seasonal_analysis, warm_weather_on_days_rating: warm_weather_on_days_rating %>
 
 <%= render 'warm_weather_benefits', seasonal_analysis: seasonal_analysis %>
 

--- a/app/views/schools/advice/heating_control/_warm_weather_notice.html.erb
+++ b/app/views/schools/advice/heating_control/_warm_weather_notice.html.erb
@@ -1,8 +1,8 @@
-<%= component 'notice', status: warm_weather_on_days_status(seasonal_analysis.heating_on_in_warm_weather_days) do %>
+<%= component 'notice', status: warm_weather_on_days_status(warm_weather_on_days_rating) do %>
  <p>
    <%= t('advice_pages.heating_control.analysis.seasonal_control.heating_on_in_warm_weather_days',
    days: seasonal_analysis.heating_on_in_warm_weather_days.to_i,
-   adjective: warm_weather_on_days_adjective(seasonal_analysis.heating_on_in_warm_weather_days)) %>
+   adjective: warm_weather_on_days_adjective(warm_weather_on_days_rating)) %>
  </p>
  <p>
    <%= t('advice_pages.heating_control.analysis.seasonal_control.percent_html',

--- a/config/locales/views/advice_pages/heating_control.yml
+++ b/config/locales/views/advice_pages/heating_control.yml
@@ -43,9 +43,11 @@ en:
           title: Seasonal control chart
       insights:
         comparison:
-          heating_on_comparison_link: how often you have heating on during warm weather
+          callout_footer: days
+          heating_on_comparison_link: How often you have heating on during warm weather
+          intro: When it comes to leaving heating on during warm weather, how do you compare with other schools?
           more_detail_html: For more detail look at how your school compares with others in your group
-          start_time_comparison_link: morning start times for heating
+          start_time_comparison_link: Morning start times for heating
           title: How do you compare?
         controls:
           average_start_time: Our analysis shows that recently the average start time for your heating was %{time}.

--- a/spec/services/schools/advice_page_benchmarks/heating_control_benchmark_generator_spec.rb
+++ b/spec/services/schools/advice_page_benchmarks/heating_control_benchmark_generator_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+RSpec.describe Schools::AdvicePageBenchmarks::HeatingControlBenchmarkGenerator, type: :service do
+
+  let(:school)      { create(:school) }
+  let(:advice_page) { create(:advice_page, key: :heating_control, fuel_type: :gas) }
+  let(:aggregate_school) { double(:aggregate_school) }
+
+  let(:service)     { Schools::AdvicePageBenchmarks::HeatingControlBenchmarkGenerator.new(advice_page: advice_page, school: school, aggregate_school: aggregate_school)}
+
+  context '#benchmark_school' do
+    let(:enough_data) { true }
+    let(:comparison) {
+      Schools::Comparison.new(
+        school_value: 10,
+        benchmark_value: 11,
+        exemplar_value: 6,
+        unit: :days
+      )
+    }
+    before(:each) do
+      allow_any_instance_of(Schools::Advice::HeatingControlService).to receive(:enough_data_for_seasonal_analysis?).and_return(enough_data)
+      allow_any_instance_of(Schools::Advice::HeatingControlService).to receive(:benchmark_warm_weather_days).and_return(comparison)
+    end
+
+    context 'not enough data' do
+      let(:enough_data) { false }
+      it 'does not benchmark' do
+        expect(service.benchmark_school).to be_nil
+      end
+    end
+    context 'with a comparison' do
+      it 'returns the comparison category' do
+        expect(service.benchmark_school).to eq :benchmark_school
+      end
+    end
+  end
+end


### PR DESCRIPTION
Implements the school comparison component and advice page benchmark for the heating control page.

We'll be benchmarking schools based on how often they have heating on during warm weather.

This PR:

* Extracts some code currently in a helper, moving it to the `HeatingControlService` and then adding methods to access the rating
* Revises the controller and templates to use the above when displaying notices about warm weather days
* Fixes a potential issue where we still try and run the seasonal analysis, even though there is limited data
* Updates the `HeatingControlService` to benchmark the school usage and adds the school comparison component to the insight page
* Adds a benchmark generator for the advice index page.
