### PR TITLE
Add one_year_saving_kwh to priority actions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ gem 'pg_search'
 gem 'calculate_in_group'
 
 # Dashboard analytics
-gem 'energy-sparks_analytics', git: 'https://github.com/Energy-Sparks/energy-sparks_analytics.git', tag: '2.8.1.1'
+gem 'energy-sparks_analytics', git: 'https://github.com/Energy-Sparks/energy-sparks_analytics.git', tag: '2.8.2'
 #gem 'energy-sparks_analytics', git: 'https://github.com/Energy-Sparks/energy-sparks_analytics.git', branch: 'aws-eb-test'
 #gem 'energy-sparks_analytics', path: '../energy-sparks_analytics'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/Energy-Sparks/energy-sparks_analytics.git
-  revision: aae1f558f9f79e03299c1cdd40c684dda4e85f8b
-  tag: 2.8.1.1
+  revision: 1de20ee7693f12ad8b61b279aa3830eaec044b8b
+  tag: 2.8.2
   specs:
     energy-sparks_analytics (1.2.1)
       activesupport (>= 6.0, < 7.1)

--- a/app/models/management_priority.rb
+++ b/app/models/management_priority.rb
@@ -39,11 +39,11 @@ class ManagementPriority < ApplicationRecord
   #Returns an Array of OpenStruct
   def self.for_school_group(school_group)
     query = <<-SQL.squish
-      SELECT a.school_id, a.id, cv.alert_type_rating_id, vars.average_one_year_saving_£, vars.one_year_saving_co2
+      SELECT a.school_id, a.id, cv.alert_type_rating_id, vars.average_one_year_saving_£, vars.one_year_saving_co2, vars.one_year_saving_kwh
       FROM management_priorities mp
       INNER JOIN alert_type_rating_content_versions cv ON mp.alert_type_rating_content_version_id = cv.id
       INNER JOIN alerts a ON mp.alert_id = a.id,
-      JSON_TO_RECORD(a.template_data) AS vars(one_year_saving_co2 TEXT, average_one_year_saving_£ TEXT)
+      JSON_TO_RECORD(a.template_data) AS vars(one_year_saving_kwh TEXT, one_year_saving_co2 TEXT, average_one_year_saving_£ TEXT)
       WHERE
         content_generation_run_id IN (
             SELECT c1.id FROM content_generation_runs c1
@@ -66,7 +66,8 @@ class ManagementPriority < ApplicationRecord
         alert_id: row[1],
         alert_type_rating_id: row[2],
         average_one_year_saving_gbp: row[3],
-        one_year_saving_co2: row[4]
+        one_year_saving_co2: row[4],
+        one_year_saving_kwh: row[5]
       )
     end
   end

--- a/app/services/school_groups/priority_actions.rb
+++ b/app/services/school_groups/priority_actions.rb
@@ -17,7 +17,8 @@ module SchoolGroups
         OpenStruct.new(
           schools: priorities.map(&:school),
           average_one_year_saving_gbp: sum_average_one_year_saving_gbp(priorities),
-          one_year_saving_co2: sum_one_year_saving_co2(priorities)
+          one_year_saving_co2: sum_one_year_saving_co2(priorities),
+          one_year_saving_kwh: sum_one_year_saving_kwh2(priorities)
         )
       end
     end
@@ -30,6 +31,10 @@ module SchoolGroups
 
     def sum_one_year_saving_co2(priorities)
       priorities.reduce(0) {|sum, saving| sum + saving.one_year_saving_co2 }
+    end
+
+    def sum_one_year_saving_kwh2(priorities)
+      priorities.reduce(0) {|sum, saving| sum + saving.one_year_saving_kwh }
     end
 
     def find_priority_actions
@@ -51,20 +56,26 @@ module SchoolGroups
         OpenStruct.new(
           school: schools.find {|s| s.id == priority.school_id },
           average_one_year_saving_gbp: average_one_year_saving_gbp(priority),
-          one_year_saving_co2: one_year_saving_co2(priority)
+          one_year_saving_co2: one_year_saving_co2(priority),
+          one_year_saving_kwh: one_year_saving_kwh(priority)
         )
       end
     end
 
+    def one_year_saving_kwh(priority)
+      value_to_i(priority.one_year_saving_kwh)
+    end
+
     def average_one_year_saving_gbp(priority)
-      money_to_i(priority.average_one_year_saving_gbp)
+      value_to_i(priority.average_one_year_saving_gbp)
     end
 
     def one_year_saving_co2(priority)
-      money_to_i(priority.one_year_saving_co2.split(" ").first)
+      value_to_i(priority.one_year_saving_co2.split(" ").first)
     end
 
-    def money_to_i(val)
+    def value_to_i(val)
+      return 0 if val.nil?
       val.gsub(/\D/, '').to_i
     end
 

--- a/app/views/school_groups/_priority_action_modal.html.erb
+++ b/app/views/school_groups/_priority_action_modal.html.erb
@@ -4,6 +4,7 @@
   <thead>
     <tr>
       <th><%= t('common.school') %></th>
+      <th><%= t('advice_pages.index.priorities.table.columns.kwh_saving') %></th>
       <th><%= t('advice_pages.index.priorities.table.columns.cost_saving') %></th>
       <th><%= t('advice_pages.index.priorities.table.columns.co2_reduction') %></th>
       <th class="no-sort"></th>
@@ -14,6 +15,9 @@
       <tr>
         <td>
           <%= link_to saving.school.name, school_path(saving.school) %>
+        </td>
+        <td data-order="<%= saving.one_year_saving_kwh %>">
+          <%= format_unit(saving.one_year_saving_kwh, :kwh) %> kWh
         </td>
         <td data-order="<%= saving.average_one_year_saving_gbp %>">
           <%= format_unit(saving.average_one_year_saving_gbp, :£) %>

--- a/app/views/school_groups/priority_actions.html.erb
+++ b/app/views/school_groups/priority_actions.html.erb
@@ -11,6 +11,7 @@
       <th><%= t('advice_pages.index.priorities.table.columns.fuel_type') %></th>
       <th data-orderable="false"></th>
       <th><%= t('components.breadcrumbs.schools') %></th>
+      <th><%= t('advice_pages.index.priorities.table.columns.kwh_saving') %></th>
       <th><%= t('advice_pages.index.priorities.table.columns.cost_saving') %></th>
       <th><%= t('advice_pages.index.priorities.table.columns.co2_reduction') %></th>
     </tr>
@@ -41,6 +42,11 @@
         <td>
           <h4>
             <%= savings.schools.length %>
+          </h4>
+        </td>
+        <td data-order="<%= savings.one_year_saving_kwh %>">
+          <h4>
+            <%= format_unit(savings.one_year_saving_kwh, :kwh) %> kWh
           </h4>
         </td>
         <td data-order="<%= savings.average_one_year_saving_gbp %>">

--- a/app/views/schools/advice/index/_priority_table.html.erb
+++ b/app/views/schools/advice/index/_priority_table.html.erb
@@ -3,6 +3,7 @@
     <tr>
       <th><%= t('advice_pages.index.priorities.table.columns.fuel_type') %></th>
       <th data-orderable="false"></th>
+      <th><%= t('advice_pages.index.priorities.table.columns.kwh_saving') %></th>
       <th><%= t('advice_pages.index.priorities.table.columns.cost_saving') %></th>
       <th><%= t('advice_pages.index.priorities.table.columns.co2_reduction') %></th>
     </tr>
@@ -22,6 +23,11 @@
             <% else %>
               <%= priority.management_priorities_title %>
             <% end %>
+          </h4>
+        </td>
+        <td data-order="<%= priority.template_variables[:one_year_saving_kwh].gsub(/(,|kWh)/, '').to_i %>">
+          <h4>
+            <%= priority.template_variables[:one_year_saving_kwh] %>
           </h4>
         </td>
         <td>

--- a/config/locales/analytics/benchmarking/content_base.yml
+++ b/config/locales/analytics/benchmarking/content_base.yml
@@ -69,6 +69,7 @@ en:
         recent_change_in_baseload: Recent change in baseload
         seasonal_baseload_variation: Seasonal baseload variation
         sept_nov_2021_2022_energy_comparison: September to November 2021 versus 2022 energy use
+        solar_generation_summary: Solar generation summary
         solar_pv_benefit_estimate: Benefit of solar PV installation
         storage_heater_consumption_during_holiday: Storage heater use during current holiday
         thermostat_sensitivity: Annual saving through 1C reduction in thermostat temperature
@@ -268,9 +269,14 @@ en:
           school_name: School name
           size_kwp: 'Size: kWp'
           size_of_reduction_rating: Size of reduction rating
+          solar_export: Export (kWh)
+          solar_generation: Generation (kWh)
+          solar_mains_consume: Mains consumption (kWh)
+          solar_mains_onsite: Total onsite consumption (kWh)
           solar_pv: Solar PV
           solar_pv_co2_last_year: Solar PV CO2 (last year)
           solar_pv_co2_previous_year: Solar PV CO2 (previous year)
+          solar_self_consume: Self consumption (kWh)
           standard_deviation_of_start_time__hours_last_year: Standard deviation of start time - hours, last year
           start_date_for_target: Start date for target
           storage_heater_co2_last_year: Storage Heater CO2 (last year)
@@ -684,6 +690,12 @@ en:
           introduction_text_html: |-
             <p>A school's baseload is the electricity consumed by appliances kept running at all times.</p>
             <p>In general, the baseload in the winter should be very similar to the summer. In practice many schools leave electric heaters on overnight when the school is unoccupied. Identifying and turning off or better timing such equipment is a quick way of saving electricity and costs.</p>
+        solar_generation_summary:
+          introduction_text_html: |-
+            <p>
+            Summarises the performance of solar panels installed on these schools over the last 12 months. Equivalent to the
+            "Benefits of having installed solar panels" table on the school's individual solar analysis.
+            </p>
         solar_pv_benefit_estimate:
           introduction_text_html: |-
             <p>

--- a/config/locales/views/advice_pages/index.yml
+++ b/config/locales/views/advice_pages/index.yml
@@ -12,6 +12,7 @@ en:
             co2_reduction: CO2 reduction
             cost_saving: Cost saving
             fuel_type: Fuel
+            kwh_saving: Energy saving (kWh)
         table_note: Use the table headings to sort the recommendations. Potential cost savings for the same fuel type are not additive.
         title: Priority actions
       show:

--- a/spec/services/school_groups/priority_actions_spec.rb
+++ b/spec/services/school_groups/priority_actions_spec.rb
@@ -68,7 +68,8 @@ RSpec.describe SchoolGroups::PriorityActions, type: :service do
       rating: 2.0,
       template_data: {
         average_one_year_saving_£: '£1,000',
-        one_year_saving_co2: '1,100 kg CO2'
+        one_year_saving_co2: '1,100 kg CO2',
+        one_year_saving_kwh: '1,111 kWh'
       }
     )
   end
@@ -80,7 +81,8 @@ RSpec.describe SchoolGroups::PriorityActions, type: :service do
       rating: 8.0,
       template_data: {
         average_one_year_saving_£: '£2,000',
-        one_year_saving_co2: '2,200 kg CO2'
+        one_year_saving_co2: '2,200 kg CO2',
+        one_year_saving_kwh: '2,222 kWh'
       }
     )
   end
@@ -92,7 +94,8 @@ RSpec.describe SchoolGroups::PriorityActions, type: :service do
       rating: 8.0,
       template_data: {
         average_one_year_saving_£: '£9,000',
-        one_year_saving_co2: '9,900 kg CO2'
+        one_year_saving_co2: '9,900 kg CO2',
+        one_year_saving_kwh: '9,999 kWh'
       }
     )
   end
@@ -126,8 +129,8 @@ RSpec.describe SchoolGroups::PriorityActions, type: :service do
     end
 
     it 'returns the expected values' do
-      school_1_priority = OpenStruct.new(school: school_1, average_one_year_saving_gbp: 1000, one_year_saving_co2: 1100)
-      school_2_priority = OpenStruct.new(school: school_2, average_one_year_saving_gbp: 2000, one_year_saving_co2: 2200)
+      school_1_priority = OpenStruct.new(school: school_1, average_one_year_saving_gbp: 1000, one_year_saving_co2: 1100, one_year_saving_kwh: 1111)
+      school_2_priority = OpenStruct.new(school: school_2, average_one_year_saving_gbp: 2000, one_year_saving_co2: 2200, one_year_saving_kwh: 2222)
       expect(priority_actions[alert_type_rating_high]).to match_array([school_1_priority, school_2_priority])
     end
 
@@ -154,6 +157,11 @@ RSpec.describe SchoolGroups::PriorityActions, type: :service do
     it 'calculates correct co2 total' do
       expect(total_savings[alert_type_rating_high].one_year_saving_co2).to eq 3300
     end
+
+    it 'calculates correct kwh total' do
+      expect(total_savings[alert_type_rating_high].one_year_saving_kwh).to eq 3333
+    end
+
   end
 
 end

--- a/spec/system/school_groups_spec.rb
+++ b/spec/system/school_groups_spec.rb
@@ -287,7 +287,8 @@ describe 'school groups', :school_groups, type: :system do
             OpenStruct.new(
               schools: [school_1],
               average_one_year_saving_gbp: 1000,
-              one_year_saving_co2: 1100
+              one_year_saving_co2: 1100,
+              one_year_saving_kwh: 2200
             )
           end
           let(:total_savings) do
@@ -313,6 +314,7 @@ describe 'school groups', :school_groups, type: :system do
               expect(page).to have_content("Spending too much money on heating")
               expect(page).to have_content("£1,000")
               expect(page).to have_content("1,100 kg CO2")
+              expect(page).to have_content("2,200 kWh")
             end
           end
 
@@ -540,12 +542,5 @@ describe 'school groups', :school_groups, type: :system do
       end
     end
 
-    context 'viewing priority_actions' do
-      around do |example|
-        ClimateControl.modify FEATURE_FLAG_ENHANCED_SCHOOL_GROUP_DASHBOARD: 'true' do
-          example.run
-        end
-      end
-    end
   end
 end

--- a/spec/system/schools/advice_pages/advice_page_index_spec.rb
+++ b/spec/system/schools/advice_pages/advice_page_index_spec.rb
@@ -51,6 +51,7 @@ RSpec.describe "advice pages", type: :system do
           average_one_year_saving_gbp: '£5,000',
           average_capital_cost: '£2,000',
           one_year_saving_co2: '9,400 kg CO2',
+          one_year_saving_kwh: '6,500 kWh',
           average_payback_years: '0 days'
         }
       )
@@ -70,6 +71,7 @@ RSpec.describe "advice pages", type: :system do
       expect(page).to have_content('Spending too much money on heating')
       expect(page).to have_content('£5,000')
       expect(page).to have_content('9,400 kg CO2')
+      expect(page).to have_content('6,500 kWh')
     end
 
   end


### PR DESCRIPTION
Updates the priority actions tables on the individual school group advice pages, plus the new school group dashboard to include the one year saving in energy use if the action is tackled.

The main code changes are in the analytics and this PR bumps the analytics version.

Otherwise there are changes to:

- the priority actions service which loads the data for the school groups
- the priority actions tab on the school advice page
- the priority actions tab and modal on the school group dashboard
 