### PR TITLE
Treating '-' as missing data

### DIFF
--- a/app/models/amr_reading_data.rb
+++ b/app/models/amr_reading_data.rb
@@ -103,7 +103,7 @@ class AmrReadingData
   end
 
   def missing_readings?(readings)
-    readings.compact.count(&:present?) < (48 - @missing_reading_threshold)
+    readings.compact.count {|hh| hh.present? && hh != '-'} < (48 - @missing_reading_threshold)
   end
 
   def valid_reading_date?(reading_date)

--- a/app/models/amr_reading_data.rb
+++ b/app/models/amr_reading_data.rb
@@ -103,7 +103,7 @@ class AmrReadingData
   end
 
   def missing_readings?(readings)
-    readings.compact.count {|hh| hh.present? && hh != '-'} < (48 - @missing_reading_threshold)
+    readings.compact.count {|reading| reading.present? && reading != '-'} < (48 - @missing_reading_threshold)
   end
 
   def valid_reading_date?(reading_date)

--- a/lib/tasks/deployment/20230413153813_remove_readings_with_all_dashes.rake
+++ b/lib/tasks/deployment/20230413153813_remove_readings_with_all_dashes.rake
@@ -1,0 +1,14 @@
+namespace :after_party do
+  desc 'Deployment task: remove_readings_with_all_dashes'
+  task remove_readings_with_all_dashes: :environment do
+    puts "Running deploy task 'remove_readings_with_all_dashes'"
+
+    #Remove all readings where the contents are only dashes.
+    AmrDataFeedReading.where(readings: Array.new(48, "-")).destroy_all
+
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord
+      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+  end
+end

--- a/lib/tasks/deployment/20230413153813_remove_readings_with_all_dashes.rake
+++ b/lib/tasks/deployment/20230413153813_remove_readings_with_all_dashes.rake
@@ -4,7 +4,21 @@ namespace :after_party do
     puts "Running deploy task 'remove_readings_with_all_dashes'"
 
     #Remove all readings where the contents are only dashes.
+    #Should remove around 780-800 records
     AmrDataFeedReading.where(readings: Array.new(48, "-")).destroy_all
+
+    #Remove all readings where there is more than one dash
+    #
+    #First where clause: find record that have a dash in the readings array
+    #this just intersects the readings with an array of containing a single dash
+    #
+    #Second where clause:
+    # uses the array_positions function to find the positions of the "-" in the readings array
+    # then calculates the cardinality of that array (which is equal to number of dashes)
+    # when limit selection to where cardinality is > 1
+    #
+    # Should end up removing around 200 records
+    AmrDataFeedReading.where('readings && ARRAY[?]', ['-']).where("cardinality(array_positions(readings, '-')) > 1").destroy_all
 
     # Update task as completed.  If you remove the line below, the task will
     # run with every deploy (or every time you call after_party:run).

--- a/spec/models/amr_reading_data_spec.rb
+++ b/spec/models/amr_reading_data_spec.rb
@@ -152,6 +152,22 @@ describe AmrReadingData do
         expect(amr_reading.warnings.first[:warnings]).to include(:missing_readings)
       end
 
+      it "with missing readings (as \"-\")" do
+        readings = amr_reading_data[:reading_data].first[:readings]
+        readings[readings.size - 1] = "-"
+        puts readings.inspect
+
+        amr_reading_data[:reading_data].first[:readings] = readings
+
+        amr_reading = AmrReadingData.new(**amr_reading_data)
+
+        expect(amr_reading.valid?).to be true
+        expect(amr_reading.warnings?).to be true
+        expect(amr_reading.valid_reading_count).to be 1
+        expect(amr_reading.warnings.count).to be 1
+        expect(amr_reading.warnings.first[:warnings]).to include(:missing_readings)
+      end
+
       it 'when dates are not quite the right format' do
         bad_date = 'AAAAAA'
         amr_reading_data[:reading_data].first[:reading_date] = bad_date
@@ -195,4 +211,5 @@ describe AmrReadingData do
       end
     end
   end
+
 end

--- a/spec/models/amr_reading_data_spec.rb
+++ b/spec/models/amr_reading_data_spec.rb
@@ -155,7 +155,6 @@ describe AmrReadingData do
       it "with missing readings (as \"-\")" do
         readings = amr_reading_data[:reading_data].first[:readings]
         readings[readings.size - 1] = "-"
-        puts readings.inspect
 
         amr_reading_data[:reading_data].first[:readings] = readings
 


### PR DESCRIPTION
The Smartest Energy CSV data includes rows which have:

- all 48 half-hourly readings as "-"
- portions of the day as dashes, e.g. 1-2 hours in the morning then dashes

These are currently being passed through for storing. When processed the array of dashes is processed via (`readings.map(&:to_f)`) which converts the dashes to zeroes. Which means it treats the data as zero readings.

When the real data appears the data is backfilled and replaced, but the behaviour isn't correct.

This PR makes a system wide change to treat "-" characters as missing values, which means rows containing that data will be rejected. This may lead to more rejected data, but is better behaviour overall.

The PR also includes an AfterParty task to clean up some existing missing data

The task:

- removes `AmrDataFeedReadings` where the `readings` are all dashes.
- removes `AmrDataFeedReadings` where there is more than one dash in the array

This will remove about a 1000 rows in the live system, leaving the data to be substituted on revalidation.