### PR TITLE
Log advice page and tab to GA

### DIFF
--- a/app/views/shared/_google_analytics.html.erb
+++ b/app/views/shared/_google_analytics.html.erb
@@ -6,12 +6,15 @@
   gtag('js', new Date());
 
   gtag('config', '<%= analytics_code %>', {
-    'custom_map': {'dimension1': 'user_role', 'dimension2': 'user_school'}
+    'custom_map': {'dimension1': 'user_role', 'dimension2': 'user_school', 'dimension3': 'advice_page', 'dimension4': 'advice_page_tab'}
   });
   <% if current_user %>
     gtag('event', 'role_dimension', {'user_role': '<%= current_user.role %>'});
     <% if current_user.school %>
       gtag('event', 'school_dimension', {'user_school': '<%= current_user.school.name %>'});
+    <% end %>
+    <% if @advice_page.present? %>
+      gtag('event', 'advice_page_dimension', {'advice_page': '<%= @advice_page.key %>', 'advice_page_tab': '<%= @tab %>'});
     <% end %>
   <% end %>
 </script>


### PR DESCRIPTION
Updates out Google Analytics custom dimensions to include the advice page key and tab where available.

This should allow us to better report based on which pages users are visiting, rather than relying on page titles.