### PR TITLE
Improve school page breadcrumbs

### DIFF
--- a/app/controllers/calendars_controller.rb
+++ b/app/controllers/calendars_controller.rb
@@ -3,6 +3,8 @@
 class CalendarsController < ApplicationController
   load_and_authorize_resource
 
+  before_action :set_breadcrumbs
+
   # GET /calendars/1
   def show
     @academic_year = academic_year
@@ -36,6 +38,10 @@ class CalendarsController < ApplicationController
   end
 
   private
+
+  def set_breadcrumbs
+    @breadcrumbs = [{ name: I18n.t('manage_school_menu.school_calendar') }] if @calendar.school?
+  end
 
   def academic_year
     academic_year_ids = @calendar.calendar_events.pluck(:academic_year_id).uniq.sort_by(&:to_i).reject(&:nil?)

--- a/app/controllers/pupils/analysis_controller.rb
+++ b/app/controllers/pupils/analysis_controller.rb
@@ -7,6 +7,7 @@ module Pupils
 
     skip_before_action :authenticate_user!
     before_action :check_aggregated_school_in_cache
+    before_action :set_breadcrumbs
 
     def index
       render params[:category] || :index
@@ -18,6 +19,13 @@ module Pupils
     end
 
     private
+
+    def set_breadcrumbs
+      @breadcrumbs = [
+        { name: I18n.t('dashboards.pupil_dashboard'), href: pupils_school_path(@school) },
+        { name: I18n.t('pupils.analysis.explore_data') }
+      ]
+    end
 
     def get_chart_config
       energy = params.require(:energy)

--- a/app/controllers/pupils/schools_controller.rb
+++ b/app/controllers/pupils/schools_controller.rb
@@ -14,6 +14,7 @@ module Pupils
     before_action only: [:show] do
       redirect_unless_permitted :show
     end
+    before_action :set_breadcrumbs
 
     def show
       authorize! :show_pupils_dash, @school
@@ -23,6 +24,10 @@ module Pupils
     end
 
   private
+
+    def set_breadcrumbs
+      @breadcrumbs = [{ name: I18n.t('dashboards.pupil_dashboard') }]
+    end
 
     def setup_default_features
       activity_setup(@school)

--- a/app/controllers/schools/audits_controller.rb
+++ b/app/controllers/schools/audits_controller.rb
@@ -2,6 +2,7 @@ module Schools
   class AuditsController < ApplicationController
     load_resource :school
     load_and_authorize_resource through: :school
+    before_action :set_breadcrumbs
 
     def index
       if can?(:manage, Audit)
@@ -41,6 +42,10 @@ module Schools
     end
 
   private
+
+    def set_breadcrumbs
+      @breadcrumbs = [{ name: I18n.t('energy_audits.title') }]
+    end
 
     def audit_params
       params.require(:audit).permit(:school_id, :title, :description, :file, :published, :involved_pupils, audit_activity_types_attributes: audit_activity_types_attributes, audit_intervention_types_attributes: audit_intervention_types_attributes)

--- a/app/controllers/schools/contacts_controller.rb
+++ b/app/controllers/schools/contacts_controller.rb
@@ -1,6 +1,7 @@
 class Schools::ContactsController < ApplicationController
   load_and_authorize_resource :school
   load_and_authorize_resource :contact, through: :school
+  before_action :set_breadcrumbs
 
   def index
     @standalone_contacts = @contacts.where(user_id: nil)
@@ -42,6 +43,10 @@ class Schools::ContactsController < ApplicationController
   end
 
 private
+
+  def set_breadcrumbs
+    @breadcrumbs = [{ name: I18n.t('manage_school_menu.manage_alert_contacts') }]
+  end
 
   def contact_params
     params.require(:contact).permit(

--- a/app/controllers/schools/downloads_controller.rb
+++ b/app/controllers/schools/downloads_controller.rb
@@ -2,11 +2,16 @@ module Schools
   class DownloadsController < ApplicationController
     load_and_authorize_resource :school
     before_action :authorized?
+    before_action :set_breadcrumbs
 
     def index
     end
 
     private
+
+    def set_breadcrumbs
+      @breadcrumbs = [{ name: I18n.t('schools.show.download_data') }]
+    end
 
     def authorized?
       unless can?(:download_school_data, @school)

--- a/app/controllers/schools/estimated_annual_consumptions_controller.rb
+++ b/app/controllers/schools/estimated_annual_consumptions_controller.rb
@@ -3,6 +3,8 @@ module Schools
     load_and_authorize_resource :school
     load_and_authorize_resource :estimated_annual_consumption, through: :school
 
+    before_action :set_breadcrumbs
+
     def index
       if @school.estimated_annual_consumptions.any?
         redirect_to edit_school_estimated_annual_consumption_path(@school, @school.latest_annual_estimate)
@@ -51,6 +53,10 @@ module Schools
     end
 
     private
+
+    def set_breadcrumbs
+      @breadcrumbs = [{ name: I18n.t('schools.estimated_annual_consumptions.breadcrumb') }]
+    end
 
     def estimated_annual_consumption_params
         params.require(:estimated_annual_consumption).permit(:electricity, :gas, :storage_heaters, :year, :school_id)

--- a/app/controllers/schools/meters_controller.rb
+++ b/app/controllers/schools/meters_controller.rb
@@ -5,6 +5,8 @@ module Schools
     load_and_authorize_resource :school
     load_and_authorize_resource through: :school
 
+    before_action :set_breadcrumbs
+
     def index
       load_meters
       @meter = @school.meters.new
@@ -78,6 +80,10 @@ module Schools
     end
 
   private
+
+    def set_breadcrumbs
+      @breadcrumbs = [{ name: I18n.t('manage_school_menu.manage_meters') }]
+    end
 
     def enough_data_for_targets?
       return nil unless can?(:view_target_data, @school)

--- a/app/controllers/schools/school_targets/progress_controller.rb
+++ b/app/controllers/schools/school_targets/progress_controller.rb
@@ -9,6 +9,7 @@ module Schools
 
       before_action :redirect_if_disabled
       before_action :check_aggregated_school_in_cache
+      before_action :set_breadcrumbs
 
       skip_before_action :authenticate_user!
 
@@ -28,6 +29,13 @@ module Schools
       end
 
       private
+
+      def set_breadcrumbs
+        @breadcrumbs = [
+          { name: I18n.t('manage_school_menu.review_targets'), href: school_school_targets_path(@school) },
+          { name: I18n.t("schools.school_targets.progress.breadcrumbs.#{action_name.to_sym}") }
+        ]
+      end
 
       #extract into helper?
       def index_for(fuel_type)

--- a/app/controllers/schools/school_targets_controller.rb
+++ b/app/controllers/schools/school_targets_controller.rb
@@ -12,6 +12,7 @@ module Schools
 
     before_action :check_aggregated_school_in_cache, only: :show
     before_action :redirect_if_disabled
+    before_action :set_breadcrumbs
 
     def index
       if @school.has_target?
@@ -97,6 +98,10 @@ module Schools
     end
 
     private
+
+    def set_breadcrumbs
+      @breadcrumbs = [{ name: I18n.t('manage_school_menu.review_targets') }]
+    end
 
     def school_target_params
       params.require(:school_target).permit(:electricity, :gas, :storage_heaters, :start_date, :target_date, :school_id)

--- a/app/controllers/schools/temperature_observations_controller.rb
+++ b/app/controllers/schools/temperature_observations_controller.rb
@@ -7,6 +7,7 @@ module Schools
     before_action :check_recording_enabled, only: [:new, :create]
     before_action :set_location_names, only: [:new, :create]
     before_action :set_inital_recording_count, only: [:new, :create]
+    before_action :set_breadcrumbs
 
     TEMPERATURE_RECORD_INCREASE = 10
 
@@ -42,6 +43,12 @@ module Schools
     end
 
   private
+
+    def set_breadcrumbs
+      @breadcrumbs = [
+        { name: I18n.t('schools.temperature_observations.index.page_title') },
+      ]
+    end
 
     def set_inital_recording_count
       @existing_location_count = @school.locations.count

--- a/app/controllers/schools/timeline_controller.rb
+++ b/app/controllers/schools/timeline_controller.rb
@@ -3,6 +3,7 @@ module Schools
     load_and_authorize_resource :school
 
     skip_before_action :authenticate_user!
+    before_action :set_breadcrumbs
 
     def show
       authorize! :index, Observation
@@ -18,6 +19,12 @@ module Schools
                                  []
                                end
       @observations = @school.observations.visible.order('at DESC').where('at BETWEEN ? AND ?', @academic_year.start_date, @academic_year.end_date)
+    end
+
+    private
+
+    def set_breadcrumbs
+      @breadcrumbs = [{ name: I18n.t('timeline.view_all_events') }]
     end
   end
 end

--- a/app/controllers/schools/times_controller.rb
+++ b/app/controllers/schools/times_controller.rb
@@ -1,6 +1,7 @@
 module Schools
   class TimesController < ApplicationController
     before_action :set_school
+    before_action :set_breadcrumbs
 
     def edit
     end
@@ -19,6 +20,10 @@ module Schools
     def set_school
       @school = School.friendly.find(params[:school_id])
       authorize! :manage_school_times, @school
+    end
+
+    def set_breadcrumbs
+      @breadcrumbs = [{ name: I18n.t('manage_school_menu.edit_school_times') }]
     end
 
     def school_params

--- a/app/controllers/schools/transport_surveys_controller.rb
+++ b/app/controllers/schools/transport_surveys_controller.rb
@@ -9,6 +9,7 @@ module Schools
     authorize_resource :transport_survey
     before_action :header_fix_enabled
     before_action :load_or_create, only: [:update]
+    before_action :set_breadcrumbs
 
     def index
       @transport_surveys = @transport_surveys.order(run_on: :desc)
@@ -41,6 +42,12 @@ module Schools
     end
 
     private
+
+    def set_breadcrumbs
+      @breadcrumbs = [
+        { name: I18n.t('activerecord.models.transport_survey.other') },
+      ]
+    end
 
     def transport_survey_params
       params.require(:transport_survey).permit(:run_on, responses: [:run_identifier, :journey_minutes, :surveyed_at, :passengers, :transport_type_id, :weather])

--- a/app/controllers/schools/user_tariffs_controller.rb
+++ b/app/controllers/schools/user_tariffs_controller.rb
@@ -2,6 +2,7 @@ module Schools
   class UserTariffsController < ApplicationController
     load_and_authorize_resource :school
     load_and_authorize_resource :user_tariff
+    before_action :set_breadcrumbs
 
     def index
       @electricity_meters = @school.meters.electricity
@@ -61,6 +62,10 @@ module Schools
     end
 
     private
+
+    def set_breadcrumbs
+      @breadcrumbs = [{ name: I18n.t('manage_school_menu.manage_tariffs') }]
+    end
 
     def default_params
       { start_date: Date.parse('2021-04-01'), end_date: Date.parse('2022-03-31'), flat_rate: true }

--- a/app/controllers/schools/users_controller.rb
+++ b/app/controllers/schools/users_controller.rb
@@ -4,6 +4,8 @@ module Schools
 
     load_and_authorize_resource :school
 
+    before_action :set_breadcrumbs
+
     def index
       authorize! :manage_users, @school
       @users = @school.users
@@ -64,6 +66,10 @@ module Schools
     end
 
     private
+
+    def set_breadcrumbs
+      @breadcrumbs = [{ name: I18n.t('manage_school_menu.manage_users') }]
+    end
 
     def user_params
       params.require(:user).permit(:name, :email, :staff_role_id, :role, :preferred_locale)

--- a/app/controllers/schools/your_school_estates_controller.rb
+++ b/app/controllers/schools/your_school_estates_controller.rb
@@ -2,6 +2,7 @@ module Schools
   class YourSchoolEstatesController < ApplicationController
     load_and_authorize_resource :school
     before_action :return_to_school_unless_feature_enabled
+    before_action :set_breadcrumbs
 
     def edit
     end
@@ -17,6 +18,10 @@ module Schools
     end
 
     private
+
+    def set_breadcrumbs
+      @breadcrumbs = [{ name: I18n.t('manage_school_menu.your_school_estate') }]
+    end
 
     def return_to_school_unless_feature_enabled
       redirect_to school_path(@school) and return unless EnergySparks::FeatureFlags.active?(:your_school_estates)

--- a/app/controllers/schools_controller.rb
+++ b/app/controllers/schools_controller.rb
@@ -34,6 +34,8 @@ class SchoolsController < ApplicationController
   #data enabled to offer a better initial user experience
   before_action :redirect_to_pupil_dash_if_not_data_enabled, only: [:show]
 
+  before_action :set_breadcrumbs
+
   def index
     @schools = School.visible.by_name
     @school_groups = SchoolGroup.by_name.select(&:has_visible_schools?)
@@ -109,6 +111,14 @@ class SchoolsController < ApplicationController
   end
 
 private
+
+  def set_breadcrumbs
+    if action_name.to_sym == :edit
+      @breadcrumbs = [{ name: I18n.t('manage_school_menu.edit_school_details') }]
+    else
+      @breadcrumbs = [{ name: I18n.t('dashboards.adult_dashboard') }]
+    end
+  end
 
   def user_signed_in_and_linked_to_school?
     user_signed_in? && (current_user.school_id == @school.id)

--- a/config/locales/views/schools/schools.yml
+++ b/config/locales/views/schools/schools.yml
@@ -159,6 +159,7 @@ en:
         validated_meter_data: Validated meter data
         we_use_sheffield_solar_pv_api_message_html: We use the <a href="https://www.solar.sheffield.ac.uk/pvlive/">University of Sheffield Solar PV</a> API for solar pv generation data, you can download the data we have for your school here
     estimated_annual_consumptions:
+      breadcrumb: Estimated annual consumption
       destroy:
         estimate_successfully_removed: Estimate successfully removed
       edit:

--- a/config/locales/views/schools/schools.yml
+++ b/config/locales/views/schools/schools.yml
@@ -399,6 +399,10 @@ en:
         tip: Tip
         your_new_target: Your new target
       progress:
+        breadcrumbs:
+          electricity: Electricity progress
+          gas: Gas progress
+          storage_heater: Storage heater progress
         charts:
           cumulative_progress: Cumulative progress
           weekly_progress: Weekly progress


### PR DESCRIPTION
Improves the display of breadcrumbs across the school pages by adding a default breadcrumb for all controllers.

There's a lot of changes, but these are mostly just adding a `before_action` to each controller and a method to set the default breadcrumb. Where possible I've used existing keys, e.g. from the Manage School menu, to make the navigation clearer.
