### PR TITLE
Translate chart period

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ gem 'pg_search'
 gem 'calculate_in_group'
 
 # Dashboard analytics
-gem 'energy-sparks_analytics', git: 'https://github.com/Energy-Sparks/energy-sparks_analytics.git', tag: '2.5.7'
+gem 'energy-sparks_analytics', git: 'https://github.com/Energy-Sparks/energy-sparks_analytics.git', tag: '2.5.8'
 #gem 'energy-sparks_analytics', git: 'https://github.com/Energy-Sparks/energy-sparks_analytics.git', branch: 'aws-eb-test'
 #gem 'energy-sparks_analytics', path: '../energy-sparks_analytics'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/Energy-Sparks/energy-sparks_analytics.git
-  revision: b55a7bf6f64efb4a84792e17ec1d4c4f541a0db8
-  tag: 2.5.7
+  revision: 60f2f8e08bf555cdd134f3a1e87cfc3564a487f3
+  tag: 2.5.8
   specs:
     energy-sparks_analytics (1.2.1)
       activesupport (~> 6.0.0)

--- a/app/models/chart_data.rb
+++ b/app/models/chart_data.rb
@@ -107,7 +107,7 @@ private
     OPERATIONS.each do |operation_type|
       manipulator = ChartManagerTimescaleManipulation.factory(operation_type, chart_config, @aggregated_school)
       allowed_operations[operation_type] = if manipulator.chart_suitable_for_timescale_manipulation?
-        timescale_description = I18n.t("chart_data.timescale_description.#{manipulator.timescale_description.downcase}", default: nil) || manipulator.timescale_description
+        timescale_description = manipulator.timescale_description
         {
           timescale_description: timescale_description,
           directions: {

--- a/config/locales/analytics/charts/chart_timescale_descriptions.yml
+++ b/config/locales/analytics/charts/chart_timescale_descriptions.yml
@@ -1,0 +1,23 @@
+---
+en:
+  charts:
+    timescale_name:
+      academicyear: academic year
+      daterange: date range
+      day: day
+      diurnal: day with large diurnal range
+      frostday: frosty day
+      frostday_3: frosty day
+      holiday: holiday
+      hotwater: summer period with hot water usage
+      includeholiday: holiday
+      month: month
+      n_weeks: "%{count} weeks"
+      optimum_start: optimum start example day
+      period: period
+      schoolweek: school week
+      up_to_a_year: year
+      week: week
+      workweek: week
+      year: year
+      years: long term

--- a/config/locales/cy/analytics/charts/chart_timescale_descriptions.yml
+++ b/config/locales/cy/analytics/charts/chart_timescale_descriptions.yml
@@ -1,0 +1,8 @@
+---
+cy:
+  charts:
+    timescale_name:
+      day: dydd
+      week: wythnos
+      year: blwyddyn
+      up_to_a_year: blwyddyn

--- a/config/locales/cy/models/chart_data.yml
+++ b/config/locales/cy/models/chart_data.yml
@@ -1,6 +1,0 @@
-cy:
-  chart_data:
-    timescale_description:
-      day: dydd
-      week: wythnos
-      year: blwyddyn

--- a/config/locales/models/chart_data.yml
+++ b/config/locales/models/chart_data.yml
@@ -1,7 +1,0 @@
----
-en:
-  chart_data:
-    timescale_description:
-      day: day
-      week: week
-      year: year


### PR DESCRIPTION
Updates the version of the analytics to incorporate translations for chart periods.

Removes previous approach implemented in the application which only supported a couple of period types.

Manually added Welsh translations for day, week, year, up to a year so the current translations are used until the full set is done.

There's a small functional change here which is a side-effect of the code changes: if there's no Welsh version of some timescales it will default to "period". I think that's reasonable for the moment and is what we use elsewhere.