### PR TITLE
Fix number of recommended activities and actions on new advice pages

### DIFF
--- a/app/controllers/schools/advice/advice_base_controller.rb
+++ b/app/controllers/schools/advice/advice_base_controller.rb
@@ -169,8 +169,11 @@ module Schools
       end
 
       def load_recommendations
-        @activity_types = @advice_page.activity_types
-        @intervention_types = @advice_page.intervention_types.limit(3)
+        activity_type_filter = ActivityTypeFilter.new(school: @school, scope: @advice_page.ordered_activity_types, query: { exclude_if_done_this_year: true })
+        @activity_types = activity_type_filter.activity_types.limit(4)
+
+        intervention_type_filter = InterventionTypeFilter.new(school: @school, scope: @advice_page.ordered_intervention_types, query: { exclude_if_done_this_year: true })
+        @intervention_types = intervention_type_filter.intervention_types.limit(4)
       end
     end
   end

--- a/app/controllers/schools/advice/advice_base_controller.rb
+++ b/app/controllers/schools/advice/advice_base_controller.rb
@@ -169,10 +169,18 @@ module Schools
       end
 
       def load_recommendations
-        activity_type_filter = ActivityTypeFilter.new(school: @school, scope: @advice_page.ordered_activity_types, query: { exclude_if_done_this_year: true })
+        activity_type_filter = ActivityTypeFilter.new(
+          school: @school,
+          scope: @advice_page.ordered_activity_types,
+          query: { exclude_if_done_this_year: true }
+        )
         @activity_types = activity_type_filter.activity_types.limit(4)
 
-        intervention_type_filter = InterventionTypeFilter.new(school: @school, scope: @advice_page.ordered_intervention_types, query: { exclude_if_done_this_year: true })
+        intervention_type_filter = InterventionTypeFilter.new(
+          school: @school,
+          scope: @advice_page.ordered_intervention_types,
+          query: { exclude_if_done_this_year: true }
+        )
         @intervention_types = intervention_type_filter.intervention_types.limit(4)
       end
     end

--- a/app/models/advice_page.rb
+++ b/app/models/advice_page.rb
@@ -39,6 +39,14 @@ class AdvicePage < ApplicationRecord
     key.humanize
   end
 
+  def ordered_activity_types
+    activity_types.order('advice_page_activity_types.position').group('activity_types.id, advice_page_activity_types.position')
+  end
+
+  def ordered_intervention_types
+    intervention_types.order('advice_page_intervention_types.position').group('intervention_types.id, advice_page_intervention_types.position')
+  end
+
   def update_activity_type_positions!(position_attributes)
     transaction do
       advice_page_activity_types.destroy_all

--- a/app/models/intervention_type.rb
+++ b/app/models/intervention_type.rb
@@ -58,6 +58,8 @@ class InterventionType < ApplicationRecord
   scope :display_order,         -> { order(:custom, :name) }
   scope :not_custom,            -> { where(custom: false) }
   scope :active_and_not_custom, -> { active.not_custom }
+  scope :custom_last,           -> { order(:custom) }
+  scope :between, ->(first_date, last_date) { where('at BETWEEN ? AND ?', first_date, last_date) }
 
   before_save :copy_searchable_attributes
 

--- a/app/services/intervention_type_filter.rb
+++ b/app/services/intervention_type_filter.rb
@@ -1,7 +1,7 @@
 class InterventionTypeFilter
   attr_reader :query
 
-  def initialize(query: {}, school: nil, scope: nil, current_date: Time.zone.today)
+  def initialize(query: {}, school:, scope: nil, current_date: Time.zone.today)
     @query = query
     @school = school
     @scope = (scope || default_scope).preload(:intervention_type_group).group('intervention_types.id')
@@ -14,26 +14,14 @@ class InterventionTypeFilter
     filtered
   end
 
-  def for_category(category)
-    intervention_types.where(intervention_type_group: category)
-  end
-
   def exclude_if_done_this_year
-    @school && @query[:exclude_if_done_this_year]
+    @query[:exclude_if_done_this_year]
   end
 
 private
 
-  def load_selected(model, key)
-    if @query[key].blank?
-      model.none
-    else
-      model.where(id: @query[key])
-    end
-  end
-
   def default_scope
-    InterventionTypes.active.custom_last
+    InterventionType.active.custom_last
   end
 
   def exclude_completed_activities(filtered)

--- a/app/services/intervention_type_filter.rb
+++ b/app/services/intervention_type_filter.rb
@@ -1,0 +1,47 @@
+class InterventionTypeFilter
+  attr_reader :query
+
+  def initialize(query: {}, school: nil, scope: nil, current_date: Time.zone.today)
+    @query = query
+    @school = school
+    @scope = (scope || default_scope).preload(:intervention_type_group).group('intervention_types.id')
+    @current_date = current_date
+  end
+
+  def intervention_types
+    filtered = @scope
+    filtered = exclude_completed_activities(filtered) if exclude_if_done_this_year
+    filtered
+  end
+
+  def for_category(category)
+    intervention_types.where(intervention_type_group: category)
+  end
+
+  def exclude_if_done_this_year
+    @school && @query[:exclude_if_done_this_year]
+  end
+
+private
+
+  def load_selected(model, key)
+    if @query[key].blank?
+      model.none
+    else
+      model.where(id: @query[key])
+    end
+  end
+
+  def default_scope
+    InterventionTypes.active.custom_last
+  end
+
+  def exclude_completed_activities(filtered)
+    academic_year = @school.academic_year_for(@current_date)
+    if academic_year
+      completed_actions = @school.observations.intervention.between(academic_year.start_date, academic_year.end_date)
+      filtered = filtered.where.not(id: completed_actions.map(&:intervention_type_id).uniq)
+    end
+    filtered
+  end
+end

--- a/app/services/intervention_type_filter.rb
+++ b/app/services/intervention_type_filter.rb
@@ -14,11 +14,11 @@ class InterventionTypeFilter
     filtered
   end
 
+private
+
   def exclude_if_done_this_year
     @query[:exclude_if_done_this_year]
   end
-
-private
 
   def default_scope
     InterventionType.active.custom_last

--- a/spec/services/intervention_type_filter_spec.rb
+++ b/spec/services/intervention_type_filter_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe InterventionTypeFilter, type: :service do
     create(:intervention_type, active: false)
   }
 
-  let(:school){ create(:school) }
+  let(:school) { create(:school) }
 
   let(:query) { {} }
   let(:scope) { nil }

--- a/spec/services/intervention_type_filter_spec.rb
+++ b/spec/services/intervention_type_filter_spec.rb
@@ -1,0 +1,59 @@
+require 'rails_helper'
+
+RSpec.describe InterventionTypeFilter, type: :service do
+
+  let(:intervention_type_1) {
+    create(:intervention_type)
+  }
+
+  let(:intervention_type_2) {
+    create(:intervention_type)
+  }
+
+  let(:intervention_type_3) {
+    create(:intervention_type, active: false)
+  }
+
+  let(:school){ create(:school) }
+
+  let(:query) { {} }
+  let(:scope) { nil }
+  let(:current_date) { Time.zone.today }
+
+  let(:service) { InterventionTypeFilter.new(query: query, school: school, scope: scope, current_date: current_date) }
+  let(:results) { service.intervention_types }
+
+  context 'with default scope' do
+    it 'should return the actions' do
+      expect(results).to match_array([intervention_type_1, intervention_type_2])
+    end
+  end
+
+  context 'with custom scope' do
+    let(:scope) { InterventionType.all }
+    it 'should return the actions' do
+      expect(results).to match_array([intervention_type_1, intervention_type_2, intervention_type_3])
+    end
+  end
+
+  context 'with query limiting results to those unrecorded this year' do
+    let(:current_date) { Date.new(2019,10,1) }
+
+    let(:academic_year){ create(:academic_year, start_date: '2019-09-01', end_date: '2020-08-31') }
+    let(:calendar){ create(:calendar, academic_years: [academic_year]) }
+    let(:school){ create(:school, calendar: calendar) }
+
+    let(:query) { {exclude_if_done_this_year: true} }
+
+    let!(:observation) { school.observations.create!(
+      observation_type: :intervention,
+      intervention_type_id: intervention_type_1.id,
+      at: Date.new(2019,9,27)) }
+
+    it 'should return a single action' do
+      expect(results).to match_array([intervention_type_2])
+    end
+  end
+
+
+end


### PR DESCRIPTION
This PR updates the advice base controller to revise how it loads recommended actions and activities

* Returns up to four of each type, so we can fully populate the page with recommendations
* Sorts the recommendations by their priority, so they are presented in order
* Filters the results to include just those that haven't already been recorded this academic year

For the filtering we have the existing `ActivityTypeFilter`. I've added a simpler version of this for filtering intervention types. These have less fields, so there's less to filter on, but I think the service is still useful as we can use it to better present suggestions elsewhere on the site.