### PR TITLE
Analytics 2.8.3 - solar changes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ gem 'pg_search'
 gem 'calculate_in_group'
 
 # Dashboard analytics
-gem 'energy-sparks_analytics', git: 'https://github.com/Energy-Sparks/energy-sparks_analytics.git', tag: '2.8.2'
+gem 'energy-sparks_analytics', git: 'https://github.com/Energy-Sparks/energy-sparks_analytics.git', tag: '2.8.3'
 #gem 'energy-sparks_analytics', git: 'https://github.com/Energy-Sparks/energy-sparks_analytics.git', branch: 'aws-eb-test'
 #gem 'energy-sparks_analytics', path: '../energy-sparks_analytics'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/Energy-Sparks/energy-sparks_analytics.git
-  revision: 1de20ee7693f12ad8b61b279aa3830eaec044b8b
-  tag: 2.8.2
+  revision: 3a587900136e8e2c0f3d5704bfc9d604187199cc
+  tag: 2.8.3
   specs:
     energy-sparks_analytics (1.2.1)
       activesupport (>= 6.0, < 7.1)
@@ -23,7 +23,7 @@ GIT
       soda-ruby (~> 0.2.25)
       statsample (~> 2.1.0)
       structured_warnings (~> 0.3.0)
-      write_xlsx (>= 0.85.5, < 1.11.0)
+      write_xlsx (>= 0.85.5, < 1.12.0)
 
 GIT
   remote: https://github.com/Energy-Sparks/statsample
@@ -672,7 +672,7 @@ GEM
     websocket-extensions (0.1.5)
     wisper (2.0.0)
     wisper-rspec (1.1.0)
-    write_xlsx (1.10.2)
+    write_xlsx (1.11.0)
       rubyzip (>= 1.0.0)
     xpath (3.2.0)
       nokogiri (~> 1.8)

--- a/lib/tasks/deployment/20230609115956_alert_solar_generation.rake
+++ b/lib/tasks/deployment/20230609115956_alert_solar_generation.rake
@@ -1,0 +1,22 @@
+namespace :after_party do
+  desc 'Deployment task: alert_solar_generation'
+  task alert_solar_generation: :environment do
+    puts "Running deploy task 'alert_solar_generation'"
+
+    AlertType.create!(
+      frequency: :weekly,
+      fuel_type: :electricity,
+      sub_category: :electricity_use,
+      title: "Solar generation summary",
+      class_name: 'AlertSolarGeneration',
+      source: :analytics,
+      has_ratings: false,
+      benchmark: true
+    ) unless AlertType.find_by_class_name('AlertSolarGeneration')
+
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord
+      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+  end
+end

--- a/spec/system/schools/advice_pages/electricity_recent_changes_spec.rb
+++ b/spec/system/schools/advice_pages/electricity_recent_changes_spec.rb
@@ -9,12 +9,12 @@ RSpec.describe "electricity recent changes advice page", type: :system do
     let(:user) { create(:school_admin, school: school) }
 
     before do
-      allow_any_instance_of(Usage::RecentUsagePeriodCalculationService).to receive(:recent_usage) do
-        OpenStruct.new(
-          date_range: [Time.zone.today, Time.zone.today - 1.week],
-          combined_usage_metric: CombinedUsageMetric.new(kwh: 12.0, £: 12.0, co2: 12.0)
-        )
-      end
+#      allow_any_instance_of(Usage::RecentUsagePeriodCalculationService).to receive(:recent_usage) do
+#        OpenStruct.new(
+#          date_range: [Time.zone.today, Time.zone.today - 1.week],
+#          combined_usage_metric: CombinedUsageMetric.new(kwh: 12.0, £: 12.0, co2: 12.0)
+#        )
+#      end
 
       sign_in(user)
       visit school_advice_electricity_recent_changes_path(school)

--- a/spec/system/schools/advice_pages/gas_recent_changes_spec.rb
+++ b/spec/system/schools/advice_pages/gas_recent_changes_spec.rb
@@ -11,12 +11,12 @@ RSpec.describe "gas recent changes advice page", type: :system do
     let(:user)  { create(:school_admin, school: school) }
 
     before do
-      allow_any_instance_of(Usage::RecentUsagePeriodCalculationService).to receive(:recent_usage) do
-        OpenStruct.new(
-          date_range: [Time.zone.today, Time.zone.today - 1.week],
-          combined_usage_metric: CombinedUsageMetric.new(kwh: 12.0, £: 12.0, co2: 12.0)
-        )
-      end
+#      allow_any_instance_of(Usage::RecentUsagePeriodCalculationService).to receive(:recent_usage) do
+#        OpenStruct.new(
+#          date_range: [Time.zone.today, Time.zone.today - 1.week],
+#          combined_usage_metric: CombinedUsageMetric.new(kwh: 12.0, £: 12.0, co2: 12.0)
+#        )
+#      end
 
       sign_in(user)
       visit school_advice_gas_recent_changes_path(school)


### PR DESCRIPTION
This PR bumps the version of the analytics to 2.8.3

The two key changes in that version are these PRs which change how the costs for a solar installation are calculated, as well as how the solar self consumption and export is estimated when we are using synthetic data.

* https://github.com/Energy-Sparks/energy-sparks_analytics/pull/546
* https://github.com/Energy-Sparks/energy-sparks_analytics/pull/557

The PR also adds a new alert that is used to generate some data for a solar benchmark
