### PR TITLE
Tweak rollbar error reporting for equivalence errors

### DIFF
--- a/app/services/equivalences/generate_equivalences.rb
+++ b/app/services/equivalences/generate_equivalences.rb
@@ -18,7 +18,7 @@ module Equivalences
             Rails.logger.debug("#{e.message} for #{@school.name}")
           rescue => e
             Rails.logger.error("#{e.message} for #{@school.name}")
-            Rollbar.error(e, job: :generate_equivalences, equivalence_type: equivalence_type, school_id: @school.id, school: @school.name)
+            Rollbar.error(e, job: :generate_equivalences, equivalence_type: equivalence_type.id, school_id: @school.id, school: @school.name)
           end
         end
       end


### PR DESCRIPTION
Help to track down an intermittent bug generating equivalances, add the id of the equivalence to the Rollbar error.