### PR TITLE
Make recent usage tab tolerant of limited data

### DIFF
--- a/app/views/school_groups/recent_usage.html.erb
+++ b/app/views/school_groups/recent_usage.html.erb
@@ -31,32 +31,66 @@
     </tr>
   </thead>
   <tbody>
-    <% @school_group.schools.visible.order(:name).each do |school| %>
-      <% recent_usage = school.recent_usage %>
+    <% @school_group.schools.data_visible.visible.order(:name).each do |school| %>
       <tr>
-        <% if @fuel_types.include?(:electricity) %>
-          <td class="<%= recent_usage&.electricity&.week&.message_class %>" data-order="<%= recent_usage&.electricity&.week&.change&.gsub('%','')&.to_f || '0' %>">
-            <%= up_downify(recent_usage&.electricity&.week&.change || 'n/a') %>
-          </td>
-          <td class="<%= recent_usage&.electricity&.year&.message_class %>" data-order="<%= recent_usage&.electricity&.year&.change&.gsub('%','')&.to_f || '0'  %>">
-            <%= up_downify(recent_usage&.electricity&.year&.change || 'n/a') %>
-          </td>
-        <% end %>
-        <% if @fuel_types.include?(:gas) %>
-          <td class="<%= recent_usage&.gas&.week&.message_class %>" data-order="<%= recent_usage&.gas&.week&.change&.gsub('%','')&.to_f || '0' %>">
-            <%= up_downify(recent_usage&.gas&.week&.change || 'n/a') %>
-          </td>
-          <td class="<%= recent_usage&.gas&.year&.message_class %>" data-order="<%= recent_usage&.gas&.year&.change&.gsub('%','')&.to_f || '0' %>">
-            <%= up_downify(recent_usage&.gas&.year&.change || 'n/a') %>
-          </td>
-        <% end %>
-        <% if @fuel_types.include?(:storage_heaters) %>
-          <td class="<%= recent_usage&.storage_heaters&.week&.message_class %>" data-order="<%= recent_usage&.storage_heaters&.week&.change&.gsub('%','')&.to_f || '0' %>">
-            <%= up_downify(recent_usage&.storage_heaters&.week&.change || 'n/a') %>
-          </td>
-          <td class="<%= recent_usage&.storage_heaters&.year&.message_class %>" data-order="<%= recent_usage&.storage_heaters&.year&.change&.gsub('%','')&.to_f || '0' %>">
-            <%= up_downify(recent_usage&.storage_heaters&.year&.change || 'n/a') %>
-          </td>
+        <% if school.data_enabled %>
+          <% recent_usage = school.recent_usage %>
+          <% if @fuel_types.include?(:electricity) %>
+            <% if recent_usage&.electricity&.week&.has_data %>
+              <td class="<%= recent_usage&.electricity&.week&.message_class %>"
+                  data-order="<%= recent_usage&.electricity&.week&.change&.gsub('%','')&.to_f || '0' %>">
+                <%= up_downify(recent_usage&.electricity&.week&.change) %>
+              </td>
+            <% else %>
+              <td data-order="0">n/a</td>
+            <% end %>
+            <% if recent_usage&.electricity&.year&.has_data %>
+              <td class="<%= recent_usage&.electricity&.year&.message_class %>"
+                  data-order="<%= recent_usage&.electricity&.year&.change&.gsub('%','')&.to_f || '0'  %>">
+                <%= up_downify(recent_usage&.electricity&.year&.change) %>
+              </td>
+            <% else %>
+              <td data-order="0">n/a</td>
+            <% end %>
+          <% end %>
+          <% if @fuel_types.include?(:gas) %>
+            <% if recent_usage&.gas&.week&.has_data %>
+              <td class="<%= recent_usage&.gas&.week&.message_class %>"
+                  data-order="<%= recent_usage&.gas&.week&.change&.gsub('%','')&.to_f || '0' %>">
+                <%= up_downify(recent_usage&.gas&.week&.change) %>
+              </td>
+            <% else %>
+              <td data-order="0">n/a</td>
+            <% end %>
+            <% if recent_usage&.gas&.year&.has_data %>
+              <td class="<%= recent_usage&.gas&.year&.message_class %>"
+                  data-order="<%= recent_usage&.gas&.year&.change&.gsub('%','')&.to_f || '0' %>">
+                <%= up_downify(recent_usage&.gas&.year&.change) %>
+              </td>
+            <% else %>
+              <td data-order="'0'">n/a</td>
+            <% end %>
+          <% end %>
+          <% if @fuel_types.include?(:storage_heaters) %>
+            <% if recent_usage&.storage_heaters&.week&.has_data %>
+              <td class="<%= recent_usage&.storage_heaters&.week&.message_class %>"
+                  data-order="<%= recent_usage&.storage_heaters&.week&.change&.gsub('%','')&.to_f || '0' %>">
+                <%= up_downify(recent_usage&.storage_heaters&.week&.change) %>
+              </td>
+            <% else %>
+              <td data-order="'0'">n/a</td>
+            <% end %>
+            <% if recent_usage&.storage_heaters&.year&.has_data %>
+              <td class="<%= recent_usage&.storage_heaters&.year&.message_class %>"
+                  data-order="<%= recent_usage&.storage_heaters&.year&.change&.gsub('%','')&.to_f || '0' %>">
+                <%= up_downify(recent_usage&.storage_heaters&.year&.change) %>
+              </td>
+            <% else %>
+              <td data-order="'0'">n/a</td>
+            <% end %>
+          <% end %>
+        <% else %>
+          <td class="text-center" colspan="<%= @fuel_types.reject{|f| f == :solar_pv}.length * 2 %>">n/a</td>
         <% end %>
         <td>
           <%= link_to school.name, school_path(school) %>

--- a/app/views/school_groups/recent_usage.html.erb
+++ b/app/views/school_groups/recent_usage.html.erb
@@ -3,6 +3,7 @@
 <table width="100%" class="mt-3 table advice-table table-sorted">
   <thead>
     <tr>
+      <th></th>
       <% if @fuel_types.include?(:electricity) %>
         <th colspan="2"><%= fa_icon fuel_type_icon(:electricity) %> <%= t('common.electricity') %></th>
       <% end %>
@@ -12,9 +13,9 @@
       <% if @fuel_types.include?(:storage_heaters) %>
         <th colspan="2"><%= fa_icon fuel_type_icon(:storage_heaters) %> <%= t('common.storage_heaters') %></th>
       <% end %>
-      <th colspan="1"><%= t('common.school') %></th>
     </tr>
     <tr>
+      <th colspan="1"><%= t('common.school') %></th>
       <% if @fuel_types.include?(:electricity) %>
         <th><%= t('common.labels.last_week') %></th>
         <th><%= t('common.labels.last_year') %></th>
@@ -27,74 +28,75 @@
         <th><%= t('common.labels.last_week') %></th>
         <th><%= t('common.labels.last_year') %></th>
       <% end %>
-      <th></th>
     </tr>
   </thead>
   <tbody>
-    <% @school_group.schools.data_visible.visible.order(:name).each do |school| %>
+    <% @school_group.schools.visible.order(:name).each do |school| %>
       <tr>
+        <td>
+          <%= link_to school.name, school_path(school) %>
+        </td>
         <% if school.data_enabled %>
           <% recent_usage = school.recent_usage %>
           <% if @fuel_types.include?(:electricity) %>
             <% if recent_usage&.electricity&.week&.has_data %>
-              <td class="<%= recent_usage&.electricity&.week&.message_class %>"
+              <td class="text-right <%= recent_usage&.electricity&.week&.message_class %>"
                   data-order="<%= recent_usage&.electricity&.week&.change&.gsub('%','')&.to_f || '0' %>">
                 <%= up_downify(recent_usage&.electricity&.week&.change) %>
               </td>
             <% else %>
-              <td data-order="0">n/a</td>
+              <td class="text-right" data-order="0">-</td>
             <% end %>
             <% if recent_usage&.electricity&.year&.has_data %>
-              <td class="<%= recent_usage&.electricity&.year&.message_class %>"
+              <td class="text-right <%= recent_usage&.electricity&.year&.message_class %>"
                   data-order="<%= recent_usage&.electricity&.year&.change&.gsub('%','')&.to_f || '0'  %>">
                 <%= up_downify(recent_usage&.electricity&.year&.change) %>
               </td>
             <% else %>
-              <td data-order="0">n/a</td>
+              <td class="text-right" data-order="0">-</td>
             <% end %>
           <% end %>
           <% if @fuel_types.include?(:gas) %>
             <% if recent_usage&.gas&.week&.has_data %>
-              <td class="<%= recent_usage&.gas&.week&.message_class %>"
+              <td class="text-right <%= recent_usage&.gas&.week&.message_class %>"
                   data-order="<%= recent_usage&.gas&.week&.change&.gsub('%','')&.to_f || '0' %>">
                 <%= up_downify(recent_usage&.gas&.week&.change) %>
               </td>
             <% else %>
-              <td data-order="0">n/a</td>
+              <td class="text-right" data-order="0">-</td>
             <% end %>
             <% if recent_usage&.gas&.year&.has_data %>
-              <td class="<%= recent_usage&.gas&.year&.message_class %>"
+              <td class="text-right <%= recent_usage&.gas&.year&.message_class %>"
                   data-order="<%= recent_usage&.gas&.year&.change&.gsub('%','')&.to_f || '0' %>">
                 <%= up_downify(recent_usage&.gas&.year&.change) %>
               </td>
             <% else %>
-              <td data-order="'0'">n/a</td>
+              <td class="text-right" data-order="'0'">-</td>
             <% end %>
           <% end %>
           <% if @fuel_types.include?(:storage_heaters) %>
             <% if recent_usage&.storage_heaters&.week&.has_data %>
-              <td class="<%= recent_usage&.storage_heaters&.week&.message_class %>"
+              <td class="text-right <%= recent_usage&.storage_heaters&.week&.message_class %>"
                   data-order="<%= recent_usage&.storage_heaters&.week&.change&.gsub('%','')&.to_f || '0' %>">
                 <%= up_downify(recent_usage&.storage_heaters&.week&.change) %>
               </td>
             <% else %>
-              <td data-order="'0'">n/a</td>
+              <td class="text-right" data-order="'0'">-</td>
             <% end %>
             <% if recent_usage&.storage_heaters&.year&.has_data %>
-              <td class="<%= recent_usage&.storage_heaters&.year&.message_class %>"
+              <td class="text-right <%= recent_usage&.storage_heaters&.year&.message_class %>"
                   data-order="<%= recent_usage&.storage_heaters&.year&.change&.gsub('%','')&.to_f || '0' %>">
                 <%= up_downify(recent_usage&.storage_heaters&.year&.change) %>
               </td>
             <% else %>
-              <td data-order="'0'">n/a</td>
+              <td class="text-right" data-order="'0'">-</td>
             <% end %>
           <% end %>
         <% else %>
-          <td class="text-center" colspan="<%= @fuel_types.reject{|f| f == :solar_pv}.length * 2 %>">n/a</td>
+          <% (@fuel_types.reject{|f| f == :solar_pv}.length * 2).times do %>
+            <td class="text-right" data-order="'0'">-</td>
+          <% end %>
         <% end %>
-        <td>
-          <%= link_to school.name, school_path(school) %>
-        </td>
       </tr>
     <% end %>
   </tbody>

--- a/spec/support/school_groups_shared_examples.rb
+++ b/spec/support/school_groups_shared_examples.rb
@@ -1,0 +1,49 @@
+RSpec.shared_examples "a public school group dashboard" do
+  it 'allows user to navigate to all tabs' do
+    visit map_school_group_path(school_group)
+    expect(current_path).to eq "/school_groups/#{school_group.slug}/map"
+    visit comparisons_school_group_path(school_group)
+    expect(current_path).to eq "/school_groups/#{school_group.slug}/comparisons"
+    visit priority_actions_school_group_path(school_group)
+    expect(current_path).to eq "/school_groups/#{school_group.slug}/priority_actions"
+    visit current_scores_school_group_path(school_group)
+    expect(current_path).to eq "/school_groups/#{school_group.slug}/current_scores"
+  end
+end
+
+RSpec.shared_examples "a private school group dashboard" do
+
+  it 'the user can only access the map view' do
+    visit map_school_group_path(school_group)
+    expect(current_path).to eq "/school_groups/#{school_group.slug}/map"
+    visit comparisons_school_group_path(school_group)
+    expect(current_path).to eq "/school_groups/#{school_group.slug}/map"
+    visit priority_actions_school_group_path(school_group)
+    expect(current_path).to eq "/school_groups/#{school_group.slug}/map"
+    visit current_scores_school_group_path(school_group)
+    expect(current_path).to eq "/school_groups/#{school_group.slug}/map"
+    expect(page).to_not have_content('View group')
+  end
+
+end
+
+RSpec.shared_examples "school dashboard navigation" do
+  it 'shows navigation' do
+    expect(page).to have_content('Recent Usage')
+    expect(page).to have_content('Comparisons')
+    expect(page).to have_content('Priority Actions')
+    expect(page).to have_content('Current Scores')
+    expect(page).to have_content('View map')
+    expect(page).not_to have_content('View group')
+    expect(page).to have_content('Scoreboard')
+  end
+
+  it 'has expected path' do
+    expect(current_path).to eq expected_path
+  end
+
+  it 'shows right breadcrumb' do
+    expect(find('ol.main-breadcrumbs').all('li').collect(&:text)).to eq(['Schools', school_group.name, breadcrumb])
+  end
+
+end

--- a/spec/system/school_groups_spec.rb
+++ b/spec/system/school_groups_spec.rb
@@ -7,8 +7,8 @@ describe 'school groups', :school_groups, type: :system do
   let!(:school_group)          { create(:school_group, public: public) }
   let!(:school_group_2)        { create(:school_group, public: false) }
   let(:public)                 { true }
-  let!(:school_1)              { create(:school, school_group: school_group, number_of_pupils: 10) }
-  let!(:school_2)              { create(:school, school_group: school_group, number_of_pupils: 20) }
+  let!(:school_1)              { create(:school, school_group: school_group, number_of_pupils: 10, data_enabled: true) }
+  let!(:school_2)              { create(:school, school_group: school_group, number_of_pupils: 20, data_enabled: true) }
   let!(:school_admin)          { create(:school_admin, school: school_1) }
   let!(:group_admin)           { create(:group_admin, school_group: school_group) }
   let!(:group_admin_2)         { create(:group_admin, school_group: school_group_2) }
@@ -127,14 +127,14 @@ describe 'school groups', :school_groups, type: :system do
         end
 
         describe '#show/recent usage' do
-          it 'shows a map page with a map div and a list of schools' do
+          it 'shows the list of schools with their usage' do
             ClimateControl.modify FEATURE_FLAG_ENHANCED_SCHOOL_GROUP_DASHBOARD: 'true' do
               changes = OpenStruct.new(change: "-16%")
               allow_any_instance_of(School).to receive(:recent_usage) do
                 OpenStruct.new(
-                  electricity: OpenStruct.new(week: changes, year: changes),
-                  gas: OpenStruct.new(week: changes, year: changes),
-                  storage_heaters: OpenStruct.new(week: changes, year: changes)
+                  electricity: OpenStruct.new(week: changes, year: changes, has_data: true),
+                  gas: OpenStruct.new(week: changes, year: changes, has_data: true),
+                  storage_heaters: OpenStruct.new(week: changes, year: changes, has_data: true)
                 )
               end
               visit school_group_path(school_group)

--- a/spec/system/school_groups_spec.rb
+++ b/spec/system/school_groups_spec.rb
@@ -110,7 +110,7 @@ describe 'school groups', :school_groups, type: :system do
 
         describe 'showing recent usage tab' do
           before(:each) do
-            changes = OpenStruct.new(change: "-16%")
+            changes = OpenStruct.new(change: "-16%", has_data: true)
             allow_any_instance_of(School).to receive(:recent_usage) do
               OpenStruct.new(
                 electricity: OpenStruct.new(week: changes, year: changes),

--- a/spec/system/school_groups_spec.rb
+++ b/spec/system/school_groups_spec.rb
@@ -1,87 +1,81 @@
 require 'rails_helper'
 
 describe 'school groups', :school_groups, type: :system do
-  let!(:user)                  { create(:user) }
-  let!(:scoreboard)            { create(:scoreboard, name: 'BANES and Frome') }
-  let!(:dark_sky_weather_area) { create(:dark_sky_area, title: 'BANES dark sky weather') }
-  let!(:school_group)          { create(:school_group, public: public) }
-  let!(:school_group_2)        { create(:school_group, public: false) }
+
   let(:public)                 { true }
+  let!(:school_group)          { create(:school_group, public: public) }
+  let!(:user)                  { create(:user) }
   let!(:school_1)              { create(:school, school_group: school_group, number_of_pupils: 10, data_enabled: true) }
   let!(:school_2)              { create(:school, school_group: school_group, number_of_pupils: 20, data_enabled: true) }
-  let!(:school_admin)          { create(:school_admin, school: school_1) }
-  let!(:group_admin)           { create(:group_admin, school_group: school_group) }
-  let!(:group_admin_2)         { create(:group_admin, school_group: school_group_2) }
 
   before do
     allow_any_instance_of(SchoolGroup).to receive(:fuel_types) { [:electricity, :gas, :storage_heaters] }
   end
 
-  context 'current school group pages with feature flag set to false' do
+  let(:feature_flag) { 'false' }
+
+  around do |example|
+    ClimateControl.modify FEATURE_FLAG_ENHANCED_SCHOOL_GROUP_DASHBOARD: feature_flag do
+      example.run
+    end
+  end
+
+  context 'current school group pages (feature disabled)' do
     describe 'when not logged in' do
-      it 'redirects enhanced page actions to school group page if feature is not enabled' do
-        ClimateControl.modify FEATURE_FLAG_ENHANCED_SCHOOL_GROUP_DASHBOARD: 'false' do
-          visit map_school_group_path(school_group)
-          expect(current_path).to eq "/school_groups/#{school_group.slug}"
-          visit comparisons_school_group_path(school_group)
-          expect(current_path).to eq "/school_groups/#{school_group.slug}"
-          visit priority_actions_school_group_path(school_group)
-          expect(current_path).to eq "/school_groups/#{school_group.slug}"
-          visit current_scores_school_group_path(school_group)
-          expect(current_path).to eq "/school_groups/#{school_group.slug}"
-        end
+      it 'redirects enhanced page actions to school group page' do
+        visit map_school_group_path(school_group)
+        expect(current_path).to eq "/school_groups/#{school_group.slug}"
+        visit comparisons_school_group_path(school_group)
+        expect(current_path).to eq "/school_groups/#{school_group.slug}"
+        visit priority_actions_school_group_path(school_group)
+        expect(current_path).to eq "/school_groups/#{school_group.slug}"
+        visit current_scores_school_group_path(school_group)
+        expect(current_path).to eq "/school_groups/#{school_group.slug}"
       end
 
       it 'does show a specific group' do
-        ClimateControl.modify FEATURE_FLAG_ENHANCED_SCHOOL_GROUP_DASHBOARD: 'false' do
-          visit school_group_path(school_group)
-          expect(page).to have_content(school_1.name)
-          expect(page).to have_content(school_2.name)
-          expect(page).to_not have_content('Recent Usage')
-          expect(page).to_not have_content('Comparisons')
-          expect(page).to_not have_content('Priority Actions')
-          expect(page).to_not have_content('Current Scores')
-        end
+        visit school_group_path(school_group)
+        expect(page).to have_content(school_1.name)
+        expect(page).to have_content(school_2.name)
+        expect(page).to_not have_content('Recent Usage')
+        expect(page).to_not have_content('Comparisons')
+        expect(page).to_not have_content('Priority Actions')
+        expect(page).to_not have_content('Current Scores')
       end
 
       it 'includes data attribute' do
-        ClimateControl.modify FEATURE_FLAG_ENHANCED_SCHOOL_GROUP_DASHBOARD: 'false' do
-          visit school_group_path(school_group)
-          expect(page).to have_selector("div[data-school-group-id='#{school_group.id}']")
-        end
+        visit school_group_path(school_group)
+        expect(page).to have_selector("div[data-school-group-id='#{school_group.id}']")
       end
 
       context 'when group is public' do
         it 'shows compare link' do
-          ClimateControl.modify FEATURE_FLAG_ENHANCED_SCHOOL_GROUP_DASHBOARD: 'false' do
-            visit school_group_path(school_group)
-            expect(page).to have_link("Compare schools")
-          end
+          visit school_group_path(school_group)
+          expect(page).to have_link("Compare schools")
         end
       end
+
       context 'when group is private' do
         let(:public)    { false }
 
         it 'doesnt show compare link' do
-          ClimateControl.modify FEATURE_FLAG_ENHANCED_SCHOOL_GROUP_DASHBOARD: 'false' do
-            visit school_group_path(school_group)
-            within('.application') do
-              expect(page).to_not have_link("Compare schools")
-            end
+          visit school_group_path(school_group)
+          within('.application') do
+            expect(page).to_not have_link("Compare schools")
           end
         end
       end
     end
 
     describe 'when logged in as school admin' do
+      let!(:user)                  { create(:school_admin, school: school_1) }
+
       before(:each) do
-        sign_in(school_admin)
+        sign_in(user)
       end
       it 'shows compare link' do
-        ClimateControl.modify FEATURE_FLAG_ENHANCED_SCHOOL_GROUP_DASHBOARD: 'false' do
-          visit school_group_path(school_group)
-          expect(page).to have_link("Compare schools")
-        end
+        visit school_group_path(school_group)
+        expect(page).to have_link("Compare schools")
       end
     end
 
@@ -89,49 +83,33 @@ describe 'school groups', :school_groups, type: :system do
       before(:each) do
         sign_in(user)
       end
+
       context 'when group is public' do
         it 'shows compare link' do
-          ClimateControl.modify FEATURE_FLAG_ENHANCED_SCHOOL_GROUP_DASHBOARD: 'false' do
-            visit school_group_path(school_group)
-            expect(page).to have_link("Compare schools")
-          end
+          visit school_group_path(school_group)
+          expect(page).to have_link("Compare schools")
         end
       end
+
       context 'when group is private' do
         it 'doesnt show compare link' do
-          ClimateControl.modify FEATURE_FLAG_ENHANCED_SCHOOL_GROUP_DASHBOARD: 'false' do
-            visit school_group_path(school_group)
-            expect(page).to have_link("Compare schools")
-          end
+          visit school_group_path(school_group)
+          expect(page).to have_link("Compare schools")
         end
       end
     end
   end
 
-  context 'enhanced school group pages with feature flag set to true' do
-    around do |example|
-      ClimateControl.modify FEATURE_FLAG_ENHANCED_SCHOOL_GROUP_DASHBOARD: 'true' do
-        example.run
-      end
-    end
+  context 'enhanced school group dashboard (feature enabled)' do
+    let(:feature_flag) { 'true' }
 
     context 'when not logged in' do
       context 'when school group is public' do
         let(:public) { true }
+        include_examples "a public school group dashboard"
 
-        it 'does not redirect enhanced page actions to school group page if feature is enabled or map page' do
-          visit map_school_group_path(school_group)
-          expect(current_path).to eq "/school_groups/#{school_group.slug}/map"
-          visit comparisons_school_group_path(school_group)
-          expect(current_path).to eq "/school_groups/#{school_group.slug}/comparisons"
-          visit priority_actions_school_group_path(school_group)
-          expect(current_path).to eq "/school_groups/#{school_group.slug}/priority_actions"
-          visit current_scores_school_group_path(school_group)
-          expect(current_path).to eq "/school_groups/#{school_group.slug}/current_scores"
-        end
-
-        describe '#show/recent usage' do
-          it 'shows a map page with a map div and a list of schools' do
+        describe 'showing recent usage tab' do
+          before(:each) do
             changes = OpenStruct.new(change: "-16%")
             allow_any_instance_of(School).to receive(:recent_usage) do
               OpenStruct.new(
@@ -141,17 +119,14 @@ describe 'school groups', :school_groups, type: :system do
               )
             end
             visit school_group_path(school_group)
-            expect(current_path).to eq "/school_groups/#{school_group.slug}"
-            expect(find('ol.main-breadcrumbs').all('li').collect(&:text)).to eq(['Schools', school_group.name, 'Group Dashboard'])
-            expect(page).to have_content('Recent Usage')
-            expect(page).to have_content('Comparisons')
-            expect(page).to have_content('Priority Actions')
-            expect(page).to have_content('Current Scores')
-            expect(page).to have_content('View map')
-            expect(page).not_to have_content('View group')
-            expect(page).to have_content('Scoreboard')
+          end
 
-            # Table content
+          include_examples "school dashboard navigation" do
+            let(:expected_path) { "/school_groups/#{school_group.slug}" }
+            let(:breadcrumb)    { 'Group Dashboard' }
+          end
+
+          it 'shows expected table content' do
             expect(page).to have_content('Electricity')
             expect(page).to have_content('Gas')
             expect(page).to have_content('Storage heaters')
@@ -164,125 +139,161 @@ describe 'school groups', :school_groups, type: :system do
           end
         end
 
-        describe '#comparisons' do
-          it 'shows a map page with a map div and a list of schools' do
+        describe 'showing comparisons' do
+
+          before(:each) do
             visit comparisons_school_group_path(school_group)
-            expect(current_path).to eq "/school_groups/#{school_group.slug}/comparisons"
-            expect(find('ol.main-breadcrumbs').all('li').collect(&:text)).to eq(['Schools', school_group.name, 'Comparisons'])
-            expect(page).to have_content('Recent Usage')
-            expect(page).to have_content('Comparisons')
-            expect(page).to have_content('Priority Actions')
-            expect(page).to have_content('Current Scores')
-            expect(page).to have_content('View map')
-            expect(page).not_to have_content('View group')
-            expect(page).to have_content('Scoreboard')
           end
+
+          include_examples "school dashboard navigation" do
+            let(:expected_path) { "/school_groups/#{school_group.slug}/comparisons" }
+            let(:breadcrumb)    { 'Comparisons' }
+          end
+
+          it 'shows expected content'
         end
 
-        describe '#priority_actions' do
-          it 'shows a map page with a map div and a list of schools' do
+        describe 'showing priority actions' do
+          let!(:alert_type) { create(:alert_type, fuel_type: :gas, frequency: :weekly) }
+          let!(:alert_type_rating) do
+            create(
+              :alert_type_rating,
+              alert_type: alert_type,
+              rating_from: 6.1,
+              rating_to: 10,
+              management_priorities_active: true,
+              description: "high"
+            )
+          end
+          let!(:alert_type_rating_content_version) do
+            create(
+              :alert_type_rating_content_version,
+              alert_type_rating: alert_type_rating,
+              management_priorities_title: 'Spending too much money on heating',
+            )
+          end
+          let(:saving) {
+            OpenStruct.new(
+              school: school_1,
+              average_one_year_saving_gbp: 1000,
+              one_year_saving_co2: 1100
+            )
+          }
+          let(:priority_actions) {
+            {
+              alert_type_rating => [saving]
+            }
+          }
+          let(:total_saving) {
+            OpenStruct.new(
+              schools: [school_1],
+              average_one_year_saving_gbp: 1000,
+              one_year_saving_co2: 1100
+            )
+          }
+          let(:total_savings) {
+            {
+              alert_type_rating => total_saving
+            }
+          }
+
+          before(:each) do
+            allow_any_instance_of(SchoolGroups::PriorityActions).to receive(:priority_actions).and_return(priority_actions)
+            allow_any_instance_of(SchoolGroups::PriorityActions).to receive(:total_savings).and_return(total_savings)
             visit priority_actions_school_group_path(school_group)
-            expect(current_path).to eq "/school_groups/#{school_group.slug}/priority_actions"
-            expect(find('ol.main-breadcrumbs').all('li').collect(&:text)).to eq(['Schools', school_group.name, 'Priority Actions'])
-            expect(page).to have_content('Recent Usage')
-            expect(page).to have_content('Comparisons')
-            expect(page).to have_content('Priority Actions')
-            expect(page).to have_content('Current Scores')
-            expect(page).to have_content('View map')
-            expect(page).not_to have_content('View group')
-            expect(page).to have_content('Scoreboard')
           end
+
+          include_examples "school dashboard navigation" do
+            let(:expected_path) { "/school_groups/#{school_group.slug}/priority_actions" }
+            let(:breadcrumb)    { 'Priority Actions' }
+          end
+
+          it 'displays list of actions' do
+            expect(page).to have_css('#school-group-priorities')
+            within('#school-group-priorities') do
+              expect(page).to have_content("Spending too much money on heating")
+              expect(page).to have_content("£1,000")
+              expect(page).to have_content("1,100 kg CO2")
+            end
+          end
+
+          it 'has a modal popup with a list of schools' do
+            first(:link, "Spending too much money on heating").click
+            expect(page).to have_content("This action has been identified as a priority for the following schools")
+            expect(page).to have_content(school_1.name)
+          end
+
         end
 
-        describe '#current_scores' do
-          it 'shows a map page with a map div and a list of schools' do
+        describe 'showing current_scores' do
+          before(:each) do
             visit current_scores_school_group_path(school_group)
-            expect(current_path).to eq "/school_groups/#{school_group.slug}/current_scores"
-            expect(find('ol.main-breadcrumbs').all('li').collect(&:text)).to eq(['Schools', school_group.name, 'Current Scores'])
-            expect(page).to have_content('Recent Usage')
-            expect(page).to have_content('Comparisons')
-            expect(page).to have_content('Priority Actions')
-            expect(page).to have_content('Current Scores')
-            expect(page).to have_content('View map')
-            expect(page).not_to have_content('View group')
-            expect(page).to have_content('Scoreboard')
           end
+
+          include_examples "school dashboard navigation" do
+            let(:expected_path) { "/school_groups/#{school_group.slug}/current_scores" }
+            let(:breadcrumb)    { 'Current Scores' }
+          end
+
+          it 'shows expected content'
         end
 
-        describe '#map' do
-          it 'shows a map page with a map div and a list of schools' do
+        describe 'showing map' do
+          before(:each) do
             visit map_school_group_path(school_group)
+          end
+
+          it 'has expected path' do
             expect(current_path).to eq "/school_groups/#{school_group.slug}/map"
+          end
+
+          it 'shows breadcrumb' do
             expect(find('ol.main-breadcrumbs').all('li').collect(&:text)).to eq(['Schools', school_group.name, 'Map'])
+          end
+
+          it 'does not show tabs' do
             expect(page).not_to have_content('Recent Usage')
             expect(page).not_to have_content('Comparisons')
             expect(page).not_to have_content('Priority Actions')
             expect(page).not_to have_content('Current Scores')
-            expect(page).to have_content('Map')
-            expect(page).to have_content(school_1.name)
-            expect(page).to have_content(school_2.name)
-            expect(page).to have_selector(:id, 'geo-json-map')
+          end
+
+          it 'shows navigation' do
             expect(page).not_to have_content('View map')
             expect(page).to have_content('View group')
             expect(page).to have_content('Scoreboard')
           end
+
+          it 'shows expected map content' do
+            expect(page).to have_content('Map')
+            expect(page).to have_content(school_1.name)
+            expect(page).to have_content(school_2.name)
+            expect(page).to have_selector(:id, 'geo-json-map')
+          end
         end
       end
 
       context 'when school group is private' do
         let(:public) { false }
-
-        it 'does not redirect enhanced page actions to school group page if feature is enabled but does redirect other actions to the map page with no view group link' do
-          visit map_school_group_path(school_group)
-          expect(current_path).to eq "/school_groups/#{school_group.slug}/map"
-          visit comparisons_school_group_path(school_group)
-          expect(current_path).to eq "/school_groups/#{school_group.slug}/map"
-          visit priority_actions_school_group_path(school_group)
-          expect(current_path).to eq "/school_groups/#{school_group.slug}/map"
-          visit current_scores_school_group_path(school_group)
-          expect(current_path).to eq "/school_groups/#{school_group.slug}/map"
-          expect(page).to_not have_content('View group')
-        end
+        include_examples "a private school group dashboard"
       end
     end
 
     context 'when logged in as a school admin' do
+      let!(:user)                  { create(:school_admin, school: school_1) }
+
       before(:each) do
-        sign_in(school_admin)
+        sign_in(user)
       end
 
       context 'when school group is public' do
         let(:public) { true }
-
-        it 'does not redirect enhanced page actions to school group page if feature is enabled or map page' do
-          ClimateControl.modify FEATURE_FLAG_ENHANCED_SCHOOL_GROUP_DASHBOARD: 'true' do
-            visit map_school_group_path(school_group)
-            expect(current_path).to eq "/school_groups/#{school_group.slug}/map"
-            visit comparisons_school_group_path(school_group)
-            expect(current_path).to eq "/school_groups/#{school_group.slug}/comparisons"
-            visit priority_actions_school_group_path(school_group)
-            expect(current_path).to eq "/school_groups/#{school_group.slug}/priority_actions"
-            visit current_scores_school_group_path(school_group)
-            expect(current_path).to eq "/school_groups/#{school_group.slug}/current_scores"
-          end
-        end
+        include_examples "a public school group dashboard"
       end
 
       context 'when school group is private' do
         let(:public) { false }
-
-        it 'does not redirect enhanced page actions to school group page if feature is enabled and does not redirect other actions to the map page' do
-          ClimateControl.modify FEATURE_FLAG_ENHANCED_SCHOOL_GROUP_DASHBOARD: 'true' do
-            visit map_school_group_path(school_group)
-            expect(current_path).to eq "/school_groups/#{school_group.slug}/map"
-            visit comparisons_school_group_path(school_group)
-            expect(current_path).to eq "/school_groups/#{school_group.slug}/comparisons"
-            visit priority_actions_school_group_path(school_group)
-            expect(current_path).to eq "/school_groups/#{school_group.slug}/priority_actions"
-            visit current_scores_school_group_path(school_group)
-            expect(current_path).to eq "/school_groups/#{school_group.slug}/current_scores"
-          end
-        end
+        include_examples "a public school group dashboard"
       end
     end
 
@@ -293,189 +304,59 @@ describe 'school groups', :school_groups, type: :system do
 
       context 'when school group is public' do
         let(:public) { true }
-
-        it 'does not redirect enhanced page actions to school group page if feature is enabled or map page' do
-          ClimateControl.modify FEATURE_FLAG_ENHANCED_SCHOOL_GROUP_DASHBOARD: 'true' do
-            visit map_school_group_path(school_group)
-            expect(current_path).to eq "/school_groups/#{school_group.slug}/map"
-            visit comparisons_school_group_path(school_group)
-            expect(current_path).to eq "/school_groups/#{school_group.slug}/comparisons"
-            visit priority_actions_school_group_path(school_group)
-            expect(current_path).to eq "/school_groups/#{school_group.slug}/priority_actions"
-            visit current_scores_school_group_path(school_group)
-            expect(current_path).to eq "/school_groups/#{school_group.slug}/current_scores"
-          end
-        end
+        include_examples "a public school group dashboard"
       end
 
       context 'when school group is private' do
         let(:public) { false }
-
-        it 'does not redirect enhanced page actions to school group page if feature is enabled and does redirect other actions to the map page' do
-          ClimateControl.modify FEATURE_FLAG_ENHANCED_SCHOOL_GROUP_DASHBOARD: 'true' do
-            visit map_school_group_path(school_group)
-            expect(current_path).to eq "/school_groups/#{school_group.slug}/map"
-            visit comparisons_school_group_path(school_group)
-            expect(current_path).to eq "/school_groups/#{school_group.slug}/map"
-            visit priority_actions_school_group_path(school_group)
-            expect(current_path).to eq "/school_groups/#{school_group.slug}/map"
-            visit current_scores_school_group_path(school_group)
-            expect(current_path).to eq "/school_groups/#{school_group.slug}/map"
-          end
-        end
+        include_examples "a private school group dashboard"
       end
     end
 
-    context 'when logged in as a group admin' do
+    context 'when logged in as the group admin' do
+      let!(:user)           { create(:group_admin, school_group: school_group) }
+
       before(:each) do
-        sign_in(group_admin)
+        sign_in(user)
       end
 
       context 'when school group is public' do
         let(:public) { true }
-
-        it 'does not redirect enhanced page actions to school group page if feature is enabled or redirect to the map page' do
-          ClimateControl.modify FEATURE_FLAG_ENHANCED_SCHOOL_GROUP_DASHBOARD: 'true' do
-            visit map_school_group_path(school_group)
-            expect(current_path).to eq "/school_groups/#{school_group.slug}/map"
-            visit comparisons_school_group_path(school_group)
-            expect(current_path).to eq "/school_groups/#{school_group.slug}/comparisons"
-            visit priority_actions_school_group_path(school_group)
-            expect(current_path).to eq "/school_groups/#{school_group.slug}/priority_actions"
-            visit current_scores_school_group_path(school_group)
-            expect(current_path).to eq "/school_groups/#{school_group.slug}/current_scores"
-          end
-        end
+        include_examples "a public school group dashboard"
       end
 
       context 'when school group is private' do
         let(:public) { false }
-
-        it 'does not redirect enhanced page actions to school group page if feature is enabled and does not redirect other actions to the map page' do
-          ClimateControl.modify FEATURE_FLAG_ENHANCED_SCHOOL_GROUP_DASHBOARD: 'true' do
-            visit map_school_group_path(school_group)
-            expect(current_path).to eq "/school_groups/#{school_group.slug}/map"
-            visit comparisons_school_group_path(school_group)
-            expect(current_path).to eq "/school_groups/#{school_group.slug}/comparisons"
-            visit priority_actions_school_group_path(school_group)
-            expect(current_path).to eq "/school_groups/#{school_group.slug}/priority_actions"
-            visit current_scores_school_group_path(school_group)
-            expect(current_path).to eq "/school_groups/#{school_group.slug}/current_scores"
-          end
-        end
+        include_examples "a public school group dashboard"
       end
     end
 
     context 'when logged in as a group admin for a different group' do
+      let!(:school_group_2)     { create(:school_group, public: false) }
+      let!(:user)               { create(:group_admin, school_group: school_group_2) }
+
       before(:each) do
-        sign_in(group_admin_2) # Admin for school group 2
+        sign_in(user)
       end
 
       context 'when school group is public' do
         let(:public) { true }
-
-        it 'does not redirect enhanced page actions to school group page if feature is enabled or redirect to the map page' do
-          ClimateControl.modify FEATURE_FLAG_ENHANCED_SCHOOL_GROUP_DASHBOARD: 'true' do
-            visit map_school_group_path(school_group)
-            expect(current_path).to eq "/school_groups/#{school_group.slug}/map"
-            visit comparisons_school_group_path(school_group)
-            expect(current_path).to eq "/school_groups/#{school_group.slug}/comparisons"
-            visit priority_actions_school_group_path(school_group)
-            expect(current_path).to eq "/school_groups/#{school_group.slug}/priority_actions"
-            visit current_scores_school_group_path(school_group)
-            expect(current_path).to eq "/school_groups/#{school_group.slug}/current_scores"
-          end
-        end
+        include_examples "a public school group dashboard"
       end
 
       context 'when school group is private' do
         let(:public) { false }
-
-        it 'does not redirect enhanced page actions to school group page if feature is enabled but does redirect other actions to the map page' do
-          ClimateControl.modify FEATURE_FLAG_ENHANCED_SCHOOL_GROUP_DASHBOARD: 'true' do
-            visit map_school_group_path(school_group)
-            expect(current_path).to eq "/school_groups/#{school_group.slug}/map"
-            visit comparisons_school_group_path(school_group)
-            expect(current_path).to eq "/school_groups/#{school_group.slug}/map"
-            visit priority_actions_school_group_path(school_group)
-            expect(current_path).to eq "/school_groups/#{school_group.slug}/map"
-            visit current_scores_school_group_path(school_group)
-            expect(current_path).to eq "/school_groups/#{school_group.slug}/map"
-          end
-        end
+        include_examples "a private school group dashboard"
       end
     end
 
-    context 'priority_actions' do
+    context 'viewing priority_actions' do
       around do |example|
         ClimateControl.modify FEATURE_FLAG_ENHANCED_SCHOOL_GROUP_DASHBOARD: 'true' do
           example.run
         end
       end
 
-      let!(:alert_type) { create(:alert_type, fuel_type: :gas, frequency: :weekly) }
-      let!(:alert_type_rating) do
-        create(
-          :alert_type_rating,
-          alert_type: alert_type,
-          rating_from: 6.1,
-          rating_to: 10,
-          management_priorities_active: true,
-          description: "high"
-        )
-      end
-      let!(:alert_type_rating_content_version) do
-        create(
-          :alert_type_rating_content_version,
-          alert_type_rating: alert_type_rating,
-          management_priorities_title: 'Spending too much money on heating',
-        )
-      end
-      let(:saving) {
-        OpenStruct.new(
-          school: school_1,
-          average_one_year_saving_gbp: 1000,
-          one_year_saving_co2: 1100
-        )
-      }
-      let(:priority_actions) {
-        {
-          alert_type_rating => [saving]
-        }
-      }
-      let(:total_saving) {
-        OpenStruct.new(
-          schools: [school_1],
-          average_one_year_saving_gbp: 1000,
-          one_year_saving_co2: 1100
-        )
-      }
-      let(:total_savings) {
-        {
-          alert_type_rating => total_saving
-        }
-      }
-
-      before do
-        allow_any_instance_of(SchoolGroups::PriorityActions).to receive(:priority_actions).and_return(priority_actions)
-        allow_any_instance_of(SchoolGroups::PriorityActions).to receive(:total_savings).and_return(total_savings)
-        visit priority_actions_school_group_path(school_group)
-      end
-
-      it 'displays list of actions' do
-        expect(page).to have_css('#school-group-priorities')
-        within('#school-group-priorities') do
-          expect(page).to have_content("Spending too much money on heating")
-          expect(page).to have_content("£1,000")
-          expect(page).to have_content("1,100 kg CO2")
-        end
-      end
-
-      it 'has a modal popup with a list of schools' do
-        first(:link, "Spending too much money on heating").click
-        expect(page).to have_content("This action has been identified as a priority for the following schools")
-        expect(page).to have_content(school_1.name)
-      end
     end
   end
 end


### PR DESCRIPTION
Makes the recent usage page tolerant of 2 cases of limited data:

* If a school is not yet data enabled, then there isn't a summary of recent usage. But the school should be in the list
* If a school has <1 year of data, then there is no year data in the summary of recent usage

The PR also includes some display tweaks:

* Ensure table values are right aligned
* Switch table ordering, to put school names on left, which feels more natural
* Put "School" title on second header row
* Replace "n/a" with a "-"

The PR also tidies up the system spec for the page:

* remove unneeded declared variables
* move other variables inside the 'describe' block where they are used, to make it clearer how they are used
* DRY up repeated checks by adding some shared examples
* Add placeholders where we don't have tests for some of the tab content yet.

I think later PRs may need to review table layout, its quite busy for large groups. Optimise query so we can avoid N+1 queries for the data and instead just load what's needed. Will require changing how we store the management table data which isn't ideal at the moment.