### PR TITLE
Solar analysis page issue when school has limited electricity data

### DIFF
--- a/app/controllers/schools/advice/solar_pv_controller.rb
+++ b/app/controllers/schools/advice/solar_pv_controller.rb
@@ -31,7 +31,7 @@ module Schools
 
       def enough_data?
         if @school.has_solar_pv?
-          existing_benefits_service.enough_data?
+          true
         else
           potential_benefits_service.enough_data?
         end

--- a/app/views/schools/advice/advice_base/not_enough_data.html.erb
+++ b/app/views/schools/advice/advice_base/not_enough_data.html.erb
@@ -4,7 +4,7 @@
       <%= t('advice_pages.not_enough_data.title') %>
     </h2>
     <p>
-      <%= t('advice_pages.not_enough_data.message', fuel_type: @advice_page.fuel_type) %>
+      <%= t('advice_pages.not_enough_data.message', fuel_type: @advice_page.t_fuel_type) %>
     </p>
     <% if @analysable.data_available_from.present? %>
       <p>


### PR DESCRIPTION
If a school doesn't have solar panels, then we need >1 of electricity to calculate benefits

If a school does have panels, then we can calculate the existing benefits with limited data. At the moment we're excluding schools from accessing the solar page when they should.

This PR fixes up the application enough data checks. A follow-up PR should change the service in the analytics.

