### PR TITLE
Add floor area and pupil numbers to CSV download for recent usage tab and priority downloads

### DIFF
--- a/app/services/school_groups/recent_usage_csv_generator.rb
+++ b/app/services/school_groups/recent_usage_csv_generator.rb
@@ -15,6 +15,8 @@ module SchoolGroups
           row = []
           row << school.name
           row << school.school_group_cluster_name if @include_cluster
+          row << school.number_of_pupils
+          row << school.floor_area
           fuel_types.each { |fuel_type| row += columns_for(fuel_type, recent_usage) }
           csv << row
         end
@@ -39,6 +41,8 @@ module SchoolGroups
       header_row = []
       header_row << I18n.t('common.school')
       header_row << I18n.t('school_groups.clusters.labels.cluster') if @include_cluster
+      header_row << School.human_attribute_name('number_of_pupils')
+      header_row << School.human_attribute_name('floor_area')
       fuel_types.each { |fuel_type| header_row += header_columns_for(fuel_type) }
       header_row
     end

--- a/app/services/school_groups/recent_usage_csv_generator.rb
+++ b/app/services/school_groups/recent_usage_csv_generator.rb
@@ -42,7 +42,7 @@ module SchoolGroups
       header_row << I18n.t('common.school')
       header_row << I18n.t('school_groups.clusters.labels.cluster') if @include_cluster
       header_row << School.human_attribute_name('number_of_pupils')
-      header_row << School.human_attribute_name('floor_area')
+      header_row << I18n.t('school_groups.labels.floor_area')
       fuel_types.each { |fuel_type| header_row += header_columns_for(fuel_type) }
       header_row
     end

--- a/app/services/school_groups/schools_priority_action_csv_generator.rb
+++ b/app/services/school_groups/schools_priority_action_csv_generator.rb
@@ -53,7 +53,7 @@ module SchoolGroups
       columns << I18n.t('school_groups.clusters.labels.cluster') if @include_cluster
       columns += [
         School.human_attribute_name('number_of_pupils'),
-        School.human_attribute_name('floor_area'),
+        I18n.t('school_groups.labels.floor_area'),
         I18n.t('advice_pages.index.priorities.table.columns.kwh_saving'),
         I18n.t('advice_pages.index.priorities.table.columns.cost_saving'),
         I18n.t('advice_pages.index.priorities.table.columns.co2_reduction')

--- a/app/services/school_groups/schools_priority_action_csv_generator.rb
+++ b/app/services/school_groups/schools_priority_action_csv_generator.rb
@@ -22,6 +22,8 @@ module SchoolGroups
             ]
             row << saving.school.school_group_cluster_name if @include_cluster
             row += [
+              saving.school.number_of_pupils,
+              saving.school.floor_area,
               saving.one_year_saving_kwh.to_s + ' kWh',
               '£' + saving.average_one_year_saving_gbp.to_s,
               saving.one_year_saving_co2.to_s + ' kg CO2'
@@ -50,6 +52,8 @@ module SchoolGroups
       ]
       columns << I18n.t('school_groups.clusters.labels.cluster') if @include_cluster
       columns += [
+        School.human_attribute_name('number_of_pupils'),
+        School.human_attribute_name('floor_area'),
         I18n.t('advice_pages.index.priorities.table.columns.kwh_saving'),
         I18n.t('advice_pages.index.priorities.table.columns.cost_saving'),
         I18n.t('advice_pages.index.priorities.table.columns.co2_reduction')

--- a/config/locales/views/school_groups/school_groups.yml
+++ b/config/locales/views/school_groups/school_groups.yml
@@ -76,6 +76,8 @@ en:
       view_group: View group
       view_map: View map
       view_scoreboard: Scoreboard
+    labels:
+      floor_area: Floor area (m2)
     priority_actions:
       intro_html: |-
         <p>We carry out daily analysis for all schools to help identify the areas where there are the biggest opportunities to reduce costs and carbon emissions.</p>

--- a/spec/services/school_groups/recent_usage_csv_generator_spec.rb
+++ b/spec/services/school_groups/recent_usage_csv_generator_spec.rb
@@ -2,8 +2,8 @@ require 'rails_helper'
 
 RSpec.describe SchoolGroups::RecentUsageCsvGenerator do
   let(:school_group) { create(:school_group) }
-  let!(:school_1)    { create(:school, school_group: school_group, number_of_pupils: 10, data_enabled: true, visible: true, active: true, name: 'A school') }
-  let!(:school_2)    { create(:school, school_group: school_group, number_of_pupils: 20, data_enabled: true, visible: true, active: true, name: 'B school') }
+  let!(:school_1)    { create(:school, school_group: school_group, number_of_pupils: 10, floor_area: nil, data_enabled: true, visible: true, active: true, name: 'A school') }
+  let!(:school_2)    { create(:school, school_group: school_group, number_of_pupils: 20, floor_area: 300, data_enabled: true, visible: true, active: true, name: 'B school') }
   let!(:cluster)     { create(:school_group_cluster, name: "A Cluster", school_group: school_group, schools: [school_1]) }
 
   include_context "school group recent usage"
@@ -30,9 +30,9 @@ RSpec.describe SchoolGroups::RecentUsageCsvGenerator do
       let(:params) { params_full.except(:metric) }
       it "returns change data as a csv for all schools in a school group" do
         expect(csv.lines.count).to eq(3)
-        expect(csv.lines[0]).to eq("School,Electricity Last week,Electricity Last year,Gas Last week,Gas Last year,Storage heaters Last week,Storage heaters Last year\n")
-        expect(csv.lines[1]).to eq("#{school_group.schools.first.name},-16%,-16%,-16%,-16%,-16%,-16%\n")
-        expect(csv.lines[2]).to eq("#{school_group.schools.second.name},-16%,-16%,-16%,-16%,-16%,-16%\n")
+        expect(csv.lines[0]).to eq("School,Number of pupils,Floor area in square metres,Electricity Last week,Electricity Last year,Gas Last week,Gas Last year,Storage heaters Last week,Storage heaters Last year\n")
+        expect(csv.lines[1]).to eq("#{school_group.schools.first.name},10,,-16%,-16%,-16%,-16%,-16%,-16%\n")
+        expect(csv.lines[2]).to eq("#{school_group.schools.second.name},20,300.0,-16%,-16%,-16%,-16%,-16%,-16%\n")
       end
       it_behaves_like "a school group recent usage csv including cluster"
     end
@@ -41,9 +41,9 @@ RSpec.describe SchoolGroups::RecentUsageCsvGenerator do
       let(:metric) { 'change' }
       it "returns change data as a csv for all schools in a school group" do
         expect(csv.lines.count).to eq(3)
-        expect(csv.lines[0]).to eq("School,Electricity Last week,Electricity Last year,Gas Last week,Gas Last year,Storage heaters Last week,Storage heaters Last year\n")
-        expect(csv.lines[1]).to eq("#{school_group.schools.first.name},-16%,-16%,-16%,-16%,-16%,-16%\n")
-        expect(csv.lines[2]).to eq("#{school_group.schools.second.name},-16%,-16%,-16%,-16%,-16%,-16%\n")
+        expect(csv.lines[0]).to eq("School,Number of pupils,Floor area in square metres,Electricity Last week,Electricity Last year,Gas Last week,Gas Last year,Storage heaters Last week,Storage heaters Last year\n")
+        expect(csv.lines[1]).to eq("#{school_group.schools.first.name},10,,-16%,-16%,-16%,-16%,-16%,-16%\n")
+        expect(csv.lines[2]).to eq("#{school_group.schools.second.name},20,300.0,-16%,-16%,-16%,-16%,-16%,-16%\n")
       end
       it_behaves_like "a school group recent usage csv including cluster"
     end
@@ -52,9 +52,9 @@ RSpec.describe SchoolGroups::RecentUsageCsvGenerator do
       let(:metric) { 'usage' }
       it 'returns usage data as a csv for all schools in a school group' do
         expect(csv.lines.count).to eq(3)
-        expect(csv.lines[0]).to eq("School,Electricity Last week,Electricity Last year,Gas Last week,Gas Last year,Storage heaters Last week,Storage heaters Last year\n")
-        expect(csv.lines[1]).to eq("#{school_group.schools.first.name},910,910,910,910,910,910\n")
-        expect(csv.lines[2]).to eq("#{school_group.schools.second.name},910,910,910,910,910,910\n")
+        expect(csv.lines[0]).to eq("School,Number of pupils,Floor area in square metres,Electricity Last week,Electricity Last year,Gas Last week,Gas Last year,Storage heaters Last week,Storage heaters Last year\n")
+        expect(csv.lines[1]).to eq("#{school_group.schools.first.name},10,,910,910,910,910,910,910\n")
+        expect(csv.lines[2]).to eq("#{school_group.schools.second.name},20,300.0,910,910,910,910,910,910\n")
       end
       it_behaves_like "a school group recent usage csv including cluster"
     end
@@ -63,9 +63,9 @@ RSpec.describe SchoolGroups::RecentUsageCsvGenerator do
       let(:metric) { 'cost' }
       it 'returns cost data as a csv for all schools in a school group' do
         expect(csv.lines.count).to eq(3)
-        expect(csv.lines[0]).to eq("School,Electricity Last week,Electricity Last year,Gas Last week,Gas Last year,Storage heaters Last week,Storage heaters Last year\n")
-        expect(csv.lines[1]).to eq("#{school_group.schools.first.name},£137,£137,£137,£137,£137,£137\n")
-        expect(csv.lines[2]).to eq("#{school_group.schools.second.name},£137,£137,£137,£137,£137,£137\n")
+        expect(csv.lines[0]).to eq("School,Number of pupils,Floor area in square metres,Electricity Last week,Electricity Last year,Gas Last week,Gas Last year,Storage heaters Last week,Storage heaters Last year\n")
+        expect(csv.lines[1]).to eq("#{school_group.schools.first.name},10,,£137,£137,£137,£137,£137,£137\n")
+        expect(csv.lines[2]).to eq("#{school_group.schools.second.name},20,300.0,£137,£137,£137,£137,£137,£137\n")
       end
       it_behaves_like "a school group recent usage csv including cluster"
     end
@@ -73,9 +73,9 @@ RSpec.describe SchoolGroups::RecentUsageCsvGenerator do
     context "with metric set to co2" do
       let(:metric) { 'co2' }
       it 'returns co2 data as a csv for all schools in a school group' do
-        expect(csv.lines[0]).to eq("School,Electricity Last week,Electricity Last year,Gas Last week,Gas Last year,Storage heaters Last week,Storage heaters Last year\n")
-        expect(csv.lines[1]).to eq("#{school_group.schools.first.name},\"8,540\",\"8,540\",\"8,540\",\"8,540\",\"8,540\",\"8,540\"\n")
-        expect(csv.lines[2]).to eq("#{school_group.schools.second.name},\"8,540\",\"8,540\",\"8,540\",\"8,540\",\"8,540\",\"8,540\"\n")
+        expect(csv.lines[0]).to eq("School,Number of pupils,Floor area in square metres,Electricity Last week,Electricity Last year,Gas Last week,Gas Last year,Storage heaters Last week,Storage heaters Last year\n")
+        expect(csv.lines[1]).to eq("#{school_group.schools.first.name},10,,\"8,540\",\"8,540\",\"8,540\",\"8,540\",\"8,540\",\"8,540\"\n")
+        expect(csv.lines[2]).to eq("#{school_group.schools.second.name},20,300.0,\"8,540\",\"8,540\",\"8,540\",\"8,540\",\"8,540\",\"8,540\"\n")
       end
       it_behaves_like "a school group recent usage csv including cluster"
     end

--- a/spec/services/school_groups/recent_usage_csv_generator_spec.rb
+++ b/spec/services/school_groups/recent_usage_csv_generator_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe SchoolGroups::RecentUsageCsvGenerator do
       let(:params) { params_full.except(:metric) }
       it "returns change data as a csv for all schools in a school group" do
         expect(csv.lines.count).to eq(3)
-        expect(csv.lines[0]).to eq("School,Number of pupils,Floor area in square metres,Electricity Last week,Electricity Last year,Gas Last week,Gas Last year,Storage heaters Last week,Storage heaters Last year\n")
+        expect(csv.lines[0]).to eq("School,Number of pupils,Floor area (m2),Electricity Last week,Electricity Last year,Gas Last week,Gas Last year,Storage heaters Last week,Storage heaters Last year\n")
         expect(csv.lines[1]).to eq("#{school_group.schools.first.name},10,,-16%,-16%,-16%,-16%,-16%,-16%\n")
         expect(csv.lines[2]).to eq("#{school_group.schools.second.name},20,300.0,-16%,-16%,-16%,-16%,-16%,-16%\n")
       end
@@ -41,7 +41,7 @@ RSpec.describe SchoolGroups::RecentUsageCsvGenerator do
       let(:metric) { 'change' }
       it "returns change data as a csv for all schools in a school group" do
         expect(csv.lines.count).to eq(3)
-        expect(csv.lines[0]).to eq("School,Number of pupils,Floor area in square metres,Electricity Last week,Electricity Last year,Gas Last week,Gas Last year,Storage heaters Last week,Storage heaters Last year\n")
+        expect(csv.lines[0]).to eq("School,Number of pupils,Floor area (m2),Electricity Last week,Electricity Last year,Gas Last week,Gas Last year,Storage heaters Last week,Storage heaters Last year\n")
         expect(csv.lines[1]).to eq("#{school_group.schools.first.name},10,,-16%,-16%,-16%,-16%,-16%,-16%\n")
         expect(csv.lines[2]).to eq("#{school_group.schools.second.name},20,300.0,-16%,-16%,-16%,-16%,-16%,-16%\n")
       end
@@ -52,7 +52,7 @@ RSpec.describe SchoolGroups::RecentUsageCsvGenerator do
       let(:metric) { 'usage' }
       it 'returns usage data as a csv for all schools in a school group' do
         expect(csv.lines.count).to eq(3)
-        expect(csv.lines[0]).to eq("School,Number of pupils,Floor area in square metres,Electricity Last week,Electricity Last year,Gas Last week,Gas Last year,Storage heaters Last week,Storage heaters Last year\n")
+        expect(csv.lines[0]).to eq("School,Number of pupils,Floor area (m2),Electricity Last week,Electricity Last year,Gas Last week,Gas Last year,Storage heaters Last week,Storage heaters Last year\n")
         expect(csv.lines[1]).to eq("#{school_group.schools.first.name},10,,910,910,910,910,910,910\n")
         expect(csv.lines[2]).to eq("#{school_group.schools.second.name},20,300.0,910,910,910,910,910,910\n")
       end
@@ -63,7 +63,7 @@ RSpec.describe SchoolGroups::RecentUsageCsvGenerator do
       let(:metric) { 'cost' }
       it 'returns cost data as a csv for all schools in a school group' do
         expect(csv.lines.count).to eq(3)
-        expect(csv.lines[0]).to eq("School,Number of pupils,Floor area in square metres,Electricity Last week,Electricity Last year,Gas Last week,Gas Last year,Storage heaters Last week,Storage heaters Last year\n")
+        expect(csv.lines[0]).to eq("School,Number of pupils,Floor area (m2),Electricity Last week,Electricity Last year,Gas Last week,Gas Last year,Storage heaters Last week,Storage heaters Last year\n")
         expect(csv.lines[1]).to eq("#{school_group.schools.first.name},10,,£137,£137,£137,£137,£137,£137\n")
         expect(csv.lines[2]).to eq("#{school_group.schools.second.name},20,300.0,£137,£137,£137,£137,£137,£137\n")
       end
@@ -73,7 +73,7 @@ RSpec.describe SchoolGroups::RecentUsageCsvGenerator do
     context "with metric set to co2" do
       let(:metric) { 'co2' }
       it 'returns co2 data as a csv for all schools in a school group' do
-        expect(csv.lines[0]).to eq("School,Number of pupils,Floor area in square metres,Electricity Last week,Electricity Last year,Gas Last week,Gas Last year,Storage heaters Last week,Storage heaters Last year\n")
+        expect(csv.lines[0]).to eq("School,Number of pupils,Floor area (m2),Electricity Last week,Electricity Last year,Gas Last week,Gas Last year,Storage heaters Last week,Storage heaters Last year\n")
         expect(csv.lines[1]).to eq("#{school_group.schools.first.name},10,,\"8,540\",\"8,540\",\"8,540\",\"8,540\",\"8,540\",\"8,540\"\n")
         expect(csv.lines[2]).to eq("#{school_group.schools.second.name},20,300.0,\"8,540\",\"8,540\",\"8,540\",\"8,540\",\"8,540\",\"8,540\"\n")
       end

--- a/spec/services/school_groups/recent_usage_csv_generator_spec.rb
+++ b/spec/services/school_groups/recent_usage_csv_generator_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe SchoolGroups::RecentUsageCsvGenerator do
   let(:school_group) { create(:school_group) }
   let!(:school_1)    { create(:school, school_group: school_group, number_of_pupils: 10, floor_area: nil, data_enabled: true, visible: true, active: true, name: 'A school') }
-  let!(:school_2)    { create(:school, school_group: school_group, number_of_pupils: 20, floor_area: 300, data_enabled: true, visible: true, active: true, name: 'B school') }
+  let!(:school_2)    { create(:school, school_group: school_group, number_of_pupils: 20, floor_area: 300.0, data_enabled: true, visible: true, active: true, name: 'B school') }
   let!(:cluster)     { create(:school_group_cluster, name: "A Cluster", school_group: school_group, schools: [school_1]) }
 
   include_context "school group recent usage"

--- a/spec/services/school_groups/schools_priority_action_csv_generator_spec.rb
+++ b/spec/services/school_groups/schools_priority_action_csv_generator_spec.rb
@@ -2,8 +2,8 @@ require 'rails_helper'
 
 RSpec.describe SchoolGroups::SchoolsPriorityActionCsvGenerator do
   let(:school_group)           { create(:school_group) }
-  let!(:school_1)              { create(:school, school_group: school_group, number_of_pupils: 10, data_enabled: true, visible: true, active: true) }
-  let!(:school_2)              { create(:school, school_group: school_group, number_of_pupils: 20, data_enabled: true, visible: true, active: true) }
+  let!(:school_1)              { create(:school, school_group: school_group, number_of_pupils: 10, floor_area: 200.0, data_enabled: true, visible: true, active: true) }
+  let!(:school_2)              { create(:school, school_group: school_group, number_of_pupils: 20, floor_area: 300.0, data_enabled: true, visible: true, active: true) }
 
   include_context "school group priority actions"
 
@@ -12,21 +12,21 @@ RSpec.describe SchoolGroups::SchoolsPriorityActionCsvGenerator do
       it 'returns priority actions data as a csv for a school group' do
         csv = SchoolGroups::SchoolsPriorityActionCsvGenerator.new(school_group: school_group, alert_type_rating_ids: [alert_type_rating.id]).export
         expect(csv.lines.count).to eq(2)
-        expect(csv.lines[0]).to eq("Fuel,Description,School,Energy saving,Cost saving,CO2 reduction\n")
-        expect(csv.lines[1]).to eq("Gas,Spending too much money on heating,#{school_group.schools.first.name},0 kWh,£1000,1100 kg CO2\n")
+        expect(csv.lines[0]).to eq("Fuel,Description,School,Number of pupils,Floor area in square metres,Energy saving,Cost saving,CO2 reduction\n")
+        expect(csv.lines[1]).to eq("Gas,Spending too much money on heating,#{school_group.schools.first.name},10,200.0,0 kWh,£1000,1100 kg CO2\n")
       end
 
       context "when including cluster" do
         subject(:csv) { SchoolGroups::SchoolsPriorityActionCsvGenerator.new(school_group: school_group, alert_type_rating_ids: [alert_type_rating.id], include_cluster: true).export }
 
         it { expect(csv.lines.count).to eq(2) }
-        it { expect(csv.lines[0]).to eq("Fuel,Description,School,Cluster,Energy saving,Cost saving,CO2 reduction\n") }
+        it { expect(csv.lines[0]).to eq("Fuel,Description,School,Cluster,Number of pupils,Floor area in square metres,Energy saving,Cost saving,CO2 reduction\n") }
         context "when school doesn't have cluster" do
-          it { expect(csv.lines[1]).to eq("Gas,Spending too much money on heating,#{school_group.schools.first.name},N/A,0 kWh,£1000,1100 kg CO2\n") }
+          it { expect(csv.lines[1]).to eq("Gas,Spending too much money on heating,#{school_group.schools.first.name},N/A,10,200.0,0 kWh,£1000,1100 kg CO2\n") }
         end
         context "when school has a cluster" do
           let!(:cluster) { create(:school_group_cluster, school_group: school_group, name: "My Cluster", schools: [school_1]) }
-          it { expect(csv.lines[1]).to eq("Gas,Spending too much money on heating,#{school_group.schools.first.name},My Cluster,0 kWh,£1000,1100 kg CO2\n") }
+          it { expect(csv.lines[1]).to eq("Gas,Spending too much money on heating,#{school_group.schools.first.name},My Cluster,10,200.0,0 kWh,£1000,1100 kg CO2\n") }
         end
       end
     end

--- a/spec/services/school_groups/schools_priority_action_csv_generator_spec.rb
+++ b/spec/services/school_groups/schools_priority_action_csv_generator_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe SchoolGroups::SchoolsPriorityActionCsvGenerator do
       it 'returns priority actions data as a csv for a school group' do
         csv = SchoolGroups::SchoolsPriorityActionCsvGenerator.new(school_group: school_group, alert_type_rating_ids: [alert_type_rating.id]).export
         expect(csv.lines.count).to eq(2)
-        expect(csv.lines[0]).to eq("Fuel,Description,School,Number of pupils,Floor area in square metres,Energy saving,Cost saving,CO2 reduction\n")
+        expect(csv.lines[0]).to eq("Fuel,Description,School,Number of pupils,Floor area (m2),Energy saving,Cost saving,CO2 reduction\n")
         expect(csv.lines[1]).to eq("Gas,Spending too much money on heating,#{school_group.schools.first.name},10,200.0,0 kWh,£1000,1100 kg CO2\n")
       end
 
@@ -20,7 +20,7 @@ RSpec.describe SchoolGroups::SchoolsPriorityActionCsvGenerator do
         subject(:csv) { SchoolGroups::SchoolsPriorityActionCsvGenerator.new(school_group: school_group, alert_type_rating_ids: [alert_type_rating.id], include_cluster: true).export }
 
         it { expect(csv.lines.count).to eq(2) }
-        it { expect(csv.lines[0]).to eq("Fuel,Description,School,Cluster,Number of pupils,Floor area in square metres,Energy saving,Cost saving,CO2 reduction\n") }
+        it { expect(csv.lines[0]).to eq("Fuel,Description,School,Cluster,Number of pupils,Floor area (m2),Energy saving,Cost saving,CO2 reduction\n") }
         context "when school doesn't have cluster" do
           it { expect(csv.lines[1]).to eq("Gas,Spending too much money on heating,#{school_group.schools.first.name},N/A,10,200.0,0 kWh,£1000,1100 kg CO2\n") }
         end

--- a/spec/system/school_groups_spec.rb
+++ b/spec/system/school_groups_spec.rb
@@ -6,7 +6,7 @@ describe 'school groups', :school_groups, type: :system do
 
   let!(:user)                  { create(:user) }
 
-  let!(:school_1)              { create(:school, school_group: school_group, number_of_pupils: 10, floor_area: nil, data_enabled: true, visible: true, active: true) }
+  let!(:school_1)              { create(:school, school_group: school_group, number_of_pupils: 10, floor_area: 200.0, data_enabled: true, visible: true, active: true) }
   let!(:school_2)              { create(:school, school_group: school_group, number_of_pupils: 20, floor_area: 300.0, data_enabled: true, visible: true, active: true) }
 
   before do
@@ -280,7 +280,7 @@ describe 'school groups', :school_groups, type: :system do
               expect(header).to match /^attachment/
               filename = "#{school_group.name}-recent-usage-change-#{Time.zone.now.strftime('%Y-%m-%d')}".parameterize + ".csv"
               expect(header).to match filename
-              expect(page.source).to have_content "School,Number of pupils,Floor area in square metres,Electricity Last week,Electricity Last year,Gas Last week,Gas Last year,Storage heaters Last week,Storage heaters Last year\n#{school_group.schools.first.name},10,,-16%,-16%,-16%,-16%,-16%,-16%\n#{school_group.schools.second.name},20,300.0,-16%,-16%,-16%,-16%,-16%,-16%\n"
+              expect(page.source).to have_content "School,Number of pupils,Floor area in square metres,Electricity Last week,Electricity Last year,Gas Last week,Gas Last year,Storage heaters Last week,Storage heaters Last year\n#{school_group.schools.first.name},10,200.0,-16%,-16%,-16%,-16%,-16%,-16%\n#{school_group.schools.second.name},20,300.0,-16%,-16%,-16%,-16%,-16%,-16%\n"
 
               visit school_group_path(school_group, metric: 'usage')
               click_on 'Download as CSV'
@@ -288,7 +288,7 @@ describe 'school groups', :school_groups, type: :system do
               expect(header).to match /^attachment/
               filename = "#{school_group.name}-recent-usage-use-kwh-#{Time.zone.now.strftime('%Y-%m-%d')}".parameterize + ".csv"
               expect(header).to match filename
-              expect(page.source).to have_content "School,Number of pupils,Floor area in square metres,Electricity Last week,Electricity Last year,Gas Last week,Gas Last year,Storage heaters Last week,Storage heaters Last year\n#{school_group.schools.first.name},10,,910,910,910,910,910,910\n#{school_group.schools.second.name},20,300.0,910,910,910,910,910,910\n"
+              expect(page.source).to have_content "School,Number of pupils,Floor area in square metres,Electricity Last week,Electricity Last year,Gas Last week,Gas Last year,Storage heaters Last week,Storage heaters Last year\n#{school_group.schools.first.name},10,200.0,910,910,910,910,910,910\n#{school_group.schools.second.name},20,300.0,910,910,910,910,910,910\n"
 
               visit school_group_path(school_group, metric: 'cost')
               click_on 'Download as CSV'
@@ -296,7 +296,7 @@ describe 'school groups', :school_groups, type: :system do
               expect(header).to match /^attachment/
               filename = "#{school_group.name}-recent-usage-cost-#{Time.zone.now.strftime('%Y-%m-%d')}".parameterize + ".csv"
               expect(header).to match filename
-              expect(page.source).to have_content "School,Number of pupils,Floor area in square metres,Electricity Last week,Electricity Last year,Gas Last week,Gas Last year,Storage heaters Last week,Storage heaters Last year\n#{school_group.schools.first.name},10,,£137,£137,£137,£137,£137,£137\n#{school_group.schools.second.name},20,300.0,£137,£137,£137,£137,£137,£137\n"
+              expect(page.source).to have_content "School,Number of pupils,Floor area in square metres,Electricity Last week,Electricity Last year,Gas Last week,Gas Last year,Storage heaters Last week,Storage heaters Last year\n#{school_group.schools.first.name},10,200.0,£137,£137,£137,£137,£137,£137\n#{school_group.schools.second.name},20,300.0,£137,£137,£137,£137,£137,£137\n"
 
               visit school_group_path(school_group, metric: 'co2')
               click_on 'Download as CSV'
@@ -304,7 +304,7 @@ describe 'school groups', :school_groups, type: :system do
               expect(header).to match /^attachment/
               filename = "#{school_group.name}-recent-usage-co2-kg-#{Time.zone.now.strftime('%Y-%m-%d')}".parameterize + ".csv"
               expect(header).to match filename
-              expect(page.source).to have_content "School,Number of pupils,Floor area in square metres,Electricity Last week,Electricity Last year,Gas Last week,Gas Last year,Storage heaters Last week,Storage heaters Last year\n#{school_group.schools.first.name},10,,\"8,540\",\"8,540\",\"8,540\",\"8,540\",\"8,540\",\"8,540\"\n#{school_group.schools.second.name},20,300.0,\"8,540\",\"8,540\",\"8,540\",\"8,540\",\"8,540\",\"8,540\"\n"
+              expect(page.source).to have_content "School,Number of pupils,Floor area in square metres,Electricity Last week,Electricity Last year,Gas Last week,Gas Last year,Storage heaters Last week,Storage heaters Last year\n#{school_group.schools.first.name},10,200.0,\"8,540\",\"8,540\",\"8,540\",\"8,540\",\"8,540\",\"8,540\"\n#{school_group.schools.second.name},20,300.0,\"8,540\",\"8,540\",\"8,540\",\"8,540\",\"8,540\",\"8,540\"\n"
             end
           end
         end
@@ -383,7 +383,6 @@ describe 'school groups', :school_groups, type: :system do
           end
 
           it 'allows a csv download of all priority actions for a school group' do
-            # first(:link, 'Download as CSV').click
             click_link('Download as CSV', id: 'download-priority-actions-school-group-csv')
             header = page.response_headers['Content-Disposition']
             expect(header).to match /^attachment/
@@ -398,7 +397,7 @@ describe 'school groups', :school_groups, type: :system do
             expect(header).to match /^attachment/
             filename = "#{school_group.name}-#{I18n.t('school_groups.titles.priority_actions')}-#{Time.zone.now.strftime('%Y-%m-%d')}".parameterize + ".csv"
             expect(header).to match filename
-            expect(page.source).to eq "Fuel,Description,School,Energy saving,Cost saving,CO2 reduction\nGas,Spending too much money on heating,#{school_group.schools.first.name},0 kWh,£1000,1100 kg CO2\n"
+            expect(page.source).to eq "Fuel,Description,School,Number of pupils,Floor area in square metres,Energy saving,Cost saving,CO2 reduction\nGas,Spending too much money on heating,#{school_group.schools.first.name},10,200.0,0 kWh,£1000,1100 kg CO2\n"
           end
 
           it 'displays list of actions' do

--- a/spec/system/school_groups_spec.rb
+++ b/spec/system/school_groups_spec.rb
@@ -280,7 +280,7 @@ describe 'school groups', :school_groups, type: :system do
               expect(header).to match /^attachment/
               filename = "#{school_group.name}-recent-usage-change-#{Time.zone.now.strftime('%Y-%m-%d')}".parameterize + ".csv"
               expect(header).to match filename
-              expect(page.source).to have_content "School,Number of pupils,Floor area in square metres,Electricity Last week,Electricity Last year,Gas Last week,Gas Last year,Storage heaters Last week,Storage heaters Last year\n#{school_group.schools.first.name},10,200.0,-16%,-16%,-16%,-16%,-16%,-16%\n#{school_group.schools.second.name},20,300.0,-16%,-16%,-16%,-16%,-16%,-16%\n"
+              expect(page.source).to have_content "School,Number of pupils,Floor area (m2),Electricity Last week,Electricity Last year,Gas Last week,Gas Last year,Storage heaters Last week,Storage heaters Last year\n#{school_group.schools.first.name},10,200.0,-16%,-16%,-16%,-16%,-16%,-16%\n#{school_group.schools.second.name},20,300.0,-16%,-16%,-16%,-16%,-16%,-16%\n"
 
               visit school_group_path(school_group, metric: 'usage')
               click_on 'Download as CSV'
@@ -288,7 +288,7 @@ describe 'school groups', :school_groups, type: :system do
               expect(header).to match /^attachment/
               filename = "#{school_group.name}-recent-usage-use-kwh-#{Time.zone.now.strftime('%Y-%m-%d')}".parameterize + ".csv"
               expect(header).to match filename
-              expect(page.source).to have_content "School,Number of pupils,Floor area in square metres,Electricity Last week,Electricity Last year,Gas Last week,Gas Last year,Storage heaters Last week,Storage heaters Last year\n#{school_group.schools.first.name},10,200.0,910,910,910,910,910,910\n#{school_group.schools.second.name},20,300.0,910,910,910,910,910,910\n"
+              expect(page.source).to have_content "School,Number of pupils,Floor area (m2),Electricity Last week,Electricity Last year,Gas Last week,Gas Last year,Storage heaters Last week,Storage heaters Last year\n#{school_group.schools.first.name},10,200.0,910,910,910,910,910,910\n#{school_group.schools.second.name},20,300.0,910,910,910,910,910,910\n"
 
               visit school_group_path(school_group, metric: 'cost')
               click_on 'Download as CSV'
@@ -296,7 +296,7 @@ describe 'school groups', :school_groups, type: :system do
               expect(header).to match /^attachment/
               filename = "#{school_group.name}-recent-usage-cost-#{Time.zone.now.strftime('%Y-%m-%d')}".parameterize + ".csv"
               expect(header).to match filename
-              expect(page.source).to have_content "School,Number of pupils,Floor area in square metres,Electricity Last week,Electricity Last year,Gas Last week,Gas Last year,Storage heaters Last week,Storage heaters Last year\n#{school_group.schools.first.name},10,200.0,£137,£137,£137,£137,£137,£137\n#{school_group.schools.second.name},20,300.0,£137,£137,£137,£137,£137,£137\n"
+              expect(page.source).to have_content "School,Number of pupils,Floor area (m2),Electricity Last week,Electricity Last year,Gas Last week,Gas Last year,Storage heaters Last week,Storage heaters Last year\n#{school_group.schools.first.name},10,200.0,£137,£137,£137,£137,£137,£137\n#{school_group.schools.second.name},20,300.0,£137,£137,£137,£137,£137,£137\n"
 
               visit school_group_path(school_group, metric: 'co2')
               click_on 'Download as CSV'
@@ -304,7 +304,7 @@ describe 'school groups', :school_groups, type: :system do
               expect(header).to match /^attachment/
               filename = "#{school_group.name}-recent-usage-co2-kg-#{Time.zone.now.strftime('%Y-%m-%d')}".parameterize + ".csv"
               expect(header).to match filename
-              expect(page.source).to have_content "School,Number of pupils,Floor area in square metres,Electricity Last week,Electricity Last year,Gas Last week,Gas Last year,Storage heaters Last week,Storage heaters Last year\n#{school_group.schools.first.name},10,200.0,\"8,540\",\"8,540\",\"8,540\",\"8,540\",\"8,540\",\"8,540\"\n#{school_group.schools.second.name},20,300.0,\"8,540\",\"8,540\",\"8,540\",\"8,540\",\"8,540\",\"8,540\"\n"
+              expect(page.source).to have_content "School,Number of pupils,Floor area (m2),Electricity Last week,Electricity Last year,Gas Last week,Gas Last year,Storage heaters Last week,Storage heaters Last year\n#{school_group.schools.first.name},10,200.0,\"8,540\",\"8,540\",\"8,540\",\"8,540\",\"8,540\",\"8,540\"\n#{school_group.schools.second.name},20,300.0,\"8,540\",\"8,540\",\"8,540\",\"8,540\",\"8,540\",\"8,540\"\n"
             end
           end
         end
@@ -397,7 +397,7 @@ describe 'school groups', :school_groups, type: :system do
             expect(header).to match /^attachment/
             filename = "#{school_group.name}-#{I18n.t('school_groups.titles.priority_actions')}-#{Time.zone.now.strftime('%Y-%m-%d')}".parameterize + ".csv"
             expect(header).to match filename
-            expect(page.source).to eq "Fuel,Description,School,Number of pupils,Floor area in square metres,Energy saving,Cost saving,CO2 reduction\nGas,Spending too much money on heating,#{school_group.schools.first.name},10,200.0,0 kWh,£1000,1100 kg CO2\n"
+            expect(page.source).to eq "Fuel,Description,School,Number of pupils,Floor area (m2),Energy saving,Cost saving,CO2 reduction\nGas,Spending too much money on heating,#{school_group.schools.first.name},10,200.0,0 kWh,£1000,1100 kg CO2\n"
           end
 
           it 'displays list of actions' do

--- a/spec/system/school_groups_spec.rb
+++ b/spec/system/school_groups_spec.rb
@@ -5,8 +5,9 @@ describe 'school groups', :school_groups, type: :system do
   let!(:school_group)          { create(:school_group, public: public) }
 
   let!(:user)                  { create(:user) }
-  let!(:school_1)              { create(:school, school_group: school_group, number_of_pupils: 10, data_enabled: true, visible: true, active: true) }
-  let!(:school_2)              { create(:school, school_group: school_group, number_of_pupils: 20, data_enabled: true, visible: true, active: true) }
+
+  let!(:school_1)              { create(:school, school_group: school_group, number_of_pupils: 10, floor_area: nil, data_enabled: true, visible: true, active: true) }
+  let!(:school_2)              { create(:school, school_group: school_group, number_of_pupils: 20, floor_area: 300.0, data_enabled: true, visible: true, active: true) }
 
   before do
     allow_any_instance_of(SchoolGroup).to receive(:fuel_types) { [:electricity, :gas, :storage_heaters] }
@@ -279,7 +280,7 @@ describe 'school groups', :school_groups, type: :system do
               expect(header).to match /^attachment/
               filename = "#{school_group.name}-recent-usage-change-#{Time.zone.now.strftime('%Y-%m-%d')}".parameterize + ".csv"
               expect(header).to match filename
-              expect(page.source).to have_content "School,Electricity Last week,Electricity Last year,Gas Last week,Gas Last year,Storage heaters Last week,Storage heaters Last year\n#{school_group.schools.first.name},-16%,-16%,-16%,-16%,-16%,-16%\n#{school_group.schools.second.name},-16%,-16%,-16%,-16%,-16%,-16%\n"
+              expect(page.source).to have_content "School,Number of pupils,Floor area in square metres,Electricity Last week,Electricity Last year,Gas Last week,Gas Last year,Storage heaters Last week,Storage heaters Last year\n#{school_group.schools.first.name},10,,-16%,-16%,-16%,-16%,-16%,-16%\n#{school_group.schools.second.name},20,300.0,-16%,-16%,-16%,-16%,-16%,-16%\n"
 
               visit school_group_path(school_group, metric: 'usage')
               click_on 'Download as CSV'
@@ -287,7 +288,7 @@ describe 'school groups', :school_groups, type: :system do
               expect(header).to match /^attachment/
               filename = "#{school_group.name}-recent-usage-use-kwh-#{Time.zone.now.strftime('%Y-%m-%d')}".parameterize + ".csv"
               expect(header).to match filename
-              expect(page.source).to have_content "School,Electricity Last week,Electricity Last year,Gas Last week,Gas Last year,Storage heaters Last week,Storage heaters Last year\n#{school_group.schools.first.name},910,910,910,910,910,910\n#{school_group.schools.second.name},910,910,910,910,910,910\n"
+              expect(page.source).to have_content "School,Number of pupils,Floor area in square metres,Electricity Last week,Electricity Last year,Gas Last week,Gas Last year,Storage heaters Last week,Storage heaters Last year\n#{school_group.schools.first.name},10,,910,910,910,910,910,910\n#{school_group.schools.second.name},20,300.0,910,910,910,910,910,910\n"
 
               visit school_group_path(school_group, metric: 'cost')
               click_on 'Download as CSV'
@@ -295,7 +296,7 @@ describe 'school groups', :school_groups, type: :system do
               expect(header).to match /^attachment/
               filename = "#{school_group.name}-recent-usage-cost-#{Time.zone.now.strftime('%Y-%m-%d')}".parameterize + ".csv"
               expect(header).to match filename
-              expect(page.source).to have_content "School,Electricity Last week,Electricity Last year,Gas Last week,Gas Last year,Storage heaters Last week,Storage heaters Last year\n#{school_group.schools.first.name},£137,£137,£137,£137,£137,£137\n#{school_group.schools.second.name},£137,£137,£137,£137,£137,£137\n"
+              expect(page.source).to have_content "School,Number of pupils,Floor area in square metres,Electricity Last week,Electricity Last year,Gas Last week,Gas Last year,Storage heaters Last week,Storage heaters Last year\n#{school_group.schools.first.name},10,,£137,£137,£137,£137,£137,£137\n#{school_group.schools.second.name},20,300.0,£137,£137,£137,£137,£137,£137\n"
 
               visit school_group_path(school_group, metric: 'co2')
               click_on 'Download as CSV'
@@ -303,7 +304,7 @@ describe 'school groups', :school_groups, type: :system do
               expect(header).to match /^attachment/
               filename = "#{school_group.name}-recent-usage-co2-kg-#{Time.zone.now.strftime('%Y-%m-%d')}".parameterize + ".csv"
               expect(header).to match filename
-              expect(page.source).to have_content "School,Electricity Last week,Electricity Last year,Gas Last week,Gas Last year,Storage heaters Last week,Storage heaters Last year\n#{school_group.schools.first.name},\"8,540\",\"8,540\",\"8,540\",\"8,540\",\"8,540\",\"8,540\"\n#{school_group.schools.second.name},\"8,540\",\"8,540\",\"8,540\",\"8,540\",\"8,540\",\"8,540\"\n"
+              expect(page.source).to have_content "School,Number of pupils,Floor area in square metres,Electricity Last week,Electricity Last year,Gas Last week,Gas Last year,Storage heaters Last week,Storage heaters Last year\n#{school_group.schools.first.name},10,,\"8,540\",\"8,540\",\"8,540\",\"8,540\",\"8,540\",\"8,540\"\n#{school_group.schools.second.name},20,300.0,\"8,540\",\"8,540\",\"8,540\",\"8,540\",\"8,540\",\"8,540\"\n"
             end
           end
         end


### PR DESCRIPTION
Have used an existing translation floor_area from activerecord.yml that is “Floor area in square metres”. Do we want to use this or just “Floor area” with no units?