### PR TITLE
Make it more obvious when events are sold out

### DIFF
--- a/app/services/events/event.rb
+++ b/app/services/events/event.rb
@@ -8,7 +8,6 @@ module Events
       @date = DateTime.parse(eventbrite.start.local)
       @url = eventbrite.url
       @sold_out = false
-      @ticket_availability = eventbrite.ticket_availability
       if eventbrite.ticket_availability.present?
         @sold_out = eventbrite.ticket_availability.is_sold_out
       end

--- a/app/services/events/event.rb
+++ b/app/services/events/event.rb
@@ -8,6 +8,7 @@ module Events
       @date = DateTime.parse(eventbrite.start.local)
       @url = eventbrite.url
       @sold_out = false
+      @ticket_availability = eventbrite.ticket_availability
       if eventbrite.ticket_availability.present?
         @sold_out = eventbrite.ticket_availability.is_sold_out
       end

--- a/app/views/home/training.html.erb
+++ b/app/views/home/training.html.erb
@@ -33,7 +33,10 @@
               </td>
               <td>
                 <h3 class="pt-1"><strong><%= link_to event.name, event.url, target: "_blank" %></strong></h3>
-                <span class="text-muted"><%= nice_date_times(event.date) %></span>
+                <span class="text-muted">
+                  <%= nice_date_times(event.date) %> |
+                  <%= event.sold_out? ? t('training.sold_out') : t('training.spaces_available') %>
+                </span>
               </td>
               <td class="text-right">
               </td>

--- a/config/locales/views/home/home.yml
+++ b/config/locales/views/home/home.yml
@@ -46,6 +46,8 @@ en:
     other: "%{count} schools"
   training:
     intro: This page lists all of our upcoming training sessions. Follow the links to our Eventbrite page to book your tickets.
+    sold_out: Sold out
+    spaces_available: Spaces available
     title: Training
   videos:
     title: User guide videos

--- a/spec/fixtures/events/events.json
+++ b/spec/fixtures/events/events.json
@@ -340,7 +340,7 @@
                "display" : "0.00 GBP",
                "major_value" : "0.00"
             },
-            "is_sold_out" : false,
+            "is_sold_out" : true,
             "start_sales_date" : null,
             "has_available_tickets" : true,
             "waitlist_available" : false,

--- a/spec/system/home_spec.rb
+++ b/spec/system/home_spec.rb
@@ -81,7 +81,9 @@ RSpec.describe "home", type: :system do
     before do
       visit root_path
       click_on('Our services')
-      expect(EventbriteSDK).to receive(:get).with(any_args).and_return response
+      expect(EventbriteSDK).to receive(:get).with(any_args) do
+        response
+      end
       within('#our-services') do
         click_on('Training')
       end

--- a/spec/system/home_spec.rb
+++ b/spec/system/home_spec.rb
@@ -76,13 +76,22 @@ RSpec.describe "home", type: :system do
     expect(page.has_content? "Enrol with Energy Sparks")
   end
 
-  it "has a training page" do
+  describe 'training page' do
+    let(:response) { JSON.load( File.new( File.join( fixture_path, "events/events.json") ) ) }
+    before do
       visit root_path
       click_on('Our services')
+      expect(EventbriteSDK).to receive(:get).with(any_args).and_return response
       within('#our-services') do
         click_on('Training')
       end
-    expect(page.has_content? 'Training')
+    end
+
+    it "has a training page" do
+      expect(page).to have_content('Training')
+      expect(page).to have_content('Sold out')
+      expect(page).to have_content('Spaces available')
+    end
   end
 
   it 'has a datasets page' do


### PR DESCRIPTION
I tried very hard to find a count of tickets remaining to also add to the page but could not find an easy way... so I stuck with the original plan of just showing "sold out" or "tickets available".