### PR TITLE
Redirect from benchmarks to advice pages

### DIFF
--- a/app/controllers/analysis_page_finder_controller.rb
+++ b/app/controllers/analysis_page_finder_controller.rb
@@ -1,18 +1,29 @@
 class AnalysisPageFinderController < ApplicationController
   skip_before_action :authenticate_user!
   include AnalysisPages
+  include ApplicationHelper
+  include AdvicePageHelper
 
   def show
     urn = params[:urn]
     analysis_class = params[:analysis_class]
 
     school = School.find_by!(urn: urn)
-    analysis_page = find_analysis_page_of_class(school, analysis_class)
 
-    if analysis_page
-      redirect_to school_analysis_path(school.slug, analysis_page.id)
+    if replace_analysis_pages?
+      alert_type = find_advice_page_of_class(analysis_class)
+      if alert_type.advice_page.present?
+        redirect_to advice_page_path(school, alert_type.advice_page)
+      else
+        redirect_to school_advice_path(school)
+      end
     else
-      redirect_back fallback_location: benchmarks_path, notice: "We couldn't take you to the correct location, sorry."
+      analysis_page = find_analysis_page_of_class(school, analysis_class)
+      if analysis_page
+        redirect_to school_analysis_path(school.slug, analysis_page.id)
+      else
+        redirect_back fallback_location: benchmarks_path, notice: "We couldn't take you to the correct location, sorry."
+      end
     end
   end
 end

--- a/app/controllers/concerns/analysis_pages.rb
+++ b/app/controllers/concerns/analysis_pages.rb
@@ -8,6 +8,11 @@ module AnalysisPages
     end
   end
 
+  def find_advice_page_of_class(analysis_class)
+    alert_type = AlertType.where("lower(class_name) = ?", analysis_class.downcase).first
+    return alert_type
+  end
+
   def setup_analysis_pages(analysis_pages)
     @heating_pages = process_analysis_templates(analysis_pages.heating)
     @electricity_pages = process_analysis_templates(analysis_pages.electricity_use)

--- a/app/controllers/concerns/analysis_pages.rb
+++ b/app/controllers/concerns/analysis_pages.rb
@@ -9,8 +9,7 @@ module AnalysisPages
   end
 
   def find_advice_page_of_class(analysis_class)
-    alert_type = AlertType.where("lower(class_name) = ?", analysis_class.downcase).first
-    return alert_type
+    AlertType.where("lower(class_name) = ?", analysis_class.downcase).first
   end
 
   def setup_analysis_pages(analysis_pages)


### PR DESCRIPTION
The benchmark pages use a custom route to link to the old analysis pages. That route uses the school url and class name. This is then used to find the latest version of that analysis page and the user is redirected to it.

We need to ensure these urls continue to work for the moment, but as the new advice pages have a predictable URL it shouldn't be needed longer term. 

For now this PR changes the controller to find the right AdvicePage instead and redirects to it. It uses the same feature flag we're using to hide the old analysis pages from the rest of the site.