### PR TITLE
Restore missing unit, ensure error page is translated

### DIFF
--- a/app/controllers/schools/advice/advice_base_controller.rb
+++ b/app/controllers/schools/advice/advice_base_controller.rb
@@ -28,7 +28,10 @@ module Schools
       rescue_from StandardError do |exception|
         Rollbar.error(exception, advice_page: advice_page_key, school: @school.name, school_id: @school.id, tab: @tab)
         raise if Rails.env.development? || @advice_page.nil?
-        render 'error', status: :internal_server_error
+        locale = LocaleFinder.new(params, request).locale
+        I18n.with_locale(locale) do
+          render 'error', status: :internal_server_error
+        end
       end
 
       def show

--- a/config/locales/cy/analytics/benchmarking/content_base.yml
+++ b/config/locales/cy/analytics/benchmarking/content_base.yml
@@ -3,6 +3,7 @@ cy:
     benchmarking:
       caveat_text:
         comparison_with_previous_period_infinite: "<p>Mae gwerth anfeidrol neu anfesuradwy yn dangos mai sero oedd y defnydd yn y cyfnod cyntaf.</p>"
+        covid_lockdown: ''
         es_data_not_in_sync_html: |-
           <p>
             Mae costau gwresogyddion nwy, trydan a stôr-wresogyddion i gyd yn defnyddio'r data

--- a/config/locales/cy/analytics/charts/chart_configuration.yml
+++ b/config/locales/cy/analytics/charts/chart_configuration.yml
@@ -1006,6 +1006,7 @@ cy:
       title:
         - Thermostatig (Penwythnos y Gaeaf)
     y_axis_label_name:
+      r2: ''
       co2: kg CO2
       days: dyddiau
       kw: kW

--- a/config/locales/cy/analytics/energy_units.yml
+++ b/config/locales/cy/analytics/energy_units.yml
@@ -9,8 +9,12 @@ cy:
       co2t: "%{value} o dunelli CO2"
       comparison_percent: "%"
       computer_console: "%{value} o gonsolau cyfrifiaduron"
+      date: ''
+      date_mmm_yyyy: ''
+      datetime: ''
       days: dyddiau
       electricity: "%{value} trydan"
+      fuel_type: ''
       gas: "%{value} nwy"
       home: "%{value} o gartrefi"
       homes_electricity: "%{value} o gartrefi (defnydd trydan)"
@@ -49,6 +53,8 @@ cy:
       r2: ''
       relative_percent: "%{sign}%{value}%"
       relative_percent_0dp: "%{sign}%{value}%"
+      school_name: ''
+      short_school_name: ''
       shower: "%{value} o gawodydd"
       smartphone: "%{value} o wefrau ffonau clyfar"
       solar_panels: "%{value} o baneli solar"
@@ -56,6 +62,7 @@ cy:
       teaching_assistant: "%{value} cynorthwyydd addysgu"
       teaching_assistant_hours: "%{value} cynorthwyydd addysgu (oriau)"
       temperature: "%{value}C"
+      timeofday: ''
       tree: "%{value} o goed"
       tv: "%{value} set teledu"
       vegetarian_dinner: "%{value} o giniawau"

--- a/config/locales/cy/analytics/energy_units.yml
+++ b/config/locales/cy/analytics/energy_units.yml
@@ -46,6 +46,7 @@ cy:
       percent_0dp: "%{value}%"
       percent_html: "%{value}&percnt;"
       pupils: "%{value} o ddisgyblion"
+      r2: ''
       relative_percent: "%{sign}%{value}%"
       relative_percent_0dp: "%{sign}%{value}%"
       shower: "%{value} o gawodydd"

--- a/config/locales/cy/views/home/attribution.yml
+++ b/config/locales/cy/views/home/attribution.yml
@@ -10,6 +10,7 @@ cy:
         terms: <a href="https://creativecommons.org/licenses/by/4.0/" target="_new">CC-BY 4.0</a>
       - name: Amcangyfrif o Gynhyrchiad Solar Ffotofoltaig
         source: <a href="https://www.solar.sheffield.ac.uk/" target="_new">Sheffield Ffotofoltaig yn Fyw</a>
+        terms: ''
       - name: Data Tymheredd Hanesyddol
         source: <a href="https://meteostat.net/" target="_new">Meteostat</a>. <br>Darparwyd data crai gan <a href="https://www.noaa.gov/" target="_new">NOAA</a>, <a href="https://www.dwd.de/" target="_new">DWD</a> ac <a href="https://dev.meteostat.net/docs/sources.html" target="_new">eraill</a>.
         terms: <a href="https://creativecommons.org/licenses/by-nc/4.0/legalcode" target="_new">CC-BY-NC 4.0</a>
@@ -18,6 +19,7 @@ cy:
         terms: <a href="https://opendatacommons.org/licenses/odbl/" target="_new">ODbL</a>
       - name: Rhagolygon y tywydd
         source: <a href="https://darksky.net/poweredby/" target="_new">Wedi'i bweru gan Dark Sky</a>.
+        terms: ''
     introduction: Mae Sbarcynni yn dibynnu ar nifer o setiau data cyhoeddus ac agored. Dyma restr o'r setiau data trydydd parti rydym yn eu mewnforio a'u defnyddio ar y wefan
     read_more_html: Gallwch hefyd ddarllen rhagor am y <a href='%{datasets_path}'>data cynhyrchu ynni a defnydd ysgolion</a> rydym yn eu defnyddio ac yn sicrhau eu bod ar gael
     source: Ffynhonnell


### PR DESCRIPTION
Transifex synchronisation removed a unit, which is causing thermostatic insights pages to fail in Welsh.

This also expose an issue with the advice error page which isn't rendering with a locale. So have wrapped that in calls to ensure its translated.