### PR TITLE
Add holiday use to storage heater page

### DIFF
--- a/app/controllers/schools/advice/storage_heaters_controller.rb
+++ b/app/controllers/schools/advice/storage_heaters_controller.rb
@@ -12,6 +12,7 @@ module Schools
 
       def analysis
         @analysis_dates = analysis_dates
+        @holiday_usage = holiday_usage_calculation_service.school_holiday_calendar_comparison
       end
 
       private
@@ -36,6 +37,17 @@ module Schools
           meter_collection: aggregate_school,
           fuel_type: :storage_heater
         ).usage_breakdown
+      end
+
+      def holiday_usage_calculation_service
+        ::Usage::HolidayUsageCalculationService.new(
+          aggregate_meter,
+          aggregate_school.holidays
+        )
+      end
+
+      def aggregate_meter
+        aggregate_school.storage_heater_meter
       end
 
       def set_seasonal_analysis

--- a/app/views/schools/advice/electricity_out_of_hours/_analysis.html.erb
+++ b/app/views/schools/advice/electricity_out_of_hours/_analysis.html.erb
@@ -15,7 +15,6 @@
       <%= t('advice_pages.electricity_out_of_hours.analysis.holiday_usage.title') %>
     </a>
   </li>
-
 </ul>
 
 <%= component 'alerts', school: @school, dashboard_alerts: @dashboard_alerts, alert_types: alert_types_for_class(AlertElectricityUsageDuringCurrentHoliday), show_links: false, show_icons: false %>

--- a/app/views/schools/advice/storage_heaters/_analysis.html.erb
+++ b/app/views/schools/advice/storage_heaters/_analysis.html.erb
@@ -25,9 +25,13 @@
       <%= t('advice_pages.storage_heaters.analysis.thermostatic_control.title') %>
     </a>
   </li>
+  <li>
+    <a href='#holiday-usage'>
+      <%= t('advice_pages.storage_heaters.analysis.holiday_usage.title') %>
+    </a>
+  </li>
 </ul>
 
-<%= component 'alerts', school: @school, dashboard_alerts: @dashboard_alerts, alert_types: alert_types_for_class(AlertStorageHeaterHeatingOnDuringHoliday), show_links: false, show_icons: false %>
 <%= component 'alerts', school: @school, dashboard_alerts: @dashboard_alerts, alert_types: alert_types_for_class(AlertStorageHeaterOutOfHours), show_links: false, show_icons: false %>
 
 <%= render 'schools/advice/section_title', section_id: 'electricity_use_for_the_last_12_months', section_title: t('advice_pages.storage_heaters.analysis.electricity_use_for_the_last_12_months.title') %>
@@ -141,3 +145,13 @@
     <%= t('advice_pages.storage_heaters.analysis.thermostatic_control.storage_heater_thermostatic.content_html') %>
   <% end %>
 <% end %>
+
+<%= render 'schools/advice/section_title', section_id: 'holiday-usage', section_title: t('advice_pages.storage_heaters.analysis.holiday_usage.title') %>
+
+<%= component 'alerts', school: @school, dashboard_alerts: @dashboard_alerts, alert_types: alert_types_for_class(AlertStorageHeaterHeatingOnDuringHoliday), show_links: false, show_icons: false %>
+
+<p><%= advice_t('storage_heaters.analysis.holiday_usage.table_intro') %></p>
+
+<%= render 'holiday_usage_table', holiday_usage: @holiday_usage %>
+
+<p><%= advice_t('storage_heaters.analysis.holiday_usage.table_footer') %></p>

--- a/app/views/schools/advice/storage_heaters/_current_holiday_usage_row.html.erb
+++ b/app/views/schools/advice/storage_heaters/_current_holiday_usage_row.html.erb
@@ -1,0 +1,27 @@
+<tr>
+  <td></td>
+  <td>
+    <%= t('analytics.from_and_to', from_date: holiday.start_date.to_s(:es_short), to_date: holiday.end_date.to_s(:es_short)) %>
+    <% if within_school_period?(holiday) %>
+      <sup>*</sup>
+    <% end %>
+  </td>
+  <% if holiday_usage[holiday].usage.present? %>
+    <td class="text-right">
+      <%= format_unit(holiday_usage[holiday].usage.kwh, :kwh, true, :target) %>
+    </td>
+    <td class="text-right">
+      <%= format_unit(average_daily_usage(holiday_usage[holiday].usage, holiday), :kwh, true, :target) %>
+    </td>
+    <td class="text-right">
+      <%= format_unit(holiday_usage[holiday].usage.£, :£, true, :target) %>
+    </td>
+    <td class="text-right">
+      <%= format_unit(holiday_usage[holiday].usage.co2, :co2, true, :target) %>
+    </td>
+  <% else %>
+    <td colspan="4" class="text-center old-data">
+      <%= t('advice_pages.not_enough_data.table_row_not_enough') %>
+    </td>
+  <% end %>
+</tr>

--- a/app/views/schools/advice/storage_heaters/_holiday_comparison_row.html.erb
+++ b/app/views/schools/advice/storage_heaters/_holiday_comparison_row.html.erb
@@ -1,0 +1,23 @@
+<% if can_compare_holiday_usage?(holiday, holiday_usage[holiday]) %>
+  <tr class="table-active">
+    <td></td>
+    <td><%= advice_t('baseload.tables.columns.percentage_difference')%></td>
+    <td class="text-right">
+      <%= format_unit(
+        relative_percent(holiday_usage[holiday].previous_holiday_usage.kwh, holiday_usage[holiday].usage.kwh), :relative_percent) %>
+    </td>
+    <td class="text-right">
+      <%= format_unit(
+      relative_percent(average_daily_usage(holiday_usage[holiday].previous_holiday_usage, holiday),
+          average_daily_usage(holiday_usage[holiday].usage, holiday)), :relative_percent) %>
+    </td>
+    <td class="text-right">
+      <%= format_unit(
+        relative_percent(holiday_usage[holiday].previous_holiday_usage.£, holiday_usage[holiday].usage.£), :relative_percent) %>
+    </td>
+    <td class="text-right">
+      <%= format_unit(
+        relative_percent(holiday_usage[holiday].previous_holiday_usage.co2, holiday_usage[holiday].usage.co2), :relative_percent) %>
+    </td>
+  </tr>
+<% end %>

--- a/app/views/schools/advice/storage_heaters/_holiday_usage_table.html.erb
+++ b/app/views/schools/advice/storage_heaters/_holiday_usage_table.html.erb
@@ -4,7 +4,7 @@
       <th>Holiday</th>
       <th>Period</th>
       <th class="text-right"><%= t('common.table.columns.use_kwh') %></th>
-      <th class="text-right"><%= advice_t('electricity_out_of_hours.analysis.tables.columns.average_daily_usage') %></th>
+      <th class="text-right"><%= advice_t('storage_heaters.analysis.tables.columns.average_daily_usage') %></th>
       <th class="text-right"><%= t('common.table.columns.cost_gbp') %></th>
       <th class="text-right"><%= t('common.table.columns.co2_kg') %></th>
     </tr>

--- a/app/views/schools/advice/storage_heaters/_previous_holiday_usage_row.html.erb
+++ b/app/views/schools/advice/storage_heaters/_previous_holiday_usage_row.html.erb
@@ -1,0 +1,26 @@
+<tr>
+  <td><%= I18nHelper.holiday(holiday.type) %></td>
+  <td>
+    <% if holiday_usage[holiday].previous_holiday.present? %>
+      <%= t('analytics.from_and_to', from_date: holiday_usage[holiday].previous_holiday.start_date.to_s(:es_short), to_date: holiday_usage[holiday].previous_holiday.end_date.to_s(:es_short)) %>
+    <% end %>
+  </td>
+  <% if holiday_usage[holiday].previous_holiday_usage.present? %>
+    <td class="text-right">
+      <%= format_unit(holiday_usage[holiday].previous_holiday_usage.kwh, :kwh, true, :target) %>
+    </td>
+    <td class="text-right">
+      <%= format_unit(average_daily_usage(holiday_usage[holiday].previous_holiday_usage, holiday), :kwh, true, :target) %>
+    </td>
+    <td class="text-right">
+      <%= format_unit(holiday_usage[holiday].previous_holiday_usage.£, :£, true, :target) %>
+    </td>
+    <td class="text-right">
+      <%= format_unit(holiday_usage[holiday].previous_holiday_usage.co2, :co2, true, :target) %>
+    </td>
+  <% else %>
+    <td colspan="4" class="text-center old-data">
+      <%= t('advice_pages.not_enough_data.table_row_not_enough') %>
+    </td>
+  <% end %>
+</tr>

--- a/config/locales/views/advice_pages/storage_heaters.yml
+++ b/config/locales/views/advice_pages/storage_heaters.yml
@@ -28,6 +28,10 @@ en:
             title: Storage heater electricity consumption by time of day
           the_table_below: The table below shows how much electricity has been used for storage heaters over the last 12 months when the school is open and closed on a school day as well as during weekends and holidays.
           title: Electricity use for the last 12 months
+        holiday_usage:
+          table_footer: There should be no reason for storage heaters to remain on during summer half term or summer holidays.
+          table_intro: The table below shows the total storage heater electricity consumption during the last year of school holidays. It includes average energy use per day to enable comparison for different length holidays.
+          title: Storage heater use during holidays
         long_term_trends:
           storage_heater_group_by_week_long_term:
             subtitle: This chart gives the breakdown or gas consumption between school day open and closed, holidays and weekends for all the full years we have data for your school
@@ -49,6 +53,9 @@ en:
           notice_html: "<p>Last year your school heating was on for %{heating_on_in_warm_weather_days} days during warm weather. This is %{assessment}.</p>"
           title: Seasonal control
           you_should_ensure: You should ensure that storage heaters are turned off during weekends and holidays, and shorten the period when they are used during the year.
+        tables:
+          columns:
+            average_daily_usage: Average daily usage (kWh)
         thermostatic_control:
           storage_heater_thermostatic:
             content_html: |-


### PR DESCRIPTION
Adds holiday use table to storage heater page

- Updates controller to load the necessary analysis
- Adds section to the page with necessary translations
- Updated specs to check for presence of all charts

There's no new chart for the holiday use