### PR TITLE
Add meter procurement routes

### DIFF
--- a/app/controllers/admin/procurement_routes_controller.rb
+++ b/app/controllers/admin/procurement_routes_controller.rb
@@ -1,0 +1,6 @@
+module Admin
+  class ProcurementRoutesController < AdminController
+    before_action :header_fix_enabled
+    load_and_authorize_resource
+  end
+end

--- a/app/controllers/admin/procurement_routes_controller.rb
+++ b/app/controllers/admin/procurement_routes_controller.rb
@@ -2,5 +2,42 @@ module Admin
   class ProcurementRoutesController < AdminController
     before_action :header_fix_enabled
     load_and_authorize_resource
+
+    def create
+      if @procurement_route.save
+        redirect_to params[:redirect_back], notice: 'Procurement route was successfully created.'
+      else
+        render :new
+      end
+    end
+
+    def update
+      if @procurement_route.update(procurement_route_params)
+        redirect_to params[:redirect_back], notice: 'Procurement route was successfully updated.'
+      else
+        render :edit
+      end
+    end
+
+    def destroy
+      @procurement_route.destroy
+      redirect_to admin_procurement_routes_path, notice: 'Procurement route was successfully deleted.'
+    end
+
+    private
+
+    def procurement_route_params
+      params.require(:procurement_route).permit(:organisation_name,
+                                                :contact_name,
+                                                :contact_email,
+                                                :loa_contact_details,
+                                                :data_prerequisites,
+                                                :new_area_data_feed,
+                                                :add_existing_data_feed,
+                                                :data_issues_contact_details,
+                                                :loa_expiry_procedure,
+                                                :comments
+                                               )
+    end
   end
 end

--- a/app/controllers/schools/meters_controller.rb
+++ b/app/controllers/schools/meters_controller.rb
@@ -104,7 +104,7 @@ module Schools
     end
 
     def meter_params
-      params.require(:meter).permit(:mpan_mprn, :meter_type, :name, :meter_serial_number, :dcc_meter, :sandbox, :earliest_available_data, :data_source_id, :admin_meter_statuses_id)
+      params.require(:meter).permit(:mpan_mprn, :meter_type, :name, :meter_serial_number, :dcc_meter, :sandbox, :earliest_available_data, :data_source_id, :procurement_route_id, :admin_meter_statuses_id)
     end
   end
 end

--- a/app/models/meter.rb
+++ b/app/models/meter.rb
@@ -17,6 +17,7 @@
 #  meter_type                     :integer
 #  mpan_mprn                      :bigint(8)
 #  name                           :string
+#  procurement_route_id           :bigint(8)
 #  pseudo                         :boolean          default(FALSE)
 #  sandbox                        :boolean          default(FALSE)
 #  school_id                      :bigint(8)        not null
@@ -30,6 +31,7 @@
 #  index_meters_on_meter_review_id                 (meter_review_id)
 #  index_meters_on_meter_type                      (meter_type)
 #  index_meters_on_mpan_mprn                       (mpan_mprn) UNIQUE
+#  index_meters_on_procurement_route_id            (procurement_route_id)
 #  index_meters_on_school_id                       (school_id)
 #  index_meters_on_solar_edge_installation_id      (solar_edge_installation_id)
 #

--- a/app/models/meter.rb
+++ b/app/models/meter.rb
@@ -51,6 +51,7 @@ class Meter < ApplicationRecord
   belongs_to :solar_edge_installation, optional: true
   belongs_to :meter_review, optional: true
   belongs_to :data_source, optional: true
+  belongs_to :procurement_route, optional: true
   belongs_to :admin_meter_status, foreign_key: 'admin_meter_statuses_id', optional: true
 
   has_one :rtone_variant_installation, required: false

--- a/app/models/procurement_route.rb
+++ b/app/models/procurement_route.rb
@@ -1,0 +1,18 @@
+# == Schema Information
+#
+# Table name: procurement_routes
+#
+#  add_existing_data_feed      :text
+#  comments                    :text
+#  contact_email               :string
+#  contact_name                :string
+#  data_issues_contact_details :text
+#  data_prerequisites          :text
+#  id                          :bigint(8)        not null, primary key
+#  loa_contact_details         :string
+#  loa_expiry_procedure        :text
+#  new_area_data_feed          :text
+#  organisation_name           :string           not null
+#
+class ProcurementRoute < ApplicationRecord
+end

--- a/app/models/procurement_route.rb
+++ b/app/models/procurement_route.rb
@@ -6,6 +6,7 @@
 #  comments                    :text
 #  contact_email               :string
 #  contact_name                :string
+#  created_at                  :datetime         not null
 #  data_issues_contact_details :text
 #  data_prerequisites          :text
 #  id                          :bigint(8)        not null, primary key
@@ -13,8 +14,10 @@
 #  loa_expiry_procedure        :text
 #  new_area_data_feed          :text
 #  organisation_name           :string           not null
+#  updated_at                  :datetime         not null
 #
 class ProcurementRoute < ApplicationRecord
   validates :organisation_name, presence: true
   has_many :meters
+  has_many :schools, -> { distinct }, through: :meters
 end

--- a/app/models/procurement_route.rb
+++ b/app/models/procurement_route.rb
@@ -15,4 +15,6 @@
 #  organisation_name           :string           not null
 #
 class ProcurementRoute < ApplicationRecord
+  validates :organisation_name, presence: true
+  has_many :meters
 end

--- a/app/views/admin/index.html.erb
+++ b/app/views/admin/index.html.erb
@@ -47,6 +47,7 @@
       <li><%= link_to "Solar PV Areas", admin_solar_pv_tuos_areas_path %></li>
       <li><%= link_to "Weather Stations", admin_weather_stations_path %></li>
       <li><%= link_to "Data Sources", admin_data_sources_path %></li>
+      <li><%= link_to "Procurement Routes", admin_procurement_routes_path %></li>
     </ul>
 
     <h2>Alerts and Equivalences</h2>

--- a/app/views/admin/procurement_routes/_form.html.erb
+++ b/app/views/admin/procurement_routes/_form.html.erb
@@ -1,0 +1,21 @@
+<div class="row p-2">
+  <div class="col-md-12 border rounded bg-light pb-2">
+    <%= render 'header', title: title do %>
+      <%= header_nav_link 'All procurement routes', admin_procurement_routes_url %>
+    <% end %>
+    <%= simple_form_for [:admin, procurement_route] do |f| %>
+      <%= redirect_back_tag params %>
+      <%= f.input :organisation_name, label: "Organisation name" %>
+      <%= f.input :contact_name %>
+      <%= f.input :contact_email %>
+      <%= f.input :loa_contact_details, label: "Who to send LOA to" %>
+      <%= f.input :data_prerequisites %>
+      <%= f.input :new_area_data_feed, label: "How to setup data feed for a new area" %>
+      <%= f.input :add_existing_data_feed, label: "How to add to an existing data feed" %>
+      <%= f.input :data_issues_contact_details, label: "Who to contact about data issues" %>
+      <%= f.input :loa_expiry_procedure, label: "What to do when LOA is about expire" %>
+      <%= f.input :comments %>
+      <%= f.submit 'Save', class: 'btn btn-primary' %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/admin/procurement_routes/_header.html.erb
+++ b/app/views/admin/procurement_routes/_header.html.erb
@@ -1,0 +1,8 @@
+<div class="d-flex justify-content-between align-items-center">
+  <h1>
+     <%= title %>
+  </h1>
+  <div>
+    <%= yield %>
+  </div>
+</div>

--- a/app/views/admin/procurement_routes/_procurement_route.html.erb
+++ b/app/views/admin/procurement_routes/_procurement_route.html.erb
@@ -1,0 +1,63 @@
+<% default = "&nbsp;".html_safe %>
+
+<div class="collapse p-4" id="procurement-route">
+  <div class="row">
+    <div class="col-6 mb-2">
+      <div class="font-weight-bolder ml-1">Contact name</div>
+      <div class="bg-white p-1 border"><%= procurement_route.contact_name.presence || default %></div>
+    </div>
+    <div class="col-6">
+      <div class="font-weight-bolder ml-1">Contact email</div>
+      <div class="bg-white p-1 border"><%= procurement_route.contact_email.presence || default %></div>
+    </div>
+  </div>
+  <div class="row pb-2">
+    <div class="col-12">
+      <div class="font-weight-bolder ml-1">Who to send LOA to</div>
+      <div class="bg-white p-1 border"><%= procurement_route.loa_contact_details.presence || default %></div>
+    </div>
+  </div>
+  <div class="row pb-2">
+    <div class="col-12">
+      <div class="font-weight-bolder ml-1">Data prerequisites</div>
+      <div class="bg-white p-1 border text-break"><%= procurement_route.data_prerequisites.presence || default %></div>
+    </div>
+  </div>
+  <div class="row pb-2">
+    <div class="col-12">
+      <div class="font-weight-bolder ml-1">How to setup data feed for a new area</div>
+      <div class="bg-white p-1 border text-break"><%= procurement_route.new_area_data_feed.presence || default %></div>
+    </div>
+  </div>
+  <div class="row pb-2">
+    <div class="col-12">
+      <div class="font-weight-bolder ml-1">How to add to an existing data feed</div>
+      <div class="bg-white p-1 border text-break"><%= procurement_route.add_existing_data_feed.presence || default %></div>
+    </div>
+  </div>
+  <div class="row pb-2">
+    <div class="col-12">
+      <div class="font-weight-bolder ml-1">Who to contact about data issues</div>
+      <div class="bg-white p-1 border text-break"><%= procurement_route.data_issues_contact_details.presence || default %></div>
+    </div>
+  </div>
+  <div class="row pb-2">
+    <div class="col-12">
+      <div class="font-weight-bolder ml-1">What to do when LOA is about expire</div>
+      <div class="bg-white p-1 border text-break"><%= procurement_route.loa_expiry_procedure.presence || default %></div>
+    </div>
+  </div>
+  <div class="row pb-2">
+    <div class="col-12">
+      <div class="font-weight-bolder ml-1">Comments</div>
+      <div class="bg-white p-1 border text-break"><%= procurement_route.comments.presence || default %></div>
+    </div>
+  </div>
+
+  <div class="row pb-2">
+    <div class="col-12">
+      <div class="badge badge-pill bg-white text-dark font-weight-normal">Created • <%= nice_date_times_today(procurement_route.created_at) %></div>
+      <div class="badge badge-pill bg-white text-dark font-weight-normal">Updated • <%= nice_date_times_today(procurement_route.updated_at) %></div>
+    </div>
+  </div>
+</div>

--- a/app/views/admin/procurement_routes/edit.html.erb
+++ b/app/views/admin/procurement_routes/edit.html.erb
@@ -1,0 +1,1 @@
+<%= render 'form', procurement_route: @procurement_route, title: "Edit #{@procurement_route.organisation_name}" %>

--- a/app/views/admin/procurement_routes/index.html.erb
+++ b/app/views/admin/procurement_routes/index.html.erb
@@ -1,3 +1,26 @@
 <%= render 'header', title: "Manage Procurement Routes" do %>
   <%= header_nav_link 'Admin', admin_url %>
 <% end %>
+
+<%= link_to 'New procurement route', new_admin_procurement_route_path, class: 'btn btn-primary' %>
+
+<table class="table table-sorted" style="width: 100%">
+  <thead>
+    <tr>
+      <th>Organisation name</th>
+      <th>Contact name</th>
+      <th class="no-sort text-right">Actions</th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @procurement_routes.each do |procurement_route| %>
+      <tr>
+        <td class="nowrap"><%= procurement_route.organisation_name %></td>
+        <td><span class="badge badge-info"><%= procurement_route.contact_name %></span></td>
+        <td class="nowrap text-right">
+          <%= link_to 'Manage', admin_procurement_route_path(procurement_route), class: "btn btn-sm" %>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/admin/procurement_routes/index.html.erb
+++ b/app/views/admin/procurement_routes/index.html.erb
@@ -1,0 +1,3 @@
+<%= render 'header', title: "Manage Procurement Routes" do %>
+  <%= header_nav_link 'Admin', admin_url %>
+<% end %>

--- a/app/views/admin/procurement_routes/new.html.erb
+++ b/app/views/admin/procurement_routes/new.html.erb
@@ -1,0 +1,1 @@
+<%= render 'form', procurement_route: @procurement_route, title: "New procurement route" %>

--- a/app/views/admin/procurement_routes/show.html.erb
+++ b/app/views/admin/procurement_routes/show.html.erb
@@ -1,0 +1,34 @@
+<%= render 'header', title: "#{@procurement_route.organisation_name} procurement route" do %>
+  <%= header_nav_link 'All procurement routes', admin_procurement_routes_url %>
+<% end %>
+
+<div class="row pb-2">
+  <div class="col-12">
+    <div class="card-deck">
+      <div class="card">
+        <div class="card-body">
+          <div>Active meters <span class="float-right badge badge-success"><%= @procurement_route.meters.active.count %></span></div>
+          <div>Inactive meters <span class="float-right badge badge-secondary"><%= @procurement_route.meters.inactive.count %></span></div>
+        </div>
+      </div>
+      <div class="card">
+        <div class="card-body">
+          <div>Associated schools <span class="float-right badge badge-success"><%=  @procurement_route.schools.count %></span></div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="bg-light border rounded py-2 mb-2">
+  <div class="col-12 clearfix">
+    <span data-toggle="collapse" href="#procurement-route" role="button" aria-expanded="true" aria-controls="procurement-route" class="badge badge-light toggler text-decoration-none collapsed">
+      <%= fa_icon("chevron-down") %><%= fa_icon("chevron-right") %>
+    </span>
+    <span class='float-right'>
+      <%= link_to 'Edit', edit_admin_procurement_route_path(@procurement_route), class: "btn btn-sm" %>
+      <%= link_to 'Delete', admin_procurement_route_path(@procurement_route), method: :delete, data: { confirm: 'Are you sure?' }, class: "btn btn-sm btn-danger" %>
+    </span>
+  </div>
+  <%= render 'procurement_route', procurement_route: @procurement_route %>
+</div>

--- a/app/views/import_mailer/_meter_table.html.erb
+++ b/app/views/import_mailer/_meter_table.html.erb
@@ -6,6 +6,7 @@
       <td><%= link_to meter.school.name, school_url(meter.school) %></td>
       <td><%= link_to meter.mpan_mprn, school_meter_url(meter.school, meter) %></td>
       <td><%= link_to meter.data_source.name, admin_data_source_url(meter.data_source) if meter.data_source %></td>
+      <td><%= link_to meter.procurement_route&.organisation_name, admin_procurement_route_url(meter.procurement_route) if meter.procurement_route %></td>
       <td><%= nice_dates(meter.last_validated_reading) %></td>
       <td><%= meter.admin_meter_status_label %></td>
       <td>

--- a/app/views/import_mailer/import_summary.html.erb
+++ b/app/views/import_mailer/import_summary.html.erb
@@ -8,6 +8,7 @@
       <th>School</th>
       <th>MPAN/MPRN</th>
       <th>Data source</th>
+      <th>Procurement route</th>
       <th>Last validated reading date</th>
       <th>Admin meter status</th>
       <th colspan="2"></th>

--- a/app/views/schools/meters/_active_meters.html.erb
+++ b/app/views/schools/meters/_active_meters.html.erb
@@ -10,6 +10,9 @@
         <%= link_to meter.data_source.try(:name), admin_data_source_path(meter.data_source) if meter.data_source %>
       </td>
       <td>
+        <%= link_to meter.procurement_route.try(:organisation_name), admin_procurement_route_path(meter.procurement_route) if meter.procurement_route %>
+      </td>
+      <td>
         <% if meter.admin_meter_status.nil? && meter.admin_meter_status_label.present? %>
           <span data-toggle="tooltip" title="Default <%= meter.fuel_type.to_s.humanize.downcase %> admin meter status for this school's school group">
             <%= meter.admin_meter_status_label %>

--- a/app/views/schools/meters/_form.html.erb
+++ b/app/views/schools/meters/_form.html.erb
@@ -39,6 +39,10 @@
       <%= form.select(:data_source_id, DataSource.all.collect { |d| [ d.name, d.id ] }, { include_blank: true }, class: 'form-control') %>
     </div>
     <div class="form-group">
+      <%= form.label :procurement_route_id, t('schools.meters.form.procurement_route') %>
+      <%= form.select(:procurement_route_id, ProcurementRoute.all.collect { |p| [ p.organisation_name, p.id ] }, { include_blank: true }, class: 'form-control') %>
+    </div>
+    <div class="form-group">
       <%= form.label :admin_meter_status, 'Admin meter status' %>
       <%= form.select(:admin_meter_statuses_id, AdminMeterStatus.all.collect { |d| [ d.label, d.id ] }, { include_blank: true }, class: 'form-control') %>
     </div>

--- a/app/views/schools/meters/_inactive_meters.html.erb
+++ b/app/views/schools/meters/_inactive_meters.html.erb
@@ -8,6 +8,9 @@
         <%= link_to meter.data_source.try(:name), admin_data_source_path(meter.data_source) if meter.data_source %>
       </td>
       <td>
+        <%= link_to meter.procurement_route.try(:organisation_name), admin_procurement_route_path(meter.procurement_route) if meter.procurement_route %>
+      </td>
+      <td>
         <%= meter.admin_meter_status_label %>
       </td>
     <% end %>

--- a/app/views/schools/meters/index.html.erb
+++ b/app/views/schools/meters/index.html.erb
@@ -79,6 +79,7 @@
       <th scope="col"><%= t('schools.meters.index.name') %></th>
       <% if current_user.admin? %>
         <th scope="col"><%= t('schools.meters.index.data_source') %></th>
+        <th scope="col"><%= t('schools.meters.index.procurement_route') %></th>
         <th scope="col"><%= t('schools.meters.index.admin_meter_status') %></th>
       <% end %>
       <th scope="col"><%= t('schools.meters.index.imported') %></th>

--- a/config/locales/views/schools/schools.yml
+++ b/config/locales/views/schools/schools.yml
@@ -268,6 +268,7 @@ en:
         name: Name
         no_active_meters: No active meters
         only_admins_message: Only admins can delete meters with meter readings
+        procurement_route: Procurement route
         readings: Readings
         report: Report
         review_meters: Review meters

--- a/config/locales/views/schools/schools.yml
+++ b/config/locales/views/schools/schools.yml
@@ -241,6 +241,7 @@ en:
         meter_point_number: Meter Point Number
         name: Name
         only_check_if_adding_an_n3rgy_test_meter: Only check if you're adding an n3rgy test meter, not used for live schools
+        procurement_route: Procurement route
         sandbox: Sandbox
         serial_number: Serial number
         title: The Meter Point Number is also known as the MPAN (for electricity meters) and the MPRN (for gas meters)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -460,6 +460,7 @@ Rails.application.routes.draw do
     resources :global_meter_attributes
     resources :consents
     resources :transport_types
+    resources :procurement_routes
     resources :data_sources do
       scope module: :data_sources do
         concerns :issueable

--- a/db/migrate/20230419100900_create_procurement_routes.rb
+++ b/db/migrate/20230419100900_create_procurement_routes.rb
@@ -1,0 +1,16 @@
+class CreateProcurementRoutes < ActiveRecord::Migration[6.0]
+  def change
+    create_table :procurement_routes do |t|
+      t.string :organisation_name, null:false
+      t.string :contact_name
+      t.string :contact_email
+      t.string :loa_contact_details
+      t.text :data_prerequisites
+      t.text :new_area_data_feed
+      t.text :add_existing_data_feed
+      t.text :data_issues_contact_details
+      t.text :loa_expiry_procedure
+      t.text :comments
+    end
+  end
+end

--- a/db/migrate/20230419100900_create_procurement_routes.rb
+++ b/db/migrate/20230419100900_create_procurement_routes.rb
@@ -11,6 +11,7 @@ class CreateProcurementRoutes < ActiveRecord::Migration[6.0]
       t.text :data_issues_contact_details
       t.text :loa_expiry_procedure
       t.text :comments
+      t.timestamps
     end
   end
 end

--- a/db/migrate/20230419130712_add_procurement_route_id_to_meter.rb
+++ b/db/migrate/20230419130712_add_procurement_route_id_to_meter.rb
@@ -1,0 +1,5 @@
+class AddProcurementRouteIdToMeter < ActiveRecord::Migration[6.0]
+  def change
+    add_reference :meters, :procurement_route, index: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -851,13 +851,13 @@ ActiveRecord::Schema.define(version: 2023_04_19_130712) do
     t.index ["replaced_by_id"], name: "index_global_meter_attributes_on_replaced_by_id"
   end
 
-  create_table "good_job_processes", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "good_job_processes", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.jsonb "state"
   end
 
-  create_table "good_job_settings", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "good_job_settings", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.text "key"
@@ -865,7 +865,7 @@ ActiveRecord::Schema.define(version: 2023_04_19_130712) do
     t.index ["key"], name: "index_good_job_settings_on_key", unique: true
   end
 
-  create_table "good_jobs", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "good_jobs", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.text "queue_name"
     t.integer "priority"
     t.jsonb "serialized_params"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -851,13 +851,13 @@ ActiveRecord::Schema.define(version: 2023_04_19_130712) do
     t.index ["replaced_by_id"], name: "index_global_meter_attributes_on_replaced_by_id"
   end
 
-  create_table "good_job_processes", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "good_job_processes", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.jsonb "state"
   end
 
-  create_table "good_job_settings", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "good_job_settings", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.text "key"
@@ -865,7 +865,7 @@ ActiveRecord::Schema.define(version: 2023_04_19_130712) do
     t.index ["key"], name: "index_good_job_settings_on_key", unique: true
   end
 
-  create_table "good_jobs", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "good_jobs", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.text "queue_name"
     t.integer "priority"
     t.jsonb "serialized_params"
@@ -1184,6 +1184,8 @@ ActiveRecord::Schema.define(version: 2023_04_19_130712) do
     t.text "data_issues_contact_details"
     t.text "loa_expiry_procedure"
     t.text "comments"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "programme_activities", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_04_19_100900) do
+ActiveRecord::Schema.define(version: 2023_04_19_130712) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
@@ -1093,11 +1093,13 @@ ActiveRecord::Schema.define(version: 2023_04_19_100900) do
     t.datetime "dcc_checked_at"
     t.bigint "data_source_id"
     t.bigint "admin_meter_statuses_id"
+    t.bigint "procurement_route_id"
     t.index ["data_source_id"], name: "index_meters_on_data_source_id"
     t.index ["low_carbon_hub_installation_id"], name: "index_meters_on_low_carbon_hub_installation_id"
     t.index ["meter_review_id"], name: "index_meters_on_meter_review_id"
     t.index ["meter_type"], name: "index_meters_on_meter_type"
     t.index ["mpan_mprn"], name: "index_meters_on_mpan_mprn", unique: true
+    t.index ["procurement_route_id"], name: "index_meters_on_procurement_route_id"
     t.index ["school_id"], name: "index_meters_on_school_id"
     t.index ["solar_edge_installation_id"], name: "index_meters_on_solar_edge_installation_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_04_18_114415) do
+ActiveRecord::Schema.define(version: 2023_04_19_100900) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
@@ -1169,6 +1169,19 @@ ActiveRecord::Schema.define(version: 2023_04_18_114415) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "name"
+  end
+
+  create_table "procurement_routes", force: :cascade do |t|
+    t.string "organisation_name", null: false
+    t.string "contact_name"
+    t.string "contact_email"
+    t.string "loa_contact_details"
+    t.text "data_prerequisites"
+    t.text "new_area_data_feed"
+    t.text "add_existing_data_feed"
+    t.text "data_issues_contact_details"
+    t.text "loa_expiry_procedure"
+    t.text "comments"
   end
 
   create_table "programme_activities", force: :cascade do |t|

--- a/spec/factories/procurement_routes.rb
+++ b/spec/factories/procurement_routes.rb
@@ -1,0 +1,14 @@
+FactoryBot.define do
+  factory :procurement_route do
+    sequence(:organisation_name) {|n| "Procurement route name #{n}"}
+    sequence(:contact_name) {|n| "Contact name #{n}" }
+    sequence(:contact_email) {|n| "contact#{n}@email.com" }
+    sequence(:loa_contact_details) {|n| "LOA contact details #{n}" }
+    sequence(:data_prerequisites) {|n| "Data prerequisites #{n}" }
+    sequence(:new_area_data_feed) {|n| "New are data feed #{n}" }
+    sequence(:add_existing_data_feed) {|n| "Add existing data feed #{n}" }
+    sequence(:data_issues_contact_details) {|n| "Procurement route contact details #{n}" }
+    sequence(:loa_expiry_procedure) {|n| "LOA expiry procedure #{n}" }
+    sequence(:comments) {|n| "Comments #{n}" }
+  end
+end

--- a/spec/models/procurement_route_spec.rb
+++ b/spec/models/procurement_route_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+RSpec.describe ProcurementRoute, type: :model do
+
+  describe 'validations' do
+    subject { build(:procurement_route) }
+    it { is_expected.to be_valid }
+    it { is_expected.to validate_presence_of(:organisation_name) }
+  end
+end

--- a/spec/system/admin/procurement_routes_spec.rb
+++ b/spec/system/admin/procurement_routes_spec.rb
@@ -1,0 +1,216 @@
+require 'rails_helper'
+
+shared_examples_for "a displayed procurement route" do
+  it "displays procurement route fields" do
+    text_attributes.keys.each do |text_field|
+      expect(page).to have_content(procurement_route[text_field])
+    end
+  end
+end
+
+shared_examples_for "a procurement route form" do
+  it "shows prefilled form" do
+    text_attributes.each do |text_field, label|
+      if procurement_route[text_field]
+        expect(page).to have_field(label, with: procurement_route[text_field])
+      else
+        # Have to do this because of the following:
+        # https://github.com/teamcapybara/capybara/pull/1169#issuecomment-44575123
+        expect(find_field(label).text).to be_blank
+      end
+    end
+  end
+end
+
+RSpec.describe 'Procurement route admin', :school_groups, type: :system, include_application_helper: true do
+  let(:setup_data)             { }
+  let!(:user)                  { }
+
+  let!(:text_attributes) { {
+    organisation_name: "Organisation name",
+    contact_name: "Contact name",
+    contact_email: "Contact email",
+    loa_contact_details: "Who to send LOA to",
+    data_prerequisites: "Data prerequisites",
+    new_area_data_feed: "How to setup data feed for a new area",
+    add_existing_data_feed: "How to add to an existing data feed",
+    data_issues_contact_details: "Who to contact about data issues",
+    loa_expiry_procedure: "What to do when LOA is about expire",
+    comments: "Comments"
+  } }
+
+  before do
+    setup_data
+    sign_in(user) if user
+  end
+
+  describe "Unauthorized access" do
+    before do
+      visit admin_procurement_routes_url
+    end
+
+    context 'when not logged in' do
+      it { expect(page).to have_content('You need to sign in or sign up before continuing.') }
+    end
+
+    context 'as a non-admin user' do
+      let!(:user) { create(:staff) }
+      it { expect(page).to have_content('You are not authorized to view that page.') }
+    end
+  end
+
+  describe "Authorized access" do
+    let!(:user) { create(:admin) }
+
+    before do
+      visit root_path
+      click_on 'Manage'
+      click_on 'Admin'
+    end
+
+    describe "Viewing index page" do
+      before do
+        click_on 'Procurement Routes'
+      end
+
+      context "when there is a procurement route" do
+        let(:existing_procurement_route) { create(:procurement_route) }
+        let(:setup_data) { existing_procurement_route }
+
+        it '' do
+          expect(ProcurementRoute.count).to eq(1)
+          expect(page).to have_content(existing_procurement_route.organisation_name)
+        end
+
+        it "has a link to manage procurement route" do
+          within('table') do
+            expect(page).to have_link('Manage')
+          end
+        end
+
+        describe "Managing a procurement route" do
+          before do
+            within('table') do
+              click_on "Manage"
+            end
+          end
+
+          context "Summary panel" do
+            let(:school) { create(:school) }
+            let(:active_meters) { 3.times { create(:gas_meter, active: true, procurement_route: existing_procurement_route, school: school) } }
+            let(:inactive_meters) { 2.times { create(:gas_meter, active: false, procurement_route: existing_procurement_route) } }
+            let(:setup_data) { [active_meters, inactive_meters] }
+
+            it { expect(page).to have_content("Active meters 3") }
+            it { expect(page).to have_content("Inactive meters 2") }
+            it { expect(page).to have_content("Associated schools 3") }
+          end
+
+          it_behaves_like "a displayed procurement route" do
+            let(:procurement_route) { existing_procurement_route }
+          end
+
+          it "has edit button" do
+            expect(page).to have_link('Edit')
+          end
+
+          describe "Editing a procurement route" do
+            before do
+              click_on "Edit"
+            end
+
+            it { expect(page).to have_content("Edit #{existing_procurement_route.organisation_name}")}
+            it_behaves_like "a procurement route form" do
+              let(:procurement_route) { existing_procurement_route }
+            end
+
+            context "and saving new data" do
+              let(:new_procurement_route) { build(:procurement_route) }
+              before do
+                text_attributes.each do |text_field, label|
+                  fill_in label, with: new_procurement_route[text_field]
+                end
+                click_button 'Save'
+              end
+              it { expect(page).to have_content("Procurement route was successfully updated") }
+              it_behaves_like "a displayed procurement route" do
+                let(:procurement_route) { new_procurement_route }
+              end
+            end
+          end
+
+          it "has a delete button" do
+            expect(page).to have_link('Delete')
+          end
+
+          describe "Deleting a procurement route" do
+            before do
+              click_on "Delete"
+            end
+            it { expect(page).to_not have_content(existing_procurement_route.organisation_name) }
+            it { expect(page).to have_content("Procurement route was successfully deleted") }
+          end
+
+          # it "has a download meters button" do
+          #   expect(page).to have_link('Meters')
+          # end
+
+          # describe "Downloading meters csv" do
+          #   before do
+          #     Timecop.freeze
+          #     click_on 'Meters'
+          #   end
+          #   after { Timecop.return }
+          #   it "shows csv contents" do
+          #     expect(page.body).to eq existing_data_source.meters.to_csv
+          #   end
+          #   it "has csv content type" do
+          #     expect(response_headers['Content-Type']).to eq 'text/csv'
+          #   end
+          #   it "has expected file name" do
+          #     expect(response_headers['Content-Disposition']).to include("energy-sparks-#{existing_data_source.name}-meters-#{Time.zone.now.iso8601}".parameterize + '.csv')
+          #   end
+          # end
+        end
+      end
+
+      it { expect(page).to have_link('New procurement route') }
+      context "creating a new procurement route" do
+        before do
+          click_on 'New procurement route'
+        end
+        it { expect(page).to have_content("New procurement route")}
+        it_behaves_like "a procurement route form" do
+          let(:procurement_route) { ProcurementRoute.new }
+        end
+        context "with invalid attributes" do
+          before do
+            click_on 'Save'
+          end
+          it { expect(page).to have_content("Organisation name *\ncan't be blank") }
+        end
+
+        context "with new valid attributes" do
+          let(:new_procurement_route) { build(:procurement_route) }
+          before do
+            text_attributes.each do |text_field, label|
+              fill_in label, with: new_procurement_route[text_field]
+            end
+            click_button 'Save'
+          end
+          it { expect(page).to have_content("Procurement route was successfully created") }
+          context "and viewing new procurement route" do
+            before do
+              within('table') do
+                click_on "Manage"
+              end
+            end
+            it_behaves_like "a displayed procurement route" do
+              let(:procurement_route) { new_procurement_route }
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR adds a new "Procurement Route” meter field similar to the existing “Data Source”: 
- [x] Create a new procurement route model with required and optional fields
- [x] add a link to a 'Procurement routes' page on the admin page under Data feeds and meter attributes, similar in functionality to the existing 'Data sources' page (list, show, add, edit, update, delete etc)
- [x] Add a 'Procurement routes' row to the import mailer summary
- [x] Add a 'Procurement route' column next to the data source column on the school meters page and a select box on the form e.g. http://localhost:3000/schools/school-name-here/meters