### PR TITLE
Improve benchmark labelling on advice index page

### DIFF
--- a/app/assets/stylesheets/advice_page.scss
+++ b/app/assets/stylesheets/advice_page.scss
@@ -76,10 +76,25 @@
   padding-top: 10px;
   font-weight: bold;
 }
+
 .advice-page-benchmark-label {
   text-align: center !important;
-  color: white;
-  font-weight: bold;
   padding-top: 10px;
   padding-bottom: 10px;
+}
+
+.advice-page-benchmark-muted-label {
+  @extend .advice-page-benchmark-label;
+  font-weight: bold;
+  color: $grey;
+}
+
+.advice-page-benchmark-colored-label {
+  @extend .advice-page-benchmark-label;
+  font-weight: bold;
+  color: white;
+  a {
+    color: inherit;
+    text-decoration: none;
+  }
 }

--- a/app/helpers/advice_page_helper.rb
+++ b/app/helpers/advice_page_helper.rb
@@ -166,5 +166,9 @@ module AdvicePageHelper
     fuel_type = 'storage_heaters' if fuel_type == "storage_heater"
     school.send("has_#{fuel_type}?".to_sym)
   end
+
+  def can_benchmark?(advice_page:)
+    Schools::AdvicePageBenchmarks::SchoolBenchmarkGenerator.can_benchmark?(advice_page: advice_page)
+  end
 end
 # rubocop:enable Naming/AsciiIdentifiers

--- a/app/services/schools/advice_page_benchmarks/school_benchmark_generator.rb
+++ b/app/services/schools/advice_page_benchmarks/school_benchmark_generator.rb
@@ -7,21 +7,31 @@ module Schools
         @aggregate_school = aggregate_school
       end
 
+      def self.can_benchmark?(advice_page:)
+        generator_for_advice_page(advice_page: advice_page).present?
+      end
+
       def self.generator_for(advice_page:, school:, aggregate_school:)
-        generator_class = case advice_page.key.to_sym
-                          when :baseload
-                            BaseloadBenchmarkGenerator
-                          when :electricity_long_term, :gas_long_term
-                            LongTermUsageBenchmarkGenerator
-                          when :electricity_out_of_hours, :gas_out_of_hours
-                            OutOfHoursUsageBenchmarkGenerator
-                          when :electricity_intraday
-                            PeakUsageBenchmarkGenerator
-                          when :thermostatic_control
-                            ThermostaticControlBenchmarkGenerator
-                          end
+        generator_class = generator_for_advice_page(advice_page: advice_page)
         return nil unless generator_class.present?
         generator_class.new(advice_page: advice_page, school: school, aggregate_school: aggregate_school)
+      end
+
+      private_class_method def self.generator_for_advice_page(advice_page:)
+        case advice_page.key.to_sym
+        when :baseload
+          BaseloadBenchmarkGenerator
+        when :electricity_long_term, :gas_long_term
+          LongTermUsageBenchmarkGenerator
+        when :electricity_out_of_hours, :gas_out_of_hours
+          OutOfHoursUsageBenchmarkGenerator
+        when :electricity_intraday
+          PeakUsageBenchmarkGenerator
+        when :thermostatic_control
+          ThermostaticControlBenchmarkGenerator
+        when :heating_control
+          HeatingControlBenchmarkGenerator
+        end
       end
 
       def perform

--- a/app/views/schools/advice/index/_page_list.html.erb
+++ b/app/views/schools/advice/index/_page_list.html.erb
@@ -1,8 +1,8 @@
-<% AdvicePage.fuel_types.keys.each do |fuel_type| %>
+<% AdvicePage.fuel_types.keys.each_with_index do |fuel_type, idx| %>
   <div class="col">
     <% if display_advice_page?(school, fuel_type) %>
       <div class="row mt-4">
-        <div class="col-2">
+        <div class="col-3">
           <h4>
             <span class="<%= fuel_type_class(fuel_type) %>">
               <%= fa_icon( fuel_type_icon(fuel_type) ) %>
@@ -10,13 +10,20 @@
             <%= t("advice_pages.nav.sections.#{fuel_type}") %>
           </h4>
         </div>
-        <div class="col-10"></div>
+        <div class="col-7"></div>
+        <div class="col-2 bg-light">
+          <% if idx == 0 %>
+            <div class="advice-page-benchmark-label">
+              How does your school compare?
+            </div>
+          <% end %>
+        </div>
       </div>
       <div class="row">
         <div class="col">
           <% sort_by_label(advice_pages.where(fuel_type: fuel_type)).each do |ap| %>
             <div class="mt-3 row d-flex align-items-center">
-              <div class="col-2">
+              <div class="col-3">
                 <h5 class="advice-page-label"><%= link_to translated_label(ap), advice_page_path(school, ap) %></h5>
               </div>
               <div class="col">
@@ -25,12 +32,16 @@
               <% school_benchmark = advice_page_benchmarks.where(advice_page: ap).first %>
               <% if school_benchmark.present? %>
                 <div class="col-2 bg-<%= school_benchmark.benchmarked_as %>">
-                  <div class="advice-page-benchmark-label">
-                    <%= t("advice_pages.benchmarks.#{school_benchmark.benchmarked_as}") %>
+                  <div class="advice-page-benchmark-colored-label">
+                    <%= link_to t("advice_pages.benchmarks.#{school_benchmark.benchmarked_as}"), advice_page_path(school, ap) %>
                   </div>
                 </div>
               <% else %>
-                <div class="col-2"></div>
+                <div class="col-2 bg-light">
+                  <div class="advice-page-benchmark-muted-label">
+                    <%= can_benchmark?(advice_page: ap) ? t("advice_pages.index.show.not_available") : t("advice_pages.index.show.not_applicable") %>
+                  </div>
+                </div>
               <% end %>
             </div>
           <% end %>

--- a/app/views/schools/advice/index/_page_list.html.erb
+++ b/app/views/schools/advice/index/_page_list.html.erb
@@ -11,10 +11,10 @@
           </h4>
         </div>
         <div class="col-7"></div>
-        <div class="col-2 bg-light">
+        <div class="col-2 <%= idx == 0 ? 'bg-light' : ''%>">
           <% if idx == 0 %>
             <div class="advice-page-benchmark-label">
-              How does your school compare?
+              <%= t("advice_pages.index.show.how_do_you_compare") %>
             </div>
           <% end %>
         </div>

--- a/config/locales/views/advice_pages/index.yml
+++ b/config/locales/views/advice_pages/index.yml
@@ -15,6 +15,7 @@ en:
         table_note: Use the table headings to sort the recommendations. Potential cost savings for the same fuel type are not additive.
         title: Priority actions
       show:
+        how_do_you_compare: How does your school compare?
         not_applicable: Not applicable
         not_available: Not available
         notice_html: |-

--- a/config/locales/views/advice_pages/index.yml
+++ b/config/locales/views/advice_pages/index.yml
@@ -15,6 +15,8 @@ en:
         table_note: Use the table headings to sort the recommendations. Potential cost savings for the same fuel type are not additive.
         title: Priority actions
       show:
+        not_applicable: Not applicable
+        not_available: Not available
         notice_html: |-
           <p>Looking for suggestions of how to start reducing your energy usage?</p>
           <p>We've recommended some priority actions to help you make progress. Or explore our detailed analysis below.</p>

--- a/spec/services/schools/advice_page_benchmarks/school_benchmark_generator_spec.rb
+++ b/spec/services/schools/advice_page_benchmarks/school_benchmark_generator_spec.rb
@@ -9,6 +9,23 @@ RSpec.describe Schools::AdvicePageBenchmarks::SchoolBenchmarkGenerator, type: :s
 
   let(:service)     { Schools::AdvicePageBenchmarks::SchoolBenchmarkGenerator.new(advice_page: advice_page, school: school, aggregate_school: aggregate_school)}
 
+  context '.can_benchmark?' do
+    let(:result) { Schools::AdvicePageBenchmarks::SchoolBenchmarkGenerator.can_benchmark?(advice_page: advice_page)}
+    context 'for existing benchmarks' do
+      [:baseload, :electricity_long_term, :gas_long_term, :electricity_out_of_hours, :gas_out_of_hours, :electricity_intraday, :thermostatic_control, :heating_control].each do |key|
+        let(:advice_page) { create(:advice_page, key: key) }
+        it "returns true for #{key}" do
+          expect(result).to eq true
+        end
+      end
+    end
+    context 'for unknown benchmark' do
+      let(:advice_page) { create(:advice_page, key: :unknown) }
+      it 'returns false' do
+        expect(result).to eq false
+      end
+    end
+  end
   context '.generator_for' do
     let(:generator) { Schools::AdvicePageBenchmarks::SchoolBenchmarkGenerator.generator_for(advice_page: advice_page, school: school, aggregate_school: aggregate_school) }
 


### PR DESCRIPTION
* Add a method and a helper to indicate whether we have an benchmark for a benchmark page
* Add a "not applicable" or "not available" message to advice index page to better indicate whether we do have a benchmark, or whether its not yet available
* Link the colour coded blocks to the relevant insights page
* Styling improvements.