### PR TITLE
Change polling for smart meters

### DIFF
--- a/app/models/meter.rb
+++ b/app/models/meter.rb
@@ -81,8 +81,12 @@ class Meter < ApplicationRecord
 
   scope :unreviewed_dcc_meter, -> { where(dcc_meter: true, consent_granted: false, meter_review: nil) }
   scope :awaiting_trusted_consent, -> { where(dcc_meter: true, consent_granted: false).where.not(meter_review: nil) }
+  scope :not_dcc, -> { where(dcc_meter: false) }
   scope :dcc, -> { where(dcc_meter: true) }
   scope :consented, -> { where(dcc_meter: true, consent_granted: true) }
+
+  scope :not_recently_checked, -> { where("dcc_checked_at is NULL OR dcc_checked_at < ?", 2.months.ago) }
+  scope :meters_to_check_against_dcc, -> { main_meter.not_dcc.not_recently_checked }
 
   scope :with_zero_reading_days_and_dates, -> {
       left_outer_joins(:amr_validated_readings)

--- a/lib/tasks/meters/dcc_meter_checker.rake
+++ b/lib/tasks/meters/dcc_meter_checker.rake
@@ -2,9 +2,7 @@ namespace :meters do
   desc 'Check which meters exist in the DCC'
   task :check_for_dcc => :environment do |_t, args|
     puts "#{DateTime.now.utc} check_for_dcc start"
-
-    meters = Meter.active.main_meter.where.not(dcc_meter: true).where(dcc_checked_at: nil)
-    Meters::DccChecker.new(meters).perform
+    Meters::DccChecker.new(Meter.meters_to_check_against_dcc).perform
     puts "#{DateTime.now.utc} check_for_dcc end"
   end
 end


### PR DESCRIPTION
When we setup new meters, we check to see if there are known to n3rgy. This allows us to detect smart meters and then get access to data via their API.

There's a rake task that runs daily to check for meters, but this never really does anything as all meters are now checked on creation.

However in some cases meters are upgraded/replaced. This means we need to regularly recheck meters, otherwise we'll miss that they've been setup. The rake task also only checked active meters, which means we might miss some that are disabled pending further setup.

This PR changes the existing Rake task to:

* check any meter that hasn't yet been checked
* check any gas or electricity meters that haven't been flagged as a smart meter (`dcc_meter == false`) and we last checked > 2 months ago

