### PR TITLE
Check if seasonal analysis was unsuccessful

### DIFF
--- a/spec/services/schools/advice/baseload_service_spec.rb
+++ b/spec/services/schools/advice/baseload_service_spec.rb
@@ -167,7 +167,7 @@ RSpec.describe Schools::Advice::BaseloadService, type: :service do
   end
 
   describe '#seasonal_variation' do
-    let(:seasonal_variation) { double(winter_kw: 1, summer_kw: 2, percentage: 3) }
+    let(:seasonal_variation) { double(winter_kw: 1, summer_kw: 2, percentage: 3.0) }
     before do
       allow_any_instance_of(Baseload::SeasonalBaseloadService).to receive(:seasonal_variation).and_return(seasonal_variation)
       allow_any_instance_of(Baseload::SeasonalBaseloadService).to receive(:estimated_costs).and_return(savings)

--- a/spec/services/schools/advice/baseload_service_spec.rb
+++ b/spec/services/schools/advice/baseload_service_spec.rb
@@ -179,7 +179,7 @@ RSpec.describe Schools::Advice::BaseloadService, type: :service do
   end
 
   describe '#seasonal_variation_by_meter' do
-    let(:seasonal_variation) { double(winter_kw: 1, summer_kw: 2, percentage: 3) }
+    let(:seasonal_variation) { double(winter_kw: 1, summer_kw: 2, percentage: 3.0) }
     let(:electricity_meter_1) { double(mpan_mprn: 'meter1', amr_data: double(end_date: Date.parse('20200101')), fuel_type: :electricity, aggregate_meter?: false) }
     let(:electricity_meter_2) { double(mpan_mprn: 'meter2', amr_data: double(end_date: Date.parse('20200101')), fuel_type: :electricity, aggregate_meter?: false) }
     let(:electricity_meters) { [electricity_meter_1, electricity_meter_2] }


### PR DESCRIPTION
Fixes an issue when the meter has data over several years, but the school only uses electricity from this meter for a portion of the year (in this case a swimming pool only used in the summer).

Checks for whether the seasonal analysis returned any results.