### PR TITLE
Add new charts to recent changes pages

### DIFF
--- a/app/views/schools/advice/electricity_recent_changes/_analysis.html.erb
+++ b/app/views/schools/advice/electricity_recent_changes/_analysis.html.erb
@@ -5,7 +5,9 @@
 <ul>
   <li><%= link_to(t('advice_pages.electricity_recent_changes.analysis.compare_recent_weeks.title'), '#compare-recent-weeks') %></li>
   <li><%= link_to(t('advice_pages.electricity_recent_changes.analysis.compare_recent_days.title'), '#compare-recent-days') %></li>
+  <li><%= link_to(t('advice_pages.electricity_recent_changes.analysis.compare_last_week.title'), '#compare-last-week') %></li>
 </ul>
+
 
 <!--  COMPARISON OF ELECTRICITY USE OVER 2 RECENT WEEKS -->
 <%= render 'schools/advice/section_title', section_id: 'compare-recent-weeks', section_title: t('advice_pages.electricity_recent_changes.analysis.compare_recent_weeks.title') %>
@@ -51,3 +53,21 @@
     <% end %>
   <% end %>
 </div>
+
+<%= render 'schools/advice/section_title', section_id: 'compare-last-week', section_title: t('advice_pages.electricity_recent_changes.analysis.compare_last_week.title') %>
+
+<%= component 'chart',
+           chart_type: :intraday_line_school_last7days,
+           school: @school,
+           analysis_controls: false,
+           no_zoom: true,
+           axis_controls: false do |c| %>
+  <% c.with_title { t('advice_pages.electricity_recent_changes.analysis.charts.compare_last_week_chart_title') } %>
+  <% c.with_subtitle { t('advice_pages.electricity_recent_changes.analysis.charts.compare_last_week_chart_subtitle') } %>
+  <% c.with_header do %>
+    <p><%= t('advice_pages.electricity_recent_changes.analysis.charts.compare_last_week_chart_explanation') %></p>
+  <% end %>
+  <% c.with_footer do %>
+    <p><%= t('advice_pages.electricity_recent_changes.analysis.charts.compare_last_week_chart_footer') %></p>
+  <% end %>
+<% end %>

--- a/app/views/schools/advice/gas_recent_changes/_analysis.html.erb
+++ b/app/views/schools/advice/gas_recent_changes/_analysis.html.erb
@@ -5,6 +5,7 @@
 <ul>
   <li><%= link_to(t('advice_pages.gas_recent_changes.analysis.compare_recent_weeks.title'), '#compare-recent-weeks') %></li>
   <li><%= link_to(t('advice_pages.gas_recent_changes.analysis.compare_recent_days.title'), '#compare-recent-days') %></li>
+  <li><%= link_to(t('advice_pages.gas_recent_changes.analysis.compare_last_week.title'), '#compare-last-week') %></li>
   <li><%= link_to(t('advice_pages.gas_recent_changes.analysis.impact_of_temperature.title'), '#impact-of-temperature') %></li>
 </ul>
 
@@ -55,6 +56,24 @@
     <% end %>
   <% end %>
 </div>
+
+<%= render 'schools/advice/section_title', section_id: 'compare-last-week', section_title: t('advice_pages.gas_recent_changes.analysis.compare_last_week.title') %>
+
+<%= component 'chart',
+           chart_type: :last_7_days_intraday_gas,
+           school: @school,
+           analysis_controls: false,
+           no_zoom: true,
+           axis_controls: false do |c| %>
+  <% c.with_title { t('advice_pages.gas_recent_changes.analysis.charts.compare_last_week_chart_title') } %>
+  <% c.with_subtitle { t('advice_pages.gas_recent_changes.analysis.charts.compare_last_week_chart_subtitle') } %>
+  <% c.with_header do %>
+    <p><%= t('advice_pages.gas_recent_changes.analysis.charts.compare_last_week_chart_explanation') %></p>
+  <% end %>
+  <% c.with_footer do %>
+    <p><%= t('advice_pages.gas_recent_changes.analysis.charts.compare_last_week_chart_footer') %></p>
+  <% end %>
+<% end %>
 
 <!--  IMPACT ON GAS USE OF TEMP -->
 <%= render 'schools/advice/section_title', section_id: 'impact-of-temperature', section_title: t('advice_pages.gas_recent_changes.analysis.impact_of_temperature.title') %>

--- a/config/locales/views/advice_pages/electricity_recent_changes.yml
+++ b/config/locales/views/advice_pages/electricity_recent_changes.yml
@@ -4,12 +4,18 @@ en:
     electricity_recent_changes:
       analysis:
         charts:
+          compare_last_week_chart_explanation: The chart automatically uses the seven most recently available days. Use the explore buttons above the chart to compare alternative days. You can click on the legend to add or remove lines from the graph to make it clearer.
+          compare_last_week_chart_footer: You can use this type of chart to understand how the school's electricity use varies throughout the week.
+          compare_last_week_chart_subtitle: A comparison between your school's electricity use throughout the day over the last 7 days.
+          compare_last_week_chart_title: Your school's half hourly electricity consumption over the last 7 days
           compare_recent_days_chart_explanation: The chart automatically uses the two most recently available days. Use the options below the chart to compare alternative days.
           compare_recent_days_chart_subtitle: A comparison between your school’s electricity use throughout the day on two recent days.
           compare_recent_days_chart_title: Your school's half hourly electricity use for two recent days
           compare_recent_weeks_chart_explanation: The chart automatically uses the last two fully available weeks. Use the options below the chart to compare alternative weeks.
           compare_recent_weeks_chart_subtitle: A comparison of  your school’s daily electricity use across two recent weeks.
           compare_recent_weeks_chart_title: Your school's daily electricity use for two recent weeks
+        compare_last_week:
+          title: Comparison of electricity use over the last 7 days
         compare_recent_days:
           title: Comparison of electricity use over 2 recent days
         compare_recent_weeks:

--- a/config/locales/views/advice_pages/gas_recent_changes.yml
+++ b/config/locales/views/advice_pages/gas_recent_changes.yml
@@ -4,6 +4,10 @@ en:
     gas_recent_changes:
       analysis:
         charts:
+          compare_last_week_chart_explanation: The chart automatically uses the seven most recently available days. Use the explore buttons above the chart to compare alternative days. You can click on the legend to add or remove lines from the graph to make it clearer.
+          compare_last_week_chart_footer: You can use this type of chart to understand how the school's gas use varies throughout the week.
+          compare_last_week_chart_subtitle: A comparison between your school's gas use throughout the day over the last 7 days.
+          compare_last_week_chart_title: Your school's half hourly gas consumption over the last 7 days
           compare_recent_days_chart_explanation: The chart automatically uses the most recently available days. Use the options below the chart to compare alternative days.
           compare_recent_days_chart_subtitle: This chart shows the gas consumption throughout the day on two recent days.
           compare_recent_days_chart_title: Your school's half hourly gas use for two recent days
@@ -13,6 +17,8 @@ en:
           impact_of_temperature_chart_explanation_html: Degree days are the inverse of temperature. The higher the degree days the lower the temperature. %{more_detail_url}. If the heating boiler is working well at your school, degree days should track the gas usage quite closely.
           impact_of_temperature_chart_subtitle_html: This chart shows your schools’ gas use between <span class="start-date">%{start_date}</span> and <span class="end-date">%{end_date}</span>, including a comparison with degree days.
           impact_of_temperature_chart_title: Your school's gas use over the last two weeks
+        compare_last_week:
+          title: Comparison of gas use over the last 7 days
         compare_recent_days:
           title: Comparison of gas use over 2 recent days
         compare_recent_weeks:

--- a/spec/system/schools/advice_pages/electricity_recent_changes_spec.rb
+++ b/spec/system/schools/advice_pages/electricity_recent_changes_spec.rb
@@ -57,6 +57,7 @@ RSpec.describe "electricity recent changes advice page", type: :system do
         expect(page).to have_content('Comparison of electricity use over 2 recent days')
         expect(page).to have_css('#chart_wrapper_calendar_picker_electricity_week_example_comparison_chart')
         expect(page).to have_css('#chart_wrapper_calendar_picker_electricity_day_example_comparison_chart')
+        expect(page).to have_css('#chart_wrapper_intraday_line_school_last7days')
       end
     end
 

--- a/spec/system/schools/advice_pages/gas_recent_changes_spec.rb
+++ b/spec/system/schools/advice_pages/gas_recent_changes_spec.rb
@@ -50,6 +50,7 @@ RSpec.describe "gas recent changes advice page", type: :system do
         expect(page).to have_css('#chart_wrapper_calendar_picker_gas_week_example_comparison_chart')
         expect(page).to have_css('#chart_wrapper_calendar_picker_gas_day_example_comparison_chart')
         expect(page).to have_css('#chart_wrapper_last_2_weeks_gas_degreedays')
+        expect(page).to have_css('#chart_wrapper_last_7_days_intraday_gas')
       end
 
       it "shows start and end dates" do


### PR DESCRIPTION
Adds an intraday 7 day breakdown chart to the gas and electricity recent changes pages.

Fairly simple change to add sections to the analysis page, the chart component and the translations for the chart text.