### PR TITLE
Reinstate controls on baseload chart

### DIFF
--- a/app/views/schools/advice/baseload/_analysis.html.erb
+++ b/app/views/schools/advice/baseload/_analysis.html.erb
@@ -51,7 +51,7 @@
 
   <%= render 'long_term_trends_table', school: @school, annual_average_baseloads: @annual_average_baseloads, analysis_dates: @analysis_dates %>
 
-  <%= component 'chart', chart_type: :baseload_versus_benchmarks, analysis_controls: false, school: @school do |c| %>
+  <%= component 'chart', chart_type: :baseload_versus_benchmarks, analysis_controls: true, school: @school do |c| %>
     <% c.with_title { t('advice_pages.baseload.analysis.charts.long_term_baseload_chart_title') } %>
     <% c.with_subtitle { t('advice_pages.baseload.analysis.charts.long_term_baseload_chart_subtitle_html', start_month_year: short_dates(@analysis_dates.start_date), end_month_year: short_dates(@analysis_dates.end_date.last_month)) } %>
     <% c.with_footer do %>


### PR DESCRIPTION
There's no forward/back navigation, but you can drill down so the controls need to be displayed.