### PR TITLE
N3rgy tooling

### DIFF
--- a/app/controllers/admin/reports/dcc_status_controller.rb
+++ b/app/controllers/admin/reports/dcc_status_controller.rb
@@ -1,8 +1,21 @@
 module Admin
   module Reports
     class DccStatusController < AdminController
+      before_action :set_consented_mpxns
+
       def index
-        @dcc_meters = Meter.dcc.sort_by(&:school)
+        @dcc_meters = Meter.dcc.where.not(sandbox: true).sort_by(&:school)
+        @schools = @dcc_meters.map(&:school).uniq
+      end
+
+      private
+
+      def set_consented_mpxns
+        @mpxns = MeterReadingsFeeds::N3rgy.new(api_key: ENV["N3RGY_API_KEY"], production: true).mpxns
+        @consent_lookup_error = false
+      rescue
+        @mpxns = []
+        @consent_lookup_error = true
       end
     end
   end

--- a/app/controllers/schools/meters_controller.rb
+++ b/app/controllers/schools/meters_controller.rb
@@ -22,7 +22,10 @@ module Schools
     def show
       manager = MeterManagement.new(@meter)
       @n3rgy_status = manager.check_n3rgy_status
-      @elements = manager.elements
+      if @n3rgy_status == :available
+        @n3rgy_consent_confirmed = manager.n3rgy_consented?
+        @available_cache_range = manager.available_cache_range
+      end
       respond_to do |format|
         format.html
         format.csv { send_data readings_to_csv(AmrValidatedReading.download_query_for_meter(@meter), AmrValidatedReading::CSV_HEADER_FOR_METER), filename: "meter-amr-readings-#{@meter.mpan_mprn}.csv" }

--- a/app/helpers/meters_helper.rb
+++ b/app/helpers/meters_helper.rb
@@ -1,0 +1,11 @@
+module MetersHelper
+  def consented_in_n3rgy?(list_of_consented_mpans, meter)
+    return nil if list_of_consented_mpans.empty?
+    list_of_consented_mpans.include? meter.mpan_mprn
+  end
+
+  def highlight_consent_mismatch?(list_of_consented_mpans, meter)
+    return false if list_of_consented_mpans.empty?
+    !meter.sandbox && meter.consent_granted && !consented_in_n3rgy?(list_of_consented_mpans, meter)
+  end
+end

--- a/app/views/admin/reports/dcc_status/index.html.erb
+++ b/app/views/admin/reports/dcc_status/index.html.erb
@@ -42,7 +42,7 @@
 
     <tbody>
       <% @dcc_meters.each do |meter| %>
-        <tr class="<%= highlight_consent_mismatch?(@mpxns, meter) ? 'bg-warning' : '' %>">
+        <tr class="<%= highlight_consent_mismatch?(@mpxns, meter) ? 'bg-danger text-white' : '' %>">
           <td><%= link_to meter.school.name, school_meters_path(meter.school) %></td>
           <td><%= link_to meter.name, school_meter_path(meter.school, meter) %></td>
           <td><%= meter.mpan_mprn %></td>

--- a/app/views/admin/reports/dcc_status/index.html.erb
+++ b/app/views/admin/reports/dcc_status/index.html.erb
@@ -44,7 +44,7 @@
       <% @dcc_meters.each do |meter| %>
         <tr class="<%= highlight_consent_mismatch?(@mpxns, meter) ? 'bg-danger text-white' : '' %>">
           <td><%= link_to meter.school.name, school_meters_path(meter.school) %></td>
-          <td><%= link_to meter.name, school_meter_path(meter.school, meter) %></td>
+          <td><%= link_to meter.name_or_mpan_mprn, school_meter_path(meter.school, meter) %></td>
           <td><%= meter.mpan_mprn %></td>
           <td><%= meter.meter_type %></td>
           <td><%= meter.active %></td>

--- a/app/views/admin/reports/dcc_status/index.html.erb
+++ b/app/views/admin/reports/dcc_status/index.html.erb
@@ -8,7 +8,20 @@
   </div>
 </div>
 
-<p>There are currently <%= @dcc_meters.count %> DCC meters in the system.</p>
+<h2>DCC Meter Summary</h2>
+
+<p>There are currently <strong><%= @dcc_meters.count %></strong> DCC meters in the system, across <strong><%= @schools.count %> schools</strong>.</p>
+
+<p>This table summarises the current status of all the DCC meters in the system. For a list of MPANs that n3rgy believe we can access, see <a href="#n3rgy-mpans">the following table</a></p>
+
+<p>
+  If a meter is shown as "Consented?" then we have informed n3rgy that we have been given consent, and are expecting to be able to receive data. We only set this value to true if we have successfully updated n3rgy.
+</p>
+
+<p>
+  The "Consent Confirmed?" column indicates whether n3rgy has recorded that we currently have
+  consent to access  meter. If there's a discrepancy then there has been a problem at their end.
+</p>
 
 <% if @dcc_meters.any? %>
   <table class="table table-condensed table-sorted">
@@ -20,6 +33,7 @@
         <th>Type</th>
         <th>Active?</th>
         <th>Consented?</th>
+        <th>Consent confirmed?</th>
         <th>Earliest validated</th>
         <th>Latest validated</th>
         <th class="data-orderable">Issues</th>
@@ -28,13 +42,14 @@
 
     <tbody>
       <% @dcc_meters.each do |meter| %>
-        <tr>
+        <tr class="<%= highlight_consent_mismatch?(@mpxns, meter) ? 'bg-warning' : '' %>">
           <td><%= link_to meter.school.name, school_meters_path(meter.school) %></td>
           <td><%= link_to meter.name, school_meter_path(meter.school, meter) %></td>
           <td><%= meter.mpan_mprn %></td>
           <td><%= meter.meter_type %></td>
           <td><%= meter.active %></td>
           <td><%= meter.consent_granted %></td>
+          <td><%= consented_in_n3rgy?(@mpxns, meter) %></td>
           <td><%= meter.first_validated_reading %></td>
           <td><%= meter.last_validated_reading %></td>
           <td>
@@ -46,4 +61,19 @@
       <% end %>
     </tbody>
   </table>
+<% end %>
+
+<h2 id="n3rgy-mpans">N3rgy Consented MPANs</h2>
+
+<p>The n3rgy API is currently reporting that we have access to the following <%= @mpxns.size %> MPANs on their
+production system</p>
+
+<% if @consent_lookup_error %>
+  <p>There was an error looking up the list of consented mpans</p>
+<% else %>
+  <ul>
+    <% @mpxns.sort.each do |mpan| %>
+      <li><%= mpan %></li>
+    <% end %>
+  </ul>
 <% end %>

--- a/app/views/schools/meters/_form.html.erb
+++ b/app/views/schools/meters/_form.html.erb
@@ -67,7 +67,6 @@
       </div>
 
       <div class="form-group">
-        <%= meter.earliest_available_data %>
         <%= form.label :earliest_available_data, t('schools.meters.form.earliest_available_data') %>
         <%= component 'date_picker_form', form: form, field_name: :earliest_available_data, value: meter.earliest_available_data&.strftime('%d/%m/%Y') %>
       </div>

--- a/app/views/schools/meters/show.html.erb
+++ b/app/views/schools/meters/show.html.erb
@@ -9,7 +9,7 @@
 </div>
 
 <div class="mb-2 alert alert-secondary row">
-  <div class="col-md-6">
+  <div class="col-md-5">
     <%= link_to "#{fa_icon('file-download')} #{t('schools.meters.show.download_readings')}".html_safe, school_meter_path(@school, @meter, format: "csv"), class: 'btn btn-info btn-sm' if @meter.amr_validated_readings.any? %>
     <%= link_to t('common.labels.edit'), edit_school_meter_path(@school, @meter), class: 'btn btn-sm btn-warning' %>
     <% if can?(:report_on, @meter) && @meter.amr_validated_readings.any? %>
@@ -25,7 +25,7 @@
     <% end %>
     <%= render 'admin/issues/modal', label: t("schools.meters.meter_issues.button_label"), meter: @meter if current_user.admin? %>
   </div>
-  <div class="col-md-6">
+  <div class="col-md-7">
     <% if @meter.dcc_meter? %>
       <% if @meter.can_withdraw_consent? && can?(:withdraw_consent, @meter) %>
         <%= link_to t('schools.meters.show.withdraw_consent'), admin_withdraw_dcc_consent_path(mpxn: @meter.mpan_mprn), method: :post, class: 'btn btn-info btn-sm' %>
@@ -44,7 +44,7 @@
 </div>
 
 <div class="row">
-  <div class="col-md-6">
+  <div class="col-md-5">
     <h3><%= t('schools.meters.show.basic_information') %></h3>
     <dl class="row">
       <% if current_user.admin? %>
@@ -65,24 +65,24 @@
       <dd class="col-sm-9"><%= nice_date_times @meter.updated_at %></dd>
     </dl>
   </div>
-  <div class="col-md-6">
+  <div class="col-md-7">
     <h3><%= t('schools.meters.show.dcc_information') %></h3>
     <% if @meter.dcc_meter? %>
       <dl class="row">
         <dt class="col-sm-3"><%= t('schools.meters.show.dcc_last_checked') %></dt>
         <dd class="col-sm-9"><%= nice_date_times @meter.dcc_checked_at %></dd>
-        <dt class="col-sm-3"><%= t('schools.meters.show.sandbox') %>?</dt>
-        <dd class="col-sm-9"><%= @meter.sandbox? %></dd>
         <dt class="col-sm-3"><%= t('schools.meters.show.n3rgy_api_status') %></dt>
-        <dd class="col-sm-9"><%= @n3rgy_status %></dd>
+        <dd class="col-sm-9"><%= @n3rgy_status.to_s.humanize %></dd>
         <dt class="col-sm-3"><%= t('schools.meters.show.user_consented') %>?</dt>
         <dd class="col-sm-9"><%= @meter.meter_review.present? %></dd>
         <dt class="col-sm-3"><%= t('schools.meters.show.dcc_consented') %>?</dt>
         <dd class="col-sm-9"><%= @meter.consent_granted? %></dd>
-        <dt class="col-sm-3"><%= t('schools.meters.show.earliest_available_data') %></dt>
-        <dd class="col-sm-9"><%= @meter.earliest_available_data %></dd>
-        <dt class="col-sm-3"><%= t('schools.meters.show.meter_elements') %></dt>
-        <dd class="col-sm-9"><%= @elements %></dd>
+        <dt class="col-sm-3"><%= t('schools.meters.show.n3rgy_consent_confirmed') %>?</dt>
+        <dd class="col-sm-9"><%= @n3rgy_consent_confirmed %></dd>
+        <dt class="col-sm-3"><%= t('schools.meters.show.available_cache_range') %></dt>
+        <dd class="col-sm-9"><%= @available_cache_range %></dd>
+        <dt class="col-sm-3"><%= t('schools.meters.show.sandbox') %>?</dt>
+        <dd class="col-sm-9"><%= @meter.sandbox? %></dd>
       </dl>
     <% else %>
       <p><%= t('schools.meters.show.not_configured_as_a_dcc_meter') %></p>

--- a/config/locales/cy/views/schools/schools.yml
+++ b/config/locales/cy/views/schools/schools.yml
@@ -301,11 +301,9 @@ cy:
         dcc_information: Gwybodaeth DCC
         dcc_last_checked: Gwiriwyd DCC ddiwethaf
         download_readings: Darlleniadau
-        earliest_available_data: Data Cynharaf Sydd Ar Gael
         grant_consent: Rhoi caniatâd
         inventory: Stocrestr
         meter: Mesurydd
-        meter_elements: Elfennau Mesurydd
         n3rgy_api_status: Statws API n3rgy
         not_configured_as_a_dcc_meter: Heb ei ffurfweddu fel mesurydd DCC
         sandbox: Blwch tywod

--- a/config/locales/views/schools/schools.yml
+++ b/config/locales/views/schools/schools.yml
@@ -296,11 +296,12 @@ en:
         no_meter_issues: No issues or notes for meter
         title: Meter Issues & Notes - %{name}
       show:
+        available_cache_range: Available date range
         basic_information: Basic information
         data_source: Data source
         dcc_consented: DCC Consented
-        dcc_information: DCC information
-        dcc_last_checked: DCC last checked
+        dcc_information: DCC (SMETS2) information
+        dcc_last_checked: Last automated check
         download_readings: Readings
         earliest_available_data: Earliest Available Data
         grant_consent: Grant consent
@@ -308,13 +309,14 @@ en:
         meter: Meter
         meter_elements: Meter Elements
         n3rgy_api_status: n3rgy API Status
+        n3rgy_consent_confirmed: n3rgy Confirm Consented
         not_configured_as_a_dcc_meter: Not configured as a DCC meter
-        sandbox: Sandbox
+        sandbox: Sandbox (test meter)
         school_meter_management: School meter management
         serial_number: Serial Number
         tariff_report: Tariff Report
         title: "%{meter_name} (%{meter_mpan_mprn})"
-        user_consented: User Consented
+        user_consented: User has consented
         withdraw_consent: Withdraw consent
     observations:
       timeline:

--- a/config/locales/views/schools/schools.yml
+++ b/config/locales/views/schools/schools.yml
@@ -303,11 +303,9 @@ en:
         dcc_information: DCC (SMETS2) information
         dcc_last_checked: Last automated check
         download_readings: Readings
-        earliest_available_data: Earliest Available Data
         grant_consent: Grant consent
         inventory: Inventory
         meter: Meter
-        meter_elements: Meter Elements
         n3rgy_api_status: n3rgy API Status
         n3rgy_consent_confirmed: n3rgy Confirm Consented
         not_configured_as_a_dcc_meter: Not configured as a DCC meter

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -247,6 +247,7 @@ Rails.application.routes.draw do
       resources :meters do
         member do
           get :inventory
+          get :n3rgy_status
           put :activate
           put :deactivate
         end

--- a/spec/services/meter_management_spec.rb
+++ b/spec/services/meter_management_spec.rb
@@ -88,21 +88,18 @@ describe MeterManagement do
     let(:n3rgy_api)         { double(:n3rgy_api) }
     let(:n3rgy_api_factory) { double(:n3rgy_api_factory, data_api: n3rgy_api) }
 
-    it "shows existing dcc meters" do
+    it "returns api status" do
       meter = create(:electricity_meter)
-      expect(n3rgy_api).to receive(:find).with(meter.mpan_mprn).and_return(true)
-      expect( MeterManagement.new(meter, n3rgy_api_factory: n3rgy_api_factory).check_n3rgy_status ).to eql(true)
-    end
+      expect(n3rgy_api).to receive(:status).with(meter.mpan_mprn).and_return(:available)
+      expect( MeterManagement.new(meter, n3rgy_api_factory: n3rgy_api_factory).check_n3rgy_status ).to eql(:available)
 
-    it "does not show non-existent dcc meters" do
-      meter = create(:electricity_meter)
-      expect(n3rgy_api).to receive(:find).with(meter.mpan_mprn).and_return(false)
-      expect( MeterManagement.new(meter, n3rgy_api_factory: n3rgy_api_factory).check_n3rgy_status ).to eql(false)
+      expect(n3rgy_api).to receive(:status).with(meter.mpan_mprn).and_return(:unknown)
+      expect( MeterManagement.new(meter, n3rgy_api_factory: n3rgy_api_factory).check_n3rgy_status ).to eql(:unknown)
     end
 
     it "handles API errors" do
       meter = create(:electricity_meter)
-      allow(n3rgy_api).to receive(:find).with(meter.mpan_mprn).and_raise(StandardError)
+      allow(n3rgy_api).to receive(:status).with(meter.mpan_mprn).and_raise(StandardError)
       expect( MeterManagement.new(meter, n3rgy_api_factory: n3rgy_api_factory).check_n3rgy_status ).to eql(:api_error)
     end
   end

--- a/spec/system/meter_management_spec.rb
+++ b/spec/system/meter_management_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe "meter management", :meters, type: :system, include_application_h
     context 'when the school has a DCC meter' do
       let!(:meter) { create(:electricity_meter, dcc_meter: true, name: 'Electricity meter', school: school, mpan_mprn: 1234567890123 ) }
 
-      let!(:data_api) { double(find: true, inventory: {device_id: 123999}, elements: [1]) }
+      let!(:data_api) { double(status: :available, readings_available_date_range: Date.today..Date.today) }
 
       before(:each) do
         allow_any_instance_of(Amr::N3rgyApiFactory).to receive(:data_api).with(meter).and_return(data_api)
@@ -207,14 +207,20 @@ RSpec.describe "meter management", :meters, type: :system, include_application_h
 
     context 'when the school has a DCC meter' do
       let!(:meter) { create(:electricity_meter, dcc_meter: true, name: 'Electricity meter', school: school, mpan_mprn: 1234567890123 ) }
-      let!(:data_api) { double(find: true, inventory: {device_id: 123999}, elements: [1]) }
+      let!(:data_api) { double(status: :available, inventory: {device_id: 123999}, readings_available_date_range: Date.today..Date.today) }
 
       before(:each) do
         allow_any_instance_of(Amr::N3rgyApiFactory).to receive(:data_api).with(meter).and_return(data_api)
+        click_on 'Manage meters'
+      end
+
+      it 'shows the status and dates' do
+        click_on meter.mpan_mprn.to_s
+        expect(page).to have_content("Available")
+        expect(page).to have_content(Date.today.iso8601)
       end
 
       it 'the meter inventory button can be shown' do
-        click_on 'Manage meters'
         click_on meter.mpan_mprn.to_s
         click_on 'Inventory'
         expect(page).to have_content('device_id')
@@ -222,21 +228,18 @@ RSpec.describe "meter management", :meters, type: :system, include_application_h
       end
 
       it 'the tariff report can be shown' do
-        click_on 'Manage meters'
         click_on meter.mpan_mprn.to_s
         click_on 'Tariff Report'
         expect(page).to have_content("Standing charges")
       end
 
       it 'the single meter attributes view can be shown' do
-        click_on 'Manage meters'
         click_on meter.mpan_mprn.to_s
         click_on 'Attributes'
         expect(page).to have_content("Individual Meter attributes")
       end
 
       it 'the dcc checkboxes and status are shown on the edit form' do
-        click_on 'Manage meters'
         click_on 'Edit'
         check "DCC Smart Meter"
         check "Sandbox"
@@ -247,7 +250,7 @@ RSpec.describe "meter management", :meters, type: :system, include_application_h
     end
 
     context 'when creating meters' do
-      let!(:data_api) { double(find: true, inventory: {device_id: 123999}, elements: [1]) }
+      let!(:data_api) { double(status: :available, inventory: {device_id: 123999}) }
 
       before(:each) do
         allow_any_instance_of(Amr::N3rgyApiFactory).to receive(:data_api).and_return(data_api)


### PR DESCRIPTION
This PR has some improvements to our admin pages to help to support debugging and investigation of issues with n3rgy meters.

This includes improvements to the dcc meter report to list:

* ignore sandbox meters
* include number of schools with meters
* add a check to see if n3rgy think the meter has been consented
* include a list of the mpans that n3rgy think are consented

And some changes to the meter page for admins:

* Remove the "elements" data
* Remove the "earliest available date" field as its unused
* Improve some of the labelling to explain fields
* Show the symbol describing the status of the meter in n3rgy, rather than just a true/false flag
* Check to see if the mpan_mprn is in the list of consented meters in n3rgy
* Include the available date range