### PR TITLE
Rename costs pages

### DIFF
--- a/config/locales/views/advice_pages/advice_pages.yml
+++ b/config/locales/views/advice_pages/advice_pages.yml
@@ -67,12 +67,12 @@ en:
       name: Advice
       pages:
         baseload: Baseload
-        electricity_costs: Costs
+        electricity_costs: Tariffs and costs
         electricity_intraday: Intraday
         electricity_long_term: Long term changes
         electricity_out_of_hours: Out of school hours
         electricity_recent_changes: Recent changes
-        gas_costs: Costs
+        gas_costs: Tariffs and costs
         gas_long_term: Long term changes
         gas_out_of_hours: Out of school hours
         gas_recent_changes: Recent changes


### PR DESCRIPTION
Renames the electricity and gas cost pages in the navbar and advice page index