### PR TITLE
Dont translate series labels for scatter plots

### DIFF
--- a/app/models/chart_data_values.rb
+++ b/app/models/chart_data_values.rb
@@ -39,7 +39,7 @@ class ChartDataValues
       @x_axis_ranges      = chart[:x_axis_ranges]
       @x_max_value        = chart[:x_max_value]
       @x_min_value        = chart[:x_min_value]
-      @x_axis_label       = chart[:x_axis_label]
+      @x_axis_label       = translated_series_item_for(chart[:x_axis_label]) if chart[:x_axis_label]
       @y_axis_label       = format_y_axis_label_for(chart[:y_axis_label])
       @configuration      = chart[:configuration]
       @advice_header      = chart[:advice_header]
@@ -433,7 +433,7 @@ private
       end
 
       @y2_axis_label = @y2_data.keys[0]
-      @y2_axis_label = 'Temperature' if @y2_axis_label.start_with?('Temp')
+      @y2_axis_label = translated_series_item_for('Temperature') if @y2_axis_label.start_with?('Temp')
 
       @y2_data.each do |data_type, data|
         data_type = tidy_and_keep_label(data_type)
@@ -584,13 +584,13 @@ private
 
   def colours_for_multiple_fuel_type_bencmark(data_type, category)
     case data_type
-    when 'Gas'
+    when translated_series_item_for('Gas')
       if benchmark_school_category?(category)
         MIDDLE_GAS
       else
         LIGHT_GAS
       end
-    when 'Electricity'
+    when translated_series_item_for('Electricity')
       if benchmark_school_category?(category)
         MIDDLE_ELECTRICITY
       else

--- a/app/models/chart_data_values.rb
+++ b/app/models/chart_data_values.rb
@@ -33,12 +33,12 @@ class ChartDataValues
       @chart              = chart
       @title              = chart[:title]
       @subtitle           = chart[:subtitle]
+      @chart1_type        = chart[:chart1_type]
+      @chart1_subtype     = chart[:chart1_subtype]
       @x_axis_categories  = translate_categories_for(chart[:x_axis])
       @x_axis_ranges      = chart[:x_axis_ranges]
       @x_max_value        = chart[:x_max_value]
       @x_min_value        = chart[:x_min_value]
-      @chart1_type        = chart[:chart1_type]
-      @chart1_subtype     = chart[:chart1_subtype]
       @x_axis_label       = chart[:x_axis_label]
       @y_axis_label       = format_y_axis_label_for(chart[:y_axis_label])
       @configuration      = chart[:configuration]
@@ -66,7 +66,7 @@ class ChartDataValues
 
   def translate_categories_for(categories)
     return categories unless categories.is_a? Array
-
+    return categories if @chart1_type == :scatter
     categories.map { |category_label| translated_series_item_for(category_label) }
   end
 

--- a/spec/models/chart_data_values_spec.rb
+++ b/spec/models/chart_data_values_spec.rb
@@ -4,11 +4,12 @@ describe ChartDataValues do
 
   let(:chart) { :management_dashboard_group_by_week_electricity }
   let(:chart_type)  { :column }
+  let(:x_axis)      { %w[Sunday Monday Tuesday Wednesday Thursday Friday Saturday] }
   let(:x_axis_ranges) { [[Date.parse('Sun, 28 Apr 2019'), Date.parse('Sun, 28 Apr 2019')]] }
   let(:config) {
     {
       title: "Comparison of last 2 weeks gas consumption - adjusted for outside temperature £7.70",
-      x_axis: %w[Sunday Monday Tuesday Wednesday Thursday Friday Saturday],
+      x_axis: x_axis,
       x_axis_ranges: x_axis_ranges,
       x_data: { "Energy:Sun21Apr19-Sat27Apr19" => [], "Energy:Sun28Apr19-Sat04May19" => [] },
       chart1_type: chart_type,
@@ -30,6 +31,17 @@ describe ChartDataValues do
     expect(chart_data_values.series_data.first[:name]).to eq "Sun 21 Apr 19 - Sat 27 Apr 19"
     expect(chart_data_values.series_data.second[:name]).to eq "Sun 28 Apr 19 - Sat 04 May 19"
     expect(chart_data_values.x_axis_categories).to eq %w[Sunday Monday Tuesday Wednesday Thursday Friday Saturday]
+  end
+
+  context 'with scatter chart' do
+    let(:chart_type)  { :scatter }
+    let(:x_axis)      { [0.1, 0.2, 0.3]}
+    it 'doesnt translate series labels' do
+      first_series = chart_data_values.series_data[0]
+      first_item = first_series[:data].first
+      #confirm that series data are numbers, not strings
+      expect(first_item[0]).to be_a Float
+    end
   end
 
   context 'when setting colours' do


### PR DESCRIPTION
Avoids trying to translate the series names on the scatter charts. This currently breaks the charts as the float values end up as strings.

The series names aren't actually displayed to users, so it isn't an issue to not translate the dates.