### PR TITLE
Allow admins to assign meter status to individual meters (2)

### DIFF
--- a/app/controllers/admin/school_groups/meter_reports_controller.rb
+++ b/app/controllers/admin/school_groups/meter_reports_controller.rb
@@ -36,7 +36,8 @@ module Admin
             'Last validated reading',
             'Large gaps (last 2 years)',
             'Modified readings (last 2 years)',
-            'Zero reading days'
+            'Zero reading days',
+            'Admin meter status'
           ]
           school_group.schools.by_name.each do |school|
             school.meters.where(meter_scope).order(:mpan_mprn).each do |meter|
@@ -51,7 +52,8 @@ module Admin
                 nice_dates(meter.last_validated_reading),
                 date_range_from_reading_gaps(meter.gappy_validated_readings),
                 meter.modified_validated_readings.count,
-                meter.zero_reading_days.count
+                meter.zero_reading_days.count,
+                meter.admin_meter_status_label
               ]
             end
           end

--- a/app/controllers/admin/school_groups_controller.rb
+++ b/app/controllers/admin/school_groups_controller.rb
@@ -55,7 +55,8 @@ module Admin
         :default_weather_station_id,
         :default_chart_preference,
         :default_issues_admin_user_id,
-        :public
+        :public,
+        :admin_meter_statuses_id
       )
     end
   end

--- a/app/controllers/schools/meters_controller.rb
+++ b/app/controllers/schools/meters_controller.rb
@@ -104,7 +104,7 @@ module Schools
     end
 
     def meter_params
-      params.require(:meter).permit(:mpan_mprn, :meter_type, :name, :meter_serial_number, :dcc_meter, :sandbox, :earliest_available_data, :data_source_id)
+      params.require(:meter).permit(:mpan_mprn, :meter_type, :name, :meter_serial_number, :dcc_meter, :sandbox, :earliest_available_data, :data_source_id, :admin_meter_statuses_id)
     end
   end
 end

--- a/app/models/admin_meter_status.rb
+++ b/app/models/admin_meter_status.rb
@@ -1,2 +1,4 @@
 class AdminMeterStatus < ApplicationRecord
+  has_many :meters, foreign_key: 'admin_meter_statuses_id'
+  has_many :school_groups, foreign_key: 'admin_meter_statuses_id'
 end

--- a/app/models/meter.rb
+++ b/app/models/meter.rb
@@ -48,6 +48,7 @@ class Meter < ApplicationRecord
   belongs_to :solar_edge_installation, optional: true
   belongs_to :meter_review, optional: true
   belongs_to :data_source, optional: true
+  belongs_to :admin_meter_status, foreign_key: 'admin_meter_statuses_id'
 
   has_one :rtone_variant_installation, required: false
 

--- a/app/models/meter.rb
+++ b/app/models/meter.rb
@@ -48,7 +48,7 @@ class Meter < ApplicationRecord
   belongs_to :solar_edge_installation, optional: true
   belongs_to :meter_review, optional: true
   belongs_to :data_source, optional: true
-  belongs_to :admin_meter_status, foreign_key: 'admin_meter_statuses_id'
+  belongs_to :admin_meter_status, foreign_key: 'admin_meter_statuses_id', optional: true
 
   has_one :rtone_variant_installation, required: false
 

--- a/app/models/meter.rb
+++ b/app/models/meter.rb
@@ -102,6 +102,10 @@ class Meter < ApplicationRecord
     school.name
   end
 
+  def admin_meter_status_label
+    admin_meter_status&.label || school&.school_group&.admin_meter_status&.label || ''
+  end
+
   def fuel_type
     meter_type.to_sym
   end

--- a/app/models/school_group.rb
+++ b/app/models/school_group.rb
@@ -58,7 +58,7 @@ class SchoolGroup < ApplicationRecord
   belongs_to :default_weather_station, class_name: 'WeatherStation', foreign_key: 'default_weather_station_id', optional: true
   belongs_to :default_scoreboard, class_name: 'Scoreboard', optional: true
   belongs_to :default_issues_admin_user, class_name: 'User', foreign_key: 'default_issues_admin_user_id', optional: true
-  belongs_to :admin_meter_status, foreign_key: 'admin_meter_statuses_id'
+  belongs_to :admin_meter_status, foreign_key: 'admin_meter_statuses_id', optional: true
 
   has_many :meter_attributes, inverse_of: :school_group, class_name: 'SchoolGroupMeterAttribute'
 

--- a/app/models/school_group.rb
+++ b/app/models/school_group.rb
@@ -58,6 +58,7 @@ class SchoolGroup < ApplicationRecord
   belongs_to :default_weather_station, class_name: 'WeatherStation', foreign_key: 'default_weather_station_id', optional: true
   belongs_to :default_scoreboard, class_name: 'Scoreboard', optional: true
   belongs_to :default_issues_admin_user, class_name: 'User', foreign_key: 'default_issues_admin_user_id', optional: true
+  belongs_to :admin_meter_status, foreign_key: 'admin_meter_statuses_id'
 
   has_many :meter_attributes, inverse_of: :school_group, class_name: 'SchoolGroupMeterAttribute'
 

--- a/app/views/admin/index.html.erb
+++ b/app/views/admin/index.html.erb
@@ -68,6 +68,7 @@
       <li><%= link_to "Transport Types", admin_transport_types_path %></li>
       <li><%= link_to "Videos", admin_videos_path %></li>
       <li><%= link_to "Background Jobs", admin_good_job_path %></li>
+      <li><%= link_to "Admin meter statuses", admin_meter_statuses_path %></li>
     </ul>
 
   </div>

--- a/app/views/admin/school_groups/_form.html.erb
+++ b/app/views/admin/school_groups/_form.html.erb
@@ -56,6 +56,11 @@
       </div>
 
       <div class="form-group">
+        <%= f.label :admin_meter_statuses_id, 'Default admin meter status' %>
+        <%= f.select(:admin_meter_statuses_id, AdminMeterStatus.all.collect { |d| [ d.label, d.id ] }, { include_blank: true }, class: 'form-control') %>
+      </div>
+
+      <div class="form-group">
         <label><%= t("admin.school_groups.default_chart_preference.form_group") %></label>
         <p class="small"><%= t("admin.school_groups.default_chart_preference.explanation") %></p>
         <% SchoolGroup.default_chart_preferences.keys.each do |preference| %>

--- a/app/views/admin/school_groups/meter_reports/show.html.erb
+++ b/app/views/admin/school_groups/meter_reports/show.html.erb
@@ -47,6 +47,7 @@
         <th>Modified readings (last 2 years)</th>
         <th>Zero reading days</th>
         <th>Issues</th>
+        <th>Admin meter status</th>
       </tr>
     </thead>
     <tbody>
@@ -73,6 +74,9 @@
              <% if meter.issues.any? %>
                 <%= render 'admin/issues/modal', meter: meter, view_mode: true %>
               <% end %>
+            </td>
+            <td>
+              <%= meter.admin_meter_status_label %>
             </td>
           </tr>
         <% end %>

--- a/app/views/import_mailer/_meter_table.html.erb
+++ b/app/views/import_mailer/_meter_table.html.erb
@@ -7,6 +7,7 @@
       <td><%= link_to meter.mpan_mprn, school_meter_url(meter.school, meter) %></td>
       <td><%= link_to meter.data_source.name, admin_data_source_url(meter.data_source) if meter.data_source %></td>
       <td><%= nice_dates(meter.last_validated_reading) %></td>
+      <td><%= meter.admin_meter_status_label %></td>
       <td>
         <%= link_to issue_type_image(:issue), school_meter_url(meter.school, meter) if meter.issues.issue.any? %>
       </td>

--- a/app/views/import_mailer/import_summary.html.erb
+++ b/app/views/import_mailer/import_summary.html.erb
@@ -9,6 +9,7 @@
       <th>MPAN/MPRN</th>
       <th>Data source</th>
       <th>Last validated reading date</th>
+      <th>Admin meter status</th>
       <th colspan="2"></th>
     </tr>
   </thead>

--- a/app/views/schools/meters/_active_meters.html.erb
+++ b/app/views/schools/meters/_active_meters.html.erb
@@ -1,10 +1,17 @@
 <% active_meters.each do |meter| %>
   <tr scope="row" class="<%='table-warning' if @invalid_mpan.include?(meter) %>">
     <td title="<%= (meter.meter_type.to_s.humanize) %>"><%= fa_icon(fuel_type_icon(meter.meter_type)) %></td>
-    <td><%= meter.mpan_mprn %></td>
+    <td>
+      <%= link_to meter.mpan_mprn, school_meter_path(@school, meter) %>
+    </td>
     <td><%= meter.name %></td>
     <% if current_user.admin? %>
-      <td><%= link_to meter.data_source.try(:name), admin_data_source_path(meter.data_source) if meter.data_source %></td>
+      <td>
+        <%= link_to meter.data_source.try(:name), admin_data_source_path(meter.data_source) if meter.data_source %>
+      </td>
+      <td>
+        <%= meter.admin_meter_status_label %>
+      </td>
     <% end %>
     <td><%= meter.amr_data_feed_readings.count %></td>
     <td><%= meter.amr_validated_readings.count %></td>
@@ -14,9 +21,6 @@
     <td><%= meter.gappy_validated_readings.count %></td>
     <td>
       <div class="btn-group btn-group-sm" role="group">
-        <% if can?(:edit, meter) %>
-          <%= link_to t('common.labels.details'), school_meter_path(@school, meter), class: 'btn btn-sm' %>
-        <% end %>
         <% if can?(:view_meter_attributes, meter) %>
           <%= link_to t('common.labels.attributes'), admin_school_single_meter_attribute_path(@school, meter), class: 'btn btn-sm' %>
         <% end %>

--- a/app/views/schools/meters/_form.html.erb
+++ b/app/views/schools/meters/_form.html.erb
@@ -67,8 +67,6 @@
         <%= form.label :earliest_available_data, t('schools.meters.form.earliest_available_data') %>
         <%= component 'date_picker_form', form: form, field_name: :earliest_available_data, value: meter.earliest_available_data&.strftime('%d/%m/%Y') %>
       </div>
-
-
     <% end %>
   </div>
 

--- a/app/views/schools/meters/_form.html.erb
+++ b/app/views/schools/meters/_form.html.erb
@@ -38,6 +38,10 @@
       <%= form.label :data_source_id, t('schools.meters.form.data_source') %>
       <%= form.select(:data_source_id, DataSource.all.collect { |d| [ d.name, d.id ] }, { include_blank: true }, class: 'form-control') %>
     </div>
+    <div class="form-group">
+      <%= form.label :admin_meter_status, 'Admin meter status' %>
+      <%= form.select(:admin_meter_statuses_id, AdminMeterStatus.all.collect { |d| [ d.label, d.id ] }, { include_blank: true }, class: 'form-control') %>
+    </div>
   <% end %>
 
   <div class="form-group">
@@ -63,6 +67,8 @@
         <%= form.label :earliest_available_data, t('schools.meters.form.earliest_available_data') %>
         <%= component 'date_picker_form', form: form, field_name: :earliest_available_data, value: meter.earliest_available_data&.strftime('%d/%m/%Y') %>
       </div>
+
+
     <% end %>
   </div>
 

--- a/app/views/schools/meters/index.html.erb
+++ b/app/views/schools/meters/index.html.erb
@@ -79,6 +79,7 @@
       <th scope="col"><%= t('schools.meters.index.name') %></th>
       <% if current_user.admin? %>
         <th scope="col"><%= t('schools.meters.index.data_source') %></th>
+        <th scope="col"><%= t('schools.meters.index.admin_meter_status') %></th>
       <% end %>
       <th scope="col"><%= t('schools.meters.index.imported') %></th>
       <th scope="col"><%= t('schools.meters.index.validated') %></th>
@@ -128,7 +129,12 @@
           <td><%= meter.mpan_mprn %></td>
           <td><%= meter.name %></td>
           <% if current_user.admin? %>
-            <td><%= link_to meter.data_source.try(:name), admin_data_source_path(meter.data_source) if meter.data_source %></td>
+            <td>
+              <%= link_to meter.data_source.try(:name), admin_data_source_path(meter.data_source) if meter.data_source %>
+            </td>
+            <td>
+              <%= meter.admin_meter_status_label %>
+            </td>
           <% end %>
           <td><%= meter.amr_data_feed_readings.count %></td>
           <td><%= meter.amr_validated_readings.count %></td>

--- a/config/locales/common.yml
+++ b/config/locales/common.yml
@@ -24,7 +24,6 @@ en:
       created: Created
       deactivate: Deactivate
       delete: Delete
-      details: Details
       download: Download
       edit: Edit
       finished: Finished

--- a/config/locales/cy/common.yml
+++ b/config/locales/cy/common.yml
@@ -23,7 +23,6 @@ cy:
       created: Crëwyd
       deactivate: Dadweithredu
       delete: Dileu
-      details: Manylion
       download: Lawrlwytho
       edit: Golygu
       finished: Wedi gorffen

--- a/config/locales/views/schools/schools.yml
+++ b/config/locales/views/schools/schools.yml
@@ -250,6 +250,7 @@ en:
         active_meters: Active meters
         active_pseudo_meters: Active pseudo meters
         add_meter: Add meter
+        admin_meter_status: Admin meter status
         data_processing_turned_on_message: Data processing must be turned on for this school before meter readings can be validated
         data_source: Data source
         details: Details

--- a/db/migrate/20230404132453_add_admin_meter_status_id_to_meter.rb
+++ b/db/migrate/20230404132453_add_admin_meter_status_id_to_meter.rb
@@ -1,0 +1,5 @@
+class AddAdminMeterStatusIdToMeter < ActiveRecord::Migration[6.0]
+  def change
+    add_column :meters, :admin_meter_statuses_id, :bigint
+  end
+end

--- a/db/migrate/20230404135501_add_admin_meter_statuses_id_to_school_group.rb
+++ b/db/migrate/20230404135501_add_admin_meter_statuses_id_to_school_group.rb
@@ -1,0 +1,5 @@
+class AddAdminMeterStatusesIdToSchoolGroup < ActiveRecord::Migration[6.0]
+  def change
+    add_column :school_groups, :admin_meter_statuses_id, :bigint
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_04_04_084117) do
+ActiveRecord::Schema.define(version: 2023_04_04_135501) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
@@ -1089,6 +1089,7 @@ ActiveRecord::Schema.define(version: 2023_04_04_084117) do
     t.bigint "meter_review_id"
     t.datetime "dcc_checked_at"
     t.bigint "data_source_id"
+    t.bigint "admin_meter_statuses_id"
     t.index ["data_source_id"], name: "index_meters_on_data_source_id"
     t.index ["low_carbon_hub_installation_id"], name: "index_meters_on_low_carbon_hub_installation_id"
     t.index ["meter_review_id"], name: "index_meters_on_meter_review_id"
@@ -1301,6 +1302,7 @@ ActiveRecord::Schema.define(version: 2023_04_04_084117) do
     t.integer "default_chart_preference", default: 0, null: false
     t.bigint "default_issues_admin_user_id"
     t.integer "default_country", default: 0, null: false
+    t.bigint "admin_meter_statuses_id"
     t.index ["default_issues_admin_user_id"], name: "index_school_groups_on_default_issues_admin_user_id"
     t.index ["default_scoreboard_id"], name: "index_school_groups_on_default_scoreboard_id"
     t.index ["default_solar_pv_tuos_area_id"], name: "index_school_groups_on_default_solar_pv_tuos_area_id"

--- a/spec/system/meter_management_spec.rb
+++ b/spec/system/meter_management_spec.rb
@@ -76,19 +76,19 @@ RSpec.describe "meter management", :meters, type: :system, include_application_h
 
       it 'the meter inventory button is not shown' do
         click_on 'Manage meters'
-        click_on 'Details'
+        click_on meter.mpan_mprn.to_s
         expect(page).not_to have_button('Inventory')
       end
 
       it 'the tariff report button is not shown' do
         click_on 'Manage meters'
-        click_on 'Details'
+        click_on meter.mpan_mprn.to_s
         expect(page).not_to have_button('Tariff Report')
       end
 
       it 'the attributes button is not shown' do
         click_on 'Manage meters'
-        click_on 'Details'
+        click_on meter.mpan_mprn.to_s
         expect(page).not_to have_button('Attributes')
       end
     end
@@ -183,7 +183,7 @@ RSpec.describe "meter management", :meters, type: :system, include_application_h
         it { expect(page).to have_css("i[class*='fa-exclamation-circle']") }
         it { expect(page).to_not have_css("i[class*='fa-exclamation-circle text-danger']") }
         context "Clicking on meter 'Details'" do
-          before { click_link 'Details' }
+          before { click_link meter.mpan_mprn.to_s }
           it { expect(page).to have_link('Issues')}
           it { expect(page).to_not have_css("i[class*='fa-exclamation-circle text-danger']") }
         end
@@ -198,7 +198,7 @@ RSpec.describe "meter management", :meters, type: :system, include_application_h
         it { expect(page).to have_css("i[class*='fa-exclamation-circle text-danger']") }
 
         context "Clicking on meter 'Details'" do
-          before { click_link 'Details' }
+          before { click_link meter.mpan_mprn.to_s }
           it { expect(page).to have_link('Issues')}
           it { expect(page).to have_css("i[class*='fa-exclamation-circle text-danger']") }
         end
@@ -215,7 +215,7 @@ RSpec.describe "meter management", :meters, type: :system, include_application_h
 
       it 'the meter inventory button can be shown' do
         click_on 'Manage meters'
-        click_on 'Details'
+        click_on meter.mpan_mprn.to_s
         click_on 'Inventory'
         expect(page).to have_content('device_id')
         expect(page).to have_content('123999')
@@ -223,14 +223,14 @@ RSpec.describe "meter management", :meters, type: :system, include_application_h
 
       it 'the tariff report can be shown' do
         click_on 'Manage meters'
-        click_on 'Details'
+        click_on meter.mpan_mprn.to_s
         click_on 'Tariff Report'
         expect(page).to have_content("Standing charges")
       end
 
       it 'the single meter attributes view can be shown' do
         click_on 'Manage meters'
-        click_on 'Details'
+        click_on meter.mpan_mprn.to_s
         click_on 'Attributes'
         expect(page).to have_content("Individual Meter attributes")
       end


### PR DESCRIPTION
- [x] Allow a Meter to be associated with an AdminMeterStatus, updating the meter edit form
- [x] Allow a SchoolGroup to have a default meter status, updating the school group edit form
- [x] Update the meters page to remove the "Details" button, replacing it with a hyperlink on the MPAN MPRN to the same location
- [x] Update the meters page to add a column for the admin meter status for a meter. If there is no meter status set on the individual meter, it should default to that of its group
- [x] Update the meter report at e.g. /admin/school_groups/all-saints-catholic-academy-trust/meter_report to include meter status column, as per meters page
- [x] Update the downloadable meter report at e.g. /admin/school_groups/all-saints-catholic-academy-trust to include column for meter status, as per meters page
- [x] Update the daily import email to include meter status column
