### PR TITLE
Fix baseload page when some meters have limited data

### DIFF
--- a/app/helpers/advice_page_helper.rb
+++ b/app/helpers/advice_page_helper.rb
@@ -102,7 +102,7 @@ module AdvicePageHelper
   end
 
   def meters_by_estimated_saving(meters)
-    meters.sort_by {|_, v| -v.estimated_saving_£ }
+    meters.sort_by {|_, v| v.estimated_saving_£.present? ? -v.estimated_saving_£ : 0.0 }
   end
 
   def meters_by_percentage_baseload(meters)

--- a/app/views/schools/advice/baseload/_seasonal_variation_breakdown_table.html.erb
+++ b/app/views/schools/advice/baseload/_seasonal_variation_breakdown_table.html.erb
@@ -12,15 +12,25 @@
   </thead>
   <tbody>
     <% meters_by_estimated_saving(seasonal_variation_by_meter).each do |mpan_mprn, variation| %>
-    <tr>
-      <td class="text-left"><%= variation.meter.present? ? variation.meter.name_or_mpan_mprn : mpan_mprn %></td>
-      <td class="text-left"><%= format_rating(variation.variation_rating) %></td>
-      <td class="text-right"><%= format_unit(variation.winter_kw, :kw) %></td>
-      <td class="text-right"><%= format_unit(variation.summer_kw, :kw) %></td>
-      <td class="text-right"><%= format_unit(variation.percentage, :percent) %></td>
-      <td class="text-right"><%= format_unit(variation.estimated_saving_£, :£) %></td>
-      <td class="text-right"><%= format_unit(variation.estimated_saving_co2, :kg) %></td>
-    </tr>
+        <tr>
+          <td class="text-left"><%= variation.meter.present? ? variation.meter.name_or_mpan_mprn : mpan_mprn %></td>
+          <% if variation.enough_data? %>
+            <td class="text-left"><%= format_rating(variation.variation_rating) %></td>
+            <td class="text-right"><%= format_unit(variation.winter_kw, :kw) %></td>
+            <td class="text-right"><%= format_unit(variation.summer_kw, :kw) %></td>
+            <td class="text-right"><%= format_unit(variation.percentage, :percent) %></td>
+            <td class="text-right"><%= format_unit(variation.estimated_saving_£, :£) %></td>
+            <td class="text-right"><%= format_unit(variation.estimated_saving_co2, :kg) %></td>
+          <% else %>
+            <td colspan="6" class="text-center old-data">
+              <% if variation.data_available_from.present? %>
+                <%= t('advice_pages.not_enough_data.table_row_data_available_from', date: variation.data_available_from.to_s(:es_short)) %>
+              <% else %>
+                <%= t('advice_pages.not_enough_data.table_row_not_enough') %>
+              <% end %>
+            </td>
+          <% end %>
+        </tr>
     <% end %>
     <tr>
       <td class="text-left"><%= t('advice_pages.baseload.tables.labels.all_meters') %></td>

--- a/app/views/schools/advice/baseload/_weekday_variation_breakdown_table.html.erb
+++ b/app/views/schools/advice/baseload/_weekday_variation_breakdown_table.html.erb
@@ -12,15 +12,25 @@
   </thead>
   <tbody>
     <% meters_by_estimated_saving(intraweek_variation_by_meter).each do |mpan_mprn, variation| %>
-    <tr>
-      <td class="text-left"><%= variation.meter.present? ? variation.meter.name_or_mpan_mprn : mpan_mprn %></td>
-      <td class="text-left"><%= format_rating(variation.variation_rating) %></td>
-      <td class="text-right"><%= format_unit(variation.max_day_kw, :kw) %></td>
-      <td class="text-right"><%= format_unit(variation.min_day_kw, :kw) %></td>
-      <td class="text-right"><%= format_unit(variation.percent_intraday_variation, :percent) %></td>
-      <td class="text-right"><%= format_unit(variation.estimated_saving_£, :£) %></td>
-      <td class="text-right"><%= format_unit(variation.estimated_saving_co2, :kg) %></td>
-    </tr>
+        <tr>
+          <td class="text-left"><%= variation && variation.meter.present? ? variation.meter.name_or_mpan_mprn : mpan_mprn %></td>
+          <% if variation.enough_data? %>
+            <td class="text-left"><%= format_rating(variation.variation_rating) %></td>
+            <td class="text-right"><%= format_unit(variation.max_day_kw, :kw) %></td>
+            <td class="text-right"><%= format_unit(variation.min_day_kw, :kw) %></td>
+            <td class="text-right"><%= format_unit(variation.percent_intraday_variation, :percent) %></td>
+            <td class="text-right"><%= format_unit(variation.estimated_saving_£, :£) %></td>
+            <td class="text-right"><%= format_unit(variation.estimated_saving_co2, :kg) %></td>
+          <% else %>
+            <td colspan="6" class="text-center old-data">
+              <% if variation.data_available_from.present? %>
+                <%= t('advice_pages.not_enough_data.table_row_data_available_from', date: variation.data_available_from.to_s(:es_short)) %>
+              <% else %>
+                <%= t('advice_pages.not_enough_data.table_row_not_enough') %>
+              <% end %>
+            </td>
+          <% end %>
+        </tr>
     <% end %>
     <tr>
       <td class="text-left"><%= t('advice_pages.baseload.tables.labels.all_meters') %></td>

--- a/config/locales/views/advice_pages/advice_pages.yml
+++ b/config/locales/views/advice_pages/advice_pages.yml
@@ -89,6 +89,8 @@ en:
       available_from: Assuming we continue to regularly receive data we expect this analysis to be available after %{available_from}.
       learn_more_html: In the meantime you can <a href="%{learn_more_link}">learn more</a> about this topic.
       message: We don't currently have enough %{fuel_type} data in order to run this analysis for your school.
+      table_row_data_available_from: Data available from %{date}
+      table_row_not_enough: not enough data
       title: Not enough data to run analysis
     tables:
       columns:

--- a/spec/services/schools/advice/baseload_service_spec.rb
+++ b/spec/services/schools/advice/baseload_service_spec.rb
@@ -174,9 +174,8 @@ RSpec.describe Schools::Advice::BaseloadService, type: :service do
     end
     it 'returns variation' do
       result = service.seasonal_variation
-      expect(result.to_h.keys).to match_array([:estimated_saving_co2, :estimated_saving_£, :percentage, :summer_kw, :variation_rating, :winter_kw, :meter])
+      expect(result.to_h.keys).to match_array([:estimated_saving_co2, :estimated_saving_£, :percentage, :summer_kw, :variation_rating, :winter_kw, :meter, :enough_data?])
     end
-
   end
 
   describe '#seasonal_variation_by_meter' do
@@ -184,15 +183,28 @@ RSpec.describe Schools::Advice::BaseloadService, type: :service do
     let(:electricity_meter_1) { double(mpan_mprn: 'meter1', amr_data: double(end_date: Date.parse('20200101')), fuel_type: :electricity, aggregate_meter?: false) }
     let(:electricity_meter_2) { double(mpan_mprn: 'meter2', amr_data: double(end_date: Date.parse('20200101')), fuel_type: :electricity, aggregate_meter?: false) }
     let(:electricity_meters) { [electricity_meter_1, electricity_meter_2] }
+    let(:enough_data)   { true }
+    let(:data_available_from) { nil }
 
     before do
       allow_any_instance_of(Baseload::SeasonalBaseloadService).to receive(:seasonal_variation).and_return(seasonal_variation)
+      allow_any_instance_of(Baseload::SeasonalBaseloadService).to receive(:enough_data?).and_return(enough_data)
+      allow_any_instance_of(Baseload::SeasonalBaseloadService).to receive(:data_available_from).and_return(data_available_from)
       allow_any_instance_of(Baseload::SeasonalBaseloadService).to receive(:estimated_costs).and_return(savings)
     end
     it 'returns variation' do
       result = service.seasonal_variation_by_meter
       expect(result.keys).to match_array(['meter1', 'meter2'])
-      expect(result['meter1'].to_h.keys).to match_array([:estimated_saving_co2, :estimated_saving_£, :percentage, :summer_kw, :variation_rating, :winter_kw, :meter])
+      expect(result['meter1'].to_h.keys).to match_array([:estimated_saving_co2, :estimated_saving_£, :percentage, :summer_kw, :variation_rating, :winter_kw, :meter, :enough_data?])
+    end
+    context 'and theres not enough data' do
+      let(:enough_data)   { false }
+      let(:data_available_from) { Date.today + 10 }
+      it 'returns a limited variation' do
+        result = service.seasonal_variation_by_meter
+        expect(result.keys).to match_array(['meter1', 'meter2'])
+        expect(result['meter1'].to_h.keys).to match_array([:meter, :enough_data?, :data_available_from])
+      end
     end
   end
 
@@ -204,7 +216,7 @@ RSpec.describe Schools::Advice::BaseloadService, type: :service do
     end
     it 'returns variation' do
       result = service.intraweek_variation
-      expect(result.to_h.keys).to match_array([:estimated_saving_co2, :estimated_saving_£, :max_day_kw, :min_day_kw, :percent_intraday_variation, :variation_rating, :meter])
+      expect(result.to_h.keys).to match_array([:estimated_saving_co2, :estimated_saving_£, :max_day_kw, :min_day_kw, :percent_intraday_variation, :variation_rating, :meter, :enough_data?])
     end
 
   end
@@ -214,16 +226,29 @@ RSpec.describe Schools::Advice::BaseloadService, type: :service do
     let(:electricity_meter_1) { double(mpan_mprn: 'meter1', amr_data: double(end_date: Date.parse('20200101')), fuel_type: :electricity, aggregate_meter?: false) }
     let(:electricity_meter_2) { double(mpan_mprn: 'meter2', amr_data: double(end_date: Date.parse('20200101')), fuel_type: :electricity, aggregate_meter?: false) }
     let(:electricity_meters) { [electricity_meter_1, electricity_meter_2] }
+    let(:enough_data)   { true }
+    let(:data_available_from) { nil }
+
     before do
       allow_any_instance_of(Baseload::IntraweekBaseloadService).to receive(:intraweek_variation).and_return(intraweek_variation)
+      allow_any_instance_of(Baseload::IntraweekBaseloadService).to receive(:enough_data?).and_return(enough_data)
+      allow_any_instance_of(Baseload::IntraweekBaseloadService).to receive(:data_available_from).and_return(data_available_from)
       allow_any_instance_of(Baseload::IntraweekBaseloadService).to receive(:estimated_costs).and_return(savings)
     end
     it 'returns variation' do
       result = service.intraweek_variation_by_meter
       expect(result.keys).to match_array(['meter1', 'meter2'])
-      expect(result['meter1'].to_h.keys).to match_array([:estimated_saving_co2, :estimated_saving_£, :max_day_kw, :min_day_kw, :percent_intraday_variation, :variation_rating, :meter])
+      expect(result['meter1'].to_h.keys).to match_array([:estimated_saving_co2, :estimated_saving_£, :max_day_kw, :min_day_kw, :percent_intraday_variation, :variation_rating, :meter, :enough_data?])
     end
-
+    context 'and theres not enough data' do
+      let(:enough_data)   { false }
+      let(:data_available_from) { Date.today + 10 }
+      it 'returns a limited variation' do
+        result = service.intraweek_variation_by_meter
+        expect(result.keys).to match_array(['meter1', 'meter2'])
+        expect(result['meter1'].to_h.keys).to match_array([:meter, :enough_data?, :data_available_from])
+      end
+    end
   end
 
   describe '#date_ranges_by_meter' do


### PR DESCRIPTION
The baseload page tries to display the seasonal and intraweek baseload variation for all meters if the school has >1 years of data.

But some of the individual meters may have <1 year of data.

This PR revises the `BaseloadService` and the templates to:

* Check whether there is enough data for both seasonal and intraweek variation
* If there is not enough data, then return a limited variation object that indicates this and provides a date when the analysis can be run for that meter
* Displays a custom row in the table for these meters to indicate to the user that there is limited data and, hopefully when the analysis can be run

