### PR TITLE
Parallelize weekly alert run (subscriptions)

### DIFF
--- a/.ebextensions/cronjob.config
+++ b/.ebextensions/cronjob.config
@@ -161,7 +161,7 @@ files:
         owner: root
         group: root
         content: |
-            45 7 * * Wed root /bin/bash -l -c 'cd /var/app/current && RAILS_ENV=production bin/run_as_webapp bundle exec rake alerts:generate_subscriptions >> log/jobs.log 2>&1'
+            30 6 * * Wed root /bin/bash -l -c 'cd /var/app/current && RAILS_ENV=production bin/run_as_webapp bundle exec rake alerts:generate_subscriptions >> log/jobs.log 2>&1'
     #
     # EMail summary of imports
     #

--- a/app/jobs/daily_regeneration_job.rb
+++ b/app/jobs/daily_regeneration_job.rb
@@ -1,6 +1,10 @@
 class DailyRegenerationJob < ApplicationJob
   queue_as :regeneration
 
+  def priority
+    10
+  end
+
   def perform(school:)
     GoodJob.logger.info("#{DateTime.now.utc} Regeneration for school #{school.name} start")
     run_validate_and_persist_readings_service_for(school)

--- a/app/jobs/generate_subscriptions_job.rb
+++ b/app/jobs/generate_subscriptions_job.rb
@@ -1,0 +1,12 @@
+class GenerateSubscriptionsJob < ApplicationJob
+  queue_as :regeneration
+
+  def priority
+    5
+  end
+
+  def perform(school_id:)
+    school = School.find(school_id)
+    Alerts::GenerateSubscriptions.new(school).perform(subscription_frequency: school.subscription_frequency)
+  end
+end

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -567,6 +567,14 @@ class School < ApplicationRecord
     country == 'wales' ? [:en, :cy] : [:en]
   end
 
+  def subscription_frequency
+    if holiday_approaching?
+      [:weekly, :termly, :before_each_holiday]
+    else
+      [:weekly]
+    end
+  end
+
   private
 
   def add_joining_observation

--- a/lib/tasks/alerts/generate_subscriptions.rake
+++ b/lib/tasks/alerts/generate_subscriptions.rake
@@ -6,7 +6,7 @@ namespace :alerts do
 
     schools.each do |school|
       puts "Running alert subscription generation for #{school.name}, including #{school.subscription_frequency.to_sentence} subscriptions"
-      GenerateSubscriptionsJob.perform(school_id: school.id)
+      GenerateSubscriptionsJob.perform_later(school_id: school.id)
     end
 
     puts "#{DateTime.now.utc} Generate subscriptions end"

--- a/lib/tasks/alerts/generate_subscriptions.rake
+++ b/lib/tasks/alerts/generate_subscriptions.rake
@@ -5,13 +5,8 @@ namespace :alerts do
     schools = School.data_enabled.process_data.visible.with_config
 
     schools.each do |school|
-      subscription_frequency = if school.holiday_approaching?
-                                 [:weekly, :termly, :before_each_holiday]
-                               else
-                                 [:weekly]
-                               end
-      puts "Running alert subscription generation for #{school.name}, including #{subscription_frequency.to_sentence} subscriptions"
-      Alerts::GenerateSubscriptions.new(school).perform(subscription_frequency: subscription_frequency)
+      puts "Running alert subscription generation for #{school.name}, including #{school.subscription_frequency.to_sentence} subscriptions"
+      GenerateSubscriptionsJob.perform(school_id: school.id)
     end
 
     puts "#{DateTime.now.utc} Generate subscriptions end"

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -721,6 +721,18 @@ describe School do
       expect(school.intervention_types_in_academic_year(Date.parse('01-01-1900'))).to eq([])
     end
 
+    describe '#subscription_frequency' do
+      it 'returns the subscription frequency for a school if there is a holiday approaching' do
+        allow(school).to receive(:holiday_approaching?) { true }
+        expect(school.subscription_frequency).to eq([:weekly, :termly, :before_each_holiday])
+      end
+
+      it 'returns the subscription frequency for a school if there is not a holiday approaching' do
+        allow(school).to receive(:holiday_approaching?) { false }
+        expect(school.subscription_frequency).to eq([:weekly])
+      end
+    end
+
     context 'when finding intervention types by date' do
       let!(:recent_observation)  { create(:observation, :intervention, at: date_1 + 1.day, school: school, intervention_type: intervention_type_2) }
       it 'finds intervention types by date, including duplicates, excluding non-intervention observations' do


### PR DESCRIPTION
Every Weds ES reruns alerts:generate_subscriptions. This loops through all schools and invokes the Alerts::GenerateSubscriptions service for each school.  The process is getting slower (and CPU intensive) as we add more schools. Further, because the process starts via cron, it may begin before we’ve finished the daily regeneration of schools which creates the potential that the email contents don’t have the very latest alert content from schools.

In order to address these issues, this PR:

- [x] Adds a new subscription_frequency method to schools that returns the correct subscription frequency depending on if there is an upcoming holiday, or not.
- [x] Creates a new job that will run the Alerts::GenerateSubscriptions service for a school and a subscription_frequency
- [x] Ensures those jobs are submitted to the regeneration queue like the daily regeneration jobs, so they’ll be processed by the same pool of workers
- [x] Sets the DailyRegenerationJob priority to 10 and the new subscription job a priority of 5, so that the regeneration jobs will always be processed first
- [x] Revises the generate_subscriptions rake task to enqueue a job for each school
- [x] Revises the timing of the generate_subscriptions job so that it starts earlier - at 6.30am instead of 7.45 am. 

