### PR TITLE
Only include agreed availability and excess availability charges if asc_limit_kw is present

### DIFF
--- a/app/models/user_tariff.rb
+++ b/app/models/user_tariff.rb
@@ -84,7 +84,14 @@ class UserTariff < ApplicationRecord
       end
     end
     user_tariff_charges.select { |c| c.units.present? }.each do |charge|
-      attrs[charge.charge_type.to_sym] = { rate: charge.value.to_s, per: charge.units.to_s }
+      charge_value = { rate: charge.value.to_s, per: charge.units.to_s }
+      charge_type = charge.charge_type.to_sym
+      #only add these charges if we also have an asc limit
+      if charge.is_type?([:agreed_availability_charge, :excess_availability_charge])
+        attrs[charge_type] = charge_value if value_for_charge(:asc_limit_kw).present?
+      else
+        attrs[charge_type] = charge_value
+      end
     end
     user_tariff_charges.select { |c| c.is_type?([:duos_red, :duos_amber, :duos_green]) }.each do |charge|
       attrs[charge.charge_type.to_sym] = charge.value.to_s

--- a/spec/models/user_tariff_spec.rb
+++ b/spec/models/user_tariff_spec.rb
@@ -158,19 +158,60 @@ describe UserTariff do
         end
       end
 
-      context "agreed_availability_charge is present" do
+      context "and agreed_availability_charge is present" do
         let(:agreed_availability_charge)  { UserTariffCharge.create(charge_type: :agreed_availability_charge, value: 6.78, units: :kva) }
         let(:user_tariff_charges) { [asc_limit_kw_charge, agreed_availability_charge] }
         it "should be included" do
           expect(attributes[:asc_limit_kw]).to eq('5.43')
         end
+        it 'should include the charge' do
+          expect(attributes[:rates]).to have_key(:agreed_availability_charge)
+        end
       end
 
-      context "excess_availability_charge is present" do
+      context "and excess_availability_charge is present" do
         let(:excess_availability_charge)  { UserTariffCharge.create(charge_type: :excess_availability_charge, value: 6.78, units: :kva) }
         let(:user_tariff_charges) { [asc_limit_kw_charge, excess_availability_charge] }
         it "should be included" do
           expect(attributes[:asc_limit_kw]).to eq('5.43')
+        end
+        it 'should include the charge' do
+          expect(attributes[:rates]).to have_key(:excess_availability_charge)
+        end
+      end
+
+      context 'only agreed availability charge is present' do
+        let(:agreed_availability_charge)  { UserTariffCharge.create(charge_type: :agreed_availability_charge, value: 6.78, units: :kva) }
+        let(:user_tariff_charges) { [agreed_availability_charge] }
+        it "should not be included" do
+          expect(attributes[:rates]).to_not have_key(:asc_limit_kw)
+        end
+        it 'should not include the charge' do
+          expect(attributes[:rates]).to_not have_key(:agreed_availability_charge)
+        end
+      end
+
+      context 'only excess_availability_charge charge is present' do
+        let(:excess_availability_charge)  { UserTariffCharge.create(charge_type: :excess_availability_charge, value: 6.78, units: :kva) }
+        let(:user_tariff_charges) { [excess_availability_charge] }
+        it "should not be included" do
+          expect(attributes).to_not have_key(:asc_limit_kw)
+        end
+        it 'should not include the charge' do
+          expect(attributes[:rates]).to_not have_key(:excess_availability_charge)
+        end
+      end
+
+      context 'all charges are present' do
+        let(:agreed_availability_charge)  { UserTariffCharge.create(charge_type: :agreed_availability_charge, value: 6.78, units: :kva) }
+        let(:excess_availability_charge)  { UserTariffCharge.create(charge_type: :excess_availability_charge, value: 6.78, units: :kva) }
+        let(:user_tariff_charges) { [asc_limit_kw_charge, agreed_availability_charge, excess_availability_charge] }
+        it "should be included" do
+          expect(attributes).to have_key(:asc_limit_kw)
+        end
+        it 'should include the charges' do
+          expect(attributes[:rates][:agreed_availability_charge]).to eq({:per => 'kva', :rate => '6.78'})
+          expect(attributes[:rates][:excess_availability_charge]).to eq({:per => 'kva', :rate => '6.78'})
         end
       end
     end
@@ -194,7 +235,6 @@ describe UserTariff do
     it "should include standing charges" do
       rates = attributes[:rates]
       expect(rates[:fixed_charge]).to eq({:per => 'month', :rate => '4.56'})
-      expect(rates[:agreed_availability_charge]).to eq({:per => 'kva', :rate => '6.78'})
     end
 
     it "should include rates with adjusted end times" do


### PR DESCRIPTION
When entering a tariff, users can enter

- an agreed supply capacity (asc_limit_kw)
- an agreed availability charge
- an excess availability charge

To calculate their agreed availability cost we need the asc limit + the agreed availability charge. Similarly for the excess availability cost we need the supply capacity and the charge.

A previous bug fix stopped the asc supply capacity being provided if the other charges weren't present. But we weren't checking for whether the asc_limit_kw was present before adding the charges. This means that the analytics still produces an error.

This PR ensures we only provide the charges if the asc limit is present. This matches the note we have on the tariff editor to prompt users to enter the extra charge.