### PR TITLE
Allow admins to assign meter status to individual meters (3)

### DIFF
--- a/app/controllers/admin/meter_statuses_controller.rb
+++ b/app/controllers/admin/meter_statuses_controller.rb
@@ -35,10 +35,16 @@ module Admin
     end
 
     def destroy
-      @admin_meter_status.destroy
-
       respond_to do |format|
-        format.html { redirect_to admin_meter_statuses_path, notice: "Meter status was successfully deleted." }
+        # Delete button is hidden in the ui when there are associated meters and school groups but
+        # this is left here as a fallback
+        if @admin_meter_status.school_groups.count.zero? && @admin_meter_status.meters.count.zero?
+          @admin_meter_status.destroy
+          notice = 'Meter status was successfully deleted.'
+        else
+          notice = 'Meter status cannot be deleted while it has associated school groups or meters.'
+        end
+        format.html { redirect_to admin_meter_statuses_path, notice: notice }
       end
     end
 

--- a/app/controllers/admin/school_groups_controller.rb
+++ b/app/controllers/admin/school_groups_controller.rb
@@ -56,7 +56,9 @@ module Admin
         :default_chart_preference,
         :default_issues_admin_user_id,
         :public,
-        :admin_meter_statuses_id
+        :admin_meter_statuses_electricity_id,
+        :admin_meter_statuses_gas_id,
+        :admin_meter_statuses_solar_pv_id
       )
     end
   end

--- a/app/models/admin_meter_status.rb
+++ b/app/models/admin_meter_status.rb
@@ -1,4 +1,10 @@
 class AdminMeterStatus < ApplicationRecord
   has_many :meters, foreign_key: 'admin_meter_statuses_id'
-  has_many :school_groups, foreign_key: 'admin_meter_statuses_id'
+  has_many :school_groups_electricity, class_name: 'SchoolGroup', foreign_key: 'admin_meter_statuses_electricity_id'
+  has_many :school_groups_gas, class_name: 'SchoolGroup', foreign_key: 'admin_meter_statuses_gas_id'
+  has_many :school_groups_solar_pv, class_name: 'SchoolGroup', foreign_key: 'admin_meter_statuses_solar_pv_id'
+
+  def school_groups
+    SchoolGroup.where('admin_meter_statuses_electricity_id = :id OR admin_meter_statuses_gas_id = :id OR admin_meter_statuses_solar_pv_id = :id', id: id)
+  end
 end

--- a/app/models/meter.rb
+++ b/app/models/meter.rb
@@ -103,7 +103,7 @@ class Meter < ApplicationRecord
   end
 
   def admin_meter_status_label
-    admin_meter_status&.label || school&.school_group&.admin_meter_status&.label || ''
+    admin_meter_status&.label || school&.school_group&.send(:"admin_meter_status_#{fuel_type}")&.label || ''
   end
 
   def fuel_type

--- a/app/models/meter.rb
+++ b/app/models/meter.rb
@@ -103,7 +103,8 @@ class Meter < ApplicationRecord
   end
 
   def admin_meter_status_label
-    admin_meter_status&.label || school&.school_group&.send(:"admin_meter_status_#{fuel_type}")&.label || ''
+    for_fuel_type = (fuel_type == :exported_solar_pv ? :solar_pv : fuel_type)
+    admin_meter_status&.label || school&.school_group&.send(:"admin_meter_status_#{for_fuel_type}")&.label || ''
   end
 
   def fuel_type

--- a/app/models/school_group.rb
+++ b/app/models/school_group.rb
@@ -58,7 +58,9 @@ class SchoolGroup < ApplicationRecord
   belongs_to :default_weather_station, class_name: 'WeatherStation', foreign_key: 'default_weather_station_id', optional: true
   belongs_to :default_scoreboard, class_name: 'Scoreboard', optional: true
   belongs_to :default_issues_admin_user, class_name: 'User', foreign_key: 'default_issues_admin_user_id', optional: true
-  belongs_to :admin_meter_status, foreign_key: 'admin_meter_statuses_id', optional: true
+  belongs_to :admin_meter_status_electricity, class_name: 'AdminMeterStatus', foreign_key: 'admin_meter_statuses_electricity_id', optional: true
+  belongs_to :admin_meter_status_gas, class_name: 'AdminMeterStatus', foreign_key: 'admin_meter_statuses_gas_id', optional: true
+  belongs_to :admin_meter_status_solar_pv, class_name: 'AdminMeterStatus', foreign_key: 'admin_meter_statuses_solar_pv_id', optional: true
 
   has_many :meter_attributes, inverse_of: :school_group, class_name: 'SchoolGroupMeterAttribute'
 

--- a/app/views/admin/meter_statuses/index.html.erb
+++ b/app/views/admin/meter_statuses/index.html.erb
@@ -13,7 +13,9 @@
         <td><%= status.label %></td>
         <td>
           <%= link_to "Edit", edit_admin_meter_status_path(status), class: 'btn btn-default' %>
-          <%= link_to 'Delete', status, method: :delete, data: { confirm: 'Are you sure you want to delete this meter status?' }, class: 'btn btn-default' %>
+          <% if status.school_groups.count.zero? && status.meters.count.zero? %>
+            <%= link_to 'Delete', status, method: :delete, data: { confirm: 'Are you sure you want to delete this meter status?' }, class: 'btn btn-default' %>
+          <% end %>
         </td>
       </tr>
     <% end %>

--- a/app/views/admin/school_groups/_form.html.erb
+++ b/app/views/admin/school_groups/_form.html.erb
@@ -56,8 +56,18 @@
       </div>
 
       <div class="form-group">
-        <%= f.label :admin_meter_statuses_id, 'Default admin meter status' %>
-        <%= f.select(:admin_meter_statuses_id, AdminMeterStatus.all.collect { |d| [ d.label, d.id ] }, { include_blank: true }, class: 'form-control') %>
+        <%= f.label :admin_meter_statuses_electricity_id, 'Default admin meter status for Electricity' %>
+        <%= f.select(:admin_meter_statuses_electricity_id, AdminMeterStatus.all.collect { |d| [ d.label, d.id ] }, { include_blank: true }, class: 'form-control') %>
+      </div>
+
+      <div class="form-group">
+        <%= f.label :admin_meter_statuses_gas_id, 'Default admin meter status for Gas' %>
+        <%= f.select(:admin_meter_statuses_gas_id, AdminMeterStatus.all.collect { |d| [ d.label, d.id ] }, { include_blank: true }, class: 'form-control') %>
+      </div>
+
+      <div class="form-group">
+        <%= f.label :admin_meter_statuses_solar_pv_id, 'Default admin meter status for Solar PV' %>
+        <%= f.select(:admin_meter_statuses_solar_pv_id, AdminMeterStatus.all.collect { |d| [ d.label, d.id ] }, { include_blank: true }, class: 'form-control') %>
       </div>
 
       <div class="form-group">

--- a/app/views/schools/meters/_active_meters.html.erb
+++ b/app/views/schools/meters/_active_meters.html.erb
@@ -10,7 +10,13 @@
         <%= link_to meter.data_source.try(:name), admin_data_source_path(meter.data_source) if meter.data_source %>
       </td>
       <td>
-        <%= meter.admin_meter_status_label %>
+        <% if meter.admin_meter_status.nil? && meter.admin_meter_status_label.present? %>
+          <span data-toggle="tooltip" title="Default <%= meter.fuel_type.to_s.humanize.downcase %> admin meter status for this school's school group">
+            <%= meter.admin_meter_status_label %>
+          </span>
+        <% else %>
+          <span><%= meter.admin_meter_status_label %></span>
+        <% end %>
       </td>
     <% end %>
     <td><%= meter.amr_data_feed_readings.count %></td>

--- a/db/migrate/20230405085418_add_extra_meter_status_defaults_to_school_groups.rb
+++ b/db/migrate/20230405085418_add_extra_meter_status_defaults_to_school_groups.rb
@@ -1,0 +1,7 @@
+class AddExtraMeterStatusDefaultsToSchoolGroups < ActiveRecord::Migration[6.0]
+  def change
+    rename_column :school_groups, :admin_meter_statuses_id, :admin_meter_statuses_electricity_id
+    add_column :school_groups, :admin_meter_statuses_gas_id, :bigint
+    add_column :school_groups, :admin_meter_statuses_solar_pv_id, :bigint
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_04_04_135501) do
+ActiveRecord::Schema.define(version: 2023_04_05_085418) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
@@ -1302,7 +1302,9 @@ ActiveRecord::Schema.define(version: 2023_04_04_135501) do
     t.integer "default_chart_preference", default: 0, null: false
     t.bigint "default_issues_admin_user_id"
     t.integer "default_country", default: 0, null: false
-    t.bigint "admin_meter_statuses_id"
+    t.bigint "admin_meter_statuses_electricity_id"
+    t.bigint "admin_meter_statuses_gas_id"
+    t.bigint "admin_meter_statuses_solar_pv_id"
     t.index ["default_issues_admin_user_id"], name: "index_school_groups_on_default_issues_admin_user_id"
     t.index ["default_scoreboard_id"], name: "index_school_groups_on_default_scoreboard_id"
     t.index ["default_solar_pv_tuos_area_id"], name: "index_school_groups_on_default_solar_pv_tuos_area_id"


### PR DESCRIPTION
- [x] Allow School Group to have separate default meter status for electricity, gas and solar meters
- [x] When defaulting the meter status for a Meter, use the right default from the group
- [x] Disallow deleting a meter status if it is in use
- [x] Add a tooltip if the meter status is a group default
