### PR TITLE
Add navbar to school group chart updates page

### DIFF
--- a/app/controllers/school_groups/chart_updates_controller.rb
+++ b/app/controllers/school_groups/chart_updates_controller.rb
@@ -4,6 +4,11 @@ module SchoolGroups
 
     def index
       redirect_to school_group_path(@school_group) and return unless can?(:update_settings, @school_group)
+      @breadcrumbs = [
+        { name: 'Schools' },
+        { name: @school_group.name, href: school_group_path(@school_group) },
+        { name: t('school_groups.chart_updates.index.group_chart_settings').capitalize }
+      ]
     end
 
     def bulk_update_charts

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -7,8 +7,9 @@
     <% if show_sub_nav?(@school, @hide_subnav) %>
       <%= render 'shared/mini_nav' %>
       <%= render 'shared/sub_nav', podium: current_school_podium, school: @school %>
-    <% elsif controller_name == 'school_groups' && can?(:update_settings, @school_group) %>
+    <% elsif controller_path.split('/').first == 'school_groups' && can?(:update_settings, @school_group) %>
       <%= render 'shared/mini_nav' %>
+      <%= render 'school_groups/sub_nav' if can?(:update_settings, @school_group) %>
     <% else %>
       <%= render 'shared/nav' %>
     <% end %>

--- a/app/views/school_groups/_enhanced_header.html.erb
+++ b/app/views/school_groups/_enhanced_header.html.erb
@@ -1,5 +1,4 @@
 <% content_for :page_title, @school_group.name + ' | ' +  t("school_groups.titles.#{action_name}") %>
-<%= render 'sub_nav' if can?(:update_settings, @school_group) %>
 
 <div class="page-breadcrumb pt-5">
   <%= component 'breadcrumbs' do |c| %>

--- a/app/views/school_groups/chart_updates/index.html.erb
+++ b/app/views/school_groups/chart_updates/index.html.erb
@@ -1,5 +1,4 @@
 <% content_for :page_title, @school_group.name + ' | ' +  t('school_groups.chart_updates.index.group_chart_settings').capitalize %>
-<%= render 'school_groups/sub_nav' if can?(:update_settings, @school_group) %>
 <div class="page-breadcrumb pt-5">
   <%= component 'breadcrumbs' do |c| %>
     <% c.with_items(@breadcrumbs) %>

--- a/app/views/school_groups/chart_updates/index.html.erb
+++ b/app/views/school_groups/chart_updates/index.html.erb
@@ -1,3 +1,11 @@
+<% content_for :page_title, @school_group.name + ' | ' +  t('school_groups.chart_updates.index.group_chart_settings').capitalize %>
+<%= render 'school_groups/sub_nav' if can?(:update_settings, @school_group) %>
+<div class="page-breadcrumb pt-5">
+  <%= component 'breadcrumbs' do |c| %>
+    <% c.with_items(@breadcrumbs) %>
+  <% end %>
+</div>
+
 <h1><%= @school_group.name %> <%= t('school_groups.chart_updates.index.group_chart_settings') %></h1>
 
 <%= simple_form_for :school_group, url: school_group_chart_update_bulk_update_charts_path(chart_update_id: @school_group.id), method: :post do |form| %>

--- a/config/locales/views/school_groups/school_groups.yml
+++ b/config/locales/views/school_groups/school_groups.yml
@@ -14,7 +14,7 @@ en:
           explanation: Choose a default option for how energy usage data is displayed in charts
           form_group: Default chart units
           usage: Display chart data in kwh, where available
-        group_chart_settings: Group Chart Settings
+        group_chart_settings: chart settings
         update_all_schools_in_this_group: Update all schools in this group
     comparisons:
       how_does_it_compare:

--- a/spec/support/school_groups_shared_examples.rb
+++ b/spec/support/school_groups_shared_examples.rb
@@ -90,6 +90,7 @@ end
 RSpec.shared_examples 'allows access to chart updates page and editing of default chart preferences' do
   it 'shows a form to select default chart units' do
     visit school_group_chart_updates_path(school_group)
+    expect(find('ol.main-breadcrumbs').all('li').collect(&:text)).to eq(['Schools', school_group.name, 'Chart settings'])
     expect(school_group.default_chart_preference).to eq('default')
     expect(school_group2.default_chart_preference).to eq('default')
     expect(school_group.schools.map(&:chart_preference).sort).to eq(['carbon','default','usage'])

--- a/spec/support/school_groups_shared_examples.rb
+++ b/spec/support/school_groups_shared_examples.rb
@@ -91,6 +91,8 @@ RSpec.shared_examples 'allows access to chart updates page and editing of defaul
   it 'shows a form to select default chart units' do
     visit school_group_chart_updates_path(school_group)
     expect(find('ol.main-breadcrumbs').all('li').collect(&:text)).to eq(['Schools', school_group.name, 'Chart settings'])
+    expect(page).to have_selector(id: "school-list-menu")
+    expect(page).to have_selector(id: "manage-school-group")
     expect(school_group.default_chart_preference).to eq('default')
     expect(school_group2.default_chart_preference).to eq('default')
     expect(school_group.schools.map(&:chart_preference).sort).to eq(['carbon','default','usage'])

--- a/spec/support/school_groups_shared_examples.rb
+++ b/spec/support/school_groups_shared_examples.rb
@@ -94,7 +94,7 @@ RSpec.shared_examples 'allows access to chart updates page and editing of defaul
     expect(school_group2.default_chart_preference).to eq('default')
     expect(school_group.schools.map(&:chart_preference).sort).to eq(['carbon','default','usage'])
     expect(school_group2.schools.map(&:chart_preference).sort).to eq(['carbon','default','usage'])
-    expect(page).to have_content("#{school_group.name} Group Chart Settings")
+    expect(page).to have_content("#{school_group.name} chart settings")
     SchoolGroup.default_chart_preferences.keys.each do |preference|
       expect(page).to have_content(I18n.t("school_groups.chart_updates.index.default_chart_preference.#{preference}"))
     end

--- a/spec/system/admin/school_groups_spec.rb
+++ b/spec/system/admin/school_groups_spec.rb
@@ -584,7 +584,7 @@ RSpec.describe 'school groups', :school_groups, type: :system, include_applicati
         expect(school_group2.default_chart_preference).to eq('default')
         expect(school_group.schools.map(&:chart_preference).sort).to eq(['carbon','default','usage'])
         expect(school_group2.schools.map(&:chart_preference).sort).to eq(['carbon','default','usage'])
-        expect(page).to have_content("BANES Group Chart Settings")
+        expect(page).to have_content("BANES chart Settings")
         SchoolGroup.default_chart_preferences.keys.each do |preference|
           expect(page).to have_content(I18n.t("school_groups.chart_updates.index.default_chart_preference.#{preference}"))
         end

--- a/spec/system/admin/school_groups_spec.rb
+++ b/spec/system/admin/school_groups_spec.rb
@@ -584,7 +584,7 @@ RSpec.describe 'school groups', :school_groups, type: :system, include_applicati
         expect(school_group2.default_chart_preference).to eq('default')
         expect(school_group.schools.map(&:chart_preference).sort).to eq(['carbon','default','usage'])
         expect(school_group2.schools.map(&:chart_preference).sort).to eq(['carbon','default','usage'])
-        expect(page).to have_content("BANES chart Settings")
+        expect(page).to have_content("BANES chart settings")
         SchoolGroup.default_chart_preferences.keys.each do |preference|
           expect(page).to have_content(I18n.t("school_groups.chart_updates.index.default_chart_preference.#{preference}"))
         end

--- a/spec/system/group_admin/permissions_spec.rb
+++ b/spec/system/group_admin/permissions_spec.rb
@@ -16,7 +16,9 @@ describe 'Group admin login and permissions' do
     visit root_path
     expect(page).to have_content(school_group.name)
 
-    click_on school.name
+    # click_on school.name
+    first(:link, school.name).click
+
     click_on 'Edit school details'
 
     fill_in 'School name', with: 'New school name'


### PR DESCRIPTION
This pr 
- [ ] adds the management subnav to the group chart settings page. 
- [ ] renames the page title 

For consistency with other group pages it also adds a breadcrumb 
