### PR TITLE
Baseload multiple meter check

### DIFF
--- a/app/services/schools/advice/baseload_service.rb
+++ b/app/services/schools/advice/baseload_service.rb
@@ -17,7 +17,7 @@ module Schools
       end
 
       def multiple_electricity_meters?
-        @school.meters.electricity.count > 1
+        electricity_meters.count > 1
       end
 
       def average_baseload_kw(period: :year)

--- a/app/services/schools/advice/baseload_service.rb
+++ b/app/services/schools/advice/baseload_service.rb
@@ -17,7 +17,7 @@ module Schools
       end
 
       def multiple_electricity_meters?
-        electricity_meters.count > 1
+        @school.meters.active.electricity.count > 1
       end
 
       def average_baseload_kw(period: :year)


### PR DESCRIPTION
The baseload service wasn't correctly counting meters. It was including inactive meters when it shouldn't