### PR TITLE
Improve layout of mail templates

### DIFF
--- a/app/views/alert_mailer/alert_email.html.erb
+++ b/app/views/alert_mailer/alert_email.html.erb
@@ -16,12 +16,12 @@
     <p>
       <%= t('alert_mailer.alert_email.your_school_has_current_target_html', target_date: nice_dates(@school.current_target.target_date), school_targets_url: school_school_targets_url(@school, params: targets_utm_parameters)) %>.
     </p>
-    <%= link_to t('alert_mailer.alert_email.view_your_progress_report'), school_school_targets_url(@school, params: targets_utm_parameters), class: 'btn btn-primary mt-3 mb-3 float-right'%>
+    <%= link_to t('alert_mailer.alert_email.view_your_progress_report'), school_school_targets_url(@school, params: targets_utm_parameters), class: 'btn btn-primary mt-3 mb-3 ax-right'%>
   <% elsif @school.has_target? %>
     <p>
       <%= t('alert_mailer.alert_email.your_school_has_target_html', target_date: nice_dates(@school.most_recent_target.target_date), school_targets_url: school_school_target_url(@school, @school.most_recent_target, params: targets_utm_parameters)) %>.
     </p>
-    <%= link_to t('alert_mailer.alert_email.set_a_new_target'), school_school_targets_url(@school, params: targets_utm_parameters), class: 'btn btn-primary mt-3 mb-3 float-right'%>
+    <%= link_to t('alert_mailer.alert_email.set_a_new_target'), school_school_targets_url(@school, params: targets_utm_parameters), class: 'btn btn-primary mt-3 mb-3 ax-right'%>
   <% else %>
     <%= render 'shared/mailer/first_target_prompt', tracking_params: targets_utm_parameters %>
   <% end %>
@@ -31,7 +31,7 @@
   <%= t('alert_mailer.alert_email.dashboard_and_analysis_message_html', school_url: school_url(@school, params: weekly_alert_utm_parameters), school_analysis_index_url: school_analysis_index_url(@school, params: weekly_alert_utm_parameters)) %>.
 </p>
 
-<%= link_to t('alert_mailer.alert_email.view_your_school_dashboard'), school_url(@school, params: weekly_alert_utm_parameters), class: 'btn btn-primary mt-3 mb-3 float-right'%>
+<%= link_to t('alert_mailer.alert_email.view_your_school_dashboard'), school_url(@school, params: weekly_alert_utm_parameters), class: 'btn btn-primary mt-3 mb-3 ax-right'%>
 
 <div class="s-3"></div>
 
@@ -40,7 +40,7 @@
 
 <%= t('alert_mailer.alert_email.education_workshops_message') %>.
 
-<%= link_to t('alert_mailer.alert_email.book_a_workshop'), education_workshops_url, class: 'btn btn-primary mt-3 mb-3 float-right'%>
+<%= link_to t('alert_mailer.alert_email.book_a_workshop'), education_workshops_url, class: 'btn btn-primary mt-3 mb-3 ax-right'%>
 
 <div class="s-3"></div>
 
@@ -80,7 +80,7 @@
 
 <%= t('alert_mailer.alert_email.need_more_help_message') %>.
 
-<%= link_to t('alert_mailer.alert_email.book_an_audit'), energy_audits_url, class: 'btn btn-primary mt-3 mb-3 float-right'%>
+<%= link_to t('alert_mailer.alert_email.book_an_audit'), energy_audits_url, class: 'btn btn-primary mt-3 mb-3 ax-right'%>
 
 <hr/>
 

--- a/app/views/bill_request_mailer/request_bill.html.erb
+++ b/app/views/bill_request_mailer/request_bill.html.erb
@@ -4,6 +4,8 @@
   <%= t('bill_request_mailer.request_bill.description') %>
 </p>
 
+<div class="s-3"></div>
+
 <%= t('bill_request_mailer.request_bill.document_details_html') %>
 
 <% if @electricity_meters.any? || @gas_meters.any? %>

--- a/app/views/onboarding_mailer/activation_email.html.erb
+++ b/app/views/onboarding_mailer/activation_email.html.erb
@@ -3,17 +3,26 @@
 <p>
   <%= t('onboarding_mailer.activation_email.paragraph_1_html', activity_categories_url: activity_categories_url) %>
 </p>
+
+<div class="s-3"></div>
+
 <p>
   <%= t('onboarding_mailer.activation_email.paragraph_2_html', intervention_type_groups_url: intervention_type_groups_url) %>
 </p>
+
+<%= link_to t('onboarding_mailer.activation_email.explore_activities'), activity_categories_url, class: 'btn btn-primary mt-3 mb-3 ax-right' %>
+
+<div class="s-3"></div>
+
 <p>
-  <%= t('onboarding_mailer.activation_email.paragraph_3_html', school_url: school_url(@school)) %>
-</p>
-<p>
-  <%= t('onboarding_mailer.activation_email.paragraph_4') %>
+  <%= t('onboarding_mailer.activation_email.paragraph_3_html', school_url: school_url(@school)) %>. <%= t('onboarding_mailer.activation_email.paragraph_4') %>
 </p>
 
+<div class="s-3"></div>
+
 <% if @target_prompt %>
+  <div class="s-3"></div>
+
   <h5 class="mb-3"><%= t('onboarding_mailer.activation_email.set_your_first_targets') %></h5>
 
   <%= render 'shared/mailer/first_target_prompt', tracking_params: targets_utm_parameters(source: "activation") %>
@@ -28,7 +37,7 @@
   <%= t('onboarding_mailer.activation_email.paragraph_5_html', user_guide_videos_url: user_guide_videos_url, training_url: training_url) %>
 </p>
 
-<%= link_to t('onboarding_mailer.activation_email.join_a_webinar'), training_url, class: 'btn btn-primary mt-3 mb-3 float-right' %>
+<%= link_to t('onboarding_mailer.activation_email.join_a_webinar'), training_url, class: 'btn btn-primary mt-3 mb-3 ax-right' %>
 
 <div class="s-3"></div>
 

--- a/app/views/onboarding_mailer/data_enabled_email.html.erb
+++ b/app/views/onboarding_mailer/data_enabled_email.html.erb
@@ -6,15 +6,25 @@
   <%= t('onboarding_mailer.data_enabled_email.paragraph_1_html', school_url: school_url(@school)) %>
 </p>
 
+<div class="s-3"></div>
+
 <p>
   <%= t('onboarding_mailer.data_enabled_email.paragraph_2') %>
 </p>
+
+<%= link_to t('onboarding_mailer.data_enabled_email.explore_data'), school_url(@school), class: 'btn btn-primary mt-3 mb-3 ax-right' %>
+
+<div class="s-3"></div>
 
 <p>
   <%= t('onboarding_mailer.data_enabled_email.paragraph_3_html', activity_categories_url: activity_categories_url) %>
 </p>
 
+<div class="s-3"></div>
+
 <% if @target_prompt %>
+  <div class="s-3"></div>
+
   <h5 class="mb-3"><%= t('onboarding_mailer.data_enabled_email.set_your_first_targets') %></h5>
 
   <%= render 'shared/mailer/first_target_prompt', tracking_params: targets_utm_parameters(source: "activation") %>
@@ -29,7 +39,7 @@
   <%= t('onboarding_mailer.data_enabled_email.paragraph_4_html', user_guide_videos_url: user_guide_videos_url, training_url: training_url) %>
 </p>
 
-<%= link_to t('onboarding_mailer.data_enabled_email.join_a_webinar'), training_url, class: 'btn btn-primary mt-3 mb-3 float-right' %>
+<%= link_to t('onboarding_mailer.data_enabled_email.join_a_webinar'), training_url, class: 'btn btn-primary mt-3 mb-3 ax-right' %>
 
 <div class="s-3"></div>
 

--- a/app/views/onboarding_mailer/onboarded_email.html.erb
+++ b/app/views/onboarding_mailer/onboarded_email.html.erb
@@ -6,17 +6,25 @@
   <%= t('onboarding_mailer.onboarded_email.we_are_working_message') %>
 </p>
 
+<div class="s-3"></div>
+
 <p>
   <%= t('onboarding_mailer.onboarded_email.paragraph_1_html', activity_categories_url: activity_categories_url) %>
 </p>
+
+<div class="s-3"></div>
 
 <p>
   <%= t('onboarding_mailer.onboarded_email.paragraph_2_html', intervention_type_groups_url: intervention_type_groups_url) %>
 </p>
 
+<div class="s-3"></div>
+
 <p>
   <%= t('onboarding_mailer.onboarded_email.paragraph_3_html', school_url: school_url(@school)) %>
 </p>
+
+<div class="s-3"></div>
 
 <p>
   <%= t('onboarding_mailer.onboarded_email.we_will_be_in_touch_shortly_message') %>

--- a/app/views/onboarding_mailer/onboarding_email_content.html.erb
+++ b/app/views/onboarding_mailer/onboarding_email_content.html.erb
@@ -3,9 +3,15 @@
 <p>
   <%= t('onboarding_mailer.onboarding_email.paragraph_1_html', school_name: @school_onboarding.school_name) %>
 </p>
+
+<div class="s-3"></div>
+
 <p>
   <%= t('onboarding_mailer.onboarding_email.paragraph_2') %>
 </p>
+
+<div class="s-3"></div>
+
 <p>
   <%= t('onboarding_mailer.onboarding_email.paragraph_3') %>
 <p>

--- a/app/views/onboarding_mailer/reminder_email_content.html.erb
+++ b/app/views/onboarding_mailer/reminder_email_content.html.erb
@@ -1,6 +1,9 @@
 <h1 class="mb-3"><%= t('onboarding_mailer.reminder_email.title') %></h1>
 
 <p><%= t('onboarding_mailer.reminder_email.paragraph_1_html', school_name: @school_onboarding.school_name) %></p>
+
+<div class="s-3"></div>
+
 <p><%= t('onboarding_mailer.reminder_email.paragraph_2') %><p>
 
 <%= link_to t('onboarding_mailer.reminder_email.paragraph_3'), onboarding_url(@school_onboarding), class: 'btn btn-primary mb-3 mt-3'%>

--- a/app/views/onboarding_mailer/welcome_email.html.erb
+++ b/app/views/onboarding_mailer/welcome_email.html.erb
@@ -4,9 +4,13 @@
   <%= t('onboarding_mailer.welcome_email.paragraph_1') %>
 </p>
 
+<div class="s-3"></div>
+
 <p>
   <%= t('onboarding_mailer.welcome_email.paragraph_2_html') %>
 </p>
+
+<div class="s-3"></div>
 
 <p>
   <%= t('onboarding_mailer.welcome_email.paragraph_3') %>

--- a/app/views/shared/mailer/_first_target_prompt.html.erb
+++ b/app/views/shared/mailer/_first_target_prompt.html.erb
@@ -9,4 +9,4 @@
 <p>
   <%= t('target_mailer.first_target_prompt.not_sure_whats_achievable') %>.
 </p>
-<%= link_to t('target_mailer.first_target_prompt.set_your_first_target'), school_school_targets_url(@school, params: tracking_params), class: 'btn btn-primary mt-3 mb-3 float-right' %>
+<%= link_to t('target_mailer.first_target_prompt.set_your_first_target'), school_school_targets_url(@school, params: tracking_params), class: 'btn btn-primary mt-3 mb-3 ax-right' %>

--- a/config/locales/mailers/mailer.yml
+++ b/config/locales/mailers/mailer.yml
@@ -59,6 +59,7 @@ en:
     get_in_touch: Get in touch
   onboarding_mailer:
     activation_email:
+      explore_activities: Explore activities
       get_in_touch_html: <a href="%{contact_url}">Get in touch</a> if you have any further questions
       header: "%{school_name} is now live on Energy Sparks"
       join_a_webinar: Join a webinar
@@ -78,6 +79,7 @@ en:
       subject: "%{school} has completed the onboarding process"
       title: "%{school_name} has completed the automatic setup process"
     data_enabled_email:
+      explore_data: Explore your data
       get_in_touch_html: <a href="%{contact_url}">Get in touch</a> if you have any further questions.
       join_a_webinar: Join a webinar
       need_some_help: Need some help?


### PR DESCRIPTION
This PR:

* fixes some layout issues in some of the application mailers. Buttons weren't floating right as templates were using wrong class, and not enough space between paragraphs
* adds some buttons to the activation and data enabled emails to better call out next action to users

