### PR TITLE
Priority actions for school groups

### DIFF
--- a/app/controllers/school_groups_controller.rb
+++ b/app/controllers/school_groups_controller.rb
@@ -26,13 +26,19 @@ class SchoolGroupsController < ApplicationController
   def priority_actions
     service = SchoolGroups::PriorityActions.new(@school_group)
     @priority_actions = service.priority_actions
-    @total_savings = service.total_savings
+    @total_savings = sort_total_savings(service.total_savings)
   end
 
   def current_scores
   end
 
   private
+
+  def sort_total_savings(total_savings)
+    total_savings.sort do |a, b|
+      b[1].average_one_year_saving_gbp <=> a[1].average_one_year_saving_gbp
+    end
+  end
 
   def redirect_unless_feature_enabled
     redirect_to school_group_path(@school_group) and return unless EnergySparks::FeatureFlags.active?(:enhanced_school_group_dashboard)

--- a/app/controllers/school_groups_controller.rb
+++ b/app/controllers/school_groups_controller.rb
@@ -24,7 +24,9 @@ class SchoolGroupsController < ApplicationController
   end
 
   def priority_actions
-    @priority_actions_service = SchoolGroups::PriorityActions.new(@school_group)
+    service = SchoolGroups::PriorityActions.new(@school_group)
+    @priority_actions = service.priority_actions
+    @total_savings = service.total_savings
   end
 
   def current_scores

--- a/app/controllers/school_groups_controller.rb
+++ b/app/controllers/school_groups_controller.rb
@@ -24,6 +24,7 @@ class SchoolGroupsController < ApplicationController
   end
 
   def priority_actions
+    @priority_actions_service = SchoolGroups::PriorityActions.new(@school_group)
   end
 
   def current_scores

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -167,8 +167,12 @@ module ApplicationHelper
     icon('far', icon_type)
   end
 
+  def alert_type_icon(alert_type, size = nil)
+    alert_type.fuel_type.nil? ? "calendar-alt #{size}" : "#{fuel_type_icon(alert_type.fuel_type)} #{size}"
+  end
+
   def alert_icon(alert, size = nil)
-    alert.alert_type.fuel_type.nil? ? "calendar-alt #{size}" : "#{fuel_type_icon(alert.alert_type.fuel_type)} #{size}"
+    alert_type_icon(alert.alert_type, size)
   end
 
   def fuel_type_icon(fuel_type)

--- a/app/helpers/school_groups_helper.rb
+++ b/app/helpers/school_groups_helper.rb
@@ -1,0 +1,9 @@
+module SchoolGroupsHelper
+  #Accepts a list of savings as produced by SchoolGroups::PriorityActions
+  #OpenStruct(school:, average_one_year_saving_gbp, :one_year_saving_co2)
+  #
+  #Sorts them by school name
+  def sort_priority_actions(list_of_savings)
+    list_of_savings.sort {|a, b| a.school.name <=> b.school.name }
+  end
+end

--- a/app/models/alert_type.rb
+++ b/app/models/alert_type.rb
@@ -82,4 +82,8 @@ class AlertType < ApplicationRecord
   def available_tables
     class_name.constantize.front_end_template_tables.map { |variable_name, values| [values[:description], variable_name] }
   end
+
+  def worst_management_priority_rating
+    ratings.where(management_priorities_active: true).order(:rating_from).last
+  end
 end

--- a/app/models/management_priority.rb
+++ b/app/models/management_priority.rb
@@ -35,4 +35,39 @@ class ManagementPriority < ApplicationRecord
   validates :priority, numericality: true
 
   scope :by_priority, -> { order(priority: :desc) }
+
+  #Returns an Array of OpenStruct
+  def self.for_school_group(school_group)
+    query = <<-SQL.squish
+      SELECT a.school_id, a.id, cv.alert_type_rating_id, vars.average_one_year_saving_£, vars.one_year_saving_co2
+      FROM management_priorities mp
+      INNER JOIN alert_type_rating_content_versions cv ON mp.alert_type_rating_content_version_id = cv.id
+      INNER JOIN alerts a ON mp.alert_id = a.id,
+      JSON_TO_RECORD(a.template_data) AS vars(one_year_saving_co2 TEXT, average_one_year_saving_£ TEXT)
+      WHERE
+        content_generation_run_id IN (
+            SELECT c1.id FROM content_generation_runs c1
+            LEFT OUTER JOIN content_generation_runs c2 ON c1.school_id = c2.school_id AND c1.created_at < c2.created_at
+            WHERE
+            c2.created_at IS NULL AND
+            c1.school_id IN (
+                SELECT id
+                FROM schools
+                WHERE school_group_id = #{school_group.id}
+                AND visible=true
+            )
+        )
+      ORDER BY a.school_id, a.id;
+    SQL
+    sanitized_query = ActiveRecord::Base.sanitize_sql_array(query)
+    ManagementPriority.connection.select_all(sanitized_query).rows.map do |row|
+      OpenStruct.new(
+        school_id: row[0],
+        alert_id: row[1],
+        alert_type_rating_id: row[2],
+        average_one_year_saving_gbp: row[3],
+        one_year_saving_co2: row[4]
+      )
+    end
+  end
 end

--- a/app/services/school_groups/priority_actions.rb
+++ b/app/services/school_groups/priority_actions.rb
@@ -1,0 +1,77 @@
+module SchoolGroups
+  class PriorityActions
+    def initialize(school_group)
+      @school_group = school_group
+    end
+
+    #returns a hash of alert_type_rating to a list of ManagementPriority
+    #there will be at most one ManagementPriority for a given alert type rating for a school
+    def priority_actions
+      @priority_actions ||= find_priority_actions
+    end
+
+    #returns a hash of alert_type_rating to a list of OpenStruct with saving values
+    def savings
+      priority_actions.transform_values do |management_priorities|
+        management_priorities.map do |priority|
+          alert = priority.alert
+          OpenStruct.new(
+            average_one_year_saving_gbp: average_one_year_saving_gbp(alert),
+            one_year_saving_co2: one_year_saving_co2(alert)
+          )
+        end
+      end
+    end
+
+    private
+
+    def one_year_saving_co2(alert)
+      money_to_i(alert.template_data["one_year_saving_co2"].split(" ").first)
+    end
+
+    def average_one_year_saving_gbp(alert)
+      money_to_i(alert.template_data["average_one_year_saving_£"])
+    end
+
+    def money_to_i(val)
+      val.gsub(/\D/, '').to_i
+    end
+
+    def find_priority_actions
+      actions = {}
+      alert_type_ratings.each do |rating|
+        actions[rating] = priorities_for_rating(rating)
+      end
+      actions.delete_if {|_, v| v.empty? }
+    end
+
+    def priorities_for_rating(rating)
+      priorities.select do |priority|
+        priority.content_version.alert_type_rating == rating
+      end
+    end
+
+    #Any alert rating where `management_priorities_active: true`. i.e. will produce a
+    #ManagementPriority record
+    #
+    #Use this to group and sum content
+    def alert_type_ratings
+      @alert_type_ratings = AlertTypeRating.management_priorities_title
+    end
+
+    #The latest ManagementPriority records for every school in group
+    def priorities
+      @priorities ||= ManagementPriority.where(content_generation_run: content_generation_runs)
+    end
+
+    #latest content generation runs for every school in the group
+    #ignoring schools with no runs
+    def content_generation_runs
+      @content_generation_runs ||= schools.map(&:latest_content).compact
+    end
+
+    def schools
+      @schools ||= @school_group.schools.visible
+    end
+  end
+end

--- a/app/views/school_groups/_priority_action_modal.html.erb
+++ b/app/views/school_groups/_priority_action_modal.html.erb
@@ -1,0 +1,32 @@
+<p>This action has been identified as a priority for the following schools.</p>
+
+<table class="table table-borderless table-sorted advice-table advice-priority-table">
+  <thead>
+    <tr>
+      <th></th>
+      <th><%= t('advice_pages.index.priorities.table.columns.cost_saving') %></th>
+      <th><%= t('advice_pages.index.priorities.table.columns.co2_reduction') %></th>
+      <th class="no-sort"></th>
+    </tr>
+  </thead>
+  <tbody>
+    <% priority_actions[alert_type_rating].each do |saving| %>
+      <tr>
+        <td>
+          <%= link_to saving.school.name, school_path(saving.school) %>
+        </td>
+        <td data-order="<%= saving.average_one_year_saving_gbp %>">
+          <%= format_unit(saving.average_one_year_saving_gbp, :£) %>
+        </td>
+        <td data-order="<%= saving.one_year_saving_co2 %>">
+          <%= format_unit(saving.one_year_saving_co2, :co2) %> kg CO2
+        </td>
+        <td>
+          <% if alert_type_rating.alert_type.advice_page.present? %>
+            <%= link_to "View analysis", advice_page_path(saving.school, alert_type_rating.alert_type.advice_page, alert_type_rating.alert_type.advice_page_tab_for_link_to, anchor: alert_type_rating.alert_type.link_to_section) %>
+          <% end %>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/school_groups/_priority_action_modal.html.erb
+++ b/app/views/school_groups/_priority_action_modal.html.erb
@@ -1,16 +1,16 @@
-<p>This action has been identified as a priority for the following schools.</p>
+<p><%= t('school_groups.priority_actions.intro') %></p>
 
 <table class="table table-borderless table-sorted advice-table advice-priority-table">
   <thead>
     <tr>
-      <th></th>
+      <th><%= t('common.school') %></th>
       <th><%= t('advice_pages.index.priorities.table.columns.cost_saving') %></th>
       <th><%= t('advice_pages.index.priorities.table.columns.co2_reduction') %></th>
       <th class="no-sort"></th>
     </tr>
   </thead>
   <tbody>
-    <% priority_actions[alert_type_rating].each do |saving| %>
+    <% sort_priority_actions(priority_actions[alert_type_rating]).each do |saving| %>
       <tr>
         <td>
           <%= link_to saving.school.name, school_path(saving.school) %>
@@ -23,7 +23,7 @@
         </td>
         <td>
           <% if alert_type_rating.alert_type.advice_page.present? %>
-            <%= link_to "View analysis", advice_page_path(saving.school, alert_type_rating.alert_type.advice_page, alert_type_rating.alert_type.advice_page_tab_for_link_to, anchor: alert_type_rating.alert_type.link_to_section) %>
+            <%= link_to t('school_groups.priority_actions.view_analysis'), advice_page_path(saving.school, alert_type_rating.alert_type.advice_page, alert_type_rating.alert_type.advice_page_tab_for_link_to, anchor: alert_type_rating.alert_type.link_to_section) %>
           <% end %>
         </td>
       </tr>

--- a/app/views/school_groups/_priority_action_modal.html.erb
+++ b/app/views/school_groups/_priority_action_modal.html.erb
@@ -1,4 +1,4 @@
-<p><%= t('school_groups.priority_actions.intro') %></p>
+<p><%= t('school_groups.priority_actions.modal_intro') %></p>
 
 <table class="table table-borderless table-sorted advice-table advice-priority-table">
   <thead>

--- a/app/views/school_groups/priority_actions.html.erb
+++ b/app/views/school_groups/priority_actions.html.erb
@@ -1,5 +1,10 @@
 <%= render 'enhanced_header' %>
 
+<%= component 'notice', status: :neutral, classes: 'mt-2 mb-4' do |c| %>
+  <%= t('school_groups.priority_actions.intro_html') %>
+<% end %>
+
+
 <table class="table table-borderless table-sorted advice-table advice-priority-table">
   <thead>
     <tr>

--- a/app/views/school_groups/priority_actions.html.erb
+++ b/app/views/school_groups/priority_actions.html.erb
@@ -28,12 +28,12 @@
             <%= savings.schools.length %>
           </h4>
         </td>
-        <td>
+        <td data-order="<%= savings.average_one_year_saving_gbp %>">
           <h4>
             <%= format_unit(savings.average_one_year_saving_gbp, :£) %>
           </h4>
         </td>
-        <td>
+        <td data-order="<%= savings.one_year_saving_co2 %>">
           <h4>
             <%= format_unit(savings.one_year_saving_co2, :co2) %> kg CO2
           </h4>

--- a/app/views/school_groups/priority_actions.html.erb
+++ b/app/views/school_groups/priority_actions.html.erb
@@ -10,7 +10,7 @@
       <th><%= t('advice_pages.index.priorities.table.columns.co2_reduction') %></th>
     </tr>
   </thead>
-  <tbody id="priority">
+  <tbody id="school-group-priorities">
     <% @total_savings.each do |alert_type_rating, savings| %>
       <tr>
         <td data-order="<%= alert_type_rating.alert_type.fuel_type %>">
@@ -20,8 +20,18 @@
         </td>
         <td>
           <h4>
-            <%= alert_type_rating.current_content.management_priorities_title %>
+            <a href="" data-toggle="modal" data-target="#action-<%= alert_type_rating.id %>">
+              <%= alert_type_rating.current_content.management_priorities_title %>
+            </a>
           </h4>
+          <%= render(FootnoteModalComponent.new(title: alert_type_rating.current_content.management_priorities_title.to_plain_text, modal_id: "action-#{alert_type_rating.id}", modal_dialog_classes: 'modal-xl modal-dialog-centered')) do |component| %>
+            <% component.with_body_content do %>
+              <%= render 'priority_action_modal',
+                alert_type_rating: alert_type_rating,
+                savings: savings,
+                priority_actions: @priority_actions %>
+            <% end %>
+          <% end %>
         </td>
         <td>
           <h4>

--- a/app/views/school_groups/priority_actions.html.erb
+++ b/app/views/school_groups/priority_actions.html.erb
@@ -1,1 +1,45 @@
 <%= render 'enhanced_header' %>
+
+<table class="table table-borderless table-sorted advice-table advice-priority-table">
+  <thead>
+    <tr>
+      <th><%= t('advice_pages.index.priorities.table.columns.fuel_type') %></th>
+      <th data-orderable="false"></th>
+      <th><%= t('components.breadcrumbs.schools') %></th>
+      <th><%= t('advice_pages.index.priorities.table.columns.cost_saving') %></th>
+      <th><%= t('advice_pages.index.priorities.table.columns.co2_reduction') %></th>
+    </tr>
+  </thead>
+  <tbody id="priority">
+    <% @priority_actions_service.savings.each do |alert_type_rating, savings| %>
+      <tr>
+        <td data-order="<%= alert_type_rating.alert_type.fuel_type %>">
+          <span class="<%=fuel_type_class(alert_type_rating.alert_type.fuel_type)%>">
+            <%= fa_icon alert_type_icon(alert_type_rating.alert_type,'fa-2x') %>
+          </span>
+        </td>
+        <td>
+          <h4>
+            <%= alert_type_rating.id %> -
+            <%= alert_type_rating.current_content.management_priorities_title %>
+          </h4>
+        </td>
+        <td>
+          <h4>
+            <%= savings.length %>
+          </h4>
+        </td>
+        <td>
+          <h4>
+            <%= format_unit( savings.reduce(0) {|sum, saving| sum + saving.average_one_year_saving_gbp }, :£) %>
+          </h4>
+        </td>
+        <td>
+          <h4>
+            <%= format_unit( savings.reduce(0) {|sum, saving| sum + saving.one_year_saving_co2 }, :co2) %> kg CO2
+          </h4>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/school_groups/priority_actions.html.erb
+++ b/app/views/school_groups/priority_actions.html.erb
@@ -11,7 +11,7 @@
     </tr>
   </thead>
   <tbody id="priority">
-    <% @priority_actions_service.savings.each do |alert_type_rating, savings| %>
+    <% @total_savings.each do |alert_type_rating, savings| %>
       <tr>
         <td data-order="<%= alert_type_rating.alert_type.fuel_type %>">
           <span class="<%=fuel_type_class(alert_type_rating.alert_type.fuel_type)%>">
@@ -20,23 +20,22 @@
         </td>
         <td>
           <h4>
-            <%= alert_type_rating.id %> -
             <%= alert_type_rating.current_content.management_priorities_title %>
           </h4>
         </td>
         <td>
           <h4>
-            <%= savings.length %>
+            <%= savings.schools.length %>
           </h4>
         </td>
         <td>
           <h4>
-            <%= format_unit( savings.reduce(0) {|sum, saving| sum + saving.average_one_year_saving_gbp }, :£) %>
+            <%= format_unit(savings.average_one_year_saving_gbp, :£) %>
           </h4>
         </td>
         <td>
           <h4>
-            <%= format_unit( savings.reduce(0) {|sum, saving| sum + saving.one_year_saving_co2 }, :co2) %> kg CO2
+            <%= format_unit(savings.one_year_saving_co2, :co2) %> kg CO2
           </h4>
         </td>
       </tr>

--- a/app/views/school_groups/priority_actions.html.erb
+++ b/app/views/school_groups/priority_actions.html.erb
@@ -29,7 +29,7 @@
               <%= alert_type_rating.current_content.management_priorities_title %>
             </a>
           </h4>
-          <%= render(FootnoteModalComponent.new(title: alert_type_rating.current_content.management_priorities_title.to_plain_text, modal_id: "action-#{alert_type_rating.id}", modal_dialog_classes: 'modal-xl modal-dialog-centered')) do |component| %>
+          <%= component 'footnote_modal', title: alert_type_rating.current_content.management_priorities_title.to_plain_text, modal_id: "action-#{alert_type_rating.id}", modal_dialog_classes: 'modal-xl modal-dialog-centered' do |component| %>
             <% component.with_body_content do %>
               <%= render 'priority_action_modal',
                 alert_type_rating: alert_type_rating,

--- a/config/locales/views/school_groups/school_groups.yml
+++ b/config/locales/views/school_groups/school_groups.yml
@@ -9,7 +9,11 @@ en:
       view_map: View map
       view_scoreboard: Scoreboard
     priority_actions:
-      intro: This action has been identified as a priority for the following schools.
+      intro_html: |-
+        <p>We carry out daily analysis for all schools to help identify the areas where there are the biggest opportunities to reduce costs and carbon emissions.</p>
+        <p>This table summarises the potential savings across this entire group of schools. Click on a heading to view the savings for individual schools and explore the detailed analysis.</p>
+        <p><strong>Note</strong>: Savings are not additive across the table as reduced usage in one area, e.g. electricity baseload, will also lead to savings in other areas, e.g. out of hours electricity usage. The potential savings are intended to help to prioritise and coordinate energy saving actions across the group. Cost savings are based on the latest tariff information we have available for the individual schools.</p>
+      modal_intro: This action has been identified as a priority for the following schools.
       view_analysis: View analysis
     show:
       currently_works_with_from:

--- a/config/locales/views/school_groups/school_groups.yml
+++ b/config/locales/views/school_groups/school_groups.yml
@@ -8,6 +8,9 @@ en:
       view_group: View group
       view_map: View map
       view_scoreboard: Scoreboard
+    priority_actions:
+      intro: This action has been identified as a priority for the following schools.
+      view_analysis: View analysis
     show:
       currently_works_with_from:
         one: Energy Sparks currently works with %{count} school from

--- a/spec/services/school_groups/priority_actions_spec.rb
+++ b/spec/services/school_groups/priority_actions_spec.rb
@@ -1,0 +1,159 @@
+require 'rails_helper'
+
+RSpec.describe SchoolGroups::PriorityActions, type: :service do
+
+  let(:school_group) { create :school_group, name: 'A Group' }
+
+  let(:school_1)  { create(:school, school_group: school_group, visible: true) }
+  let(:school_2)  { create(:school, school_group: school_group, visible: true) }
+  let(:school_3)  { create(:school, school_group: school_group, visible: false) }
+
+  let!(:alert_type) { create(:alert_type, fuel_type: :gas, frequency: :weekly) }
+  let!(:alert_type_rating_low) do
+    create(
+      :alert_type_rating,
+      alert_type: alert_type,
+      rating_from: 0,
+      rating_to: 4,
+      management_priorities_active: true,
+      description: "low"
+    )
+  end
+  let!(:alert_type_rating_content_version_low) do
+    create(
+      :alert_type_rating_content_version,
+      alert_type_rating: alert_type_rating_low,
+      management_priorities_title: 'Spending too much money on heating (low)',
+    )
+  end
+  let!(:alert_type_rating_medium) do
+    create(
+      :alert_type_rating,
+      alert_type: alert_type,
+      rating_from: 4.1,
+      rating_to: 6,
+      management_priorities_active: true,
+      description: "medium"
+    )
+  end
+  let!(:alert_type_rating_content_version_medium) do
+    create(
+      :alert_type_rating_content_version,
+      alert_type_rating: alert_type_rating_medium,
+      management_priorities_title: 'Spending too much money on heating (medium)',
+    )
+  end
+  let!(:alert_type_rating_high) do
+    create(
+      :alert_type_rating,
+      alert_type: alert_type,
+      rating_from: 6.1,
+      rating_to: 10,
+      management_priorities_active: true,
+      description: "high"
+    )
+  end
+  let!(:alert_type_rating_content_version_high) do
+    create(
+      :alert_type_rating_content_version,
+      alert_type_rating: alert_type_rating_high,
+      management_priorities_title: 'Spending too much money on heating (high)',
+    )
+  end
+
+  let!(:alert_school_1) do
+    create(:alert, :with_run,
+      alert_type: alert_type,
+      run_on: Date.today, school: school_1,
+      rating: 2.0,
+      template_data: {
+        average_one_year_saving_£: '£1,000',
+        one_year_saving_co2: '1,100 kg CO2'
+      }
+    )
+  end
+
+  let!(:alert_school_2) do
+    create(:alert, :with_run,
+      alert_type: alert_type,
+      run_on: Date.today, school: school_2,
+      rating: 8.0,
+      template_data: {
+        average_one_year_saving_£: '£2,000',
+        one_year_saving_co2: '2,200 kg CO2'
+      }
+    )
+  end
+
+  let!(:alert_school_3) do
+    create(:alert, :with_run,
+      alert_type: alert_type,
+      run_on: Date.today, school: school_3,
+      rating: 8.0,
+      template_data: {
+        average_one_year_saving_£: '£9,000',
+        one_year_saving_co2: '9,900 kg CO2'
+      }
+    )
+  end
+
+  let(:service) { SchoolGroups::PriorityActions.new(school_group) }
+
+  before do
+    #just run the services to set up rest of test data
+    Alerts::GenerateContent.new(school_1).perform
+    Alerts::GenerateContent.new(school_2).perform
+    Alerts::GenerateContent.new(school_3).perform
+  end
+
+  context '#priority_actions' do
+    let(:priority_actions)  { service.priority_actions }
+
+    it 'always keys the hash on the alert type rating with highest range' do
+      expect(priority_actions).to_not have_key(alert_type_rating_low)
+      expect(priority_actions).to_not have_key(alert_type_rating_medium)
+      expect(priority_actions).to have_key(alert_type_rating_high)
+    end
+
+    it 'does not include ratings without priorities' do
+      priority_actions.each do |_k,v|
+        expect(v).to_not be_empty
+      end
+    end
+
+    it 'only includes results for visible schools' do
+      expect(priority_actions[alert_type_rating_high].length).to eq 2
+    end
+
+    it 'returns the expected values' do
+      school_1_priority = OpenStruct.new(school: school_1, average_one_year_saving_gbp: 1000, one_year_saving_co2: 1100)
+      school_2_priority = OpenStruct.new(school: school_2, average_one_year_saving_gbp: 2000, one_year_saving_co2: 2200)
+      expect(priority_actions[alert_type_rating_high]).to match_array([school_1_priority, school_2_priority])
+    end
+
+  end
+
+  context '#total_savings' do
+    let(:total_savings)  { service.total_savings }
+
+    it 'returns a hash keyed on alert type rating to a total saving and school count' do
+      expect(total_savings).to_not have_key(alert_type_rating_low)
+      expect(total_savings).to_not have_key(alert_type_rating_medium)
+      expect(total_savings).to have_key(alert_type_rating_high)
+      expect(total_savings[alert_type_rating_high]).to be_a OpenStruct
+    end
+
+    it 'lists the schools' do
+      expect(total_savings[alert_type_rating_high].schools).to match_array([school_1, school_2])
+    end
+
+    it 'calculates correct gbp total' do
+      expect(total_savings[alert_type_rating_high].average_one_year_saving_gbp).to eq 3000
+    end
+
+    it 'calculates correct co2 total' do
+      expect(total_savings[alert_type_rating_high].one_year_saving_co2).to eq 3300
+    end
+  end
+
+end

--- a/spec/system/school_groups_spec.rb
+++ b/spec/system/school_groups_spec.rb
@@ -110,7 +110,7 @@ describe 'school groups', :school_groups, type: :system do
 
   context 'enhanced school group pages with feature flag set to true' do
     around do |example|
-      ClimateControl.modify FEATURE_FLAG_REPLACE_ANALYSIS_PAGES: 'true' do
+      ClimateControl.modify FEATURE_FLAG_ENHANCED_SCHOOL_GROUP_DASHBOARD: 'true' do
         example.run
       end
     end
@@ -408,7 +408,7 @@ describe 'school groups', :school_groups, type: :system do
 
     context 'priority_actions' do
       around do |example|
-        ClimateControl.modify FEATURE_FLAG_REPLACE_ANALYSIS_PAGES: 'true' do
+        ClimateControl.modify FEATURE_FLAG_ENHANCED_SCHOOL_GROUP_DASHBOARD: 'true' do
           example.run
         end
       end

--- a/spec/system/school_groups_spec.rb
+++ b/spec/system/school_groups_spec.rb
@@ -109,128 +109,122 @@ describe 'school groups', :school_groups, type: :system do
   end
 
   context 'enhanced school group pages with feature flag set to true' do
+    around do |example|
+      ClimateControl.modify FEATURE_FLAG_REPLACE_ANALYSIS_PAGES: 'true' do
+        example.run
+      end
+    end
+
     context 'when not logged in' do
       context 'when school group is public' do
         let(:public) { true }
 
         it 'does not redirect enhanced page actions to school group page if feature is enabled or map page' do
-          ClimateControl.modify FEATURE_FLAG_ENHANCED_SCHOOL_GROUP_DASHBOARD: 'true' do
-            visit map_school_group_path(school_group)
-            expect(current_path).to eq "/school_groups/#{school_group.slug}/map"
-            visit comparisons_school_group_path(school_group)
-            expect(current_path).to eq "/school_groups/#{school_group.slug}/comparisons"
-            visit priority_actions_school_group_path(school_group)
-            expect(current_path).to eq "/school_groups/#{school_group.slug}/priority_actions"
-            visit current_scores_school_group_path(school_group)
-            expect(current_path).to eq "/school_groups/#{school_group.slug}/current_scores"
-          end
+          visit map_school_group_path(school_group)
+          expect(current_path).to eq "/school_groups/#{school_group.slug}/map"
+          visit comparisons_school_group_path(school_group)
+          expect(current_path).to eq "/school_groups/#{school_group.slug}/comparisons"
+          visit priority_actions_school_group_path(school_group)
+          expect(current_path).to eq "/school_groups/#{school_group.slug}/priority_actions"
+          visit current_scores_school_group_path(school_group)
+          expect(current_path).to eq "/school_groups/#{school_group.slug}/current_scores"
         end
 
         describe '#show/recent usage' do
           it 'shows a map page with a map div and a list of schools' do
-            ClimateControl.modify FEATURE_FLAG_ENHANCED_SCHOOL_GROUP_DASHBOARD: 'true' do
-              changes = OpenStruct.new(change: "-16%")
-              allow_any_instance_of(School).to receive(:recent_usage) do
-                OpenStruct.new(
-                  electricity: OpenStruct.new(week: changes, year: changes),
-                  gas: OpenStruct.new(week: changes, year: changes),
-                  storage_heaters: OpenStruct.new(week: changes, year: changes)
-                )
-              end
-              visit school_group_path(school_group)
-              expect(current_path).to eq "/school_groups/#{school_group.slug}"
-              expect(find('ol.main-breadcrumbs').all('li').collect(&:text)).to eq(['Schools', school_group.name, 'Group Dashboard'])
-              expect(page).to have_content('Recent Usage')
-              expect(page).to have_content('Comparisons')
-              expect(page).to have_content('Priority Actions')
-              expect(page).to have_content('Current Scores')
-              expect(page).to have_content('View map')
-              expect(page).not_to have_content('View group')
-              expect(page).to have_content('Scoreboard')
-
-              # Table content
-              expect(page).to have_content('Electricity')
-              expect(page).to have_content('Gas')
-              expect(page).to have_content('Storage heaters')
-              expect(page).to have_content('School')
-              expect(page).to have_content('Last week')
-              expect(page).to have_content('Last year')
-              expect(page).to have_content(school_1.name)
-              expect(page).to have_content(school_2.name)
-              expect(page).to have_content('-16%')
+            changes = OpenStruct.new(change: "-16%")
+            allow_any_instance_of(School).to receive(:recent_usage) do
+              OpenStruct.new(
+                electricity: OpenStruct.new(week: changes, year: changes),
+                gas: OpenStruct.new(week: changes, year: changes),
+                storage_heaters: OpenStruct.new(week: changes, year: changes)
+              )
             end
+            visit school_group_path(school_group)
+            expect(current_path).to eq "/school_groups/#{school_group.slug}"
+            expect(find('ol.main-breadcrumbs').all('li').collect(&:text)).to eq(['Schools', school_group.name, 'Group Dashboard'])
+            expect(page).to have_content('Recent Usage')
+            expect(page).to have_content('Comparisons')
+            expect(page).to have_content('Priority Actions')
+            expect(page).to have_content('Current Scores')
+            expect(page).to have_content('View map')
+            expect(page).not_to have_content('View group')
+            expect(page).to have_content('Scoreboard')
+
+            # Table content
+            expect(page).to have_content('Electricity')
+            expect(page).to have_content('Gas')
+            expect(page).to have_content('Storage heaters')
+            expect(page).to have_content('School')
+            expect(page).to have_content('Last week')
+            expect(page).to have_content('Last year')
+            expect(page).to have_content(school_1.name)
+            expect(page).to have_content(school_2.name)
+            expect(page).to have_content('-16%')
           end
         end
 
         describe '#comparisons' do
           it 'shows a map page with a map div and a list of schools' do
-            ClimateControl.modify FEATURE_FLAG_ENHANCED_SCHOOL_GROUP_DASHBOARD: 'true' do
-              visit comparisons_school_group_path(school_group)
-              expect(current_path).to eq "/school_groups/#{school_group.slug}/comparisons"
-              expect(find('ol.main-breadcrumbs').all('li').collect(&:text)).to eq(['Schools', school_group.name, 'Comparisons'])
-              expect(page).to have_content('Recent Usage')
-              expect(page).to have_content('Comparisons')
-              expect(page).to have_content('Priority Actions')
-              expect(page).to have_content('Current Scores')
-              expect(page).to have_content('View map')
-              expect(page).not_to have_content('View group')
-              expect(page).to have_content('Scoreboard')
-            end
+            visit comparisons_school_group_path(school_group)
+            expect(current_path).to eq "/school_groups/#{school_group.slug}/comparisons"
+            expect(find('ol.main-breadcrumbs').all('li').collect(&:text)).to eq(['Schools', school_group.name, 'Comparisons'])
+            expect(page).to have_content('Recent Usage')
+            expect(page).to have_content('Comparisons')
+            expect(page).to have_content('Priority Actions')
+            expect(page).to have_content('Current Scores')
+            expect(page).to have_content('View map')
+            expect(page).not_to have_content('View group')
+            expect(page).to have_content('Scoreboard')
           end
         end
 
         describe '#priority_actions' do
           it 'shows a map page with a map div and a list of schools' do
-            ClimateControl.modify FEATURE_FLAG_ENHANCED_SCHOOL_GROUP_DASHBOARD: 'true' do
-              visit priority_actions_school_group_path(school_group)
-              expect(current_path).to eq "/school_groups/#{school_group.slug}/priority_actions"
-              expect(find('ol.main-breadcrumbs').all('li').collect(&:text)).to eq(['Schools', school_group.name, 'Priority Actions'])
-              expect(page).to have_content('Recent Usage')
-              expect(page).to have_content('Comparisons')
-              expect(page).to have_content('Priority Actions')
-              expect(page).to have_content('Current Scores')
-              expect(page).to have_content('View map')
-              expect(page).not_to have_content('View group')
-              expect(page).to have_content('Scoreboard')
-            end
+            visit priority_actions_school_group_path(school_group)
+            expect(current_path).to eq "/school_groups/#{school_group.slug}/priority_actions"
+            expect(find('ol.main-breadcrumbs').all('li').collect(&:text)).to eq(['Schools', school_group.name, 'Priority Actions'])
+            expect(page).to have_content('Recent Usage')
+            expect(page).to have_content('Comparisons')
+            expect(page).to have_content('Priority Actions')
+            expect(page).to have_content('Current Scores')
+            expect(page).to have_content('View map')
+            expect(page).not_to have_content('View group')
+            expect(page).to have_content('Scoreboard')
           end
         end
 
         describe '#current_scores' do
           it 'shows a map page with a map div and a list of schools' do
-            ClimateControl.modify FEATURE_FLAG_ENHANCED_SCHOOL_GROUP_DASHBOARD: 'true' do
-              visit current_scores_school_group_path(school_group)
-              expect(current_path).to eq "/school_groups/#{school_group.slug}/current_scores"
-              expect(find('ol.main-breadcrumbs').all('li').collect(&:text)).to eq(['Schools', school_group.name, 'Current Scores'])
-              expect(page).to have_content('Recent Usage')
-              expect(page).to have_content('Comparisons')
-              expect(page).to have_content('Priority Actions')
-              expect(page).to have_content('Current Scores')
-              expect(page).to have_content('View map')
-              expect(page).not_to have_content('View group')
-              expect(page).to have_content('Scoreboard')
-            end
+            visit current_scores_school_group_path(school_group)
+            expect(current_path).to eq "/school_groups/#{school_group.slug}/current_scores"
+            expect(find('ol.main-breadcrumbs').all('li').collect(&:text)).to eq(['Schools', school_group.name, 'Current Scores'])
+            expect(page).to have_content('Recent Usage')
+            expect(page).to have_content('Comparisons')
+            expect(page).to have_content('Priority Actions')
+            expect(page).to have_content('Current Scores')
+            expect(page).to have_content('View map')
+            expect(page).not_to have_content('View group')
+            expect(page).to have_content('Scoreboard')
           end
         end
 
         describe '#map' do
           it 'shows a map page with a map div and a list of schools' do
-            ClimateControl.modify FEATURE_FLAG_ENHANCED_SCHOOL_GROUP_DASHBOARD: 'true' do
-              visit map_school_group_path(school_group)
-              expect(current_path).to eq "/school_groups/#{school_group.slug}/map"
-              expect(find('ol.main-breadcrumbs').all('li').collect(&:text)).to eq(['Schools', school_group.name, 'Map'])
-              expect(page).not_to have_content('Recent Usage')
-              expect(page).not_to have_content('Comparisons')
-              expect(page).not_to have_content('Priority Actions')
-              expect(page).not_to have_content('Current Scores')
-              expect(page).to have_content('Map')
-              expect(page).to have_content(school_1.name)
-              expect(page).to have_content(school_2.name)
-              expect(page).to have_selector(:id, 'geo-json-map')
-              expect(page).not_to have_content('View map')
-              expect(page).to have_content('View group')
-              expect(page).to have_content('Scoreboard')
-            end
+            visit map_school_group_path(school_group)
+            expect(current_path).to eq "/school_groups/#{school_group.slug}/map"
+            expect(find('ol.main-breadcrumbs').all('li').collect(&:text)).to eq(['Schools', school_group.name, 'Map'])
+            expect(page).not_to have_content('Recent Usage')
+            expect(page).not_to have_content('Comparisons')
+            expect(page).not_to have_content('Priority Actions')
+            expect(page).not_to have_content('Current Scores')
+            expect(page).to have_content('Map')
+            expect(page).to have_content(school_1.name)
+            expect(page).to have_content(school_2.name)
+            expect(page).to have_selector(:id, 'geo-json-map')
+            expect(page).not_to have_content('View map')
+            expect(page).to have_content('View group')
+            expect(page).to have_content('Scoreboard')
           end
         end
       end
@@ -239,17 +233,15 @@ describe 'school groups', :school_groups, type: :system do
         let(:public) { false }
 
         it 'does not redirect enhanced page actions to school group page if feature is enabled but does redirect other actions to the map page with no view group link' do
-          ClimateControl.modify FEATURE_FLAG_ENHANCED_SCHOOL_GROUP_DASHBOARD: 'true' do
-            visit map_school_group_path(school_group)
-            expect(current_path).to eq "/school_groups/#{school_group.slug}/map"
-            visit comparisons_school_group_path(school_group)
-            expect(current_path).to eq "/school_groups/#{school_group.slug}/map"
-            visit priority_actions_school_group_path(school_group)
-            expect(current_path).to eq "/school_groups/#{school_group.slug}/map"
-            visit current_scores_school_group_path(school_group)
-            expect(current_path).to eq "/school_groups/#{school_group.slug}/map"
-            expect(page).to_not have_content('View group')
-          end
+          visit map_school_group_path(school_group)
+          expect(current_path).to eq "/school_groups/#{school_group.slug}/map"
+          visit comparisons_school_group_path(school_group)
+          expect(current_path).to eq "/school_groups/#{school_group.slug}/map"
+          visit priority_actions_school_group_path(school_group)
+          expect(current_path).to eq "/school_groups/#{school_group.slug}/map"
+          visit current_scores_school_group_path(school_group)
+          expect(current_path).to eq "/school_groups/#{school_group.slug}/map"
+          expect(page).to_not have_content('View group')
         end
       end
     end
@@ -415,6 +407,12 @@ describe 'school groups', :school_groups, type: :system do
     end
 
     context 'priority_actions' do
+      around do |example|
+        ClimateControl.modify FEATURE_FLAG_REPLACE_ANALYSIS_PAGES: 'true' do
+          example.run
+        end
+      end
+
       let!(:alert_type) { create(:alert_type, fuel_type: :gas, frequency: :weekly) }
       let!(:alert_type_rating) do
         create(


### PR DESCRIPTION
Initial spike of creating a summary of priority actions for school groups.

Things to ensure we've tested and resolved:

* [x] schools for a group may not yet have any priority actions
* [x] the alert type rating content version may have changed since the actions were calculated for a school, so we need to ensure we're using the current content for all schools, not the version they were generated with. This will likely be rare, but could happen
* [x] the Management Priorities are associated with an AlertTypeRating, so we need to aggregate up to the AlertType level, as otherwise we will have separate values for e.g. "Average baseload" and "High baseload", which will mean the table has duplicate rows and the totals will be off
* [x] ensure totals are sorted by price by default
* [x] ensure table sorts correctly
* [x] add popup with list of schools
* [x] add system spec
* [x] extract text to YML
* [x] sort modal entries by school name by defaults
* [x] add some explanatory text to indicate how we calculated these values, including some references to their tariffs. The savings are large so may need to be justified
* [x] further refactor and optimise service