### PR TITLE
Translations for text on intervention completion partials

### DIFF
--- a/app/views/schools/interventions/_points.html.erb
+++ b/app/views/schools/interventions/_points.html.erb
@@ -1,19 +1,19 @@
 <% if points&.positive? %>
-  <h4 class="text-center"><strong>You've just scored <%= points %> points!</strong></h4>
+  <h4 class="text-center"><strong><%= t('interventions.completed.points_scored', points: points) %></strong></h4>
 <% end %>
 
 <% if podium && podium.includes_school? && can?(:read, podium.scoreboard) %>
   <% if podium.school_position.position == 1 %>
     <h4 class="text-center">
-      You've recorded <%= pluralize(completed_actions.count, 'action') %> so far this year
-      and your school is currently in <%= current_school_podium.school_position.ordinal %> place.
+      <%= t('interventions.completed.actions_completed', count: completed_actions.count) %>
+      <%= t('interventions.completed.current_school_position', position: current_school_podium.school_position.ordinal) %>
     </h4>
   <% else %>
     <h4 class="text-center">
-      You've recorded <%= pluralize(completed_actions.count, 'action') %> so far this year
-      and need to score <%= podium.next_school_position.points - podium.school_position.points %> points to reach <%= current_school_podium.next_school_position.ordinal %> place.
+      <%= t('interventions.completed.actions_completed', count: completed_actions.count) %>
+      <%= t('interventions.completed.points_to_change_position', points: podium.next_school_position.points - podium.school_position.points, position: current_school_podium.next_school_position.ordinal) %>
     </h4>
   <% end %>
 <% end %>
 
-<h4 class="text-center">Choose your next action from the suggestions below.</h4>
+<h4 class="text-center"><%= t('interventions.completed.choose_next_action') %></h4>

--- a/app/views/schools/interventions/completed.html.erb
+++ b/app/views/schools/interventions/completed.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, "#{@school.name} Action" %>
+<% content_for :page_title, t('interventions.completed.page_title', school: school.name) %>
 
 <h1 class="text-center"><%= t('interventions.completed.title') %></h1>
 

--- a/app/views/schools/interventions/completed.html.erb
+++ b/app/views/schools/interventions/completed.html.erb
@@ -1,6 +1,6 @@
 <% content_for :page_title, "#{@school.name} Action" %>
 
-<h1 class="text-center">Congratulations! We've recorded your action.</h1>
+<h1 class="text-center"><%= t('interventions.completed.title') %></h1>
 
 <div class="row">
   <div class="col-md-6">
@@ -34,7 +34,7 @@
     <div class="col card-deck actions">
       <div class="card surrounding-schools">
         <div class="card-footer text-center">
-          <%= link_to 'View your action', school_intervention_path(@school, @observation), class: "btn btn-lg btn-light rounded-pill font-weight-bold" %>
+          <%= link_to t('interventions.completed.view_action'), school_intervention_path(@school, @observation), class: "btn btn-lg btn-light rounded-pill font-weight-bold" %>
         </div>
       </div>
     </div>
@@ -44,7 +44,7 @@
       <% if current_school_podium && can?(:read, current_school_podium.scoreboard) %>
         <div class="card surrounding-schools">
           <div class="card-footer text-center">
-            <%= link_to 'See the scoreboard', scoreboard_path(current_school_podium.scoreboard), class: "btn btn-lg btn-light rounded-pill font-weight-bold" %>
+            <%= link_to t('interventions.completed.see_scoreboard'), scoreboard_path(current_school_podium.scoreboard), class: "btn btn-lg btn-light rounded-pill font-weight-bold" %>
           </div>
         </div>
       <% end %>
@@ -58,12 +58,12 @@
   <div class="row padded-row bg-light">
     <div class="col">
       <div class="d-flex justify-content-between align-items-center">
-        <h4><strong>Suggested actions for your school</strong></h4>
+        <h4><strong><%= t('interventions.completed.suggested_actions') %></strong></h4>
         <div>
-          <%= link_to 'View all actions', intervention_type_groups_path, class: "btn btn-outline-dark rounded-pill font-weight-bold" %>
+          <%= link_to t('interventions.completed.view_all_actions'), intervention_type_groups_path, class: "btn btn-outline-dark rounded-pill font-weight-bold" %>
         </div>
       </div>
-      <p>Our suggestions based on your energy use alerts and any energy audit completed at your school</p>
+      <p><%= t('interventions.completed.our_suggestions') %></p>
       <%= render "intervention_type_groups/cards", intervention_types: @suggested_actions, card_deck_css: "" %>
     </div>
   </div>

--- a/app/views/schools/interventions/completed.html.erb
+++ b/app/views/schools/interventions/completed.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, t('interventions.completed.page_title', school: school.name) %>
+<% content_for :page_title, t('interventions.completed.page_title', school: @school.name) %>
 
 <h1 class="text-center"><%= t('interventions.completed.title') %></h1>
 

--- a/app/views/schools/interventions/index.html.erb
+++ b/app/views/schools/interventions/index.html.erb
@@ -1,7 +1,7 @@
-<h1>Your energy saving actions</h1>
+<h1><%= t('interventions.index.title') %></h1>
 
 <% if can? :create, Observation %>
-  <p><%= link_to 'Record an energy saving action', intervention_type_groups_path, class: 'btn btn-primary' %></p>
+  <p><%= link_to t('interventions.index.record_action'), intervention_type_groups_path, class: 'btn btn-primary' %></p>
 <% end %>
 
 <table class="table table-borderless">

--- a/config/locales/views/interventions/interventions.yml
+++ b/config/locales/views/interventions/interventions.yml
@@ -8,6 +8,7 @@ en:
       choose_next_action: Choose your next action from the suggestions below.
       current_school_position: and your school is currently in %{position} place.
       our_suggestions: Our suggestions based on your energy use alerts and any energy audit completed at your school
+      page_title: Action completed for %{school}
       points_scored: You've just scored %{points} points!
       points_to_change_position: and need to score %{points} points to reach %{position} place.
       see_scoreboard: See the scoreboard

--- a/config/locales/views/interventions/interventions.yml
+++ b/config/locales/views/interventions/interventions.yml
@@ -1,6 +1,20 @@
 ---
 en:
   interventions:
+    completed:
+      actions_completed:
+        one: You've recorded 1 action so far this year
+        other: You've recorded %{count} actions so far this year
+      choose_next_action: Choose your next action from the suggestions below.
+      current_school_position: and your school is currently in %{position} place.
+      our_suggestions: Our suggestions based on your energy use alerts and any energy audit completed at your school
+      points_scored: You've just scored %{points} points!
+      points_to_change_position: and need to score %{points} points to reach %{position} place.
+      see_scoreboard: See the scoreboard
+      suggested_actions: Suggested actions for your school
+      title: Congratulations! We've recorded your action.
+      view_action: View your action
+      view_all_actions: View all actions
     edit:
       page_title: Update energy saving action
       title: Update your energy saving action
@@ -18,6 +32,9 @@ en:
       when_did_you_complete_this_action: When did you complete this action?
       you_can_add_formatting_label: You can add formatting, links and attach images using the toolbar below. Hover over each icon to learn what it does
       you_can_record_label: You can record both recent and older actions to build up a complete record of all of the energy saving activities you've carried out as a school
+    index:
+      record_action: Record an energy saving action
+      title: Your energy saving actions
     new:
       page_title: Record energy saving action
       title: Record an energy saving action for your school

--- a/config/locales/views/interventions/interventions.yml
+++ b/config/locales/views/interventions/interventions.yml
@@ -8,7 +8,7 @@ en:
       choose_next_action: Choose your next action from the suggestions below.
       current_school_position: and your school is currently in %{position} place.
       our_suggestions: Our suggestions based on your energy use alerts and any energy audit completed at your school
-      page_title: Action completed for %{school}
+      page_title: "%{school} Action"
       points_scored: You've just scored %{points} points!
       points_to_change_position: and need to score %{points} points to reach %{position} place.
       see_scoreboard: See the scoreboard


### PR DESCRIPTION
This PR provides translations for strings on the intervention (action) pages.

Pluralized strings are handled by providing "one" and "other" keys.

Ordinals (1st, 2nd etc) are already supported in the translation files.

Translation strings that start with interpolation placeholders need to be quoted.
