### PR TITLE
Ignore invalid rows in single read converter

### DIFF
--- a/app/services/amr/single_read_converter.rb
+++ b/app/services/amr/single_read_converter.rb
@@ -25,6 +25,9 @@ module Amr
     # For here we need to determine the period by counting the index into the array
     def perform
       @single_reading_array.each do |single_reading|
+        #ignore rows that dont have necessary information
+        next unless single_reading[:reading_date].present? && single_reading[:mpan_mprn].present?
+
         reading_day = Date.parse(single_reading[:reading_date])
         reading = single_reading[:readings].first.to_f
 

--- a/spec/services/amr/single_read_converter_spec.rb
+++ b/spec/services/amr/single_read_converter_spec.rb
@@ -390,6 +390,24 @@ module Amr
       end
     end
 
+    context 'missing mpan_mprn' do
+      let(:readings) { [{:amr_data_feed_config_id=>6, :mpan_mprn=>nil, reading_date: Date.parse('27 Aug 2019').to_s, readings: [15.2, 1.4, 1.3, 1.4, 1.3, 1.4, 1.3, 1.3, 1.4, 6.5, 2.3, 3.2, 1.8, 1.6, 2.0, 3.0, 2.0, 1.3, 1.7, 1.4, 1.1, 0.9, 1.2, 0.9, 1.7, 0.8, 0.8, 0.8, 1.2, 1.1, 1.7, 2.0, 2.8, 3.8, 1.6, 0.5, 0.7, 0.9, 1.2, 1.2, 1.2, 1.3, 1.3, 1.2, 1.2, 1.2, 1.3, 99.0]}] }
+
+      it 'ignores row' do
+        results = SingleReadConverter.new(readings).perform
+        expect(results).to be_empty
+      end
+    end
+
+    context 'missing date' do
+      let(:readings) { [{:amr_data_feed_config_id=>6, :mpan_mprn=>"12345678", reading_date: nil, readings: [15.2, 1.4, 1.3, 1.4, 1.3, 1.4, 1.3, 1.3, 1.4, 6.5, 2.3, 3.2, 1.8, 1.6, 2.0, 3.0, 2.0, 1.3, 1.7, 1.4, 1.1, 0.9, 1.2, 0.9, 1.7, 0.8, 0.8, 0.8, 1.2, 1.1, 1.7, 2.0, 2.8, 3.8, 1.6, 0.5, 0.7, 0.9, 1.2, 1.2, 1.2, 1.3, 1.3, 1.2, 1.2, 1.2, 1.3, 99.0]}] }
+
+      it 'ignores row' do
+        results = SingleReadConverter.new(readings).perform
+        expect(results).to be_empty
+      end
+    end
+
     context 'dodgy data' do
       let(:readings) { [{:amr_data_feed_config_id=>6, :mpan_mprn=>"Primary school", :reading_date=>"123456789012", :readings=>["01/01/2019"]}] }
 


### PR DESCRIPTION
It seems like Excel sometimes adds extra blank rows to the end of exported CSV files. This is causing some manually converted files to fail to load as the system is not expecting an empty row.

Improve tolerance of the SingleReadConverter to skip rows without an mpan or date. Normally these would be caught and rejected in the next step of processing.