### PR TITLE
Temporary analytics branch - solar changes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,8 +23,8 @@ gem 'pg_search'
 gem 'calculate_in_group'
 
 # Dashboard analytics
-gem 'energy-sparks_analytics', git: 'https://github.com/Energy-Sparks/energy-sparks_analytics.git', tag: '2.8.1.1'
-#gem 'energy-sparks_analytics', git: 'https://github.com/Energy-Sparks/energy-sparks_analytics.git', branch: 'aws-eb-test'
+#gem 'energy-sparks_analytics', git: 'https://github.com/Energy-Sparks/energy-sparks_analytics.git', tag: '2.8.1.1'
+gem 'energy-sparks_analytics', git: 'https://github.com/Energy-Sparks/energy-sparks_analytics.git', branch: 'aws-eb-test'
 #gem 'energy-sparks_analytics', path: '../energy-sparks_analytics'
 
 # Using master due to it having a patch which doesn't override Enumerable#sum if it's already defined

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/Energy-Sparks/energy-sparks_analytics.git
-  revision: 620b267ce757be57757cd29b425d8a6ecd6a550d
+  revision: d5c332e6892740404cab92d6a2a74bb7d9d3ec30
   branch: aws-eb-test
   specs:
     energy-sparks_analytics (1.2.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/Energy-Sparks/energy-sparks_analytics.git
-  revision: ffccf8ad0cc286e4d79839d9c943102c1f732923
+  revision: 2312f5315e83bbb093679d3a406a1646f8061a52
   branch: aws-eb-test
   specs:
     energy-sparks_analytics (1.2.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/Energy-Sparks/energy-sparks_analytics.git
-  revision: d5c332e6892740404cab92d6a2a74bb7d9d3ec30
+  revision: ffccf8ad0cc286e4d79839d9c943102c1f732923
   branch: aws-eb-test
   specs:
     energy-sparks_analytics (1.2.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/Energy-Sparks/energy-sparks_analytics.git
-  revision: aae1f558f9f79e03299c1cdd40c684dda4e85f8b
-  tag: 2.8.1.1
+  revision: 620b267ce757be57757cd29b425d8a6ecd6a550d
+  branch: aws-eb-test
   specs:
     energy-sparks_analytics (1.2.1)
       activesupport (>= 6.0, < 7.1)

--- a/config/locales/analytics/benchmarking/content_base.yml
+++ b/config/locales/analytics/benchmarking/content_base.yml
@@ -69,6 +69,7 @@ en:
         recent_change_in_baseload: Recent change in baseload
         seasonal_baseload_variation: Seasonal baseload variation
         sept_nov_2021_2022_energy_comparison: September to November 2021 versus 2022 energy use
+        solar_generation_summary: Solar generation summary
         solar_pv_benefit_estimate: Benefit of solar PV installation
         storage_heater_consumption_during_holiday: Storage heater use during current holiday
         thermostat_sensitivity: Annual saving through 1C reduction in thermostat temperature
@@ -268,9 +269,14 @@ en:
           school_name: School name
           size_kwp: 'Size: kWp'
           size_of_reduction_rating: Size of reduction rating
+          solar_export: Export (kWh)
+          solar_generation: Generation (kWh)
+          solar_mains_consume: Mains consumption (kWh)
+          solar_mains_onsite: Total onsite consumption (kWh)
           solar_pv: Solar PV
           solar_pv_co2_last_year: Solar PV CO2 (last year)
           solar_pv_co2_previous_year: Solar PV CO2 (previous year)
+          solar_self_consume: Self consumption (kWh)
           standard_deviation_of_start_time__hours_last_year: Standard deviation of start time - hours, last year
           start_date_for_target: Start date for target
           storage_heater_co2_last_year: Storage Heater CO2 (last year)
@@ -684,6 +690,12 @@ en:
           introduction_text_html: |-
             <p>A school's baseload is the electricity consumed by appliances kept running at all times.</p>
             <p>In general, the baseload in the winter should be very similar to the summer. In practice many schools leave electric heaters on overnight when the school is unoccupied. Identifying and turning off or better timing such equipment is a quick way of saving electricity and costs.</p>
+        solar_generation_summary:
+          introduction_text_html: |-
+            <p>
+            Summarises the performance of solar panels installed on these schools over the last 12 months. Equivalent to the
+            "Benefits of having installed solar panels" table on the school's individual solar analysis.
+            </p>
         solar_pv_benefit_estimate:
           introduction_text_html: |-
             <p>

--- a/lib/tasks/deployment/20230609115956_alert_solar_generation.rake
+++ b/lib/tasks/deployment/20230609115956_alert_solar_generation.rake
@@ -1,0 +1,22 @@
+namespace :after_party do
+  desc 'Deployment task: alert_solar_generation'
+  task alert_solar_generation: :environment do
+    puts "Running deploy task 'alert_solar_generation'"
+
+    AlertType.create!(
+      frequency: :weekly,
+      fuel_type: :electricity,
+      sub_category: :electricity_use,
+      title: "Solar generation summary",
+      class_name: 'AlertSolarGeneration',
+      source: :analytics,
+      has_ratings: false,
+      benchmark: true
+    ) unless AlertType.find_by_class_name('AlertSolarGeneration')
+
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord
+      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+  end
+end


### PR DESCRIPTION
This is a temporary branch that will be used to do a test release of the analytics that includes the code from these PRs:

* https://github.com/Energy-Sparks/energy-sparks_analytics/pull/546
* https://github.com/Energy-Sparks/energy-sparks_analytics/pull/557

That analytics PR has been merged into an `aws-eb-test` branch in the analytics. This is to make it easier to merge in other bug fixes, as its not clear yet how long we may need to test this on the test server.

The PR:

* Changes the application to use the analytics `aws-eb-test` on a temporary basis
* Adds a new alert that is used to generate some data for a solar benchmark

The PR should not be merged into master, it will later be replaced with a proper analytics release.

