### PR TITLE
Remove prompt for target from activation email

### DIFF
--- a/app/mailers/onboarding_mailer.rb
+++ b/app/mailers/onboarding_mailer.rb
@@ -32,7 +32,6 @@ class OnboardingMailer < LocaleMailer
     @school = params[:school]
     @title = @school.name
     @to = user_emails(params[:users])
-    @target_prompt = params[:target_prompt]
     make_bootstrap_mail(to: @to, subject: default_i18n_subject(school: @school.name, locale: locale_param))
   end
 

--- a/app/services/activation_email_sender.rb
+++ b/app/services/activation_email_sender.rb
@@ -7,24 +7,14 @@ class ActivationEmailSender
     unless @school.has_school_onboarding_event?(:activation_email_sent)
       users = @school.activation_users
       if users.any?
-        target_prompt = include_target_prompt_in_email?
-        OnboardingMailer.with_user_locales(users: users, school: @school, target_prompt: target_prompt) { |mailer| mailer.activation_email.deliver_now }
+        OnboardingMailer.with_user_locales(users: users, school: @school) { |mailer| mailer.activation_email.deliver_now }
 
         onboarding_service.record_event(@school.school_onboarding, :activation_email_sent)
-        record_target_event(@school, :first_target_sent) if target_prompt
       end
     end
   end
 
   private
-
-  def include_target_prompt_in_email?
-    Targets::SchoolTargetService.targets_enabled?(@school) && Targets::SchoolTargetService.new(@school).enough_data?
-  end
-
-  def record_target_event(school, event)
-    school.school_target_events.create(event: event)
-  end
 
   def onboarding_service
     @onboarding_service ||= Onboarding::Service.new

--- a/app/views/onboarding_mailer/activation_email.html.erb
+++ b/app/views/onboarding_mailer/activation_email.html.erb
@@ -20,17 +20,6 @@
 
 <div class="s-3"></div>
 
-<% if @target_prompt %>
-  <div class="s-3"></div>
-
-  <h5 class="mb-3"><%= t('onboarding_mailer.activation_email.set_your_first_targets') %></h5>
-
-  <%= render 'shared/mailer/first_target_prompt', tracking_params: targets_utm_parameters(source: "activation") %>
-
-  <div class="s-3"></div>
-
-<% end %>
-
 <h5 class="mb-3"><%= t('onboarding_mailer.activation_email.need_some_help') %></h5>
 
 <p>

--- a/config/locales/mailers/mailer.yml
+++ b/config/locales/mailers/mailer.yml
@@ -70,7 +70,6 @@ en:
       paragraph_4: We will be in touch shortly to confirm when we have completed getting access to your energy data.
       paragraph_5_html: For help using Energy Sparks please read our <a href="https://energysparks.uk/resources/12/download">User Guide</a>, watch our <a href="%{user_guide_videos_url}">Training Videos</a> or join one of our <a href="%{training_url}">live webinar training</a> sessions.
       paragraph_6: We hope Energy Sparks will empower your pupils, school staff, and wider school community to take action to make your school more energy efficient.
-      set_your_first_targets: Set your first targets
       subject: "%{school} is live on Energy Sparks"
       thanks_for_joining: Thanks for joining!
       the_energy_sparks_team: The Energy Sparks Team

--- a/spec/services/activation_email_sender_spec.rb
+++ b/spec/services/activation_email_sender_spec.rb
@@ -45,18 +45,6 @@ describe ActivationEmailSender, :schools, type: :service do
           expect(email.to).to eql [onboarding_user.email]
         end
 
-        it 'records target invite if enough data' do
-          allow_any_instance_of(::Targets::SchoolTargetService).to receive(:enough_data?).and_return(true)
-          service.send
-          expect(school.has_school_target_event?(:first_target_sent)).to be true
-        end
-
-        it 'does not records target invite if not enough data' do
-          allow_any_instance_of(::Targets::SchoolTargetService).to receive(:enough_data?).and_return(false)
-          service.send
-          expect(school.has_school_target_event?(:first_target_sent)).to be false
-        end
-
         it 'records that an email was sent' do
           service.send
           expect(school_onboarding).to have_event(:activation_email_sent)
@@ -116,22 +104,6 @@ describe ActivationEmailSender, :schools, type: :service do
             expect(matcher).to have_link("Get in touch")
           end
 
-          context 'request to set targets' do
-            let(:enough_data) { true }
-            it 'when enough data' do
-              allow_any_instance_of(::Targets::SchoolTargetService).to receive(:enough_data?).and_return(true)
-              service.send
-              expect(email_body).to include("Set your first targets")
-              expect(matcher).to have_link("Set your first target")
-            end
-
-            it 'but not when not enough data' do
-              allow_any_instance_of(::Targets::SchoolTargetService).to receive(:enough_data?).and_return(false)
-              service.send
-              expect(email_body).to_not include("Set your first targets")
-              expect(matcher).to_not have_link("Set your first target")
-            end
-          end
         end
       end
     end


### PR DESCRIPTION
Removes a section from the activation email prompting a school to set a target.