### PR TITLE
Add a date limit to the amr data feed reading lookup

### DIFF
--- a/app/services/import_notifier.rb
+++ b/app/services/import_notifier.rb
@@ -7,8 +7,9 @@ class ImportNotifier
     find_with_config do |config|
       if config.import_warning_days.present?
         Meter.active
-          #that have ever had readings loaded from this config (~ data source)
+          #that have readings loaded from this config (~ data source) in the last 12 months
           .joins(:amr_data_feed_readings).where("amr_data_feed_readings.amr_data_feed_config_id=?", config.id)
+          .where("amr_data_feed_readings.created_at >= NOW() - INTERVAL '1 year'")
           #and where the latest validated reading is older than what we expect in the config
           .joins(:amr_validated_readings).group('meters.id').having("MAX(amr_validated_readings.reading_date) < NOW() - INTERVAL '? days'", config.import_warning_days)
       else


### PR DESCRIPTION
Only check to see what configs we've used to load data for a meter in the last 12 months, not all time.

This significantly improves the "meters running behind" check and should involve less paging through data on the database.