### PR TITLE
Improve sorting of gas & electricity meter breakdown tables

### DIFF
--- a/app/assets/stylesheets/analysis.scss
+++ b/app/assets/stylesheets/analysis.scss
@@ -81,6 +81,12 @@ div.popover {
   }
 }
 
+.table-with-totals-footer {
+  tfoot tr:last-of-type  {
+    @extend .table-success
+  }
+}
+
 .analysis, hr.analysis {
   margin-top: 40px;
 }

--- a/app/controllers/schools/advice/base_long_term_controller.rb
+++ b/app/controllers/schools/advice/base_long_term_controller.rb
@@ -36,7 +36,7 @@ module Schools
       end
 
       def sorted_meters_for_breakdown(annual_usage_meter_breakdown)
-        meters = @school.meters.where(mpan_mprn: annual_usage_meter_breakdown.meters).order(:name, :mpan_mprn)
+        meters = @school.meters.where(mpan_mprn: annual_usage_meter_breakdown.meters).order(:mpan_mprn)
         meters.index_by(&:mpan_mprn)
       end
 

--- a/app/controllers/schools/advice/baseload_controller.rb
+++ b/app/controllers/schools/advice/baseload_controller.rb
@@ -51,7 +51,7 @@ module Schools
       end
 
       def options_for_meter_select
-        [aggregate_meter_adapter] + @school.meters.active.electricity.sort_by(&:name_or_mpan_mprn)
+        [aggregate_meter_adapter] + @school.meters.active.electricity.sort_by(&:mpan_mprn)
       end
 
       def set_economic_tariffs_change_caveats

--- a/app/controllers/schools/advice/electricity_costs_controller.rb
+++ b/app/controllers/schools/advice/electricity_costs_controller.rb
@@ -4,7 +4,7 @@ module Schools
       private
 
       def set_meters
-        @meters = @school.meters.active.electricity
+        @meters = @school.meters.active.electricity.order(:mpan_mprn)
       end
 
       def aggregate_meter

--- a/app/views/schools/advice/baseload/_meter_breakdown_table.html.erb
+++ b/app/views/schools/advice/baseload/_meter_breakdown_table.html.erb
@@ -2,6 +2,7 @@
   <thead class="thead-dark">
     <tr>
       <th><%= t('advice_pages.baseload.tables.columns.meter') %></th>
+      <th></th>
       <th class="text-right"><%= t('advice_pages.baseload.tables.columns.average_annual_baseload_kw') %></th>
       <th class="text-right"><%= t('advice_pages.baseload.tables.columns.average_annual_baseload_gbp') %></th>
       <th class="text-right"><%= t('advice_pages.baseload.tables.columns.change_since_previous_year') %></th>
@@ -11,7 +12,8 @@
   <tbody>
     <% meters_by_percentage_baseload(baseload_meter_breakdown).each do |mpan_mprn, breakdown| %>
     <tr>
-      <td><%= breakdown.meter.present? ? breakdown.meter.name_or_mpan_mprn : mpan_mprn %></td>
+      <td><%= breakdown.meter.present? ? breakdown.meter.mpan_mprn : mpan_mprn %></td>
+      <td><%= breakdown.meter.present? ? breakdown.meter.name : '' %></td>
       <td class="text-right"><%= format_unit(breakdown.baseload_kw, :kw) %></td>
       <td class="text-right"><%= format_unit(breakdown.baseload_cost_£, :£) %></td>
       <td class="text-right"><%= format_unit(breakdown.baseload_change_kw, :kw) %></td>
@@ -20,6 +22,7 @@
     <% end %>
     <tr>
       <td><%= t('advice_pages.baseload.tables.labels.all_meters') %></td>
+      <td></td>
       <td class="text-right"><%= format_unit(baseload_meter_breakdown_total.baseload_kw, :kw) %></td>
       <td class="text-right"><%= format_unit(baseload_meter_breakdown_total.baseload_cost_£, :£) %></td>
       <td class="text-right"><%= format_unit(baseload_meter_breakdown_total.baseload_change_kw, :kw) %></td>

--- a/app/views/schools/advice/baseload/_meter_breakdown_table.html.erb
+++ b/app/views/schools/advice/baseload/_meter_breakdown_table.html.erb
@@ -1,8 +1,8 @@
 <table class="table table-sm table-with-totals-footer table-sorted">
   <thead class="thead-dark">
     <tr>
-      <th><%= t('advice_pages.baseload.tables.columns.meter') %></th>
-      <th class='no-sort'></th>
+      <th class="text-left"><%= t('advice_pages.baseload.tables.columns.meter') %></th>
+      <th class="text-left no-sort"><%= t('advice_pages.baseload.tables.columns.name') %></th>
       <th class="text-right"><%= t('advice_pages.baseload.tables.columns.average_annual_baseload_kw') %></th>
       <th class="text-right"><%= t('advice_pages.baseload.tables.columns.average_annual_baseload_gbp') %></th>
       <th class="text-right"><%= t('advice_pages.baseload.tables.columns.change_since_previous_year') %></th>

--- a/app/views/schools/advice/baseload/_meter_breakdown_table.html.erb
+++ b/app/views/schools/advice/baseload/_meter_breakdown_table.html.erb
@@ -14,10 +14,18 @@
     <tr>
       <td><%= breakdown.meter.present? ? breakdown.meter.mpan_mprn : mpan_mprn %></td>
       <td><%= breakdown.meter.present? ? breakdown.meter.name : '' %></td>
-      <td class="text-right"><%= format_unit(breakdown.baseload_kw, :kw) %></td>
-      <td class="text-right"><%= format_unit(breakdown.baseload_cost_£, :£) %></td>
-      <td class="text-right"><%= format_unit(breakdown.baseload_change_kw, :kw) %></td>
-      <td class="text-right"><%= format_unit(breakdown.percentage_baseload, :percent) %></td>
+      <td class="text-right" data-order="<%= breakdown.baseload_kw %>">
+        <%= format_unit(breakdown.baseload_kw, :kw) %>
+      </td>
+      <td class="text-right" data-order="<%= breakdown.baseload_cost_£ %>">
+        <%= format_unit(breakdown.baseload_cost_£, :£) %>
+      </td>
+      <td class="text-right" data-order="<%= breakdown.baseload_change_kw %>">
+        <%= format_unit(breakdown.baseload_change_kw, :kw) %>
+      </td>
+      <td class="text-right" data-order="<%= breakdown.percentage_baseload %>">
+        <%= format_unit(breakdown.percentage_baseload, :percent) %>
+      </td>
     </tr>
     <% end %>
   </tbody>
@@ -25,10 +33,18 @@
     <tr>
       <td><%= t('advice_pages.baseload.tables.labels.all_meters') %></td>
       <td></td>
-      <td class="text-right"><%= format_unit(baseload_meter_breakdown_total.baseload_kw, :kw) %></td>
-      <td class="text-right"><%= format_unit(baseload_meter_breakdown_total.baseload_cost_£, :£) %></td>
-      <td class="text-right"><%= format_unit(baseload_meter_breakdown_total.baseload_change_kw, :kw) %></td>
-      <td class="text-right"><%= format_unit(baseload_meter_breakdown_total.percentage_baseload, :percent) %></td>
+      <td class="text-right">
+        <%= format_unit(baseload_meter_breakdown_total.baseload_kw, :kw) %>
+      </td>
+      <td class="text-right">
+        <%= format_unit(baseload_meter_breakdown_total.baseload_cost_£, :£) %>
+      </td>
+      <td class="text-right">
+        <%= format_unit(baseload_meter_breakdown_total.baseload_change_kw, :kw) %>
+      </td>
+      <td class="text-right">
+        <%= format_unit(baseload_meter_breakdown_total.percentage_baseload, :percent) %>
+      </td>
     </tr>
   </tfoot>
 </table>

--- a/app/views/schools/advice/baseload/_meter_breakdown_table.html.erb
+++ b/app/views/schools/advice/baseload/_meter_breakdown_table.html.erb
@@ -1,8 +1,8 @@
-<table class="table table-sm table-with-totals">
+<table class="table table-sm table-with-totals-footer table-sorted">
   <thead class="thead-dark">
     <tr>
       <th><%= t('advice_pages.baseload.tables.columns.meter') %></th>
-      <th></th>
+      <th class='no-sort'></th>
       <th class="text-right"><%= t('advice_pages.baseload.tables.columns.average_annual_baseload_kw') %></th>
       <th class="text-right"><%= t('advice_pages.baseload.tables.columns.average_annual_baseload_gbp') %></th>
       <th class="text-right"><%= t('advice_pages.baseload.tables.columns.change_since_previous_year') %></th>
@@ -20,6 +20,8 @@
       <td class="text-right"><%= format_unit(breakdown.percentage_baseload, :percent) %></td>
     </tr>
     <% end %>
+  </tbody>
+  <tfoot>
     <tr>
       <td><%= t('advice_pages.baseload.tables.labels.all_meters') %></td>
       <td></td>
@@ -28,6 +30,6 @@
       <td class="text-right"><%= format_unit(baseload_meter_breakdown_total.baseload_change_kw, :kw) %></td>
       <td class="text-right"><%= format_unit(baseload_meter_breakdown_total.percentage_baseload, :percent) %></td>
     </tr>
-  </tbody>
+  </tfoot>
 </table>
 <%= render 'schools/advice/how_have_we_analysed_your_data_table_caption', data_target: "how-have-we-analysed-your-data-footnotes" %>

--- a/app/views/schools/advice/baseload/_seasonal_variation_breakdown_table.html.erb
+++ b/app/views/schools/advice/baseload/_seasonal_variation_breakdown_table.html.erb
@@ -1,9 +1,9 @@
-<table class="table table-sm table-with-totals">
+<table class="table table-sm table-with-totals-footer table-sorted">
   <thead class="thead-dark">
     <tr>
       <th class="text-left"><%= t('advice_pages.baseload.tables.columns.meter') %></th>
-      <th></th>
-      <th class="text-left"><%= t('advice_pages.baseload.tables.columns.assessment') %></th>
+      <th class="text-left no-sort"><%= t('advice_pages.baseload.tables.columns.name') %></th>
+      <th class="text-left no-sort"><%= t('advice_pages.baseload.tables.columns.assessment') %></th>
       <th class="text-right"><%= t('advice_pages.baseload.tables.columns.baseload_in_winter') %></th>
       <th class="text-right"><%= t('advice_pages.baseload.tables.columns.baseload_in_summer') %></th>
       <th class="text-right"><%= t('advice_pages.baseload.tables.columns.percentage_difference') %></th>
@@ -18,11 +18,21 @@
           <td><%= variation.meter.present? ? variation.meter.name : '' %></td>
           <% if variation.enough_data? %>
             <td class="text-left"><%= format_rating(variation.variation_rating) %></td>
-            <td class="text-right"><%= format_unit(variation.winter_kw, :kw) %></td>
-            <td class="text-right"><%= format_unit(variation.summer_kw, :kw) %></td>
-            <td class="text-right"><%= format_unit(variation.percentage, :percent) %></td>
-            <td class="text-right"><%= format_unit(variation.estimated_saving_£, :£) %></td>
-            <td class="text-right"><%= format_unit(variation.estimated_saving_co2, :kg) %></td>
+            <td class="text-right" data-order="<%= variation.winter_kw %>">
+              <%= format_unit(variation.winter_kw, :kw) %>
+            </td>
+            <td class="text-right" data-order="<%= variation.summer_kw %>">
+              <%= format_unit(variation.summer_kw, :kw) %>
+            </td>
+            <td class="text-right" data-order="<%= variation.percentage %>">
+              <%= format_unit(variation.percentage, :percent) %>
+            </td>
+            <td class="text-right" data-order="<%= variation.estimated_saving_£ %>">
+              <%= format_unit(variation.estimated_saving_£, :£) %>
+            </td>
+            <td class="text-right" data-order="<%= variation.estimated_saving_co2 %>">
+              <%= format_unit(variation.estimated_saving_co2, :kg) %>
+            </td>
           <% else %>
             <td colspan="6" class="text-center old-data">
               <% if variation.data_available_from.present? %>
@@ -34,6 +44,8 @@
           <% end %>
         </tr>
     <% end %>
+  <tbody>
+  <tfoot>
     <tr>
       <td class="text-left"><%= t('advice_pages.baseload.tables.labels.all_meters') %></td>
       <td></td>
@@ -44,6 +56,6 @@
       <td class="text-right"><%= format_target(seasonal_variation.estimated_saving_£, :£) %></td>
       <td class="text-right"><%= format_target(seasonal_variation.estimated_saving_co2, :kg) %></td>
     </tr>
-  </tbody>
+  </tfoot>
 </table>
 <%= render 'schools/advice/how_have_we_analysed_your_data_table_caption', data_target: "how-have-we-analysed-your-data-footnotes" %>

--- a/app/views/schools/advice/baseload/_seasonal_variation_breakdown_table.html.erb
+++ b/app/views/schools/advice/baseload/_seasonal_variation_breakdown_table.html.erb
@@ -2,6 +2,7 @@
   <thead class="thead-dark">
     <tr>
       <th class="text-left"><%= t('advice_pages.baseload.tables.columns.meter') %></th>
+      <th></th>
       <th class="text-left"><%= t('advice_pages.baseload.tables.columns.assessment') %></th>
       <th class="text-right"><%= t('advice_pages.baseload.tables.columns.baseload_in_winter') %></th>
       <th class="text-right"><%= t('advice_pages.baseload.tables.columns.baseload_in_summer') %></th>
@@ -13,7 +14,8 @@
   <tbody>
     <% meters_by_estimated_saving(seasonal_variation_by_meter).each do |mpan_mprn, variation| %>
         <tr>
-          <td class="text-left"><%= variation.meter.present? ? variation.meter.name_or_mpan_mprn : mpan_mprn %></td>
+          <td class="text-left"><%= variation.meter.present? ? variation.meter.mpan_mprn : mpan_mprn %></td>
+          <td><%= variation.meter.present? ? variation.meter.name : '' %></td>
           <% if variation.enough_data? %>
             <td class="text-left"><%= format_rating(variation.variation_rating) %></td>
             <td class="text-right"><%= format_unit(variation.winter_kw, :kw) %></td>
@@ -34,6 +36,7 @@
     <% end %>
     <tr>
       <td class="text-left"><%= t('advice_pages.baseload.tables.labels.all_meters') %></td>
+      <td></td>
       <td class="text-left"><%= format_rating(seasonal_variation.variation_rating) %></td>
       <td class="text-right"><%= format_target(seasonal_variation.winter_kw, :kwh) %></td>
       <td class="text-right"><%= format_target(seasonal_variation.summer_kw, :kwh) %></td>

--- a/app/views/schools/advice/baseload/_weekday_variation_breakdown_table.html.erb
+++ b/app/views/schools/advice/baseload/_weekday_variation_breakdown_table.html.erb
@@ -1,9 +1,9 @@
-<table class="table table-sm table-with-totals">
+<table class="table table-sm table-with-totals-footer table-sorted">
   <thead class="thead-dark">
     <tr>
       <th class="text-left"><%= t('advice_pages.baseload.tables.columns.meter') %></th>
-      <th></th>
-      <th class="text-left"><%= t('advice_pages.baseload.tables.columns.assessment') %></th>
+      <th class="text-left no-sort"><%= t('advice_pages.baseload.tables.columns.name') %></th>
+      <th class="text-left no-sort"><%= t('advice_pages.baseload.tables.columns.assessment') %></th>
       <th class="text-right"><%= t('advice_pages.baseload.tables.columns.highest_day_baseload') %></th>
       <th class="text-right"><%= t('advice_pages.baseload.tables.columns.lowest_day_baseload') %></th>
       <th class="text-right"><%= t('advice_pages.baseload.tables.columns.percentage_difference') %></th>
@@ -17,12 +17,24 @@
           <td class="text-left"><%= variation && variation.meter.present? ? variation.meter.mpan_mprn : mpan_mprn %></td>
           <td><%= variation && variation.meter.present? ? variation.meter.name : '' %></td>
           <% if variation.enough_data? %>
-            <td class="text-left"><%= format_rating(variation.variation_rating) %></td>
-            <td class="text-right"><%= format_unit(variation.max_day_kw, :kw) %> (<%= t_weekday(intraweek_variation.max_day) %>)</td>
-            <td class="text-right"><%= format_unit(variation.min_day_kw, :kw) %> (<%= t_weekday(intraweek_variation.min_day) %>)</td>
-            <td class="text-right"><%= format_unit(variation.percent_intraday_variation, :percent) %></td>
-            <td class="text-right"><%= format_unit(variation.estimated_saving_£, :£) %></td>
-            <td class="text-right"><%= format_unit(variation.estimated_saving_co2, :kg) %></td>
+            <td class="text-left" data-order="<%= variation.variation_rating %>">
+              <%= format_rating(variation.variation_rating) %>
+            </td>
+            <td class="text-right" data-order="<%= variation.max_day_kw %>">
+              <%= format_unit(variation.max_day_kw, :kw) %> (<%= t_weekday(intraweek_variation.max_day) %>)
+            </td>
+            <td class="text-right" data-order="<%= variation.min_day_kw %>">
+              <%= format_unit(variation.min_day_kw, :kw) %> (<%= t_weekday(intraweek_variation.min_day) %>)
+            </td>
+            <td class="text-right" data-order="<%= variation.percent_intraday_variation %>">
+              <%= format_unit(variation.percent_intraday_variation, :percent) %>
+            </td>
+            <td class="text-right" data-order="<%= variation.estimated_saving_£ %>">
+              <%= format_unit(variation.estimated_saving_£, :£) %>
+            </td>
+            <td class="text-right" data-order="<%= variation.estimated_saving_co2 %>">
+              <%= format_unit(variation.estimated_saving_co2, :kg) %>
+            </td>
           <% else %>
             <td colspan="6" class="text-center old-data">
               <% if variation.data_available_from.present? %>
@@ -34,6 +46,8 @@
           <% end %>
         </tr>
     <% end %>
+  </tbody>
+  <tfoot>
     <tr>
       <td class="text-left"><%= t('advice_pages.baseload.tables.labels.all_meters') %></td>
       <td></td>
@@ -44,6 +58,6 @@
       <td class="text-right"><%= format_target(intraweek_variation.estimated_saving_£, :£) %></td>
       <td class="text-right"><%= format_target(intraweek_variation.estimated_saving_co2, :kg) %></td>
     </tr>
-  </tbody>
+  </tfoot>
 </table>
 <%= render 'schools/advice/how_have_we_analysed_your_data_table_caption', data_target: "how-have-we-analysed-your-data-footnotes" %>

--- a/app/views/schools/advice/baseload/_weekday_variation_breakdown_table.html.erb
+++ b/app/views/schools/advice/baseload/_weekday_variation_breakdown_table.html.erb
@@ -2,6 +2,7 @@
   <thead class="thead-dark">
     <tr>
       <th class="text-left"><%= t('advice_pages.baseload.tables.columns.meter') %></th>
+      <th></th>
       <th class="text-left"><%= t('advice_pages.baseload.tables.columns.assessment') %></th>
       <th class="text-right"><%= t('advice_pages.baseload.tables.columns.highest_day_baseload') %></th>
       <th class="text-right"><%= t('advice_pages.baseload.tables.columns.lowest_day_baseload') %></th>
@@ -13,7 +14,8 @@
   <tbody>
     <% meters_by_estimated_saving(intraweek_variation_by_meter).each do |mpan_mprn, variation| %>
         <tr>
-          <td class="text-left"><%= variation && variation.meter.present? ? variation.meter.name_or_mpan_mprn : mpan_mprn %></td>
+          <td class="text-left"><%= variation && variation.meter.present? ? variation.meter.mpan_mprn : mpan_mprn %></td>
+          <td><%= variation && variation.meter.present? ? variation.meter.name : '' %></td>
           <% if variation.enough_data? %>
             <td class="text-left"><%= format_rating(variation.variation_rating) %></td>
             <td class="text-right"><%= format_unit(variation.max_day_kw, :kw) %> (<%= t_weekday(intraweek_variation.max_day) %>)</td>
@@ -34,6 +36,7 @@
     <% end %>
     <tr>
       <td class="text-left"><%= t('advice_pages.baseload.tables.labels.all_meters') %></td>
+      <td></td>
       <td class="text-left"><%= format_rating(intraweek_variation.variation_rating) %></td>
       <td class="text-right"><%= format_target(intraweek_variation.max_day_kw, :kwh) %></td>
       <td class="text-right"><%= format_target(intraweek_variation.min_day_kw, :kwh) %></td>

--- a/app/views/schools/advice/electricity_costs/_cost_breakdown_by_meter.html.erb
+++ b/app/views/schools/advice/electricity_costs/_cost_breakdown_by_meter.html.erb
@@ -6,20 +6,23 @@
 <table class="table table-sm advice-table table-with-totals">
   <thead>
     <th class="text-left"><%= advice_t('electricity_costs.tables.columns.meter') %></th>
+    <th class="text-left"></th>
     <th class="text-right"><%= advice_t('electricity_costs.tables.columns.cost') %></th>
   </thead>
   <tbody>
     <% annual_costs_breakdown_by_meter.sort{|a,b| a[0].name_or_mpan_mprn <=> b[0].name_or_mpan_mprn }.each do |meter, cost| %>
       <tr>
         <td class="text-left">
-          <%= meter.name_or_mpan_mprn %>
+          <%= meter.mpan_mprn %>
           <% if cost.days < 365 %> * <% end %>
         </td>
+        <td class="text-left"><%= meter.name %></td>
         <td class="text-right"><%= FormatEnergyUnit.format_pounds(:£, cost.£, :text, :approx_accountant, true) %></td>
       </tr>
     <% end %>
     <tr>
       <td class="text-left"><%= advice_t('electricity_costs.tables.labels.total') %></td>
+      <td></td>
       <td class="text-right"><%= FormatEnergyUnit.format_pounds(:£, annual_costs.£, :text, :approx_accountant, true) %></td>
     </tr>
   </tbody>

--- a/app/views/schools/advice/electricity_costs/_cost_breakdown_by_meter.html.erb
+++ b/app/views/schools/advice/electricity_costs/_cost_breakdown_by_meter.html.erb
@@ -3,10 +3,10 @@
   <%= advice_t('electricity_costs.analysis.cost_breakdown_by_meter.intro', period: format_unit(annual_costs.days/365.0, :years), start_date: short_dates(@costs_service_analysis_date_range.first), end_date: short_dates(@costs_service_analysis_date_range.last)) %>
 </p>
 
-<table class="table table-sm advice-table table-with-totals">
+<table class="table table-sm advice-table table-with-totals-footer table-sorted">
   <thead>
     <th class="text-left"><%= advice_t('electricity_costs.tables.columns.meter') %></th>
-    <th class="text-left"></th>
+    <th class="text-left no-sort"><%= advice_t('electricity_costs.tables.columns.name') %></th>
     <th class="text-right"><%= advice_t('electricity_costs.tables.columns.cost') %></th>
   </thead>
   <tbody>
@@ -17,15 +17,17 @@
           <% if cost.days < 365 %> * <% end %>
         </td>
         <td class="text-left"><%= meter.name %></td>
-        <td class="text-right"><%= FormatEnergyUnit.format_pounds(:£, cost.£, :text, :approx_accountant, true) %></td>
+        <td class="text-right" data-order="<%= cost.£ %>"><%= FormatEnergyUnit.format_pounds(:£, cost.£, :text, :approx_accountant, true) %></td>
       </tr>
     <% end %>
+  <tbody>
+  <tfoot>
     <tr>
       <td class="text-left"><%= advice_t('electricity_costs.tables.labels.total') %></td>
       <td></td>
       <td class="text-right"><%= FormatEnergyUnit.format_pounds(:£, annual_costs.£, :text, :approx_accountant, true) %></td>
     </tr>
-  </tbody>
+  </tfoot>
 </table>
 <% partial_meter_data = annual_costs_breakdown_by_meter.select { |meter, costs| costs.days < 365} %>
 <% if partial_meter_data.present? %>

--- a/app/views/schools/advice/electricity_long_term/_meter_breakdown.html.erb
+++ b/app/views/schools/advice/electricity_long_term/_meter_breakdown.html.erb
@@ -12,10 +12,10 @@
 
 <p><%= t('advice_pages.electricity_long_term.analysis.meter_breakdown.table_introduction', start_date: annual_usage_meter_breakdown.start_date.to_s(:es_short), end_date: annual_usage_meter_breakdown.end_date.to_s(:es_short)) %></p>
 
-<table class="table table-sm table-with-totals">
+<table class="table table-sm table-with-totals-footer table-sorted">
   <thead class="thead-dark">
     <th><%= t('advice_pages.electricity_long_term.tables.columns.meter') %></th>
-    <th></th>
+    <th class='no-sort'><%= t('advice_pages.electricity_long_term.tables.columns.name') %></th>
     <th class="text-right"><%= t('advice_pages.electricity_long_term.tables.columns.annual_usage_kwh') %></th>
     <th class="text-right"><%= t('advice_pages.electricity_long_term.tables.columns.annual_usage_gbp') %></th>
     <th class="text-right"><%= t('advice_pages.electricity_long_term.tables.columns.percent') %></th>
@@ -26,12 +26,22 @@
       <tr>
         <td><%= meter.mpan_mprn %></td>
         <td><%= meter.name %></td>
-        <td class="text-right"><%= format_unit(annual_usage_meter_breakdown.usage(mpan_mprn).kwh, :kwh) %></td>
-        <td class="text-right"><%= format_unit(annual_usage_meter_breakdown.usage(mpan_mprn).£, :£) %></td>
-        <td class="text-right"><%= format_unit(annual_usage_meter_breakdown.usage(mpan_mprn).percent, :percent) %></td>
-        <td class="text-right"><%= format_unit(annual_usage_meter_breakdown.annual_percent_change(mpan_mprn), :percent) %></td>
+        <td class="text-right" data-order="<%= annual_usage_meter_breakdown.usage(mpan_mprn).kwh %>">
+          <%= format_unit(annual_usage_meter_breakdown.usage(mpan_mprn).kwh, :kwh) %>
+        </td>
+        <td class="text-right" data-order="<%= annual_usage_meter_breakdown.usage(mpan_mprn).£ %>">
+          <%= format_unit(annual_usage_meter_breakdown.usage(mpan_mprn).£, :£) %>
+        </td>
+        <td class="text-right" data-order="<%= annual_usage_meter_breakdown.usage(mpan_mprn).percent %>">
+          <%= format_unit(annual_usage_meter_breakdown.usage(mpan_mprn).percent, :percent) %>
+        </td>
+        <td class="text-right" data-order="<%= annual_usage_meter_breakdown.annual_percent_change(mpan_mprn) %>">
+          <%= format_unit(annual_usage_meter_breakdown.annual_percent_change(mpan_mprn), :percent) %>
+        </td>
       </tr>
     <% end %>
+  </tbody>
+  <tfoot>
     <tr>
       <td><%= t('advice_pages.electricity_long_term.tables.labels.all_meters') %></td>
       <td></td>
@@ -40,7 +50,7 @@
       <td class="text-right"><%= format_unit(annual_usage_meter_breakdown.total_usage.percent, :percent) %></td>
       <td class="text-right"><%= format_unit(annual_usage_meter_breakdown.total_annual_percent_change, :percent) %></td>
     </tr>
-  </tbody>
+  </tfoot>
 </table>
 <%= render 'schools/advice/how_have_we_analysed_your_data_table_caption', data_target: "how-have-we-analysed-your-data-footnotes" %>
 <p><%= t('advice_pages.electricity_long_term.analysis.meter_breakdown.table_explanation') %></p>

--- a/app/views/schools/advice/electricity_long_term/_meter_breakdown.html.erb
+++ b/app/views/schools/advice/electricity_long_term/_meter_breakdown.html.erb
@@ -15,6 +15,7 @@
 <table class="table table-sm table-with-totals">
   <thead class="thead-dark">
     <th><%= t('advice_pages.electricity_long_term.tables.columns.meter') %></th>
+    <th></th>
     <th class="text-right"><%= t('advice_pages.electricity_long_term.tables.columns.annual_usage_kwh') %></th>
     <th class="text-right"><%= t('advice_pages.electricity_long_term.tables.columns.annual_usage_gbp') %></th>
     <th class="text-right"><%= t('advice_pages.electricity_long_term.tables.columns.percent') %></th>
@@ -23,7 +24,8 @@
   <tbody>
     <% meters_for_breakdown.each do |mpan_mprn, meter| %>
       <tr>
-        <td><%= meter.name_or_mpan_mprn %></td>
+        <td><%= meter.mpan_mprn %></td>
+        <td><%= meter.name %></td>
         <td class="text-right"><%= format_unit(annual_usage_meter_breakdown.usage(mpan_mprn).kwh, :kwh) %></td>
         <td class="text-right"><%= format_unit(annual_usage_meter_breakdown.usage(mpan_mprn).£, :£) %></td>
         <td class="text-right"><%= format_unit(annual_usage_meter_breakdown.usage(mpan_mprn).percent, :percent) %></td>
@@ -32,6 +34,7 @@
     <% end %>
     <tr>
       <td><%= t('advice_pages.electricity_long_term.tables.labels.all_meters') %></td>
+      <td></td>
       <td class="text-right"><%= format_unit(annual_usage_meter_breakdown.total_usage.kwh, :kwh) %></td>
       <td class="text-right"><%= format_unit(annual_usage_meter_breakdown.total_usage.£, :£) %></td>
       <td class="text-right"><%= format_unit(annual_usage_meter_breakdown.total_usage.percent, :percent) %></td>

--- a/app/views/schools/advice/gas_costs/_cost_breakdown_by_meter.html.erb
+++ b/app/views/schools/advice/gas_costs/_cost_breakdown_by_meter.html.erb
@@ -7,20 +7,23 @@
 <table class="table table-sm advice-table table-with-totals">
   <thead>
     <th class="text-left"><%= advice_t('gas_costs.tables.columns.meter') %></th>
+    <th class="text-left"></th>
     <th class="text-right"><%= advice_t('gas_costs.tables.columns.cost') %></th>
   </thead>
   <tbody>
     <% annual_costs_breakdown_by_meter.sort{|a,b| a[0].name_or_mpan_mprn <=> b[0].name_or_mpan_mprn }.each do |meter, cost| %>
       <tr>
         <td class="text-left">
-          <%= meter.name_or_mpan_mprn %>
+          <%= meter.mpan_mprn %>
           <% if cost.days < 365 %> * <% end %>
         </td>
+        <td class="text-left"><%= meter.name %></td>
         <td class="text-right"><%= FormatEnergyUnit.format_pounds(:£, cost.£, :text, :approx_accountant, true) %></td>
       </tr>
     <% end %>
     <tr>
       <td class="text-left"><%= advice_t('gas_costs.tables.labels.total') %></td>
+      <td></td>
       <td class="text-right"><%= FormatEnergyUnit.format_pounds(:£, annual_costs.£, :text, :approx_accountant, true) %></td>
     </tr>
   </tbody>

--- a/app/views/schools/advice/gas_costs/_cost_breakdown_by_meter.html.erb
+++ b/app/views/schools/advice/gas_costs/_cost_breakdown_by_meter.html.erb
@@ -4,10 +4,10 @@
   <%= advice_t('gas_costs.analysis.cost_breakdown_by_meter.intro', period: format_unit(annual_costs.days/365.0, :years), start_date: short_dates(@costs_service_analysis_date_range.first), end_date: short_dates(@costs_service_analysis_date_range.last)) %>
 </p>
 
-<table class="table table-sm advice-table table-with-totals">
+<table class="table table-sm advice-table table-with-totals-footer table-sorted">
   <thead>
     <th class="text-left"><%= advice_t('gas_costs.tables.columns.meter') %></th>
-    <th class="text-left"></th>
+    <th class="text-left"><%= advice_t('gas_costs.tables.columns.name') %></th>
     <th class="text-right"><%= advice_t('gas_costs.tables.columns.cost') %></th>
   </thead>
   <tbody>
@@ -18,15 +18,17 @@
           <% if cost.days < 365 %> * <% end %>
         </td>
         <td class="text-left"><%= meter.name %></td>
-        <td class="text-right"><%= FormatEnergyUnit.format_pounds(:£, cost.£, :text, :approx_accountant, true) %></td>
+        <td class="text-right" data-order="<%= cost.£ %>"><%= FormatEnergyUnit.format_pounds(:£, cost.£, :text, :approx_accountant, true) %></td>
       </tr>
     <% end %>
+  </tbody>
+  <tfoot>
     <tr>
       <td class="text-left"><%= advice_t('gas_costs.tables.labels.total') %></td>
       <td></td>
       <td class="text-right"><%= FormatEnergyUnit.format_pounds(:£, annual_costs.£, :text, :approx_accountant, true) %></td>
     </tr>
-  </tbody>
+  </tfoot>
 </table>
 <% partial_meter_data = annual_costs_breakdown_by_meter.select { |meter, costs| costs.days < 365} %>
 <% if partial_meter_data.present? %>

--- a/app/views/schools/advice/gas_long_term/_meter_breakdown.html.erb
+++ b/app/views/schools/advice/gas_long_term/_meter_breakdown.html.erb
@@ -15,6 +15,7 @@
 <table class="table table-sm table-with-totals">
   <thead class="thead-dark">
     <th><%= t('advice_pages.gas_long_term.tables.columns.meter') %></th>
+    <th></th>
     <th class="text-right"><%= t('advice_pages.gas_long_term.tables.columns.annual_usage_kwh') %></th>
     <th class="text-right"><%= t('advice_pages.gas_long_term.tables.columns.annual_usage_gbp') %></th>
     <th class="text-right"><%= t('advice_pages.gas_long_term.tables.columns.percent') %></th>
@@ -23,7 +24,8 @@
   <tbody>
     <% meters_for_breakdown.each do |mpan_mprn, meter| %>
       <tr>
-        <td><%= meter.name_or_mpan_mprn %></td>
+        <td><%= meter.mpan_mprn %></td>
+        <td><%= meter.name %></td>
         <td class="text-right"><%= format_unit(annual_usage_meter_breakdown.usage(mpan_mprn).kwh, :kwh) %></td>
         <td class="text-right"><%= format_unit(annual_usage_meter_breakdown.usage(mpan_mprn).£, :£) %></td>
         <td class="text-right"><%= format_unit(annual_usage_meter_breakdown.usage(mpan_mprn).percent, :percent) %></td>

--- a/app/views/schools/advice/gas_long_term/_meter_breakdown.html.erb
+++ b/app/views/schools/advice/gas_long_term/_meter_breakdown.html.erb
@@ -34,6 +34,7 @@
     <% end %>
     <tr>
       <td><%= t('advice_pages.gas_long_term.tables.labels.all_meters') %></td>
+      <td></td>
       <td class="text-right"><%= format_unit(annual_usage_meter_breakdown.total_usage.kwh, :kwh) %></td>
       <td class="text-right"><%= format_unit(annual_usage_meter_breakdown.total_usage.£, :£) %></td>
       <td class="text-right"><%= format_unit(annual_usage_meter_breakdown.total_usage.percent, :percent) %></td>

--- a/app/views/schools/advice/gas_long_term/_meter_breakdown.html.erb
+++ b/app/views/schools/advice/gas_long_term/_meter_breakdown.html.erb
@@ -12,10 +12,10 @@
 
 <p><%= t('advice_pages.gas_long_term.analysis.meter_breakdown.table_introduction', start_date: annual_usage_meter_breakdown.start_date.to_s(:es_short), end_date: annual_usage_meter_breakdown.end_date.to_s(:es_short)) %></p>
 
-<table class="table table-sm table-with-totals">
+<table class="table table-sm table-with-totals-footer table-sorted">
   <thead class="thead-dark">
     <th><%= t('advice_pages.gas_long_term.tables.columns.meter') %></th>
-    <th></th>
+    <th class='no-sort'><%= t('advice_pages.gas_long_term.tables.columns.name') %></th>
     <th class="text-right"><%= t('advice_pages.gas_long_term.tables.columns.annual_usage_kwh') %></th>
     <th class="text-right"><%= t('advice_pages.gas_long_term.tables.columns.annual_usage_gbp') %></th>
     <th class="text-right"><%= t('advice_pages.gas_long_term.tables.columns.percent') %></th>
@@ -26,12 +26,22 @@
       <tr>
         <td><%= meter.mpan_mprn %></td>
         <td><%= meter.name %></td>
-        <td class="text-right"><%= format_unit(annual_usage_meter_breakdown.usage(mpan_mprn).kwh, :kwh) %></td>
-        <td class="text-right"><%= format_unit(annual_usage_meter_breakdown.usage(mpan_mprn).£, :£) %></td>
-        <td class="text-right"><%= format_unit(annual_usage_meter_breakdown.usage(mpan_mprn).percent, :percent) %></td>
-        <td class="text-right"><%= format_unit(annual_usage_meter_breakdown.annual_percent_change(mpan_mprn), :percent) %></td>
+        <td class="text-right" data-order="<%= annual_usage_meter_breakdown.usage(mpan_mprn).kwh %>">
+          <%= format_unit(annual_usage_meter_breakdown.usage(mpan_mprn).kwh, :kwh) %>
+        </td>
+        <td class="text-right" data-order="<%= annual_usage_meter_breakdown.usage(mpan_mprn).£ %>">
+          <%= format_unit(annual_usage_meter_breakdown.usage(mpan_mprn).£, :£) %>
+        </td>
+        <td class="text-right" data-order="<%= annual_usage_meter_breakdown.usage(mpan_mprn).percent %>">
+          <%= format_unit(annual_usage_meter_breakdown.usage(mpan_mprn).percent, :percent) %>
+        </td>
+        <td class="text-right" data-order="<%= annual_usage_meter_breakdown.annual_percent_change(mpan_mprn) %>">
+          <%= format_unit(annual_usage_meter_breakdown.annual_percent_change(mpan_mprn), :percent) %>
+        </td>
       </tr>
     <% end %>
+  </tbody>
+  <tfoot>
     <tr>
       <td><%= t('advice_pages.gas_long_term.tables.labels.all_meters') %></td>
       <td></td>
@@ -40,7 +50,7 @@
       <td class="text-right"><%= format_unit(annual_usage_meter_breakdown.total_usage.percent, :percent) %></td>
       <td class="text-right"><%= format_unit(annual_usage_meter_breakdown.total_annual_percent_change, :percent) %></td>
     </tr>
-  </tbody>
+  </tfoot>
 </table>
 <%= render 'schools/advice/how_have_we_analysed_your_data_table_caption', data_target: "how-have-we-analysed-your-data-footnotes" %>
 <p><%= t('advice_pages.gas_long_term.analysis.meter_breakdown.table_explanation') %></p>

--- a/config/locales/views/advice_pages/baseload.yml
+++ b/config/locales/views/advice_pages/baseload.yml
@@ -82,6 +82,7 @@ en:
           highest_day_baseload: Highest day baseload (kW)
           lowest_day_baseload: Lowest day baseload (kW)
           meter: Meter
+          name: Name
           percentage_difference: "% difference"
           percentage_of_total: "% of total baseload"
           potential_saving_co2: CO2 reduction (kg)

--- a/config/locales/views/advice_pages/electricity_costs.yml
+++ b/config/locales/views/advice_pages/electricity_costs.yml
@@ -72,5 +72,6 @@ en:
         columns:
           cost: Cost (£)
           meter: Meter
+          name: Name
         labels:
           total: Total

--- a/config/locales/views/advice_pages/electricity_long_term.yml
+++ b/config/locales/views/advice_pages/electricity_long_term.yml
@@ -81,6 +81,7 @@ en:
           annual_usage_kwh: Annual usage (kWh)
           estimated_savings_gbp: Estimated saving (£)
           meter: Meter
+          name: Name
           percent: Percent of total use
         labels:
           all_meters: All meters

--- a/config/locales/views/advice_pages/gas_costs.yml
+++ b/config/locales/views/advice_pages/gas_costs.yml
@@ -56,5 +56,6 @@ en:
         columns:
           cost: Cost (£)
           meter: Meter
+          name: Name
         labels:
           total: Total

--- a/config/locales/views/advice_pages/gas_long_term.yml
+++ b/config/locales/views/advice_pages/gas_long_term.yml
@@ -78,6 +78,7 @@ en:
           annual_usage_kwh: Annual usage (kWh)
           estimated_savings_gbp: Estimated saving (£)
           meter: Meter
+          name: Name
           percent: Percent of total use
         labels:
           all_meters: All meters


### PR DESCRIPTION

- [x] Ensure all tables that show a list of meters have an MPAN/MPRN column as the first column
- [x] Ensure all tables that show a list of meters have the meter name as the second column.
- [x] Ensure all tables that show a list of meters are sorted by mpan by default
- [x] Ensure all tables that show a list of meters have sortable columns for mpan and mprn
- [x] Ensure all tables that show a list of meters have sortable columns for any values, e.g. % change, annual consumption. Need to ensure that columns that include numbers are sorted by the numeric not the formatted value. Columns that display dates should be sorted by the ISO date, not the formatted date