### PR TITLE
Combine csv downloads for recent usage tab on school group dashboard

### DIFF
--- a/app/controllers/school_groups_controller.rb
+++ b/app/controllers/school_groups_controller.rb
@@ -62,7 +62,7 @@ class SchoolGroupsController < ApplicationController
 
   def csv_filename_for(action)
     title = I18n.t("school_groups.titles.#{action}")
-    "#{@school_group.name}-#{title}#{Time.zone.now.strftime('%Y-%m-%d')}".parameterize + ".csv"
+    "#{@school_group.name}-#{title}-#{Time.zone.now.strftime('%Y-%m-%d')}".parameterize + ".csv"
   end
 
   def priority_actions_csv

--- a/app/controllers/school_groups_controller.rb
+++ b/app/controllers/school_groups_controller.rb
@@ -60,9 +60,9 @@ class SchoolGroupsController < ApplicationController
 
   private
 
-  def csv_filename_for(action, metric_label: '')
+  def csv_filename_for(action)
     title = I18n.t("school_groups.titles.#{action}")
-    "#{@school_group.name}-#{title}-#{metric_label}#{Time.zone.now.strftime('%Y-%m-%d')}".parameterize + ".csv"
+    "#{@school_group.name}-#{title}#{Time.zone.now.strftime('%Y-%m-%d')}".parameterize + ".csv"
   end
 
   def priority_actions_csv
@@ -134,10 +134,8 @@ class SchoolGroupsController < ApplicationController
           render 'recent_usage'
         end
         format.csv do
-          metric = params['metric'] || 'change'
-          metric_label = I18n.t("school_groups.show.metric.#{metric}") + '-'
-          send_data SchoolGroups::RecentUsageCsvGenerator.new(school_group: @school_group, metric: metric, include_cluster: include_cluster).export,
-          filename: csv_filename_for('recent_usage', metric_label: metric_label)
+          send_data SchoolGroups::RecentUsageCsvGenerator.new(school_group: @school_group, include_cluster: include_cluster).export,
+          filename: csv_filename_for('recent_usage')
         end
       end
     else

--- a/app/services/school_groups/recent_usage_csv_generator.rb
+++ b/app/services/school_groups/recent_usage_csv_generator.rb
@@ -1,6 +1,6 @@
 module SchoolGroups
   class RecentUsageCsvGenerator
-    METRICS_HEADERS = [:change, :usage, :cost, :co2].freeze
+    METRIC_HEADERS = [:change, :usage, :cost, :co2].freeze
     METRICS = [:change, :usage, :cost_text, :co2].freeze
 
     def initialize(school_group:, include_cluster: false)

--- a/app/views/school_groups/recent_usage.html.erb
+++ b/app/views/school_groups/recent_usage.html.erb
@@ -23,7 +23,7 @@
         </div>
       <% end %>
       <div>
-        <%= link_to t('school_groups.download_as_csv'), school_group_path(@school_group, format: :csv, metric: params['metric']), class: 'btn btn-sm btn-outline-dark rounded-pill font-weight-bold' %>
+        <%= link_to t('school_groups.download_as_csv'), school_group_path(@school_group, format: :csv), class: 'btn btn-sm btn-outline-dark rounded-pill font-weight-bold' %>
       </div>
     </div>
 

--- a/config/locales/views/school_groups/school_groups.yml
+++ b/config/locales/views/school_groups/school_groups.yml
@@ -198,7 +198,7 @@ en:
       if_you_would_like_support_enrol_here_html: If you would like Energy Sparks to support your school to reduce its carbon emissions, enrol <a href='%{enrol_path}'>here</a>
       in_partnership_with: in partnership with
       metric:
-        change: "% change"
+        change: "% Change"
         co2: CO2 (kg)
         cost: Cost (£)
         usage: Use (kWh)

--- a/spec/support/school_group_shared_contexts.rb
+++ b/spec/support/school_group_shared_contexts.rb
@@ -1,22 +1,44 @@
 RSpec.shared_context "school group recent usage" do
   before do
     allow_any_instance_of(SchoolGroup).to receive(:fuel_types) { [:electricity, :gas, :storage_heaters] }
-    changes = OpenStruct.new(
+    electricity_changes = OpenStruct.new(
       change: "-16%",
       usage: '910',
       cost: '£137',
       co2: '8,540',
       change_text: "-16%",
       usage_text: '910',
-      cost_text: '£137',
+      cost_text: '137',
       co2_text: '8,540',
+      has_data: true
+    )
+    gas_changes = OpenStruct.new(
+      change: "-5%",
+      usage: '500',
+      cost: '£200',
+      co2: '4,000',
+      change_text: "-5%",
+      usage_text: '500',
+      cost_text: '200',
+      co2_text: '4,000',
+      has_data: true
+    )
+    storage_heater_changes = OpenStruct.new(
+      change: "-12%",
+      usage: '312',
+      cost: '£111',
+      co2: '1,111',
+      change_text: "-12%",
+      usage_text: '312',
+      cost_text: '111',
+      co2_text: '1,111',
       has_data: true
     )
     allow_any_instance_of(School).to receive(:recent_usage) do
       OpenStruct.new(
-        electricity: OpenStruct.new(week: changes, year: changes),
-        gas: OpenStruct.new(week: changes, year: changes),
-        storage_heaters: OpenStruct.new(week: changes, year: changes)
+        electricity: OpenStruct.new(week: electricity_changes, year: electricity_changes),
+        gas: OpenStruct.new(week: gas_changes, year: gas_changes),
+        storage_heaters: OpenStruct.new(week: storage_heater_changes, year: storage_heater_changes)
       )
     end
   end

--- a/spec/system/school_groups_spec.rb
+++ b/spec/system/school_groups_spec.rb
@@ -282,33 +282,29 @@ describe 'school groups', :school_groups, type: :system do
               click_on 'Download as CSV'
               header = page.response_headers['Content-Disposition']
               expect(header).to match /^attachment/
-              filename = "#{school_group.name}-recent-usage-change-#{Time.zone.now.strftime('%Y-%m-%d')}".parameterize + ".csv"
+              filename = "#{school_group.name}-recent-usage-#{Time.zone.now.strftime('%Y-%m-%d')}".parameterize + ".csv"
               expect(header).to match filename
-              expect(page.source).to have_content "School,Number of pupils,Floor area (m2),Electricity Last week,Electricity Last year,Gas Last week,Gas Last year,Storage heaters Last week,Storage heaters Last year\n#{school_group.schools.first.name},10,200.0,-16%,-16%,-16%,-16%,-16%,-16%\n#{school_group.schools.second.name},20,300.0,-16%,-16%,-16%,-16%,-16%,-16%\n"
 
               visit school_group_path(school_group, metric: 'usage')
               click_on 'Download as CSV'
               header = page.response_headers['Content-Disposition']
               expect(header).to match /^attachment/
-              filename = "#{school_group.name}-recent-usage-use-kwh-#{Time.zone.now.strftime('%Y-%m-%d')}".parameterize + ".csv"
+              filename = "#{school_group.name}-recent-usage-#{Time.zone.now.strftime('%Y-%m-%d')}".parameterize + ".csv"
               expect(header).to match filename
-              expect(page.source).to have_content "School,Number of pupils,Floor area (m2),Electricity Last week,Electricity Last year,Gas Last week,Gas Last year,Storage heaters Last week,Storage heaters Last year\n#{school_group.schools.first.name},10,200.0,910,910,910,910,910,910\n#{school_group.schools.second.name},20,300.0,910,910,910,910,910,910\n"
 
               visit school_group_path(school_group, metric: 'cost')
               click_on 'Download as CSV'
               header = page.response_headers['Content-Disposition']
               expect(header).to match /^attachment/
-              filename = "#{school_group.name}-recent-usage-cost-#{Time.zone.now.strftime('%Y-%m-%d')}".parameterize + ".csv"
+              filename = "#{school_group.name}-recent-usage-#{Time.zone.now.strftime('%Y-%m-%d')}".parameterize + ".csv"
               expect(header).to match filename
-              expect(page.source).to have_content "School,Number of pupils,Floor area (m2),Electricity Last week,Electricity Last year,Gas Last week,Gas Last year,Storage heaters Last week,Storage heaters Last year\n#{school_group.schools.first.name},10,200.0,£137,£137,£137,£137,£137,£137\n#{school_group.schools.second.name},20,300.0,£137,£137,£137,£137,£137,£137\n"
 
               visit school_group_path(school_group, metric: 'co2')
               click_on 'Download as CSV'
               header = page.response_headers['Content-Disposition']
               expect(header).to match /^attachment/
-              filename = "#{school_group.name}-recent-usage-co2-kg-#{Time.zone.now.strftime('%Y-%m-%d')}".parameterize + ".csv"
+              filename = "#{school_group.name}-recent-usage-#{Time.zone.now.strftime('%Y-%m-%d')}".parameterize + ".csv"
               expect(header).to match filename
-              expect(page.source).to have_content "School,Number of pupils,Floor area (m2),Electricity Last week,Electricity Last year,Gas Last week,Gas Last year,Storage heaters Last week,Storage heaters Last year\n#{school_group.schools.first.name},10,200.0,\"8,540\",\"8,540\",\"8,540\",\"8,540\",\"8,540\",\"8,540\"\n#{school_group.schools.second.name},20,300.0,\"8,540\",\"8,540\",\"8,540\",\"8,540\",\"8,540\",\"8,540\"\n"
             end
           end
         end
@@ -446,7 +442,7 @@ describe 'school groups', :school_groups, type: :system do
             let(:breadcrumb)    { 'Current Scores' }
           end
 
-          it 'allows a csv download of recent data metrics' do
+          it 'allows a csv download of scores' do
             click_on 'Download as CSV'
             header = page.response_headers['Content-Disposition']
             expect(header).to match /^attachment/


### PR DESCRIPTION
This PR changes the CSV downloads for the Recent usage tab on the school group dashboard.

Instead of having separate downloads for each metric, we instead have a single download that includes all of the metrics (%, kwh, £, co2) for both periods (last week, last year) for all fuel types. This is intended to be a convenience for anyone intending to do any analysis that would otherwise involve downloading and combining separate files.

The tests have been revised to use separate values for each fuel type to better check that the right values are in the right columns. 

I've also simplified the system spec so its just checking that the download is available and that the generated file name is correct. The service spec already covers the format and content of the CSV.