### PR TITLE
Tidy up admin options on school manage meters page

### DIFF
--- a/app/models/meter.rb
+++ b/app/models/meter.rb
@@ -79,7 +79,8 @@ class Meter < ApplicationRecord
   scope :sub_meter, -> { where(pseudo: true, meter_type: SUB_METER_TYPES) }
   scope :no_amr_validated_readings, -> { left_outer_joins(:amr_validated_readings).where(amr_validated_readings: { meter_id: nil }) }
 
-  scope :unreviewed_dcc_meter, -> { where(dcc_meter: true, consent_granted: false, meter_review: nil) }
+  scope :unreviewed_dcc_meter, -> { where(dcc_meter: true, consent_granted: false, meter_review_id: nil) }
+  scope :reviewed_dcc_meter, -> { where(dcc_meter: true).where.not(meter_review_id: nil) }
   scope :awaiting_trusted_consent, -> { where(dcc_meter: true, consent_granted: false).where.not(meter_review: nil) }
   scope :not_dcc, -> { where(dcc_meter: false) }
   scope :dcc, -> { where(dcc_meter: true) }

--- a/app/views/admin/school_groups/_default_issues_admin_user.html.erb
+++ b/app/views/admin/school_groups/_default_issues_admin_user.html.erb
@@ -1,0 +1,7 @@
+<% if school_group.default_issues_admin_user_id %>
+  <span class="badge border badge-pill border-secondary font-weight-normal">
+    <%= link_to "Default Issues Admin • " + (school_group.default_issues_admin_user == current_user ? "You" : school_group.default_issues_admin_user.display_name),
+      polymorphic_path([:admin, Issue], user: school_group.default_issues_admin_user),
+      class: 'text-decoration-none' %>
+  </span>
+<% end %>

--- a/app/views/admin/school_groups/show.html.erb
+++ b/app/views/admin/school_groups/show.html.erb
@@ -12,13 +12,7 @@
     Pupils in active schools: <span class="badge badge-success"><%= number_with_delimiter @school_group.schools.visible.map(&:number_of_pupils).compact.sum %>
   </div>
   <div class="col-lg-6 text-right">
-    <% if @school_group.default_issues_admin_user %>
-      <span class="badge border badge-pill border-secondary font-weight-normal">
-        <%= link_to "Default Issues Admin • " + (@school_group.default_issues_admin_user == current_user ? "You" : @school_group.default_issues_admin_user.display_name),
-          polymorphic_path([:admin, Issue], user: @school_group.default_issues_admin_user),
-          class: 'text-decoration-none' %>
-      </span>
-    <% end %>
+    <%= render 'default_issues_admin_user', school_group: @school_group %>
   </div>
 </div>
 <div class="row pb-2">

--- a/app/views/schools/meters/index.html.erb
+++ b/app/views/schools/meters/index.html.erb
@@ -10,7 +10,7 @@
     <%= render 'admin/shared/dashboard_message', messageable: @school %>
   <% end %>
   <div class="alert alert-secondary mb-2">
-    <% if can?(:validate_meters, @school) && @school.meters_with_readings.any? %>
+    <% if can?(:validate_meters, @school) && @school.meters_with_readings.any? && @school.process_data? %>
       <%= link_to t('schools.meters.index.validate_meter_readings'), school_meter_readings_validation_path(@school), method: :post, class: 'btn' %>
     <% else %>
       <button type="button" class="btn disabled" data-toggle="tooltip" data-placement="top" title="<%= t('schools.meters.index.data_processing_turned_on_message') %>">

--- a/app/views/schools/meters/index.html.erb
+++ b/app/views/schools/meters/index.html.erb
@@ -10,7 +10,7 @@
     <%= render 'admin/shared/dashboard_message', messageable: @school %>
   <% end %>
   <div class="alert alert-secondary mb-2">
-    <% if can?(:validate_meters, @school) && @school.meters_with_readings.any? && 1==2%>
+    <% if can?(:validate_meters, @school) && @school.meters_with_readings.any? %>
       <%= link_to t('schools.meters.index.validate_meter_readings'), school_meter_readings_validation_path(@school), method: :post, class: 'btn' %>
     <% else %>
       <button type="button" class="btn disabled" data-toggle="tooltip" data-placement="top" title="<%= t('schools.meters.index.data_processing_turned_on_message') %>">

--- a/app/views/schools/meters/index.html.erb
+++ b/app/views/schools/meters/index.html.erb
@@ -12,10 +12,16 @@
     <%= render 'admin/shared/dashboard_message', messageable: @school %>
   <% end %>
   <div class="alert alert-secondary mb-2">
-    <%= link_to t('schools.meters.index.school_downloads'), school_downloads_path(@school), class: 'btn' %>
-    <% if can? :manage_solar_feed_configuration, School %>
-    <%= link_to t('schools.meters.index.manage_solar_api_feeds'), school_solar_feeds_configuration_index_path(@school), class: 'btn' %>
+    <% if can?(:validate_meters, @school) && @school.meters_with_readings.any? && @school.process_data? %>
+      <%= link_to t('schools.meters.index.validate_meter_readings'), school_meter_readings_validation_path(@school), method: :post, class: 'btn' %>
     <% end %>
+
+    <%= link_to t('schools.meters.index.school_downloads'), school_downloads_path(@school), class: 'btn' %>
+
+    <% if can? :manage_solar_feed_configuration, School %>
+      <%= link_to t('schools.meters.index.manage_solar_api_feeds'), school_solar_feeds_configuration_index_path(@school), class: 'btn' %>
+    <% end %>
+
     <% if can? :manage, MeterReview %>
       <% if @school.meters.reviewed_dcc_meter %>
         <%= link_to t('schools.meters.index.meter_reviews'), admin_school_meter_reviews_path(@school), class: 'btn' %>
@@ -25,18 +31,6 @@
       <% end %>
     <% end %>
   </div>
-<% end %>
-
-<% if can?(:validate_meters, @school) && @school.meters_with_readings.any? %>
-  <% if @school.process_data? %>
-    <div class="alert alert-secondary mb-2">
-      <%= link_to t('schools.meters.index.validate_meter_readings'), school_meter_readings_validation_path(@school), method: :post, class: 'btn mr-3' %>
-    </div>
-  <% else %>
-    <div class="alert alert-warning mb-2">
-      <%= t('schools.meters.index.data_processing_turned_on_message') %>
-    </div>
-  <% end %>
 <% end %>
 
 <% unless @invalid_mpan.empty? %>

--- a/app/views/schools/meters/index.html.erb
+++ b/app/views/schools/meters/index.html.erb
@@ -10,8 +10,12 @@
     <%= render 'admin/shared/dashboard_message', messageable: @school %>
   <% end %>
   <div class="alert alert-secondary mb-2">
-    <% if can?(:validate_meters, @school) && @school.meters_with_readings.any? && @school.process_data? %>
+    <% if can?(:validate_meters, @school) && @school.meters_with_readings.any? && 1==2%>
       <%= link_to t('schools.meters.index.validate_meter_readings'), school_meter_readings_validation_path(@school), method: :post, class: 'btn' %>
+    <% else %>
+      <button type="button" class="btn disabled" data-toggle="tooltip" data-placement="top" title="<%= t('schools.meters.index.data_processing_turned_on_message') %>">
+        <%= t('schools.meters.index.validate_meter_readings') %>
+      </button>
     <% end %>
 
     <%= link_to t('schools.meters.index.school_downloads'), school_downloads_path(@school), class: 'btn' %>

--- a/app/views/schools/meters/index.html.erb
+++ b/app/views/schools/meters/index.html.erb
@@ -1,9 +1,7 @@
 <div class='d-flex justify-content-between align-items-baseline'>
   <h1><%= t('schools.meters.index.title') %></h1>
-  <% if current_user.admin? && @school&.school_group&.default_issues_admin_user&.present? %>
-    <span class="badge border badge-pill border-secondary font-weight-normal">
-      <%= @school.default_issues_admin_user&.display_name %>
-    </span>
+  <% if current_user.admin? && @school&.school_group %>
+    <%= render 'admin/school_groups/default_issues_admin_user', school_group: @school&.school_group %>
   <% end %>
 </div>
 

--- a/app/views/schools/meters/index.html.erb
+++ b/app/views/schools/meters/index.html.erb
@@ -29,7 +29,6 @@
   <% if @school.process_data? %>
     <div class="alert alert-secondary mb-2">
       <%= link_to t('schools.meters.index.validate_meter_readings'), school_meter_readings_validation_path(@school), method: :post, class: 'btn mr-3' %>
-      <%= t('schools.meters.index.this_may_take_some_time') %>
     </div>
   <% else %>
     <div class="alert alert-warning mb-2">

--- a/app/views/schools/meters/index.html.erb
+++ b/app/views/schools/meters/index.html.erb
@@ -22,9 +22,6 @@
         <%= link_to t('schools.meters.index.review_meters'), new_admin_school_meter_review_path(@school), class: 'btn' %>
       <% end %>
     <% end %>
-    <% if can? :manage, UserTariff %>
-      <%= link_to t('schools.meters.index.manage_tariffs'), school_user_tariffs_path(@school), class: 'btn' %>
-    <% end %>
   </div>
 <% end %>
 

--- a/app/views/schools/meters/index.html.erb
+++ b/app/views/schools/meters/index.html.erb
@@ -17,7 +17,9 @@
     <%= link_to t('schools.meters.index.manage_solar_api_feeds'), school_solar_feeds_configuration_index_path(@school), class: 'btn' %>
     <% end %>
     <% if can? :manage, MeterReview %>
-      <%= link_to t('schools.meters.index.meter_reviews'), admin_school_meter_reviews_path(@school), class: 'btn' %>
+      <% if @school.meters.reviewed_dcc_meter %>
+        <%= link_to t('schools.meters.index.meter_reviews'), admin_school_meter_reviews_path(@school), class: 'btn' %>
+      <% end %>
       <% if @pending_reviews %>
         <%= link_to t('schools.meters.index.review_meters'), new_admin_school_meter_review_path(@school), class: 'btn' %>
       <% end %>

--- a/app/views/schools/meters/index.html.erb
+++ b/app/views/schools/meters/index.html.erb
@@ -1,8 +1,8 @@
 <div class='d-flex justify-content-between align-items-baseline'>
   <h1><%= t('schools.meters.index.title') %></h1>
-  <% if current_user.admin? %>
+  <% if current_user.admin? && @school&.school_group&.default_issues_admin_user&.present? %>
     <span class="badge border badge-pill border-secondary font-weight-normal">
-      <%= @school.default_issues_admin_user.display_name %>
+      <%= @school.default_issues_admin_user&.display_name %>
     </span>
   <% end %>
 </div>

--- a/app/views/schools/meters/index.html.erb
+++ b/app/views/schools/meters/index.html.erb
@@ -1,24 +1,31 @@
-<h1><%= t('schools.meters.index.title') %></h1>
+<div class='d-flex justify-content-between align-items-baseline'>
+  <h1><%= t('schools.meters.index.title') %></h1>
+  <% if current_user.admin? %>
+    <span class="badge border badge-pill border-secondary font-weight-normal">
+      <%= @school.default_issues_admin_user.display_name %>
+    </span>
+  <% end %>
+</div>
 
 <% if current_user.admin? %>
   <% if can? :manage, DashboardMessage %>
     <%= render 'admin/shared/dashboard_message', messageable: @school %>
   <% end %>
-<div class="alert alert-secondary mb-2">
-  <%= link_to t('schools.meters.index.school_downloads'), school_downloads_path(@school), class: 'btn' %>
-  <% if can? :manage_solar_feed_configuration, School %>
-  <%= link_to t('schools.meters.index.manage_solar_api_feeds'), school_solar_feeds_configuration_index_path(@school), class: 'btn' %>
-  <% end %>
-  <% if can? :manage, MeterReview %>
-    <%= link_to t('schools.meters.index.meter_reviews'), admin_school_meter_reviews_path(@school), class: 'btn' %>
-    <% if @pending_reviews %>
-      <%= link_to t('schools.meters.index.review_meters'), new_admin_school_meter_review_path(@school), class: 'btn' %>
+  <div class="alert alert-secondary mb-2">
+    <%= link_to t('schools.meters.index.school_downloads'), school_downloads_path(@school), class: 'btn' %>
+    <% if can? :manage_solar_feed_configuration, School %>
+    <%= link_to t('schools.meters.index.manage_solar_api_feeds'), school_solar_feeds_configuration_index_path(@school), class: 'btn' %>
     <% end %>
-  <% end %>
-  <% if can? :manage, UserTariff %>
-    <%= link_to t('schools.meters.index.manage_tariffs'), school_user_tariffs_path(@school), class: 'btn' %>
-  <% end %>
-</div>
+    <% if can? :manage, MeterReview %>
+      <%= link_to t('schools.meters.index.meter_reviews'), admin_school_meter_reviews_path(@school), class: 'btn' %>
+      <% if @pending_reviews %>
+        <%= link_to t('schools.meters.index.review_meters'), new_admin_school_meter_review_path(@school), class: 'btn' %>
+      <% end %>
+    <% end %>
+    <% if can? :manage, UserTariff %>
+      <%= link_to t('schools.meters.index.manage_tariffs'), school_user_tariffs_path(@school), class: 'btn' %>
+    <% end %>
+  </div>
 <% end %>
 
 <% if can?(:validate_meters, @school) && @school.meters_with_readings.any? %>
@@ -30,20 +37,6 @@
   <% else %>
     <div class="alert alert-warning mb-2">
       <%= t('schools.meters.index.data_processing_turned_on_message') %>
-    </div>
-  <% end %>
-<% end %>
-
-<% if can?(:view_target_data, @school) %>
-  <% if @enough_data_for_targets %>
-    <div class="alert alert-success mb-2">
-      <%= link_to t('schools.meters.index.view_target_data'), admin_school_target_data_path(@school), class: 'btn mr-3' %>
-      <%= t('schools.meters.index.school_enough_data_message') %>
-    </div>
-  <% else %>
-    <div class="alert alert-warning mb-2">
-      <%= link_to t('schools.meters.index.view_target_data'), admin_school_target_data_path(@school), class: 'btn mr-3' %>
-      <%= t('schools.meters.index.school_not_enough_data_message') %>
     </div>
   <% end %>
 <% end %>

--- a/app/views/shared/_manage_school.html.erb
+++ b/app/views/shared/_manage_school.html.erb
@@ -23,6 +23,7 @@
     <%= link_to t('manage_school_menu.manage_school_group'), admin_school_group_path(school.school_group), class: 'dropdown-item' if school.school_group && can?(:manage, school.school_group) %>
     <%= link_to t('manage_school_menu.manage_issues'), admin_school_issues_path(school), class: 'dropdown-item' if can? :manage, Issue %>
     <%= link_to t('manage_school_menu.batch_reports'), school_reports_path(school), class: 'dropdown-item' if can? :view_content_reports, school %>
+    <%= link_to t('schools.meters.index.view_target_data'), admin_school_target_data_path(@school), class: 'dropdown-item' if current_user.admin? %>
     <%= link_to t('manage_school_menu.review_targets'), school_school_targets_path(school), class: 'dropdown-item' if current_user.admin? && Targets::SchoolTargetService.targets_enabled?(school) && can?(:manage, SchoolTarget) && Targets::SchoolTargetService.new(school).enough_data? %>
     <%= link_to t('manage_school_menu.expert_analysis'), admin_school_analysis_path(school), class: 'dropdown-item' if can? :expert_analyse, school %>
     <% if replace_analysis_pages? %>

--- a/config/locales/cy/views/schools/schools.yml
+++ b/config/locales/cy/views/schools/schools.yml
@@ -257,7 +257,6 @@ cy:
         active_pseudo_meters: Mesuryddion ffug gweithredol
         add_meter: Ychwanegu mesurydd
         admin_meter_status: Statws mesurydd gweinyddol
-        data_processing_turned_on_message: Rhaid troi prosesu data ymlaen ar gyfer yr ysgol hon cyn y gellir dilysu darlleniadau mesurydd
         data_source: Ffynhonnell ddata
         details: Manylion
         first: Cyntaf

--- a/config/locales/cy/views/schools/schools.yml
+++ b/config/locales/cy/views/schools/schools.yml
@@ -278,8 +278,6 @@ cy:
         report: Adrodd
         review_meters: Adolygu mesuryddion
         school_downloads: Lawrlwythiadau ysgol
-        school_enough_data_message: Mae gan yr ysgol hon ddigon o ddata ar gyfer o leiaf un math o danwydd i gynhyrchu targedau
-        school_not_enough_data_message: Nid oes gan yr ysgol hon ddigon o ddata i gynhyrchu targedau
         this_may_take_some_time: Gall hyn gymryd peth amser!
         title: Mesuryddion
         validate_meter_readings: Dilysu darlleniadau mesurydd

--- a/config/locales/cy/views/schools/schools.yml
+++ b/config/locales/cy/views/schools/schools.yml
@@ -266,7 +266,6 @@ cy:
         large_gaps: Bylchau mawr
         latest: Diweddaraf
         manage_solar_api_feeds: Rheoli ffrydiau API Solar
-        manage_tariffs: Rheoli tariffau
         meter: Mesurydd
         meter_reviews: Adolygiadau mesurydd
         mpan_warning_message: Mae yna fesuryddion trydan gydag MPAN nad yw'n ymddangos bod ganddynt y digid gwirio cywir
@@ -278,7 +277,6 @@ cy:
         report: Adrodd
         review_meters: Adolygu mesuryddion
         school_downloads: Lawrlwythiadau ysgol
-        this_may_take_some_time: Gall hyn gymryd peth amser!
         title: Mesuryddion
         validate_meter_readings: Dilysu darlleniadau mesurydd
         validated: Dilyswyd

--- a/config/locales/cy/views/schools/schools.yml
+++ b/config/locales/cy/views/schools/schools.yml
@@ -257,6 +257,7 @@ cy:
         active_pseudo_meters: Mesuryddion ffug gweithredol
         add_meter: Ychwanegu mesurydd
         admin_meter_status: Statws mesurydd gweinyddol
+        data_processing_turned_on_message: Rhaid troi prosesu data ymlaen ar gyfer yr ysgol hon cyn y gellir dilysu darlleniadau mesurydd
         data_source: Ffynhonnell ddata
         details: Manylion
         first: Cyntaf

--- a/config/locales/views/schools/schools.yml
+++ b/config/locales/views/schools/schools.yml
@@ -279,8 +279,6 @@ en:
         report: Report
         review_meters: Review meters
         school_downloads: School downloads
-        school_enough_data_message: This school has enough data for at least one fuel type to generate targets
-        school_not_enough_data_message: This school does not have enough data to generate targets
         this_may_take_some_time: This may take some time!
         title: Manage meters
         validate_meter_readings: Validate meter readings

--- a/config/locales/views/schools/schools.yml
+++ b/config/locales/views/schools/schools.yml
@@ -268,7 +268,7 @@ en:
         latest: Latest
         manage_solar_api_feeds: Manage Solar API feeds
         meter: Meter
-        meter_reviews: Meter reviews
+        meter_reviews: Completed DCC meter reviews
         mpan_warning_message: There are electricity meters with MPANs that don't appear to have the correct check digit
         name: Name
         no_active_meters: No active meters

--- a/config/locales/views/schools/schools.yml
+++ b/config/locales/views/schools/schools.yml
@@ -258,7 +258,6 @@ en:
         active_pseudo_meters: Active pseudo meters
         add_meter: Add meter
         admin_meter_status: Admin meter status
-        data_processing_turned_on_message: Data processing must be turned on for this school before meter readings can be validated
         data_source: Data source
         details: Details
         first: First

--- a/config/locales/views/schools/schools.yml
+++ b/config/locales/views/schools/schools.yml
@@ -267,7 +267,6 @@ en:
         large_gaps: Large gaps
         latest: Latest
         manage_solar_api_feeds: Manage Solar API feeds
-        manage_tariffs: Manage tariffs
         meter: Meter
         meter_reviews: Meter reviews
         mpan_warning_message: There are electricity meters with MPANs that don't appear to have the correct check digit
@@ -277,9 +276,8 @@ en:
         procurement_route: Procurement route
         readings: Readings
         report: Report
-        review_meters: Review meters
+        review_meters: Pending DCC meter reviews
         school_downloads: School downloads
-        this_may_take_some_time: This may take some time!
         title: Manage meters
         validate_meter_readings: Validate meter readings
         validated: Validated

--- a/config/locales/views/schools/schools.yml
+++ b/config/locales/views/schools/schools.yml
@@ -282,7 +282,7 @@ en:
         school_enough_data_message: This school has enough data for at least one fuel type to generate targets
         school_not_enough_data_message: This school does not have enough data to generate targets
         this_may_take_some_time: This may take some time!
-        title: Meters
+        title: Manage meters
         validate_meter_readings: Validate meter readings
         validated: Validated
         validated_readings: Validated Readings

--- a/config/locales/views/schools/schools.yml
+++ b/config/locales/views/schools/schools.yml
@@ -258,6 +258,7 @@ en:
         active_pseudo_meters: Active pseudo meters
         add_meter: Add meter
         admin_meter_status: Admin meter status
+        data_processing_turned_on_message: Data processing must be turned on for this school before meter readings can be validated
         data_source: Data source
         details: Details
         first: First

--- a/spec/models/meter_spec.rb
+++ b/spec/models/meter_spec.rb
@@ -24,15 +24,37 @@ describe 'Meter', :meters do
     end
 
     context 'when finding meters for consent' do
-      let!(:meter_review) { create(:meter_review) }
-      let!(:electricity_meter_reviewed) { create(:electricity_meter, dcc_meter: true, meter_review: meter_review, mpan_mprn: 1234567890111) }
-      let!(:electricity_meter_not_reviewed) { create(:electricity_meter, dcc_meter: true, mpan_mprn: 1234567890222) }
-      let!(:electricity_meter_not_dcc) { create(:electricity_meter, dcc_meter: false, mpan_mprn: 1234567890333) }
-      let!(:electricity_meter_consent_granted_already) { create(:electricity_meter, dcc_meter: true, consent_granted: true, mpan_mprn: 1234567890444) }
+      let(:meter_review) { create(:meter_review) }
+      let(:electricity_meter_reviewed) { create(:electricity_meter, dcc_meter: true, meter_review: meter_review, mpan_mprn: 1234567890111) }
+      let(:electricity_meter_not_reviewed) { create(:electricity_meter, dcc_meter: true, mpan_mprn: 1234567890222, meter_review_id: nil, consent_granted: false) }
+      let(:electricity_meter_not_dcc) { create(:electricity_meter, dcc_meter: false, mpan_mprn: 1234567890333) }
+      let(:electricity_meter_consent_granted_already) { create(:electricity_meter, dcc_meter: true, consent_granted: true, mpan_mprn: 1234567890444) }
 
       it 'awaiting_trusted_consent is only dcc meters with reviews' do
         expect(Meter.awaiting_trusted_consent).to match_array([electricity_meter_reviewed])
       end
+    end
+
+    context 'when finding meters for review' do
+      let(:meter_review) { create(:meter_review) }
+      let(:electricity_meter_reviewed) { create(:electricity_meter, dcc_meter: true, meter_review: meter_review, mpan_mprn: 1234567890111) }
+      let(:electricity_meter_not_reviewed) { create(:electricity_meter, dcc_meter: true, mpan_mprn: 1234567890222, meter_review_id: nil, consent_granted: false) }
+      let(:electricity_meter_not_dcc) { create(:electricity_meter, dcc_meter: false, mpan_mprn: 1234567890333) }
+      let(:electricity_meter_consent_granted_already) { create(:electricity_meter, dcc_meter: true, consent_granted: true, mpan_mprn: 1234567890444) }
+
+      it 'returns a collection of reviewed meters' do
+        expect(Meter.reviewed_dcc_meter).to match_array([electricity_meter_reviewed])
+      end
+
+      it 'returns a collection of unreviewed meters' do
+        expect(Meter.unreviewed_dcc_meter).to match_array([electricity_meter_not_reviewed])
+      end
+    end
+  end
+
+  describe '#reviewed_dcc_meter' do
+    it 'returns a collection of reviewed meters' do
+
     end
   end
 

--- a/spec/models/meter_spec.rb
+++ b/spec/models/meter_spec.rb
@@ -52,12 +52,6 @@ describe 'Meter', :meters do
     end
   end
 
-  describe '#reviewed_dcc_meter' do
-    it 'returns a collection of reviewed meters' do
-
-    end
-  end
-
   describe 'valid?' do
     describe 'mpan_mprn' do
       context 'with an electricity meter' do

--- a/spec/system/admin/meter_reviews/meter_reviews_spec.rb
+++ b/spec/system/admin/meter_reviews/meter_reviews_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe 'meter_reviews', type: :system do
     context 'when viewing meters for school' do
       it 'displays a link to perform a review' do
         visit school_meters_path(school)
-        expect(page).to have_link("Review meters", href: new_admin_school_meter_review_path(school))
+        expect(page).to have_link("Pending DCC meter reviews", href: new_admin_school_meter_review_path(school))
       end
     end
   end
@@ -215,12 +215,13 @@ RSpec.describe 'meter_reviews', type: :system do
     end
 
     context 'when viewing meters' do
+      let(:meter_review) { create(:meter_review) }
+      let(:electricity_meter_reviewed) { create(:electricity_meter, dcc_meter: true, meter_review: meter_review, mpan_mprn: 1234567890111, school: school) }
+
       it 'provides a link to meter reviews' do
         visit school_meters_path(school)
-        expect(page).to have_link("Meter reviews", href: admin_school_meter_reviews_path(school) )
+        expect(page).to have_link("Completed DCC meter reviews", href: admin_school_meter_reviews_path(school) )
       end
     end
   end
-
-
 end

--- a/spec/system/admin/school_creation_spec.rb
+++ b/spec/system/admin/school_creation_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe "school creation", :schools, type: :system do
     click_on 'Next'
 
     expect(page).to have_content("St Mary's School")
-    expect(page).to have_content("Meters")
+    expect(page).to have_content("Manage meters")
 
     school = School.where(urn: '4444244').first
     expect(school.key_stages).to match_array([ks1])

--- a/spec/system/meter_management_spec.rb
+++ b/spec/system/meter_management_spec.rb
@@ -346,9 +346,6 @@ RSpec.describe "meter management", :meters, type: :system, include_application_h
           click_on 'Manage meters'
         end
 
-        it 'should say' do
-          expect(page).to have_content("This school has enough data for at least one fuel type to generate targets")
-        end
         it 'should link to detail' do
           expect(page).to have_link("View target data", href: admin_school_target_data_path(school))
         end
@@ -358,10 +355,6 @@ RSpec.describe "meter management", :meters, type: :system, include_application_h
         before(:each) do
           allow_any_instance_of(Targets::SchoolTargetService).to receive(:enough_data?).and_return(false)
           click_on 'Manage meters'
-        end
-
-        it 'should say' do
-          expect(page).to have_content("This school does not have enough data to generate targets")
         end
 
         it 'should link to detail' do

--- a/spec/system/schools/user_tariffs_spec.rb
+++ b/spec/system/schools/user_tariffs_spec.rb
@@ -17,9 +17,8 @@ describe 'user tariffs', type: :system do
     context 'has navigation links' do
       it 'from meters page to user tariffs index' do
         visit school_meters_path(school)
-        within '.application' do
-          click_link('Manage tariffs')
-        end
+        click_link('Manage School')
+        click_link('Manage tariffs')
         expect(page).to have_content(I18n.t('schools.user_tariffs.index.title'))
         expect(page).to have_link('cost analysis pages')
       end


### PR DESCRIPTION
This PR covers a number of small cosmetic changes to the meters index page to tidy up the page for admin users:

- [x] Changes the heading on the page to “Manage meters”
- [x] Adds the name of the default issues admin for the school group (similar to what is now on the admin school group page) appearing for Energy Sparks admins only.
- [x] Removes the “View target data” section, replacing it with a “View target data” link in the admin section of the Manage School menu
- [x] Removes the “Manage tariffs” button from the page, as there’s an link in the Manage school menu
- [x] Changes the text on the “Review meters” button (which links to new_admin_school_meter_review_path) to be “Pending DCC meter reviews”
- [x] Changes the text on the “Meter reviews” button (which links to admin_school_meter_reviews_path) to be “Completed DCC meter reviews”
- [x] Changes the “Completed DCC meter reviews” button so it only appear is there are any completed meter reviews
- [x] Combines the remaining options in the alert `alert-secondary mb-2` sections (the grey notices) into a single grey bar. Ordered as: Validate meter readings, School downloads, Manage Solar API feeds, Pending DCC meter reviews, Completed DCC meter reviews. 
- [x] Removes the “This may take some time!” warning