### PR TITLE
Change wording on gas insights "how do you compare" section

### DIFF
--- a/config/locales/views/advice_pages/gas_long_term.yml
+++ b/config/locales/views/advice_pages/gas_long_term.yml
@@ -60,7 +60,7 @@ en:
       insights:
         comparison:
           callout_footer: annual gas usage
-          how_do_you_compare: How does your gas use for the last 12 months compare to other %{school_type} schools on Energy Sparks, with a similar number of pupils?
+          how_do_you_compare: How does your gas use for the last 12 months compare to other %{school_type} schools on Energy Sparks, with a similar floor area?
           more_detail_html: For more detail, <a href="%{link}">compare with other schools in your group</a>
           title: How do you compare?
         current_usage:

--- a/config/locales/views/advice_pages/gas_out_of_hours.yml
+++ b/config/locales/views/advice_pages/gas_out_of_hours.yml
@@ -57,7 +57,7 @@ en:
       insights:
         comparison:
           callout_footer: annual usage
-          how_do_you_compare: How does your gas usage out of school hours compare to other %{school_type} schools on Energy Sparks, with a similar number of pupils?
+          how_do_you_compare: How does your gas usage out of school hours compare to other %{school_type} schools on Energy Sparks, with a similar floor area?
           more_detail_html: For more detail, <a href="%{link}">compare with other schools in your group</a>
           title: How do you compare?
         next_steps: Make sure that your heating is set to only heat the school when it needs to be warm. Heating and hot water can be switched off for evenings, weekends and holidays and heating should not come on too early in the mornings. Use a checklist of energy saving tasks to be completed before holidays.

--- a/config/locales/views/school_groups/school_groups.yml
+++ b/config/locales/views/school_groups/school_groups.yml
@@ -22,10 +22,10 @@ en:
         electricity_intraday: How does the electricity intraday usage analysis of your schools compare to other schools on Energy Sparks, with a similar number of pupils?
         electricity_long_term: How does the long term changes in electricity consumption of your schools compare to other schools on Energy Sparks, with a similar number of pupils?
         electricity_out_of_hours: How does the out of school hours electricity use of your schools compare to other schools on Energy Sparks, with a similar number of pupils?
-        gas_long_term: How does the long term changes in gas consumption of your schools compare to other schools on Energy Sparks, with a similar number of pupils?
-        gas_out_of_hours: How does the out of school hours gas use of your schools compare to other schools on Energy Sparks, with a similar number of pupils?
-        heating_control: How does the heating control analysis of your schools compare to other schools on Energy Sparks, with a similar number of pupils?
-        thermostatic_control: How does the thermostatic control analysis of your schools compare to other schools on Energy Sparks, with a similar number of pupils?
+        gas_long_term: How does the long term changes in gas consumption of your schools compare to other schools on Energy Sparks, with a similar floor area?
+        gas_out_of_hours: How does the out of school hours gas use of your schools compare to other schools on Energy Sparks, with a similar floor area?
+        heating_control: How does the heating control analysis of your schools compare to other schools on Energy Sparks, with a similar floor area?
+        thermostatic_control: How does the thermostatic control analysis of your schools compare to other schools on Energy Sparks, with a similar floor area?
       view_all_school_comparison_benchmarks: View all school comparison benchmarks
       view_detailed_comparison: View detailed comparison
     header:


### PR DESCRIPTION
Have changed this for all the gas comparisons on the school group pages.
Have changed the text on the gas_out_of_hours and gas_recent_changes advice pages - however the other gas ones seem to work differently so I have left those as is.