### PR TITLE
Ensure required dates in meter attribute form

### DIFF
--- a/app/jobs/school_batch_run_job.rb
+++ b/app/jobs/school_batch_run_job.rb
@@ -9,5 +9,11 @@ class SchoolBatchRunJob < ApplicationJob
     school_batch_run.update(status: :running)
     ContentRegenerator.new(school_batch_run.school, school_batch_run).perform
     school_batch_run.update(status: :done)
+  rescue => e
+    school_batch_run.error(e.message)
+    school_batch_run.info("FAILED")
+    school_batch_run.update(status: :failed)
+    #ensure job is marked as failed by re-throwing exception
+    raise
   end
 end

--- a/app/models/school_batch_run.rb
+++ b/app/models/school_batch_run.rb
@@ -20,7 +20,7 @@ class SchoolBatchRun < ApplicationRecord
   belongs_to :school
   has_many :school_batch_run_log_entries
 
-  enum status: [:pending, :running, :done]
+  enum status: [:pending, :running, :done, :failed]
 
   scope :by_date, -> { order(created_at: :desc) }
 

--- a/app/views/shared/meter_attributes/_date.html.erb
+++ b/app/views/shared/meter_attributes/_date.html.erb
@@ -1,1 +1,1 @@
-<%= form.input field_name, as: :tempus_dominus_date, default_date: value.blank? ? '' : Date.parse(value), required: field.required?, label: label.try(:to_s).try(:humanize), hint: field.hint%>
+<%= form.input field_name, as: :tempus_dominus_date, default_date: value.blank? ? '' : Date.parse(value), label: label.try(:to_s).try(:humanize), hint: field.hint, input_html: {required: field.required?}%>


### PR DESCRIPTION
We had a bug where a required date was not added to a meter attribute. This caused a failure in the analytics. 

This PR has:

- [ ] a fix for the meter attribute editor date field to properly mark them as required
- [ ] a "failed" status for the school batch run jobs, so we can distinguish between jobs that have failed and finished, and those that are still running (and perhaps stuck in a loop)
- [ ] an update to the analytics gem, to add some more error tolerant code to avoid the infinite loop

The fix for the date field is not ideal, as the user doesn't get a proper validation message. But I'm not sure of another way to handle it.

The issue is:

* the date field is now properly marked as required, so the form now won't submit
* as part of the validation process, the date field receives focus as a missing required field
* but, because we set `allowInputToggle` in `datepickers.js`, when the field gets focus it triggers the date input widget to open, with a default date of today
* the widget displays overrides the rest of the validation, so the user doesn't see the usual "please fill in this field" client-side validation message

So the user doesn't really see a prompt that they had missed something. Disabling `allowInputToggle` does let the validation message show, but it then means that the user must manually click a button to see the calendar widget. 

I've not changed that behaviour as it looks like we probably rely on that for some user facing forms.

I'm inclined to leave this for now and later revisit, e.g. to change the calendar widget configuration for admins, or alternatively do all the validation on the server side instead. But I was looking for a simple fix to avoid errors. And this is also easy to revert if we find there are any data issues.

 