### PR TITLE
Tweak GA events

### DIFF
--- a/app/views/shared/_google_analytics.html.erb
+++ b/app/views/shared/_google_analytics.html.erb
@@ -14,7 +14,8 @@
       gtag('event', 'school_dimension', {'user_school': '<%= current_user.school.name %>'});
     <% end %>
     <% if @advice_page.present? %>
-      gtag('event', 'advice_page_dimension', {'advice_page': '<%= @advice_page.key %>', 'advice_page_tab': '<%= @tab %>'});
+      gtag('event', 'advice_page_dimension', {'advice_page': '<%= @advice_page.key %>'});
+      gtag('event', 'advice_page_tab', {'advice_page_tab': '<%= @tab %>'});
     <% end %>
   <% end %>
 </script>


### PR DESCRIPTION
Am not sure the GA events are being recorded correctly for the advice pages.

This tweaks the event callbacks to match what we're doing elsewhere. Can review changes next week.