### PR TITLE
Fix bug with n3rgy status check

### DIFF
--- a/app/controllers/schools/meters_controller.rb
+++ b/app/controllers/schools/meters_controller.rb
@@ -20,12 +20,7 @@ module Schools
     end
 
     def show
-      manager = MeterManagement.new(@meter)
-      @n3rgy_status = manager.check_n3rgy_status
-      if @n3rgy_status == :available
-        @n3rgy_consent_confirmed = manager.n3rgy_consented?
-        @available_cache_range = manager.available_cache_range
-      end
+      set_n3rgy_status
       respond_to do |format|
         format.html
         format.csv { send_data readings_to_csv(AmrValidatedReading.download_query_for_meter(@meter), AmrValidatedReading::CSV_HEADER_FOR_METER), filename: "meter-amr-readings-#{@meter.mpan_mprn}.csv" }
@@ -83,6 +78,17 @@ module Schools
     end
 
   private
+
+    def set_n3rgy_status
+      return unless can?(:view_dcc_data, @school)
+      manager = MeterManagement.new(@meter)
+      @known_to_n3rgy = manager.is_meter_known_to_n3rgy?
+      if @known_to_n3rgy && @meter.dcc_meter
+        @n3rgy_status = manager.check_n3rgy_status
+        @n3rgy_consent_confirmed = manager.n3rgy_consented?
+        @available_cache_range = manager.available_cache_range if @n3rgy_status == :available
+      end
+    end
 
     def set_breadcrumbs
       @breadcrumbs = [{ name: I18n.t('manage_school_menu.manage_meters') }]

--- a/app/services/meter_management.rb
+++ b/app/services/meter_management.rb
@@ -14,28 +14,37 @@ class MeterManagement
     mpxns = MeterReadingsFeeds::N3rgy.new(api_key: ENV["N3RGY_API_KEY"], production: true).mpxns
     mpxns.include? @meter.mpan_mprn
   rescue => e
-    Rails.logger.error "Exception: checking consented status of meter #{@meter.mpan_mprn} : #{e.class} #{e.message}"
-    Rails.logger.error e.backtrace.join("\n")
-    Rollbar.error(e)
-    return [:api_error]
+    Rails.logger.warn "Error fetching list of consented mpans #{e.class} #{e.message}"
+    Rails.logger.warn e.backtrace.join("\n")
+    Rollbar.warning(e)
+    return nil
   end
 
   def available_cache_range
     return [] unless @meter.dcc_meter?
     @n3rgy_api_factory.data_api(@meter).readings_available_date_range(@meter.mpan_mprn, @meter.fuel_type)
   rescue => e
-    Rails.logger.error "Exception: checking available date range of meter #{@meter.mpan_mprn} : #{e.class} #{e.message}"
-    Rails.logger.error e.backtrace.join("\n")
-    Rollbar.error(e)
+    Rails.logger.warn "Error fetching available cache range for #{@meter.mpan_mprn} #{e.class} #{e.message}"
+    Rails.logger.warn e.backtrace.join("\n")
+    Rollbar.warning(e, meter: @meter.id, mpan: @meter.mpan_mprn)
     return [:api_error]
+  end
+
+  def is_meter_known_to_n3rgy?
+    @n3rgy_api_factory.data_api(@meter).find(@meter.mpan_mprn)
+  rescue => e
+    Rails.logger.warn "Error looking up #{@meter.mpan_mprn} #{e.class} #{e.message}"
+    Rails.logger.warn e.backtrace.join("\n")
+    Rollbar.warning(e, meter: @meter.id, mpan: @meter.mpan_mprn)
+    return false
   end
 
   def check_n3rgy_status
     @n3rgy_api_factory.data_api(@meter).status(@meter.mpan_mprn)
   rescue => e
-    Rails.logger.error "Exception: checking status of meter #{@meter.mpan_mprn} : #{e.class} #{e.message}"
-    Rails.logger.error e.backtrace.join("\n")
-    Rollbar.error(e)
+    Rails.logger.warn "Error checking status of #{@meter.mpan_mprn} #{e.class} #{e.message}"
+    Rails.logger.warn e.backtrace.join("\n")
+    Rollbar.warning(e, meter: @meter.id, mpan: @meter.mpan_mprn)
     return :api_error
   end
 
@@ -43,9 +52,9 @@ class MeterManagement
     return nil unless @meter.dcc_meter?
     @n3rgy_api_factory.data_api(@meter).elements(@meter.mpan_mprn, @meter.meter_type)
   rescue => e
-    Rails.logger.error "Exception: checking elements of meter #{@meter.mpan_mprn} : #{e.class} #{e.message}"
-    Rails.logger.error e.backtrace.join("\n")
-    Rollbar.error(e)
+    Rails.logger.warn "Exception: checking elements of meter #{@meter.mpan_mprn} : #{e.class} #{e.message}"
+    Rails.logger.warn e.backtrace.join("\n")
+    Rollbar.warning(e)
     return :api_error
   end
 

--- a/app/services/meter_review_service.rb
+++ b/app/services/meter_review_service.rb
@@ -31,14 +31,12 @@ class MeterReviewService
     raise MeterReviewError.new("You must select at least one meter") if meters.empty?
     meters.each do |meter|
       raise MeterReviewError.new("#{meter.mpan_mprn} is not a DCC meter") unless meter.dcc_meter?
-      raise MeterReviewError.new("#{meter.mpan_mprn} not found in DCC api") unless valid_status(meter)
+      raise MeterReviewError.new("#{meter.mpan_mprn} not found in DCC api") unless is_meter_known_to_n3rgy?(meter)
     end
   end
 
-  def valid_status(meter)
-    # NB check_n3rgy_status may return :api_error symbol,
-    # which evaluates as true if you're not careful..
-    MeterManagement.new(meter).check_n3rgy_status == true
+  def is_meter_known_to_n3rgy?(meter)
+    MeterManagement.new(meter).is_meter_known_to_n3rgy?
   end
 
   def current_consent

--- a/app/views/schools/meters/_inactive_meters.html.erb
+++ b/app/views/schools/meters/_inactive_meters.html.erb
@@ -1,7 +1,9 @@
 <% inactive_meters.each do |meter| %>
   <tr scope="row">
     <td title="<%= (meter.meter_type.to_s.humanize) %>"><%= fa_icon(fuel_type_icon(meter.meter_type)) %></td>
-    <td><%= meter.mpan_mprn %></td>
+    <td>
+      <%= link_to meter.mpan_mprn, school_meter_path(@school, meter) %>
+    </td>
     <td><%= meter.name %></td>
     <% if current_user.admin? %>
       <td>
@@ -22,8 +24,8 @@
     <td><%= meter.gappy_validated_readings.count %></td>
     <td>
       <div class="btn-group btn-group-sm" role="group">
-        <% if can?(:edit, meter) %>
-          <%= link_to t('schools.meters.index.details'), school_meter_path(@school, meter), class: 'btn btn-sm' %>
+        <% if can?(:view_meter_attributes, meter) %>
+          <%= link_to t('common.labels.attributes'), admin_school_single_meter_attribute_path(@school, meter), class: 'btn btn-sm' %>
         <% end %>
         <% if can?(:report_on, meter) && meter.amr_validated_readings.any? %>
           <%= link_to t('schools.meters.index.report'), admin_reports_amr_validated_reading_path(meter), class: 'btn btn-sm' %>
@@ -45,7 +47,6 @@
         <% else %>
           <button class="btn btn-sm" disabled title="<%= t('schools.meters.index.only_admins_message') %>"><%= t('common.labels.delete') %></button>
         <% end %>
-
       </div>
     </td>
   </tr>

--- a/app/views/schools/meters/index.html.erb
+++ b/app/views/schools/meters/index.html.erb
@@ -54,7 +54,7 @@
   </div>
 <% end %>
 
-<% colspan = current_user.admin? ? 12 : 11 %>
+<% colspan = current_user.admin? ? 14 : 11 %>
 <% first_colspan = current_user.admin? ? 3 : 2 %>
 
 <div class="table-responsive">

--- a/app/views/schools/meters/show.html.erb
+++ b/app/views/schools/meters/show.html.erb
@@ -66,32 +66,34 @@
     </dl>
   </div>
   <div class="col-md-7">
-    <h3><%= t('schools.meters.show.dcc_information') %></h3>
-    <% if @meter.dcc_meter? %>
-      <dl class="row">
-        <dt class="col-sm-3"><%= t('schools.meters.show.dcc_last_checked') %></dt>
-        <dd class="col-sm-9"><%= nice_date_times @meter.dcc_checked_at %></dd>
-        <dt class="col-sm-3"><%= t('schools.meters.show.n3rgy_api_status') %></dt>
-        <dd class="col-sm-9"><%= @n3rgy_status.to_s.humanize %></dd>
-        <dt class="col-sm-3"><%= t('schools.meters.show.user_consented') %>?</dt>
-        <dd class="col-sm-9"><%= @meter.meter_review.present? %></dd>
-        <dt class="col-sm-3"><%= t('schools.meters.show.dcc_consented') %>?</dt>
-        <dd class="col-sm-9"><%= @meter.consent_granted? %></dd>
-        <dt class="col-sm-3"><%= t('schools.meters.show.n3rgy_consent_confirmed') %>?</dt>
-        <dd class="col-sm-9"><%= @n3rgy_consent_confirmed %></dd>
-        <dt class="col-sm-3"><%= t('schools.meters.show.available_cache_range') %></dt>
-        <dd class="col-sm-9"><%= @available_cache_range %></dd>
-        <dt class="col-sm-3"><%= t('schools.meters.show.sandbox') %>?</dt>
-        <dd class="col-sm-9"><%= @meter.sandbox? %></dd>
-      </dl>
-    <% else %>
-      <p><%= t('schools.meters.show.not_configured_as_a_dcc_meter') %></p>
-      <dl class="row">
-        <dt class="col-sm-3"><%= t('schools.meters.show.dcc_last_checked') %></dt>
-        <dd class="col-sm-9"><%= nice_date_times @meter.dcc_checked_at %></dd>
-        <dt class="col-sm-3"><%= t('schools.meters.show.n3rgy_api_status') %></dt>
-        <dd class="col-sm-9"><%= @n3rgy_status %></dd>
-      </dl>
+    <% if current_user.admin? %>
+      <h3><%= t('schools.meters.show.dcc_information') %></h3>
+      <% if @meter.dcc_meter? %>
+        <dl class="row">
+          <dt class="col-sm-3"><%= t('schools.meters.show.n3rgy_known_meter') %></dt>
+          <dd class="col-sm-9"><%= @known_to_n3rgy %></dd>
+          <dt class="col-sm-3"><%= t('schools.meters.show.user_consented') %>?</dt>
+          <dd class="col-sm-9"><%= @meter.meter_review.present? %></dd>
+          <dt class="col-sm-3"><%= t('schools.meters.show.dcc_consented') %>?</dt>
+          <dd class="col-sm-9"><%= @meter.consent_granted? %></dd>
+          <dt class="col-sm-3"><%= t('schools.meters.show.n3rgy_consent_confirmed') %>?</dt>
+          <dd class="col-sm-9"><%= @n3rgy_consent_confirmed %></dd>
+          <dt class="col-sm-3"><%= t('schools.meters.show.n3rgy_api_status') %></dt>
+          <dd class="col-sm-9"><%= @n3rgy_status.to_s.humanize %></dd>
+          <dt class="col-sm-3"><%= t('schools.meters.show.available_cache_range') %></dt>
+          <dd class="col-sm-9"><%= @available_cache_range %></dd>
+          <dt class="col-sm-3"><%= t('schools.meters.show.sandbox') %>?</dt>
+          <dd class="col-sm-9"><%= @meter.sandbox? %></dd>
+        </dl>
+      <% else %>
+        <p><%= t('schools.meters.show.not_configured_as_a_dcc_meter') %></p>
+        <dl class="row">
+          <dt class="col-sm-3"><%= t('schools.meters.show.dcc_last_checked') %></dt>
+          <dd class="col-sm-9"><%= nice_date_times @meter.dcc_checked_at %></dd>
+          <dt class="col-sm-3"><%= t('schools.meters.show.n3rgy_known_meter') %></dt>
+          <dd class="col-sm-9"><%= @known_to_n3rgy %></dd>
+        </dl>
+      <% end %>
     <% end %>
   </div>
 </div>

--- a/config/locales/cy/views/schools/schools.yml
+++ b/config/locales/cy/views/schools/schools.yml
@@ -259,7 +259,6 @@ cy:
         admin_meter_status: Statws mesurydd gweinyddol
         data_processing_turned_on_message: Rhaid troi prosesu data ymlaen ar gyfer yr ysgol hon cyn y gellir dilysu darlleniadau mesurydd
         data_source: Ffynhonnell ddata
-        details: Manylion
         first: Cyntaf
         imported: Mewnforiwyd
         inactive_meters: Mesuryddion anweithredol

--- a/config/locales/views/schools/schools.yml
+++ b/config/locales/views/schools/schools.yml
@@ -308,6 +308,7 @@ en:
         meter: Meter
         n3rgy_api_status: n3rgy API Status
         n3rgy_consent_confirmed: n3rgy Confirm Consented
+        n3rgy_known_meter: Available from n3rgy?
         not_configured_as_a_dcc_meter: Not configured as a DCC meter
         sandbox: Sandbox (test meter)
         school_meter_management: School meter management

--- a/config/locales/views/schools/schools.yml
+++ b/config/locales/views/schools/schools.yml
@@ -260,7 +260,6 @@ en:
         admin_meter_status: Admin meter status
         data_processing_turned_on_message: Data processing must be turned on for this school before meter readings can be validated
         data_source: Data source
-        details: Details
         first: First
         imported: Imported
         inactive_meters: Inactive meters

--- a/spec/services/meter_management_spec.rb
+++ b/spec/services/meter_management_spec.rb
@@ -84,6 +84,26 @@ describe MeterManagement do
     end
   end
 
+  describe 'is_meter_known_to_n3rgy?' do
+    let(:n3rgy_api)         { double(:n3rgy_api) }
+    let(:n3rgy_api_factory) { double(:n3rgy_api_factory, data_api: n3rgy_api) }
+
+    it "returns api status" do
+      meter = create(:electricity_meter)
+      expect(n3rgy_api).to receive(:find).with(meter.mpan_mprn).and_return(true)
+      expect( MeterManagement.new(meter, n3rgy_api_factory: n3rgy_api_factory).is_meter_known_to_n3rgy? ).to be true
+
+      expect(n3rgy_api).to receive(:find).with(meter.mpan_mprn).and_return(false)
+      expect( MeterManagement.new(meter, n3rgy_api_factory: n3rgy_api_factory).is_meter_known_to_n3rgy? ).to be false
+    end
+
+    it "handles API errors" do
+      meter = create(:electricity_meter)
+      allow(n3rgy_api).to receive(:find).with(meter.mpan_mprn).and_raise(StandardError)
+      expect( MeterManagement.new(meter, n3rgy_api_factory: n3rgy_api_factory).is_meter_known_to_n3rgy? ).to be false
+    end
+  end
+
   describe 'check_n3rgy_status' do
     let(:n3rgy_api)         { double(:n3rgy_api) }
     let(:n3rgy_api_factory) { double(:n3rgy_api_factory, data_api: n3rgy_api) }

--- a/spec/services/meter_review_service_spec.rb
+++ b/spec/services/meter_review_service_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe MeterReviewService do
   context 'when completing a review' do
 
     before do
-      allow_any_instance_of(MeterManagement).to receive(:check_n3rgy_status).and_return(true)
+      allow_any_instance_of(MeterManagement).to receive(:is_meter_known_to_n3rgy?).and_return(true)
     end
 
     context 'and school has consent' do
@@ -72,14 +72,8 @@ RSpec.describe MeterReviewService do
         service.complete_review!([ dcc_meter ])
       }.to raise_error(MeterReviewService::MeterReviewError)
     end
-    it 'raises error if meter not found in DCC api (api error)' do
-      expect_any_instance_of(MeterManagement).to receive(:check_n3rgy_status).and_return(:api_error)
-      expect {
-        service.complete_review!([ dcc_meter ])
-      }.to raise_error(MeterReviewService::MeterReviewError)
-    end
-    it 'raises error if meter not found in DCC api (false)' do
-      expect_any_instance_of(MeterManagement).to receive(:check_n3rgy_status).and_return(false)
+    it 'raises error if meter not found in DCC api' do
+      expect_any_instance_of(MeterManagement).to receive(:is_meter_known_to_n3rgy?).and_return(false)
       expect {
         service.complete_review!([ dcc_meter ])
       }.to raise_error(MeterReviewService::MeterReviewError)

--- a/spec/system/admin/meter_reviews/meter_reviews_spec.rb
+++ b/spec/system/admin/meter_reviews/meter_reviews_spec.rb
@@ -111,7 +111,7 @@ RSpec.describe 'meter_reviews', type: :system do
   context 'when performing a review' do
 
     before(:each) do
-      allow_any_instance_of(MeterManagement).to receive(:check_n3rgy_status).and_return(true)
+      allow_any_instance_of(MeterManagement).to receive(:is_meter_known_to_n3rgy?).and_return(true)
       login_as(admin)
       visit root_path
       click_on 'Admin'

--- a/spec/system/meter_management_spec.rb
+++ b/spec/system/meter_management_spec.rb
@@ -207,7 +207,7 @@ RSpec.describe "meter management", :meters, type: :system, include_application_h
 
     context 'when the school has a DCC meter' do
       let!(:meter) { create(:electricity_meter, dcc_meter: true, name: 'Electricity meter', school: school, mpan_mprn: 1234567890123 ) }
-      let!(:data_api) { double(status: :available, inventory: {device_id: 123999}, readings_available_date_range: Date.today..Date.today) }
+      let!(:data_api) { double(find: true, status: :available, inventory: {device_id: 123999}, readings_available_date_range: Date.today..Date.today) }
 
       before(:each) do
         allow_any_instance_of(Amr::N3rgyApiFactory).to receive(:data_api).with(meter).and_return(data_api)


### PR DESCRIPTION
Changes to admin interface to better display information from the n3rgy API introduced an issue with the Meter Review process. A method that should have been returning a boolean was not returning a symbol. This meant that reviews cannot be processed.

This PR fixes that issue by adding a new method in MeterManagement to check whether a meter is in n3rgy, separate from its "status" which returns one of several different symbols.

As part of implementing the fix I've further tidied up the diagnostic information to:

* ensure its only displayed to admins
* reduce number of API calls if a meter isn't known to n3rgy
* fix up some minor display issues and further improve the diagnostics
