### PR TITLE
3056 add school group to pupil login select box

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -458,4 +458,12 @@ module ApplicationHelper
   def replace_analysis_pages?
     EnergySparks::FeatureFlags.active?(:replace_analysis_pages)
   end
+
+  def school_name_group(school)
+    if school.school_group
+      "#{school.name} (#{school.school_group.name})"
+    else
+      school.name
+    end
+  end
 end

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -61,7 +61,7 @@
             <h3><%= t('devise.sessions.new.pupil_sign_in_for') %> <%= @school&.name %></h3>
             <%= f.hidden_field :school_id, value: @school&.id %>
           <% else %>
-            <%= f.input :school_id, as: :select, collection: @schools, label_method: :name, label: t('devise.sessions.new.select_your_school') %>
+            <%= f.input :school_id, as: :select, collection: @schools, label_method: lambda { |school| school_name_group(school) } , label: t('devise.sessions.new.select_your_school') %>
           <% end %>
           <%= f.input :password, as: :string, label: t('devise.sessions.new.your_pupil_password'), input_html: {autocapitalize: :none}%>
           <%= f.submit t('devise.sessions.new.sign_in'), class: 'btn btn-primary' %>
@@ -71,4 +71,3 @@
 
   </div>
 </div>
-

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -263,4 +263,16 @@ describe ApplicationHelper do
       expect(helper.i18n_key_from('Some Thing')).to eq('some_thing')
     end
   end
+
+  describe '#school_name_group' do
+    let(:school_group)          { create(:school_group, name: 'Some School Group') }
+    let(:school_with_group)     { create(:school, name: "School One", school_group: school_group) }
+    let(:school_without_group)  { create(:school, name: "School Two") }
+    it 'handles school with group' do
+      expect(helper.school_name_group(school_with_group)).to eq('School One (Some School Group)')
+    end
+    it 'handles school without group' do
+      expect(helper.school_name_group(school_without_group)).to eq('School Two')
+    end
+  end
 end

--- a/spec/system/pupils/pupil_password_spec.rb
+++ b/spec/system/pupils/pupil_password_spec.rb
@@ -3,7 +3,8 @@ require 'rails_helper'
 
 describe 'pupil passwords' do
 
-  let(:school){ create(:school) }
+  let(:school_group){ create(:school_group, name: 'MySchoolGroup') }
+  let(:school){ create(:school, name: 'MySchool', school_group: school_group) }
   let!(:pupil){ create(:pupil, pupil_password: 'theelectrons', school: school) }
 
   it 'allows the pupil to log in just using the pupil password' do
@@ -35,7 +36,7 @@ describe 'pupil passwords' do
   it 'allows the pupil to select their school' do
     visit new_user_session_path(role: :pupil)
 
-    select school.name, from: 'Select your school'
+    select 'MySchool (MySchoolGroup)', from: 'Select your school'
     fill_in 'Your pupil password', with: 'theelectrons'
     within '#pupil' do
       click_on 'Sign in'

--- a/spec/system/pupils/pupil_password_spec.rb
+++ b/spec/system/pupils/pupil_password_spec.rb
@@ -44,5 +44,4 @@ describe 'pupil passwords' do
     expect(page).to have_content('Signed in successfully')
     expect(page.current_path).to eq(pupils_school_path(school))
   end
-
 end


### PR DESCRIPTION
This PR adds the school group name to the dropdown of school names when using the pupil login page (to disambiguate schools with the same names)
