### PR TITLE
Rework school group meters query

### DIFF
--- a/app/models/meter.rb
+++ b/app/models/meter.rb
@@ -61,6 +61,7 @@ class Meter < ApplicationRecord
   has_many :issue_meters, dependent: :destroy
   has_many :issues, through: :issue_meters
 
+  has_one :school_group, through: :school
   has_and_belongs_to_many :user_tariffs, inverse_of: :meters
 
   CREATABLE_METER_TYPES = [:electricity, :gas, :solar_pv, :exported_solar_pv].freeze
@@ -82,7 +83,7 @@ class Meter < ApplicationRecord
 
   scope :with_counts, -> {
                             left_outer_joins(:amr_validated_readings)
-                            .group('meters.id')
+                            .group('schools.id', 'meters.id')
                             .select(
                               "meters.*,
                                MIN(amr_validated_readings.reading_date) AS first_validated_reading_date,

--- a/app/views/admin/school_groups/meter_reports/show.html.erb
+++ b/app/views/admin/school_groups/meter_reports/show.html.erb
@@ -51,13 +51,12 @@
       </tr>
     </thead>
     <tbody>
-      <% @school_group.schools.by_name.each do |school| %>
-        <% school.meters.where(@meter_scope).with_counts.order(:mpan_mprn).each do |meter| %>
+        <% @meters.each do |meter| %>
           <tr>
-            <td><%= link_to(school.name, school_path(school)) %></td>
+            <td><%= link_to(meter.school.name, school_path(meter.school)) %></td>
             <td><%= fa_icon fuel_type_icon(meter.meter_type) %></td>
             <td>
-              <%= link_to(meter.mpan_mprn, school_meter_path(school, meter)) %>
+              <%= link_to(meter.mpan_mprn, school_meter_path(meter.school, meter)) %>
             </td>
             <td><%= link_to(meter.name.present? ? meter.name : meter.meter_type.to_s.humanize, admin_reports_amr_validated_reading_path(meter)) if AmrValidatedReading.where(meter_id: meter.id).any? %></td>
             <% if @meter_scope.empty? %>
@@ -80,7 +79,6 @@
             </td>
           </tr>
         <% end %>
-      <% end %>
     </tbody>
   </table>
 </div>


### PR DESCRIPTION
Reworks the school group meter report to query directly for meters associated with a school group, so the list of meters, start and end dates and count of zero readings can be done entirely in the database.

This seems faster than the loop over schools and meters.

We might still need to optimise the checks for gappy readings. 