### PR TITLE
Enhance style of new pages

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -52,5 +52,6 @@
 @import "activations";
 @import "toggler";
 @import "advice_page";
+@import "compare";
 
 @import "../../components/**/*"; // loaded here so bootstrap SASS variables are available

--- a/app/assets/stylesheets/compare.scss
+++ b/app/assets/stylesheets/compare.scss
@@ -1,0 +1,18 @@
+.compare .card-columns {
+  @include media-breakpoint-only(xl) {
+    column-count: 2;
+  }
+  @include media-breakpoint-only(lg) {
+    column-count: 2;
+  }
+  @include media-breakpoint-only(md) {
+    column-count: 2;
+  }
+  @include media-breakpoint-only(sm) {
+    column-count: 1;
+  }
+}
+
+.compare .fa-li.fa-check {
+  padding-bottom: 0px;
+}

--- a/app/controllers/compare_controller.rb
+++ b/app/controllers/compare_controller.rb
@@ -1,7 +1,5 @@
 class CompareController < ApplicationController
   include UserTypeSpecific
-
-  before_action :header_fix_enabled
   skip_before_action :authenticate_user!
 
   before_action :filter

--- a/app/views/compare/_school_type_filter.html.erb
+++ b/app/views/compare/_school_type_filter.html.erb
@@ -1,12 +1,14 @@
-<div class="smaller"><%= t('compare.limit_by_school_type') %></div>
-<div class="nowrap ensure-one-checked">
+<label><%= t('compare.limit_by_school_type') %></label>
+<div class="ensure-one-checked">
   <% School.school_types.keys.each do |school_type| %>
-    <%= check_box_tag('school_types[]', school_type, @filter[:school_types].include?(school_type) || @filter[:school_types].none?, id: "#{type}_#{school_type}") %>
-    <%= label_tag "#{type}_#{school_type}", t('common.school_types.' + school_type),
-        data: {
-          toggle: "tooltip",
-          placement: "bottom",
-          delay: { "show": 500, "hide": 100 }},
-        title: "Select at least one" %>
+    <div class="form-check form-check-inline">
+      <%= check_box_tag('school_types[]', school_type, @filter[:school_types].include?(school_type) || @filter[:school_types].none?, class: "form-check-input", id: "#{type}_#{school_type}") %>
+      <%= label_tag "#{type}_#{school_type}", t('common.school_types.' + school_type),
+          data: {
+            toggle: "tooltip",
+            placement: "bottom",
+            delay: { "show": 500, "hide": 100 }},
+          title: "Select at least one", class: "form-check-label" %>
+    </div>
   <% end %>
 </div>

--- a/app/views/compare/_school_type_filter.html.erb
+++ b/app/views/compare/_school_type_filter.html.erb
@@ -8,7 +8,7 @@
             toggle: "tooltip",
             placement: "bottom",
             delay: { "show": 500, "hide": 100 }},
-          title: "Select at least one", class: "form-check-label" %>
+          title: t('compare.filter.select_one'), class: "form-check-label" %>
     </div>
   <% end %>
 </div>

--- a/app/views/compare/_school_type_summary.html.erb
+++ b/app/views/compare/_school_type_summary.html.erb
@@ -1,2 +1,2 @@
-<p><%= t('compare.filter.school_types_html', school_types: @filter[:school_types].map {|st| tag.strong(t('common.school_types.' + st))}.to_sentence.html_safe) %>
+<p><%= t('compare.filter.school_types_html', school_types: @filter[:school_types].map {|st| tag.span(t('common.school_types.' + st), class: 'badge badge-light border')}.join(' ').html_safe) %>
 </p>

--- a/app/views/compare/_school_type_summary.html.erb
+++ b/app/views/compare/_school_type_summary.html.erb
@@ -1,2 +1,2 @@
-<p><%= t('compare.filter.school_types_html', school_types: @filter[:school_types].map {|st| tag.span(t('common.school_types.' + st), class: 'badge badge-pill badge-light bg-white border')}.join(' ').html_safe) %>
+<p><%= t('compare.filter.school_types_html', school_types: @filter[:school_types].map {|st| tag.span(t('common.school_types.' + st), class: 'badge badge-info')}.join(' ').html_safe) %>
 </p>

--- a/app/views/compare/_school_type_summary.html.erb
+++ b/app/views/compare/_school_type_summary.html.erb
@@ -1,2 +1,2 @@
-<p><%= t('compare.filter.school_types_html', school_types: @filter[:school_types].map {|st| tag.span(t('common.school_types.' + st), class: 'badge badge-light border')}.join(' ').html_safe) %>
+<p><%= t('compare.filter.school_types_html', school_types: @filter[:school_types].map {|st| tag.span(t('common.school_types.' + st), class: 'badge badge-pill badge-light bg-white border')}.join(' ').html_safe) %>
 </p>

--- a/app/views/compare/_summary.html.erb
+++ b/app/views/compare/_summary.html.erb
@@ -1,7 +1,6 @@
 <div class="p-3 mb-3 rounded border clearfix">
   <%= link_to t('compare.filter.change_options'), compare_index_url(index_params), class: 'btn btn-sm float-right' %>
   <p><%= t('compare.filter.title') %></p>
-
   <% if @filter[:search] == 'type' %>
     <p><%= t('compare.filter.schools_with_type_html', school_type: (@filter[:school_type].present? ? t("common.school_types.#{@filter[:school_type]}") : t('compare.filter.all_school_types'))) %></p>
   <% else %>

--- a/app/views/compare/_summary.html.erb
+++ b/app/views/compare/_summary.html.erb
@@ -1,16 +1,17 @@
-<div class="p-3 mb-3 rounded border clearfix">
+<div class="p-3 mb-3 bg-light rounded border clearfix">
   <%= link_to t('compare.filter.change_options'), compare_index_url(index_params), class: 'btn btn-sm float-right' %>
-  <p><%= t('compare.filter.title') %></p>
   <% if @filter[:search] == 'type' %>
-    <p><%= t('compare.filter.schools_with_type_html', school_type: (@filter[:school_type].present? ? t("common.school_types.#{@filter[:school_type]}") : t('compare.filter.all_school_types'))) %></p>
+    <p><%= t('compare.filter.schools_with_type_html', school_type: tag.span(@filter[:school_type].present? ? t("common.school_types.#{@filter[:school_type]}") : t('compare.filter.all_school_types'), class: 'badge border bg-white')) %></p>
   <% else %>
-    <% if @filter[:search] == 'group' %>
-      <p><%= t('compare.filter.schools_in_school_group_html', school_group: current_school_group.name) %></p>
-    <% elsif @filter[:search] == 'country' %>
-      <p><%= t('compare.filter.schools_with_country_html', country: (@filter[:country].present? ? t("school_statistics.#{@filter[:country]}") : t('compare.filter.all_countries'))) %></p>
-    <% elsif @filter[:search] == 'groups' %>
-      <p><%= t('compare.filter.schools_in_school_groups_html', school_groups: SchoolGroup.find(@filter[:school_group_ids]).map {|school_group| tag.span(school_group.name, class: 'badge badge-info')}.join(' ').html_safe) %></p>
-    <% end %>
+    <p>
+      <% if @filter[:search] == 'group' %>
+        <%= t('compare.filter.schools_in_school_group_html', school_group: tag.span(current_school_group.name, class: 'badge border bg-white')) %>
+      <% elsif @filter[:search] == 'country' %>
+        <%= t('compare.filter.schools_with_country_html', country: tag.span(@filter[:country].present? ? t("school_statistics.#{@filter[:country]}") : t('compare.filter.all_countries'), class: 'badge border badge-light bg-white')) %>
+      <% elsif @filter[:search] == 'groups' %>
+        <%= t('compare.filter.schools_in_school_groups_html', school_groups: SchoolGroup.find(@filter[:school_group_ids]).map {|school_group| tag.span(school_group.name, class: 'badge bg-white border')}.join(' ').html_safe) %>
+      <% end %>
+    </p>
     <%= render 'school_type_summary' %>
   <% end %>
 </div>

--- a/app/views/compare/_summary.html.erb
+++ b/app/views/compare/_summary.html.erb
@@ -2,15 +2,15 @@
   <%= link_to t('compare.filter.change_benchmark'), benchmarks_compare_index_path(index_params.except(:benchmark)), class: 'btn btn-sm float-right ml-2' if action_name == 'show' %>
   <%= link_to t('compare.filter.change_options'), compare_index_path(index_params), class: 'btn btn-sm float-right' %>
   <% if @filter[:search] == 'type' %>
-    <p><%= t('compare.filter.schools_with_type_html', school_type: tag.span(@filter[:school_type].present? ? t("common.school_types.#{@filter[:school_type]}") : t('compare.filter.all_school_types'), class: 'badge border bg-white')) %></p>
+    <p><%= t('compare.filter.schools_with_type_html', school_type: tag.span(@filter[:school_type].present? ? t("common.school_types.#{@filter[:school_type]}") : t('compare.filter.all_school_types'), class: 'badge badge-info')) %></p>
   <% else %>
     <p>
       <% if @filter[:search] == 'group' %>
-        <%= t('compare.filter.schools_in_school_group_html', school_group: tag.span(current_school_group.name, class: 'badge border bg-white')) %>
+        <%= t('compare.filter.schools_in_school_group_html', school_group: tag.span(current_school_group.name, class: 'badge badge-info')) %>
       <% elsif @filter[:search] == 'country' %>
-        <%= t('compare.filter.schools_with_country_html', country: tag.span(@filter[:country].present? ? t("school_statistics.#{@filter[:country]}") : t('compare.filter.all_countries'), class: 'badge border badge-light bg-white')) %>
+        <%= t('compare.filter.schools_with_country_html', country: tag.span(@filter[:country].present? ? t("school_statistics.#{@filter[:country]}") : t('compare.filter.all_countries'), class: 'badge badge-info')) %>
       <% elsif @filter[:search] == 'groups' %>
-        <%= t('compare.filter.schools_in_school_groups_html', school_groups: SchoolGroup.find(@filter[:school_group_ids]).map {|school_group| tag.span(school_group.name, class: 'badge bg-white border')}.join(' ').html_safe) %>
+        <%= t('compare.filter.schools_in_school_groups_html', school_groups: SchoolGroup.find(@filter[:school_group_ids]).map {|school_group| tag.span(school_group.name, class: 'badge badge-info')}.join(' ').html_safe) %>
       <% end %>
     </p>
     <%= render 'school_type_summary' %>

--- a/app/views/compare/_summary.html.erb
+++ b/app/views/compare/_summary.html.erb
@@ -1,5 +1,6 @@
 <div class="p-3 mb-3 bg-light rounded border clearfix">
-  <%= link_to t('compare.filter.change_options'), compare_index_url(index_params), class: 'btn btn-sm float-right' %>
+  <%= link_to t('compare.filter.change_benchmark'), benchmarks_compare_index_path(index_params.except(:benchmark)), class: 'btn btn-sm float-right ml-2' if action_name == 'show' %>
+  <%= link_to t('compare.filter.change_options'), compare_index_path(index_params), class: 'btn btn-sm float-right' %>
   <% if @filter[:search] == 'type' %>
     <p><%= t('compare.filter.schools_with_type_html', school_type: tag.span(@filter[:school_type].present? ? t("common.school_types.#{@filter[:school_type]}") : t('compare.filter.all_school_types'), class: 'badge border bg-white')) %></p>
   <% else %>

--- a/app/views/compare/_summary.html.erb
+++ b/app/views/compare/_summary.html.erb
@@ -1,4 +1,4 @@
-<div class="bg-light p-3 mb-3 rounded border clearfix">
+<div class="p-3 mb-3 rounded border clearfix">
   <%= link_to t('compare.filter.change_options'), compare_index_url(index_params), class: 'btn btn-sm float-right' %>
   <p><%= t('compare.filter.title') %></p>
 
@@ -10,7 +10,7 @@
     <% elsif @filter[:search] == 'country' %>
       <p><%= t('compare.filter.schools_with_country_html', country: (@filter[:country].present? ? t("school_statistics.#{@filter[:country]}") : t('compare.filter.all_countries'))) %></p>
     <% elsif @filter[:search] == 'groups' %>
-      <p><%= t('compare.filter.schools_in_school_groups_html', school_groups: SchoolGroup.find(@filter[:school_group_ids]).map {|school_group| tag.strong(school_group.name)}.to_sentence.html_safe) %></p>
+      <p><%= t('compare.filter.schools_in_school_groups_html', school_groups: SchoolGroup.find(@filter[:school_group_ids]).map {|school_group| tag.span(school_group.name, class: 'badge badge-info')}.join(' ').html_safe) %></p>
     <% end %>
     <%= render 'school_type_summary' %>
   <% end %>

--- a/app/views/compare/benchmarks.html.erb
+++ b/app/views/compare/benchmarks.html.erb
@@ -7,17 +7,19 @@
 <p><%= t('compare.benchmarks.description') %></p>
 
 <% @benchmark_groups.each do |benchmark_group| %>
-  <h4><%= benchmark_group[:name] %></h4>
+  <h4><strong><%= benchmark_group[:name] %></strong></h4>
   <div class="row">
-    <div class="col-sm-6">
-      <ul>
-        <% benchmark_group[:benchmarks].each do |benchmark, title| %>
-          <li><%= link_to title, compare_path(benchmark, @filter) %></li>
-        <% end %>
-      </ul>
-    </div>
-    <div class="col-sm-6">
+    <div class="col-sm-12">
       <%= benchmark_group[:description] %>
     </div>
+    <%= benchmark_group[:benchmarks].each_slice((benchmark_group[:benchmarks].length / 2.0).round) do |set| %>
+      <div class="col-sm-6">
+        <ul>
+          <% set.each do |benchmark, title| %>
+            <li><%= link_to title, compare_path(benchmark, @filter) %></li>
+          <% end %>
+        </ul>
+      </div>
+    <% end %>
   </div>
 <% end %>

--- a/app/views/compare/benchmarks.html.erb
+++ b/app/views/compare/benchmarks.html.erb
@@ -4,22 +4,18 @@
 
 <%= render 'summary' %>
 
-<p><%= t('compare.benchmarks.description') %></p>
+<h4><%= t('compare.benchmarks.description') %></h4>
 
 <% @benchmark_groups.each do |benchmark_group| %>
-  <h4><strong><%= benchmark_group[:name] %></strong></h4>
-  <div class="row">
-    <div class="col-sm-12">
-      <%= benchmark_group[:description] %>
+  <div class="compare card mb-4">
+    <div class="card-header"><%= %><%= benchmark_group[:name] %></div>
+    <div class="card-body pb-0">
+      <div class="card-subtitle text-muted"><%= benchmark_group[:description] %></div>
+      <ul class="fa-ul card-columns">
+        <% benchmark_group[:benchmarks].each do |benchmark, title| %>
+          <li class="pt-1"><i class="fa-li fas fa-check"></i><%= link_to title, compare_path(benchmark, @filter) %></li>
+        <% end %>
+      </ul>
     </div>
-    <%= benchmark_group[:benchmarks].each_slice((benchmark_group[:benchmarks].length / 2.0).round) do |set| %>
-      <div class="col-sm-6">
-        <ul>
-          <% set.each do |benchmark, title| %>
-            <li><%= link_to title, compare_path(benchmark, @filter) %></li>
-          <% end %>
-        </ul>
-      </div>
-    <% end %>
   </div>
 <% end %>

--- a/app/views/compare/index.html.erb
+++ b/app/views/compare/index.html.erb
@@ -1,7 +1,10 @@
 <% content_for :page_title, t('compare.index.title') %>
 
-<h1><%= t('compare.index.title') %></h1>
-
+<div class="row mt-2">
+  <div class="col">
+    <p class="display-3"><strong><%= t('compare.index.title') %></strong></p>
+  </div>
+</div>
 <div class="row">
   <div class="col-sm-6">
     <p><%= t("compare.index.intro") %></p>

--- a/app/views/compare/tab_content/_country.html.erb
+++ b/app/views/compare/tab_content/_country.html.erb
@@ -1,6 +1,6 @@
 <div class="tab-pane fade show <%= ' active' unless current_school_group %>" id="country" role="tabpanel" aria-labelledby="country-tab">
   <h4 class='my-2'><%= t('compare.index.country.title') %></h4>
-  <div id="by_country" class="bg-light p-3 rounded border">
+  <div class="bg-light p-3 rounded border">
     <%= form_tag benchmarks_compare_index_path, method: :get do %>
       <%= hidden_field_tag(:search, 'country') %>
         <label><%= t('compare.filter.country') %></label>

--- a/app/views/compare/tab_content/_country.html.erb
+++ b/app/views/compare/tab_content/_country.html.erb
@@ -16,7 +16,7 @@
       </div>
       <%= render 'school_type_filter', type: 'categories' %>
       <div class="pt-2">
-        <%= submit_tag 'Compare schools', class: 'btn btn-sm' %>
+        <%= submit_tag 'Compare schools', class: 'btn' %>
       </div>
     <% end %>
   </div>

--- a/app/views/compare/tab_content/_country.html.erb
+++ b/app/views/compare/tab_content/_country.html.erb
@@ -3,15 +3,16 @@
   <div id="by_country" class="bg-light p-3 rounded border">
     <%= form_tag benchmarks_compare_index_path, method: :get do %>
       <%= hidden_field_tag(:search, 'country') %>
-      <% School.countries.keys.each do |country| %>
-        <div class="form-check pl-0">
-          <%= radio_button_tag('country', country, @filter[:country] == country, id: country) %>
-          <%= label_tag country, t('school_statistics.' + country) %>
+        <label><%= t('compare.filter.country') %></label>
+        <% School.countries.keys.each do |country| %>
+        <div class="form-check">
+          <%= radio_button_tag('country', country, @filter[:country] == country, id: country, class: 'form-check-input') %>
+          <%= label_tag country, t('school_statistics.' + country), class: 'form-check-label' %>
         </div>
       <% end %>
-      <div class="form-check pl-0">
-        <%= radio_button_tag 'country', '', @filter[:country].blank? %>
-        <%= label_tag 'country_', t('compare.filter.all_countries') %>
+      <div class="form-check pb-3">
+        <%= radio_button_tag 'country', '', @filter[:country].blank?, class: 'form-check-input' %>
+        <%= label_tag 'country_', t('compare.filter.all_countries'), class: 'form-check-label' %>
       </div>
       <%= render 'school_type_filter', type: 'categories' %>
       <div class="pt-2">

--- a/app/views/compare/tab_content/_group.html.erb
+++ b/app/views/compare/tab_content/_group.html.erb
@@ -6,7 +6,7 @@
       <%= hidden_field_tag('school_group_ids[]', current_school_group.id) %>
       <%= render 'school_type_filter', type: 'group' %>
       <div class="pt-2">
-        <%= submit_tag 'Compare schools', class: 'btn btn-sm' %>
+        <%= submit_tag 'Compare schools', class: 'btn' %>
       </div>
     <% end %>
   </div>

--- a/app/views/compare/tab_content/_groups.html.erb
+++ b/app/views/compare/tab_content/_groups.html.erb
@@ -4,8 +4,10 @@
   <div class="bg-light p-3 rounded border">
     <%= form_tag benchmarks_compare_index_path, method: :get do %>
       <%= hidden_field_tag(:search, 'groups') %>
-      <%= label_tag 'school_group_ids', t('compare.filter.school_groups') %>
-      <%= select_tag('school_group_ids', options_from_collection_for_select(SchoolGroup.all.by_name.select(&:has_visible_schools?), "id", "name", @filter[:school_group_ids]), multiple: true, class: 'form-control select2') %>
+      <div class="form-group">
+        <%= label_tag 'school_group_ids', t('compare.filter.school_groups') %>
+        <%= select_tag('school_group_ids', options_from_collection_for_select(SchoolGroup.all.by_name.select(&:has_visible_schools?), "id", "name", @filter[:school_group_ids]), multiple: true, class: 'form-control select2') %>
+      </div>
       <%= render 'school_type_filter', type: 'groups' %>
       <div class="pt-2">
         <%= submit_tag 'Compare schools', class: 'btn btn-sm' %>

--- a/app/views/compare/tab_content/_groups.html.erb
+++ b/app/views/compare/tab_content/_groups.html.erb
@@ -9,7 +9,7 @@
       </div>
       <%= render 'school_type_filter', type: 'groups' %>
       <div class="pt-2">
-        <%= submit_tag 'Compare schools', class: 'btn btn-sm' %>
+        <%= submit_tag 'Compare schools', class: 'btn' %>
       </div>
     <% end %>
   </div>

--- a/app/views/compare/tab_content/_groups.html.erb
+++ b/app/views/compare/tab_content/_groups.html.erb
@@ -1,6 +1,5 @@
 <div class="tab-pane fade show" id="groups" role="tabpanel" aria-labelledby="groups-tab">
   <h4 class='my-2'><%= t('compare.index.groups.title') %></h4>
-
   <div class="bg-light p-3 rounded border">
     <%= form_tag benchmarks_compare_index_path, method: :get do %>
       <%= hidden_field_tag(:search, 'groups') %>

--- a/app/views/compare/tab_content/_type.html.erb
+++ b/app/views/compare/tab_content/_type.html.erb
@@ -6,7 +6,7 @@
       <%= label_tag :school_type, t('compare.filter.school_type') %>
       <%= select_tag :school_type, options_for_select(School.school_types.keys.map {|key, value| [t("common.school_types.#{key}"), key]}, @filter[:school_type]), include_blank: t('compare.filter.all_school_types'), class: 'form-control' %>
        <div class="pt-2">
-        <%= submit_tag 'Compare schools', class: 'btn btn-sm' %>
+        <%= submit_tag 'Compare schools', class: 'btn' %>
       </div>
     <% end %>
   </div>

--- a/app/views/compare/tab_content/_type.html.erb
+++ b/app/views/compare/tab_content/_type.html.erb
@@ -3,7 +3,8 @@
   <div class="bg-light p-3 rounded border">
     <%= form_tag benchmarks_compare_index_path, method: :get do %>
       <%= hidden_field_tag(:search, 'type') %>
-      <%= select_tag :school_type, options_for_select(School.school_types.keys.map {|key, value| [t("common.school_types.#{key}"), key]}, @filter[:school_type]), include_blank: t('compare.filter.all_school_types') %>
+      <%= label_tag :school_type, t('compare.filter.school_type') %>
+      <%= select_tag :school_type, options_for_select(School.school_types.keys.map {|key, value| [t("common.school_types.#{key}"), key]}, @filter[:school_type]), include_blank: t('compare.filter.all_school_types'), class: 'form-control' %>
        <div class="pt-2">
         <%= submit_tag 'Compare schools', class: 'btn btn-sm' %>
       </div>

--- a/config/locales/views/compare/compare.yml
+++ b/config/locales/views/compare/compare.yml
@@ -11,11 +11,11 @@ en:
       country: 'Select country:'
       school_groups: 'Select school groups:'
       school_type: 'Select school type:'
-      school_types_html: Including %{school_types}
-      schools_in_school_group_html: Schools in the <strong>%{school_group}</strong> group
-      schools_in_school_groups_html: 'Schools in groups: %{school_groups}'
-      schools_with_country_html: 'Schools in country: <strong>%{country}</strong>'
-      schools_with_type_html: 'Schools of type: <strong>%{school_type}</strong>'
+      school_types_html: 'Including: %{school_types}'
+      schools_in_school_group_html: Comparing schools in the %{school_group} group
+      schools_in_school_groups_html: 'Comparing schools in groups: %{school_groups}'
+      schools_with_country_html: Comparing schools in %{country}
+      schools_with_type_html: 'Comparing schools of type: %{school_type}'
       title: 'Comparing:'
     index:
       country:

--- a/config/locales/views/compare/compare.yml
+++ b/config/locales/views/compare/compare.yml
@@ -17,7 +17,6 @@ en:
       schools_in_school_groups_html: 'Comparing schools in groups: %{school_groups}'
       schools_with_country_html: Comparing schools in %{country}
       schools_with_type_html: 'Comparing schools of type: %{school_type}'
-      title: 'Comparing:'
     index:
       country:
         tab: Choose country

--- a/config/locales/views/compare/compare.yml
+++ b/config/locales/views/compare/compare.yml
@@ -10,6 +10,7 @@ en:
       change_options: Change options
       country: 'Select country:'
       school_groups: 'Select school groups:'
+      school_type: 'Select school type:'
       school_types_html: Including %{school_types}
       schools_in_school_group_html: Schools in the <strong>%{school_group}</strong> group
       schools_in_school_groups_html: 'Schools in groups: %{school_groups}'

--- a/config/locales/views/compare/compare.yml
+++ b/config/locales/views/compare/compare.yml
@@ -17,6 +17,7 @@ en:
       schools_in_school_groups_html: 'Comparing schools in groups: %{school_groups}'
       schools_with_country_html: Comparing schools in %{country}
       schools_with_type_html: 'Comparing schools of type: %{school_type}'
+      select_one: Select at least one
     index:
       country:
         tab: Choose country

--- a/config/locales/views/compare/compare.yml
+++ b/config/locales/views/compare/compare.yml
@@ -5,9 +5,10 @@ en:
       description: Click on a benchmark to compare the selected schools
       title: Choose school comparison benchmark
     filter:
-      all_countries: All countries
+      all_countries: All
       all_school_types: All school types
       change_options: Change options
+      country: 'Select country:'
       school_groups: 'Select school groups:'
       school_types_html: Including %{school_types} schools
       schools_in_school_group_html: Schools in the <strong>%{school_group}</strong> group

--- a/config/locales/views/compare/compare.yml
+++ b/config/locales/views/compare/compare.yml
@@ -5,7 +5,7 @@ en:
       description: Click on a benchmark to compare the selected schools
       title: Choose school comparison benchmark
     filter:
-      all_countries: All
+      all_countries: All countries
       all_school_types: All school types
       change_options: Change options
       country: 'Select country:'

--- a/config/locales/views/compare/compare.yml
+++ b/config/locales/views/compare/compare.yml
@@ -7,6 +7,7 @@ en:
     filter:
       all_countries: All countries
       all_school_types: All school types
+      change_benchmark: Change benchmark
       change_options: Change options
       country: 'Select country:'
       school_groups: 'Select school groups:'

--- a/config/locales/views/compare/compare.yml
+++ b/config/locales/views/compare/compare.yml
@@ -10,7 +10,7 @@ en:
       change_options: Change options
       country: 'Select country:'
       school_groups: 'Select school groups:'
-      school_types_html: Including %{school_types} schools
+      school_types_html: Including %{school_types}
       schools_in_school_group_html: Schools in the <strong>%{school_group}</strong> group
       schools_in_school_groups_html: 'Schools in groups: %{school_groups}'
       schools_with_country_html: 'Schools in country: <strong>%{country}</strong>'

--- a/spec/system/compare_spec.rb
+++ b/spec/system/compare_spec.rb
@@ -65,6 +65,8 @@ describe 'compare pages', :compare, type: :system do
         expect(page).to_not have_content('chart data')
       end
     end
+
+    it { expect(page).to have_link('Change benchmark') }
   end
 
   shared_examples "a form filter" do |id:, school_types_excluding: nil, school_type: nil, country: nil, school_groups: nil|


### PR DESCRIPTION
See what you think @ldodds - I have made the benchmark list page groups into cards - not 100% convinced on the way it looks but easy enough to change. Also see what you think about the search filters. Also I'm not such a fan of the massive header on the front page but it does match the other pages...

Index / search filter page:
- [x] Make sure the index page heading matches that of activities
- [x] Boostrap-ify search filters
- [x] Remove extra spacing above title

Benchmark list page:
- [x] Each benchmark group to have a title, followed by the description, then two columns of benchmarks
- [x] Add button to change benchmark

Benchmark & Results pages
- [x] Style the summary filter so selected items are more prominent - consider using bootstrap badges for selected elements

Any other feedback…