### PR TITLE
Replace count with any?

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -97,7 +97,7 @@ class Ability
       can :deactivate, Meter, { active: true }.merge(related_school_scope)
       can [:destroy, :delete], Meter, related_school_scope
       cannot [:destroy, :delete], Meter do |meter|
-        meter.amr_data_feed_readings.count > 0
+        meter.amr_data_feed_readings.any?
       end
       can :manage, Observation, related_school_scope
       can :manage, TransportSurvey, related_school_scope


### PR DESCRIPTION
The ability.rb has a check on number of amr_data_feed_readings to stop anyone deleting meters that have data in the system.

This is called once for all inactive meters, whenever an admin and school admin users view the page.