### PR TITLE
Clarify error message for admin when uploading files that find meters using serial numbers

### DIFF
--- a/app/models/amr_reading_data.rb
+++ b/app/models/amr_reading_data.rb
@@ -12,6 +12,7 @@ class AmrReadingData
   WARNING_DUPLICATE_READING = 'Another reading exists for the same Mpan or MPRN for the same date'.freeze
 
   ERROR_UNABLE_TO_PARSE_FILE = 'Unable to parse the file'.freeze
+  ERROR_NO_VALID_READINGS = 'No valid readings in file'.freeze
 
   WARNINGS = {
     inconsistent_reading_date_format: WARNING_INCONSISTENT_DATE_FORMAT,
@@ -62,7 +63,7 @@ class AmrReadingData
 
   def any_valid_readings?
     if valid_reading_count == 0
-      errors.add(:reading_data, ERROR_UNABLE_TO_PARSE_FILE)
+      errors.add(:reading_data, ERROR_NO_VALID_READINGS)
     end
   end
 

--- a/app/views/admin/amr_uploaded_readings/new.html.erb
+++ b/app/views/admin/amr_uploaded_readings/new.html.erb
@@ -25,6 +25,15 @@
           <p>File was processed, but there are data errors.</p>
           <p><strong>Reading count</strong>: <%= @amr_reading_data.reading_count %></p>
           <p><strong>Valid reading count</strong>: <%= @amr_reading_data.valid_reading_count %></p>
+          <% if @amr_reading_data.valid_reading_count == 0 && @amr_data_feed_config.lookup_by_serial_number == true %>
+            <p>
+              This configuration finds meters using the serial number in the file.
+            </p>
+            <p>
+              As there are no readings you should check to make sure the serial number has been correctly added to the
+              meter. Otherwise all the data can be rejected.
+            </p>
+          <% end %>
         <% else %>
           <p>Could not process the file</p>
         <% end %>

--- a/spec/services/amr/csv_parser_and_upserter_spec.rb
+++ b/spec/services/amr/csv_parser_and_upserter_spec.rb
@@ -211,7 +211,7 @@ module Amr
 
       it 'should not create records for empty rows (comma, comma)' do
         expect(write_file_and_parse(sheffield_empty_readings, sheffield_config)).to eq 0
-        expect(AmrDataFeedImportLog.first.error_messages).to eq AmrReadingData::ERROR_UNABLE_TO_PARSE_FILE
+        expect(AmrDataFeedImportLog.first.error_messages).to eq AmrReadingData::ERROR_NO_VALID_READINGS
       end
 
       it 'should not create records for empty rows (comma, comma) but still process file' do
@@ -243,7 +243,7 @@ module Amr
         FileUtils.mkdir_p frome_config.local_bucket_path
         expect(write_file_and_parse(example_sheffield_gas, frome_config)).to be 0
 
-        expect(AmrDataFeedImportLog.first.error_messages).to eq AmrReadingData::ERROR_UNABLE_TO_PARSE_FILE
+        expect(AmrDataFeedImportLog.first.error_messages).to eq AmrReadingData::ERROR_NO_VALID_READINGS
       end
     end
 

--- a/spec/system/admin/amr_uploaded_readings_spec.rb
+++ b/spec/system/admin/amr_uploaded_readings_spec.rb
@@ -105,13 +105,13 @@ describe AmrUploadedReading, type: :system do
     it 'is helpful if a very different format file is loaded' do
       attach_file('amr_uploaded_reading[data_file]', 'spec/fixtures/amr_upload_data_files/example-sheffield-file.csv')
       click_on 'Preview'
-      expect(page).to have_content(AmrReadingData::ERROR_UNABLE_TO_PARSE_FILE)
+      expect(page).to have_content(AmrReadingData::ERROR_NO_VALID_READINGS)
     end
 
     it 'is helpful if a dodgy date format file is loaded' do
       attach_file('amr_uploaded_reading[data_file]', 'spec/fixtures/amr_upload_data_files/banes-bad-example-date-file.csv')
       click_on 'Preview'
-      expect(page).to have_content(AmrReadingData::ERROR_UNABLE_TO_PARSE_FILE)
+      expect(page).to have_content(AmrReadingData::ERROR_NO_VALID_READINGS)
     end
 
     it 'is helpful if a single dodgy date format is in the file loaded' do


### PR DESCRIPTION
A data feed config can be configured to lookup meters by serial number. The admins need to add these to the database. 

If all the serial numbers in a file are missing, then this leads to an error as we have no valid readings in the file. This PR just tweaks the error reporting on the admin form to prompt them to check for this where necessary.

Also ensured there's different messages for "unable to parse file" and "no valid readings" as those are different situations. 