### PR TITLE
Reduce CloudWatch logging of GoodJob queues

### DIFF
--- a/lib/tasks/jobs/send_good_job_queue_metrics_to_cloudwatch.rake
+++ b/lib/tasks/jobs/send_good_job_queue_metrics_to_cloudwatch.rake
@@ -7,7 +7,7 @@ namespace :jobs do
     GoodJob::Job.distinct(:queue_name).pluck(:queue_name).each do |queue_name|
       commands = []
 
-      [:scheduled, :retried, :queued, :running, :finished, :discarded].each do |status|
+      [:queued].each do |status|
         count = GoodJob::Job.where(queue_name: queue_name).send(status).count
 
         commands << (command_template % {

--- a/lib/tasks/jobs/send_good_job_queue_metrics_to_cloudwatch.rake
+++ b/lib/tasks/jobs/send_good_job_queue_metrics_to_cloudwatch.rake
@@ -7,6 +7,7 @@ namespace :jobs do
     GoodJob::Job.distinct(:queue_name).pluck(:queue_name).each do |queue_name|
       commands = []
 
+      # possible statuses: [:scheduled, :retried, :queued, :running, :finished, :discarded]
       [:queued].each do |status|
         count = GoodJob::Job.where(queue_name: queue_name).send(status).count
 


### PR DESCRIPTION
When we first starting using GoodJob we started logging all available metrics for the queues.

Now that we've had it running for a while, its clear that the main thing we want to monitor is the size of the queue. As this shows how quickly the queues get processed.

This PR updates the rake task that logs the metrics to just record that information. 