### PR TITLE
Further tweaks to interactive report

### DIFF
--- a/app/controllers/admin/school_groups/meter_reports_controller.rb
+++ b/app/controllers/admin/school_groups/meter_reports_controller.rb
@@ -6,7 +6,7 @@ module Admin
 
       def show
         respond_to do |format|
-          format.html { @meters = meter_report.meters }
+          format.html { @meters = meter_report.meters(full_detail: false) }
           format.csv { send_data meter_report.csv, filename: meter_report.csv_filename }
         end
       end

--- a/app/models/meter.rb
+++ b/app/models/meter.rb
@@ -17,6 +17,7 @@
 #  meter_type                     :integer
 #  mpan_mprn                      :bigint(8)
 #  name                           :string
+#  procurement_route_id           :bigint(8)
 #  pseudo                         :boolean          default(FALSE)
 #  sandbox                        :boolean          default(FALSE)
 #  school_id                      :bigint(8)        not null
@@ -30,6 +31,7 @@
 #  index_meters_on_meter_review_id                 (meter_review_id)
 #  index_meters_on_meter_type                      (meter_type)
 #  index_meters_on_mpan_mprn                       (mpan_mprn) UNIQUE
+#  index_meters_on_procurement_route_id            (procurement_route_id)
 #  index_meters_on_school_id                       (school_id)
 #  index_meters_on_solar_edge_installation_id      (solar_edge_installation_id)
 #
@@ -49,6 +51,7 @@ class Meter < ApplicationRecord
   belongs_to :solar_edge_installation, optional: true
   belongs_to :meter_review, optional: true
   belongs_to :data_source, optional: true
+  belongs_to :procurement_route, optional: true
   belongs_to :admin_meter_status, foreign_key: 'admin_meter_statuses_id', optional: true
 
   has_one :rtone_variant_installation, required: false

--- a/app/services/school_groups/meter_report.rb
+++ b/app/services/school_groups/meter_report.rb
@@ -52,13 +52,22 @@ module SchoolGroups
       end
     end
 
-    def meters
-      Meter.where(@meter_scope)
-        .joins(:school)
-        .joins(:school_group)
-        .where(schools: { school_group: @school_group })
-        .with_counts
-        .order("schools.name", :mpan_mprn)
+    def meters(full_detail: true)
+      if full_detail
+        Meter.where(@meter_scope)
+          .joins(:school)
+          .joins(:school_group)
+          .where(schools: { school_group: @school_group })
+          .with_counts
+          .order("schools.name", :mpan_mprn)
+      else
+        Meter.where(@meter_scope)
+          .joins(:school)
+          .joins(:school_group)
+          .where(schools: { school_group: @school_group })
+          .with_reading_dates
+          .order("schools.name", :mpan_mprn)
+      end
     end
   end
 end

--- a/app/views/admin/reports/meter_reports/index.html.erb
+++ b/app/views/admin/reports/meter_reports/index.html.erb
@@ -18,7 +18,7 @@
           <td>
             <div class='btn-group'>
               <%= link_to 'Meter Report', admin_school_group_meter_report_path(school_group), class: 'btn' %>
-              <%= link_to 'Download CSV', admin_school_group_meter_report_path(school_group, format: :csv) , class: 'btn' %>
+              <%= link_to "#{fa_icon('envelope')} Meter report".html_safe, deliver_admin_school_group_meter_report_path(school_group) , class: 'btn', title: "Email meter report csv", method: :update, data: { confirm: "Are you sure you want to send the meter report to #{current_user.email}?" } %>
               <%= link_to 'Download meter collections', admin_schools_meter_collections_path(anchor: "school-group-#{school_group.id}"), class: 'btn' %>
             </div>
           </td>

--- a/app/views/admin/school_groups/meter_reports/show.html.erb
+++ b/app/views/admin/school_groups/meter_reports/show.html.erb
@@ -8,8 +8,8 @@
 <p>You can download the individual meter collections (unvalidated, validated and aggregated) for each school</p>
 <p><%= link_to "Download meter collections", admin_schools_meter_collections_path(anchor: "school-group-#{@school_group.id}") %>
 
-<p>You can download this school group meter report as CSV</p>
-<p><%= link_to "Download CSV", admin_school_group_meter_report_path(@school_group, format: :csv) %>
+<p>You can request this school group meter report as CSV</p>
+<%= link_to "#{fa_icon('envelope')} Meter report".html_safe, deliver_admin_school_group_meter_report_path(@school_group) , class: 'btn btn-sm', title: "Email meter report csv", method: :update, data: { confirm: "Are you sure you want to send the meter report to #{current_user.email}?" } %>
 
 <% unless @meter_scope.empty? %>
   <h2>Meters</h2>
@@ -67,7 +67,7 @@
             <td class="gappy-dates"><%= date_range_from_reading_gaps(meter.gappy_validated_readings) %></td>
             <td class="modified-dates"><%= meter.modified_validated_readings.count %></td>
             <td class="<%= meter.zero_reading_days_warning? ? 'table-danger' : ''%>">
-              <%= meter.zero_reading_days_count %>
+              <%= y_n(meter.zero_reading_days.any?) %>
             </td>
             <td>
              <% if meter.issues.any? %>

--- a/app/views/admin/school_groups/meter_reports/show.html.erb
+++ b/app/views/admin/school_groups/meter_reports/show.html.erb
@@ -9,7 +9,7 @@
 <p><%= link_to "Download meter collections", admin_schools_meter_collections_path(anchor: "school-group-#{@school_group.id}") %>
 
 <p>You can request this school group meter report as CSV</p>
-<%= link_to "#{fa_icon('envelope')} Meter report".html_safe, deliver_admin_school_group_meter_report_path(@school_group) , class: 'btn btn-sm', title: "Email meter report csv", method: :update, data: { confirm: "Are you sure you want to send the meter report to #{current_user.email}?" } %>
+<%= link_to "#{fa_icon('envelope')} Meter report".html_safe, deliver_admin_school_group_meter_report_path(@school_group, all_meters: params[:all_meters]) , class: 'btn btn-sm', title: "Email meter report csv", method: :update, data: { confirm: "Are you sure you want to send the meter report to #{current_user.email}?" } %>
 
 <% unless @meter_scope.empty? %>
   <h2>Meters</h2>

--- a/app/views/admin/school_groups/show.html.erb
+++ b/app/views/admin/school_groups/show.html.erb
@@ -51,7 +51,6 @@
   <%= link_to 'Meter attributes', admin_school_group_meter_attributes_path(@school_group), class: 'btn btn-sm' %>
   <%= link_to 'Meter updates', admin_school_group_meter_updates_path(@school_group), class: 'btn btn-sm' %>
   <%= link_to 'Meter report', admin_school_group_meter_report_path(@school_group), class: 'btn btn-sm' %>
-  <%= link_to "#{fa_icon('file-download')} Meter report".html_safe, admin_school_group_meter_report_path(@school_group, format: :csv) , class: 'btn btn-sm', title: "Download meter report csv" %>
   <%= link_to "#{fa_icon('envelope')} Meter report".html_safe, deliver_admin_school_group_meter_report_path(@school_group) , class: 'btn btn-sm', title: "Email meter report csv", method: :update, data: { confirm: "Are you sure you want to send the meter report to #{current_user.email}?" } %>
   <%= link_to "#{fa_icon('file-download')} Issues".html_safe, admin_school_group_issues_path(@school_group, format: :csv) , class: 'btn btn-sm', title: "Download issues csv" %>
   <div title="School groups can only be deleted if there are no associated schools or users" rel="tooltip">

--- a/spec/system/admin/reports/school_group_meter_reports_spec.rb
+++ b/spec/system/admin/reports/school_group_meter_reports_spec.rb
@@ -25,18 +25,8 @@ describe 'school group meter reports', type: :system do
       expect(page).to have_content("School group meter data reports")
       expect(page).to have_content(school_group.name)
       expect(page).to have_link("Meter Report")
-      expect(page).to have_link("Download CSV")
+      expect(page).to have_link(href: deliver_admin_school_group_meter_report_path(school_group))
       expect(page).to have_link("Download meter collections")
-    end
-
-    it 'downloads csv' do
-      click_on "Download CSV"
-      header = page.response_headers['Content-Disposition']
-      expect(header).to match /^attachment/
-      expect(header).to match /#{school_group.name.parameterize}-meter-report.csv$/
-      expect(page.source).to have_content(school.name)
-      expect(page.source).to have_content(meter.mpan_mprn)
-      expect(page.source).to have_content(data_source.name)
     end
   end
 
@@ -49,7 +39,7 @@ describe 'school group meter reports', type: :system do
 
     it 'links to downloads and all meters' do
       expect(page).to have_content("#{school_group.name} meter report")
-      expect(page).to have_link("Download CSV")
+      expect(page).to have_link(href: deliver_admin_school_group_meter_report_path(school_group))
       expect(page).to have_link("Download meter collections")
     end
 
@@ -65,16 +55,6 @@ describe 'school group meter reports', type: :system do
       expect(page).to have_content(meter.mpan_mprn)
       expect(page).to have_content(meter_inactive.mpan_mprn)
       expect(page).not_to have_link("Show all meters")
-    end
-
-    it 'downloads csv' do
-      click_on "Download CSV"
-      header = page.response_headers['Content-Disposition']
-      expect(header).to match /^attachment/
-      expect(header).to match /#{school_group.name.parameterize}-meter-report.csv$/
-      expect(page.source).to have_content(school.name)
-      expect(page.source).to have_content(meter.mpan_mprn)
-      expect(page.source).to have_content(data_source.name)
     end
   end
 end

--- a/spec/system/admin/school_groups_spec.rb
+++ b/spec/system/admin/school_groups_spec.rb
@@ -206,11 +206,7 @@ RSpec.describe 'school groups', :school_groups, type: :system, include_applicati
           before { click_link 'Meter report', href: admin_school_group_meter_report_path(school_group) }
           it { expect(page).to have_current_path(admin_school_group_meter_report_path(school_group)) }
         end
-        it { expect(page).to have_link('Meter report', href: admin_school_group_meter_report_path(school_group, format: :csv)) }
-        context "clicking 'Download meter report' button" do
-          before { click_link 'Meter report', href: admin_school_group_meter_report_path(school_group, format: :csv) }
-          it { expect(page).to have_current_path(admin_school_group_meter_report_path(school_group, format: :csv)) }
-        end
+        it { expect(page).to have_link(href: deliver_admin_school_group_meter_report_path(school_group)) }
         it { expect(page).to have_link('Issues') }
         context "clicking 'Download issues' button" do
           before { click_link 'Issues' }


### PR DESCRIPTION
* Don't include counts of zero days on the interactive report, to see if this version works OK and at least provides some information.
* Remove the old CSV download link on the admin school group page, the main meter report page and the individual meter report page
* Add the "request report by email" button to the admin index page and to the individual report page
* Ensure the "all meters" option is added to the request when needed