### PR TITLE
Memoize aggregate school

### DIFF
--- a/app/controllers/concerns/school_aggregation.rb
+++ b/app/controllers/concerns/school_aggregation.rb
@@ -32,7 +32,7 @@ private
   end
 
   def aggregate_school
-    aggregate_school_service.aggregate_school
+    @aggregate_school ||= aggregate_school_service.aggregate_school
   end
 
   def number_of_solar_readings


### PR DESCRIPTION
I realised that compared to the current analysis controller, the new advice page base controller and sub-classes are calling `SchoolAggregation.aggregate_school` multiple times for each request.

This means that currently we are deserialising the aggregated school (`MeterCollection`) from the Rails cache multiple times for each request. This explains why the current pages are 1-2 seconds slower than the current analysis even though, in most cases, we aren't doing significantly more work.

This changes the `SchoolAggregation.aggregate_school` to memoize the aggregate school. This greatly reduces the response times for some of the pages (proportional to how many times we call `aggregate_school`).

