### PR TITLE
Implement holiday breakdown tables for storage heater page

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,9 +23,9 @@ gem 'pg_search'
 gem 'calculate_in_group'
 
 # Dashboard analytics
-gem 'energy-sparks_analytics', git: 'https://github.com/Energy-Sparks/energy-sparks_analytics.git', tag: '2.5.3'
+gem 'energy-sparks_analytics', git: 'https://github.com/Energy-Sparks/energy-sparks_analytics.git', tag: '2.5.4'
 #gem 'energy-sparks_analytics', git: 'https://github.com/Energy-Sparks/energy-sparks_analytics.git', branch: 'aws-eb-test'
-# gem 'energy-sparks_analytics', path: '../energy-sparks_analytics'
+#gem 'energy-sparks_analytics', path: '../energy-sparks_analytics'
 
 # Using master due to it having a patch which doesn't override Enumerable#sum if it's already defined
 # Last proper release does that, causing all kinds of weird behaviour (+ not defined etc)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/Energy-Sparks/energy-sparks_analytics.git
-  revision: ef8fefae03f45a1072bed5b3e4cff890ef2ef674
-  tag: 2.5.3
+  revision: df06bf4664f9b386e4bc75b757dccd213cab3be4
+  tag: 2.5.4
   specs:
     energy-sparks_analytics (1.2.1)
       activesupport (~> 6.0.0)

--- a/app/controllers/schools/advice/advice_base_controller.rb
+++ b/app/controllers/schools/advice/advice_base_controller.rb
@@ -26,8 +26,6 @@ module Schools
       include DashboardAlerts
 
       rescue_from StandardError do |exception|
-        puts exception
-        puts exception.backtrace
         Rollbar.error(exception, advice_page: advice_page_key, school: @school.name, school_id: @school.id, tab: @tab)
         raise if Rails.env.development? || @advice_page.nil?
         render 'error', status: :internal_server_error

--- a/app/controllers/schools/advice/advice_base_controller.rb
+++ b/app/controllers/schools/advice/advice_base_controller.rb
@@ -26,6 +26,8 @@ module Schools
       include DashboardAlerts
 
       rescue_from StandardError do |exception|
+        puts exception
+        puts exception.backtrace
         Rollbar.error(exception, advice_page: advice_page_key, school: @school.name, school_id: @school.id, tab: @tab)
         raise if Rails.env.development? || @advice_page.nil?
         render 'error', status: :internal_server_error

--- a/app/controllers/schools/advice/base_out_of_hours_controller.rb
+++ b/app/controllers/schools/advice/base_out_of_hours_controller.rb
@@ -10,6 +10,7 @@ module Schools
 
       def analysis
         @annual_usage_breakdown = annual_usage_breakdown_service.usage_breakdown
+        @holiday_usage = holiday_usage_calculation_service.school_holiday_calendar_comparison
         @analysis_dates = analysis_dates
       end
 
@@ -27,8 +28,20 @@ module Schools
           end_date: end_date,
           one_years_data: one_years_data?(start_date, end_date),
           recent_data: recent_data?(end_date),
-          months_analysed: months_analysed(start_date, end_date)
+          months_of_data: months_between(start_date, end_date),
+          last_full_week_start_date: last_full_week_start_date(end_date),
+          last_full_week_end_date: last_full_week_end_date(end_date),
         )
+      end
+
+      #for charts that use the last full week
+      def last_full_week_start_date(end_date)
+        (end_date - 13.months).beginning_of_week - 1
+      end
+
+      #for charts that use the last full week
+      def last_full_week_end_date(end_date)
+        end_date.prev_week.end_of_week - 1
       end
 
       def benchmark_school(annual_usage_breakdown)
@@ -44,6 +57,13 @@ module Schools
         ::Usage::AnnualUsageBreakdownService.new(
           meter_collection: aggregate_school,
           fuel_type: fuel_type
+        )
+      end
+
+      def holiday_usage_calculation_service
+        ::Usage::HolidayUsageCalculationService.new(
+          aggregate_meter,
+          aggregate_school.holidays
         )
       end
 

--- a/app/controllers/schools/advice/base_out_of_hours_controller.rb
+++ b/app/controllers/schools/advice/base_out_of_hours_controller.rb
@@ -35,11 +35,13 @@ module Schools
       end
 
       #for charts that use the last full week
+      #beginning of the week is Sunday
       def last_full_week_start_date(end_date)
         (end_date - 13.months).beginning_of_week - 1
       end
 
       #for charts that use the last full week
+      #end of the week is Saturday
       def last_full_week_end_date(end_date)
         end_date.prev_week.end_of_week - 1
       end

--- a/app/helpers/advice_page_helper.rb
+++ b/app/helpers/advice_page_helper.rb
@@ -182,5 +182,24 @@ module AdvicePageHelper
   def t_weekday(week_day)
     I18n.t('date.day_names')[week_day]
   end
+
+  #sort an array of SchoolPeriod objects
+  def sort_school_periods(periods)
+    periods.sort { |a, b| a.start_date <=> b.start_date }
+  end
+
+  def can_compare_holiday_usage?(holiday, holiday_usage)
+    return false unless holiday_usage.usage.present?
+    return false unless holiday_usage.previous_holiday_usage.present?
+    Time.zone.today > holiday.end_date
+  end
+
+  def within_school_period?(school_period)
+    @analysis_dates.end_date > school_period.start_date && @analysis_dates.end_date < school_period.end_date
+  end
+
+  def average_daily_usage(usage, school_period)
+    return usage.kwh / (school_period.end_date - school_period.start_date).to_i
+  end
 end
 # rubocop:enable Naming/AsciiIdentifiers

--- a/app/helpers/advice_page_helper.rb
+++ b/app/helpers/advice_page_helper.rb
@@ -199,7 +199,7 @@ module AdvicePageHelper
   end
 
   def average_daily_usage(usage, school_period)
-    return usage.kwh / (school_period.end_date - school_period.start_date).to_i
+    return usage.kwh / (school_period.end_date - school_period.start_date)
   end
 end
 # rubocop:enable Naming/AsciiIdentifiers

--- a/app/views/schools/advice/electricity_out_of_hours/_analysis.html.erb
+++ b/app/views/schools/advice/electricity_out_of_hours/_analysis.html.erb
@@ -10,6 +10,12 @@
       <%= t('advice_pages.electricity_out_of_hours.analysis.usage_by_day_of_week.title') %>
     </a>
   </li>
+  <li>
+    <a href='#holiday-usage'>
+      <%= t('advice_pages.electricity_out_of_hours.analysis.holiday_usage.title') %>
+    </a>
+  </li>
+
 </ul>
 
 <%= render 'schools/advice/section_title', section_id: 'last_twelve_months', section_title: t('advice_pages.electricity_out_of_hours.analysis.last_twelve_months.title') %>
@@ -36,3 +42,30 @@
     <%= t('advice_pages.electricity_out_of_hours.analysis.usage_by_day_of_week.electricity_by_day_of_week_tolerant_chart.footer') %>
   <% end %>
 <% end %>
+
+<%= render 'schools/advice/section_title', section_id: 'holiday-usage', section_title: t('advice_pages.electricity_out_of_hours.analysis.holiday_usage.title') %>
+
+<% if @analysis_dates.months_of_data >= 14 %>
+  <%= component 'chart', chart_type: :alert_group_by_week_electricity_14_months, school: @school do |c| %>
+    <% c.with_title do %>
+      <%= advice_t('electricity_out_of_hours.analysis.holiday_usage.alert_group_by_week_electricity_14_months.title') %>
+    <% end %>
+    <% c.with_subtitle do %>
+      <%= advice_t('electricity_out_of_hours.analysis.holiday_usage.alert_group_by_week_electricity_14_months.subtitle_html',
+        start_date: @analysis_dates.last_full_week_start_date.to_s(:es_short),
+        end_date: @analysis_dates.last_full_week_end_date.to_s(:es_short))
+       %>
+    <% end %>
+    <% c.with_header do %>
+      <p>
+        <%= advice_t('electricity_out_of_hours.analysis.holiday_usage.alert_group_by_week_electricity_14_months.header') %>
+      </p>
+    <% end %>
+  <% end %>
+<% end %>
+
+<p><%= advice_t('electricity_out_of_hours.analysis.holiday_usage.table_intro') %></p>
+
+<%= render 'holiday_usage_table', holiday_usage: @holiday_usage %>
+
+<p><%= advice_t('electricity_out_of_hours.analysis.holiday_usage.table_footer') %></p>

--- a/app/views/schools/advice/electricity_out_of_hours/_current_holiday_usage_row.html.erb
+++ b/app/views/schools/advice/electricity_out_of_hours/_current_holiday_usage_row.html.erb
@@ -1,0 +1,27 @@
+<tr>
+  <td></td>
+  <td>
+    <%= t('analytics.from_and_to', from_date: holiday.start_date.to_s(:es_short), to_date: holiday.end_date.to_s(:es_short)) %>
+    <% if within_school_period?(holiday) %>
+      <sup>*</sup>
+    <% end %>
+  </td>
+  <% if holiday_usage[holiday].usage.present? %>
+    <td class="text-right">
+      <%= format_unit(holiday_usage[holiday].usage.kwh, :kwh, true, :target) %>
+    </td>
+    <td class="text-right">
+      <%= format_unit(average_daily_usage(holiday_usage[holiday].usage, holiday), :kwh, true, :target) %>
+    </td>
+    <td class="text-right">
+      <%= format_unit(holiday_usage[holiday].usage.£, :£, true, :target) %>
+    </td>
+    <td class="text-right">
+      <%= format_unit(holiday_usage[holiday].usage.co2, :co2, true, :target) %>
+    </td>
+  <% else %>
+    <td colspan="3" class="text-center old-data">
+      <%= t('advice_pages.not_enough_data.table_row_not_enough') %>
+    </td>
+  <% end %>
+</tr>

--- a/app/views/schools/advice/electricity_out_of_hours/_current_holiday_usage_row.html.erb
+++ b/app/views/schools/advice/electricity_out_of_hours/_current_holiday_usage_row.html.erb
@@ -20,7 +20,7 @@
       <%= format_unit(holiday_usage[holiday].usage.co2, :co2, true, :target) %>
     </td>
   <% else %>
-    <td colspan="3" class="text-center old-data">
+    <td colspan="4" class="text-center old-data">
       <%= t('advice_pages.not_enough_data.table_row_not_enough') %>
     </td>
   <% end %>

--- a/app/views/schools/advice/electricity_out_of_hours/_holiday_comparison_row.html.erb
+++ b/app/views/schools/advice/electricity_out_of_hours/_holiday_comparison_row.html.erb
@@ -1,0 +1,23 @@
+<% if can_compare_holiday_usage?(holiday, holiday_usage[holiday]) %>
+  <tr class="table-active">
+    <td></td>
+    <td><%= advice_t('baseload.tables.columns.percentage_difference')%></td>
+    <td class="text-right">
+      <%= format_unit(
+        relative_percent(holiday_usage[holiday].previous_holiday_usage.kwh, holiday_usage[holiday].usage.kwh), :relative_percent) %>
+    </td>
+    <td class="text-right">
+      <%= format_unit(
+      relative_percent(average_daily_usage(holiday_usage[holiday].previous_holiday_usage, holiday),
+          average_daily_usage(holiday_usage[holiday].usage, holiday)), :relative_percent) %>
+    </td>
+    <td class="text-right">
+      <%= format_unit(
+        relative_percent(holiday_usage[holiday].previous_holiday_usage.£, holiday_usage[holiday].usage.£), :relative_percent) %>
+    </td>
+    <td class="text-right">
+      <%= format_unit(
+        relative_percent(holiday_usage[holiday].previous_holiday_usage.co2, holiday_usage[holiday].usage.co2), :relative_percent) %>
+    </td>
+  </tr>
+<% end %>

--- a/app/views/schools/advice/electricity_out_of_hours/_holiday_usage_table.html.erb
+++ b/app/views/schools/advice/electricity_out_of_hours/_holiday_usage_table.html.erb
@@ -1,0 +1,25 @@
+<table class="table advice-table">
+  <thead>
+    <tr>
+      <th>Holiday</th>
+      <th>Period</th>
+      <th class="text-right"><%= t('common.table.columns.use_kwh') %></th>
+      <th class="text-right"><%= advice_t('electricity_out_of_hours.analysis.tables.columns.average_daily_usage') %></th>
+      <th class="text-right"><%= t('common.table.columns.cost_gbp') %></th>
+      <th class="text-right"><%= t('common.table.columns.co2_kg') %></th>
+    </tr>
+  </thead>
+  <tbody>
+    <% periods = sort_school_periods(holiday_usage.keys) %>
+    <% periods.each do |holiday| %>
+      <%= render 'previous_holiday_usage_row', holiday: holiday, holiday_usage: holiday_usage %>
+      <%= render 'current_holiday_usage_row', holiday: holiday, holiday_usage: holiday_usage %>
+      <%= render 'holiday_comparison_row', holiday: holiday, holiday_usage: holiday_usage %>
+    <% end %>
+  </tbody>
+</table>
+<% if within_school_period?(periods.last) %>
+  <div class="text-right advice-table-caption">
+    <sup>*</sup> <%= t('advice_pages.tables.notice.partial_holiday')%>
+  </div>
+<% end %>

--- a/app/views/schools/advice/electricity_out_of_hours/_previous_holiday_usage_row.html.erb
+++ b/app/views/schools/advice/electricity_out_of_hours/_previous_holiday_usage_row.html.erb
@@ -12,7 +12,6 @@
     <td class="text-right">
       <%= format_unit(average_daily_usage(holiday_usage[holiday].previous_holiday_usage, holiday), :kwh, true, :target) %>
     </td>
-
     <td class="text-right">
       <%= format_unit(holiday_usage[holiday].previous_holiday_usage.£, :£, true, :target) %>
     </td>
@@ -20,7 +19,7 @@
       <%= format_unit(holiday_usage[holiday].previous_holiday_usage.co2, :co2, true, :target) %>
     </td>
   <% else %>
-    <td colspan="3" class="text-center old-data">
+    <td colspan="4" class="text-center old-data">
       <%= t('advice_pages.not_enough_data.table_row_not_enough') %>
     </td>
   <% end %>

--- a/app/views/schools/advice/electricity_out_of_hours/_previous_holiday_usage_row.html.erb
+++ b/app/views/schools/advice/electricity_out_of_hours/_previous_holiday_usage_row.html.erb
@@ -1,0 +1,27 @@
+<tr>
+  <td><%= I18nHelper.holiday(holiday.type) %></td>
+  <td>
+    <% if holiday_usage[holiday].previous_holiday.present? %>
+      <%= t('analytics.from_and_to', from_date: holiday_usage[holiday].previous_holiday.start_date.to_s(:es_short), to_date: holiday_usage[holiday].previous_holiday.end_date.to_s(:es_short)) %>
+    <% end %>
+  </td>
+  <% if holiday_usage[holiday].previous_holiday_usage.present? %>
+    <td class="text-right">
+      <%= format_unit(holiday_usage[holiday].previous_holiday_usage.kwh, :kwh, true, :target) %>
+    </td>
+    <td class="text-right">
+      <%= format_unit(average_daily_usage(holiday_usage[holiday].previous_holiday_usage, holiday), :kwh, true, :target) %>
+    </td>
+
+    <td class="text-right">
+      <%= format_unit(holiday_usage[holiday].previous_holiday_usage.£, :£, true, :target) %>
+    </td>
+    <td class="text-right">
+      <%= format_unit(holiday_usage[holiday].previous_holiday_usage.co2, :co2, true, :target) %>
+    </td>
+  <% else %>
+    <td colspan="3" class="text-center old-data">
+      <%= t('advice_pages.not_enough_data.table_row_not_enough') %>
+    </td>
+  <% end %>
+</tr>

--- a/config/locales/views/advice_pages/advice_pages.yml
+++ b/config/locales/views/advice_pages/advice_pages.yml
@@ -137,6 +137,7 @@ en:
         total: Total
         user_supplied: User supplied
       notice:
+        partial_holiday: only partial data available for current holiday
         partial_months: indicates a partial month
         partial_year: indicates a partial year
         three_significant_figures: Data in this table are presented to 3 significant figures.

--- a/config/locales/views/advice_pages/electricity_out_of_hours.yml
+++ b/config/locales/views/advice_pages/electricity_out_of_hours.yml
@@ -3,6 +3,14 @@ en:
   advice_pages:
     electricity_out_of_hours:
       analysis:
+        holiday_usage:
+          alert_group_by_week_electricity_14_months:
+            header: This chart can help your school compare electricity use during holidays
+            subtitle_html: This chart gives the breakdown of electricity consumption between school day open and closed, holidays and weekends for each week between <span class='start-date'>%{start_date}</span> and <span class='end-date'>%{end_date}</span>
+            title: Electricity use by week for the last 14 months
+          table_footer: Ideally the summary holiday should be lower than other holidays as more equipment and appliances can be switched off.
+          table_intro: The table below shows a summary of your electricity usage during the last year of school holidays.
+          title: Holiday usage
         last_twelve_months:
           table:
             co2_kg: kg/co2
@@ -12,7 +20,10 @@ en:
             total: Total
           table_introduction: The table below shows how much electricity has been used when the school is open and closed on a school day as well as during weekends and holidays.
           title: Last 12 months
-        summary: This section gives a more detailed analysis of your school’s out of hours electricity use and some things to look out for. For good energy management, you want most of your energy use to be when the school is open.
+        summary: This section gives a more detailed analysis of your school's out of hours electricity use and some things to look out for. For good energy management, you want most of your energy use to be when the school is open.
+        tables:
+          columns:
+            average_daily_usage: Average daily usage (kWh)
         title: Analysis
         usage_by_day_of_week:
           daytype_breakdown_electricity_tolerant_chart:

--- a/spec/system/schools/advice_pages/gas_out_of_hours_spec.rb
+++ b/spec/system/schools/advice_pages/gas_out_of_hours_spec.rb
@@ -7,6 +7,19 @@ RSpec.describe "gas out of hours advice page", type: :system do
 
   context 'as school admin' do
     let(:user)  { create(:school_admin, school: school) }
+    let(:school_period) { Holiday.new(:xmas, "Xmas 2021/2022", Date.new(2021,12,18), Date.new(2022,01,3), nil) }
+    let(:holiday_usage) {
+      OpenStruct.new(
+        usage: CombinedUsageMetric.new(
+          £: 12.0,
+          kwh: 12.0,
+          co2: 12.0,
+          percent: 0.4
+        ),
+        previous_holiday: nil,
+        previous_holiday_usage: nil
+      )
+    }
 
     before do
       combined_usage_metric = CombinedUsageMetric.new(
@@ -29,6 +42,14 @@ RSpec.describe "gas out of hours advice page", type: :system do
       end
       allow_any_instance_of(Usage::AnnualUsageCategoryBreakdown).to receive(:total) { combined_usage_metric }
       allow_any_instance_of(Usage::AnnualUsageCategoryBreakdown).to receive(:potential_savings) { combined_usage_metric }
+
+      allow(meter_collection).to receive(:holidays).and_return(nil)
+
+      school_holiday_calendar_comparison = {
+        school_period => holiday_usage
+      }
+
+      allow_any_instance_of(Usage::HolidayUsageCalculationService).to receive(:school_holiday_calendar_comparison) { school_holiday_calendar_comparison }
 
       sign_in(user)
       visit school_advice_gas_out_of_hours_path(school)


### PR DESCRIPTION
Adds holiday use table to storage heater page

* Updates controller to load the necessary analysis
* Adds section to the page with necessary translations
* Updated specs to check for presence of all charts

There's no new chart for the holiday use