### PR TITLE
Solar panel report

### DIFF
--- a/app/controllers/admin/reports/solar_panels_controller.rb
+++ b/app/controllers/admin/reports/solar_panels_controller.rb
@@ -1,0 +1,9 @@
+module Admin
+  module Reports
+    class SolarPanelsController < AdminController
+      def index
+        @solar_panels = MeterAttribute.solar_panels
+      end
+    end
+  end
+end

--- a/app/models/meter_attribute.rb
+++ b/app/models/meter_attribute.rb
@@ -59,8 +59,8 @@ class MeterAttribute < ApplicationRecord
     MeterAttribute.connection.select_all(sanitized_query).rows.map do |row|
       OpenStruct.new(
         meter_attribute_id: row[0],
-        meter_id: row[1],
-        school_id: row[2],
+        school_id: row[1],
+        meter: Meter.find(row[2]),
         start_date: row[3],
         end_date: row[4],
         kwp: row[5],

--- a/app/models/meter_attribute.rb
+++ b/app/models/meter_attribute.rb
@@ -45,4 +45,31 @@ class MeterAttribute < ApplicationRecord
       end
     end
   end
+
+  def self.solar_panels
+    query = <<-SQL.squish
+      SELECT ma.id, m.school_id, ma.meter_id, solar.*
+      FROM meter_attributes ma
+      INNER JOIN meters m ON ma.meter_id = m.id,
+      JSON_TO_RECORD(ma.input_data) AS solar(start_date TEXT, end_date TEXT, kwp TEXT, orientation TEXT, tilt TEXT, shading TEXT, fit_£_per_kwh TEXT, maximum_export_level_kw TEXT)
+      WHERE ma.attribute_type='solar_pv' AND ma.deleted_by_id IS NULL AND ma.replaced_by_id IS NULL
+      ORDER BY meter_id;
+    SQL
+    sanitized_query = ActiveRecord::Base.sanitize_sql_array(query)
+    MeterAttribute.connection.select_all(sanitized_query).rows.map do |row|
+      OpenStruct.new(
+        meter_attribute_id: row[0],
+        meter_id: row[1],
+        school_id: row[2],
+        start_date: row[3],
+        end_date: row[4],
+        kwp: row[5],
+        orientation: row[6],
+        tilt: row[7],
+        shading: row[8],
+        fit_£_per_kwh: row[9],
+        maximum_export_level_kw: row[10]
+      )
+    end
+  end
 end

--- a/app/views/admin/reports/index.html.erb
+++ b/app/views/admin/reports/index.html.erb
@@ -40,6 +40,7 @@
       <li><%= link_to "Tariff imports report", admin_reports_tariff_import_logs_path %></li>
       <li><%= link_to "Tariffs report", admin_reports_tariffs_path %></li>
       <li><%= link_to "PROB data report", admin_prob_data_reports_path %></li>
+      <li><%= link_to "Solar Panels", admin_reports_solar_panels_path %></li>
     </ul>
 
     <h3>Transifex</h3>

--- a/app/views/admin/reports/solar_panels/index.html.erb
+++ b/app/views/admin/reports/solar_panels/index.html.erb
@@ -43,7 +43,8 @@
         <td><%= solar_panel_config.maximum_export_level_kw %></td>
         <td>
           <div class="btn-group">
-          <%= link_to('History', admin_school_meter_attribute_path(solar_panel_config.meter.school, id: solar_panel_config.meter_attribute_id), class: 'btn btn-small') %>
+            <%= link_to 'Edit', edit_admin_school_meter_attribute_path(solar_panel_config.meter.school, id: solar_panel_config.meter_attribute_id), class: 'btn btn-sm' %>
+            <%= link_to('History', admin_school_meter_attribute_path(solar_panel_config.meter.school, id: solar_panel_config.meter_attribute_id), class: 'btn btn-sm') %>
           </div>
         </td>
       </tr>

--- a/app/views/admin/reports/solar_panels/index.html.erb
+++ b/app/views/admin/reports/solar_panels/index.html.erb
@@ -1,0 +1,53 @@
+<% content_for :page_title, 'Solar Panel Report' %>
+
+<h1>Solar Panel Summary</h1>
+
+<p>
+  This report summarises the solar panels configured on Energy Sparks to allow us
+  to generate synthetic solar data.
+</p>
+
+<p>
+  Solar panel overrides are not included.
+</p>
+
+<div class="row">
+  <table class="table table-sorted">
+    <thead>
+    <tr>
+      <th>School</th>
+      <th>Meter</th>
+      <th>Start date</th>
+      <th>End date</th>
+      <th>kwp</th>
+      <th>orientation</th>
+      <th>tilt</th>
+      <th>shading</th>
+      <th>fit_£_per_kwh</th>
+      <th>maximum_export_level_kw</th>
+      <th></th>
+    </tr>
+    </thead>
+    <tbody>
+    <% @solar_panels.each do |solar_panel_config| %>
+      <tr>
+        <td><%= link_to(solar_panel_config.meter.school_name, school_path(solar_panel_config.meter.school)) %></td>
+        <td><%= link_to(solar_panel_config.meter.display_name, school_meter_path(solar_panel_config.meter.school, solar_panel_config.meter)) %></td>
+        <td><%= solar_panel_config.start_date %></td>
+        <td><%= solar_panel_config.end_date %></td>
+        <td><%= solar_panel_config.kwp %></td>
+        <td><%= solar_panel_config.orientation %></td>
+        <td><%= solar_panel_config.tilt %></td>
+        <td><%= solar_panel_config.shading %></td>
+        <td><%= solar_panel_config.fit_£_per_kwh %></td>
+        <td><%= solar_panel_config.maximum_export_level_kw %></td>
+        <td>
+          <div class="btn-group">
+          <%= link_to('History', admin_school_meter_attribute_path(solar_panel_config.meter.school, id: solar_panel_config.meter_attribute_id), class: 'btn btn-small') %>
+          </div>
+        </td>
+      </tr>
+    <% end %>
+    </tbody>
+  </table>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -523,6 +523,7 @@ Rails.application.routes.draw do
       resources :transifex_loads, only: [:index, :show]
       resources :activity_types, only: [:index, :show]
       resources :dcc_status, only: [:index]
+      resources :solar_panels, only: [:index]
     end
 
     resource :settings, only: [:show, :update]

--- a/spec/models/meter_attribute_spec.rb
+++ b/spec/models/meter_attribute_spec.rb
@@ -60,7 +60,7 @@ describe MeterAttribute do
     it 'returns expected data' do
       expect(solar_panels.size).to eq 1
       expect(panel.meter_attribute_id).to eq solar_attribute.id
-      expect(panel.meter_id).to eq solar_attribute.meter.id
+      expect(panel.meter).to eq solar_attribute.meter
       expect(panel.school_id).to eq solar_attribute.meter.school.id
       expect(panel.start_date).to eq '2022-01-01'
       expect(panel.end_date).to eq '2023-01-01'

--- a/spec/models/meter_attribute_spec.rb
+++ b/spec/models/meter_attribute_spec.rb
@@ -50,4 +50,25 @@ describe MeterAttribute do
     end
 
   end
+
+  describe '.solar_panels' do
+    let(:config)  { {start_date: "2022-01-01", kwp: "10", end_date: "2023-01-01", orientation: '0', tilt: '30', shading: '6', fit_£_per_kwh: '0.3', maximum_export_level_kw: '5'} }
+    let!(:solar_attribute) { create(:meter_attribute, attribute_type: :solar_pv, input_data: config)}
+    let!(:other_attribute) { create(:meter_attribute, attribute_type: :tariff, input_data: {type: 'economy_7'})}
+    let(:solar_panels)  { MeterAttribute.solar_panels }
+    let(:panel)         { solar_panels.first }
+    it 'returns expected data' do
+      expect(solar_panels.size).to eq 1
+      expect(panel.meter_attribute_id).to eq solar_attribute.id
+      expect(panel.meter_id).to eq solar_attribute.meter.id
+      expect(panel.school_id).to eq solar_attribute.meter.school.id
+      expect(panel.start_date).to eq '2022-01-01'
+      expect(panel.end_date).to eq '2023-01-01'
+      expect(panel.orientation).to eq '0'
+      expect(panel.tilt).to eq '30'
+      expect(panel.shading).to eq '6'
+      expect(panel.fit_£_per_kwh).to eq '0.3'
+      expect(panel.maximum_export_level_kw).to eq '5'
+    end
+  end
 end


### PR DESCRIPTION
Adds a new admin report to summarise the solar panel configuration across the site.

* Adds a new query to extract the configuration from the MeterAttributes model
* Adds new report to the admin reports section with a simple tabular view of the attributes, with links to school, meter and the configuration

This should help us take stock of which schools are using synthetic solar data and the size of the installations across the service.