### PR TITLE
Fix broken storage heater progress report

### DIFF
--- a/app/views/schools/school_targets/progress/current.html.erb
+++ b/app/views/schools/school_targets/progress/current.html.erb
@@ -92,7 +92,7 @@
 
   <h3><%= t('schools.school_targets.progress.current.progress_charts') %></h3>
 
-  <%= render 'charts', school: @school, fuel_type: @fuel_type, progress: @progress %>
+  <%= render 'charts', school: @school, fuel_type: @fuel_type == :storage_heaters ? :storage_heater : @fuel_type, progress: @progress %>
 
   <% if current_user.present? && current_user.analytics? %>
     <h2><%= t('schools.school_targets.progress.current.debug') %></h2>


### PR DESCRIPTION
This fixes an error where a chart config is requested for the pluralised storage heater fuel type which doesn't exist e.g.
```
>> @chart_name
=> :targeting_and_tracking_weekly_storage_heaters_to_date_cumulative_line
>> ChartManager.build_chart_config(ChartManager::STANDARD_CHART_CONFIGURATION[@chart_name])
!! #<NoMethodError: undefined method `key?' for nil:NilClass>
>> ChartManager.build_chart_config(ChartManager::STANDARD_CHART_CONFIGURATION[:targeting_and_tracking_weekly_storage_heater_to_date_cumulative_line])
=> {:name=>"Cumulative progress versus target", :chart1_type=>:line, :chart1_subtype=>nil, :meter_definition=>:storage_heater_meter, :x_axis=>:week, :series_breakdown=>:none, :yaxis_units=>:kwh, :yaxis_scaling=>:none, :timescale=>:up_to_a_year, :replace_series_label=>[["Energy:<school_name>: target", "target"], ["Energy:<school_name>", "actual"]], :nullify_trailing_zeros=>true, :restrict_y1_axis=>[:kwh, :co2], :ignore_single_series_failure=>true, :target=>{:calculation_type=>:day, :extend_chart_into_future=>true, :truncate_before_start_date=>true}, :cumulative=>true}
>>
```