### PR TITLE
Tariffs with only agreed/excess availability charges need to have an asc limit

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -56,6 +56,7 @@
 //= require form_wizard
 //= require trix_customisations
 //= require multi_select
+//= require depends_on
 
 //= require table_sorting
 //= require mailchimp

--- a/app/assets/javascripts/depends_on.js
+++ b/app/assets/javascripts/depends_on.js
@@ -1,0 +1,33 @@
+"use strict"
+
+$(document).ready(function() {
+
+  $(document).on('change','input[data-dependee]',function() {
+    let id = $(this).attr("data-dependee");
+    handler(id);
+  });
+
+  $(document).on('change','input[data-dependant]',function() {
+    let id = $(this).prop('id');
+    handler(id);
+  });
+
+  function handler(id) {
+    let dependee = $('#' + id);
+    let dependants = $('input[data-dependee="' + id + '"]');
+
+    var dependant_has_value = false;
+    dependants.each(function() {
+      let dependant_value = $(this).val();
+      if (dependant_value.length > 0) {
+        dependant_has_value = true;
+      }
+    });
+
+    if (dependant_has_value === true && dependee.val().length == 0) {
+      $('#' + id).tooltip('show');
+    } else {
+      $('#' + id).tooltip('hide');
+    }
+  }
+});

--- a/app/assets/javascripts/depends_on.js
+++ b/app/assets/javascripts/depends_on.js
@@ -4,15 +4,15 @@ $(document).ready(function() {
 
   $(document).on('change','input[data-dependee]',function() {
     let id = $(this).attr("data-dependee");
-    handler(id);
+    depends_on(id);
   });
 
   $(document).on('change','input[data-dependant]',function() {
     let id = $(this).prop('id');
-    handler(id);
+    depends_on(id);
   });
 
-  function handler(id) {
+  function depends_on(id) {
     let dependee = $('#' + id);
     let dependants = $('input[data-dependee="' + id + '"]');
 

--- a/app/helpers/tariffs_helper.rb
+++ b/app/helpers/tariffs_helper.rb
@@ -117,6 +117,10 @@ module TariffsHelper
     settings(charge_type).fetch(:label, default)
   end
 
+  def user_tariff_charge_type_tip(charge_type)
+    settings(charge_type).fetch(:tip, '')
+  end
+
   def settings(charge_type)
     UserTariffCharge.charge_types[charge_type.to_sym] || {}
   end

--- a/app/models/user_tariff.rb
+++ b/app/models/user_tariff.rb
@@ -49,7 +49,8 @@ class UserTariff < ApplicationRecord
   end
 
   def to_hash
-    hash = {
+    rates = rates_attrs
+    {
       start_date: start_date.to_s(:es_compact),
       end_date: end_date.to_s(:es_compact),
       source: :manually_entered,
@@ -58,14 +59,9 @@ class UserTariff < ApplicationRecord
       sub_type: '',
       rates: rates,
       vat: vat_rate,
-      climate_change_levy: ccl
-    }
-
-    if rates.key?(:agreed_availability_charge) || rates.key?(:excess_availability_charge)
-      hash[:asc_limit_kw] = value_for_charge(:asc_limit_kw)
-    end
-
-    hash
+      climate_change_levy: ccl,
+      asc_limit_kw: (value_for_charge(:asc_limit_kw) if rates_has_availability_charge?(rates))
+    }.compact
   end
 
   def value_for_charge(type)
@@ -76,7 +72,7 @@ class UserTariff < ApplicationRecord
 
   private
 
-  def rates
+  def rates_attrs
     attrs = {}
     if flat_rate
       if (first_price = user_tariff_prices.first)
@@ -95,6 +91,10 @@ class UserTariff < ApplicationRecord
     end
     attrs[:tnuos] = tnuos
     attrs
+  end
+
+  def rates_has_availability_charge?(rates)
+    rates.key?(:agreed_availability_charge) || rates.key?(:excess_availability_charge)
   end
 
   def hour_minutes(time)

--- a/app/models/user_tariff.rb
+++ b/app/models/user_tariff.rb
@@ -49,7 +49,7 @@ class UserTariff < ApplicationRecord
   end
 
   def to_hash
-    {
+    hash = {
       start_date: start_date.to_s(:es_compact),
       end_date: end_date.to_s(:es_compact),
       source: :manually_entered,
@@ -58,9 +58,14 @@ class UserTariff < ApplicationRecord
       sub_type: '',
       rates: rates,
       vat: vat_rate,
-      asc_limit_kw: value_for_charge(:asc_limit_kw),
       climate_change_levy: ccl
     }
+
+    if rates.key?(:agreed_availability_charge) || rates.key?(:excess_availability_charge)
+      hash[:asc_limit_kw] = value_for_charge(:asc_limit_kw)
+    end
+
+    hash
   end
 
   def value_for_charge(type)

--- a/app/models/user_tariff_charge.rb
+++ b/app/models/user_tariff_charge.rb
@@ -56,10 +56,12 @@ class UserTariffCharge < ApplicationRecord
         units: [:day, :month, :quarter]
       },
       agreed_availability_charge: {
-        units: [:kva]
+        units: [:kva],
+        tip: I18n.t('user_tariff_charge.available_capacity_tip')
       },
       excess_availability_charge: {
-        units: [:kva]
+        units: [:kva],
+        tip: I18n.t('user_tariff_charge.available_capacity_tip')
       },
       settlement_agency_fee: {
         units: [:day, :month, :quarter]

--- a/app/views/schools/user_tariff_charges/_charge_availability.html.erb
+++ b/app/views/schools/user_tariff_charges/_charge_availability.html.erb
@@ -1,15 +1,15 @@
 <table class="table table-charges">
   <tbody>
     <%= f.fields_for :agreed_availability_charge do |ff| %>
-      <%= render 'charge_basic_row', user_tariff_charge: user_tariff_charge_for_type(user_tariff_charges, :agreed_availability_charge), f: ff %>
+      <%= render 'charge_basic_row', user_tariff_charge: user_tariff_charge_for_type(user_tariff_charges, :agreed_availability_charge), f: ff, data: { dependee: 'user_tariff_charges_asc_limit_kw_value' } %>
     <% end %>
 
     <%= f.fields_for :excess_availability_charge do |ff| %>
-      <%= render 'charge_basic_row', user_tariff_charge: user_tariff_charge_for_type(user_tariff_charges, :excess_availability_charge), f: ff %>
+      <%= render 'charge_basic_row', user_tariff_charge: user_tariff_charge_for_type(user_tariff_charges, :excess_availability_charge), f: ff, data: { dependee: 'user_tariff_charges_asc_limit_kw_value' } %>
     <% end %>
 
     <%= f.fields_for :asc_limit_kw do |ff| %>
-      <%= render 'charge_basic_row', user_tariff_charge: user_tariff_charge_for_type(user_tariff_charges, :asc_limit_kw), f: ff %>
+      <%= render 'charge_basic_row', user_tariff_charge: user_tariff_charge_for_type(user_tariff_charges, :asc_limit_kw), f: ff, title: I18n.t('user_tariff_charge.available_capacity_tooltip'), data: { toggle: "tooltip", placement: "right", trigger: "manual", dependant: true } %>
     <% end %>
   </tbody>
 </table>

--- a/app/views/schools/user_tariff_charges/_charge_basic_row.html.erb
+++ b/app/views/schools/user_tariff_charges/_charge_basic_row.html.erb
@@ -1,13 +1,17 @@
 <%= render 'shared/errors', subject: user_tariff_charge, subject_name: 'charge' %>
+
 <tr>
   <td class="description">
     <%= user_tariff_charge_type_description(user_tariff_charge.charge_type) %>
+    <% if tip = user_tariff_charge_type_tip(user_tariff_charge.charge_type) %>
+      <br /><small class="text-muted"><%= tip %></small>
+    <% end %>
   </td>
   <td class="value">
     <%= user_tariff_charge_type_value_label(user_tariff_charge.charge_type) %>
   </td>
   <td class="value">
-      <%= f.input :value, pattern: '[0-9.]+', label: false, input_html: { value: user_tariff_charge.value }, required: false %>
+    <%= f.input :value, pattern: '[0-9.]+', label: false, input_html: { value: user_tariff_charge.value}.merge(local_assigns.slice(:data, :title)), required: false %>
   </td>
   <td class="units">
     <% if user_tariff_charge_type_units_for(user_tariff_charge.charge_type).any? %>

--- a/config/locales/models/user_tariff_charge.yml
+++ b/config/locales/models/user_tariff_charge.yml
@@ -8,6 +8,8 @@ en:
     quarter: quarter
   user_tariff_charge:
     available_capacity: Available capacity
+    available_capacity_tip: Available capacity should be entered if this field is set
+    available_capacity_tooltip: Available capacity should be entered if Agreed availability charge or Excess availability charge are set
     data_collection_dcda_agent_charge: Data Collection DC/DA Agent Charge
     nhh_automatic_meter_reading_charge: NHH automatic meter reading charge
     nhh_metering_agent_charge: NHH metering agent charge

--- a/config/locales/models/user_tariff_charge.yml
+++ b/config/locales/models/user_tariff_charge.yml
@@ -8,7 +8,7 @@ en:
     quarter: quarter
   user_tariff_charge:
     available_capacity: Available capacity
-    available_capacity_tip: Available capacity should be entered if this field is set
+    available_capacity_tip: Available capacity should also be entered, otherwise this setting will be ignored
     available_capacity_tooltip: Available capacity should be entered if Agreed availability charge or Excess availability charge are set
     data_collection_dcda_agent_charge: Data Collection DC/DA Agent Charge
     nhh_automatic_meter_reading_charge: NHH automatic meter reading charge


### PR DESCRIPTION
* Adds "tips" to the agreed / excess availability charge fields (see below)
* Uses JS to add a tooltip to the asc limit field if it has not been provided when one of the above two fields have (see below)
* Only sends asc limit to Analytics if agreed or excess availability charge are present

![Screenshot 2023-05-22 at 14 22 01](https://github.com/Energy-Sparks/energy-sparks/assets/6051/11f58be5-67ce-470e-bcf2-9cc5deb4ffe9)
