### PR TITLE
Update PostgreSQL image for both github actions test jobs

### DIFF
--- a/.github/workflows/rubyonrails.yml
+++ b/.github/workflows/rubyonrails.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       postgres:
-        image: postgres:14-alpine
+        image: postgres:14
         ports:
           - "5432:5432"
         env:
@@ -47,7 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       postgres:
-        image: postgres:14-alpine
+        image: postgres:14
         ports:
           - "5432:5432"
         env:


### PR DESCRIPTION
There's an open issue with the alpine linux version of the PostgreQSL image we use for running our github actions test jobs see  https://github.com/docker-library/postgres/issues/1076 so changing here to an equivalent versioned tag.