### PR TITLE
Ignore "minimum_might_not_be_accurate"

### DIFF
--- a/app/services/alerts/adapters/report.rb
+++ b/app/services/alerts/adapters/report.rb
@@ -18,8 +18,7 @@ module Alerts
 
       def displayable?
         valid &&
-          !enough_data.nil? &&
-          !(enough_data == :not_enough) &&
+          enough_data == :enough &&
           relevance == :relevant &&
           !rating.nil?
       end

--- a/spec/services/alerts/adapters/report_spec.rb
+++ b/spec/services/alerts/adapters/report_spec.rb
@@ -13,5 +13,14 @@ describe Alerts::Adapters::Report do
 
     it{ expect( Alerts::Adapters::Report.new(valid: true, rating: nil, enough_data: :enough, relevance: :not_relevant)).to_not be_displayable }
     it{ expect( Alerts::Adapters::Report.new(valid: true, rating: nil, enough_data: :enough, relevance: nil)).to_not be_displayable }
+
+    it{ expect( Alerts::Adapters::Report.new(valid: false, rating: 2.0, enough_data: :minimum_might_not_be_accurate, relevance: :relevant)).to_not be_displayable }
+
+    it{ expect( Alerts::Adapters::Report.new(valid: true, rating: nil, enough_data: :minimum_might_not_be_accurate, relevance: nil)).to_not be_displayable }
+
+    it{ expect( Alerts::Adapters::Report.new(valid: true, rating: nil, enough_data: :minimum_might_not_be_accurate, relevance: :relevant)).to_not be_displayable }
+
+    it{ expect( Alerts::Adapters::Report.new(valid: true, rating: 2.0, enough_data: :minimum_might_not_be_accurate, relevance: :relevant)).to_not be_displayable }
+
   end
 end


### PR DESCRIPTION
The alert base class (`ContentBase`) has a method `enough_data` which is used to indicate if there is enough data to run an alert. It can return three values: `:enough`, `:not_enough`, ':minimum_might_not_be_accurate`.

Only two alerts actually return the third value: `AlertImpendingHoliday` and `AlertChangeInElectricityBaseloadShortTerm`, all other alerts return the other values.

The `ContentBase` class also has a method called `make_available_to_users?` which only returns true if an alert is relevant for a school and `enough_data` returns a value of `:enough_data`. The application uses this method to decide whether to store the variables generated by the alert.

So it does _not_ store variables if an alert returns `:minimum_might_not_be_accurate`.

This PR updates the `Alerts::Adapters::Report.displayable?` method to align it with `make_available_to_users?`. E.g. so that an alert is only considered displayable to users if `enough_data` returns `:enough_data`. 

This fixes a bug in `AlertChangeInElectricityBaseloadShortTerm` where there alert is returning `:minimum_might_not_be_accurate` but we are not saving any variables. This leads to the alert messages for users being empty.

It's not clear why we have two different approaches to deciding whether something is displayable, or why they aren't consistent. 

Or why the `:minimum_might_not_be_accurate` option is needed if its so rarely used and is the intention is that users shouldn't see that output.  In the new service interfaces for the advice pages we're just using a simple boolean (`AnalysableMixin.enough_data?`).

I've elected to fix the application side as I think the business logic should sit there.