### PR TITLE
Implement holiday breakdown tables for gas out of hours page

### DIFF
--- a/app/views/schools/advice/electricity_out_of_hours/_analysis.html.erb
+++ b/app/views/schools/advice/electricity_out_of_hours/_analysis.html.erb
@@ -15,12 +15,7 @@
       <%= t('advice_pages.electricity_out_of_hours.analysis.holiday_usage.title') %>
     </a>
   </li>
-
 </ul>
-
-<%= component 'alerts', school: @school, dashboard_alerts: @dashboard_alerts, alert_types: alert_types_for_class(AlertElectricityUsageDuringCurrentHoliday), show_links: false, show_icons: false %>
-<%= component 'alerts', school: @school, dashboard_alerts: @dashboard_alerts, alert_types: alert_types_for_class(AlertPreviousHolidayComparisonElectricity), show_links: false, show_icons: false %>
-<%= component 'alerts', school: @school, dashboard_alerts: @dashboard_alerts, alert_types: alert_types_for_class(AlertPreviousYearHolidayComparisonElectricity), show_links: false, show_icons: false %>
 
 <%= render 'schools/advice/section_title', section_id: 'last_twelve_months', section_title: t('advice_pages.electricity_out_of_hours.analysis.last_twelve_months.title') %>
 
@@ -48,6 +43,10 @@
 <% end %>
 
 <%= render 'schools/advice/section_title', section_id: 'holiday-usage', section_title: t('advice_pages.electricity_out_of_hours.analysis.holiday_usage.title') %>
+
+<%= component 'alerts', school: @school, dashboard_alerts: @dashboard_alerts, alert_types: alert_types_for_class(AlertElectricityUsageDuringCurrentHoliday), show_links: false, show_icons: false %>
+<%= component 'alerts', school: @school, dashboard_alerts: @dashboard_alerts, alert_types: alert_types_for_class(AlertPreviousHolidayComparisonElectricity), show_links: false, show_icons: false %>
+<%= component 'alerts', school: @school, dashboard_alerts: @dashboard_alerts, alert_types: alert_types_for_class(AlertPreviousYearHolidayComparisonElectricity), show_links: false, show_icons: false %>
 
 <% if @analysis_dates.months_of_data >= 14 %>
   <%= component 'chart', chart_type: :alert_group_by_week_electricity_14_months, school: @school do |c| %>

--- a/app/views/schools/advice/gas_out_of_hours/_analysis.html.erb
+++ b/app/views/schools/advice/gas_out_of_hours/_analysis.html.erb
@@ -10,11 +10,12 @@
       <%= t('advice_pages.gas_out_of_hours.analysis.usage_by_day_of_week.title') %>
     </a>
   </li>
+  <li>
+    <a href='#holiday-usage'>
+      <%= t('advice_pages.gas_out_of_hours.analysis.holiday_usage.title') %>
+    </a>
+  </li>
 </ul>
-
-<%= component 'alerts', school: @school, dashboard_alerts: @dashboard_alerts, alert_types: alert_types_for_class(AlertGasHeatingHotWaterOnDuringHoliday), show_links: false, show_icons: false %>
-<%= component 'alerts', school: @school, dashboard_alerts: @dashboard_alerts, alert_types: alert_types_for_class(AlertPreviousHolidayComparisonGas), show_links: false, show_icons: false %>
-<%= component 'alerts', school: @school, dashboard_alerts: @dashboard_alerts, alert_types: alert_types_for_class(AlertPreviousYearHolidayComparisonGas), show_links: false, show_icons: false %>
 
 <%= render 'schools/advice/section_title', section_id: 'last_twelve_months', section_title: t('advice_pages.gas_out_of_hours.analysis.last_twelve_months.title') %>
 
@@ -62,3 +63,34 @@
     insights_school_advice_heating_control_path: insights_school_advice_heating_control_path(@school)) %>
   <% end %>
 <% end %>
+
+<%= render 'schools/advice/section_title', section_id: 'holiday-usage', section_title: t('advice_pages.gas_out_of_hours.analysis.holiday_usage.title') %>
+
+<%= component 'alerts', school: @school, dashboard_alerts: @dashboard_alerts, alert_types: alert_types_for_class(AlertGasHeatingHotWaterOnDuringHoliday), show_links: false, show_icons: false %>
+<%= component 'alerts', school: @school, dashboard_alerts: @dashboard_alerts, alert_types: alert_types_for_class(AlertPreviousHolidayComparisonGas), show_links: false, show_icons: false %>
+<%= component 'alerts', school: @school, dashboard_alerts: @dashboard_alerts, alert_types: alert_types_for_class(AlertPreviousYearHolidayComparisonGas), show_links: false, show_icons: false %>
+
+<% if @analysis_dates.months_of_data >= 14 %>
+  <%= component 'chart', chart_type: :alert_group_by_week_gas_14_months, school: @school do |c| %>
+    <% c.with_title do %>
+      <%= advice_t('gas_out_of_hours.analysis.holiday_usage.alert_group_by_week_gas_14_months.title') %>
+    <% end %>
+    <% c.with_subtitle do %>
+      <%= advice_t('gas_out_of_hours.analysis.holiday_usage.alert_group_by_week_gas_14_months.subtitle_html',
+        start_date: @analysis_dates.last_full_week_start_date.to_s(:es_short),
+        end_date: @analysis_dates.last_full_week_end_date.to_s(:es_short))
+       %>
+    <% end %>
+    <% c.with_header do %>
+      <p>
+        <%= advice_t('gas_out_of_hours.analysis.holiday_usage.alert_group_by_week_gas_14_months.header') %>
+      </p>
+    <% end %>
+  <% end %>
+<% end %>
+
+<p><%= advice_t('gas_out_of_hours.analysis.holiday_usage.table_intro') %></p>
+
+<%= render 'holiday_usage_table', holiday_usage: @holiday_usage %>
+
+<p><%= advice_t('gas_out_of_hours.analysis.holiday_usage.table_footer') %></p>

--- a/app/views/schools/advice/gas_out_of_hours/_current_holiday_usage_row.html.erb
+++ b/app/views/schools/advice/gas_out_of_hours/_current_holiday_usage_row.html.erb
@@ -1,0 +1,27 @@
+<tr>
+  <td></td>
+  <td>
+    <%= t('analytics.from_and_to', from_date: holiday.start_date.to_s(:es_short), to_date: holiday.end_date.to_s(:es_short)) %>
+    <% if within_school_period?(holiday) %>
+      <sup>*</sup>
+    <% end %>
+  </td>
+  <% if holiday_usage[holiday].usage.present? %>
+    <td class="text-right">
+      <%= format_unit(holiday_usage[holiday].usage.kwh, :kwh, true, :target) %>
+    </td>
+    <td class="text-right">
+      <%= format_unit(average_daily_usage(holiday_usage[holiday].usage, holiday), :kwh, true, :target) %>
+    </td>
+    <td class="text-right">
+      <%= format_unit(holiday_usage[holiday].usage.£, :£, true, :target) %>
+    </td>
+    <td class="text-right">
+      <%= format_unit(holiday_usage[holiday].usage.co2, :co2, true, :target) %>
+    </td>
+  <% else %>
+    <td colspan="4" class="text-center old-data">
+      <%= t('advice_pages.not_enough_data.table_row_not_enough') %>
+    </td>
+  <% end %>
+</tr>

--- a/app/views/schools/advice/gas_out_of_hours/_holiday_comparison_row.html.erb
+++ b/app/views/schools/advice/gas_out_of_hours/_holiday_comparison_row.html.erb
@@ -1,0 +1,23 @@
+<% if can_compare_holiday_usage?(holiday, holiday_usage[holiday]) %>
+  <tr class="table-active">
+    <td></td>
+    <td><%= advice_t('baseload.tables.columns.percentage_difference')%></td>
+    <td class="text-right">
+      <%= format_unit(
+        relative_percent(holiday_usage[holiday].previous_holiday_usage.kwh, holiday_usage[holiday].usage.kwh), :relative_percent) %>
+    </td>
+    <td class="text-right">
+      <%= format_unit(
+      relative_percent(average_daily_usage(holiday_usage[holiday].previous_holiday_usage, holiday),
+          average_daily_usage(holiday_usage[holiday].usage, holiday)), :relative_percent) %>
+    </td>
+    <td class="text-right">
+      <%= format_unit(
+        relative_percent(holiday_usage[holiday].previous_holiday_usage.£, holiday_usage[holiday].usage.£), :relative_percent) %>
+    </td>
+    <td class="text-right">
+      <%= format_unit(
+        relative_percent(holiday_usage[holiday].previous_holiday_usage.co2, holiday_usage[holiday].usage.co2), :relative_percent) %>
+    </td>
+  </tr>
+<% end %>

--- a/app/views/schools/advice/gas_out_of_hours/_holiday_usage_table.html.erb
+++ b/app/views/schools/advice/gas_out_of_hours/_holiday_usage_table.html.erb
@@ -1,0 +1,25 @@
+<table class="table advice-table">
+  <thead>
+    <tr>
+      <th>Holiday</th>
+      <th>Period</th>
+      <th class="text-right"><%= t('common.table.columns.use_kwh') %></th>
+      <th class="text-right"><%= advice_t('gas_out_of_hours.analysis.tables.columns.average_daily_usage') %></th>
+      <th class="text-right"><%= t('common.table.columns.cost_gbp') %></th>
+      <th class="text-right"><%= t('common.table.columns.co2_kg') %></th>
+    </tr>
+  </thead>
+  <tbody>
+    <% periods = sort_school_periods(holiday_usage.keys) %>
+    <% periods.each do |holiday| %>
+      <%= render 'previous_holiday_usage_row', holiday: holiday, holiday_usage: holiday_usage %>
+      <%= render 'current_holiday_usage_row', holiday: holiday, holiday_usage: holiday_usage %>
+      <%= render 'holiday_comparison_row', holiday: holiday, holiday_usage: holiday_usage %>
+    <% end %>
+  </tbody>
+</table>
+<% if within_school_period?(periods.last) %>
+  <div class="text-right advice-table-caption">
+    <sup>*</sup> <%= t('advice_pages.tables.notice.partial_holiday')%>
+  </div>
+<% end %>

--- a/app/views/schools/advice/gas_out_of_hours/_previous_holiday_usage_row.html.erb
+++ b/app/views/schools/advice/gas_out_of_hours/_previous_holiday_usage_row.html.erb
@@ -1,0 +1,26 @@
+<tr>
+  <td><%= I18nHelper.holiday(holiday.type) %></td>
+  <td>
+    <% if holiday_usage[holiday].previous_holiday.present? %>
+      <%= t('analytics.from_and_to', from_date: holiday_usage[holiday].previous_holiday.start_date.to_s(:es_short), to_date: holiday_usage[holiday].previous_holiday.end_date.to_s(:es_short)) %>
+    <% end %>
+  </td>
+  <% if holiday_usage[holiday].previous_holiday_usage.present? %>
+    <td class="text-right">
+      <%= format_unit(holiday_usage[holiday].previous_holiday_usage.kwh, :kwh, true, :target) %>
+    </td>
+    <td class="text-right">
+      <%= format_unit(average_daily_usage(holiday_usage[holiday].previous_holiday_usage, holiday), :kwh, true, :target) %>
+    </td>
+    <td class="text-right">
+      <%= format_unit(holiday_usage[holiday].previous_holiday_usage.£, :£, true, :target) %>
+    </td>
+    <td class="text-right">
+      <%= format_unit(holiday_usage[holiday].previous_holiday_usage.co2, :co2, true, :target) %>
+    </td>
+  <% else %>
+    <td colspan="4" class="text-center old-data">
+      <%= t('advice_pages.not_enough_data.table_row_not_enough') %>
+    </td>
+  <% end %>
+</tr>

--- a/config/locales/views/advice_pages/electricity_out_of_hours.yml
+++ b/config/locales/views/advice_pages/electricity_out_of_hours.yml
@@ -8,8 +8,8 @@ en:
             header: This chart can help your school compare electricity use during holidays
             subtitle_html: This chart gives the breakdown of electricity consumption between school day open and closed, holidays and weekends for each week between <span class='start-date'>%{start_date}</span> and <span class='end-date'>%{end_date}</span>
             title: Electricity use by week for the last 14 months
-          table_footer: Ideally the summary holiday should be lower than other holidays as more equipment and appliances can be switched off.
-          table_intro: The table below shows a summary of your electricity usage during the last year of school holidays.
+          table_footer: There may be reasons for some holidays to have higher energy use, for example additional security lighting in winter or contractors working on school property. Ideally the summary holiday should be lower than other holidays as more equipment and appliances can be switched off.
+          table_intro: The table below shows a summary of your electricity usage during the last year of school holidays. It includes average energy use per day to enable comparison for different length holidays.
           title: Holiday usage
         last_twelve_months:
           table:

--- a/config/locales/views/advice_pages/gas_out_of_hours.yml
+++ b/config/locales/views/advice_pages/gas_out_of_hours.yml
@@ -3,6 +3,14 @@ en:
   advice_pages:
     gas_out_of_hours:
       analysis:
+        holiday_usage:
+          alert_group_by_week_gas_14_months:
+            header: This chart can help your school compare gas use during holidays
+            subtitle_html: This chart gives the breakdown of gas consumption between school day open and closed, holidays and weekends for each week between <span class='start-date'>%{start_date}</span> and <span class='end-date'>%{end_date}</span>
+            title: Gas use by week for the last 14 months
+          table_footer: Winter holidays would be expected to have higher gas use due to frost protection settings.
+          table_intro: The table below shows a summary of your gas usage during the last year of school holidays. It includes average energy use per day to enable comparison for different length holidays.
+          title: Holiday usage
         last_twelve_months:
           table:
             co2_kg: kg/co2
@@ -13,6 +21,9 @@ en:
           table_introduction: The table below shows how much gas has been used when the school is open and closed on a school day as well as during weekends and holidays.
           title: Last 12 months
         summary: This section gives a more detailed analysis of your school’s out of hours gas use and some things to look out for. For good energy management, you want most of your energy use to be when the school is open.
+        tables:
+          columns:
+            average_daily_usage: Average daily usage (kWh)
         title: Analysis
         usage_by_day_of_week:
           daytype_breakdown_gas_tolerant_chart:

--- a/spec/system/schools/advice_pages/gas_out_of_hours_spec.rb
+++ b/spec/system/schools/advice_pages/gas_out_of_hours_spec.rb
@@ -82,6 +82,8 @@ RSpec.describe "gas out of hours advice page", type: :system do
         expect(page).to have_css('#chart_wrapper_daytype_breakdown_gas_tolerant')
         expect(page).to have_css('#chart_wrapper_gas_by_day_of_week_tolerant')
         expect(page).to have_css('#chart_wrapper_gas_heating_season_intraday_up_to_1_year')
+        expect(page).to have_content("Holiday usage")
+        expect(page).to have_content(Date.new(2021,12,18).to_s(:es_short))
       end
     end
 


### PR DESCRIPTION
Following up earlier PR that adds this section to the electricity page, this adds the "Holiday usage" section to the gas page.

* Adds the necessary partials and translations
* Uses right chart for gas vs electricity
* Customise text in translations, and some text changes for electricity
* Moves the alert notices from the top of the electricity and gas pages into the new section

