### PR TITLE
3228 school dashboard charts skip a week

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ gem 'pg_search'
 gem 'calculate_in_group'
 
 # Dashboard analytics
-gem 'energy-sparks_analytics', git: 'https://github.com/Energy-Sparks/energy-sparks_analytics.git', tag: '2.7.4'
+gem 'energy-sparks_analytics', git: 'https://github.com/Energy-Sparks/energy-sparks_analytics.git', tag: '2.7.5'
 #gem 'energy-sparks_analytics', git: 'https://github.com/Energy-Sparks/energy-sparks_analytics.git', branch: 'aws-eb-test'
 #gem 'energy-sparks_analytics', path: '../energy-sparks_analytics'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/Energy-Sparks/energy-sparks_analytics.git
-  revision: a92978432f3e8fa301f464a68a9918335b045131
-  tag: 2.7.4
+  revision: d0bca8718824b0d2ad8555ae055daf474ee319f0
+  tag: 2.7.5
   specs:
     energy-sparks_analytics (1.2.1)
       activesupport (>= 6.0, < 7.1)

--- a/app/controllers/schools/advice/advice_base_controller.rb
+++ b/app/controllers/schools/advice/advice_base_controller.rb
@@ -154,7 +154,7 @@ module Schools
 
       #for charts that use the last full week
       def last_full_week_end_date(end_date)
-        end_date.prev_week.end_of_week - 1
+        end_date.end_of_week - 1
       end
 
       def analysis_dates

--- a/app/controllers/schools/advice/base_long_term_controller.rb
+++ b/app/controllers/schools/advice/base_long_term_controller.rb
@@ -55,16 +55,6 @@ module Schools
         )
       end
 
-      #for charts that use the last full week
-      def last_full_week_start_date(end_date)
-        end_date.prev_year.end_of_week
-      end
-
-      #for charts that use the last full week
-      def last_full_week_end_date(end_date)
-        end_date.prev_week.end_of_week - 1
-      end
-
       def usage_service
         @usage_service ||= Schools::Advice::LongTermUsageService.new(@school, aggregate_school, fuel_type)
       end

--- a/spec/mailers/admin_mailer_spec.rb
+++ b/spec/mailers/admin_mailer_spec.rb
@@ -5,6 +5,11 @@ RSpec.describe AdminMailer do
   let(:email) { ActionMailer::Base.deliveries.last }
   let(:to) { 'test@test.com' }
 
+  around do |example|
+    ClimateControl.modify ENVIRONMENT_IDENTIFIER: 'unknown' do
+      example.run
+    end
+  end
 
   describe '#school_group_meters_report' do
 


### PR DESCRIPTION
Fixes issue with school dashboard charts skipping a week:

* Updates to analytics 2.7.5 which has the actual bug fix
* Adjust date calculations in advice controllers to reflect changes

There's an unrelated fix to a spec that was failing for me due to an environment difference.