### PR TITLE
Advice page index and benchmark labels

### DIFF
--- a/app/views/schools/advice/index/_page_list.html.erb
+++ b/app/views/schools/advice/index/_page_list.html.erb
@@ -14,7 +14,7 @@
         <div class="col-2 <%= idx == 0 ? 'bg-light' : ''%>">
           <% if idx == 0 %>
             <div class="advice-page-benchmark-label">
-              <%= t("advice_pages.index.show.how_do_you_compare") %>
+              <strong><%= t("advice_pages.index.show.how_do_you_compare") %></strong>
             </div>
           <% end %>
         </div>

--- a/config/locales/views/advice_pages/advice_pages.yml
+++ b/config/locales/views/advice_pages/advice_pages.yml
@@ -10,7 +10,7 @@ en:
     benchmarks:
       benchmark_school: Well managed
       exemplar_school: Exemplar
-      other_school: Improving
+      other_school: Action needed
       your_school: Your school
     breadcrumbs:
       root: Advice

--- a/config/locales/views/advice_pages/index.yml
+++ b/config/locales/views/advice_pages/index.yml
@@ -16,8 +16,8 @@ en:
         title: Priority actions
       show:
         how_do_you_compare: How does your school compare?
-        not_applicable: Not applicable
-        not_available: Not available
+        not_applicable: No comparison
+        not_available: Not enough data
         notice_html: |-
           <p>Looking for suggestions of how to start reducing your energy usage?</p>
           <p>We've recommended some priority actions to help you make progress. Or explore our detailed analysis below.</p>


### PR DESCRIPTION
* Rename "Improving" to "Action needed" across the advice page index and insight page benchmarks
* Make title more obvious on advice page index
* Change labels for "not applicable" and "not available" to clarify what they mean