### PR TITLE
Formatting tweaks to school group comparisons tab

### DIFF
--- a/app/components/school_group_comparison_component/school_group_comparison_component.html.erb
+++ b/app/components/school_group_comparison_component/school_group_comparison_component.html.erb
@@ -1,55 +1,58 @@
 <div class="pb-2">
   <strong><%= t("advice_pages.#{@advice_page_key}.page_title") %></strong>
   <p><%= t("school_groups.comparisons.how_does_it_compare.#{@advice_page_key}", default: '') %></p>
-  <div
-    id="<%= @id %>"
-    class="school-group-comparison-component-callout-row row mt-4">
-    <% categories.each do |category| %>
-      <% count = count_for(category) %>
-      <div class="col-md-4 justify-content-center <%=category%> d-flex">
-          <div class="school-group-comparison-component-callout-box">
-            <div class="body m-2">
-              <% label = t('school_count', count: count).split(' ') %>
+
+  <div class="col">
+    <div
+      id="<%= @id %>"
+      class="school-group-comparison-component-callout-row row mt-4">
+      <% categories.each do |category| %>
+        <% count = count_for(category) %>
+        <div class="col-md-4 justify-content-center <%=category%> d-flex">
+            <div class="school-group-comparison-component-callout-box">
               <div class="body m-2">
-                <h2>
-                  <% if count.positive? %>
-                    <a href='#' data-toggle="modal" data-target="#<%= @advice_page_key.to_s.camelize + category.to_s.camelize %>ModalCenter">
+                <% label = t('school_count', count: count).split(' ') %>
+                <div class="body m-2">
+                  <h2>
+                    <% if count.positive? %>
+                      <a href='#' data-toggle="modal" data-target="#<%= @advice_page_key.to_s.camelize + category.to_s.camelize %>ModalCenter">
+                        <%= label.first %>
+                      </a>
+                    <% else %>
                       <%= label.first %>
-                    </a>
-                  <% else %>
-                    <%= label.first %>
-                  <% end %>
-                </h2>
-              </div>
-              <div class="footer mb-2">
-                <small><%= label.last.capitalize %></small>
-              </div>
-              <% if count.positive? %>
-                <%= render(FootnoteModalComponent.new(title: modal_title_for(category), modal_id: modal_id_for(category))) do |component| %>
-                  <% component.with_body_content do %>
-                    <table class="table table-borderless table-sorted advice-table advice-priority-table">
-                      <thead>
-                        <tr>
-                          <th><%= t('common.school') %></th>
-                          <th class="no-sort"></th>
-                        </tr>
-                      </thead>
-                      <tbody>
-                        <% @comparison[category]&.each do |school| %>
+                    <% end %>
+                  </h2>
+                </div>
+                <div class="footer mb-2">
+                  <small><%= label.last.capitalize %></small>
+                </div>
+                <% if count.positive? %>
+                  <%= render(FootnoteModalComponent.new(title: modal_title_for(category), modal_id: modal_id_for(category))) do |component| %>
+                    <% component.with_body_content do %>
+                      <table class="table table-borderless table-sorted advice-table advice-priority-table">
+                        <thead>
                           <tr>
-                            <td class='text-left'><%= link_to school['school_name'], school_path(id: school['school_slug']) %></td>
-                            <td class='text-right'><%= link_to t('school_groups.priority_actions.view_analysis'), advice_page_path_for(school['school_slug']) %></td>
+                            <th><%= t('common.school') %></th>
+                            <th class="no-sort"></th>
                           </tr>
-                        <% end %>
-                      </tbody>
-                    </table>
+                        </thead>
+                        <tbody>
+                          <% @comparison[category]&.each do |school| %>
+                            <tr>
+                              <td class='text-left'><%= link_to school['school_name'], school_path(id: school['school_slug']) %></td>
+                              <td class='text-right'><%= link_to t('school_groups.priority_actions.view_analysis'), advice_page_path_for(school['school_slug']) %></td>
+                            </tr>
+                          <% end %>
+                        </tbody>
+                      </table>
+                    <% end %>
                   <% end %>
                 <% end %>
-              <% end %>
+              </div>
             </div>
-          </div>
-      </div>
-    <% end %>
+        </div>
+      <% end %>
+    </div>
   </div>
   <div class="school-group-comparison-component-footer-row row">
     <div class="col-md-4 justify-content-center d-flex">

--- a/app/components/school_group_comparison_component/school_group_comparison_component.html.erb
+++ b/app/components/school_group_comparison_component/school_group_comparison_component.html.erb
@@ -10,23 +10,27 @@
           <div class="school-group-comparison-component-callout-box">
             <div class="body m-2">
               <% label = t('school_count', count: count).split(' ') %>
-              <h2>
-                <% if count.positive? %>
-                  <a href='#' data-toggle="modal" data-target="#<%= @advice_page_key.to_s.camelize + category.to_s.camelize %>ModalCenter">
+              <div class="body m-2">
+                <h2>
+                  <% if count.positive? %>
+                    <a href='#' data-toggle="modal" data-target="#<%= @advice_page_key.to_s.camelize + category.to_s.camelize %>ModalCenter">
+                      <%= label.first %>
+                    </a>
+                  <% else %>
                     <%= label.first %>
-                  </a>
-                <% else %>
-                  <%= label.first %>
-                <% end %>
-              </h2>
-              <h3><%= label.last.capitalize %></h3>
+                  <% end %>
+                </h2>
+              </div>
+              <div class="footer mb-2">
+                <small><%= label.last.capitalize %></small>
+              </div>
               <% if count.positive? %>
                 <%= render(FootnoteModalComponent.new(title: modal_title_for(category), modal_id: modal_id_for(category))) do |component| %>
                   <% component.with_body_content do %>
                     <table class="table table-borderless table-sorted advice-table advice-priority-table">
                       <thead>
                         <tr>
-                          <th ><%= t('common.school') %></th>
+                          <th><%= t('common.school') %></th>
                           <th class="no-sort"></th>
                         </tr>
                       </thead>

--- a/app/models/school_group.rb
+++ b/app/models/school_group.rb
@@ -154,6 +154,10 @@ class SchoolGroup < ApplicationRecord
     SchoolGroups::CategoriseSchools.new(school_group: self).categorise_schools
   end
 
+  def categorise_schools_by_fuel_type
+    SchoolGroups::CategoriseSchools.new(school_group: self).categorise_schools_by_fuel_type
+  end
+
   private
 
   def this_academic_year

--- a/app/models/school_group.rb
+++ b/app/models/school_group.rb
@@ -154,10 +154,6 @@ class SchoolGroup < ApplicationRecord
     SchoolGroups::CategoriseSchools.new(school_group: self).categorise_schools
   end
 
-  def categorise_schools_by_fuel_type
-    SchoolGroups::CategoriseSchools.new(school_group: self).categorise_schools_by_fuel_type
-  end
-
   private
 
   def this_academic_year

--- a/app/services/school_groups/categorise_schools.rb
+++ b/app/services/school_groups/categorise_schools.rb
@@ -5,20 +5,14 @@ module SchoolGroups
     end
 
     def categorise_schools
-      benchmarks_grouped_by_advice_page.each_with_object({}) do |(advice_page_key, school_results), categorised_schools|
-        categorised_schools[advice_page_key.to_sym] = school_results.group_by do |school_result|
-          AdvicePageSchoolBenchmark.benchmarked_as.key(school_result['benchmarked_as']).to_sym
-        end
+      find_advice_page_school_benchmarks.reduce(init_hash) do |results, school_result|
+        r = SchoolResult.new(school_result)
+        results[r.fuel_type][r.advice_page_key][r.benchmarked_as] << school_result
+        results
       end
     end
 
     private
-
-    def benchmarks_grouped_by_advice_page
-      find_advice_page_school_benchmarks.group_by do |advice_page_school_benchmark|
-        advice_page_school_benchmark['advice_page_key'].to_sym
-      end
-    end
 
     def find_advice_page_school_benchmarks
       sanitized_query = ActiveRecord::Base.sanitize_sql_array(query)
@@ -29,6 +23,7 @@ module SchoolGroups
       <<-SQL.squish
         SELECT
         advice_pages.key AS advice_page_key,
+        advice_pages.fuel_type AS fuel_type,
         schools.id AS school_id,
         schools.slug AS school_slug,
         schools.name AS school_name,
@@ -41,6 +36,36 @@ module SchoolGroups
         AND schools.visible = true
         ORDER BY advice_pages.key, schools.name;
       SQL
+    end
+
+    def init_hash
+      Hash.new do |results, fuel_type|
+        results[fuel_type] = Hash.new do |advice_pages, advice_page_key|
+          advice_pages[advice_page_key] = Hash.new do |benchmarks, benchmarked_as|
+            benchmarks[benchmarked_as] = []
+          end
+        end
+      end
+    end
+  end
+
+  class SchoolResult
+    attr_reader :result
+
+    def initialize(school_result)
+      @result = school_result
+    end
+
+    def fuel_type
+      @fuel_type ||= result['fuel_type'] ? AdvicePage.fuel_types.key(result['fuel_type']).to_sym : :other
+    end
+
+    def advice_page_key
+      @advice_page_key ||= result['advice_page_key'].to_sym
+    end
+
+    def benchmarked_as
+      @benchmarked_as ||= AdvicePageSchoolBenchmark.benchmarked_as.key(result['benchmarked_as']).to_sym
     end
   end
 end

--- a/app/views/school_groups/comparisons.html.erb
+++ b/app/views/school_groups/comparisons.html.erb
@@ -1,10 +1,13 @@
 <%= render 'enhanced_header' %>
 <p class=mt-3><%= link_to t('school_groups.comparisons.view_all_school_comparison_benchmarks'), benchmarks_compare_index_path(search: 'groups', school_group_ids: [@school_group.id]) %></p>
-<% @school_group.categorise_schools.each do |advice_page_key, comparison| %>
-  <%= component 'school_group_comparison', id: 'group-comparison-baseload', comparison: comparison, advice_page_key: advice_page_key %>
-  <p class=pb-5>
-    <%= link_to t('school_groups.comparisons.view_detailed_comparison'), compare_path(benchmark: compare_benchmark_key_for(advice_page_key), school_group_ids: [@school_group.id]) %>
-  </p>
+<% @school_group.categorise_schools.each do |fuel_type, advice_pages| %>
+  <h2><%= t("advice_pages.fuel_type.#{fuel_type}").capitalize %></h2>
+  <% advice_pages.each do |advice_page_key, comparison| %>
+    <%= component 'school_group_comparison', id: 'group-comparison-baseload', comparison: comparison, advice_page_key: advice_page_key %>
+    <p class=pb-5>
+      <%= link_to t('school_groups.comparisons.view_detailed_comparison'), compare_path(benchmark: compare_benchmark_key_for(advice_page_key), school_group_ids: [@school_group.id]) %>
+    </p>
+  <% end %>
 <% end %>
 
 

--- a/config/locales/views/advice_pages/advice_pages.yml
+++ b/config/locales/views/advice_pages/advice_pages.yml
@@ -24,6 +24,7 @@ en:
     fuel_type:
       electricity: electricity
       gas: gas
+      other: other
       solar_pv: solar PV
       storage_heater: storage heater
     how_have_we_analysed_your_data:

--- a/spec/services/school_groups/categorise_schools_spec.rb
+++ b/spec/services/school_groups/categorise_schools_spec.rb
@@ -3,140 +3,152 @@ require 'rails_helper'
 RSpec.describe SchoolGroups::CategoriseSchools, type: :service do
   let(:school_group) { create :school_group, name: 'A Group' }
   let(:school_group_2) { create :school_group, name: 'A Group 2' }
-  let!(:baseload_advice_pages) { create(:advice_page, key: 'baseload') }
-  let!(:electricity_intraday_advice_pages) { create(:advice_page, key: 'electricity_intraday') }
-  let!(:electricity_long_term_advice_pages) { create(:advice_page, key: 'electricity_long_term') }
+
+  let!(:advice_pages) {
+    {
+      total_energy_use: create(:advice_page, key: 'total_energy_use', fuel_type: nil),
+      electricity_intraday: create(:advice_page, key: 'electricity_intraday', fuel_type: :electricity),
+      electricity_long_term: create(:advice_page, key: 'electricity_long_term', fuel_type: :electricity),
+      gas_long_term: create(:advice_page, key: 'gas_long_term', fuel_type: :gas)
+    }
+  }
 
   before do
     (1..24).each { |i| create(:school, id: i, name: "School #{i}", school_group: school_group, active: true, visible: true) }
     (25..26).each { |i| create(:school, id: i, name: "School #{i}", school_group: school_group, active: true, visible: false) }
     (27..30).each { |i| create(:school, id: i, name: "School #{i}", school_group: school_group_2, active: true, visible: true) }
-    upsert_advice_page_school_benchmarks
+    create_advice_page_school_benchmarks
   end
 
-  it 'returns a hash of sorted/categorised school group visible schools keyed by advice page key and benchmarked as' do
-    expect(SchoolGroups::CategoriseSchools.new(school_group: school_group).categorise_schools).to eq(
-      {
-        :baseload => {
-          :other_school =>
-            [
-              { "advice_page_key" => "baseload", "school_id" => 1, "school_slug" => "school-1", "school_name" => "School 1", "benchmarked_as" => 0 },
-              { "advice_page_key" => "baseload", "school_id" => 2, "school_slug" => "school-2", "school_name" => "School 2", "benchmarked_as" => 0 },
-              { "advice_page_key" => "baseload", "school_id" => 3, "school_slug" => "school-3", "school_name" => "School 3", "benchmarked_as" => 0},
-              {"advice_page_key" => "baseload", "school_id" => 4, "school_slug" => "school-4", "school_name" => "School 4", "benchmarked_as" => 0},
-              {"advice_page_key" => "baseload", "school_id" => 5, "school_slug" => "school-5", "school_name" => "School 5", "benchmarked_as" => 0},
-              {"advice_page_key" => "baseload", "school_id" => 6, "school_slug" => "school-6", "school_name" => "School 6", "benchmarked_as" => 0},
-              {"advice_page_key" => "baseload", "school_id" => 7, "school_slug" => "school-7", "school_name" => "School 7", "benchmarked_as" => 0},
-              {"advice_page_key" => "baseload", "school_id" => 8, "school_slug" => "school-8", "school_name" => "School 8", "benchmarked_as" => 0}
-            ],
-          :benchmark_school =>
-            [
-              {"advice_page_key" => "baseload", "school_id" => 10, "school_slug" => "school-10", "school_name" => "School 10", "benchmarked_as" => 1},
-              {"advice_page_key" => "baseload", "school_id" => 11, "school_slug" => "school-11", "school_name" => "School 11", "benchmarked_as" => 1},
-              {"advice_page_key" => "baseload", "school_id" => 12, "school_slug" => "school-12", "school_name" => "School 12", "benchmarked_as" => 1},
-              {"advice_page_key" => "baseload", "school_id" => 13, "school_slug" => "school-13", "school_name" => "School 13", "benchmarked_as" => 1},
-              {"advice_page_key" => "baseload", "school_id" => 14, "school_slug" => "school-14", "school_name" => "School 14", "benchmarked_as" => 1},
-              {"advice_page_key" => "baseload", "school_id" => 15, "school_slug" => "school-15", "school_name" => "School 15", "benchmarked_as" => 1},
-              {"advice_page_key" => "baseload", "school_id" => 16, "school_slug" => "school-16", "school_name" => "School 16", "benchmarked_as" => 1},
-              {"advice_page_key" => "baseload", "school_id" => 9, "school_slug" => "school-9", "school_name" => "School 9", "benchmarked_as" => 1}
-            ],
-          :exemplar_school =>
-            [
-              {"advice_page_key" => "baseload", "school_id" => 17, "school_slug" => "school-17", "school_name" => "School 17", "benchmarked_as" => 2},
-              {"advice_page_key" => "baseload", "school_id" => 18, "school_slug" => "school-18", "school_name" => "School 18", "benchmarked_as" => 2},
-              {"advice_page_key" => "baseload", "school_id" => 19, "school_slug" => "school-19", "school_name" => "School 19", "benchmarked_as" => 2},
-              {"advice_page_key" => "baseload", "school_id" => 20, "school_slug" => "school-20", "school_name" => "School 20", "benchmarked_as" => 2},
-              {"advice_page_key" => "baseload", "school_id" => 21, "school_slug" => "school-21", "school_name" => "School 21", "benchmarked_as" => 2},
-              {"advice_page_key" => "baseload", "school_id" => 22, "school_slug" => "school-22", "school_name" => "School 22", "benchmarked_as" => 2},
-              {"advice_page_key" => "baseload", "school_id" => 23, "school_slug" => "school-23", "school_name" => "School 23", "benchmarked_as" => 2},
-              {"advice_page_key" => "baseload", "school_id" => 24, "school_slug" => "school-24", "school_name" => "School 24", "benchmarked_as" => 2}
-            ]
-          },
-        :electricity_intraday => {
-          :benchmark_school =>
-            [
-              {"advice_page_key" => "electricity_intraday", "school_id" => 1, "school_slug" => "school-1", "school_name" => "School 1", "benchmarked_as" => 1},
-              {"advice_page_key" => "electricity_intraday", "school_id" => 2, "school_slug" => "school-2", "school_name" => "School 2", "benchmarked_as" => 1},
-              {"advice_page_key" => "electricity_intraday", "school_id" => 3, "school_slug" => "school-3", "school_name" => "School 3", "benchmarked_as" => 1},
-              {"advice_page_key" => "electricity_intraday", "school_id" => 4, "school_slug" => "school-4", "school_name" => "School 4", "benchmarked_as" => 1},
-              {"advice_page_key" => "electricity_intraday", "school_id" => 5, "school_slug" => "school-5", "school_name" => "School 5", "benchmarked_as" => 1},
-              {"advice_page_key" => "electricity_intraday", "school_id" => 6, "school_slug" => "school-6", "school_name" => "School 6", "benchmarked_as" => 1},
-              {"advice_page_key" => "electricity_intraday", "school_id" => 7, "school_slug" => "school-7", "school_name" => "School 7", "benchmarked_as" => 1},
-              {"advice_page_key" => "electricity_intraday", "school_id" => 8, "school_slug" => "school-8", "school_name" => "School 8", "benchmarked_as" => 1}
-            ],
-          :exemplar_school =>
-            [
-              {"advice_page_key" => "electricity_intraday", "school_id" => 10, "school_slug" => "school-10", "school_name" => "School 10", "benchmarked_as" => 2},
-              {"advice_page_key" => "electricity_intraday", "school_id" => 11, "school_slug" => "school-11", "school_name" => "School 11", "benchmarked_as" => 2},
-              {"advice_page_key" => "electricity_intraday", "school_id" => 12, "school_slug" => "school-12", "school_name" => "School 12", "benchmarked_as" => 2},
-              {"advice_page_key" => "electricity_intraday", "school_id" => 13, "school_slug" => "school-13", "school_name" => "School 13", "benchmarked_as" => 2},
-              {"advice_page_key" => "electricity_intraday", "school_id" => 14, "school_slug" => "school-14", "school_name" => "School 14", "benchmarked_as" => 2},
-              {"advice_page_key" => "electricity_intraday", "school_id" => 15, "school_slug" => "school-15", "school_name" => "School 15", "benchmarked_as" => 2},
-              {"advice_page_key" => "electricity_intraday", "school_id" => 16, "school_slug" => "school-16", "school_name" => "School 16", "benchmarked_as" => 2},
-              {"advice_page_key" => "electricity_intraday", "school_id" => 9, "school_slug" => "school-9", "school_name" => "School 9", "benchmarked_as" => 2}
-            ],
-          :other_school =>
-            [
-              {"advice_page_key" => "electricity_intraday", "school_id" => 17, "school_slug" => "school-17", "school_name" => "School 17", "benchmarked_as" => 0},
-              {"advice_page_key" => "electricity_intraday", "school_id" => 18, "school_slug" => "school-18", "school_name" => "School 18", "benchmarked_as" => 0},
-              {"advice_page_key" => "electricity_intraday", "school_id" => 19, "school_slug" => "school-19", "school_name" => "School 19", "benchmarked_as" => 0},
-              {"advice_page_key" => "electricity_intraday", "school_id" => 20, "school_slug" => "school-20", "school_name" => "School 20", "benchmarked_as" => 0},
-              {"advice_page_key" => "electricity_intraday", "school_id" => 21, "school_slug" => "school-21", "school_name" => "School 21", "benchmarked_as" => 0},
-              {"advice_page_key" => "electricity_intraday", "school_id" => 22, "school_slug" => "school-22", "school_name" => "School 22", "benchmarked_as" => 0},
-              {"advice_page_key" => "electricity_intraday", "school_id" => 23, "school_slug" => "school-23", "school_name" => "School 23", "benchmarked_as" => 0},
-              {"advice_page_key" => "electricity_intraday", "school_id" => 24, "school_slug" => "school-24", "school_name" => "School 24", "benchmarked_as" => 0}
-            ]
-          },
-        :electricity_long_term => {
-          :exemplar_school =>
-            [
-              {"advice_page_key" => "electricity_long_term", "school_id" => 1, "school_slug" => "school-1", "school_name" => "School 1", "benchmarked_as" => 2},
-              {"advice_page_key" => "electricity_long_term", "school_id" => 2, "school_slug" => "school-2", "school_name" => "School 2", "benchmarked_as" => 2},
-              {"advice_page_key" => "electricity_long_term", "school_id" => 3, "school_slug" => "school-3", "school_name" => "School 3", "benchmarked_as" => 2},
-              {"advice_page_key" => "electricity_long_term", "school_id" => 4, "school_slug" => "school-4", "school_name" => "School 4", "benchmarked_as" => 2},
-              {"advice_page_key" => "electricity_long_term", "school_id" => 5, "school_slug" => "school-5", "school_name" => "School 5", "benchmarked_as" => 2},
-              {"advice_page_key" => "electricity_long_term", "school_id" => 6, "school_slug" => "school-6", "school_name" => "School 6", "benchmarked_as" => 2},
-              {"advice_page_key" => "electricity_long_term", "school_id" => 7, "school_slug" => "school-7", "school_name" => "School 7", "benchmarked_as" => 2},
-              {"advice_page_key" => "electricity_long_term", "school_id" => 8, "school_slug" => "school-8", "school_name" => "School 8", "benchmarked_as" => 2}
-            ],
-          :other_school =>
-            [
-              {"advice_page_key" => "electricity_long_term", "school_id" => 10, "school_slug" => "school-10", "school_name" => "School 10", "benchmarked_as" => 0},
-              {"advice_page_key" => "electricity_long_term", "school_id" => 11, "school_slug" => "school-11", "school_name" => "School 11", "benchmarked_as" => 0},
-              {"advice_page_key" => "electricity_long_term", "school_id" => 12, "school_slug" => "school-12", "school_name" => "School 12", "benchmarked_as" => 0},
-              {"advice_page_key" => "electricity_long_term", "school_id" => 13, "school_slug" => "school-13", "school_name" => "School 13", "benchmarked_as" => 0},
-              {"advice_page_key" => "electricity_long_term", "school_id" => 14, "school_slug" => "school-14", "school_name" => "School 14", "benchmarked_as" => 0},
-              {"advice_page_key" => "electricity_long_term", "school_id" => 15, "school_slug" => "school-15", "school_name" => "School 15", "benchmarked_as" => 0},
-              {"advice_page_key" => "electricity_long_term", "school_id" => 16, "school_slug" => "school-16", "school_name" => "School 16", "benchmarked_as" => 0},
-              {"advice_page_key" => "electricity_long_term", "school_id" => 9, "school_slug" => "school-9", "school_name" => "School 9", "benchmarked_as" => 0}
-            ],
-          :benchmark_school =>
-            [
-              {"advice_page_key" => "electricity_long_term", "school_id" => 17, "school_slug" => "school-17", "school_name" => "School 17", "benchmarked_as" => 1},
-              {"advice_page_key" => "electricity_long_term", "school_id" => 18, "school_slug" => "school-18", "school_name" => "School 18", "benchmarked_as" => 1},
-              {"advice_page_key" => "electricity_long_term", "school_id" => 19, "school_slug" => "school-19", "school_name" => "School 19", "benchmarked_as" => 1},
-              {"advice_page_key" => "electricity_long_term", "school_id" => 20, "school_slug" => "school-20", "school_name" => "School 20", "benchmarked_as" => 1},
-              {"advice_page_key" => "electricity_long_term", "school_id" => 21, "school_slug" => "school-21", "school_name" => "School 21", "benchmarked_as" => 1},
-              {"advice_page_key" => "electricity_long_term", "school_id" => 22, "school_slug" => "school-22", "school_name" => "School 22", "benchmarked_as" => 1},
-              {"advice_page_key" => "electricity_long_term", "school_id" => 23, "school_slug" => "school-23", "school_name" => "School 23", "benchmarked_as" => 1},
-              {"advice_page_key" => "electricity_long_term", "school_id" => 24, "school_slug" => "school-24", "school_name" => "School 24", "benchmarked_as" => 1}
-            ]
-          }
-        }
-    )
+  subject!(:results) { SchoolGroups::CategoriseSchools.new(school_group: school_group).categorise_schools }
+
+  let(:expected_results) {
+    {:electricity=>
+      {:electricity_intraday=>
+        {:other_school=>
+          [{"advice_page_key"=>"electricity_intraday", "fuel_type"=>0, "school_id"=>1, "school_slug"=>"school-1", "school_name"=>"School 1", "benchmarked_as"=>0},
+           {"advice_page_key"=>"electricity_intraday", "fuel_type"=>0, "school_id"=>2, "school_slug"=>"school-2", "school_name"=>"School 2", "benchmarked_as"=>0},
+           {"advice_page_key"=>"electricity_intraday", "fuel_type"=>0, "school_id"=>3, "school_slug"=>"school-3", "school_name"=>"School 3", "benchmarked_as"=>0},
+           {"advice_page_key"=>"electricity_intraday", "fuel_type"=>0, "school_id"=>4, "school_slug"=>"school-4", "school_name"=>"School 4", "benchmarked_as"=>0},
+           {"advice_page_key"=>"electricity_intraday", "fuel_type"=>0, "school_id"=>5, "school_slug"=>"school-5", "school_name"=>"School 5", "benchmarked_as"=>0},
+           {"advice_page_key"=>"electricity_intraday", "fuel_type"=>0, "school_id"=>6, "school_slug"=>"school-6", "school_name"=>"School 6", "benchmarked_as"=>0},
+           {"advice_page_key"=>"electricity_intraday", "fuel_type"=>0, "school_id"=>7, "school_slug"=>"school-7", "school_name"=>"School 7", "benchmarked_as"=>0},
+           {"advice_page_key"=>"electricity_intraday", "fuel_type"=>0, "school_id"=>8, "school_slug"=>"school-8", "school_name"=>"School 8", "benchmarked_as"=>0}],
+         :exemplar_school=>
+          [{"advice_page_key"=>"electricity_intraday", "fuel_type"=>0, "school_id"=>10, "school_slug"=>"school-10", "school_name"=>"School 10", "benchmarked_as"=>2},
+           {"advice_page_key"=>"electricity_intraday", "fuel_type"=>0, "school_id"=>11, "school_slug"=>"school-11", "school_name"=>"School 11", "benchmarked_as"=>2},
+           {"advice_page_key"=>"electricity_intraday", "fuel_type"=>0, "school_id"=>12, "school_slug"=>"school-12", "school_name"=>"School 12", "benchmarked_as"=>2},
+           {"advice_page_key"=>"electricity_intraday", "fuel_type"=>0, "school_id"=>13, "school_slug"=>"school-13", "school_name"=>"School 13", "benchmarked_as"=>2},
+           {"advice_page_key"=>"electricity_intraday", "fuel_type"=>0, "school_id"=>14, "school_slug"=>"school-14", "school_name"=>"School 14", "benchmarked_as"=>2},
+           {"advice_page_key"=>"electricity_intraday", "fuel_type"=>0, "school_id"=>15, "school_slug"=>"school-15", "school_name"=>"School 15", "benchmarked_as"=>2},
+           {"advice_page_key"=>"electricity_intraday", "fuel_type"=>0, "school_id"=>16, "school_slug"=>"school-16", "school_name"=>"School 16", "benchmarked_as"=>2},
+           {"advice_page_key"=>"electricity_intraday", "fuel_type"=>0, "school_id"=>9, "school_slug"=>"school-9", "school_name"=>"School 9", "benchmarked_as"=>2}],
+         :benchmark_school=>
+          [{"advice_page_key"=>"electricity_intraday", "fuel_type"=>0, "school_id"=>17, "school_slug"=>"school-17", "school_name"=>"School 17", "benchmarked_as"=>1},
+           {"advice_page_key"=>"electricity_intraday", "fuel_type"=>0, "school_id"=>18, "school_slug"=>"school-18", "school_name"=>"School 18", "benchmarked_as"=>1},
+           {"advice_page_key"=>"electricity_intraday", "fuel_type"=>0, "school_id"=>19, "school_slug"=>"school-19", "school_name"=>"School 19", "benchmarked_as"=>1},
+           {"advice_page_key"=>"electricity_intraday", "fuel_type"=>0, "school_id"=>20, "school_slug"=>"school-20", "school_name"=>"School 20", "benchmarked_as"=>1},
+           {"advice_page_key"=>"electricity_intraday", "fuel_type"=>0, "school_id"=>21, "school_slug"=>"school-21", "school_name"=>"School 21", "benchmarked_as"=>1},
+           {"advice_page_key"=>"electricity_intraday", "fuel_type"=>0, "school_id"=>22, "school_slug"=>"school-22", "school_name"=>"School 22", "benchmarked_as"=>1},
+           {"advice_page_key"=>"electricity_intraday", "fuel_type"=>0, "school_id"=>23, "school_slug"=>"school-23", "school_name"=>"School 23", "benchmarked_as"=>1},
+           {"advice_page_key"=>"electricity_intraday", "fuel_type"=>0, "school_id"=>24, "school_slug"=>"school-24", "school_name"=>"School 24", "benchmarked_as"=>1}]},
+       :electricity_long_term=>
+        {:other_school=>
+          [{"advice_page_key"=>"electricity_long_term", "fuel_type"=>0, "school_id"=>1, "school_slug"=>"school-1", "school_name"=>"School 1", "benchmarked_as"=>0},
+           {"advice_page_key"=>"electricity_long_term", "fuel_type"=>0, "school_id"=>2, "school_slug"=>"school-2", "school_name"=>"School 2", "benchmarked_as"=>0},
+           {"advice_page_key"=>"electricity_long_term", "fuel_type"=>0, "school_id"=>3, "school_slug"=>"school-3", "school_name"=>"School 3", "benchmarked_as"=>0},
+           {"advice_page_key"=>"electricity_long_term", "fuel_type"=>0, "school_id"=>4, "school_slug"=>"school-4", "school_name"=>"School 4", "benchmarked_as"=>0},
+           {"advice_page_key"=>"electricity_long_term", "fuel_type"=>0, "school_id"=>5, "school_slug"=>"school-5", "school_name"=>"School 5", "benchmarked_as"=>0},
+           {"advice_page_key"=>"electricity_long_term", "fuel_type"=>0, "school_id"=>6, "school_slug"=>"school-6", "school_name"=>"School 6", "benchmarked_as"=>0},
+           {"advice_page_key"=>"electricity_long_term", "fuel_type"=>0, "school_id"=>7, "school_slug"=>"school-7", "school_name"=>"School 7", "benchmarked_as"=>0},
+           {"advice_page_key"=>"electricity_long_term", "fuel_type"=>0, "school_id"=>8, "school_slug"=>"school-8", "school_name"=>"School 8", "benchmarked_as"=>0}],
+         :exemplar_school=>
+          [{"advice_page_key"=>"electricity_long_term", "fuel_type"=>0, "school_id"=>10, "school_slug"=>"school-10", "school_name"=>"School 10", "benchmarked_as"=>2},
+           {"advice_page_key"=>"electricity_long_term", "fuel_type"=>0, "school_id"=>11, "school_slug"=>"school-11", "school_name"=>"School 11", "benchmarked_as"=>2},
+           {"advice_page_key"=>"electricity_long_term", "fuel_type"=>0, "school_id"=>12, "school_slug"=>"school-12", "school_name"=>"School 12", "benchmarked_as"=>2},
+           {"advice_page_key"=>"electricity_long_term", "fuel_type"=>0, "school_id"=>13, "school_slug"=>"school-13", "school_name"=>"School 13", "benchmarked_as"=>2},
+           {"advice_page_key"=>"electricity_long_term", "fuel_type"=>0, "school_id"=>14, "school_slug"=>"school-14", "school_name"=>"School 14", "benchmarked_as"=>2},
+           {"advice_page_key"=>"electricity_long_term", "fuel_type"=>0, "school_id"=>15, "school_slug"=>"school-15", "school_name"=>"School 15", "benchmarked_as"=>2},
+           {"advice_page_key"=>"electricity_long_term", "fuel_type"=>0, "school_id"=>16, "school_slug"=>"school-16", "school_name"=>"School 16", "benchmarked_as"=>2},
+           {"advice_page_key"=>"electricity_long_term", "fuel_type"=>0, "school_id"=>9, "school_slug"=>"school-9", "school_name"=>"School 9", "benchmarked_as"=>2}],
+         :benchmark_school=>
+          [{"advice_page_key"=>"electricity_long_term", "fuel_type"=>0, "school_id"=>17, "school_slug"=>"school-17", "school_name"=>"School 17", "benchmarked_as"=>1},
+           {"advice_page_key"=>"electricity_long_term", "fuel_type"=>0, "school_id"=>18, "school_slug"=>"school-18", "school_name"=>"School 18", "benchmarked_as"=>1},
+           {"advice_page_key"=>"electricity_long_term", "fuel_type"=>0, "school_id"=>19, "school_slug"=>"school-19", "school_name"=>"School 19", "benchmarked_as"=>1},
+           {"advice_page_key"=>"electricity_long_term", "fuel_type"=>0, "school_id"=>20, "school_slug"=>"school-20", "school_name"=>"School 20", "benchmarked_as"=>1},
+           {"advice_page_key"=>"electricity_long_term", "fuel_type"=>0, "school_id"=>21, "school_slug"=>"school-21", "school_name"=>"School 21", "benchmarked_as"=>1},
+           {"advice_page_key"=>"electricity_long_term", "fuel_type"=>0, "school_id"=>22, "school_slug"=>"school-22", "school_name"=>"School 22", "benchmarked_as"=>1},
+           {"advice_page_key"=>"electricity_long_term", "fuel_type"=>0, "school_id"=>23, "school_slug"=>"school-23", "school_name"=>"School 23", "benchmarked_as"=>1},
+           {"advice_page_key"=>"electricity_long_term", "fuel_type"=>0, "school_id"=>24, "school_slug"=>"school-24", "school_name"=>"School 24", "benchmarked_as"=>1}]}},
+     :gas=>
+      {:gas_long_term=>
+        {:other_school=>
+          [{"advice_page_key"=>"gas_long_term", "fuel_type"=>1, "school_id"=>1, "school_slug"=>"school-1", "school_name"=>"School 1", "benchmarked_as"=>0},
+           {"advice_page_key"=>"gas_long_term", "fuel_type"=>1, "school_id"=>2, "school_slug"=>"school-2", "school_name"=>"School 2", "benchmarked_as"=>0},
+           {"advice_page_key"=>"gas_long_term", "fuel_type"=>1, "school_id"=>3, "school_slug"=>"school-3", "school_name"=>"School 3", "benchmarked_as"=>0},
+           {"advice_page_key"=>"gas_long_term", "fuel_type"=>1, "school_id"=>4, "school_slug"=>"school-4", "school_name"=>"School 4", "benchmarked_as"=>0},
+           {"advice_page_key"=>"gas_long_term", "fuel_type"=>1, "school_id"=>5, "school_slug"=>"school-5", "school_name"=>"School 5", "benchmarked_as"=>0},
+           {"advice_page_key"=>"gas_long_term", "fuel_type"=>1, "school_id"=>6, "school_slug"=>"school-6", "school_name"=>"School 6", "benchmarked_as"=>0},
+           {"advice_page_key"=>"gas_long_term", "fuel_type"=>1, "school_id"=>7, "school_slug"=>"school-7", "school_name"=>"School 7", "benchmarked_as"=>0},
+           {"advice_page_key"=>"gas_long_term", "fuel_type"=>1, "school_id"=>8, "school_slug"=>"school-8", "school_name"=>"School 8", "benchmarked_as"=>0}],
+         :exemplar_school=>
+          [{"advice_page_key"=>"gas_long_term", "fuel_type"=>1, "school_id"=>10, "school_slug"=>"school-10", "school_name"=>"School 10", "benchmarked_as"=>2},
+           {"advice_page_key"=>"gas_long_term", "fuel_type"=>1, "school_id"=>11, "school_slug"=>"school-11", "school_name"=>"School 11", "benchmarked_as"=>2},
+           {"advice_page_key"=>"gas_long_term", "fuel_type"=>1, "school_id"=>12, "school_slug"=>"school-12", "school_name"=>"School 12", "benchmarked_as"=>2},
+           {"advice_page_key"=>"gas_long_term", "fuel_type"=>1, "school_id"=>13, "school_slug"=>"school-13", "school_name"=>"School 13", "benchmarked_as"=>2},
+           {"advice_page_key"=>"gas_long_term", "fuel_type"=>1, "school_id"=>14, "school_slug"=>"school-14", "school_name"=>"School 14", "benchmarked_as"=>2},
+           {"advice_page_key"=>"gas_long_term", "fuel_type"=>1, "school_id"=>15, "school_slug"=>"school-15", "school_name"=>"School 15", "benchmarked_as"=>2},
+           {"advice_page_key"=>"gas_long_term", "fuel_type"=>1, "school_id"=>16, "school_slug"=>"school-16", "school_name"=>"School 16", "benchmarked_as"=>2},
+           {"advice_page_key"=>"gas_long_term", "fuel_type"=>1, "school_id"=>9, "school_slug"=>"school-9", "school_name"=>"School 9", "benchmarked_as"=>2}],
+         :benchmark_school=>
+          [{"advice_page_key"=>"gas_long_term", "fuel_type"=>1, "school_id"=>17, "school_slug"=>"school-17", "school_name"=>"School 17", "benchmarked_as"=>1},
+           {"advice_page_key"=>"gas_long_term", "fuel_type"=>1, "school_id"=>18, "school_slug"=>"school-18", "school_name"=>"School 18", "benchmarked_as"=>1},
+           {"advice_page_key"=>"gas_long_term", "fuel_type"=>1, "school_id"=>19, "school_slug"=>"school-19", "school_name"=>"School 19", "benchmarked_as"=>1},
+           {"advice_page_key"=>"gas_long_term", "fuel_type"=>1, "school_id"=>20, "school_slug"=>"school-20", "school_name"=>"School 20", "benchmarked_as"=>1},
+           {"advice_page_key"=>"gas_long_term", "fuel_type"=>1, "school_id"=>21, "school_slug"=>"school-21", "school_name"=>"School 21", "benchmarked_as"=>1},
+           {"advice_page_key"=>"gas_long_term", "fuel_type"=>1, "school_id"=>22, "school_slug"=>"school-22", "school_name"=>"School 22", "benchmarked_as"=>1},
+           {"advice_page_key"=>"gas_long_term", "fuel_type"=>1, "school_id"=>23, "school_slug"=>"school-23", "school_name"=>"School 23", "benchmarked_as"=>1},
+           {"advice_page_key"=>"gas_long_term", "fuel_type"=>1, "school_id"=>24, "school_slug"=>"school-24", "school_name"=>"School 24", "benchmarked_as"=>1}]}},
+     :other=>
+      {:total_energy_use=>
+        {:other_school=>
+          [{"advice_page_key"=>"total_energy_use", "fuel_type"=>nil, "school_id"=>1, "school_slug"=>"school-1", "school_name"=>"School 1", "benchmarked_as"=>0},
+           {"advice_page_key"=>"total_energy_use", "fuel_type"=>nil, "school_id"=>2, "school_slug"=>"school-2", "school_name"=>"School 2", "benchmarked_as"=>0},
+           {"advice_page_key"=>"total_energy_use", "fuel_type"=>nil, "school_id"=>3, "school_slug"=>"school-3", "school_name"=>"School 3", "benchmarked_as"=>0},
+           {"advice_page_key"=>"total_energy_use", "fuel_type"=>nil, "school_id"=>4, "school_slug"=>"school-4", "school_name"=>"School 4", "benchmarked_as"=>0},
+           {"advice_page_key"=>"total_energy_use", "fuel_type"=>nil, "school_id"=>5, "school_slug"=>"school-5", "school_name"=>"School 5", "benchmarked_as"=>0},
+           {"advice_page_key"=>"total_energy_use", "fuel_type"=>nil, "school_id"=>6, "school_slug"=>"school-6", "school_name"=>"School 6", "benchmarked_as"=>0},
+           {"advice_page_key"=>"total_energy_use", "fuel_type"=>nil, "school_id"=>7, "school_slug"=>"school-7", "school_name"=>"School 7", "benchmarked_as"=>0},
+           {"advice_page_key"=>"total_energy_use", "fuel_type"=>nil, "school_id"=>8, "school_slug"=>"school-8", "school_name"=>"School 8", "benchmarked_as"=>0}],
+         :exemplar_school=>
+          [{"advice_page_key"=>"total_energy_use", "fuel_type"=>nil, "school_id"=>10, "school_slug"=>"school-10", "school_name"=>"School 10", "benchmarked_as"=>2},
+           {"advice_page_key"=>"total_energy_use", "fuel_type"=>nil, "school_id"=>11, "school_slug"=>"school-11", "school_name"=>"School 11", "benchmarked_as"=>2},
+           {"advice_page_key"=>"total_energy_use", "fuel_type"=>nil, "school_id"=>12, "school_slug"=>"school-12", "school_name"=>"School 12", "benchmarked_as"=>2},
+           {"advice_page_key"=>"total_energy_use", "fuel_type"=>nil, "school_id"=>13, "school_slug"=>"school-13", "school_name"=>"School 13", "benchmarked_as"=>2},
+           {"advice_page_key"=>"total_energy_use", "fuel_type"=>nil, "school_id"=>14, "school_slug"=>"school-14", "school_name"=>"School 14", "benchmarked_as"=>2},
+           {"advice_page_key"=>"total_energy_use", "fuel_type"=>nil, "school_id"=>15, "school_slug"=>"school-15", "school_name"=>"School 15", "benchmarked_as"=>2},
+           {"advice_page_key"=>"total_energy_use", "fuel_type"=>nil, "school_id"=>16, "school_slug"=>"school-16", "school_name"=>"School 16", "benchmarked_as"=>2},
+           {"advice_page_key"=>"total_energy_use", "fuel_type"=>nil, "school_id"=>9, "school_slug"=>"school-9", "school_name"=>"School 9", "benchmarked_as"=>2}],
+         :benchmark_school=>
+          [{"advice_page_key"=>"total_energy_use", "fuel_type"=>nil, "school_id"=>17, "school_slug"=>"school-17", "school_name"=>"School 17", "benchmarked_as"=>1},
+           {"advice_page_key"=>"total_energy_use", "fuel_type"=>nil, "school_id"=>18, "school_slug"=>"school-18", "school_name"=>"School 18", "benchmarked_as"=>1},
+           {"advice_page_key"=>"total_energy_use", "fuel_type"=>nil, "school_id"=>19, "school_slug"=>"school-19", "school_name"=>"School 19", "benchmarked_as"=>1},
+           {"advice_page_key"=>"total_energy_use", "fuel_type"=>nil, "school_id"=>20, "school_slug"=>"school-20", "school_name"=>"School 20", "benchmarked_as"=>1},
+           {"advice_page_key"=>"total_energy_use", "fuel_type"=>nil, "school_id"=>21, "school_slug"=>"school-21", "school_name"=>"School 21", "benchmarked_as"=>1},
+           {"advice_page_key"=>"total_energy_use", "fuel_type"=>nil, "school_id"=>22, "school_slug"=>"school-22", "school_name"=>"School 22", "benchmarked_as"=>1},
+           {"advice_page_key"=>"total_energy_use", "fuel_type"=>nil, "school_id"=>23, "school_slug"=>"school-23", "school_name"=>"School 23", "benchmarked_as"=>1},
+           {"advice_page_key"=>"total_energy_use", "fuel_type"=>nil, "school_id"=>24, "school_slug"=>"school-24", "school_name"=>"School 24", "benchmarked_as"=>1}]}}}
+  }
+
+  it 'returns a hash of sorted/categorised school group visible schools keyed by fuel type, advice page key and benchmarked as' do
+    expect(results).to eq(expected_results)
   end
 
-  def upsert_advice_page_school_benchmarks
-    advice_page_school_benchmarks = []
-    (1..8).each { |i| advice_page_school_benchmarks << { advice_page_id: baseload_advice_pages.id, school_id: i, benchmarked_as: 0, created_at: Time.zone.today, updated_at: Time.zone.today } }
-    (9..16).each { |i| advice_page_school_benchmarks << { advice_page_id: baseload_advice_pages.id, school_id: i, benchmarked_as: 1, created_at: Time.zone.today, updated_at: Time.zone.today } }
-    (17..30).each { |i| advice_page_school_benchmarks << { advice_page_id: baseload_advice_pages.id, school_id: i, benchmarked_as: 2, created_at: Time.zone.today, updated_at: Time.zone.today } }
-    (1..8).each { |i| advice_page_school_benchmarks << { advice_page_id: electricity_intraday_advice_pages.id, school_id: i, benchmarked_as: 1, created_at: Time.zone.today, updated_at: Time.zone.today } }
-    (9..16).each { |i| advice_page_school_benchmarks << { advice_page_id: electricity_intraday_advice_pages.id, school_id: i, benchmarked_as: 2, created_at: Time.zone.today, updated_at: Time.zone.today } }
-    (17..30).each { |i| advice_page_school_benchmarks << { advice_page_id: electricity_intraday_advice_pages.id, school_id: i, benchmarked_as: 0, created_at: Time.zone.today, updated_at: Time.zone.today } }
-    (1..8).each { |i| advice_page_school_benchmarks << { advice_page_id: electricity_long_term_advice_pages.id, school_id: i, benchmarked_as: 2, created_at: Time.zone.today, updated_at: Time.zone.today } }
-    (9..16).each { |i| advice_page_school_benchmarks << { advice_page_id: electricity_long_term_advice_pages.id, school_id: i, benchmarked_as: 0, created_at: Time.zone.today, updated_at: Time.zone.today } }
-    (17..30).each { |i| advice_page_school_benchmarks << { advice_page_id: electricity_long_term_advice_pages.id, school_id: i, benchmarked_as: 1, created_at: Time.zone.today, updated_at: Time.zone.today } }
-    AdvicePageSchoolBenchmark.upsert_all(advice_page_school_benchmarks)
+  def create_advice_page_school_benchmarks
+    advice_pages.keys.each do |advice_page_key|
+      (1..8).each { |i| AdvicePageSchoolBenchmark.create(advice_page: advice_pages[advice_page_key], school_id: i, benchmarked_as: :other_school) }
+      (9..16).each { |i| AdvicePageSchoolBenchmark.create(advice_page: advice_pages[advice_page_key], school_id: i, benchmarked_as: :exemplar_school) }
+      (17..30).each { |i| AdvicePageSchoolBenchmark.create(advice_page: advice_pages[advice_page_key], school_id: i, benchmarked_as: :benchmark_school) }
+    end
   end
 end


### PR DESCRIPTION
The general formatting tweaks were fine, the school comparisons stuff was rather complex just to add in fuel type...

This covers:
- Add in subtitles for each fuel type, with the relevant comparisons within each. The subtitles should be h2 to match the formatting of the section headings on the analysis pages
- The side of the various comparison components is misaligned with the rest of the page body. Looks like it might need a bootstrap row/col to align better.
- The font-size on the cards inside the comparison components is too large. Make them match the school comparison component (see screenshots)
![Screenshot 2023-06-15 at 13 12 45](https://github.com/Energy-Sparks/energy-sparks/assets/6051/40fc5e25-95e7-4b72-85e4-80bc1674fbb4)

This was already done:
- Change title in popup model. From, e.g. “ Baseload analysis • Well managed” to “Baseload analysis > Well managed” so its consistent with the breadcrumb
![Screenshot 2023-06-15 at 13 13 36](https://github.com/Energy-Sparks/energy-sparks/assets/6051/6f64aee1-9c9f-43e4-b301-b7197a4ceb28)

Where there is no fuel type - have used the term "other" for now as the fuel type header.