### PR TITLE
Push entire "meters running behind" query into database

### DIFF
--- a/app/services/import_notifier.rb
+++ b/app/services/import_notifier.rb
@@ -4,55 +4,44 @@ class ImportNotifier
   end
 
   def meters_running_behind
-    find_with_config do |config|
-      if config.import_warning_days.present?
-        Meter.active
-          #that have readings loaded from this config (~ data source) in the last 12 months
-          .joins(:amr_data_feed_readings).where("amr_data_feed_readings.amr_data_feed_config_id=?", config.id)
-          .where("amr_data_feed_readings.created_at >= NOW() - INTERVAL '1 year'")
-          #and where the latest validated reading is older than what we expect in the config
-          .joins(:amr_validated_readings).group('meters.id').having("MAX(amr_validated_readings.reading_date) < NOW() - INTERVAL '? days'", config.import_warning_days)
-      else
-        []
-      end
-    end
+    meters = Meter.active
+    .joins(:amr_data_feed_readings)
+    .where("amr_data_feed_readings.created_at >= NOW() - INTERVAL '1 year'")
+    .joins("INNER JOIN amr_data_feed_configs on amr_data_feed_readings.amr_data_feed_config_id = amr_data_feed_configs.id")
+    .where.not("amr_data_feed_configs.import_warning_days" => nil)
+    .joins(:amr_validated_readings)
+    .group('meters.id')
+    .having("MAX(amr_validated_readings.reading_date) < NOW() - MIN(amr_data_feed_configs.import_warning_days) * '1 day'::interval")
+    meters.sort_by {|m| [m.school.area_name, m.meter_type, m.school_name, m.mpan_mprn]}
   end
 
   #data feed readings, creating in last 24 hours, where the readings are ALL blank
   #nil, numeric, string values are not blank, so this equates to an array of ['']
   def meters_with_blank_data(from: 24.hours.ago, to: Time.zone.now)
-    Meter.active
+    meters = Meter.active
     .joins(:amr_data_feed_readings)
     .where("amr_data_feed_readings.readings = ARRAY[?]", Array.new(48, '')) #where readings is empty string
     .joins("INNER JOIN amr_data_feed_import_logs on amr_data_feed_readings.amr_data_feed_import_log_id = amr_data_feed_import_logs.id") #manually join to import logs
     .where('import_time BETWEEN :from AND :to', from: from, to: to) #limit to period
     .distinct #distinct meters
+    meters.sort_by {|m| [m.school.area_name, m.meter_type, m.school_name, m.mpan_mprn]}
   end
 
   #data feed readings, creating in last 24 hours, where the readings are ALL 0 or 0.0
   #this version is slightly different to original as that used ruby to cast values to a float
   #this meant any dodgy chars, e.g. '-', where treated as 0.0
   def meters_with_zero_data(from: 24.hours.ago, to: Time.zone.now)
-    Meter.active
+    meters = Meter.active
     .where.not(meter_type: :exported_solar_pv) # exported solar PV is legitimately zero on some days
     .joins(:amr_data_feed_readings)
     .where("amr_data_feed_readings.readings = ARRAY[?] OR amr_data_feed_readings.readings = ARRAY[?]", Array.new(48, '0'), Array.new(48, '0.0')) #where readings are 0, or 0.0
     .joins("INNER JOIN amr_data_feed_import_logs on amr_data_feed_readings.amr_data_feed_import_log_id = amr_data_feed_import_logs.id") #manually join to import logs
     .where('import_time BETWEEN :from AND :to', from: from, to: to) #limit to period
     .distinct #distinct meters
+    meters.sort_by {|m| [m.school.area_name, m.meter_type, m.school_name, m.mpan_mprn]}
   end
 
   def notify(from:, to:)
     ImportMailer.with(meters_running_behind: meters_running_behind, meters_with_blank_data: meters_with_blank_data(from: from, to: to), meters_with_zero_data: meters_with_zero_data(from: from, to: to), description: @description).import_summary.deliver_now
-  end
-
-  private
-
-  def find_with_config
-    meters = []
-    AmrDataFeedConfig.order(:description).each do |config|
-      meters = meters | yield(config)
-    end
-    meters.sort_by {|m| [m.school.area_name, m.meter_type, m.school_name, m.mpan_mprn]}
   end
 end


### PR DESCRIPTION
Currently we loop over every data feed config and run the same query so that we can check its warning days, if it has one.

For some configs this is very quick, others very slow.

This changes the code to just join against the `amr_data_feed_configs` table, where the `import_warning_days` is not null, then check whether the latest meter data is older than the minimum value of the warning days.

This means we do one query rather than several. Overall I think this version is faster!
