### PR TITLE
Small tweaks to the performance of school group reports

### DIFF
--- a/app/controllers/admin/school_groups/meter_reports_controller.rb
+++ b/app/controllers/admin/school_groups/meter_reports_controller.rb
@@ -46,7 +46,7 @@ module Admin
                 meter.meter_type,
                 meter.mpan_mprn,
                 meter.name,
-                meter.data_source.try(:name),
+                meter.data_source.try(:name) || '',
                 y_n(meter.active),
                 nice_dates(meter.first_validated_reading),
                 nice_dates(meter.last_validated_reading),

--- a/app/models/meter.rb
+++ b/app/models/meter.rb
@@ -133,7 +133,7 @@ class Meter < ApplicationRecord
     # only interested if there are enough non_ORIG readings
     return [] unless amr_validated_readings.since(since_date).modified.count >= gap_size
     # find chunks where consecutive readings were all non-ORIG
-    gaps = amr_validated_readings.since(since_date).by_date.chunk_while { |r1, r2| r1.modified && r2.modified }
+    gaps = amr_validated_readings.since(since_date).by_date.select(:reading_date, :status).chunk_while { |r1, r2| r1.status != 'ORIG' && r2.status != 'ORIG' }
     # return chunks of specified size or bigger
     gaps.select { |gap| gap.count >= gap_size }
   end
@@ -143,7 +143,7 @@ class Meter < ApplicationRecord
   end
 
   def zero_reading_days_warning?
-    return true if fuel_type == :electricity && zero_reading_days.count > 0
+    return true if fuel_type == :electricity && zero_reading_days.any?
   end
 
   def name_or_mpan_mprn


### PR DESCRIPTION
Couple of smallish performance tweaks to the school group report

- use `.any?` instead of `.count`
- just `select` the fields we need for display of gaps
- do checks for modified readings against the model attribute (`.status`) rather than using a secondary query (`.modified`)

