### PR TITLE
Add school name type and address to adult and pupil dashboard

### DIFF
--- a/app/assets/stylesheets/dashboards.scss
+++ b/app/assets/stylesheets/dashboards.scss
@@ -1,3 +1,22 @@
+.dashboard-title {
+  div.dashboard-school-title {
+    h1 {
+      padding-bottom: 0px;
+      margin-bottom: 0px;
+    }
+    .dashboard-school-address {
+      color: #6c757d !important;
+      font-size: 80%;
+      .badge {
+        font-size: inherit;
+      }
+      small {
+        font-size: inherit;
+      }
+    }
+  }
+}
+
 div.dashboards {
   div.analysis-chart, div.simulator-chart {
     height: 400px;

--- a/app/views/pupils/schools/_pupil_dashboard_buttons.html.erb
+++ b/app/views/pupils/schools/_pupil_dashboard_buttons.html.erb
@@ -1,0 +1,7 @@
+<% if show_admin_page_switch?(school) %>
+  <% if params[:no_data] %>
+    <%= link_to t('pupils.schools.show.admin_view'), pupils_school_path(school), class: 'btn btn-outline-dark bg-warning rounded-pill font-weight-bold' %>
+  <% else %>
+    <%= link_to t('pupils.schools.show.user_view'), pupils_school_path(school, no_data: true), class: 'btn btn-outline-dark bg-warning rounded-pill font-weight-bold' %>
+  <% end %>
+<% end %>

--- a/app/views/pupils/schools/show.html.erb
+++ b/app/views/pupils/schools/show.html.erb
@@ -1,17 +1,7 @@
 <%= content_for :page_title, t('pupils.schools.show.title', school_name: @school.name) %>
 
-<% if show_admin_page_switch?(@school) %>
-  <div class="row mt-2 mb-2">
-    <div class="col">
-      <div class="float-right">
-        <% if params[:no_data] %>
-          <%= link_to t('pupils.schools.show.admin_view'), pupils_school_path(@school), class: 'btn btn-outline-dark bg-warning rounded-pill font-weight-bold' %>
-        <% else %>
-          <%= link_to t('pupils.schools.show.user_view'), pupils_school_path(@school, no_data: true), class: 'btn btn-outline-dark bg-warning rounded-pill font-weight-bold' %>
-        <% end %>
-      </div>
-    </div>
-  </div>
+<%= render 'shared/dashboard_title', school: @school do %>
+  <%= render 'pupil_dashboard_buttons', school: @school %>
 <% end %>
 
 <% if @show_data_enabled_features %>

--- a/app/views/schools/_adult_dashboard_buttons.html.erb
+++ b/app/views/schools/_adult_dashboard_buttons.html.erb
@@ -1,0 +1,25 @@
+<% if show_data_enabled_features %>
+  <% if school.school_group && can?(:compare, school.school_group) %>
+    <%= link_to t('schools.schools.compare_schools'), benchmarks_path(benchmark: {school_group_ids: [school.school_group.id]}), class: 'btn btn-outline-dark rounded-pill font-weight-bold' %>
+  <% end %>
+  <% unless replace_analysis_pages? %>
+    <% if co2_pages && co2_pages.any? %>
+      <% co2_pages.each do |page| %>
+        <%= link_to t('schools.schools.carbon_emissions'), school_analysis_path(school, page.analysis_page), class: 'btn btn-outline-dark rounded-pill font-weight-bold' %>
+      <% end %>
+    <% end %>
+  <% end %>
+  <% if school.configuration %>
+    <% unless replace_analysis_pages? %>
+      <%= link_to public ? t('pupils.analysis.explore_data') : t('schools.schools.explore_data'), pupils_school_analysis_path(school), class: 'btn btn-outline-dark rounded-pill font-weight-bold' %>
+    <% end %>
+    <%= link_to public ? t('pupils.analysis.review_energy_analysis') : t('schools.schools.review_energy_analysis'), school_advice_link(school), class: 'btn btn-outline-dark rounded-pill font-weight-bold' %>
+  <% end %>
+<% end %>
+<% if show_admin_page_switch?(school) %>
+  <% if params[:no_data] %>
+    <%= link_to 'Admin view', school_path(school), class: 'btn btn-outline-dark bg-warning rounded-pill font-weight-bold' %>
+  <% else %>
+    <%= link_to 'User view', school_path(school, no_data: true), class: 'btn btn-outline-dark bg-warning rounded-pill font-weight-bold' %>
+  <% end %>
+<% end %>

--- a/app/views/schools/show.html.erb
+++ b/app/views/schools/show.html.erb
@@ -1,6 +1,8 @@
 <%= content_for :page_title, t('schools.show.dashboard_title', school_name: @school.name) %>
 
-<%= render 'shared/dashboard_title', school: @school, co2_pages: @co2_pages, public: true, show_data_enabled_features: @show_data_enabled_features %>
+<%= render 'shared/dashboard_title', school: @school do %>
+  <%= render 'adult_dashboard_buttons', school: @school, co2_pages: @co2_pages, public: true, show_data_enabled_features: @show_data_enabled_features %>
+<% end %>
 
 <% if @overview_data %>
   <h2><%= t('schools.show.summary_of_recent_energy_usage') %></h2>

--- a/app/views/shared/_dashboard_title.html.erb
+++ b/app/views/shared/_dashboard_title.html.erb
@@ -1,6 +1,12 @@
-<div class="d-flex justify-content-between align-items-center">
-  <h1><%= t('schools.show.adult_dashboard') %></h1>
-  <div class="h5">
+<div class="d-flex justify-content-between align-items-center pb-4 dashboard-title">
+  <div class="dashboard-school-title">
+    <h1><%= @school.name %></h1>
+    <span class="dashboard-school-address">
+      <span class="badge badge-secondary"><%= @school.school_type.humanize %></span>
+      <%= @school.address %> <%= @school.postcode %>
+    </span>
+  </div>
+  <div class="dashboard-buttons">
     <% if show_data_enabled_features %>
       <% if school.school_group && can?(:compare, school.school_group) %>
         <%= link_to t('schools.schools.compare_schools'), benchmarks_path(benchmark: {school_group_ids: [school.school_group.id]}), class: 'btn btn-outline-dark rounded-pill font-weight-bold' %>

--- a/app/views/shared/_dashboard_title.html.erb
+++ b/app/views/shared/_dashboard_title.html.erb
@@ -1,36 +1,12 @@
 <div class="d-flex justify-content-between align-items-center pb-4 dashboard-title">
   <div class="dashboard-school-title">
-    <h1><%= @school.name %></h1>
+    <h1><%= school.name %></h1>
     <span class="dashboard-school-address">
-      <span class="badge badge-secondary"><%= @school.school_type.humanize %></span>
-      <%= @school.address %> <%= @school.postcode %>
+      <span class="badge badge-secondary"><%= school.school_type.humanize %></span>
+      <%= school.address %> <%= school.postcode %>
     </span>
   </div>
   <div class="dashboard-buttons">
-    <% if show_data_enabled_features %>
-      <% if school.school_group && can?(:compare, school.school_group) %>
-        <%= link_to t('schools.schools.compare_schools'), benchmarks_path(benchmark: {school_group_ids: [school.school_group.id]}), class: 'btn btn-outline-dark rounded-pill font-weight-bold' %>
-      <% end %>
-      <% unless replace_analysis_pages? %>
-        <% if co2_pages && co2_pages.any? %>
-          <% co2_pages.each do |page| %>
-            <%= link_to t('schools.schools.carbon_emissions'), school_analysis_path(school, page.analysis_page), class: 'btn btn-outline-dark rounded-pill font-weight-bold' %>
-          <% end %>
-        <% end %>
-      <% end %>
-      <% if school.configuration %>
-        <% unless replace_analysis_pages? %>
-          <%= link_to public ? t('pupils.analysis.explore_data') : t('schools.schools.explore_data'), pupils_school_analysis_path(school), class: 'btn btn-outline-dark rounded-pill font-weight-bold' %>
-        <% end %>
-        <%= link_to public ? t('pupils.analysis.review_energy_analysis') : t('schools.schools.review_energy_analysis'), school_advice_link(school), class: 'btn btn-outline-dark rounded-pill font-weight-bold' %>
-      <% end %>
-    <% end %>
-    <% if show_admin_page_switch?(school) %>
-      <% if params[:no_data] %>
-        <%= link_to 'Admin view', school_path(school), class: 'btn btn-outline-dark bg-warning rounded-pill font-weight-bold' %>
-      <% else %>
-        <%= link_to 'User view', school_path(school, no_data: true), class: 'btn btn-outline-dark bg-warning rounded-pill font-weight-bold' %>
-      <% end %>
-    <% end %>
+    <%= yield %>
   </div>
 </div>

--- a/config/locales/cy/views/schools/schools.yml
+++ b/config/locales/cy/views/schools/schools.yml
@@ -332,7 +332,6 @@ cy:
       add_alert_contacts: Ychwanegu cysylltiadau rhybuddio
       add_consumption_estimate: "Ychwanegwch amcangyfrif o'ch defnydd %{fuels} blynyddol fel y gallwn ddarparu adroddiad cynnydd manylach i'ch helpu i gyrraedd eich targedau"
       add_estimate: Ychwanegu amcangyfrif
-      adult_dashboard: Dangosfwrdd Oedolion
       co2_kg: CO2 (kg)
       coming_soon: Dod yn fuan
       complete_activities: Dysgwch ddisgyblion am ynni a newid hinsawdd o fewn cyd-destun eich ysgol eich hun drwy gwblhau ein gweithgareddau sydd ar gael am ddim

--- a/config/locales/views/schools/schools.yml
+++ b/config/locales/views/schools/schools.yml
@@ -500,7 +500,6 @@ en:
       add_alert_contacts: Add alert contacts
       add_consumption_estimate: Add an estimate of your annual %{fuels} consumption so we can provide you with a more detailed progress report to help you achieve your targets
       add_estimate: Add an estimate
-      adult_dashboard: Adult Dashboard
       co2_kg: CO2 (kg)
       coming_soon: Coming Soon
       complete_activities: Teach pupils about energy and climate change within the context of your own school by completing our freely available activities

--- a/spec/system/admin/alert_type_management_ratings_spec.rb
+++ b/spec/system/admin/alert_type_management_ratings_spec.rb
@@ -127,6 +127,12 @@ RSpec.describe 'alert type management', type: :system do
 
   describe 'creating alert content' do
 
+    around do |example|
+      ClimateControl.modify FEATURE_FLAG_REPLACE_FIND_OUT_MORES: 'false' do
+        example.run
+      end
+    end
+
     let!(:alert) do
       create(:alert, alert_type: gas_fuel_alert_type, template_data: {gas_percentage: '10%', chart_a: :example_chart_value}, school: create(:school))
     end

--- a/spec/system/admin/school_onboarding_spec.rb
+++ b/spec/system/admin/school_onboarding_spec.rb
@@ -272,7 +272,9 @@ RSpec.describe "onboarding", :schools, type: :system do
       expect(page).to have_content 'Schools recently onboarded'
 
       click_on onboarding.school_name
-      expect(page).to have_content 'Adult Dashboard'
+      within('.dashboard-school-title') do
+        expect(page).to have_content(school.name)
+      end
     end
   end
 end

--- a/spec/system/home_spec.rb
+++ b/spec/system/home_spec.rb
@@ -170,7 +170,9 @@ RSpec.describe "home", type: :system do
 
       it 'redirects from teacher page' do
         visit "/teachers/schools/#{school.slug}"
-        expect(page).to have_content('Adult Dashboard')
+        within('.dashboard-school-title') do
+          expect(page).to have_content(school.name)
+        end
       end
 
       it 'does not redirect to holding page' do

--- a/spec/system/school_alerts_spec.rb
+++ b/spec/system/school_alerts_spec.rb
@@ -13,6 +13,11 @@ RSpec.describe "school alerts", type: :system do
   end
 
   context 'with generated alert' do
+    around do |example|
+      ClimateControl.modify FEATURE_FLAG_REPLACE_ANALYSIS_PAGES: 'false' do
+        example.run
+      end
+    end
 
     describe 'Find Out More' do
 

--- a/spec/system/school_spec.rb
+++ b/spec/system/school_spec.rb
@@ -26,7 +26,9 @@ RSpec.describe "school adult dashboard", type: :system do
           it 'renders a loading page and then back to the dashboard page on success' do
             visit school_path(school)
 
-            expect(page).to have_content('Adult Dashboard')
+            within('.dashboard-school-title') do
+              expect(page).to have_content(school.name)
+            end
             # if redirect fails it will still be processing
             expect(page).to_not have_content('processing')
             expect(page).to_not have_content("we're having trouble processing your energy data today")
@@ -58,7 +60,6 @@ RSpec.describe "school adult dashboard", type: :system do
 
         it 'and redirects to pupil dashboard' do
           visit school_path(school)
-          expect(page).to_not have_content("Adult Dashboard")
           expect(page).to_not have_content("Energy Sparks is processing all of this school's data to provide today's analysis")
           expect(page).to have_content("No activities completed, make a start!")
         end

--- a/spec/system/schools/advice_pages/advice_pages_spec.rb
+++ b/spec/system/schools/advice_pages/advice_pages_spec.rb
@@ -146,13 +146,6 @@ RSpec.describe "advice pages", type: :system do
         end
       end
 
-      it 'links to advice pages from manage school menu' do
-        within '#manage_school_menu' do
-          click_on 'Advice pages'
-        end
-        expect(page).to have_content("Energy efficiency advice")
-      end
-
       it 'links from admin page' do
         visit admin_path
         click_on 'Advice Pages'

--- a/spec/system/schools/analysis_pages_spec.rb
+++ b/spec/system/schools/analysis_pages_spec.rb
@@ -31,6 +31,12 @@ RSpec.describe "analysis page", type: :system do
 
     let!(:alert) { create(:alert, :with_run, alert_type: gas_fuel_alert_type, school: school, rating: 9.0) }
 
+    around do |example|
+      ClimateControl.modify FEATURE_FLAG_REPLACE_ANALYSIS_PAGES: 'false' do
+        example.run
+      end
+    end
+
     before do
       Alerts::GenerateContent.new(school).perform
 

--- a/spec/system/schools/dashboard/manage_school_spec.rb
+++ b/spec/system/schools/dashboard/manage_school_spec.rb
@@ -66,7 +66,6 @@ RSpec.describe "manage school", type: :system do
         expect(page).to have_link("Batch reports")
         expect(page).to have_link("Review targets")
         expect(page).to have_link("Expert analysis")
-        expect(page).to have_link("Advice pages")
         expect(page).to have_link("Remove school")
       end
     end
@@ -85,7 +84,6 @@ RSpec.describe "manage school", type: :system do
         expect(page).to_not have_link("Batch reports")
         expect(page).to_not have_link("Review targets")
         expect(page).to_not have_link("Expert analysis")
-        expect(page).to_not have_link("Advice pages")
         expect(page).to_not have_link("Remove school")
       end
     end

--- a/spec/system/schools/dashboard/navigation_spec.rb
+++ b/spec/system/schools/dashboard/navigation_spec.rb
@@ -29,19 +29,7 @@ RSpec.shared_examples "navigation" do
   end
 
   it 'has links to analysis' do
-    expect(page).to have_link("Explore data")
     expect(page).to have_link("Review energy analysis")
-  end
-
-  context 'with co2 analysis' do
-    before(:each) do
-      co2_page = double(analysis_title: 'Some CO2 page', analysis_page: 'analysis/page/co2')
-      expect_any_instance_of(SchoolsController).to receive(:process_analysis_templates).and_return([co2_page])
-      visit school_path(test_school, switch: true)
-    end
-    it 'shows link to co2 analysis page' do
-      expect(page).to have_link("Carbon emissions")
-    end
   end
 
   context 'when school has partners' do
@@ -203,7 +191,9 @@ RSpec.describe "adult dashboard navigation", type: :system do
     it "doesn't allow download of other schools data" do
       other_school = create(:school)
       visit school_path(other_school)
-      expect(page).to have_content("Adult Dashboard")
+      within '.dashboard-school-title' do
+        expect(page).to have_content(other_school.name)
+      end
       expect(page).not_to have_link("Download your data")
     end
 
@@ -283,7 +273,9 @@ RSpec.describe "adult dashboard navigation", type: :system do
     it "doesn't allow download of other schools data" do
       other_school = create(:school)
       visit school_path(other_school)
-      expect(page).to have_content("Adult Dashboard")
+      within '.dashboard-school-title' do
+        expect(page).to have_content(other_school.name)
+      end
       expect(page).not_to have_link("Download your data")
     end
 
@@ -375,7 +367,9 @@ RSpec.describe "adult dashboard navigation", type: :system do
 
     it 'shows download link' do
       visit school_path(school)
-      expect(page).to have_content("Adult Dashboard")
+      within '.dashboard-school-title' do
+        expect(page).to have_content(school.name)
+      end
       expect(page).to have_link("Download your data")
     end
 
@@ -402,7 +396,6 @@ RSpec.describe "adult dashboard navigation", type: :system do
       end
       it 'overrides flag and shows data-enabled links' do
         expect(page).to have_link("Compare schools")
-        expect(page).to have_link("Explore data")
         expect(page).to have_link("Review energy analysis")
         expect(page).to have_link("Download your data")
       end

--- a/spec/system/schools/live_data_spec.rb
+++ b/spec/system/schools/live_data_spec.rb
@@ -20,7 +20,9 @@ RSpec.describe 'live data', type: :system do
     end
 
     it 'does not let me view live data' do
-      expect(page).to have_content("Dashboard")
+      within '.dashboard-school-title' do
+        expect(page).to have_content(school.name)
+      end
       expect(page).to_not have_content("live data")
     end
   end


### PR DESCRIPTION
Changes school dashboard so the school name, type and address is displayed at the top.

Common markup is factored out into a partial.

The PR also fixes up a number of tests that are broken when these feature flags are on:

```
FEATURE_FLAG_REPLACE_ANALYSIS_PAGES="true"
FEATURE_FLAG_REPLACE_FIND_OUT_MORES=true
```


