### PR TITLE
Provide tool for admin to check ranges of unvalidated data for a list of meters

### DIFF
--- a/app/controllers/admin/reports/unvalidated_readings_controller.rb
+++ b/app/controllers/admin/reports/unvalidated_readings_controller.rb
@@ -1,0 +1,27 @@
+module Admin
+  module Reports
+    class UnvalidatedReadingsController < AdminController
+      def show
+        @report = run_report
+      end
+
+      private
+
+      def run_report
+        if params[:mpans].present?
+          param = params[:mpans]
+          if param["list"].present?
+            return AmrDataFeedReading.unvalidated_data_report_for_mpans(tidy(param["list"]))
+          else
+            return []
+          end
+        end
+        []
+      end
+
+      def tidy(list)
+        list.split("\n").map(&:strip)
+      end
+    end
+  end
+end

--- a/app/models/amr_data_feed_reading.rb
+++ b/app/models/amr_data_feed_reading.rb
@@ -87,8 +87,11 @@ class AmrDataFeedReading < ApplicationRecord
         SELECT mpan_mprn, meter_id, identifier, amr_data_feed_configs.description, reading_date,
         CASE
           WHEN reading_date ~ '\\d{2}-(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)-\\d{2}' THEN to_date(reading_date, 'DD-MON-YY')
+          WHEN date_format='%d-%m-%Y' AND reading_date~'\\d{4}-\\d{2}-\\d{2}' THEN to_date(reading_date, 'YYYY-MM-DD')
           WHEN date_format='%d-%m-%Y' THEN to_date(reading_date, 'DD-MM-YYYY')
+          WHEN date_format='%d/%m/%Y' AND reading_date~'\\d{4}-\\d{2}-\\d{2}' THEN to_date(reading_date, 'YYYY-MM-DD')
           WHEN date_format='%d/%m/%Y' THEN to_date(reading_date, 'DD/MM/YYYY')
+          WHEN date_format='%d/%m/%y' AND reading_date~'\\d{4}-\\d{2}-\\d{2}' THEN to_date(reading_date, 'YYYY-MM-DD')
           WHEN date_format='%d/%m/%y' THEN to_date(reading_date, 'DD/MM/YY')
           WHEN date_format='%Y-%m-%d' THEN to_date(reading_date, 'YYYY-MM-DD')
           WHEN date_format='%Y-%m-%d' THEN to_date(reading_date, 'YYYY-MM-DD ')

--- a/app/models/amr_data_feed_reading.rb
+++ b/app/models/amr_data_feed_reading.rb
@@ -80,9 +80,9 @@ class AmrDataFeedReading < ApplicationRecord
     QUERY
   end
 
-  def self.unvalidated_data_report_for_mpans(mpans)
+  def self.build_unvalidated_data_report_query(mpans)
     list_of_mpans = mpans.map {|m| "'#{m}'"}.join(',')
-    query = <<~QUERY
+    <<~QUERY
       SELECT mpan_mprn, meter_id, identifier, description, MIN(parsed_date) as earliest_reading, MAX(parsed_date) as latest_reading FROM (
         SELECT mpan_mprn, meter_id, identifier, amr_data_feed_configs.description, reading_date,
         CASE
@@ -108,6 +108,10 @@ class AmrDataFeedReading < ApplicationRecord
       GROUP BY mpan_mprn, meter_id, identifier, description
       ORDER by mpan_mprn, meter_id, latest_reading DESC
     QUERY
+  end
+
+  def self.unvalidated_data_report_for_mpans(mpans)
+    query = build_unvalidated_data_report_query(mpans)
     ActiveRecord::Base.connection.execute(ActiveRecord::Base.sanitize_sql(query))
   end
 end

--- a/app/models/amr_data_feed_reading.rb
+++ b/app/models/amr_data_feed_reading.rb
@@ -79,4 +79,33 @@ class AmrDataFeedReading < ApplicationRecord
       ORDER BY s.id, m.mpan_mprn ASC
     QUERY
   end
+
+  def self.unvalidated_data_report_for_mpans(mpans)
+    list_of_mpans = mpans.map {|m| "'#{m}'"}.join(',')
+    query = <<~QUERY
+      SELECT mpan_mprn, meter_id, identifier, description, MIN(parsed_date) as earliest_reading, MAX(parsed_date) as latest_reading FROM (
+        SELECT mpan_mprn, meter_id, identifier, amr_data_feed_configs.description, reading_date,
+        CASE
+          WHEN date_format='%d-%m-%Y' THEN to_date(reading_date, 'DD-MM-YYYY')
+          WHEN date_format='%d/%m/%Y' THEN to_date(reading_date, 'DD/MM/YYYY')
+          WHEN date_format='%d/%m/%y' THEN to_date(reading_date, 'DD/MM/YY')
+          WHEN date_format='%Y-%m-%d' THEN to_date(reading_date, 'YYYY-MM-DD')
+          WHEN date_format='%Y-%m-%d' THEN to_date(reading_date, 'YYYY-MM-DD ')
+          WHEN date_format='%y-%m-%d' THEN to_date(reading_date, 'YY-MM-DD ')
+          WHEN date_format='"%d-%m-%Y"' THEN to_date(reading_date, '"DD-MM-YYYY"')
+          WHEN date_format='%d/%m/%Y %H:%M:%S' THEN to_date(reading_date, 'DD/MM/YYYY HH24:MI::SS')
+          WHEN date_format='%H:%M:%S %a %d/%m/%Y' THEN to_date(reading_date, 'HH24:MI::SS Dy DD/MM/YYYY')
+          WHEN date_format='%e %b %Y %H:%M:%S' THEN to_date(reading_date, 'DD Mon YYYY HH24:MI::SS')
+          WHEN date_format='%b %e %Y %I:%M%p' THEN to_date(reading_date, 'Mon DD YYYY HH12:MIam')
+          ELSE NULL
+        END parsed_date
+        FROM amr_data_feed_readings
+        JOIN amr_data_feed_configs ON amr_data_feed_configs.id = amr_data_feed_readings.amr_data_feed_config_id
+        WHERE mpan_mprn IN (#{list_of_mpans})
+        ) as raw_data
+      GROUP BY mpan_mprn, meter_id, identifier, description
+      ORDER by mpan_mprn, meter_id, latest_reading DESC
+    QUERY
+    ActiveRecord::Base.connection.execute(ActiveRecord::Base.sanitize_sql(query))
+  end
 end

--- a/app/models/amr_data_feed_reading.rb
+++ b/app/models/amr_data_feed_reading.rb
@@ -86,6 +86,7 @@ class AmrDataFeedReading < ApplicationRecord
       SELECT mpan_mprn, meter_id, identifier, description, MIN(parsed_date) as earliest_reading, MAX(parsed_date) as latest_reading FROM (
         SELECT mpan_mprn, meter_id, identifier, amr_data_feed_configs.description, reading_date,
         CASE
+          WHEN reading_date ~ '\\d{2}-(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)-\\d{2}' THEN to_date(reading_date, 'DD-MON-YY')
           WHEN date_format='%d-%m-%Y' THEN to_date(reading_date, 'DD-MM-YYYY')
           WHEN date_format='%d/%m/%Y' THEN to_date(reading_date, 'DD/MM/YYYY')
           WHEN date_format='%d/%m/%y' THEN to_date(reading_date, 'DD/MM/YY')
@@ -95,6 +96,7 @@ class AmrDataFeedReading < ApplicationRecord
           WHEN date_format='"%d-%m-%Y"' THEN to_date(reading_date, '"DD-MM-YYYY"')
           WHEN date_format='%d/%m/%Y %H:%M:%S' THEN to_date(reading_date, 'DD/MM/YYYY HH24:MI::SS')
           WHEN date_format='%H:%M:%S %a %d/%m/%Y' THEN to_date(reading_date, 'HH24:MI::SS Dy DD/MM/YYYY')
+          WHEN date_format='%e %b %Y %H:%M:%S' AND reading_date~'\\d{4}-\\d{2}-\\d{2}' THEN to_date(reading_date, 'YYYY-MM-DD')
           WHEN date_format='%e %b %Y %H:%M:%S' THEN to_date(reading_date, 'DD Mon YYYY HH24:MI::SS')
           WHEN date_format='%b %e %Y %I:%M%p' THEN to_date(reading_date, 'Mon DD YYYY HH12:MIam')
           ELSE NULL

--- a/app/views/admin/reports/index.html.erb
+++ b/app/views/admin/reports/index.html.erb
@@ -34,6 +34,7 @@
   <div class="col">
     <h3>Data & Tariffs</h3>
     <ul>
+      <li><%= link_to "Unvalidated readings", admin_reports_unvalidated_readings_path %></li>
       <li><%= link_to "Recent manual imports", admin_reports_data_loads_path %></li>
       <li><%= link_to "AMR File imports report", admin_reports_amr_data_feed_import_logs_path %></li>
       <li><%= link_to "School group meter reports", admin_reports_meter_reports_path %></li>

--- a/app/views/admin/reports/unvalidated_readings/show.html.erb
+++ b/app/views/admin/reports/unvalidated_readings/show.html.erb
@@ -1,0 +1,35 @@
+<% content_for :page_title, 'Unvalidated readings report' %>
+
+<h1>Unvalidated readings report</h1>
+
+<%= simple_form_for :mpans, url: admin_reports_unvalidated_readings_path, method: "GET", html: { class: 'form' } do |f| %>
+  <%= f.input :list, as: :text, input_html: {'rows' => 20, 'cols' => 10, value: params[:mpans].present? ? params[:mpans]["list"]: ''} %>
+  <%= f.submit "Run report", class: "btn btn-primary" %>
+<% end %>
+
+<% if @report.any? %>
+  <table class="table table-sm">
+    <thead>
+      <tr>
+        <th>MPAN/MPRN</th>
+        <th>Meter</th>
+        <th>Config identifier</th>
+        <th>Config name</th>
+        <th>Earliest reading</th>
+        <th>Latest reading</th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @report.each do |row| %>
+        <tr>
+          <td><%= row['mpan_mprn'] %></td>
+          <td><%= row['meter_id'] %></td>
+          <td><%= row['identifier'] %></td>
+          <td><%= row['description'] %></td>
+          <td><%= row['earliest_reading'] %></td>
+          <td><%= row['latest_reading'] %></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+<% end %>

--- a/app/views/admin/reports/unvalidated_readings/show.html.erb
+++ b/app/views/admin/reports/unvalidated_readings/show.html.erb
@@ -2,13 +2,37 @@
 
 <h1>Unvalidated readings report</h1>
 
+<p>
+This form can be used to generate a report from the unvalidated meter data. This includes all of the
+raw data loaded into the system over the last few years.
+</p>
+
+<p>
+Add one or more MPANs/MPRNs into the box below, one per line. Then run the report.
+</p>
+
+<p>
+If the MPANs/MPRNs are found then you'll get a table that lists the meter associated with that
+meter (if any) and one row for each data feed config used to load data for that meter, along with the
+earliest and latest reading dates. This is necessary because data is received by multiple routes.
+</p>
+
+<p>
+The results are sorted by MPAN then DESCENDING order of reading date, so the most recent date is first.
+</p>
+
+<p>
+It's possible for this report to break if the raw readings have been loaded with an incorrect date format.
+If you get an error add a Trello card indicating which MPANs you were trying to view.
+</p>
+
 <%= simple_form_for :mpans, url: admin_reports_unvalidated_readings_path, method: "GET", html: { class: 'form' } do |f| %>
   <%= f.input :list, as: :text, input_html: {'rows' => 20, 'cols' => 10, value: params[:mpans].present? ? params[:mpans]["list"]: ''} %>
   <%= f.submit "Run report", class: "btn btn-primary" %>
 <% end %>
 
 <% if @report.any? %>
-  <table class="table table-sm">
+  <table class="advice-table mt-4 table table-sm">
     <thead>
       <tr>
         <th>MPAN/MPRN</th>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -527,6 +527,7 @@ Rails.application.routes.draw do
       resources :activity_types, only: [:index, :show]
       resources :dcc_status, only: [:index]
       resources :solar_panels, only: [:index]
+      resource :unvalidated_readings, only: [:show]
       resource :funder_allocations, only: [:show] do
         post :deliver
       end

--- a/spec/models/amr_data_feed_reading_spec.rb
+++ b/spec/models/amr_data_feed_reading_spec.rb
@@ -1,28 +1,60 @@
-# == Schema Information
-#
-# Table name: amr_data_feed_readings
-#
-#  id                      :bigint(8)        not null, primary key
-#  amr_data_feed_config_id :integer          not null
-#  meter_id                :integer
-#  mpan_mprn               :bigint(8)        not null
-#  reading_date            :date             not null
-#  readings                :decimal(, )      not null, is an Array
-#  postcode                :text
-#  school                  :text
-#  description             :text
-#  units                   :text
-#  total                   :decimal(, )
-#  meter_serial_number     :text
-#  provider_record_id      :text
-#  type                    :text
-#  created_at              :datetime         not null
-#  updated_at              :datetime         not null
-#
-
 require 'rails_helper'
 
 describe AmrDataFeedReading do
 
+  describe '.unvalidated_data_report_for_mpans' do
+
+    let(:date_format)   { '%d-%m-%Y' }
+    let(:reading_date)  { '28-06-2023' }
+    let!(:config)      { create(:amr_data_feed_config, date_format: date_format) }
+    let!(:reading)     { create(:amr_data_feed_reading, reading_date: reading_date, amr_data_feed_config: config)}
+
+    let(:results)  { AmrDataFeedReading.unvalidated_data_report_for_mpans([reading.mpan_mprn]) }
+
+    it 'returns the expected data' do
+      expect(results[0]['mpan_mprn']).to eq reading.mpan_mprn
+      expect(results[0]['meter_id']).to eq reading.meter.id
+      expect(results[0]['identifier']).to eq config.identifier
+      expect(results[0]['description']).to eq config.description
+      expect(results[0]['earliest_reading']).to eq Date.new(2023,6,28).iso8601
+      expect(results[0]['latest_reading']).to eq Date.new(2023,6,28).iso8601
+    end
+
+    context 'with other date formats' do
+      FORMATS = {
+        '%d/%m/%Y' => '28/06/2023',
+        '%Y-%m-%d' => '2023-06-28',
+        '%y-%m-%d' => '23-06-28',
+        '%H:%M:%S %a %d/%m/%Y' => '14:00:00 Wed 28/06/2023',
+        '%e %b %Y %H:%M:%S' => '28 Jun 2023 14:00:00',
+        '%b %e %Y %I:%M%p' => 'Jun 28 2023 02:00pm'
+      }
+
+      FORMATS.each do |format,read_date|
+        context "it parses #{format}" do
+          let(:date_format)   { format }
+          let(:reading_date)  { read_date }
+          it { expect(results[0]['latest_reading']).to eq Date.new(2023,6,28).iso8601 }
+        end
+      end
+    end
+
+    context 'with incorrectly loaded data' do
+      FORMATS = {
+        '%Y-%m-%d' => '28-Jun-23',
+        '%d-%m-%Y' => '2023-06-28',
+        '%e %b %Y %H:%M:%S' => '2023-06-28'
+      }
+
+      FORMATS.each do |format,read_date|
+        context "it parses #{read_date} despite format being #{format}" do
+          let(:date_format)   { format }
+          let(:reading_date)  { read_date }
+          it { expect(results[0]['latest_reading']).to eq Date.new(2023,6,28).iso8601 }
+        end
+      end
+    end
+
+  end
 
 end


### PR DESCRIPTION
This PR adds a new admin report that summarises data the unvalidated data in the `AmrDataFeedReading` table for a list of mpans.

The admins need to be able to confirm the latest reading dates for a given list of mpans. Sometimes those mpans are associated with meters, but sometimes they are not yet linked to meters. E.g. if they are starting to load data before the school has been onboarded.

Checking the dates allows them to re-request data from suppliers on a weekly basis, where those feeds are not fully automated.

Creating this type of report is tricky as the `AmrDataFeedReading` `reading_date` column is an unparsed date: we parse it when validating the data. That will get changed in the next few months but, for now I've written a query that is capable of converting the range of date formats used to load data into a date. 

I've translated the Ruby strftime formats we use in the data feed configs into the formats that postgres understands.

I've written some basic specs and have manually tested the query against the live database for performance (which seems OK) and to flush out edge cases (I've added support for some of these and specs for them).

This is a quick prototype that will get reworked following feedback.