### PR TITLE
Fix table issue with group level accounting charges and costs

### DIFF
--- a/app/components/meter_costs_table_component.rb
+++ b/app/components/meter_costs_table_component.rb
@@ -99,7 +99,7 @@ class MeterCostsTableComponent < ViewComponent::Base
   end
 
   def other
-    [:feed_in_tariff_levy, :climate_change_levy__2021_22, :renewable_energy_obligation]
+    [:feed_in_tariff_levy, :climate_change_levy__2021_22, :renewable_energy_obligation] + MeterAttributes.default_economic_rates.structure.keys
   end
 
   def vat_charges

--- a/config/locales/views/advice_pages/advice_pages.yml
+++ b/config/locales/views/advice_pages/advice_pages.yml
@@ -111,6 +111,7 @@ en:
           commodity_rate: Commodity rate
           data_collection_dcda_agent_charge: DC/DA agent charge
           day_night: "%{time_from} to %{time_to}"
+          daytime_rate: Daytime rate
           duos_amber: Duos (Amber)
           duos_green: Duos (Green)
           duos_red: Duos (Red)
@@ -121,7 +122,9 @@ en:
           meter_asset_provider_charge: Meter asset provider charge
           nhh_automatic_meter_reading_charge: NHH Automatic meter reading charge
           nhh_metering_agent_charge: NHH Metering agent charge
+          nighttime_rate: Night-time rate
           non_commodity_rate: Non commodit rate
+          rate: Rate
           reactive_power_charge: Reactive power charge
           renewable_energy_obligation: Renewable energy obligation
           settlement_agency_fee: Settlement agency fee


### PR DESCRIPTION
```
irb(main):045:0> MeterAttributes.default_tariff_rates.keys
=> [:standing_charge, :climate_change_levy, :renewable_energy_obligation, :feed_in_tariff_levy, :agreed_capacity, :agreed_availability_charge, :excess_availability_charge, :settlement_agency_fee, :reactive_power_charge, :data_collection_dcda_agent_charge, :nhh_automatic_meter_reading_charge, :half_hourly_data_charge, :fixed_charge, :nhh_metering_agent_charge, :meter_asset_provider_charge, :site_fee, :other]
```