### PR TITLE
3211 avoid passing incomplete user tariffs to analytics

### DIFF
--- a/app/models/meter.rb
+++ b/app/models/meter.rb
@@ -175,7 +175,7 @@ class Meter < ApplicationRecord
   end
 
   def user_tariff_meter_attributes
-    user_tariffs.map(&:meter_attribute)
+    user_tariffs.complete.map(&:meter_attribute)
   end
 
   def all_meter_attributes

--- a/app/models/user_tariff.rb
+++ b/app/models/user_tariff.rb
@@ -31,21 +31,9 @@ class UserTariff < ApplicationRecord
   scope :by_start_date, -> { order(start_date: :asc) }
   scope :electricity, -> { where(fuel_type: 'electricity') }
   scope :gas, -> { where(fuel_type: 'gas') }
-  # scope :has_prices, -> { joins(:user_tariff_prices).where.not(user_tariff_prices: { id: nil }) }
-  # scope :has_charges, -> { joins(:user_tariff_charges).where.not(user_tariff_charges: { id: nil }) }
 
-  scope :has_prices, -> {
-    where(
-      "EXISTS (SELECT 1 from user_tariff_prices WHERE user_tariffs.id = user_tariff_prices.user_tariff_id)",
-      )
-  }
-
-  scope :has_charges, -> {
-    where(
-      "EXISTS (SELECT 1 from user_tariff_charges WHERE user_tariffs.id = user_tariff_charges.user_tariff_id)",
-      )
-  }
-
+  scope :has_prices, -> { where(id: UserTariffPrice.select(:user_tariff_id)) }
+  scope :has_charges, -> { where(id: UserTariffCharge.select(:user_tariff_id)) }
   scope :complete, -> { has_prices.or(has_charges) }
 
   def electricity?

--- a/app/models/user_tariff.rb
+++ b/app/models/user_tariff.rb
@@ -31,6 +31,22 @@ class UserTariff < ApplicationRecord
   scope :by_start_date, -> { order(start_date: :asc) }
   scope :electricity, -> { where(fuel_type: 'electricity') }
   scope :gas, -> { where(fuel_type: 'gas') }
+  # scope :has_prices, -> { joins(:user_tariff_prices).where.not(user_tariff_prices: { id: nil }) }
+  # scope :has_charges, -> { joins(:user_tariff_charges).where.not(user_tariff_charges: { id: nil }) }
+
+  scope :has_prices, -> {
+    where(
+      "EXISTS (SELECT 1 from user_tariff_prices WHERE user_tariffs.id = user_tariff_prices.user_tariff_id)",
+      )
+  }
+
+  scope :has_charges, -> {
+    where(
+      "EXISTS (SELECT 1 from user_tariff_charges WHERE user_tariffs.id = user_tariff_charges.user_tariff_id)",
+      )
+  }
+
+  scope :complete, -> { has_prices.or(has_charges) }
 
   def electricity?
     fuel_type.to_sym == :electricity

--- a/spec/models/user_tariff_spec.rb
+++ b/spec/models/user_tariff_spec.rb
@@ -84,6 +84,33 @@ describe UserTariff do
       expect(meter_attribute[:accounting_tariff_generic][0][:source]).to eq(:manually_entered)
       expect(meter_attribute[:accounting_tariff_generic][0][:type]).to eq(:flat)
     end
+
+    context '#complete' do
+      context 'with prices and charges' do
+        it "should include tariff" do
+          expect(UserTariff.complete).to include(user_tariff)
+        end
+      end
+      context 'without prices or charges' do
+        let(:user_tariff_prices)  { [] }
+        let(:user_tariff_charges)  { [] }
+        it "should not include tariff" do
+          expect(UserTariff.complete).not_to include(user_tariff)
+        end
+      end
+      context 'without prices' do
+        let(:user_tariff_prices)  { [] }
+        it "should include tariff" do
+          expect(UserTariff.complete).to include(user_tariff)
+        end
+      end
+      context 'without charges' do
+        let(:user_tariff_charges)  { [] }
+        it "should include tariff" do
+          expect(UserTariff.complete).to include(user_tariff)
+        end
+      end
+    end
   end
 
   context 'with differential electricity tariff' do


### PR DESCRIPTION
User tariffs are defined in a multi-step process, adding prices and charges, but can be left in an incomplete state. This causes errors when passed to the analytics as meter attributes.

This PR applies a scope to the user tariffs to ensure that only tariffs that have either prices or charges (or both) as passed to the analytics.
