### PR TITLE
Fix some issues with school target reporting

### DIFF
--- a/app/classes/targets/fuel_progress.rb
+++ b/app/classes/targets/fuel_progress.rb
@@ -18,7 +18,7 @@ module Targets
       @recent_data
     end
 
-    def can_chart?
+    def valid?
       @usage.present? && @target.present?
     end
 

--- a/app/views/schools/school_targets/_target_table_row.html.erb
+++ b/app/views/schools/school_targets/_target_table_row.html.erb
@@ -2,7 +2,7 @@
   <td class="icon"><span class="<%=fuel_type_class(fuel_type)%>"><%= fa_icon fuel_type_icon(fuel_type) %></span></td>
   <td><%= fuel_type.to_s.humanize %></td>
   <td class="text-right"><%= -school_target[fuel_type] %>%</td>
-  <% if fuel_progress.present? && fuel_progress.can_chart? %>
+  <% if fuel_progress.present? && fuel_progress.valid? %>
       <td class="text-right"><%= up_downify(format_target(fuel_progress.progress, :relative_percent)) %></td>
       <td class="text-right"><%= link_to t('schools.school_targets.target_table_row.view_monthly_report'), report_link, class: "btn btn-outline-dark font-weight-bold" %></td>
   <% else %>

--- a/lib/tasks/deployment/20230411111243_remove_target_advice.rake
+++ b/lib/tasks/deployment/20230411111243_remove_target_advice.rake
@@ -1,0 +1,15 @@
+namespace :after_party do
+  desc 'Deployment task: remove_target_advice'
+  task remove_target_advice: :environment do
+    puts "Running deploy task 'remove_target_advice'"
+
+    ["AdviceTargetsElectricity", "AdviceTargetsGas"].each do |class_name|
+      AlertType.find_by_class_name(class_name)&.destroy
+    end
+
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord
+      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+  end
+end

--- a/spec/services/targets/generate_progress_service_spec.rb
+++ b/spec/services/targets/generate_progress_service_spec.rb
@@ -199,10 +199,29 @@ describe Targets::GenerateProgressService do
         allow_any_instance_of(TargetsService).to receive(:progress).and_return(progress)
         allow_any_instance_of(TargetsService).to receive(:recent_data?).and_return(true)
       end
-      it 'generates' do
+      it 'still generates' do
         expect( service.generate! ).to eq school_target
       end
     end
+
+    context 'and there is an error in the progress report generation' do
+      let(:target) { service.generate! }
+
+      before(:each) do
+        allow_any_instance_of(TargetsService).to receive(:enough_data_to_set_target?).and_return(true)
+        allow_any_instance_of(TargetsService).to receive(:progress).and_raise(StandardError.new('test requested'))
+      end
+
+      it 'records when last run' do
+        expect( target.report_last_generated ).to_not be_nil
+      end
+
+      it 'sets values to nil' do
+        expect( target.electricity_progress ).to eq({})
+        expect( target.electricity_report ).to be_nil
+      end
+    end
+
   end
 
 end


### PR DESCRIPTION
Fixes several issues with school targets feature:

* [x] Avoid storing empty FuelProgress instances, which can happen if exceptions are thrown calculating cumulative & monthly progress
* [x] For gas, check whether we can actually generate a report in the "enough data" check. This avoids throwing repeated exceptions if a school doesn't have enough data to generate a summer heating model
* [x] Disable old target advice pages, as these were never used