### PR TITLE
Update to 2.6.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ gem 'pg_search'
 gem 'calculate_in_group'
 
 # Dashboard analytics
-gem 'energy-sparks_analytics', git: 'https://github.com/Energy-Sparks/energy-sparks_analytics.git', tag: '2.6.1'
+gem 'energy-sparks_analytics', git: 'https://github.com/Energy-Sparks/energy-sparks_analytics.git', tag: '2.6.2'
 #gem 'energy-sparks_analytics', git: 'https://github.com/Energy-Sparks/energy-sparks_analytics.git', branch: 'aws-eb-test'
 #gem 'energy-sparks_analytics', path: '../energy-sparks_analytics'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/Energy-Sparks/energy-sparks_analytics.git
-  revision: 2da4663ea97c1bb7cf3604fffb75e3608bafa43f
-  tag: 2.6.1
+  revision: 992942bdf1d7518fba31aea39b5e53ec839843fc
+  tag: 2.6.2
   specs:
     energy-sparks_analytics (1.2.1)
       activesupport (~> 6.0.0)
@@ -132,7 +132,7 @@ GEM
       aws-sigv4 (~> 1.4)
     aws-sigv4 (1.4.0)
       aws-eventstream (~> 1, >= 1.0.2)
-    backports (3.21.0)
+    backports (3.24.1)
     bcrypt (3.1.16)
     benchmark-memory (0.1.2)
       memory_profiler (~> 0.9)
@@ -390,7 +390,7 @@ GEM
       childprocess (>= 0.6.3, < 5)
       iniparse (~> 1.4)
       rexml (~> 3.2)
-    packable (1.3.15)
+    packable (1.3.17)
       backports
     pagy (5.6.3)
     parallel (1.21.0)

--- a/config/locales/analytics/benchmarking/content_base.yml
+++ b/config/locales/analytics/benchmarking/content_base.yml
@@ -118,6 +118,7 @@ en:
           baseload_percent: Baseload as a percent of total usage
           blended_current_rate: Blended current rate
           change: Change
+          change_co2: Change CO2
           change_excluding_solar: Change (excluding solar)
           change_in_annual_co2: Change in annual CO2
           change_in_annual_electricity_co2_excluding_solar: Change in annual electricity CO2 (excluding solar)
@@ -131,6 +132,7 @@ en:
           change_in_heating_costs_between_last_2_years: Change in heating costs between last 2 years
           change_kwh: Change kWh
           change_pct: Change %
+          change_pct_co2: Change CO2 %
           change_£: Change £
           change_£current: Change £ (latest tariff)
           co2_last_year: CO2 (last year)
@@ -542,6 +544,24 @@ en:
               the unadjusted previous year value. The adjusted percent change is a better
               indicator of the work a school might have done to reduce its energy consumption as
               it&apos;s not dependent on temperature differences between the two years.
+            </p>
+        easter_shutdown_2023_energy_comparison:
+          introduction_text_html: |-
+            <p>
+            This benchmark shows the change in energy consumption between the most recent holiday, and the last week of the previous school term.
+            </p>
+            <p>
+            This comparison compares the latest available data for the most recent holiday with an adjusted figure for the last week of the school term, scaling to the same number of days and adjusting for changes in outside temperature and the latest tariff. The change in £ is the saving or increased cost for the most recent holiday to date compared to term time consumption.
+            </p>
+            <p>
+              Schools' solar PV production has been removed from the comparison.
+            </p>
+            <p>
+              CO2 values for electricity (including where the CO2 is
+              aggregated across electricity, gas, storage heaters) is difficult
+              to compare for short periods as it is dependent on the carbon intensity
+              of the national grid on the days being compared and this could vary by up to
+              300&percnt; from day to day.
             </p>
         electricity_consumption_during_holiday:
           introduction_text_html: "<p>This benchmark shows the projected electricity costs for the current holiday. No data for a school is shown once the holiday is over. The projection calculation is based on the consumption patterns during the holiday so far.</p>"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -851,13 +851,13 @@ ActiveRecord::Schema.define(version: 2023_04_18_114415) do
     t.index ["replaced_by_id"], name: "index_global_meter_attributes_on_replaced_by_id"
   end
 
-  create_table "good_job_processes", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "good_job_processes", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.jsonb "state"
   end
 
-  create_table "good_job_settings", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "good_job_settings", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.text "key"
@@ -865,7 +865,7 @@ ActiveRecord::Schema.define(version: 2023_04_18_114415) do
     t.index ["key"], name: "index_good_job_settings_on_key", unique: true
   end
 
-  create_table "good_jobs", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "good_jobs", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.text "queue_name"
     t.integer "priority"
     t.jsonb "serialized_params"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -851,13 +851,13 @@ ActiveRecord::Schema.define(version: 2023_04_18_114415) do
     t.index ["replaced_by_id"], name: "index_global_meter_attributes_on_replaced_by_id"
   end
 
-  create_table "good_job_processes", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "good_job_processes", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.jsonb "state"
   end
 
-  create_table "good_job_settings", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "good_job_settings", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.text "key"
@@ -865,7 +865,7 @@ ActiveRecord::Schema.define(version: 2023_04_18_114415) do
     t.index ["key"], name: "index_good_job_settings_on_key", unique: true
   end
 
-  create_table "good_jobs", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "good_jobs", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.text "queue_name"
     t.integer "priority"
     t.jsonb "serialized_params"


### PR DESCRIPTION
Update to analytics 2.6.2 and copy over updated YAML file.

Changes the definition of the Easter shutdown benchmark tables and introductory text.