### PR TITLE
Update links and titles for managing school groups and scoreboards on admin page

### DIFF
--- a/app/views/admin/index.html.erb
+++ b/app/views/admin/index.html.erb
@@ -15,8 +15,8 @@
 
     <h2>Schools, groups and scoreboards</h2>
     <ul>
-      <li><%= link_to "Find school by MPXN", admin_meters_path %></li>
       <li><%= link_to "Manage School Groups", admin_school_groups_path %></li>
+      <li><%= link_to "Find school by MPXN", admin_meters_path %></li>
       <li><%= link_to "Manage Scoreboards", admin_scoreboards_path %></li>
     </ul>
 

--- a/app/views/admin/index.html.erb
+++ b/app/views/admin/index.html.erb
@@ -16,8 +16,8 @@
     <h2>Schools, groups and scoreboards</h2>
     <ul>
       <li><%= link_to "Find school by MPXN", admin_meters_path %></li>
-      <li><%= link_to "Edit School Groups", admin_school_groups_path %></li>
-      <li><%= link_to "Edit Scoreboards", admin_scoreboards_path %></li>
+      <li><%= link_to "Manage School Groups", admin_school_groups_path %></li>
+      <li><%= link_to "Manage Scoreboards", admin_scoreboards_path %></li>
     </ul>
 
     <h2>Users and consent</h2>

--- a/app/views/admin/scoreboards/index.html.erb
+++ b/app/views/admin/scoreboards/index.html.erb
@@ -1,5 +1,5 @@
 
-<h1>Scoreboards</h1>
+<h1>Manage Scoreboards</h1>
 
 <% if @scoreboards.any? %>
   <table class="table table-condensed">

--- a/spec/system/admin/school_groups_spec.rb
+++ b/spec/system/admin/school_groups_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe 'school groups', :school_groups, type: :system, include_applicati
     describe "Viewing school groups index page" do
       let(:setup_data) { create_data_for_school_groups(school_groups) }
       before do
-        click_on 'Edit School Groups'
+        click_on 'Manage School Groups'
       end
 
       context "with multiple groups" do
@@ -90,7 +90,7 @@ RSpec.describe 'school groups', :school_groups, type: :system, include_applicati
       let!(:dark_sky_weather_area)  { create(:dark_sky_area, title: 'BANES dark sky weather') }
 
       before do
-        click_on 'Edit School Groups'
+        click_on 'Manage School Groups'
         click_on 'New school group'
       end
 
@@ -123,7 +123,7 @@ RSpec.describe 'school groups', :school_groups, type: :system, include_applicati
       let!(:issues_admin) { }
       let!(:school_group) { create :school_group, default_issues_admin_user: issues_admin }
       before do
-        click_on 'Edit School Groups'
+        click_on 'Manage School Groups'
         within "table" do
           click_on 'Manage'
         end
@@ -400,7 +400,7 @@ RSpec.describe 'school groups', :school_groups, type: :system, include_applicati
     describe "Editing a school group" do
       let!(:school_group) { create(:school_group, name: 'BANES', public: true) }
       before do
-        click_on 'Edit School Groups'
+        click_on 'Manage School Groups'
         within "table" do
           click_on 'Manage'
         end
@@ -419,7 +419,7 @@ RSpec.describe 'school groups', :school_groups, type: :system, include_applicati
     describe "Deleting a school group" do
       let!(:school_group) { create(:school_group) }
       before do
-        click_on 'Edit School Groups'
+        click_on 'Manage School Groups'
         within "table" do
           click_on 'Manage'
         end
@@ -449,7 +449,7 @@ RSpec.describe 'school groups', :school_groups, type: :system, include_applicati
       let!(:issue) { create(:issue, issue_type: :issue, status: :open, updated_by: admin, issueable: school, fuel_type: :gas) }
       before do
         Timecop.freeze
-        click_on 'Edit School Groups'
+        click_on 'Manage School Groups'
         within "table" do
           click_on 'Manage'
         end
@@ -508,7 +508,7 @@ RSpec.describe 'school groups', :school_groups, type: :system, include_applicati
 
 
       before do
-        click_on 'Edit School Groups'
+        click_on 'Manage School Groups'
         within "table" do
           click_on 'Manage', match: :first
         end
@@ -572,7 +572,7 @@ RSpec.describe 'school groups', :school_groups, type: :system, include_applicati
         create :school, active: false, school_group: school_group2, chart_preference: 'default'
         create :school, active: false, school_group: school_group2, chart_preference: 'carbon'
         create :school, active: false, school_group: school_group2, chart_preference: 'usage'
-        click_on 'Edit School Groups'
+        click_on 'Manage School Groups'
         within "table" do
           click_on 'Manage', match: :first
         end
@@ -601,7 +601,7 @@ RSpec.describe 'school groups', :school_groups, type: :system, include_applicati
       let!(:partners) { 3.times.collect { create(:partner) } }
       let!(:school_group)      { create(:school_group, name: 'BANES') }
       before do
-        click_on 'Edit School Groups'
+        click_on 'Manage School Groups'
         within "table" do
           click_on 'Manage'
         end


### PR DESCRIPTION
This pr
- [x] Updates the “Edit School Groups” link on the admin page to say “Manage School Groups” and make it first option
- [x] Updates the “Edit Scoreboards” link to say “Manage Scoreboards”
- [x] updates the /admin/scoreboards page so the title is “Manage Scoreboards”