### PR TITLE
Tidy UX and add extra explanatory text to school group pages

### DIFF
--- a/app/assets/stylesheets/colours.scss
+++ b/app/assets/stylesheets/colours.scss
@@ -92,3 +92,24 @@ $colours-dark: (
 .bg-other_school {
   background-color: $bg-negative !important;
 }
+
+.txt-exemplar_school {
+  text-decoration: underline;
+  text-decoration-color: $green;
+  text-decoration-thickness: 3px;
+  font-weight: bolder;
+}
+
+.txt-benchmark_school {
+  text-decoration: underline;
+  text-decoration-color: $light-orange;
+  text-decoration-thickness: 3px;
+  font-weight: bolder;
+}
+
+.txt-other_school {
+  text-decoration: underline;
+  text-decoration-color: $bg-negative;
+  text-decoration-thickness: 3px;
+  font-weight: bolder;
+}

--- a/app/assets/stylesheets/school.scss
+++ b/app/assets/stylesheets/school.scss
@@ -170,3 +170,7 @@ div.award {
 div.calendars {
   font-size: 100% !important;
 }
+
+.scrollable-title {
+  scroll-margin-top: 100px;
+}

--- a/app/components/school_group_comparison_component/school_group_comparison_component.html.erb
+++ b/app/components/school_group_comparison_component/school_group_comparison_component.html.erb
@@ -52,7 +52,7 @@
                             <tr>
                               <td class='text-left'><%= link_to school['school_name'], school_path(id: school['school_slug']) %></td>
                               <% if include_cluster? %>
-                                <td class='text-right'><%= school['cluster_name'] || t('common.labels.not_applicable') %></td>
+                                <td class='text-right'><%= school['cluster_name'] || t('common.labels.not_set') %></td>
                               <% end %>
                               <td class='text-right'><%= link_to t('school_groups.priority_actions.view_analysis'), advice_page_path_for(school['school_slug']) %></td>
                             </tr>

--- a/app/components/school_group_comparison_component/school_group_comparison_component.html.erb
+++ b/app/components/school_group_comparison_component/school_group_comparison_component.html.erb
@@ -29,6 +29,9 @@
                 <% if count.positive? %>
                   <%= render(FootnoteModalComponent.new(title: tag.small(modal_title_for(category)), modal_id: modal_id_for(category))) do |component| %>
                     <% component.with_body_content do %>
+                      <div class="text-left">
+                        <%= t('school_groups.comparisons.modal_subtitle_html', category_id: category, category: t("advice_pages.benchmarks.#{category}")) %>
+                      </div>
                       <% if csv_download_link %>
                         <div class='text-right pt-3'>
                           <%= csv_download_link %>

--- a/app/helpers/advice_page_helper.rb
+++ b/app/helpers/advice_page_helper.rb
@@ -205,5 +205,9 @@ module AdvicePageHelper
   def icon_tooltip(text = '')
     tag.span(fa_icon('info-circle'), data: { toggle: "tooltip", placement: "top", title: text }, class: 'text-muted') if text.present?
   end
+
+  def formatted_unit_to_num(value)
+    value.gsub(/(,|kWh|kg CO2)/, '').to_i
+  end
 end
 # rubocop:enable Naming/AsciiIdentifiers

--- a/app/models/alert_type_rating.rb
+++ b/app/models/alert_type_rating.rb
@@ -91,8 +91,19 @@ class AlertTypeRating < ApplicationRecord
     intervention_types.order('alert_type_rating_intervention_types.position').group('intervention_types.id, alert_type_rating_intervention_types.position')
   end
 
+  def priority_action_modal_text?
+    I18n.t('school_groups.priority_actions.alert_types').key?("#{alert_type_class_key}_html".to_sym)
+  end
+
+  def priority_action_modal_text
+    I18n.t("school_groups.priority_actions.alert_types.#{alert_type_class_key}_html")
+  end
 
 private
+
+  def alert_type_class_key
+    alert_type.class_name.underscore
+  end
 
   def save_and_replace(content, to_replace)
     transaction do

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -606,7 +606,7 @@ class School < ApplicationRecord
   end
 
   def school_group_cluster_name
-    school_group_cluster.try(:name) || I18n.t('common.labels.not_applicable')
+    school_group_cluster.try(:name) || I18n.t('common.labels.not_set')
   end
 
   private

--- a/app/services/school_groups/priority_actions_csv_generator.rb
+++ b/app/services/school_groups/priority_actions_csv_generator.rb
@@ -14,9 +14,9 @@ module SchoolGroups
           row << alert_type_rating.alert_type&.fuel_type&.humanize
           row << alert_type_rating&.current_content&.management_priorities_title&.to_plain_text
           row << savings.schools&.length
-          row << ApplicationController.helpers.format_unit(savings&.one_year_saving_kwh, Float) + ' kWh'
+          row << ApplicationController.helpers.format_unit(savings&.one_year_saving_kwh, Float)
           row << '£' + ApplicationController.helpers.format_unit(savings&.average_one_year_saving_gbp, Float)
-          row << ApplicationController.helpers.format_unit(savings&.one_year_saving_co2, Float) + ' kg CO2'
+          row << ApplicationController.helpers.format_unit(savings&.one_year_saving_co2, Float)
 
           csv << row
         end

--- a/app/services/school_groups/schools_priority_action_csv_generator.rb
+++ b/app/services/school_groups/schools_priority_action_csv_generator.rb
@@ -24,9 +24,9 @@ module SchoolGroups
             row += [
               saving.school.number_of_pupils,
               saving.school.floor_area,
-              saving.one_year_saving_kwh.to_s + ' kWh',
+              saving.one_year_saving_kwh.to_s,
               '£' + saving.average_one_year_saving_gbp.to_s,
-              saving.one_year_saving_co2.to_s + ' kg CO2'
+              saving.one_year_saving_co2.to_s
             ]
             csv << row
           end

--- a/app/views/school_groups/_enhanced_header.html.erb
+++ b/app/views/school_groups/_enhanced_header.html.erb
@@ -7,11 +7,11 @@
   <div class="col-md-4">
     <div class='btn-group float-right mt-4'>
       <% if current_page?(action: 'map') %>
-        <%= link_to(t('school_groups.header.view_group'), school_group_path(@school_group), class: 'btn') if can?(:compare, @school_group) %>
+        <%= link_to(t('school_groups.header.view_group'), school_group_path(@school_group), class: 'btn btn-outline-dark rounded-pill font-weight-bold') if can?(:compare, @school_group) %>
       <% else %>
-        <%= link_to t('school_groups.header.view_map'), map_school_group_path(@school_group), class: 'btn' %>
+        <%= link_to t('school_groups.header.view_map'), map_school_group_path(@school_group), class: 'btn btn-outline-dark rounded-pill font-weight-bold' %>
       <% end %>
-      <%= link_to t('school_groups.header.view_scoreboard'), scoreboard_path(@school_group.default_scoreboard), class: 'btn' if @school_group.default_scoreboard %>
+      <%= link_to t('school_groups.header.view_scoreboard'), scoreboard_path(@school_group.default_scoreboard), class: 'btn btn-outline-dark rounded-pill font-weight-bold' if @school_group.default_scoreboard %>
     </div>
   </div>
 </div>
@@ -58,5 +58,3 @@
     </li>
   </ul>
 <% end %>
-
-

--- a/app/views/school_groups/_enhanced_header.html.erb
+++ b/app/views/school_groups/_enhanced_header.html.erb
@@ -11,7 +11,6 @@
       <% else %>
         <%= link_to t('school_groups.header.view_map'), map_school_group_path(@school_group), class: 'btn btn-outline-dark rounded-pill font-weight-bold' %>
       <% end %>
-      <%= link_to t('school_groups.header.view_scoreboard'), scoreboard_path(@school_group.default_scoreboard), class: 'btn btn-outline-dark rounded-pill font-weight-bold' if @school_group.default_scoreboard %>
     </div>
   </div>
 </div>

--- a/app/views/school_groups/_enhanced_header.html.erb
+++ b/app/views/school_groups/_enhanced_header.html.erb
@@ -16,13 +16,17 @@
   </div>
 </div>
 
-<p>
-<% if @partners.any? %>
-  <%= t("school_groups.show.we_are_working_with.#{@school_group.group_type}.in_partnership_with_html", count: @school_group.visible_schools_count, partners: list_of_partners_as_links(@partners)) %>.
-<% else %>
-  <%= t("school_groups.show.we_are_working_with.#{@school_group.group_type}.no_partnership", count: @school_group.visible_schools_count) %>.
-<% end %>
-</p>
+<div class="row">
+  <div class="col-md-12">
+    <p>
+    <% if @partners.any? %>
+      <%= t("school_groups.show.we_are_working_with.#{@school_group.group_type}.in_partnership_with_html", count: @school_group.visible_schools_count, partners: list_of_partners_as_links(@partners)) %>.
+    <% else %>
+      <%= t("school_groups.show.we_are_working_with.#{@school_group.group_type}.no_partnership", count: @school_group.visible_schools_count) %>.
+    <% end %>
+    </p>
+  </div>
+</div>
 
 <% if @show_school_group_message && @school_group.dashboard_message&.message&.present? %>
   <div class='row'>
@@ -34,27 +38,31 @@
   </div>
 <% end %>
 
-<% unless current_page?(action: 'map') %>
-  <ul class="nav nav-tabs locales">
-    <li class="nav-item">
-      <a class="nav-link <%= 'active' if current_page?(action: 'show') %>" href="<%= school_group_path(@school_group) %>">
-        <%= t("school_groups.titles.recent_usage") %>
-      </a>
-    </li>
-    <li class="nav-item">
-      <a class="nav-link <%= 'active' if current_page?(action: 'comparisons') %>" href="<%= comparisons_school_group_path(@school_group) %>">
-        <%= t("school_groups.titles.comparisons") %>
-      </a>
-    </li>
-    <li class="nav-item">
-      <a class="nav-link <%= 'active' if current_page?(action: 'priority_actions') %>" href="<%= priority_actions_school_group_path(@school_group) %>">
-        <%= t("school_groups.titles.priority_actions") %>
-      </a>
-    </li>
-    <li class="nav-item">
-      <a class="nav-link <%= 'active' if current_page?(action: 'current_scores') %>" href="<%= current_scores_school_group_path(@school_group) %>">
-        <%= t("school_groups.titles.current_scores") %>
-      </a>
-    </li>
-  </ul>
-<% end %>
+<div class="row">
+  <div class="col-md-12">
+    <% unless current_page?(action: 'map') %>
+      <ul class="nav nav-tabs locales">
+        <li class="nav-item">
+          <a class="nav-link <%= 'active' if current_page?(action: 'show') %>" href="<%= school_group_path(@school_group) %>">
+            <%= t("school_groups.titles.recent_usage") %>
+          </a>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link <%= 'active' if current_page?(action: 'comparisons') %>" href="<%= comparisons_school_group_path(@school_group) %>">
+            <%= t("school_groups.titles.comparisons") %>
+          </a>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link <%= 'active' if current_page?(action: 'priority_actions') %>" href="<%= priority_actions_school_group_path(@school_group) %>">
+            <%= t("school_groups.titles.priority_actions") %>
+          </a>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link <%= 'active' if current_page?(action: 'current_scores') %>" href="<%= current_scores_school_group_path(@school_group) %>">
+            <%= t("school_groups.titles.current_scores") %>
+          </a>
+        </li>
+      </ul>
+    <% end %>
+  </div>
+</div>

--- a/app/views/school_groups/_priority_action_modal.html.erb
+++ b/app/views/school_groups/_priority_action_modal.html.erb
@@ -1,3 +1,9 @@
+<div class="text-left">
+  <% if alert_type_rating.priority_action_modal_text? %>
+    <%= alert_type_rating.priority_action_modal_text.html_safe %>
+  <% end %>
+</div>
+
 <p><%= t('school_groups.priority_actions.modal_intro') %></p>
 
 <div class='text-right pt-3'>

--- a/app/views/school_groups/_priority_action_modal.html.erb
+++ b/app/views/school_groups/_priority_action_modal.html.erb
@@ -1,7 +1,7 @@
 <p><%= t('school_groups.priority_actions.modal_intro') %></p>
 
 <div class='text-right pt-3'>
-  <%= link_to t('school_groups.download_as_csv'), priority_actions_school_group_path(@school_group, format: :csv, alert_type_rating_ids: [alert_type_rating.id]), class: 'btn btn-sm', id: 'download-priority-actions-school-csv' %>
+  <%= link_to t('school_groups.download_as_csv'), priority_actions_school_group_path(@school_group, format: :csv, alert_type_rating_ids: [alert_type_rating.id]), class: 'btn btn-sm btn-outline-dark rounded-pill font-weight-bold', id: 'download-priority-actions-school-csv' %>
 </div>
 
 <table class="table table-borderless table-sorted advice-table advice-priority-table">

--- a/app/views/school_groups/_priority_action_modal.html.erb
+++ b/app/views/school_groups/_priority_action_modal.html.erb
@@ -35,13 +35,13 @@
           </td>
         <% end %>
         <td class="text-right" data-order="<%= saving.one_year_saving_kwh %>">
-          <%= format_unit(saving.one_year_saving_kwh, :kwh) %> kWh
+          <%= format_unit(saving.one_year_saving_kwh, :kwh) %>
         </td>
         <td class="text-right" data-order="<%= saving.average_one_year_saving_gbp %>">
           <%= format_unit(saving.average_one_year_saving_gbp, :£) %>
         </td>
         <td class="text-right" data-order="<%= saving.one_year_saving_co2 %>">
-          <%= format_unit(saving.one_year_saving_co2, :co2) %> kg CO2
+          <%= format_unit(saving.one_year_saving_co2, :co2) %>
         </td>
         <td class="text-right">
           <% if alert_type_rating.alert_type.advice_page.present? %>

--- a/app/views/school_groups/comparisons.html.erb
+++ b/app/views/school_groups/comparisons.html.erb
@@ -16,7 +16,12 @@
       <% if index != 0 %><hr><% end %>
       <div class="d-flex justify-content-between align-items-top">
         <div>
-          <h2 class="scrollable-title scrollable" id="<%= fuel_type %>-comparisons"><%= t("advice_pages.fuel_type.#{fuel_type}").capitalize %></h2>
+          <h2 class="scrollable-title scrollable" id="<%= fuel_type %>-comparisons">
+            <span class="<%= fuel_type_class(fuel_type) %>">
+              <%= fa_icon( fuel_type_icon(fuel_type) ) %>
+            </span>
+            <%= t("advice_pages.fuel_type.#{fuel_type}").capitalize %>
+          </h2>
         </div>
         <div>
           <%= link_to "#" do %>

--- a/app/views/school_groups/comparisons.html.erb
+++ b/app/views/school_groups/comparisons.html.erb
@@ -5,7 +5,7 @@
   <% advice_pages.each do |advice_page_key, comparison| %>
     <%= component('school_group_comparison', id: 'group-comparison-baseload', comparison: comparison, advice_page_key: advice_page_key, include_cluster: can?(:update_settings, @school_group)) do |component| %>
       <% component.with_csv_download_link do %>
-        <%= link_to t('school_groups.download_as_csv'), comparisons_school_group_path(@school_group, format: :csv, advice_page_keys: [advice_page_key]), class: 'btn btn-sm', id: "download-comparisons-school-csv-#{advice_page_key}" %>
+        <%= link_to t('school_groups.download_as_csv'), comparisons_school_group_path(@school_group, format: :csv, advice_page_keys: [advice_page_key]), class: 'btn btn-sm btn-outline-dark rounded-pill font-weight-bold', id: "download-comparisons-school-csv-#{advice_page_key}" %>
       <% end %>
     <% end %>
     <p class=pb-5>

--- a/app/views/school_groups/comparisons.html.erb
+++ b/app/views/school_groups/comparisons.html.erb
@@ -1,15 +1,39 @@
 <%= render 'enhanced_header' %>
-<p class=mt-3><%= link_to t('school_groups.comparisons.view_all_school_comparison_benchmarks'), benchmarks_compare_index_path(search: 'groups', school_group_ids: [@school_group.id]) %></p>
-<% @school_group.categorise_schools.each do |fuel_type, advice_pages| %>
-  <h2><%= t("advice_pages.fuel_type.#{fuel_type}").capitalize %></h2>
-  <% advice_pages.each do |advice_page_key, comparison| %>
-    <%= component('school_group_comparison', id: 'group-comparison-baseload', comparison: comparison, advice_page_key: advice_page_key, include_cluster: can?(:update_settings, @school_group)) do |component| %>
-      <% component.with_csv_download_link do %>
-        <%= link_to t('school_groups.download_as_csv'), comparisons_school_group_path(@school_group, format: :csv, advice_page_keys: [advice_page_key]), class: 'btn btn-sm btn-outline-dark rounded-pill font-weight-bold', id: "download-comparisons-school-csv-#{advice_page_key}" %>
+
+<div class="row mt-4">
+  <div class="col-md-12">
+    <p>
+      <%= t('school_groups.comparisons.introduction_html',
+        fuel_types: @school_group.categorise_schools.keys.map {|f| "<a href='##{f}-comparisons'>" + t("advice_pages.fuel_type.#{f}") + "</a>"}.to_sentence.html_safe,
+        link: benchmarks_compare_index_path(search: 'groups', school_group_ids: [@school_group.id])) %>
+    </p>
+  </div>
+</div>
+
+<div class="row">
+  <div class="col-md-12">
+    <% @school_group.categorise_schools.each_with_index do |(fuel_type, advice_pages), index| %>
+      <% if index != 0 %><hr><% end %>
+      <div class="d-flex justify-content-between align-items-top">
+        <div>
+          <h2 class="scrollable-title scrollable" id="<%= fuel_type %>-comparisons"><%= t("advice_pages.fuel_type.#{fuel_type}").capitalize %></h2>
+        </div>
+        <div>
+          <%= link_to "#" do %>
+            <%= t('common.back_to_top') %> <i class="fa fa-arrow-up" data-toggle="tooltip" title="<%= t('common.back_to_top') %>"></i>
+          <% end if index != 0 %>
+        </div>
+      </div>
+      <% advice_pages.each do |advice_page_key, comparison| %>
+        <%= component('school_group_comparison', id: 'group-comparison-baseload', comparison: comparison, advice_page_key: advice_page_key, include_cluster: can?(:update_settings, @school_group)) do |component| %>
+          <% component.with_csv_download_link do %>
+            <%= link_to t('school_groups.download_as_csv'), comparisons_school_group_path(@school_group, format: :csv, advice_page_keys: [advice_page_key]), class: 'btn btn-sm btn-outline-dark rounded-pill font-weight-bold', id: "download-comparisons-school-csv-#{advice_page_key}" %>
+          <% end %>
+        <% end %>
+        <p class=pb-5>
+          <%= link_to t('school_groups.comparisons.view_detailed_comparison'), compare_path(benchmark: compare_benchmark_key_for(advice_page_key), school_group_ids: [@school_group.id]) %>
+        </p>
       <% end %>
     <% end %>
-    <p class=pb-5>
-      <%= link_to t('school_groups.comparisons.view_detailed_comparison'), compare_path(benchmark: compare_benchmark_key_for(advice_page_key), school_group_ids: [@school_group.id]) %>
-    </p>
-  <% end %>
-<% end %>
+  </div>
+</div>

--- a/app/views/school_groups/current_scores.html.erb
+++ b/app/views/school_groups/current_scores.html.erb
@@ -32,24 +32,24 @@
       <% schools.each do |school| %>
         <tr>
           <td>
-            <h3><span class="badge badge-primary"><%= '=' if schools.size > 1 %><%= position %></span></h3>
+            <h4><span class="badge badge-primary"><%= '=' if schools.size > 1 %><%= position %></span></h4>
           </td>
           <td>
             <h3><%= link_to school.name, school_path(school) %></h3>
           </td>
           <% if can?(:update_settings, @school_group) %>
             <td>
-              <h3><%= school.school_group_cluster_name %></h3>
+              <h4><%= school.school_group_cluster_name %></h4>
             </td>
           <% end %>
           <td>
-            <h3>
+            <h4>
             <%= link_to school.sum_points, school_timeline_path(school, academic_year: @academic_year), class: 'badge badge-success' %>
             &nbsp;
             <% if school.recent_points&.positive? %>
               <i class="fa fa-arrow-up" data-toggle="tooltip" title="<%= t('scoreboard.score_tooltip') %>"></i>
             <% end %>
-            </h3>
+            </h4>
           </td>
         </tr>
       <% end %>

--- a/app/views/school_groups/current_scores.html.erb
+++ b/app/views/school_groups/current_scores.html.erb
@@ -1,5 +1,17 @@
 <%= render 'enhanced_header' %>
 
+<div class="row mt-4">
+  <div class="col-md-12">
+    <p><%= t('school_groups.current_scores.introduction') %></p>
+    <% if @school_group.default_scoreboard.present? %>
+      <p>
+        <%= t('school_groups.current_scores.regional_scoreboard_html',
+          scoreboard: scoreboard_path(@school_group.default_scoreboard)) %>
+      </p>
+    <% end %>
+  </div>
+</div>
+
 <div class='text-right pt-3'>
   <%= link_to t('school_groups.download_as_csv'), current_scores_school_group_path(@school_group, format: :csv), class: 'btn btn-sm btn-outline-dark rounded-pill font-weight-bold' %>
 </div>
@@ -20,18 +32,24 @@
       <% schools.each do |school| %>
         <tr>
           <td>
-            <span class="badge badge-primary"><%= '=' if schools.size > 1 %><%= position %></span>
+            <h3><span class="badge badge-primary"><%= '=' if schools.size > 1 %><%= position %></span></h3>
           </td>
-          <td><%= link_to school.name, school_path(school) %></td>
+          <td>
+            <h3><%= link_to school.name, school_path(school) %></h3>
+          </td>
           <% if can?(:update_settings, @school_group) %>
-            <td><%= school.school_group_cluster_name %></td>
+            <td>
+              <h3><%= school.school_group_cluster_name %></h3>
+            </td>
           <% end %>
           <td>
+            <h3>
             <%= link_to school.sum_points, school_timeline_path(school, academic_year: @academic_year), class: 'badge badge-success' %>
             &nbsp;
             <% if school.recent_points&.positive? %>
               <i class="fa fa-arrow-up" data-toggle="tooltip" title="<%= t('scoreboard.score_tooltip') %>"></i>
             <% end %>
+            </h3>
           </td>
         </tr>
       <% end %>

--- a/app/views/school_groups/current_scores.html.erb
+++ b/app/views/school_groups/current_scores.html.erb
@@ -1,7 +1,7 @@
 <%= render 'enhanced_header' %>
 
 <div class='text-right pt-3'>
-  <%= link_to t('school_groups.download_as_csv'), current_scores_school_group_path(@school_group, format: :csv), class: 'btn btn-sm' %>
+  <%= link_to t('school_groups.download_as_csv'), current_scores_school_group_path(@school_group, format: :csv), class: 'btn btn-sm btn-outline-dark rounded-pill font-weight-bold' %>
 </div>
 
 <table width="100%" class="mt-3 table advice-table">

--- a/app/views/school_groups/map.html.erb
+++ b/app/views/school_groups/map.html.erb
@@ -1,17 +1,14 @@
 <%= render 'enhanced_header' %>
 
 <div class="row">
-  <div class="col-8">
+  <div class="col-md-12">
     <div class="school-group-map map" id="geo-json-map" data-school-group-id="<%= @school_group.id %>"></div>
-  </div>
-  <div class="col-4">
-
   </div>
 </div>
 
 <% @school_group.schools.includes(:configuration).visible.by_name.each do |school| %>
   <div class='pb-2'>
-    <h4><%= link_to school.name, school_path(school) %></h5>
+    <h4><%= link_to school.name, school_path(school) %></h4>
     <p>
       <span class="badge badge-secondary"><%= t("common.school_types.#{school.school_type}") %></span>
       <% if school.configuration %>

--- a/app/views/school_groups/priority_actions.html.erb
+++ b/app/views/school_groups/priority_actions.html.erb
@@ -5,7 +5,7 @@
 <% end %>
 
 <div class='text-right'>
-  <%= link_to t('school_groups.download_as_csv'), priority_actions_school_group_path(@school_group, format: :csv), class: 'btn btn-sm', id: 'download-priority-actions-school-group-csv' %>
+  <%= link_to t('school_groups.download_as_csv'), priority_actions_school_group_path(@school_group, format: :csv), class: 'btn btn-sm btn-outline-dark rounded-pill font-weight-bold', id: 'download-priority-actions-school-group-csv' %>
 </div>
 
 <table class="table table-borderless table-sorted advice-table advice-priority-table">

--- a/app/views/school_groups/priority_actions.html.erb
+++ b/app/views/school_groups/priority_actions.html.erb
@@ -1,68 +1,74 @@
 <%= render 'enhanced_header' %>
 
-<%= component 'notice', status: :neutral, classes: 'mt-2 mb-4' do |c| %>
-  <%= t('school_groups.priority_actions.intro_html') %>
-<% end %>
-
-<div class='text-right'>
-  <%= link_to t('school_groups.download_as_csv'), priority_actions_school_group_path(@school_group, format: :csv), class: 'btn btn-sm btn-outline-dark rounded-pill font-weight-bold', id: 'download-priority-actions-school-group-csv' %>
+<div class="row mt-4">
+  <div class="col-md-12">
+    <%= t('school_groups.priority_actions.intro_html') %>
+  </div>
 </div>
 
-<table class="table table-borderless table-sorted advice-table advice-priority-table">
-  <thead>
-    <tr>
-      <th><%= t('advice_pages.index.priorities.table.columns.fuel_type') %></th>
-      <th data-orderable="false"></th>
-      <th class="text-right"><%= t('components.breadcrumbs.schools') %></th>
-      <th class="text-right"><%= t('advice_pages.index.priorities.table.columns.kwh_saving') %></th>
-      <th class="text-right"><%= t('advice_pages.index.priorities.table.columns.cost_saving') %></th>
-      <th class="text-right"><%= t('advice_pages.index.priorities.table.columns.co2_reduction') %></th>
-    </tr>
-  </thead>
-  <tbody id="school-group-priorities">
-    <% @total_savings.each do |alert_type_rating, savings| %>
-      <tr>
-        <td data-order="<%= alert_type_rating.alert_type.fuel_type %>">
-          <span class="<%=fuel_type_class(alert_type_rating.alert_type.fuel_type)%>">
-            <%= fa_icon alert_type_icon(alert_type_rating.alert_type,'fa-2x') %>
-          </span>
-        </td>
-        <td>
-          <h4>
-            <a href="" data-toggle="modal" data-target="#action-<%= alert_type_rating.id %>">
-              <%= alert_type_rating.current_content.management_priorities_title %>
-            </a>
-          </h4>
-          <%= component 'footnote_modal', title: alert_type_rating.current_content.management_priorities_title.to_plain_text, modal_id: "action-#{alert_type_rating.id}", modal_dialog_classes: 'modal-xl modal-dialog-centered' do |component| %>
-            <% component.with_body_content do %>
-              <%= render 'priority_action_modal',
-                alert_type_rating: alert_type_rating,
-                savings: savings,
-                priority_actions: @priority_actions %>
-            <% end %>
-          <% end %>
-        </td>
-        <td class="text-right">
-          <h4>
-            <%= savings.schools.length %>
-          </h4>
-        </td>
-        <td  class="text-right" data-order="<%= savings.one_year_saving_kwh %>">
-          <h4>
-            <%= format_unit(savings.one_year_saving_kwh, :kwh) %> kWh
-          </h4>
-        </td>
-        <td class="text-right" data-order="<%= savings.average_one_year_saving_gbp %>">
-          <h4>
-            <%= format_unit(savings.average_one_year_saving_gbp, :£) %>
-          </h4>
-        </td>
-        <td class="text-right" data-order="<%= savings.one_year_saving_co2 %>">
-          <h4>
-            <%= format_unit(savings.one_year_saving_co2, :co2) %> kg CO2
-          </h4>
-        </td>
-      </tr>
-    <% end %>
-  </tbody>
-</table>
+<div class="row">
+  <div class="col-md-12">
+    <div class='text-right'>
+      <%= link_to t('school_groups.download_as_csv'), priority_actions_school_group_path(@school_group, format: :csv), class: 'btn btn-sm btn-outline-dark rounded-pill font-weight-bold', id: 'download-priority-actions-school-group-csv' %>
+    </div>
+
+    <table class="table table-borderless table-sorted advice-table advice-priority-table">
+      <thead>
+        <tr>
+          <th><%= t('advice_pages.index.priorities.table.columns.fuel_type') %></th>
+          <th data-orderable="false"></th>
+          <th class="text-right"><%= t('components.breadcrumbs.schools') %></th>
+          <th class="text-right"><%= t('advice_pages.index.priorities.table.columns.kwh_saving') %></th>
+          <th class="text-right"><%= t('advice_pages.index.priorities.table.columns.cost_saving') %></th>
+          <th class="text-right"><%= t('advice_pages.index.priorities.table.columns.co2_reduction') %></th>
+        </tr>
+      </thead>
+      <tbody id="school-group-priorities">
+        <% @total_savings.each do |alert_type_rating, savings| %>
+          <tr>
+            <td data-order="<%= alert_type_rating.alert_type.fuel_type %>">
+              <span class="<%=fuel_type_class(alert_type_rating.alert_type.fuel_type)%>">
+                <%= fa_icon alert_type_icon(alert_type_rating.alert_type,'fa-2x') %>
+              </span>
+            </td>
+            <td>
+              <h4>
+                <a href="" data-toggle="modal" data-target="#action-<%= alert_type_rating.id %>">
+                  <%= alert_type_rating.current_content.management_priorities_title %>
+                </a>
+              </h4>
+              <%= component 'footnote_modal', title: alert_type_rating.current_content.management_priorities_title.to_plain_text, modal_id: "action-#{alert_type_rating.id}", modal_dialog_classes: 'modal-xl modal-dialog-centered' do |component| %>
+                <% component.with_body_content do %>
+                  <%= render 'priority_action_modal',
+                    alert_type_rating: alert_type_rating,
+                    savings: savings,
+                    priority_actions: @priority_actions %>
+                <% end %>
+              <% end %>
+            </td>
+            <td class="text-right">
+              <h4>
+                <%= savings.schools.length %>
+              </h4>
+            </td>
+            <td  class="text-right" data-order="<%= savings.one_year_saving_kwh %>">
+              <h4>
+                <%= format_unit(savings.one_year_saving_kwh, :kwh) %> kWh
+              </h4>
+            </td>
+            <td class="text-right" data-order="<%= savings.average_one_year_saving_gbp %>">
+              <h4>
+                <%= format_unit(savings.average_one_year_saving_gbp, :£) %>
+              </h4>
+            </td>
+            <td class="text-right" data-order="<%= savings.one_year_saving_co2 %>">
+              <h4>
+                <%= format_unit(savings.one_year_saving_co2, :co2) %> kg CO2
+              </h4>
+            </td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+</div>

--- a/app/views/school_groups/priority_actions.html.erb
+++ b/app/views/school_groups/priority_actions.html.erb
@@ -15,6 +15,10 @@
     <table class="table table-borderless table-sorted advice-table advice-priority-table">
       <thead>
         <tr>
+          <th colspan="3"><th>
+          <th colspan="3"><%= t('advice_pages.index.priorities.table.columns.savings') %></th>
+        </tr>
+        <tr>
           <th><%= t('advice_pages.index.priorities.table.columns.fuel_type') %></th>
           <th data-orderable="false"></th>
           <th class="text-right"><%= t('components.breadcrumbs.schools') %></th>
@@ -32,11 +36,9 @@
               </span>
             </td>
             <td>
-              <h4>
                 <a href="" data-toggle="modal" data-target="#action-<%= alert_type_rating.id %>">
                   <%= alert_type_rating.current_content.management_priorities_title %>
                 </a>
-              </h4>
               <%= component 'footnote_modal', title: alert_type_rating.current_content.management_priorities_title.to_plain_text, modal_id: "action-#{alert_type_rating.id}", modal_dialog_classes: 'modal-xl modal-dialog-centered' do |component| %>
                 <% component.with_body_content do %>
                   <%= render 'priority_action_modal',
@@ -47,24 +49,16 @@
               <% end %>
             </td>
             <td class="text-right">
-              <h4>
                 <%= savings.schools.length %>
-              </h4>
             </td>
             <td  class="text-right" data-order="<%= savings.one_year_saving_kwh %>">
-              <h4>
-                <%= format_unit(savings.one_year_saving_kwh, :kwh) %> kWh
-              </h4>
+                <%= format_unit(savings.one_year_saving_kwh, :kwh) %>
             </td>
             <td class="text-right" data-order="<%= savings.average_one_year_saving_gbp %>">
-              <h4>
                 <%= format_unit(savings.average_one_year_saving_gbp, :£) %>
-              </h4>
             </td>
             <td class="text-right" data-order="<%= savings.one_year_saving_co2 %>">
-              <h4>
-                <%= format_unit(savings.one_year_saving_co2, :co2) %> kg CO2
-              </h4>
+                <%= format_unit(savings.one_year_saving_co2, :co2) %>
             </td>
           </tr>
         <% end %>

--- a/app/views/school_groups/recent_usage.html.erb
+++ b/app/views/school_groups/recent_usage.html.erb
@@ -1,134 +1,146 @@
 <%= render 'enhanced_header' %>
 
-<div class="d-flex justify-content-between mt-4">
-  <%= form_with url: school_group_path(@school_group), method: :get do |f| %>
-    <div>
-      <label class="mr-2"><%= t("school_groups.show.change_units") %>:</label>
-      <% ['change', 'usage', 'cost', 'co2'].each do |metric| %>
-        <div class="form-check form-check-inline">
-          <%= f.radio_button :metric, metric, onclick: 'this.form.submit();', class: 'form-check-input', checked: radio_button_checked_for(metric) %>
-          <%= f.label :metric, t("school_groups.show.metric.#{metric}"), value: metric, class: 'form-check-label' %>
-        </div>
-      <% end %>
-    </div>
-  <% end %>
-  <div>
-    <%= link_to t('school_groups.download_as_csv'), school_group_path(@school_group, format: :csv, metric: params['metric']), class: 'btn btn-sm btn-outline-dark rounded-pill font-weight-bold' %>
+<div class="row mt-4">
+  <div class="col-md-12">
+    <p>
+      <%= t("school_groups.show.recent_usage_intro.#{@school_group.group_type}") %>
+    </p>
   </div>
 </div>
 
-<table width="100%" class="mt-3 table advice-table table-sorted">
-  <thead>
-    <tr>
-      <th></th>
-      <% if can?(:update_settings, @school_group) %>
-        <th></th>
+<div class="row mt-4">
+  <div class="col-md-12">
+    <div class="d-flex justify-content-between">
+      <%= form_with url: school_group_path(@school_group), method: :get do |f| %>
+        <div>
+          <label class="mr-2"><%= t("school_groups.show.change_units") %>:</label>
+          <% ['change', 'usage', 'cost', 'co2'].each do |metric| %>
+            <div class="form-check form-check-inline">
+              <%= f.radio_button :metric, metric, onclick: 'this.form.submit();', class: 'form-check-input', checked: radio_button_checked_for(metric) %>
+              <%= f.label :metric, t("school_groups.show.metric.#{metric}"), value: metric, class: 'form-check-label' %>
+            </div>
+          <% end %>
+        </div>
       <% end %>
-      <% if @fuel_types.include?(:electricity) %>
-        <th colspan="2" class="text-center"><%= fa_icon fuel_type_icon(:electricity) %> <%= t('common.electricity') %></th>
-      <% end %>
-      <% if @fuel_types.include?(:gas) %>
-        <th colspan="2" class="text-center"><%= fa_icon fuel_type_icon(:gas) %> <%= t('common.gas') %></th>
-      <% end %>
-      <% if @fuel_types.include?(:storage_heaters) %>
-        <th colspan="2" class="text-center"><%= fa_icon fuel_type_icon(:storage_heaters) %> <%= t('common.storage_heaters') %></th>
-      <% end %>
-    </tr>
-    <tr>
-      <th colspan="1"><%= t('common.school') %></th>
-      <% if can?(:update_settings, @school_group) %>
-        <th><%= t('school_groups.clusters.labels.cluster') %></th>
-      <% end %>
-      <% if @fuel_types.include?(:electricity) %>
-        <th class="text-right"><%= t('common.labels.last_week') %></th>
-        <th class="text-right"><%= t('common.labels.last_year') %></th>
-      <% end %>
-      <% if @fuel_types.include?(:gas) %>
-        <th class="text-right"><%= t('common.labels.last_week') %></th>
-        <th class="text-right"><%= t('common.labels.last_year') %></th>
-      <% end %>
-      <% if @fuel_types.include?(:storage_heaters) %>
-        <th class="text-right"><%= t('common.labels.last_week') %></th>
-        <th class="text-right"><%= t('common.labels.last_year') %></th>
-      <% end %>
-    </tr>
-  </thead>
-  <tbody>
-    <% @school_group.schools.visible.order(:name).each do |school| %>
-      <tr>
-        <td>
-          <%= link_to school.name, school_path(school) %>
-        </td>
-        <% if can?(:update_settings, @school_group) %>
-          <td>
-            <%= school.school_group_cluster_name %>
-          </td>
-        <% end %>
-        <% if school.data_enabled %>
-          <% recent_usage = school&.recent_usage %>
+      <div>
+        <%= link_to t('school_groups.download_as_csv'), school_group_path(@school_group, format: :csv, metric: params['metric']), class: 'btn btn-sm btn-outline-dark rounded-pill font-weight-bold' %>
+      </div>
+    </div>
+
+    <table width="100%" class="mt-3 table advice-table table-sorted">
+      <thead>
+        <tr>
+          <th></th>
+          <% if can?(:update_settings, @school_group) %>
+            <th></th>
+          <% end %>
           <% if @fuel_types.include?(:electricity) %>
-            <% if recent_usage&.electricity&.week&.has_data %>
-              <td class="text-right <%= recent_usage&.electricity&.week&.message_class %>"
-                  data-order="<%= value_for(recent_usage&.electricity&.week, formatted: false) %>">
-                <%= up_downify(value_for(recent_usage&.electricity&.week, formatted: true)) %>
-              </td>
-            <% else %>
-              <td class="text-right" data-order="0">-</td>
-            <% end %>
-
-            <% if recent_usage&.electricity&.year&.has_data %>
-              <td class="text-right <%= recent_usage&.electricity&.year&.message_class %>"
-                  data-order="<%= value_for(recent_usage&.electricity&.year, formatted: false) %>">
-                <%= up_downify(value_for(recent_usage&.electricity&.year, formatted: true)) %>
-              </td>
-            <% else %>
-              <td class="text-right" data-order="0">-</td>
-            <% end %>
+            <th colspan="2" class="text-center"><%= fa_icon fuel_type_icon(:electricity) %> <%= t('common.electricity') %></th>
           <% end %>
-
           <% if @fuel_types.include?(:gas) %>
-            <% if recent_usage&.gas&.week&.has_data %>
-              <td class="text-right <%= recent_usage&.gas&.week&.message_class %>"
-                  data-order="<%= value_for(recent_usage&.gas&.week, formatted: false) %>">
-                <%= up_downify(value_for(recent_usage&.gas&.week, formatted: true)) %>
-              </td>
-            <% else %>
-              <td class="text-right" data-order="0">-</td>
-            <% end %>
-            <% if recent_usage&.gas&.year&.has_data %>
-              <td class="text-right <%= recent_usage&.gas&.year&.message_class %>"
-                  data-order="<%= value_for(recent_usage&.gas&.year, formatted: false) %>">
-                <%= up_downify(value_for(recent_usage&.gas&.year, formatted: true)) %>
-              </td>
-            <% else %>
-              <td class="text-right" data-order="'0'">-</td>
-            <% end %>
+            <th colspan="2" class="text-center"><%= fa_icon fuel_type_icon(:gas) %> <%= t('common.gas') %></th>
           <% end %>
-
           <% if @fuel_types.include?(:storage_heaters) %>
-            <% if recent_usage&.storage_heaters&.week&.has_data %>
-              <td class="text-right <%= recent_usage&.storage_heaters&.week&.message_class %>"
-                  data-order="<%= value_for(recent_usage&.storage_heaters&.week, formatted: false) %>">
-                <%= up_downify(value_for(recent_usage&.storage_heaters&.week, formatted: true)) %>
-              </td>
-            <% else %>
-              <td class="text-right" data-order="'0'">-</td>
-            <% end %>
-            <% if recent_usage&.storage_heaters&.year&.has_data %>
-              <td class="text-right <%= recent_usage&.storage_heaters&.year&.message_class %>"
-                  data-order="<%= value_for(recent_usage&.storage_heaters&.year, formatted: false) %>">
-                <%= up_downify(value_for(recent_usage&.storage_heaters&.year, formatted: true)) %>
-              </td>
-            <% else %>
-              <td class="text-right" data-order="'0'">-</td>
-            <% end %>
+            <th colspan="2" class="text-center"><%= fa_icon fuel_type_icon(:storage_heaters) %> <%= t('common.storage_heaters') %></th>
           <% end %>
-        <% else %>
-          <% (@fuel_types.reject{|f| f == :solar_pv}.length * 2).times do %>
-            <td class="text-right" data-order="'0'">-</td>
+        </tr>
+        <tr>
+          <th colspan="1"><%= t('common.school') %></th>
+          <% if can?(:update_settings, @school_group) %>
+            <th><%= t('school_groups.clusters.labels.cluster') %></th>
           <% end %>
+          <% if @fuel_types.include?(:electricity) %>
+            <th class="text-right"><%= t('common.labels.last_week') %></th>
+            <th class="text-right"><%= t('common.labels.last_year') %></th>
+          <% end %>
+          <% if @fuel_types.include?(:gas) %>
+            <th class="text-right"><%= t('common.labels.last_week') %></th>
+            <th class="text-right"><%= t('common.labels.last_year') %></th>
+          <% end %>
+          <% if @fuel_types.include?(:storage_heaters) %>
+            <th class="text-right"><%= t('common.labels.last_week') %></th>
+            <th class="text-right"><%= t('common.labels.last_year') %></th>
+          <% end %>
+        </tr>
+      </thead>
+      <tbody>
+        <% @school_group.schools.visible.order(:name).each do |school| %>
+          <tr>
+            <td>
+              <%= link_to school.name, school_path(school) %>
+            </td>
+            <% if can?(:update_settings, @school_group) %>
+              <td>
+                <%= school.school_group_cluster_name %>
+              </td>
+            <% end %>
+            <% if school.data_enabled %>
+              <% recent_usage = school&.recent_usage %>
+              <% if @fuel_types.include?(:electricity) %>
+                <% if recent_usage&.electricity&.week&.has_data %>
+                  <td class="text-right <%= recent_usage&.electricity&.week&.message_class %>"
+                      data-order="<%= value_for(recent_usage&.electricity&.week, formatted: false) %>">
+                    <%= up_downify(value_for(recent_usage&.electricity&.week, formatted: true)) %>
+                  </td>
+                <% else %>
+                  <td class="text-right" data-order="0">-</td>
+                <% end %>
+
+                <% if recent_usage&.electricity&.year&.has_data %>
+                  <td class="text-right <%= recent_usage&.electricity&.year&.message_class %>"
+                      data-order="<%= value_for(recent_usage&.electricity&.year, formatted: false) %>">
+                    <%= up_downify(value_for(recent_usage&.electricity&.year, formatted: true)) %>
+                  </td>
+                <% else %>
+                  <td class="text-right" data-order="0">-</td>
+                <% end %>
+              <% end %>
+
+              <% if @fuel_types.include?(:gas) %>
+                <% if recent_usage&.gas&.week&.has_data %>
+                  <td class="text-right <%= recent_usage&.gas&.week&.message_class %>"
+                      data-order="<%= value_for(recent_usage&.gas&.week, formatted: false) %>">
+                    <%= up_downify(value_for(recent_usage&.gas&.week, formatted: true)) %>
+                  </td>
+                <% else %>
+                  <td class="text-right" data-order="0">-</td>
+                <% end %>
+                <% if recent_usage&.gas&.year&.has_data %>
+                  <td class="text-right <%= recent_usage&.gas&.year&.message_class %>"
+                      data-order="<%= value_for(recent_usage&.gas&.year, formatted: false) %>">
+                    <%= up_downify(value_for(recent_usage&.gas&.year, formatted: true)) %>
+                  </td>
+                <% else %>
+                  <td class="text-right" data-order="'0'">-</td>
+                <% end %>
+              <% end %>
+
+              <% if @fuel_types.include?(:storage_heaters) %>
+                <% if recent_usage&.storage_heaters&.week&.has_data %>
+                  <td class="text-right <%= recent_usage&.storage_heaters&.week&.message_class %>"
+                      data-order="<%= value_for(recent_usage&.storage_heaters&.week, formatted: false) %>">
+                    <%= up_downify(value_for(recent_usage&.storage_heaters&.week, formatted: true)) %>
+                  </td>
+                <% else %>
+                  <td class="text-right" data-order="'0'">-</td>
+                <% end %>
+                <% if recent_usage&.storage_heaters&.year&.has_data %>
+                  <td class="text-right <%= recent_usage&.storage_heaters&.year&.message_class %>"
+                      data-order="<%= value_for(recent_usage&.storage_heaters&.year, formatted: false) %>">
+                    <%= up_downify(value_for(recent_usage&.storage_heaters&.year, formatted: true)) %>
+                  </td>
+                <% else %>
+                  <td class="text-right" data-order="'0'">-</td>
+                <% end %>
+              <% end %>
+            <% else %>
+              <% (@fuel_types.reject{|f| f == :solar_pv}.length * 2).times do %>
+                <td class="text-right" data-order="'0'">-</td>
+              <% end %>
+            <% end %>
+          </tr>
         <% end %>
-      </tr>
-    <% end %>
-  </tbody>
-</table>
+      </tbody>
+    </table>
+  </div>
+</div>

--- a/app/views/school_groups/recent_usage.html.erb
+++ b/app/views/school_groups/recent_usage.html.erb
@@ -13,7 +13,7 @@
     </div>
   <% end %>
   <div>
-    <%= link_to t('school_groups.download_as_csv'), school_group_path(@school_group, format: :csv, metric: params['metric']), class: 'btn btn-sm' %>
+    <%= link_to t('school_groups.download_as_csv'), school_group_path(@school_group, format: :csv, metric: params['metric']), class: 'btn btn-sm btn-outline-dark rounded-pill font-weight-bold' %>
   </div>
 </div>
 

--- a/app/views/schools/advice/index/_priority_table.html.erb
+++ b/app/views/schools/advice/index/_priority_table.html.erb
@@ -29,9 +29,9 @@
             <% end %>
           </h4>
         </td>
-        <td data-order="<%= priority.template_variables[:one_year_saving_kwh].gsub(/(,|kWh)/, '').to_i %>">
+        <td data-order="<%= formatted_unit_to_num(priority.template_variables[:one_year_saving_kwh]) %>">
           <h4>
-            <%= priority.template_variables[:one_year_saving_kwh].gsub(/(,|kWh)/, '') %>
+            <%= format_unit(formatted_unit_to_num(priority.template_variables[:one_year_saving_kwh]), :kwh) %>
           </h4>
         </td>
         <td>
@@ -39,9 +39,9 @@
             <%= priority.template_variables[:average_one_year_saving_gbp] %>
           </h4>
         </td>
-        <td data-order="<%= priority.template_variables[:one_year_saving_co2].gsub(/(,|kg CO2)/, '').to_i %>">
+        <td data-order="<%= formatted_unit_to_num(priority.template_variables[:one_year_saving_co2]) %>">
           <h4>
-            <%= priority.template_variables[:one_year_saving_co2].gsub(/(,|kg CO2)/, '') %>
+            <%= format_unit(formatted_unit_to_num(priority.template_variables[:one_year_saving_co2]), :co2) %>
           </h4>
         </td>
       </tr>

--- a/app/views/schools/advice/index/_priority_table.html.erb
+++ b/app/views/schools/advice/index/_priority_table.html.erb
@@ -1,6 +1,10 @@
 <table class="table table-borderless table-sorted advice-table advice-priority-table">
   <thead>
     <tr>
+      <th colspan="2"><th>
+      <th colspan="3"><%= t('advice_pages.index.priorities.table.columns.savings') %></th>
+    </tr>
+    <tr>
       <th><%= t('advice_pages.index.priorities.table.columns.fuel_type') %></th>
       <th data-orderable="false"></th>
       <th><%= t('advice_pages.index.priorities.table.columns.kwh_saving') %></th>
@@ -27,7 +31,7 @@
         </td>
         <td data-order="<%= priority.template_variables[:one_year_saving_kwh].gsub(/(,|kWh)/, '').to_i %>">
           <h4>
-            <%= priority.template_variables[:one_year_saving_kwh] %>
+            <%= priority.template_variables[:one_year_saving_kwh].gsub(/(,|kWh)/, '') %>
           </h4>
         </td>
         <td>
@@ -37,7 +41,7 @@
         </td>
         <td data-order="<%= priority.template_variables[:one_year_saving_co2].gsub(/(,|kg CO2)/, '').to_i %>">
           <h4>
-            <%= priority.template_variables[:one_year_saving_co2] %>
+            <%= priority.template_variables[:one_year_saving_co2].gsub(/(,|kg CO2)/, '') %>
           </h4>
         </td>
       </tr>

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -149,6 +149,7 @@ ignore_unused:
   - 'advice_pages.gas_costs.charts.cost_1_year_accounting_breakdown*'
   - 'advice_pages.tables.tooltips.bill_components.*'
   - 'school_groups.show.we_are_working_with.*'
+  - 'school_groups.priority_actions.alert_types.*_html'
 # - '{devise,kaminari,will_paginate}.*'
 # - 'simple_form.{yes,no}'
 # - 'simple_form.{placeholders,hints,labels}.*'

--- a/config/locales/views/advice_pages/advice_pages.yml
+++ b/config/locales/views/advice_pages/advice_pages.yml
@@ -51,8 +51,8 @@ en:
       school_comparisons: School comparisons
       school_comparisons_introduction_html: |-
         <p>School comparisons are based on benchmarking your school against comparable schools based on the characteristics outlined below.</p>
-        <p>"Exemplar" schools represent the top 17.5% of Energy Sparks schools</p>
-        <p>"Well managed" schools represent the top 30% of Energy Sparks schools</p>
+        <p>"<strong>Exemplar</strong>" schools represent the top 17.5% of Energy Sparks schools</p>
+        <p>"<strong>Well managed</strong>" schools represent the top 30% of Energy Sparks schools</p>
       total_energy_use_table:
         columns:
           aggregated_meter_date_range: Meter date range

--- a/config/locales/views/advice_pages/index.yml
+++ b/config/locales/views/advice_pages/index.yml
@@ -9,11 +9,12 @@ en:
         intro: Prioritise the following actions to reduce your costs and carbon dioxide emissions.
         table:
           columns:
-            co2_reduction: CO2 reduction
-            cost_saving: Cost saving
+            co2_reduction: CO2 (kg)
+            cost_saving: Cost (£)
             description: Description
             fuel_type: Fuel
-            kwh_saving: Energy saving
+            kwh_saving: Energy (kWh)
+            savings: Savings
         table_note: Use the table headings to sort the recommendations. Potential cost savings for the same fuel type are not additive.
         title: Priority actions
       show:

--- a/config/locales/views/school_groups/school_groups.yml
+++ b/config/locales/views/school_groups/school_groups.yml
@@ -73,7 +73,6 @@ en:
         <p>"<span class="txt-exemplar_school">Exemplar</span>" schools represent the top 17.5% of Energy Sparks schools</p>
         <p>"<span class="txt-benchmark_school">Well managed</span>" schools represent the top 30% of Energy Sparks schools</p>
         <p>These schools are benchmarked as <span class="txt-%{category_id}">%{category}</span>.</p>
-      view_all_school_comparison_benchmarks: view all school comparison benchmarks
       view_detailed_comparison: View detailed comparison
     current_scores:
       introduction: Schools score points by recording their activities and energy saving actions. These are the scores for the current academic year.
@@ -85,7 +84,6 @@ en:
       view_all_schools: View all schools
       view_group: View group
       view_map: View map
-      view_scoreboard: Scoreboard
     labels:
       floor_area: Floor area (m2)
     priority_actions:

--- a/config/locales/views/school_groups/school_groups.yml
+++ b/config/locales/views/school_groups/school_groups.yml
@@ -66,7 +66,8 @@ en:
         gas_out_of_hours: How does the out of school hours gas use of your schools compare to other schools on Energy Sparks, with a similar floor area?
         heating_control: How does the heating control analysis of your schools compare to other schools on Energy Sparks, with a similar floor area?
         thermostatic_control: How does the thermostatic control analysis of your schools compare to other schools on Energy Sparks, with a similar floor area?
-      view_all_school_comparison_benchmarks: View all school comparison benchmarks
+      introduction_html: View a comparison of %{fuel_types} usage across a number of key benchmarks. Or <a href="%{link}">explore all school comparison benchmarks for this group</a>.
+      view_all_school_comparison_benchmarks: view all school comparison benchmarks
       view_detailed_comparison: View detailed comparison
     download_as_csv: Download as CSV
     header:
@@ -101,6 +102,10 @@ en:
         cost: Cost (£)
         usage: Use (kWh)
       not_visible_schools: Not visible schools
+      recent_usage_intro:
+        general: A summary of the recent energy usage across schools in this group.
+        local_authority: A summary of the recent energy usage across schools in this local authority.
+        multi_academy_trust: A summary of the recent energy usage across schools in this multi-academy trust.
       we_are_working_with:
         general:
           in_partnership_with_html:

--- a/config/locales/views/school_groups/school_groups.yml
+++ b/config/locales/views/school_groups/school_groups.yml
@@ -87,10 +87,93 @@ en:
     labels:
       floor_area: Floor area (m2)
     priority_actions:
+      alert_types:
+        alert_electricity_annual_versus_benchmark_html: |-
+          <p>
+          These savings are based on comparing electricity usage over the last 12 months against the best performing schools.
+          </p>
+        alert_electricity_baseload_versus_benchmark_html: |-
+          <p>
+            Electricity baseload is the electricity needed to provide power to appliances that keep running at all times.
+            It can be the fastest way of reducing a school's energy costs and reducing its carbon footprint.
+          </p>
+          <p>
+           These figures represent a comparison of school baseload over the last 12 months against the best performing schools.
+          </p>
+        alert_electricity_peak_kw_versus_benchmark_html: ''
+        alert_gas_annual_versus_benchmark_html: |-
+          <p>
+          These savings are based on comparing gas usage over the last 12 months against the best performing schools.
+          </p>
+        alert_heating_coming_on_too_early_html: |-
+          <p>
+          These savings are based on changing the average morning start time for heating in each school. So that the
+          heating comes on later each day to minimise waste outside of school hours.
+          </p>
+          <p>
+          Getting the heating control right for your schools can save money and carbon very quickly as well as improving the learning environment for students.
+          </p>
+        alert_heating_sensitivity_advice_html: |-
+          <p>
+            Even the best performing schools can reduce energy usage by turning down the heating.
+          </p>
+          <p>
+            Getting the heating control right for your schools can save money and carbon very quickly as well as improving the learning environment for students.
+          </p>
+        alert_out_of_hours_electricity_usage_html: |-
+          <p>
+            Out of hours electricity use is the amount of electricity used when the school is closed - overnight, at weekends and during the holidays. Reducing out of hours electricity use is one of the easiest, and cheapest ways of saving
+            lots of energy.
+          </p>
+          <p>
+            These figures are based on a comparison of electricity usage outside of school hours against the best performing
+            schools. Ensuring that school opening hours are up to date will improve the accuracy of the analysis.
+          </p>
+        alert_out_of_hours_gas_usage_html: |-
+          <p>
+            Out of hours gas use is the amount of gas used when the school is closed - overnight, at weekends and during the holidays. Reducing out of hours gas use is one of the easiest, and cheapest ways of saving
+            lots of energy.
+          </p>
+          <p>
+            These figures are based on a comparison of gas usage outside of school hours against the best performing
+            schools. Ensuring that school opening hours are up to date will improve the accuracy of the analysis.
+          </p>
+        alert_seasonal_heating_school_days_html: |-
+          <p>
+            Turning the boiler off in warm weather, for example earlier in the Spring and later in the Winter, can
+            reduce gas usage.
+          </p>
+          <p>
+            These savings are based on our analysis of when the heating has been on in schools during warm weather.
+            View the detailed analysis for each school for more information.
+          </p>
+        alert_seasonal_heating_school_days_storage_heaters_html: |-
+          <p>
+            Turning the heating off in warm weather, for example earlier in the Spring and later in the Winter, can
+            reduce gas usage.
+          </p>
+          <p>
+            These savings are based on our analysis of when the storage heaters has been on in schools during warm weather.
+            View the detailed analysis for each school for more information.
+          </p>
+        alert_solar_pv_benefit_estimator_html: |-
+          <p>
+          These savings are based on the estimated annual savings in energy use if solar panels were installed in these schools.
+          </p>
+          <p>
+          The savings do not include capital costs. View the analysis for individual schools for more information on our estimates.
+          </p>
+        alert_thermostatic_control_html: |-
+          <p>
+            A building with good thermostatic control means that the colder it is outside the higher the gas consumption for heating.
+          </p>
+          <p>
+            These savings are based on improving the thermostatic control in schools, to use less gas when the weather is warmer. This
+            can checking thermostats or configuring weather compensation settings on boilers.
+          </p>
       intro_html: |-
-        <p>We carry out daily analysis for all schools to help identify the areas where there are the biggest opportunities to reduce costs and carbon emissions.</p>
-        <p>This table summarises the potential savings across this entire group of schools. Click on a heading to view the savings for individual schools and explore the detailed analysis.</p>
-        <p><strong>Note</strong>: Savings are not additive across the table as reduced usage in one area, e.g. electricity baseload, will also lead to savings in other areas, e.g. out of hours electricity usage. The potential savings are intended to help to prioritise and coordinate energy saving actions across the group. Cost savings are based on the latest tariff information we have available for the individual schools.</p>
+        <p>We carry out daily analysis for all schools to identify the areas where there are the biggest opportunities to reduce costs and carbon emissions.</p>
+        <p>This page summarises these potential savings across this entire group of schools. Click on a heading to view the savings for individual schools and explore the detailed analysis.</p>
       modal_intro: This action has been identified as a priority for the following schools.
       view_analysis: View analysis
     show:

--- a/config/locales/views/school_groups/school_groups.yml
+++ b/config/locales/views/school_groups/school_groups.yml
@@ -100,7 +100,13 @@ en:
           <p>
            These figures represent a comparison of school baseload over the last 12 months against the best performing schools.
           </p>
-        alert_electricity_peak_kw_versus_benchmark_html: ''
+        alert_electricity_peak_kw_versus_benchmark_html: |-
+          <p>
+          Electricity use varies at different times of the day. Usage will be at a peak in the middle of the day, but should be low overnight.
+          </p>
+          <p>
+          These figures represent a comparison of usage at peak times against the best performing schools.
+          </p>
         alert_gas_annual_versus_benchmark_html: |-
           <p>
           These savings are based on comparing gas usage over the last 12 months against the best performing schools.

--- a/config/locales/views/school_groups/school_groups.yml
+++ b/config/locales/views/school_groups/school_groups.yml
@@ -75,6 +75,9 @@ en:
         <p>These schools are benchmarked as <span class="txt-%{category_id}">%{category}</span>.</p>
       view_all_school_comparison_benchmarks: view all school comparison benchmarks
       view_detailed_comparison: View detailed comparison
+    current_scores:
+      introduction: Schools score points by recording their activities and energy saving actions. These are the scores for the current academic year.
+      regional_scoreboard_html: View how the schools rank against others in <a href="%{scoreboard}">their regional scoreboard</a>.
     download_as_csv: Download as CSV
     header:
       compare_schools: Compare schools

--- a/config/locales/views/school_groups/school_groups.yml
+++ b/config/locales/views/school_groups/school_groups.yml
@@ -67,6 +67,12 @@ en:
         heating_control: How does the heating control analysis of your schools compare to other schools on Energy Sparks, with a similar floor area?
         thermostatic_control: How does the thermostatic control analysis of your schools compare to other schools on Energy Sparks, with a similar floor area?
       introduction_html: View a comparison of %{fuel_types} usage across a number of key benchmarks. Or <a href="%{link}">explore all school comparison benchmarks for this group</a>.
+      modal_subtitle_html: |-
+        <p>School are benchmarked as comparable schools based on the key characteristics including
+        floor area, location, pupil numbers and type.</p>
+        <p>"<span class="txt-exemplar_school">Exemplar</span>" schools represent the top 17.5% of Energy Sparks schools</p>
+        <p>"<span class="txt-benchmark_school">Well managed</span>" schools represent the top 30% of Energy Sparks schools</p>
+        <p>These schools are benchmarked as <span class="txt-%{category_id}">%{category}</span>.</p>
       view_all_school_comparison_benchmarks: view all school comparison benchmarks
       view_detailed_comparison: View detailed comparison
     download_as_csv: Download as CSV

--- a/config/locales/views/school_groups/school_groups.yml
+++ b/config/locales/views/school_groups/school_groups.yml
@@ -82,7 +82,7 @@ en:
       compare_schools: Compare schools
       scoreboard: Scoreboard
       view_all_schools: View all schools
-      view_group: View group
+      view_group: View dashboard
       view_map: View map
     labels:
       floor_area: Floor area (m2)

--- a/spec/components/school_group_comparison_component_spec.rb
+++ b/spec/components/school_group_comparison_component_spec.rb
@@ -45,14 +45,14 @@ RSpec.describe SchoolGroupComparisonComponent, type: :component do
   context "Include cluster is not enabled" do
     let(:include_cluster) { false }
     it { expect(html).to_not have_content('Cluster') }
-    it { expect(html).to_not have_content('N/A') }
+    it { expect(html).to_not have_content('Not set') }
     it { expect(html).to_not have_content('My Area') }
   end
 
   context "Include cluster is enabled" do
     let(:include_cluster) { true }
     it { expect(html).to have_content('Cluster') }
-    it { expect(html).to have_content('N/A') }
+    it { expect(html).to have_content('Not set') }
     it { expect(html).to have_content('My Area') }
   end
 end

--- a/spec/services/school_groups/current_scores_csv_generator_spec.rb
+++ b/spec/services/school_groups/current_scores_csv_generator_spec.rb
@@ -23,10 +23,10 @@ RSpec.describe SchoolGroups::CurrentScoresCsvGenerator do
         expect(csv.lines.count).to eq(6)
         expect(csv.lines[0]).to eq("Position,School,Cluster,Score\n")
         expect(csv.lines[1]).to eq("=1,School 1,My Cluster,20\n")
-        expect(csv.lines[2]).to eq("=1,School 2,N/A,20\n")
-        expect(csv.lines[3]).to eq("2,School 3,N/A,18\n")
-        expect(csv.lines[4]).to eq("-,School 4,N/A,0\n")
-        expect(csv.lines[5]).to eq("-,School 5,N/A,0\n")
+        expect(csv.lines[2]).to eq("=1,School 2,Not set,20\n")
+        expect(csv.lines[3]).to eq("2,School 3,Not set,18\n")
+        expect(csv.lines[4]).to eq("-,School 4,Not set,0\n")
+        expect(csv.lines[5]).to eq("-,School 5,Not set,0\n")
       end
     end
   end

--- a/spec/services/school_groups/priority_actions_csv_generator_spec.rb
+++ b/spec/services/school_groups/priority_actions_csv_generator_spec.rb
@@ -12,8 +12,8 @@ RSpec.describe SchoolGroups::PriorityActionsCsvGenerator do
     it 'returns priority actions data as a csv for a school group' do
       csv = SchoolGroups::PriorityActionsCsvGenerator.new(school_group: school_group.reload).export
       expect(csv.lines.count).to eq(2)
-      expect(csv.lines[0]).to eq("Fuel,Description,Schools,Energy saving,Cost saving,CO2 reduction\n")
-      expect(csv.lines[1]).to eq("Gas,Spending too much money on heating,1,\"2,200 kWh\",\"£1,000\",\"1,100 kg CO2\"\n")
+      expect(csv.lines[0]).to eq("Fuel,Description,Schools,Energy (kWh),Cost (£),CO2 (kg)\n")
+      expect(csv.lines[1]).to eq("Gas,Spending too much money on heating,1,\"2,200\",\"£1,000\",\"1,100\"\n")
     end
   end
 end

--- a/spec/services/school_groups/recent_usage_csv_generator_spec.rb
+++ b/spec/services/school_groups/recent_usage_csv_generator_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe SchoolGroups::RecentUsageCsvGenerator do
       it { expect(csv.lines.count).to eq(3) }
       it { expect(csv.lines[0]).to start_with("School,Cluster,")}
       it { expect(csv.lines[1]).to start_with("#{school_group.schools.first.name},A Cluster,")}
-      it { expect(csv.lines[2]).to start_with("#{school_group.schools.second.name},N/A,")}
+      it { expect(csv.lines[2]).to start_with("#{school_group.schools.second.name},Not set,")}
     end
   end
 

--- a/spec/services/school_groups/schools_priority_action_csv_generator_spec.rb
+++ b/spec/services/school_groups/schools_priority_action_csv_generator_spec.rb
@@ -12,21 +12,21 @@ RSpec.describe SchoolGroups::SchoolsPriorityActionCsvGenerator do
       it 'returns priority actions data as a csv for a school group' do
         csv = SchoolGroups::SchoolsPriorityActionCsvGenerator.new(school_group: school_group, alert_type_rating_ids: [alert_type_rating.id]).export
         expect(csv.lines.count).to eq(2)
-        expect(csv.lines[0]).to eq("Fuel,Description,School,Number of pupils,Floor area (m2),Energy saving,Cost saving,CO2 reduction\n")
-        expect(csv.lines[1]).to eq("Gas,Spending too much money on heating,#{school_group.schools.first.name},10,200.0,0 kWh,£1000,1100 kg CO2\n")
+        expect(csv.lines[0]).to eq("Fuel,Description,School,Number of pupils,Floor area (m2),Energy (kWh),Cost (£),CO2 (kg)\n")
+        expect(csv.lines[1]).to eq("Gas,Spending too much money on heating,#{school_group.schools.first.name},10,200.0,0,£1000,1100\n")
       end
 
       context "when including cluster" do
         subject(:csv) { SchoolGroups::SchoolsPriorityActionCsvGenerator.new(school_group: school_group, alert_type_rating_ids: [alert_type_rating.id], include_cluster: true).export }
 
         it { expect(csv.lines.count).to eq(2) }
-        it { expect(csv.lines[0]).to eq("Fuel,Description,School,Cluster,Number of pupils,Floor area (m2),Energy saving,Cost saving,CO2 reduction\n") }
+        it { expect(csv.lines[0]).to eq("Fuel,Description,School,Cluster,Number of pupils,Floor area (m2),Energy (kWh),Cost (£),CO2 (kg)\n") }
         context "when school doesn't have cluster" do
-          it { expect(csv.lines[1]).to eq("Gas,Spending too much money on heating,#{school_group.schools.first.name},N/A,10,200.0,0 kWh,£1000,1100 kg CO2\n") }
+          it { expect(csv.lines[1]).to eq("Gas,Spending too much money on heating,#{school_group.schools.first.name},Not set,10,200.0,0,£1000,1100\n") }
         end
         context "when school has a cluster" do
           let!(:cluster) { create(:school_group_cluster, school_group: school_group, name: "My Cluster", schools: [school_1]) }
-          it { expect(csv.lines[1]).to eq("Gas,Spending too much money on heating,#{school_group.schools.first.name},My Cluster,10,200.0,0 kWh,£1000,1100 kg CO2\n") }
+          it { expect(csv.lines[1]).to eq("Gas,Spending too much money on heating,#{school_group.schools.first.name},My Cluster,10,200.0,0,£1000,1100\n") }
         end
       end
     end

--- a/spec/support/school_group_shared_contexts.rb
+++ b/spec/support/school_group_shared_contexts.rb
@@ -269,11 +269,11 @@ RSpec.shared_context "school group current scores" do
       OpenStruct.new(
         with_points: OpenStruct.new(
                        schools_with_positions: {
-                        1 => [OpenStruct.new(name: 'School 1', sum_points: 20, school_group_cluster_name: "My Cluster"), OpenStruct.new(name: 'School 2', sum_points: 20, school_group_cluster_name: "N/A")],
-                        2 => [OpenStruct.new(name: 'School 3', sum_points: 18, school_group_cluster_name: "N/A")]
+                        1 => [OpenStruct.new(name: 'School 1', sum_points: 20, school_group_cluster_name: "My Cluster"), OpenStruct.new(name: 'School 2', sum_points: 20, school_group_cluster_name: "Not set")],
+                        2 => [OpenStruct.new(name: 'School 3', sum_points: 18, school_group_cluster_name: "Not set")]
                        }
                      ),
-        without_points: [OpenStruct.new(name: 'School 4', school_group_cluster_name: "N/A"), OpenStruct.new(name: 'School 5', school_group_cluster_name: "N/A")]
+        without_points: [OpenStruct.new(name: 'School 4', school_group_cluster_name: "Not set"), OpenStruct.new(name: 'School 5', school_group_cluster_name: "Not set")]
       )
     end
   end

--- a/spec/support/school_groups_shared_examples.rb
+++ b/spec/support/school_groups_shared_examples.rb
@@ -273,7 +273,7 @@ RSpec.shared_examples "not showing the cluster column" do
   end
   it "doesn't show the cluster column" do
     expect(page).to_not have_content('Cluster')
-    expect(page).to_not have_content('N/A')
+    expect(page).to_not have_content('Not set')
   end
 end
 
@@ -285,7 +285,7 @@ RSpec.shared_examples "showing the cluster column" do
   it { expect(page).to have_content('Cluster') }
 
   context "school does not have a cluster" do
-    it { expect(page).to have_content('N/A') }
+    it { expect(page).to have_content('Not set') }
   end
 
   context "school is in a cluster" do

--- a/spec/system/school_groups_spec.rb
+++ b/spec/system/school_groups_spec.rb
@@ -400,7 +400,7 @@ describe 'school groups', :school_groups, type: :system do
             expect(header).to match /^attachment/
             filename = "#{school_group.name}-#{I18n.t('school_groups.titles.priority_actions')}-#{Time.zone.now.strftime('%Y-%m-%d')}".parameterize + ".csv"
             expect(header).to match filename
-            expect(page.source).to eq "Fuel,Description,Schools,Energy saving,Cost saving,CO2 reduction\nGas,Spending too much money on heating,1,\"2,200 kWh\",\"£1,000\",\"1,100 kg CO2\"\n"
+            expect(page.source).to eq "Fuel,Description,Schools,Energy (kWh),Cost (£),CO2 (kg)\nGas,Spending too much money on heating,1,\"2,200\",\"£1,000\",\"1,100\"\n"
           end
 
           it 'allows a csv download of a specific priority action for schools in a school group' do
@@ -409,7 +409,7 @@ describe 'school groups', :school_groups, type: :system do
             expect(header).to match /^attachment/
             filename = "#{school_group.name}-#{I18n.t('school_groups.titles.priority_actions')}-#{Time.zone.now.strftime('%Y-%m-%d')}".parameterize + ".csv"
             expect(header).to match filename
-            expect(page.source).to eq "Fuel,Description,School,Number of pupils,Floor area (m2),Energy saving,Cost saving,CO2 reduction\nGas,Spending too much money on heating,#{school_group.schools.first.name},10,200.0,0 kWh,£1000,1100 kg CO2\n"
+            expect(page.source).to eq "Fuel,Description,School,Number of pupils,Floor area (m2),Energy (kWh),Cost (£),CO2 (kg)\nGas,Spending too much money on heating,#{school_group.schools.first.name},10,200.0,0,£1000,1100\n"
           end
 
           it 'displays list of actions' do
@@ -417,8 +417,8 @@ describe 'school groups', :school_groups, type: :system do
             within('#school-group-priorities') do
               expect(page).to have_content("Spending too much money on heating")
               expect(page).to have_content("£1,000")
-              expect(page).to have_content("1,100 kg CO2")
-              expect(page).to have_content("2,200 kWh")
+              expect(page).to have_content("1,100")
+              expect(page).to have_content("2,200")
             end
           end
 
@@ -484,8 +484,7 @@ describe 'school groups', :school_groups, type: :system do
 
           it 'shows navigation' do
             expect(page).not_to have_content('View map')
-            expect(page).to have_content('View group')
-            expect(page).to have_content('Scoreboard')
+            expect(page).to have_content('View dashboard')
           end
 
           it 'shows expected map content' do

--- a/spec/system/school_groups_spec.rb
+++ b/spec/system/school_groups_spec.rb
@@ -172,6 +172,10 @@ describe 'school groups', :school_groups, type: :system do
           end
 
           describe 'changes in metrics params' do
+            it 'shows intro text' do
+              expect(page).to have_content('A summary of the recent energy usage across schools in this group.')
+            end
+
             it 'shows expected table content for change when there are no metrics params' do
               visit school_group_path(school_group, {})
               expect(page).to have_content('Electricity')
@@ -318,6 +322,14 @@ describe 'school groups', :school_groups, type: :system do
           include_examples "school dashboard navigation" do
             let(:expected_path) { "/school_groups/#{school_group.slug}/comparisons" }
             let(:breadcrumb)    { 'Comparisons' }
+          end
+
+          it 'displays introduction and links' do
+            expect(page).to have_link("explore all school comparison benchmarks for this group")
+            expect(page).to have_css('#electricity-comparisons')
+            expect(page).to have_css('#gas-comparisons')
+            expect(page).to have_link('electricity', href: '#electricity-comparisons')
+            expect(page).to have_link('gas', href: '#gas-comparisons')
           end
 
           it 'shows expected content' do

--- a/spec/system/schools/advice_pages/advice_page_index_spec.rb
+++ b/spec/system/schools/advice_pages/advice_page_index_spec.rb
@@ -70,8 +70,8 @@ RSpec.describe "advice pages", type: :system do
     it 'displays the priorities in a table' do
       expect(page).to have_content('Spending too much money on heating')
       expect(page).to have_content('£5,000')
-      expect(page).to have_content('9,400 kg CO2')
-      expect(page).to have_content('6,500 kWh')
+      expect(page).to have_content('9,400')
+      expect(page).to have_content('6,500')
     end
 
   end


### PR DESCRIPTION
This PR has a number of text and UX improvements to the school group dashboard. 

Unfortunately it's snowballed a bit as I've been tweaking. The changes are primarily to add new text to the pages, tidy up styling and layout.

Summary of changes:

* Add introductory text to each tab to explain what is on the page

* Styling updates for all of the buttons to match school dashboard
* Addition of fuel type icons and in-page navigation on the comparison tab
* Additional of explanatory text to the popups for school comparison, along with styled category names
* Moving scoreboard link into the current scores tab, and tweaked font size to more prominently show schools with scores
* Added introductory text to the priority action modals so there's some explanation of the analysis
* Moved the units in the values in the priority action table into the header, which required some changes to the CSV generation as well as the main templates
* Made the school group map wider
* Plus some other tweaks

