### PR TITLE
Improve SolarEdge feed setup process

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ gem 'pg_search'
 gem 'calculate_in_group'
 
 # Dashboard analytics
-gem 'energy-sparks_analytics', git: 'https://github.com/Energy-Sparks/energy-sparks_analytics.git', tag: '2.5.8'
+gem 'energy-sparks_analytics', git: 'https://github.com/Energy-Sparks/energy-sparks_analytics.git', tag: '2.6.0'
 #gem 'energy-sparks_analytics', git: 'https://github.com/Energy-Sparks/energy-sparks_analytics.git', branch: 'aws-eb-test'
 #gem 'energy-sparks_analytics', path: '../energy-sparks_analytics'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/Energy-Sparks/energy-sparks_analytics.git
-  revision: 60f2f8e08bf555cdd134f3a1e87cfc3564a487f3
-  tag: 2.5.8
+  revision: fbd14aa2f524fce7041243b26e93663eafb6f5f7
+  tag: 2.6.0
   specs:
     energy-sparks_analytics (1.2.1)
       activesupport (~> 6.0.0)

--- a/app/services/solar/base_download_and_upsert.rb
+++ b/app/services/solar/base_download_and_upsert.rb
@@ -9,10 +9,10 @@ module Solar
     def perform
       download_and_upsert
     rescue => e
-      import_log.update!(error_messages: "Error downloading data from #{start_date} to #{end_date} : #{e.message}")
+      import_log.update!(error_messages: "Error downloading data from #{start_date} to #{end_date} for #{school.name} : #{e.class}  #{e.message}")
       Rails.logger.error "Exception: downloading solar data from #{start_date} to #{end_date} : #{e.class} #{e.message}"
       Rails.logger.error e.backtrace.join("\n")
-      Rollbar.error(e, job: job, school: school.name, start_date: start_date, end_date: end_date)
+      Rollbar.error(e, job: job, school: school.name, start_date: start_date, end_date: end_date, installation_id: @installation.id)
     end
 
     protected

--- a/app/services/solar/low_carbon_hub_upserter.rb
+++ b/app/services/solar/low_carbon_hub_upserter.rb
@@ -18,12 +18,14 @@ module Solar
         meter = Meter.find_or_create_by!(
           meter_type: meter_type,
           mpan_mprn: mpan_mprn,
-          low_carbon_hub_installation_id: @low_carbon_hub_installation.id,
-          school: @low_carbon_hub_installation.school,
-          pseudo: true
+          school: @low_carbon_hub_installation.school
         ) do |new_record|
           new_record.name = meter_type.to_s.humanize
+          new_record.pseudo = true
+          new_record.low_carbon_hub_installation = @low_carbon_hub_installation
         end
+
+        update_existing_meter_if_needed(meter)
 
         Amr::DataFeedUpserter.new(data_feed_reading_array(readings_hash, meter.id, mpan_mprn), @amr_data_feed_import_log).perform
         Rails.logger.info "Upserted #{@amr_data_feed_import_log.records_updated} inserted #{@amr_data_feed_import_log.records_imported}for #{@low_carbon_hub_installation.rbee_meter_id} at #{@low_carbon_hub_installation.school.name}"
@@ -31,6 +33,17 @@ module Solar
     end
 
     private
+
+    #manually created meters may not be associated with the installation, update
+    #if not
+    def update_existing_meter_if_needed(meter)
+      if !meter.pseudo? || meter.low_carbon_hub_installation.nil?
+        meter.update!(
+          pseudo: true,
+          low_carbon_hub_installation: @low_carbon_hub_installation
+        )
+      end
+    end
 
     def data_feed_reading_array(readings_hash, meter_id, mpan_mprn)
       readings_hash.map do |reading_date, one_day_amr_reading|

--- a/app/services/solar/solar_edge_download_and_upsert.rb
+++ b/app/services/solar/solar_edge_download_and_upsert.rb
@@ -20,7 +20,7 @@ module Solar
     private
 
     def solar_edge_api
-      SolarEdgeSolarPV.new(@installation.api_key)
+      SolarEdgeAPI.new(@installation.api_key)
     end
   end
 end

--- a/app/services/solar/solar_edge_installation_factory.rb
+++ b/app/services/solar/solar_edge_installation_factory.rb
@@ -1,0 +1,64 @@
+require 'dashboard'
+
+module Solar
+  class SolarEdgeInstallationFactory
+    def initialize(
+        school:,
+        mpan:,
+        site_id:,
+        api_key:,
+        amr_data_feed_config:
+      )
+      @school = school
+      @mpan = mpan
+      @site_id = site_id
+      @api_key = api_key
+      @amr_data_feed_config = amr_data_feed_config
+      raise ArgumentError, 'Amr Data Feed Config is not set for the Solar Edge API' unless amr_data_feed_config.solar_edge_api?
+    end
+
+    def self.update_information(installation)
+      begin
+        solar_edge_api = SolarEdgeAPI.new(installation.api_key)
+        installation.update(information: {
+          site_details: solar_edge_api.site_details,
+          dates: solar_edge_api.site_start_end_dates(installation.site_id)
+        })
+      rescue => e
+        Rollbar.error(e, job: :solar_download, school: installation.school)
+      end
+    end
+
+    def perform
+      installation = SolarEdgeInstallation.where(school_id: @school.id, mpan: @mpan, site_id: @site_id, api_key: @api_key, amr_data_feed_config: @amr_data_feed_config).first_or_create!
+
+      installation.update(information: information)
+
+      # Retrieve two days worth of data, just to get the meters set up and ensure some data comes back
+      SolarEdgeDownloadAndUpsert.new(
+        installation: installation,
+        start_date: first_reading_date,
+        end_date: first_reading_date + 1.day
+      ).perform
+
+      installation
+    end
+
+    private
+
+    def solar_edge_api
+      @solar_edge_api ||= SolarEdgeAPI.new(@api_key)
+    end
+
+    def first_reading_date
+      @first_reading_date ||= solar_edge_api.site_start_end_dates(@site_id).first
+    end
+
+    def information
+      {
+        site_details: solar_edge_api.site_details,
+        dates: solar_edge_api.site_start_end_dates(@site_id)
+      }
+    end
+  end
+end

--- a/app/views/schools/meters/_inactive_meters.html.erb
+++ b/app/views/schools/meters/_inactive_meters.html.erb
@@ -1,0 +1,49 @@
+<% inactive_meters.each do |meter| %>
+  <tr scope="row">
+    <td title="<%= (meter.meter_type.to_s.humanize) %>"><%= fa_icon(fuel_type_icon(meter.meter_type)) %></td>
+    <td><%= meter.mpan_mprn %></td>
+    <td><%= meter.name %></td>
+    <% if current_user.admin? %>
+      <td>
+        <%= link_to meter.data_source.try(:name), admin_data_source_path(meter.data_source) if meter.data_source %>
+      </td>
+      <td>
+        <%= meter.admin_meter_status_label %>
+      </td>
+    <% end %>
+    <td><%= meter.amr_data_feed_readings.count %></td>
+    <td><%= meter.amr_validated_readings.count %></td>
+    <td><%= short_dates meter.first_validated_reading %></td>
+    <td><%= short_dates meter.last_validated_reading %></td>
+    <td><%= meter.zero_reading_days.count %></td>
+    <td><%= meter.gappy_validated_readings.count %></td>
+    <td>
+      <div class="btn-group btn-group-sm" role="group">
+        <% if can?(:edit, meter) %>
+          <%= link_to t('schools.meters.index.details'), school_meter_path(@school, meter), class: 'btn btn-sm' %>
+        <% end %>
+        <% if can?(:report_on, meter) && meter.amr_validated_readings.any? %>
+          <%= link_to t('schools.meters.index.report'), admin_reports_amr_validated_reading_path(meter), class: 'btn btn-sm' %>
+        <% end %>
+        <% if can?(:report_on, meter) && meter.amr_validated_readings.any? %>
+          <%= link_to school_meter_path(@school, meter, format: "csv"), class: 'btn btn-info btn-sm' do %>
+            <%= fa_icon('file-download') %>
+          <% end %>
+        <% end %>
+        <%= render 'admin/issues/modal', meter: meter if current_user.admin? %>
+      </div>
+    </td>
+    <td>
+      <div class="btn-group btn-group-sm" role="group">
+        <%= link_to t('common.labels.edit'), edit_school_meter_path(@school, meter), class: 'btn btn-sm' if can?(:edit, meter) %>
+        <%= link_to t('common.labels.activate'), activate_school_meter_path(@school, meter), method: :put, class: 'btn btn-sm' if can?(:activate, meter) %>
+        <% if can? :delete, meter %>
+          <%= link_to t('common.labels.delete'), school_meter_path(@school, meter), method: :delete, data: { confirm: t('common.confirm') }, class: 'btn btn-sm' %>
+        <% else %>
+          <button class="btn btn-sm" disabled title="<%= t('schools.meters.index.only_admins_message') %>"><%= t('common.labels.delete') %></button>
+        <% end %>
+
+      </div>
+    </td>
+  </tr>
+<% end %>

--- a/app/views/schools/meters/index.html.erb
+++ b/app/views/schools/meters/index.html.erb
@@ -116,64 +116,18 @@
   </tbody>
   <% end %>
 
-  <% if @inactive_meters.any? %>
+  <% if @inactive_meters.any? || @inactive_pseudo_meters.any? %>
     <thead>
       <tr class="bg-light">
         <th colspan="<%= colspan %>"><%= t('schools.meters.index.inactive_meters') %></th>
       </tr>
     </thead>
     <tbody>
-      <% @inactive_meters.each do |meter| %>
-        <tr scope="row">
-          <td title="<%= (meter.meter_type.to_s.humanize) %>"><%= fa_icon(fuel_type_icon(meter.meter_type)) %></td>
-          <td><%= meter.mpan_mprn %></td>
-          <td><%= meter.name %></td>
-          <% if current_user.admin? %>
-            <td>
-              <%= link_to meter.data_source.try(:name), admin_data_source_path(meter.data_source) if meter.data_source %>
-            </td>
-            <td>
-              <%= meter.admin_meter_status_label %>
-            </td>
-          <% end %>
-          <td><%= meter.amr_data_feed_readings.count %></td>
-          <td><%= meter.amr_validated_readings.count %></td>
-          <td><%= short_dates meter.first_validated_reading %></td>
-          <td><%= short_dates meter.last_validated_reading %></td>
-          <td><%= meter.zero_reading_days.count %></td>
-          <td><%= meter.gappy_validated_readings.count %></td>
-          <td>
-            <div class="btn-group btn-group-sm" role="group">
-              <% if can?(:edit, meter) %>
-                <%= link_to t('schools.meters.index.details'), school_meter_path(@school, meter), class: 'btn btn-sm' %>
-              <% end %>
-              <% if can?(:report_on, meter) && meter.amr_validated_readings.any? %>
-                <%= link_to t('schools.meters.index.report'), admin_reports_amr_validated_reading_path(meter), class: 'btn btn-sm' %>
-              <% end %>
-              <% if can?(:report_on, meter) && meter.amr_validated_readings.any? %>
-                <%= link_to school_meter_path(@school, meter, format: "csv"), class: 'btn btn-info btn-sm' do %>
-                  <%= fa_icon('file-download') %>
-                <% end %>
-              <% end %>
-              <%= render 'admin/issues/modal', meter: meter if current_user.admin? %>
-            </div>
-          </td>
-          <td>
-            <div class="btn-group btn-group-sm" role="group">
-              <%= link_to t('common.labels.edit'), edit_school_meter_path(@school, meter), class: 'btn btn-sm' if can?(:edit, meter) %>
-              <%= link_to t('common.labels.activate'), activate_school_meter_path(@school, meter), method: :put, class: 'btn btn-sm' if can?(:activate, meter) %>
-              <% if can? :delete, meter %>
-                <%= link_to t('common.labels.delete'), school_meter_path(@school, meter), method: :delete, data: { confirm: t('common.confirm') }, class: 'btn btn-sm' %>
-              <% else %>
-                <button class="btn btn-sm" disabled title="<%= t('schools.meters.index.only_admins_message') %>"><%= t('common.labels.delete') %></button>
-              <% end %>
-
-            </div>
-          </td>
-        </tr>
-      <% end %>
+      <%= render 'inactive_meters', inactive_meters: @inactive_meters %>
+      <%= render 'inactive_meters', inactive_meters: @inactive_pseudo_meters %>
     </tbody>
   <% end %>
+
 </table>
 </div>
 

--- a/app/views/schools/solar_edge_installations/show.html.erb
+++ b/app/views/schools/solar_edge_installations/show.html.erb
@@ -1,0 +1,22 @@
+<h1><%= @school.name %> Site id <%= @solar_edge_installation.site_id %></h1>
+
+<p><%= link_to "All Solar API feeds for #{@school.name}",  school_solar_feeds_configuration_index_path(@school) %>
+
+<table class="table">
+  <thead>
+    <tr>
+      <th>Field</th>
+      <th>Value</th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @solar_edge_installation.information.each do |key, value| %>
+      <tr>
+        <th><%= key %></th>
+        <td><%= value %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<p><%= link_to 'Delete', school_solar_edge_installation_path(@school, @solar_edge_installation), method: :delete, data: { confirm: 'Are you sure?' }, class: 'btn' %>

--- a/app/views/schools/solar_feeds_configuration/_solar_edge_feeds.html.erb
+++ b/app/views/schools/solar_feeds_configuration/_solar_edge_feeds.html.erb
@@ -9,7 +9,7 @@
       </tr>
       <% solar_edge_installations.each do |installation| %>
         <tr>
-          <td><%= installation.mpan %></td>
+          <td><%= link_to installation.mpan, school_solar_edge_installation_path(school, installation) %></td>
           <td><%= installation.site_id %></td>
           <td><%= installation.api_key %></td>
           <td>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -239,7 +239,7 @@ Rails.application.routes.draw do
 
       resources :solar_feeds_configuration, only: [:index]
 
-      resources :solar_edge_installations, only: [:new, :create, :edit, :update, :destroy]
+      resources :solar_edge_installations, only: [:new, :show, :create, :edit, :update, :destroy]
       resources :low_carbon_hub_installations, only: [:new, :show, :create, :edit, :update, :destroy]
       resources :rtone_variant_installations, only: [:new, :create, :edit, :update, :destroy]
 

--- a/lib/tasks/solar/import_solar_edge_readings.rake
+++ b/lib/tasks/solar/import_solar_edge_readings.rake
@@ -7,7 +7,7 @@ namespace :solar do
 
     puts "#{DateTime.now.utc} import_solar_edge_readings start"
     SolarEdgeInstallation.all.each do |installation|
-      puts "Running for #{installation.site_id}"
+      puts "Running for #{installation.school.name} #{installation.site_id}"
       Solar::SolarEdgeDownloadAndUpsert.new(installation: installation, start_date: start_date, end_date: end_date).perform
     end
     Database::VacuumService.new([:amr_data_feed_readings]).perform

--- a/spec/services/solar/low_carbon_hub_upserter_spec.rb
+++ b/spec/services/solar/low_carbon_hub_upserter_spec.rb
@@ -1,0 +1,146 @@
+require 'rails_helper'
+
+module Solar
+  describe LowCarbonHubUpserter do
+
+    let!(:school)               { create(:school) }
+    let(:rbee_meter_id)         { "216057958" }
+
+    let(:low_carbon_hub_installation)  { create(:low_carbon_hub_installation, rbee_meter_id: rbee_meter_id, school: school)}
+    let(:import_log)    { create(:amr_data_feed_import_log) }
+
+    let(:solar_pv_readings)           { { "Sun, 29 Nov 2020" => Array.new(48, 1.0), "Mon, 30 Nov 2020" => Array.new(48, 2.0) } }
+    let(:electricity_readings)        { { "Sun, 29 Nov 2020" => Array.new(48, 3.0), "Mon, 30 Nov 2020" => Array.new(48, 4.0) } }
+    let(:exported_solar_pv_readings)  { { "Sun, 29 Nov 2020" => Array.new(48, 5.0), "Mon, 30 Nov 2020" => Array.new(48, 6.0) } }
+
+    let(:start_date)            { Date.parse('02/08/2016') }
+    let(:end_date)              { start_date + 1.day }
+
+    let(:readings) do
+      {
+        solar_pv: {
+          mpan_mprn: expected_solar_pv_mpan,
+          readings: {
+            start_date => OneDayAMRReading.new(70000000123085, start_date, 'ORIG', nil, start_date, Array.new(48, 0.25)),
+            end_date => OneDayAMRReading.new(70000000123085, end_date, 'ORIG', nil, end_date, Array.new(48, 0.5))
+          }
+        },
+        electricity: {
+          mpan_mprn: expected_electricity_mpan,
+          readings: {
+            start_date => OneDayAMRReading.new(90000000123085, start_date, 'ORIG', nil, start_date, Array.new(48, 0.25)),
+            end_date => OneDayAMRReading.new(90000000123085, end_date, 'ORIG', nil, end_date, Array.new(48, 0.5))
+          }
+        },
+        exported_solar_pv: {
+          mpan_mprn: expected_exported_solar_pv_mpan,
+          readings: {
+            start_date => OneDayAMRReading.new(60000000123085, start_date, 'ORIG', nil, start_date, Array.new(48, 0.25)),
+            end_date => OneDayAMRReading.new(60000000123085, end_date, 'ORIG', nil, end_date, Array.new(48, 0.5))
+          }
+        },
+      }
+    end
+
+    let(:mpan) { 1112223334445 }
+    let(:expected_solar_pv_mpan) { "7#{mpan.to_s}".to_i }
+    let(:expected_electricity_mpan) { "9#{mpan.to_s}".to_i }
+    let(:expected_exported_solar_pv_mpan) { "6#{mpan.to_s}".to_i }
+
+    context 'with no existing meters' do
+      it 'creates new pseudo meters' do
+        expect {
+          LowCarbonHubUpserter.new(installation: low_carbon_hub_installation, readings: readings, import_log: import_log).perform
+        }.to change { Meter.count }.by(3)
+        expect(low_carbon_hub_installation.meters.solar_pv.first.mpan_mprn).to eq(expected_solar_pv_mpan)
+        expect(low_carbon_hub_installation.meters.solar_pv.first.name).to eq("Solar pv")
+        expect(low_carbon_hub_installation.meters.electricity.last.mpan_mprn).to eq(expected_electricity_mpan)
+        expect(low_carbon_hub_installation.meters.electricity.last.name).to eq("Electricity")
+        expect(low_carbon_hub_installation.meters.exported_solar_pv.last.mpan_mprn).to eq(expected_exported_solar_pv_mpan)
+        expect(low_carbon_hub_installation.meters.exported_solar_pv.last.name).to eq("Exported solar pv")
+      end
+
+      it 'creates amr readings' do
+        expect {
+          LowCarbonHubUpserter.new(installation: low_carbon_hub_installation, readings: readings, import_log: import_log).perform
+        }.to change { AmrDataFeedReading.count }.by(6)
+        amr_reading = low_carbon_hub_installation.meters.find_by_mpan_mprn(expected_solar_pv_mpan).amr_data_feed_readings.last
+        expect(amr_reading.readings[0]).to eq('0.5')
+        amr_reading = low_carbon_hub_installation.meters.find_by_mpan_mprn(expected_electricity_mpan).amr_data_feed_readings.last
+        expect(amr_reading.readings[0]).to eq('0.5')
+        amr_reading = low_carbon_hub_installation.meters.find_by_mpan_mprn(expected_exported_solar_pv_mpan).amr_data_feed_readings.last
+        expect(amr_reading.readings[0]).to eq('0.5')
+      end
+
+      it 'does not log any errors or warnings' do
+        LowCarbonHubUpserter.new(installation: low_carbon_hub_installation, readings: readings, import_log: import_log).perform
+        amr_data_feed_import_log = AmrDataFeedImportLog.last
+        expect(amr_data_feed_import_log.error_messages).to be_blank
+        expect(amr_data_feed_import_log.amr_reading_warnings).to be_empty
+      end
+    end
+
+    context 'when pseudo meter exists' do
+      let!(:existing_pseudo_meter) { create(:electricity_meter, low_carbon_hub_installation: low_carbon_hub_installation, name: "Existing meter", mpan_mprn: expected_electricity_mpan, school: low_carbon_hub_installation.school, pseudo: true )}
+
+      context 'with all fields' do
+        it 'creates new pseudo meters where required' do
+          expect {
+            LowCarbonHubUpserter.new(installation: low_carbon_hub_installation, readings: readings, import_log: import_log).perform
+          }.to change { Meter.count }.by(2)
+          expect(low_carbon_hub_installation.meters.solar_pv.first.mpan_mprn).to eq(expected_solar_pv_mpan)
+          expect(low_carbon_hub_installation.meters.solar_pv.first.name).to eq("Solar pv")
+          expect(low_carbon_hub_installation.meters.exported_solar_pv.last.mpan_mprn).to eq(expected_exported_solar_pv_mpan)
+          expect(low_carbon_hub_installation.meters.exported_solar_pv.last.name).to eq("Exported solar pv")
+
+          existing_pseudo_meter.reload
+          expect(existing_pseudo_meter.name).to eq("Existing meter")
+        end
+
+        it 'creates all the amr readings' do
+          expect {
+            LowCarbonHubUpserter.new(installation: low_carbon_hub_installation, readings: readings, import_log: import_log).perform
+          }.to change { AmrDataFeedReading.count }.by(6)
+          amr_reading = low_carbon_hub_installation.meters.find_by_mpan_mprn(expected_solar_pv_mpan).amr_data_feed_readings.last
+          expect(amr_reading.readings[0]).to eq('0.5')
+          amr_reading = low_carbon_hub_installation.meters.find_by_mpan_mprn(expected_electricity_mpan).amr_data_feed_readings.last
+          expect(amr_reading.readings[0]).to eq('0.5')
+          amr_reading = low_carbon_hub_installation.meters.find_by_mpan_mprn(expected_exported_solar_pv_mpan).amr_data_feed_readings.last
+          expect(amr_reading.readings[0]).to eq('0.5')
+        end
+      end
+
+      context 'with no installation or pseudo flag' do
+        let!(:existing_pseudo_meter) { create(:electricity_meter, low_carbon_hub_installation: nil, name: "Existing meter", mpan_mprn: expected_electricity_mpan, school: low_carbon_hub_installation.school, pseudo: false )}
+
+        it 'creates new pseudo meters where required' do
+          expect {
+            LowCarbonHubUpserter.new(installation: low_carbon_hub_installation, readings: readings, import_log: import_log).perform
+          }.to change { Meter.count }.by(2)
+          expect(low_carbon_hub_installation.meters.solar_pv.first.mpan_mprn).to eq(expected_solar_pv_mpan)
+          expect(low_carbon_hub_installation.meters.solar_pv.first.name).to eq("Solar pv")
+          expect(low_carbon_hub_installation.meters.exported_solar_pv.last.mpan_mprn).to eq(expected_exported_solar_pv_mpan)
+          expect(low_carbon_hub_installation.meters.exported_solar_pv.last.name).to eq("Exported solar pv")
+
+          existing_pseudo_meter.reload
+          expect(existing_pseudo_meter.name).to eq("Existing meter")
+          expect(existing_pseudo_meter.low_carbon_hub_installation).to eq low_carbon_hub_installation
+          expect(existing_pseudo_meter.pseudo?).to be true
+        end
+
+        it 'creates all the amr readings' do
+          expect {
+            LowCarbonHubUpserter.new(installation: low_carbon_hub_installation, readings: readings, import_log: import_log).perform
+          }.to change { AmrDataFeedReading.count }.by(6)
+          amr_reading = low_carbon_hub_installation.meters.find_by_mpan_mprn(expected_solar_pv_mpan).amr_data_feed_readings.last
+          expect(amr_reading.readings[0]).to eq('0.5')
+          amr_reading = low_carbon_hub_installation.meters.find_by_mpan_mprn(expected_electricity_mpan).amr_data_feed_readings.last
+          expect(amr_reading.readings[0]).to eq('0.5')
+          amr_reading = low_carbon_hub_installation.meters.find_by_mpan_mprn(expected_exported_solar_pv_mpan).amr_data_feed_readings.last
+          expect(amr_reading.readings[0]).to eq('0.5')
+        end
+
+      end
+    end
+  end
+end

--- a/spec/services/solar/solar_edge_download_and_upsert_spec.rb
+++ b/spec/services/solar/solar_edge_download_and_upsert_spec.rb
@@ -26,7 +26,7 @@ module Solar
     let(:upserter)  { Solar::SolarEdgeDownloadAndUpsert.new(installation: installation, start_date: requested_start_date, end_date: requested_end_date)}
 
     before(:each) do
-      expect(SolarEdgeSolarPV).to receive(:new).with(installation.api_key).and_return(api)
+      expect(SolarEdgeAPI).to receive(:new).with(installation.api_key).and_return(api)
     end
 
     it "should handle and log exceptions" do

--- a/spec/system/solar_edge_installation_spec.rb
+++ b/spec/system/solar_edge_installation_spec.rb
@@ -15,6 +15,10 @@ RSpec.describe "Solar edge installation management", :solar_edge_installations, 
   context 'as an admin' do
 
     before(:each) do
+      allow_any_instance_of(SolarEdgeAPI).to receive(:site_details).and_return({})
+      allow_any_instance_of(SolarEdgeAPI).to receive(:site_start_end_dates).and_return([Date.yesterday, Date.today])
+      allow_any_instance_of(SolarEdgeAPI).to receive(:smart_meter_data).and_return({})
+
       sign_in(admin)
       visit school_meters_path(school)
     end
@@ -37,7 +41,7 @@ RSpec.describe "Solar edge installation management", :solar_edge_installations, 
         fill_in(:solar_edge_installation_api_key, with: api_key)
 
         expect { click_on 'Submit'}.to change { SolarEdgeInstallation.count }.by(1)
-        expect(page).to have_content("New Solar Edge API feed created")
+        expect(page).to have_content("Solar Edge installation was successfully created")
 
         expect(SolarEdgeInstallation.first.mpan).to eql mpan
         expect(SolarEdgeInstallation.first.site_id).to eql site_id


### PR DESCRIPTION
A range of improvements to the setup and management of SolarEdge API feeds

* Updates the analytics to incorporate bug fixes in the SolarEdgeAPI class, including ability to import only partially metered data
* Fixes a long standing issue that Solar Edge imports fail if an admin has already created the pseudo meters
* Populates the `information` field at setup and after editing a feed config, to provide some debug information if there are problems
* Triggers some API requests, including a small data load at creation of a new Solar Edge feed to flush out API issues early and ensure that necessary pseudo meters are created
* Improves the logging and error reporting to clarify which import has failed, if it occurs