### PR TITLE
Calculate correct out of hours usage benchmark

### DIFF
--- a/app/controllers/schools/advice/base_out_of_hours_controller.rb
+++ b/app/controllers/schools/advice/base_out_of_hours_controller.rb
@@ -34,8 +34,8 @@ module Schools
       def benchmark_school(annual_usage_breakdown)
         Schools::Comparison.new(
           school_value: annual_usage_breakdown.out_of_hours.kwh,
-          benchmark_value: (annual_usage_breakdown.out_of_hours.kwh * BenchmarkMetrics::BENCHMARK_OUT_OF_HOURS_USE_PERCENT_ELECTRICITY),
-          exemplar_value: (annual_usage_breakdown.out_of_hours.kwh * BenchmarkMetrics::EXEMPLAR_OUT_OF_HOURS_USE_PERCENT_ELECTRICITY),
+          benchmark_value: (annual_usage_breakdown.total.kwh * BenchmarkMetrics::BENCHMARK_OUT_OF_HOURS_USE_PERCENT_ELECTRICITY),
+          exemplar_value: (annual_usage_breakdown.total.kwh * BenchmarkMetrics::EXEMPLAR_OUT_OF_HOURS_USE_PERCENT_ELECTRICITY),
           unit: :kwh
         )
       end

--- a/app/services/schools/advice_page_benchmarks/out_of_hours_usage_benchmark_generator.rb
+++ b/app/services/schools/advice_page_benchmarks/out_of_hours_usage_benchmark_generator.rb
@@ -12,8 +12,8 @@ module Schools
         annual_usage_breakdown = usage_service.usage_breakdown
         Schools::Comparison.new(
           school_value: annual_usage_breakdown.out_of_hours.kwh,
-          benchmark_value: (annual_usage_breakdown.out_of_hours.kwh * BenchmarkMetrics::BENCHMARK_OUT_OF_HOURS_USE_PERCENT_ELECTRICITY),
-          exemplar_value: (annual_usage_breakdown.out_of_hours.kwh * BenchmarkMetrics::EXEMPLAR_OUT_OF_HOURS_USE_PERCENT_ELECTRICITY),
+          benchmark_value: (annual_usage_breakdown.total.kwh * BenchmarkMetrics::BENCHMARK_OUT_OF_HOURS_USE_PERCENT_ELECTRICITY),
+          exemplar_value: (annual_usage_breakdown.total.kwh * BenchmarkMetrics::EXEMPLAR_OUT_OF_HOURS_USE_PERCENT_ELECTRICITY),
           unit: :kwh
         )
       end

--- a/spec/services/schools/advice_page_benchmarks/out_of_hours_usage_benchmark_generator_spec.rb
+++ b/spec/services/schools/advice_page_benchmarks/out_of_hours_usage_benchmark_generator_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe Schools::AdvicePageBenchmarks::OutOfHoursUsageBenchmarkGenerator,
 
     context 'with a comparison' do
       it 'returns the comparison category' do
-        expect(service.benchmark_school).to eq :other_school
+        expect(service.benchmark_school).to eq :exemplar_school
       end
     end
 


### PR DESCRIPTION
We were incorrectly calculating the benchmark and exemplar out of hours usage as a % of the schools out of hour usage, rather than the school's total usage.

This PR fixes that issue.