### PR TITLE
Skip checking whether meters are SMETS2 meters on test server

### DIFF
--- a/lib/tasks/meters/dcc_meter_checker.rake
+++ b/lib/tasks/meters/dcc_meter_checker.rake
@@ -2,7 +2,11 @@ namespace :meters do
   desc 'Check which meters exist in the DCC'
   task :check_for_dcc => :environment do |_t, args|
     puts "#{DateTime.now.utc} check_for_dcc start"
-    Meters::DccChecker.new(Meter.meters_to_check_against_dcc).perform
+    if ENV['ENVIRONMENT_IDENTIFIER'] == "production"
+      Meters::DccChecker.new(Meter.meters_to_check_against_dcc).perform
+    else
+      puts "#{Time.zone.now} Only running checks on production server"
+    end
     puts "#{DateTime.now.utc} check_for_dcc end"
   end
 end


### PR DESCRIPTION
Add an environment check to the rake task, so its skipped on the test server.

Avoids doing a lot of API calls and then sending an email when we don't need them.