### PR TITLE
Fix for indexed reading format

### DIFF
--- a/spec/services/amr/single_read_converter_spec.rb
+++ b/spec/services/amr/single_read_converter_spec.rb
@@ -376,6 +376,18 @@ module Amr
         results = SingleReadConverter.new(readings, indexed: true).perform
         expect(results).to eq indexed_output
       end
+
+      it 'handles files with multiple mpans' do
+        #create test data that consists of 2 days readings for 2 different meters
+        two_meters_worth_of_readings = readings + readings.map {|r| {amr_data_feed_config_id: 6, mpan_mprn: "123456789012", reading_date: r[:reading_date], readings: r[:readings]} }
+
+        results = SingleReadConverter.new(two_meters_worth_of_readings, indexed: true).perform
+
+        #create expected output: 2 x 2 days readings for 2 meters
+        expected_results = indexed_output + indexed_output.map {|r| {amr_data_feed_config_id: 6, meter_id: nil, mpan_mprn: "123456789012", reading_date: r[:reading_date], readings: r[:readings] } }
+
+        expect(results).to eq expected_results
+      end
     end
 
     context 'dodgy data' do


### PR DESCRIPTION
I recently added support for processing CSV files where the rows do not have timestamps and are just 48 rows of readings for each day. This is currently used in the Opus HH format.

There was a bug in the original code in which it was only processing the first meter correctly. Then the rest of the data wasn't imported. 

This was due to a bug in the logic that determined which array index should be populated for each row. I'd written it to support multiple days for a single meter, but failed where there were multiple days and multiple meters.

The revised logic properly tracks which mpan is being processed. I've added a test for this situation.