### PR TITLE
3212 dont allow users to delete rates for day night tariffs

### DIFF
--- a/app/models/user_tariff_price.rb
+++ b/app/models/user_tariff_price.rb
@@ -34,9 +34,8 @@ class UserTariffPrice < ApplicationRecord
   DAY_RATE_DESCRIPTION = 'Day rate'.freeze
 
   def time_range
-    first = start_time + 1.minute
-    last = end_time < start_time ? end_time + 1.day : end_time
-    first...last
+    last_time = end_time < start_time ? end_time + 1.day : end_time
+    start_time + 1.minute..last_time - 1.minute
   end
 
   private

--- a/app/models/user_tariff_price.rb
+++ b/app/models/user_tariff_price.rb
@@ -42,7 +42,7 @@ class UserTariffPrice < ApplicationRecord
   private
 
   def no_time_overlaps
-    self.user_tariff.user_tariff_prices.without(self).each do |other_price|
+    user_tariff.user_tariff_prices.without(self).each do |other_price|
       errors.add(:start_time, 'overlaps with another time range') if other_price.time_range.include?(start_time)
       errors.add(:end_time, 'overlaps with another time range') if other_price.time_range.include?(end_time)
     end

--- a/app/views/schools/user_tariff_differential_prices/index.html.erb
+++ b/app/views/schools/user_tariff_differential_prices/index.html.erb
@@ -17,12 +17,6 @@
 
   <br/>
 
-  <%= link_to t('schools.user_tariff_differential_prices.index.add_rate'), new_school_user_tariff_user_tariff_differential_price_path(@school, @user_tariff), {class: 'btn', remote: true, 'data-toggle' =>  "modal", 'data-target' => '#modal-window'} %>
-
-  <br/>
-  <br/>
-  <br/>
-
   <%= link_to t('common.labels.previous'), edit_school_user_tariff_path(@school, @user_tariff), class: 'btn' %>
   <%= link_to t('common.labels.next'), school_user_tariff_user_tariff_charges_path(@school, @user_tariff), class: 'btn' %>
 

--- a/app/views/schools/user_tariffs/_rates_table.html.erb
+++ b/app/views/schools/user_tariffs/_rates_table.html.erb
@@ -10,7 +10,6 @@
         <% if allow_edits %>
           <td class="value">
             <%= link_to t('common.labels.edit'), edit_school_user_tariff_user_tariff_differential_price_path(school, user_tariff, user_tariff_price), { class: 'btn user-tariff-show-button', remote: true, 'data-toggle' =>  "modal", 'data-target' => '#modal-window' } %>
-            <%= link_to t('common.labels.delete'), school_user_tariff_user_tariff_differential_price_path(school, user_tariff, user_tariff_price), method: :delete, data: { confirm: t('common.confirm') }, class: 'btn btn-danger user-tariff-show-button' %>
           </td>
         <% end %>
       </tr>

--- a/config/locales/cy/views/schools/user_tariffs.yml
+++ b/config/locales/cy/views/schools/user_tariffs.yml
@@ -32,7 +32,6 @@ cy:
           start_time: Amser cychwyn
           value: Cyfradd mewn £/kWh
       index:
-        add_rate: Ychwanegu cyfradd
         consumption_charges: Costau defnydd
         title: Ychwanegu costau defnydd ar gyfer pob cyfnod amser ar gyfer y tariff hwn
         using_your_bill_introduction: Gan ddefnyddio'ch bil, rhowch gymaint o fanylion ag y gallwch am y costau defnydd sy'n gysylltiedig â'r tariff hwn

--- a/config/locales/views/schools/user_tariffs.yml
+++ b/config/locales/views/schools/user_tariffs.yml
@@ -33,7 +33,6 @@ en:
           start_time: Start time
           value: Rate in £/kWh
       index:
-        add_rate: Add rate
         consumption_charges: Consumption charges
         title: Add consumption charges for each time period for this tariff
         using_your_bill_introduction: Using your bill, please provide as much detail as you can about the consumption charges associated with this tariff

--- a/spec/models/user_tariff_spec.rb
+++ b/spec/models/user_tariff_spec.rb
@@ -191,23 +191,32 @@ describe UserTariff do
       expect(user_tariff_price_1.errors[:start_time]).to include("can't be the same as end time")
     end
 
-    context 'when times overlap' do
-      let(:user_tariff_price_1)  { UserTariffPrice.new(start_time: '00:00', end_time: '07:00', value: 1.23, units: 'kwh') }
-      let(:user_tariff_price_2)  { UserTariffPrice.new(start_time: '07:00', end_time: '00:00', value: 2.46, units: 'kwh') }
+    it "should allow end time of one range to be start time of next" do
+      expect(user_tariff).to be_valid
+      user_tariff_price_1.update(end_time: user_tariff_price_2.start_time)
+      expect(user_tariff_price_1).to be_valid
+      expect(user_tariff).to be_valid
+    end
 
-      it "should prevent overlapping start time" do
-        expect(user_tariff).to be_valid
-        user_tariff_price_2.update(start_time: '06:30')
-        expect(user_tariff_price_2).not_to be_valid
-        expect(user_tariff_price_2.errors[:start_time]).to include("overlaps with another time range")
-      end
+    it "should prevent overlapping start time" do
+      expect(user_tariff).to be_valid
+      user_tariff_price_2.update(start_time: user_tariff_price_1.end_time - 1.minute)
+      expect(user_tariff_price_2).not_to be_valid
+      expect(user_tariff_price_2.errors[:start_time]).to include("overlaps with another time range")
+    end
 
-      it "should prevent overlapping end time" do
-        expect(user_tariff).to be_valid
-        user_tariff_price_1.update(end_time: '07:30')
-        expect(user_tariff_price_1).not_to be_valid
-        expect(user_tariff_price_1.errors[:end_time]).to include("overlaps with another time range")
-      end
+    it "should prevent overlapping end time" do
+      expect(user_tariff).to be_valid
+      user_tariff_price_1.update(end_time: user_tariff_price_2.start_time + 1.minute)
+      expect(user_tariff_price_1).not_to be_valid
+      expect(user_tariff_price_1.errors[:end_time]).to include("overlaps with another time range")
+    end
+
+    it "should handle midnight end time as next day" do
+      expect(user_tariff).to be_valid
+      user_tariff_price_2.update(start_time: '07:00', end_time: '00:00')
+      user_tariff_price_1.update(start_time: '08:00', end_time: '09:00')
+      expect(user_tariff_price_1).not_to be_valid
     end
   end
 end

--- a/spec/system/schools/user_tariffs_spec.rb
+++ b/spec/system/schools/user_tariffs_spec.rb
@@ -240,13 +240,13 @@ describe 'user tariffs', type: :system do
 
         select '00', from: 'user_tariff_price_start_time_4i'
         select '30', from: 'user_tariff_price_start_time_5i'
-        select '08', from: 'user_tariff_price_end_time_4i'
+        select '06', from: 'user_tariff_price_end_time_4i'
         select '30', from: 'user_tariff_price_end_time_5i'
 
         fill_in 'Rate in £/kWh', with: '1.5'
         click_button('Save')
 
-        expect(page).to have_content('Night rate (00:30 to 08:30)')
+        expect(page).to have_content('Night rate (00:30 to 06:30)')
         expect(page).to have_content('Day rate (07:00 to 00:00)')
         expect(page).to have_content('£1.50 per kWh')
         expect(page).to have_content('£0.00 per kWh')
@@ -266,7 +266,7 @@ describe 'user tariffs', type: :system do
         expect(user_tariff.meters).to match_array([electricity_meter])
         user_tariff_price = user_tariff.user_tariff_prices.first
         expect(user_tariff_price.start_time.to_s(:time)).to eq('00:30')
-        expect(user_tariff_price.end_time.to_s(:time)).to eq('08:30')
+        expect(user_tariff_price.end_time.to_s(:time)).to eq('06:30')
         expect(user_tariff_price.value.to_s).to eq('1.5')
         expect(user_tariff_price.units).to eq('kwh')
         user_tariff_price = user_tariff.user_tariff_prices.last

--- a/spec/system/schools/user_tariffs_spec.rb
+++ b/spec/system/schools/user_tariffs_spec.rb
@@ -233,6 +233,8 @@ describe 'user tariffs', type: :system do
 
         expect(page).to have_content('Night rate (00:00 to 07:00)')
         expect(page).to have_content('Day rate (07:00 to 00:00)')
+        expect(page).not_to have_link('Add rate')
+        expect(page).not_to have_link('Delete')
 
         first('.user-tariff-show-button').click
 


### PR DESCRIPTION
This PR removes the option to add or delete differential user tariff prices - we only allow 2prices (night and day) which are created automatically. 

The actual price and start and end times can still be edited.

There is now validation to ensure that time ranges can't overlap for a given user tariff.
