### PR TITLE
Check for target meter calculation errors

### DIFF
--- a/app/services/targets/generate_progress_service.rb
+++ b/app/services/targets/generate_progress_service.rb
@@ -126,10 +126,10 @@ module Targets
     def enough_data_to_calculate_target?(fuel_type)
       begin
         return false unless target_service(fuel_type).enough_data_to_set_target?
-        #introduce extra check for gas only. Sometimes the heating model fails
-        #because there isn't enough data in summer. So trigger that here if possible
-        #needs a better upstream fix
-        target_service(fuel_type).progress if fuel_type == :gas
+        calculation_error = target_service(fuel_type).target_meter_calculation_problem
+        if calculation_error.present?
+          raise StandardError, calculation_error[:text]
+        end
         true
       rescue => e
         report_to_rollbar_once(e, fuel_type)

--- a/spec/services/targets/generate_progress_service_spec.rb
+++ b/spec/services/targets/generate_progress_service_spec.rb
@@ -49,6 +49,7 @@ describe Targets::GenerateProgressService do
     context 'and there is an error in the progress report generation' do
       before(:each) do
         allow_any_instance_of(TargetsService).to receive(:enough_data_to_set_target?).and_return(true)
+        allow_any_instance_of(TargetsService).to receive(:target_meter_calculation_problem).and_return(nil)
         allow_any_instance_of(TargetsService).to receive(:progress).and_raise(StandardError.new('test requested'))
       end
 
@@ -79,6 +80,7 @@ describe Targets::GenerateProgressService do
 
         before(:each) do
           allow_any_instance_of(TargetsService).to receive(:enough_data_to_set_target?).and_return(true)
+          allow_any_instance_of(TargetsService).to receive(:target_meter_calculation_problem).and_return(nil)
           allow_any_instance_of(TargetsService).to receive(:progress).and_return(progress)
         end
 
@@ -93,6 +95,7 @@ describe Targets::GenerateProgressService do
 
       before(:each) do
         allow_any_instance_of(TargetsService).to receive(:enough_data_to_set_target?).and_return(true)
+        allow_any_instance_of(TargetsService).to receive(:target_meter_calculation_problem).and_return(nil)
         allow_any_instance_of(TargetsService).to receive(:progress).and_return(progress)
       end
 
@@ -105,6 +108,7 @@ describe Targets::GenerateProgressService do
   context '#current_monthly_target' do
     before(:each) do
       allow_any_instance_of(TargetsService).to receive(:enough_data_to_set_target?).and_return(true)
+      allow_any_instance_of(TargetsService).to receive(:target_meter_calculation_problem).and_return(nil)
       allow_any_instance_of(TargetsService).to receive(:progress).and_return(progress)
     end
 
@@ -117,6 +121,7 @@ describe Targets::GenerateProgressService do
 
       before(:each) do
         allow_any_instance_of(TargetsService).to receive(:enough_data_to_set_target?).and_return(true)
+        allow_any_instance_of(TargetsService).to receive(:target_meter_calculation_problem).and_return(nil)
         allow_any_instance_of(TargetsService).to receive(:progress).and_return(progress)
       end
 
@@ -129,6 +134,7 @@ describe Targets::GenerateProgressService do
   context '#current_monthly_usage' do
     before(:each) do
       allow_any_instance_of(TargetsService).to receive(:enough_data_to_set_target?).and_return(true)
+      allow_any_instance_of(TargetsService).to receive(:target_meter_calculation_problem).and_return(nil)
       allow_any_instance_of(TargetsService).to receive(:progress).and_return(progress)
     end
 
@@ -160,6 +166,7 @@ describe Targets::GenerateProgressService do
 
       before(:each) do
         allow_any_instance_of(TargetsService).to receive(:enough_data_to_set_target?).and_return(true)
+        allow_any_instance_of(TargetsService).to receive(:target_meter_calculation_problem).and_return(nil)
         allow_any_instance_of(TargetsService).to receive(:progress).and_return(progress)
         allow_any_instance_of(TargetsService).to receive(:recent_data?).and_return(true)
       end
@@ -196,6 +203,7 @@ describe Targets::GenerateProgressService do
 
       before(:each) do
         allow_any_instance_of(TargetsService).to receive(:enough_data_to_set_target?).and_return(true)
+        allow_any_instance_of(TargetsService).to receive(:target_meter_calculation_problem).and_return(nil)
         allow_any_instance_of(TargetsService).to receive(:progress).and_return(progress)
         allow_any_instance_of(TargetsService).to receive(:recent_data?).and_return(true)
       end
@@ -209,6 +217,7 @@ describe Targets::GenerateProgressService do
 
       before(:each) do
         allow_any_instance_of(TargetsService).to receive(:enough_data_to_set_target?).and_return(true)
+        allow_any_instance_of(TargetsService).to receive(:target_meter_calculation_problem).and_return(nil)
         error = StandardError.new('test requested')
         allow_any_instance_of(TargetsService).to receive(:progress).and_raise(error)
         expect(Rollbar).to receive(:error).with(error, scope: :generate_progress, school_id: school.id, school: school.name, fuel_type: :electricity)


### PR DESCRIPTION
Revise approach for reporting errors from generating the target meter.

Instead check for the error reports logged by the TargetSchool class, then rethrow as exception. Ideally we should refactor the analytics to throw these directly, but for the moment this should help clarify error reports in Rollbar.

