### PR TITLE
Support default school group data sources

### DIFF
--- a/app/controllers/admin/school_groups/meter_updates_controller.rb
+++ b/app/controllers/admin/school_groups/meter_updates_controller.rb
@@ -5,6 +5,22 @@ module Admin
 
       def index
       end
+
+      def bulk_update_meters
+        meters = @school_group.meters.where(meter_type: meter_types)
+        meters.update_all(data_source_id: meter_update_params[:data_source_id])
+        redirect_to(admin_school_group_path(@school_group), notice: "Meters successfully updated for #{meters.count} for all #{meter_types.to_sentence} meters for this school group.") and return
+      end
+
+      private
+
+      def meter_types
+        @meter_types ||= meter_update_params['meter_update_id'] == 'solar_pv' ? %w(solar_pv exported_solar_pv) : [meter_update_params['meter_update_id']]
+      end
+
+      def meter_update_params
+        params.permit(:data_source_id, :meter_update_id)
+      end
     end
   end
 end

--- a/app/controllers/admin/school_groups/meter_updates_controller.rb
+++ b/app/controllers/admin/school_groups/meter_updates_controller.rb
@@ -1,0 +1,10 @@
+module Admin
+  module SchoolGroups
+    class MeterUpdatesController < AdminController
+      load_and_authorize_resource :school_group
+
+      def index
+      end
+    end
+  end
+end

--- a/app/controllers/admin/school_groups/meter_updates_controller.rb
+++ b/app/controllers/admin/school_groups/meter_updates_controller.rb
@@ -8,7 +8,7 @@ module Admin
 
       def bulk_update_meters
         meters = @school_group.meters.where(meter_type: meter_types)
-        if meters.update_all(data_source_id: meter_update_params[:data_source_id])
+        if meters.update_all(data_source_id: meter_update_params['data_source_id']&.to_i)
           redirect_to(admin_school_group_meter_updates_path(@school_group), notice: "#{meters.count} #{meter_types.to_sentence} #{'meter'.pluralize(meters.count)} successfully updated for this school group.") and return
         else
           render :index, status: :unprocessable_entity
@@ -18,11 +18,11 @@ module Admin
       private
 
       def meter_types
-        @meter_types ||= meter_update_params['meter_update_id'] == 'solar_pv' ? %w(solar_pv exported_solar_pv) : [meter_update_params['meter_update_id']]
+        @meter_types ||= params['meter_update_id'] == 'solar_pv' ? %w(solar_pv exported_solar_pv) : [params['meter_update_id']]
       end
 
       def meter_update_params
-        params.permit(:data_source_id, :meter_update_id)
+        params.require(:meter).permit(:data_source_id)
       end
     end
   end

--- a/app/controllers/admin/school_groups/meter_updates_controller.rb
+++ b/app/controllers/admin/school_groups/meter_updates_controller.rb
@@ -9,7 +9,8 @@ module Admin
       def bulk_update_meters
         meters = @school_group.meters.where(meter_type: meter_types)
         if meters.update_all(data_source_id: meter_update_params['data_source_id']&.to_i)
-          redirect_to(admin_school_group_meter_updates_path(@school_group), notice: "#{meters.count} #{meter_types.to_sentence} #{'meter'.pluralize(meters.count)} successfully updated for this school group.") and return
+          notice = "#{meters.count} #{meter_types.to_sentence} #{'meter'.pluralize(meters.count)} successfully updated for this school group."
+          redirect_to(admin_school_group_meter_updates_path(@school_group), notice: notice) and return
         else
           render :index, status: :unprocessable_entity
         end

--- a/app/controllers/admin/school_groups/meter_updates_controller.rb
+++ b/app/controllers/admin/school_groups/meter_updates_controller.rb
@@ -8,8 +8,11 @@ module Admin
 
       def bulk_update_meters
         meters = @school_group.meters.where(meter_type: meter_types)
-        meters.update_all(data_source_id: meter_update_params[:data_source_id])
-        redirect_to(admin_school_group_path(@school_group), notice: "Meters successfully updated for #{meters.count} for all #{meter_types.to_sentence} meters for this school group.") and return
+        if meters.update_all(data_source_id: meter_update_params[:data_source_id])
+          redirect_to(admin_school_group_meter_updates_path(@school_group), notice: "#{meters.count} #{meter_types.to_sentence} #{'meter'.pluralize(meters.count)} successfully updated for this school group.") and return
+        else
+          render :index, status: :unprocessable_entity
+        end
       end
 
       private

--- a/app/controllers/admin/school_groups_controller.rb
+++ b/app/controllers/admin/school_groups_controller.rb
@@ -58,7 +58,10 @@ module Admin
         :public,
         :admin_meter_statuses_electricity_id,
         :admin_meter_statuses_gas_id,
-        :admin_meter_statuses_solar_pv_id
+        :admin_meter_statuses_solar_pv_id,
+        :default_data_source_electricity_id,
+        :default_data_source_gas_id,
+        :default_data_source_solar_pv_id
       )
     end
   end

--- a/app/models/school_group.rb
+++ b/app/models/school_group.rb
@@ -40,6 +40,7 @@ class SchoolGroup < ApplicationRecord
   friendly_id :name, use: [:finders, :slugged, :history]
 
   has_many :schools
+  has_many :meters, through: :schools
   has_many :school_onboardings
   has_many :calendars, through: :schools
   has_many :users

--- a/app/models/school_group.rb
+++ b/app/models/school_group.rb
@@ -61,6 +61,9 @@ class SchoolGroup < ApplicationRecord
   belongs_to :admin_meter_status_electricity, class_name: 'AdminMeterStatus', foreign_key: 'admin_meter_statuses_electricity_id', optional: true
   belongs_to :admin_meter_status_gas, class_name: 'AdminMeterStatus', foreign_key: 'admin_meter_statuses_gas_id', optional: true
   belongs_to :admin_meter_status_solar_pv, class_name: 'AdminMeterStatus', foreign_key: 'admin_meter_statuses_solar_pv_id', optional: true
+  belongs_to :default_data_source_electricity, class_name: 'DataSource', foreign_key: 'default_data_source_electricity_id', optional: true
+  belongs_to :default_data_source_gas, class_name: 'DataSource', foreign_key: 'default_data_source_gas_id', optional: true
+  belongs_to :default_data_source_solar_pv, class_name: 'DataSource', foreign_key: 'default_data_source_solar_pv_id', optional: true
 
   has_many :meter_attributes, inverse_of: :school_group, class_name: 'SchoolGroupMeterAttribute'
 

--- a/app/views/admin/school_groups/_form.html.erb
+++ b/app/views/admin/school_groups/_form.html.erb
@@ -71,6 +71,21 @@
       </div>
 
       <div class="form-group">
+        <%= f.label :default_data_source_electricity_id, 'Default data source for Electricity' %>
+        <%= f.select(:default_data_source_electricity_id, DataSource.all.collect { |d| [ d.name, d.id ] }, { include_blank: true }, class: 'form-control') %>
+      </div>
+
+      <div class="form-group">
+        <%= f.label :default_data_source_gas_id, 'Default data source for Gas' %>
+        <%= f.select(:default_data_source_gas_id, DataSource.all.collect { |d| [ d.name, d.id ] }, { include_blank: true }, class: 'form-control') %>
+      </div>
+
+      <div class="form-group">
+        <%= f.label :default_data_source_solar_pv_id, 'Default data source for Solar PV' %>
+        <%= f.select(:default_data_source_solar_pv_id, DataSource.all.collect { |d| [ d.name, d.id ] }, { include_blank: true }, class: 'form-control') %>
+      </div>
+
+      <div class="form-group">
         <label><%= t("admin.school_groups.default_chart_preference.form_group") %></label>
         <p class="small"><%= t("admin.school_groups.default_chart_preference.explanation") %></p>
         <% SchoolGroup.default_chart_preferences.keys.each do |preference| %>

--- a/app/views/admin/school_groups/meter_updates/index.html.erb
+++ b/app/views/admin/school_groups/meter_updates/index.html.erb
@@ -1,0 +1,12 @@
+<h1>Bulk meter updates: <%= @school_group.name %></h1>
+
+<% [:electricity, :gas, :solar_pv].each do |fuel_type| %>
+  <%= form_with url: admin_school_group_meter_update_bulk_update_meters_url(meter_update_id: fuel_type), method: :post, format: :html do |form| %>
+    <div class="form-group pb-4">
+      <%= form.label :data_source_id, "Bulk update data source for all #{fuel_type.to_s.humanize.downcase} meters" %>
+      <%= form.select :data_source_id, options_from_collection_for_select(DataSource.all, 'id', 'name', @school_group.send("default_data_source_#{fuel_type}_id")), {include_blank: 'none'}, { class: 'form-control mb-2' } %>
+
+      <%= form.submit 'Update', class: 'btn' %>
+    </div>
+  <% end %>
+<% end %>

--- a/app/views/admin/school_groups/meter_updates/index.html.erb
+++ b/app/views/admin/school_groups/meter_updates/index.html.erb
@@ -1,11 +1,10 @@
 <h1>Bulk meter updates: <%= @school_group.name %></h1>
 
 <% [:electricity, :gas, :solar_pv].each do |fuel_type| %>
-  <%= form_with url: admin_school_group_meter_update_bulk_update_meters_url(meter_update_id: fuel_type), method: :post, format: :html do |form| %>
+  <%= simple_form_for :meter, url: admin_school_group_meter_update_bulk_update_meters_url(meter_update_id: fuel_type), method: :post do |form| %>
     <div class="form-group pb-4">
       <%= form.label :data_source_id, "Bulk update data source for all #{fuel_type.to_s.humanize.downcase} meters" %>
       <%= form.select :data_source_id, options_from_collection_for_select(DataSource.all, 'id', 'name', @school_group.send("default_data_source_#{fuel_type}_id")), {include_blank: 'none'}, { class: 'form-control mb-2' } %>
-
       <%= form.submit 'Update', class: 'btn' %>
     </div>
   <% end %>

--- a/app/views/admin/school_groups/show.html.erb
+++ b/app/views/admin/school_groups/show.html.erb
@@ -48,6 +48,7 @@
   <%= link_to 'Edit', edit_admin_school_group_path(@school_group), class: 'btn btn-sm' %>
   <%= link_to 'Manage partners', admin_school_group_partners_path(@school_group), class: 'btn btn-sm' %>
   <%= link_to 'Meter attributes', admin_school_group_meter_attributes_path(@school_group), class: 'btn btn-sm' %>
+  <%= link_to 'Meter updates', admin_school_group_meter_updates_path(@school_group), class: 'btn btn-sm' %>
   <%= link_to 'Meter report', admin_school_group_meter_report_path(@school_group), class: 'btn btn-sm' %>
   <%= link_to "#{fa_icon('file-download')} Meter report".html_safe, admin_school_group_meter_report_path(@school_group, format: :csv) , class: 'btn btn-sm', title: "Download meter report csv" %>
   <%= link_to "#{fa_icon('file-download')} Issues".html_safe, admin_school_group_issues_path(@school_group, format: :csv) , class: 'btn btn-sm', title: "Download issues csv" %>

--- a/app/views/schools/meters/_form.html.erb
+++ b/app/views/schools/meters/_form.html.erb
@@ -75,3 +75,22 @@
     <%= form.submit submit_label, class: 'btn btn-primary'%>
   </div>
 <% end %>
+
+<script>
+  $("input[type='radio'][name='meter[meter_type]']").change(function () {
+    switch($("input[type='radio'][name='meter[meter_type]']:checked").val()) {
+      case 'electricity':
+        document.getElementById('meter_data_source_id').value=<%= @school&.school_group&.default_data_source_electricity_id %>
+        break;
+      case 'gas':
+        document.getElementById('meter_data_source_id').value=<%= @school&.school_group&.default_data_source_gas_id %>
+        break;
+      case 'solar_pv':
+        document.getElementById('meter_data_source_id').value=<%= @school&.school_group&.default_data_source_solar_pv_id %>
+        break;
+      case 'exported_solar_pv':
+        document.getElementById('meter_data_source_id').value=<%= @school&.school_group&.default_data_source_solar_pv_id %>
+        break;
+    }
+  })
+</script>

--- a/app/views/schools/meters/_form.html.erb
+++ b/app/views/schools/meters/_form.html.erb
@@ -80,16 +80,16 @@
   $("input[type='radio'][name='meter[meter_type]']").change(function () {
     switch($("input[type='radio'][name='meter[meter_type]']:checked").val()) {
       case 'electricity':
-        document.getElementById('meter_data_source_id').value=<%= @school&.school_group&.default_data_source_electricity_id %>
+        document.getElementById('meter_data_source_id').value=<%= @school&.school_group&.default_data_source_electricity_id || 'null' %>
         break;
       case 'gas':
-        document.getElementById('meter_data_source_id').value=<%= @school&.school_group&.default_data_source_gas_id %>
+        document.getElementById('meter_data_source_id').value=<%= @school&.school_group&.default_data_source_gas_id || 'null' %>
         break;
       case 'solar_pv':
-        document.getElementById('meter_data_source_id').value=<%= @school&.school_group&.default_data_source_solar_pv_id %>
+        document.getElementById('meter_data_source_id').value=<%= @school&.school_group&.default_data_source_solar_pv_id || 'null' %>
         break;
       case 'exported_solar_pv':
-        document.getElementById('meter_data_source_id').value=<%= @school&.school_group&.default_data_source_solar_pv_id %>
+        document.getElementById('meter_data_source_id').value=<%= @school&.school_group&.default_data_source_solar_pv_id || 'null' %>
         break;
     }
   })

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -372,7 +372,9 @@ Rails.application.routes.draw do
     resources :school_groups do
       scope module: :school_groups do
         resources :meter_attributes
-        resources :meter_updates
+        resources :meter_updates, only: [:index] do
+          post :bulk_update_meters
+        end
         resources :school_onboardings, only: [:index] do
           collection do
             post :reminders

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -372,6 +372,7 @@ Rails.application.routes.draw do
     resources :school_groups do
       scope module: :school_groups do
         resources :meter_attributes
+        resources :meter_updates
         resources :school_onboardings, only: [:index] do
           collection do
             post :reminders

--- a/db/migrate/20230405110515_add_default_data_sources_to_school_group.rb
+++ b/db/migrate/20230405110515_add_default_data_sources_to_school_group.rb
@@ -1,0 +1,7 @@
+class AddDefaultDataSourcesToSchoolGroup < ActiveRecord::Migration[6.0]
+  def change
+    add_column :school_groups, :default_data_source_electricity_id, :bigint
+    add_column :school_groups, :default_data_source_gas_id, :bigint
+    add_column :school_groups, :default_data_source_solar_pv_id, :bigint
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_04_05_085418) do
+ActiveRecord::Schema.define(version: 2023_04_05_110515) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
@@ -1305,6 +1305,9 @@ ActiveRecord::Schema.define(version: 2023_04_05_085418) do
     t.bigint "admin_meter_statuses_electricity_id"
     t.bigint "admin_meter_statuses_gas_id"
     t.bigint "admin_meter_statuses_solar_pv_id"
+    t.bigint "default_data_source_electricity_id"
+    t.bigint "default_data_source_gas_id"
+    t.bigint "default_data_source_solar_pv_id"
     t.index ["default_issues_admin_user_id"], name: "index_school_groups_on_default_issues_admin_user_id"
     t.index ["default_scoreboard_id"], name: "index_school_groups_on_default_scoreboard_id"
     t.index ["default_solar_pv_tuos_area_id"], name: "index_school_groups_on_default_solar_pv_tuos_area_id"


### PR DESCRIPTION
- [x] Update School Group model to allow a separate default Data Source to be set for electricity, gas and solar meters
- [x] Add a new admin only page "Meter Updates" at a school group level, linked from the admin view of school group, e.g. /admin/school_groups/aces-academies-trust. Add button next to Meter Attributes
- [x] On the "Meter Updates" page provide a form to allow an admin to bulk update the Data Source attribute for all meters of a specified type, for all schools in that group. E.g. set all Gas meters to "British Gas".
- [x] On the above form, the default selected data source for a meter type should be the default set for the group (if any)
- [x] After doing a bulk update, it should confirm how many meters were updated
- [x] On the meter creation form, the Data Source field should default to the right value for the School Group associated with the school. This means changing the meter type radio button should change the selected default value.