### PR TITLE
Keep up to a month of batch data

### DIFF
--- a/app/services/alerts/content_deletion_service.rb
+++ b/app/services/alerts/content_deletion_service.rb
@@ -1,6 +1,6 @@
 module Alerts
   class ContentDeletionService
-    DEFAULT_OLDER_THAN = 3.months.ago.beginning_of_month
+    DEFAULT_OLDER_THAN = 1.month.ago.beginning_of_month
     attr_reader :older_than
 
     def initialize(older_than = DEFAULT_OLDER_THAN)

--- a/app/services/alerts/delete_alert_generation_run_service.rb
+++ b/app/services/alerts/delete_alert_generation_run_service.rb
@@ -1,6 +1,6 @@
 module Alerts
   class DeleteAlertGenerationRunService
-    DEFAULT_OLDER_THAN = 3.months.ago.beginning_of_month
+    DEFAULT_OLDER_THAN = 1.month.ago.beginning_of_month
     attr_reader :older_than
 
     def initialize(older_than = DEFAULT_OLDER_THAN)

--- a/app/services/alerts/delete_benchmark_run_service.rb
+++ b/app/services/alerts/delete_benchmark_run_service.rb
@@ -1,6 +1,6 @@
 module Alerts
   class DeleteBenchmarkRunService
-    DEFAULT_OLDER_THAN = 3.months.ago.beginning_of_month
+    DEFAULT_OLDER_THAN = 1.month.ago.beginning_of_month
     attr_reader :older_than
 
     def initialize(older_than = DEFAULT_OLDER_THAN)

--- a/app/services/alerts/delete_content_generation_run_service.rb
+++ b/app/services/alerts/delete_content_generation_run_service.rb
@@ -1,6 +1,6 @@
 module Alerts
   class DeleteContentGenerationRunService
-    DEFAULT_OLDER_THAN = 3.months.ago.beginning_of_month
+    DEFAULT_OLDER_THAN = 1.month.ago.beginning_of_month
     attr_reader :older_than
 
     def initialize(older_than = DEFAULT_OLDER_THAN)

--- a/spec/services/alerts/content_deletion_service_spec.rb
+++ b/spec/services/alerts/content_deletion_service_spec.rb
@@ -8,7 +8,7 @@ describe Alerts::ContentDeletionService, type: :service do
   let(:electricity_fuel_alert_type)     { create(:alert_type, fuel_type: :electricity, frequency: :termly, description: alert_type_description) }
 
   it 'defaults to beginning of month, 3 months ago' do
-    expect(service.older_than).to eql(3.months.ago.beginning_of_month)
+    expect(service.older_than).to eql(1.months.ago.beginning_of_month)
   end
 
   it 'calls delete!' do

--- a/spec/services/alerts/delete_alert_generation_run_service_spec.rb
+++ b/spec/services/alerts/delete_alert_generation_run_service_spec.rb
@@ -7,13 +7,13 @@ describe Alerts::DeleteAlertGenerationRunService, type: :service do
   let(:gas_fuel_alert_type)             { create(:alert_type, fuel_type: :gas, frequency: :termly, description: alert_type_description) }
   let(:electricity_fuel_alert_type)     { create(:alert_type, fuel_type: :electricity, frequency: :termly, description: alert_type_description) }
 
-  it 'defaults to beginning of month, 3 months ago' do
-    expect(service.older_than).to eql(3.months.ago.beginning_of_month)
+  it 'defaults to beginning of month, 1 month ago' do
+    expect(service.older_than).to eql(1.months.ago.beginning_of_month)
   end
 
   describe '#delete' do
     it 'doesnt delete new runs' do
-      date_time = (Time.zone.now - 3.months)
+      date_time = (Time.zone.now - 1.months)
       school.alert_generation_runs.create!(created_at: date_time + 1.day)
       school.alert_generation_runs.create!(created_at: date_time + 1.week)
       school.alert_generation_runs.create!(created_at: date_time + 1.month)
@@ -25,14 +25,14 @@ describe Alerts::DeleteAlertGenerationRunService, type: :service do
     context 'when there are older runs to delete' do
       it 'deletes only the older runs' do
         school.alert_generation_runs.create!(created_at: Time.zone.now)
-        school.alert_generation_runs.create!(created_at: (Time.zone.now - 3.months).beginning_of_month + 1.day)
+        school.alert_generation_runs.create!(created_at: (Time.zone.now - 1.months).beginning_of_month + 1.day)
         school.alert_generation_runs.create!(created_at: (Time.zone.now - 3.months).beginning_of_month)
         school.alert_generation_runs.create!(created_at: (Time.zone.now - 6.months).beginning_of_month)
         expect(AlertGenerationRun.count).to eq 4
         expect { service.delete! }.to change(AlertGenerationRun, :count).from(4).to(2)
       end
       it 'deletes all of the dependent objects' do
-        date_time = (Time.zone.now - 3.months).beginning_of_month
+        date_time = (Time.zone.now - 1.months).beginning_of_month
         alert_generation_run = school.alert_generation_runs.create!(created_at: date_time)
         create(:alert, school: school, alert_type: gas_fuel_alert_type, created_at: date_time, alert_generation_run: alert_generation_run)
         create(:alert, school: school, alert_type: electricity_fuel_alert_type, created_at: date_time, alert_generation_run: alert_generation_run)

--- a/spec/services/alerts/delete_benchmark_run_service_spec.rb
+++ b/spec/services/alerts/delete_benchmark_run_service_spec.rb
@@ -20,8 +20,8 @@ describe Alerts::DeleteBenchmarkRunService, type: :service do
 
   let(:service)   { Alerts::DeleteBenchmarkRunService.new }
 
-  it 'defaults to beginning of month, 3 months ago' do
-    expect(service.older_than).to eql(3.months.ago.beginning_of_month)
+  it 'defaults to beginning of month, 1 month ago' do
+    expect(service.older_than).to eql(1.months.ago.beginning_of_month)
   end
 
   it 'doesnt delete new runs' do
@@ -30,7 +30,7 @@ describe Alerts::DeleteBenchmarkRunService, type: :service do
   end
 
   context 'when there are older runs to delete' do
-    let(:created_at)        { Time.zone.now - 6.months }
+    let(:created_at)        { Time.zone.now - 3.months }
 
     let!(:new_run)          { BenchmarkResultGenerationRun.create! }
     let!(:new_school_run)   { BenchmarkResultSchoolGenerationRun.create(school: school,

--- a/spec/services/alerts/delete_content_generation_run_service_spec.rb
+++ b/spec/services/alerts/delete_content_generation_run_service_spec.rb
@@ -7,12 +7,12 @@ describe Alerts::DeleteContentGenerationRunService, type: :service do
 
   let(:service)   { Alerts::DeleteContentGenerationRunService.new }
 
-  it 'defaults to beginning of month, 3 months ago' do
-    expect(service.older_than).to eql(3.months.ago.beginning_of_month)
+  it 'defaults to beginning of month, 1 month ago' do
+    expect(service.older_than).to eql(1.months.ago.beginning_of_month)
   end
 
   it 'doesnt delete new runs' do
-    date_time = (Time.zone.now - 3.months)
+    date_time = (Time.zone.now - 1.months)
     school.content_generation_runs.create!(created_at: date_time + 1.day)
     school.content_generation_runs.create!(created_at: date_time + 1.week)
     school.content_generation_runs.create!(created_at: date_time + 1.month)


### PR DESCRIPTION
A while ago we started deleting older data generated by the overnight batch processes, removing anything that was >3.months old.

The database is growing more rapidly as we have more schools and as there's less need to keep these artefacts I've changed the window to be one month.

Actually, as the logic is `1.month.ago.beginning_of_month` we'll be keeping a bit more than a month which is fine.