### PR TITLE
Revise colours on navbar

### DIFF
--- a/app/assets/stylesheets/colours.scss
+++ b/app/assets/stylesheets/colours.scss
@@ -59,8 +59,22 @@ $colours-light: (
   "carbon"   : $light-grey
 );
 
+$colours-dark: (
+  "electric" : $electric-dark,
+  "gas"      : $gas-dark,
+  "storage"  : $storage-dark,
+  "solar"    : $solar-dark,
+  "carbon"   : $grey
+);
+
 @each $tag, $colour in $colours-light {
   .bg-#{$tag}-light {
+    background-color: $colour;
+  }
+}
+
+@each $tag, $colour in $colours-dark {
+  .bg-#{$tag}-dark {
     background-color: $colour;
   }
 }

--- a/app/assets/stylesheets/toggler.scss
+++ b/app/assets/stylesheets/toggler.scss
@@ -10,4 +10,5 @@
 
 .toggler i.fas {
   cursor: pointer;
+  margin-left: -0.65rem;
 }

--- a/app/components/page_nav_component.rb
+++ b/app/components/page_nav_component.rb
@@ -58,12 +58,13 @@ class PageNavComponent < ViewComponent::Base
   end
 
   class ItemComponent < ViewComponent::Base
-    attr_reader :name, :href, :match_controller
+    attr_reader :name, :href, :match_controller, :classes
 
-    def initialize(name:, href:, match_controller: false)
+    def initialize(name:, href:, classes: nil, match_controller: false)
       @name = name
       @href = href
       @match_controller = match_controller
+      @classes = classes
     end
 
     def current_controller?(href)
@@ -76,6 +77,7 @@ class PageNavComponent < ViewComponent::Base
 
     def call
       args = { class: "nav-link border-bottom item small" }
+      args[:class] += " #{classes}" if classes
       args[:class] += ' current' if current_item?(href)
       link_to(name, href, args)
     end

--- a/app/components/page_nav_component/page_nav_component.scss
+++ b/app/components/page_nav_component/page_nav_component.scss
@@ -1,7 +1,83 @@
 .page-nav-component a.nav-link.item:hover {
-  background-color: $light;
+  background-color: $light-grey;
 }
 
 .page-nav-component a.nav-link.current {
+  font-weight: bolder;
+}
+
+.page-nav-component a.electric-section {
+  background-color: $electric-dark;
+  color: white;
+  font-weight: bold;
+}
+
+.page-nav-component a.nav-link.electric-item {
+  border-left: 1px solid $electric-light;
+}
+
+.page-nav-component a.nav-link.electric-item:hover {
+  background-color: rgba(147, 255, 246, 0.5); //electric-light, 0.5 opacity
+}
+
+.page-nav-component a.nav-link.electric-item.current {
+  background-color: rgba(147, 255, 246, 0.5); //electric-light, 0.5 opacity
+  font-weight: bolder;
+}
+
+.page-nav-component a.gas-section {
+  background-color: $gas-dark;
+  color: white;
+  font-weight: bold;
+}
+
+.page-nav-component a.nav-link.gas-item {
+  border-left: 1px solid $gas-light;
+}
+
+.page-nav-component a.nav-link.gas-item:hover {
+  background-color: rgba(255, 221, 75, 0.5); //gas-light, 0.5 opacity;
+}
+
+.page-nav-component a.nav-link.gas-item.current {
+  background-color: rgba(255, 221, 75, 0.5); //gas-light, 0.5 opacity;
+  font-weight: bolder;
+}
+
+.page-nav-component a.solar-section {
+  background-color: $solar-dark;
+  color: white;
+  font-weight: bold;
+}
+
+.page-nav-component a.nav-link.solar-item {
+  border-left: 1px solid $solar-light;
+}
+
+.page-nav-component a.nav-link.solar-item:hover {
+  background-color: rgba(161, 255, 233, 0.5); //solar-light, 0.5 opacity;
+}
+
+.page-nav-component a.nav-link.solar-item.current {
+  background-color: rgba(161, 255, 233, 0.5); //solar-light, 0.5 opacity;
+  font-weight: bolder;
+}
+
+.page-nav-component a.storage-section {
+  background-color: $storage-dark;
+  color: white;
+  font-weight: bold;
+}
+
+.page-nav-component a.nav-link.storage-item {
+  border-left: 1px solid $storage-light;
+}
+
+.page-nav-component a.nav-link.storage-item:hover {
+  background-color: rgba(224, 151, 252, 0.5); //storage-light, 0.5 opacity;
+}
+
+.page-nav-component a.nav-link.storage-item.current {
+  background-color: rgba(224, 151, 252, 0.5); //storage-light, 0.5 opacity;
   font-weight: bolder;
 }

--- a/app/views/schools/advice/_nav.html.erb
+++ b/app/views/schools/advice/_nav.html.erb
@@ -2,24 +2,24 @@
   <% c.with_section do |s| %>
     <% s.with_item(name: t('advice_pages.nav.pages.total_energy_use'), href: school_advice_total_energy_use_path(@school)) %>
   <% end %>
-  <% c.with_section(name: t('advice_pages.nav.sections.electricity'), icon: 'bolt', classes: 'bg-electric-light', visible: @school.has_electricity?) do |s| %>
+  <% c.with_section(name: t('advice_pages.nav.sections.electricity'), icon: 'bolt', classes: 'electric-section', visible: @school.has_electricity?) do |s| %>
     <% sort_by_label(advice_pages.where(fuel_type: :electricity)).each do |ap| %>
-      <% s.with_item(name: translated_label(ap), href: advice_page_path(@school, ap)) %>
+      <% s.with_item(name: translated_label(ap), href: advice_page_path(@school, ap), classes: 'electric-item') %>
     <% end %>
   <% end %>
-  <% c.with_section(name: t('advice_pages.nav.sections.gas'), icon: 'fire', classes: 'bg-gas-light', visible: @school.has_gas?) do |s| %>
+  <% c.with_section(name: t('advice_pages.nav.sections.gas'), icon: 'fire', classes: 'gas-section', visible: @school.has_gas?) do |s| %>
     <% sort_by_label(advice_pages.where(fuel_type: :gas)).each do |ap| %>
-      <% s.with_item(name: translated_label(ap), href: advice_page_path(@school, ap)) %>
+      <% s.with_item(name: translated_label(ap), href: advice_page_path(@school, ap), classes: 'gas-item') %>
     <% end %>
   <% end %>
-  <% c.with_section(name: t('advice_pages.nav.sections.storage_heater'), icon: 'window-maximize', classes: 'bg-storage-light', visible: @school.has_storage_heaters?) do |s| %>
+  <% c.with_section(name: t('advice_pages.nav.sections.storage_heater'), icon: 'window-maximize', classes: 'storage-section', visible: @school.has_storage_heaters?) do |s| %>
     <% sort_by_label(advice_pages.where(fuel_type: :storage_heater)).each do |ap| %>
-      <% s.with_item(name: translated_label(ap), href: advice_page_path(@school, ap)) %>
+      <% s.with_item(name: translated_label(ap), href: advice_page_path(@school, ap), classes: 'storage-item') %>
     <% end %>
   <% end %>
-  <% c.with_section(name: t('advice_pages.nav.sections.solar_pv'), icon: 'sun', classes: 'bg-solar-light', visible: @school.has_electricity?) do |s| %>
+  <% c.with_section(name: t('advice_pages.nav.sections.solar_pv'), icon: 'sun', classes: 'solar-section', visible: @school.has_electricity?) do |s| %>
     <% sort_by_label(advice_pages.where(fuel_type: :solar_pv)).each do |ap| %>
-      <% s.with_item(name: translated_label(ap), href: advice_page_path(@school, ap)) %>
+      <% s.with_item(name: translated_label(ap), href: advice_page_path(@school, ap), classes: 'solar-item') %>
     <% end %>
   <% end %>
 <% end %>


### PR DESCRIPTION
Restyles the navbar:

- Adds support for adding classes to individual items
- Changes section styling to use "dark" version of standard fuel type colours
- Adds colour border to items to help group them
- Adds some negative margin to the icon to align text better
- Add custom hover and "current" item colours to better identify which page is being selected, or is currently selected