### PR TITLE
Missing translations on school details form

### DIFF
--- a/app/views/schools/_details_form.html.erb
+++ b/app/views/schools/_details_form.html.erb
@@ -8,7 +8,7 @@
 
 <div class="form-group">
   <%= f.label :funding_status %>
-  <%= f.select :funding_status, options_for_select(School.funding_statuses.map {|key, value| [key.titleize, key]}, f.object.funding_status), {include_blank: false}, { class: 'form-control' } %>
+  <%= f.select :funding_status, options_for_select(School.funding_statuses.map {|key, value| [t("schools.funding_status.#{key}"), key]}, f.object.funding_status), {include_blank: false}, { class: 'form-control' } %>
 </div>
 
 <% if current_user.admin? %>
@@ -29,7 +29,7 @@
   <h2><%= t('schools.school_details.location') %></h2>
   <div class="form-group">
     <%= f.label :country %>
-    <%= f.select :country, options_for_select(School.countries.map {|key, value| [key.titleize, key]}, f.object.country), {include_blank: false}, { class: 'form-control' } %>
+    <%= f.select :country, options_for_select(School.countries.map {|key, value| [t('school_statistics.' + key), key]}, f.object.country), {include_blank: false}, { class: 'form-control' } %>
   </div>
   <p><%= t('schools.school_details.geocode_message') %></p>
   <div class="form-group">

--- a/app/views/schools/edit.html.erb
+++ b/app/views/schools/edit.html.erb
@@ -1,12 +1,11 @@
 <div class="row justify-content-md-center">
   <div class="col col-md-10 col-lg-8">
-    <h1>Editing School</h1>
+    <h1><%= t('schools.school_details.editing') %></h1>
 
-    <%= render 'form', school: @school, submit_text: 'Update School'%>
+    <%= render 'form', school: @school, submit_text: t('schools.school_details.update_school') %>
 
     <div class="other-actions">
-      <%= link_to 'Back', school_path(@school), class: 'btn btn-secondary' %>
+      <%= link_to t('common.labels.back'), school_path(@school), class: 'btn btn-secondary' %>
     </div>
   </div>
 </div>
-

--- a/app/views/schools/new.html.erb
+++ b/app/views/schools/new.html.erb
@@ -1,11 +1,11 @@
 <div class="row justify-content-md-center">
   <div class="col col-md-10 col-lg-8">
-    <h1>New School</h1>
+    <h1><%= t('schools.school_details.new') %></h1>
 
-    <%= render 'form', school: @school, submit_text: 'Next'%>
+    <%= render 'form', school: @school, submit_text: t('common.labels.next') %>
 
     <div class="other-actions">
-      <%= link_to 'Back', schools_path, class: 'btn btn-secondary' %>
+      <%= link_to t('common.labels.back'), schools_path, class: 'btn btn-secondary' %>
     </div>
   </div>
 </div>

--- a/config/locales/views/schools/schools.yml
+++ b/config/locales/views/schools/schools.yml
@@ -192,6 +192,9 @@ en:
         tip: Tip
         your_estimate: Your estimate
         your_recent_energy_bills: Your recent energy bills should provide the data you need
+    funding_status:
+      private_school: Private School
+      state_school: State School
     inactive:
       description: We are still in the process of setting up your school on Energy Sparks. You will get an email notification when your school's account is activated on Energy Sparks.
       other_schools: other schools
@@ -333,14 +336,17 @@ en:
       analysis_preferences: Analysis Preferences
       basic_details: Basic details
       created: "%{school_name} was created on %{created_at}"
+      editing: Editing School
       floor_area_hint: If you don't know this please leave it blank and we will try to obtain this information from your Local Authority or MAT
       geocode_message: Leave these blank to have them set from the postcode
       key_stage: Key stages
       key_stage_message: If you are in Scotland, KS1 covers P2 and P3, KS2 covers P4 to P7, KS3 covers S1 to S3, KS4 covers S4 and S5, KS5 is S6
       location: Location
+      new: New School
       percentage_free_school_meals_hint: If you don't know, please leave this field blank.
       school_features: School features
       stage_of_education: Stage of education
+      update_school: Update School
       urn_hint: This is your URN in England, SEED in Scotland
       view_on_map: View on map
     school_group:


### PR DESCRIPTION
There was still some untranslated text on the school details forms:

* Page titles for New/Editing School
* Update School button
* Back button
* Funding Status
* Countries

Where possible I've used existing translations to fill in the missing words.