### PR TITLE
Fix javascript error on baseload chart

### DIFF
--- a/app/assets/javascripts/analysis.js
+++ b/app/assets/javascripts/analysis.js
@@ -218,20 +218,23 @@ function processAnnotations(loaded_annotations, chart){
     var date = new Date(annotation.date);
     var point = xAxis.series[0].getValidPoints()[categoryIndex];
     var date = new Date(annotation.date);
-    if(xAxis.series[0].stackKey){
-      var y = point.total;
-    } else {
-      var y = point.y;
+
+    if (point) {
+      if(xAxis.series[0].stackKey){
+        var y = point.total;
+      } else {
+        var y = point.y;
+      }
+      return {
+        point: {
+          x: categoryIndex,
+          y: y,
+          xAxis: 0,
+          yAxis: 0,
+        },
+        text: '<a href="' + annotation.url + '"><i class="fas fa-'+annotation.icon+'" data-toggle="tooltip" data-placement="right" title="(' + date.toLocaleDateString() + ') ' + annotation.event + '"></i></a>',
+      };
     }
-    return {
-      point: {
-        x: categoryIndex,
-        y: y,
-        xAxis: 0,
-        yAxis: 0,
-      },
-      text: '<a href="' + annotation.url + '"><i class="fas fa-'+annotation.icon+'" data-toggle="tooltip" data-placement="right" title="(' + date.toLocaleDateString() + ') ' + annotation.event + '"></i></a>',
-    };
   });
   chart.addAnnotation({
     labelOptions:{

--- a/app/services/charts/annotate.rb
+++ b/app/services/charts/annotate.rb
@@ -40,7 +40,7 @@ module Charts
           id: intervention.id,
           event: intervention.intervention_type.name,
           date: intervention.at.to_date,
-          x_axis_category: intervention.at.strftime('%Y-%m-%d'),
+          x_axis_category: intervention.at.strftime('%d-%m-%Y'),
           icon: intervention.intervention_type.intervention_type_group.icon
         }
       end

--- a/spec/services/charts/annotate_spec.rb
+++ b/spec/services/charts/annotate_spec.rb
@@ -134,7 +134,7 @@ describe Charts::Annotate do
           expect(subject).to eq(
             [
               {
-                x_axis_category: '2018-06-28',
+                x_axis_category: '28-06-2018',
                 event: 'Changed boiler',
                 id: intervention_1.id,
                 date: Date.new(2018, 6, 28),
@@ -154,14 +154,14 @@ describe Charts::Annotate do
           expect(subject).to eq(
             [
               {
-                x_axis_category: '2018-06-28',
+                x_axis_category: '28-06-2018',
                 event: 'Changed boiler',
                 id: intervention_1.id,
                 date: Date.new(2018, 6, 28),
                 icon: 'question-circle'
               },
               {
-                x_axis_category: '2018-07-08',
+                x_axis_category: '08-07-2018',
                 event: 'Changed bulbs',
                 id: intervention_2.id,
                 date: Date.new(2018, 7, 8),


### PR DESCRIPTION
For some charts we add annotations that indicate when the school took action. At the moment this is limited to the dashboard charts and one of the baseload charts.

The javascript is expecting that if there are annotations then the chart point labels (a date for these charts) should match the label given in the JSON produced for each annotation.

The date format for the baseload chart seems to have changed. But the `Charts::Annotate` class was producing a different format. The mismatched caused an error.

This PR:

* Changes the date format in the `Annotate` class to match the baseload chart
* Adds a check in the JS for whether we have a point before trying to create an annotation
