### PR TITLE
Integrate new benchmarks

### DIFF
--- a/app/controllers/schools/advice/base_out_of_hours_controller.rb
+++ b/app/controllers/schools/advice/base_out_of_hours_controller.rb
@@ -33,9 +33,9 @@ module Schools
 
       def benchmark_school(annual_usage_breakdown)
         Schools::Comparison.new(
-          school_value: annual_usage_breakdown&.out_of_hours&.kwh,
-          benchmark_value: nil,
-          exemplar_value: annual_usage_breakdown&.potential_savings(versus: :exemplar_school)&.kwh,
+          school_value: annual_usage_breakdown.out_of_hours.kwh,
+          benchmark_value: (annual_usage_breakdown.out_of_hours.kwh * BenchmarkMetrics::BENCHMARK_OUT_OF_HOURS_USE_PERCENT_ELECTRICITY),
+          exemplar_value: (annual_usage_breakdown.out_of_hours.kwh * BenchmarkMetrics::EXEMPLAR_OUT_OF_HOURS_USE_PERCENT_ELECTRICITY),
           unit: :kwh
         )
       end

--- a/app/services/schools/advice/peak_usage_service.rb
+++ b/app/services/schools/advice/peak_usage_service.rb
@@ -33,7 +33,7 @@ module Schools
       def benchmark_peak_usage
         Schools::Comparison.new(
           school_value: average_peak_kw,
-          benchmark_value: nil,
+          benchmark_value: peak_usage_benchmarking_service.average_peak_usage_kw(compare: :benchmark_school),
           exemplar_value: peak_usage_benchmarking_service.average_peak_usage_kw(compare: :exemplar_school),
           unit: :kw
         )

--- a/app/services/schools/advice_page_benchmarks/out_of_hours_usage_benchmark_generator.rb
+++ b/app/services/schools/advice_page_benchmarks/out_of_hours_usage_benchmark_generator.rb
@@ -11,9 +11,9 @@ module Schools
       def benchmark_usage
         annual_usage_breakdown = usage_service.usage_breakdown
         Schools::Comparison.new(
-          school_value: annual_usage_breakdown&.out_of_hours&.kwh,
-          benchmark_value: nil,
-          exemplar_value: annual_usage_breakdown&.potential_savings(versus: :exemplar_school)&.kwh,
+          school_value: annual_usage_breakdown.out_of_hours.kwh,
+          benchmark_value: (annual_usage_breakdown.out_of_hours.kwh * BenchmarkMetrics::BENCHMARK_OUT_OF_HOURS_USE_PERCENT_ELECTRICITY),
+          exemplar_value: (annual_usage_breakdown.out_of_hours.kwh * BenchmarkMetrics::EXEMPLAR_OUT_OF_HOURS_USE_PERCENT_ELECTRICITY),
           unit: :kwh
         )
       end


### PR DESCRIPTION
With the latest analytics updates, we can now calculate peak kw values and out of hours usage values for a `benchmark_school`.

This PR updates the relevant services/benchmarks to use the new feature.