### PR TITLE
Award bonus points for adding photos to activities and actions

### DIFF
--- a/app/controllers/admin/settings_controller.rb
+++ b/app/controllers/admin/settings_controller.rb
@@ -30,7 +30,7 @@ module Admin
         params.require(:site_settings).permit(
           :message_for_no_contacts, :message_for_no_pupil_accounts,
           :management_priorities_dashboard_limit, :management_priorities_page_limit,
-          :default_import_warning_days,
+          :default_import_warning_days, :photo_bonus_points,
           :electricity_price, :solar_export_price, :gas_price,
           temperature_recording_months: []
         )
@@ -38,7 +38,7 @@ module Admin
         params.require(:site_settings).permit(
           :message_for_no_contacts, :message_for_no_pupil_accounts,
           :management_priorities_dashboard_limit, :management_priorities_page_limit,
-          :default_import_warning_days,
+          :default_import_warning_days, :photo_bonus_points,
           temperature_recording_months: []
         )
       end

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -55,6 +55,6 @@ class Activity < ApplicationRecord
   end
 
   def description_includes_images?
-    description.body.to_trix_html.include?("figure")
+    description&.body&.to_trix_html&.include?("figure")
   end
 end

--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -70,6 +70,7 @@ class Observation < ApplicationRecord
   private
 
   def add_points_for_included_images
+    return unless EnergySparks::FeatureFlags.active?(:activities_2023)
     # Do not add points if site wide photo bonus points are set to nil or zero
     return unless SiteSettings.current.photo_bonus_points&.nonzero?
     return unless description_includes_images?

--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -65,12 +65,17 @@ class Observation < ApplicationRecord
   has_rich_text :description
 
   before_save :add_points_for_interventions
+  before_save :add_points_for_included_images
 
   def description_includes_images?
     description.body.to_trix_html.include?("figure")
   end
 
   private
+
+  def add_points_for_included_images
+    self.points = self.points + SiteSettings.current.photo_bonus_points
+  end
 
   def add_points_for_interventions
     if intervention?

--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -66,7 +66,11 @@ class Observation < ApplicationRecord
 
   before_save :add_points_for_interventions
 
-private
+  def description_includes_images?
+    description.body.to_trix_html.include?("figure")
+  end
+
+  private
 
   def add_points_for_interventions
     if intervention?

--- a/app/models/site_settings.rb
+++ b/app/models/site_settings.rb
@@ -17,6 +17,8 @@
 class SiteSettings < ApplicationRecord
   store_accessor :prices, :electricity_price, :solar_export_price, :gas_price
   validates :electricity_price, :solar_export_price, :gas_price, numericality: { only_float: true, allow_blank: false }, if: -> { EnergySparks::FeatureFlags.active?(:use_site_settings_current_prices) }
+  validates :photo_bonus_points, numericality: { greater_than_or_equal_to: 0 }
+
   after_save :delete_current_prices_cache
 
   CURRENT_PRICES_CACHE_KEY = 'site_settings_current_prices'.freeze

--- a/app/views/activities/_form.html.erb
+++ b/app/views/activities/_form.html.erb
@@ -40,6 +40,14 @@
     <small class="form-text text-muted">
       <%= t('activities.form.tell_us_more_formatting_message') %>.
     </small>
+    <% if EnergySparks::FeatureFlags.active?(:activities_2023) && SiteSettings.current&.photo_bonus_points&.nonzero? %>
+      <small class="form-text text-muted">
+        <%= t('activities.form.adding_a_photo_to_document_your_activity_will_score_you') %>
+        <span class="badge badge-success"><%= SiteSettings.current.photo_bonus_points %></span>
+        <%= t('activities.form.bonus_points', count: SiteSettings.current.photo_bonus_points) %>
+      </small>
+    <% end %>
+
     <%= f.rich_text_area :description, required: true %>
   </div>
 

--- a/app/views/admin/settings/show.html.erb
+++ b/app/views/admin/settings/show.html.erb
@@ -7,6 +7,7 @@
   <%= f.input :management_priorities_page_limit, hint: 'How many entries to show on the management priorities page '%>
   <%= f.input :temperature_recording_months, as: :check_boxes, collection: @temperature_setting_months, checked: f.object.temperature_recording_months %>
   <%= f.input :default_import_warning_days %>
+  <%= f.input :photo_bonus_points, label: 'Bonus points for adding photos to activities and actions' %>
 
   <% if EnergySparks::FeatureFlags.active?(:use_site_settings_current_prices) %>
     <hr />

--- a/app/views/schools/interventions/_form.html.erb
+++ b/app/views/schools/interventions/_form.html.erb
@@ -24,7 +24,6 @@
     </small>
   <% end %>
 
-
   <div class="mt-4">
     <%= f.rich_text_area :description, wrapper_html: {class: ''}%>
   </div>

--- a/app/views/schools/interventions/_form.html.erb
+++ b/app/views/schools/interventions/_form.html.erb
@@ -15,8 +15,18 @@
   <%= f.label t('interventions.form.tell_us_more'), for: :description %>
   <small class="form-text text-muted"><%= t('interventions.form.adding_some_background_detail_label') %></small>
   <small class="form-text text-muted"><%= t('interventions.form.you_can_add_formatting_label') %>.</small>
+
+  <% if EnergySparks::FeatureFlags.active?(:activities_2023) && SiteSettings.current&.photo_bonus_points&.nonzero? %>
+    <small class="form-text text-muted">
+      <%= t('interventions.form.adding_a_photo_to_document_your_action_will_score_you') %>
+      <span class="badge badge-success"><%= SiteSettings.current.photo_bonus_points %></span>
+      <%= t('interventions.form.bonus_points', count: SiteSettings.current.photo_bonus_points) %>
+    </small>
+  <% end %>
+
+
   <div class="mt-4">
-  <%= f.rich_text_area :description, wrapper_html: {class: ''}%>
+    <%= f.rich_text_area :description, wrapper_html: {class: ''}%>
   </div>
 </fieldset>
 <fieldset>

--- a/config/locales/views/activities/activities.yml
+++ b/config/locales/views/activities/activities.yml
@@ -22,6 +22,10 @@ en:
       page_title: Update activity
       update_your_activity: Update your activity
     form:
+      adding_a_photo_to_document_your_activity_will_score_you: Adding a photo to document your activity will score you
+      bonus_points:
+        one: bonus point
+        other: bonus points
       build_a_record_message: You can record a recent activity and older activities to build up a record of all of the energy saving activities you've carried out as a school
       cancel: Cancel
       completing_this_activity:

--- a/config/locales/views/interventions/interventions.yml
+++ b/config/locales/views/interventions/interventions.yml
@@ -20,7 +20,11 @@ en:
       page_title: Update energy saving action
       title: Update your energy saving action
     form:
+      adding_a_photo_to_document_your_action_will_score_you: Adding a photo to document your action will score you
       adding_some_background_detail_label: Adding some background detail can help you track and monitor improvements
+      bonus_points:
+        one: bonus point
+        other: bonus points
       if_pupils_were_involved_label: If pupils were involved in proposing, planning, fund-raising or carrying out this action then recording this action will score
       points_for_your_school:
         one: points for your school

--- a/db/migrate/20230719141228_add_photo_bonus_points_to_site_settings.rb
+++ b/db/migrate/20230719141228_add_photo_bonus_points_to_site_settings.rb
@@ -1,0 +1,5 @@
+class AddPhotoBonusPointsToSiteSettings < ActiveRecord::Migration[6.0]
+  def change
+    add_column :site_settings, :photo_bonus_points, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -854,13 +854,13 @@ ActiveRecord::Schema.define(version: 2023_07_19_141228) do
     t.index ["replaced_by_id"], name: "index_global_meter_attributes_on_replaced_by_id"
   end
 
-  create_table "good_job_processes", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "good_job_processes", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.jsonb "state"
   end
 
-  create_table "good_job_settings", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "good_job_settings", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.text "key"
@@ -868,7 +868,7 @@ ActiveRecord::Schema.define(version: 2023_07_19_141228) do
     t.index ["key"], name: "index_good_job_settings_on_key", unique: true
   end
 
-  create_table "good_jobs", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "good_jobs", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.text "queue_name"
     t.integer "priority"
     t.jsonb "serialized_params"
@@ -1168,9 +1168,11 @@ ActiveRecord::Schema.define(version: 2023_07_19_141228) do
     t.bigint "audit_id"
     t.boolean "involved_pupils", default: false, null: false
     t.bigint "school_target_id"
+    t.bigint "programme_id"
     t.index ["activity_id"], name: "index_observations_on_activity_id"
     t.index ["audit_id"], name: "index_observations_on_audit_id"
     t.index ["intervention_type_id"], name: "index_observations_on_intervention_type_id"
+    t.index ["programme_id"], name: "index_observations_on_programme_id"
     t.index ["school_id"], name: "index_observations_on_school_id"
     t.index ["school_target_id"], name: "index_observations_on_school_target_id"
   end
@@ -1222,6 +1224,7 @@ ActiveRecord::Schema.define(version: 2023_07_19_141228) do
     t.boolean "default", default: false
     t.datetime "created_at", precision: 6, default: "2022-07-06 12:00:00", null: false
     t.datetime "updated_at", precision: 6, default: "2022-07-06 12:00:00", null: false
+    t.integer "bonus_score", default: 0
   end
 
   create_table "programmes", force: :cascade do |t|
@@ -1983,6 +1986,7 @@ ActiveRecord::Schema.define(version: 2023_07_19_141228) do
   add_foreign_key "observations", "activities", on_delete: :nullify
   add_foreign_key "observations", "audits"
   add_foreign_key "observations", "intervention_types", on_delete: :restrict
+  add_foreign_key "observations", "programmes", on_delete: :cascade
   add_foreign_key "observations", "school_targets"
   add_foreign_key "observations", "schools", on_delete: :cascade
   add_foreign_key "programmes", "programme_types", on_delete: :cascade

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -854,13 +854,13 @@ ActiveRecord::Schema.define(version: 2023_07_19_141228) do
     t.index ["replaced_by_id"], name: "index_global_meter_attributes_on_replaced_by_id"
   end
 
-  create_table "good_job_processes", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "good_job_processes", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.jsonb "state"
   end
 
-  create_table "good_job_settings", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "good_job_settings", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.text "key"
@@ -868,7 +868,7 @@ ActiveRecord::Schema.define(version: 2023_07_19_141228) do
     t.index ["key"], name: "index_good_job_settings_on_key", unique: true
   end
 
-  create_table "good_jobs", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "good_jobs", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.text "queue_name"
     t.integer "priority"
     t.jsonb "serialized_params"
@@ -1168,11 +1168,9 @@ ActiveRecord::Schema.define(version: 2023_07_19_141228) do
     t.bigint "audit_id"
     t.boolean "involved_pupils", default: false, null: false
     t.bigint "school_target_id"
-    t.bigint "programme_id"
     t.index ["activity_id"], name: "index_observations_on_activity_id"
     t.index ["audit_id"], name: "index_observations_on_audit_id"
     t.index ["intervention_type_id"], name: "index_observations_on_intervention_type_id"
-    t.index ["programme_id"], name: "index_observations_on_programme_id"
     t.index ["school_id"], name: "index_observations_on_school_id"
     t.index ["school_target_id"], name: "index_observations_on_school_target_id"
   end
@@ -1224,7 +1222,6 @@ ActiveRecord::Schema.define(version: 2023_07_19_141228) do
     t.boolean "default", default: false
     t.datetime "created_at", precision: 6, default: "2022-07-06 12:00:00", null: false
     t.datetime "updated_at", precision: 6, default: "2022-07-06 12:00:00", null: false
-    t.integer "bonus_score", default: 0
   end
 
   create_table "programmes", force: :cascade do |t|
@@ -1986,7 +1983,6 @@ ActiveRecord::Schema.define(version: 2023_07_19_141228) do
   add_foreign_key "observations", "activities", on_delete: :nullify
   add_foreign_key "observations", "audits"
   add_foreign_key "observations", "intervention_types", on_delete: :restrict
-  add_foreign_key "observations", "programmes", on_delete: :cascade
   add_foreign_key "observations", "school_targets"
   add_foreign_key "observations", "schools", on_delete: :cascade
   add_foreign_key "programmes", "programme_types", on_delete: :cascade

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_06_30_103731) do
+ActiveRecord::Schema.define(version: 2023_07_19_141228) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
@@ -1565,6 +1565,7 @@ ActiveRecord::Schema.define(version: 2023_06_30_103731) do
     t.jsonb "temperature_recording_months", default: ["10", "11", "12", "1", "2", "3", "4"]
     t.jsonb "prices"
     t.integer "default_import_warning_days", default: 10
+    t.integer "photo_bonus_points", default: 0
   end
 
   create_table "sms_records", force: :cascade do |t|

--- a/spec/models/observation_spec.rb
+++ b/spec/models/observation_spec.rb
@@ -24,7 +24,7 @@ describe Observation do
   end
 
   context 'activities' do
-    it 'adds points if an activity has an image in its activity description' do
+    it 'sets the score if an activity has an image in its activity description' do
       activity = create(:activity, description: "<div><figure></figure></div>")
       SiteSettings.current.update(photo_bonus_points: 15)
       observation = build(:observation, observation_type: :activity, activity: activity)
@@ -32,7 +32,7 @@ describe Observation do
       expect(observation.points).to eq(15)
     end
 
-    it 'adds points if an activity has an image in its observation description' do
+    it 'sets the score if an activity has an image in its observation description' do
       activity = create(:activity, description: "<div></div>")
       SiteSettings.current.update(photo_bonus_points: 15)
       observation = build(:observation, observation_type: :activity, activity: activity, description: "<div><figure></figure></div>")
@@ -40,7 +40,7 @@ describe Observation do
       expect(observation.points).to eq(15)
     end
 
-    it 'does not add points if an activity has no image in its activity or observation description' do
+    it 'does not sets a score if an activity has no image in its activity or observation description' do
       activity = create(:activity, description: "<div></div>")
       SiteSettings.current.update(photo_bonus_points: 15)
       observation = build(:observation, observation_type: :activity, activity: activity, description: "<div></div>")
@@ -52,14 +52,15 @@ describe Observation do
   context 'interventions' do
     let!(:intervention_type){ create(:intervention_type, score: 50) }
 
-    it 'adds points if an intervention has an image in its description' do
-      SiteSettings.current.update(photo_bonus_points: 25)
+    before { SiteSettings.current.update(photo_bonus_points: 25) }
+
+    it 'sets the score if an intervention has an image in its description' do
       observation = build(:observation, observation_type: :intervention, intervention_type: intervention_type, involved_pupils: false, description: "<div><figure></figure></div>")
       observation.save
       expect(observation.points).to eq(25)
     end
 
-    it 'adds no points if an intervention has no image in its description' do
+    it 'sets the score if an intervention has no image in its description' do
       SiteSettings.current.update(photo_bonus_points: 25)
       observation = build(:observation, observation_type: :intervention, intervention_type: intervention_type, involved_pupils: false, description: "<div></div>")
       observation.save
@@ -78,7 +79,13 @@ describe Observation do
       expect(observation.points).to eq(50)
     end
 
-    it 'does not set score if pupils not involved' do
+    it 'sets the score if pupils involved and the description contains an image' do
+      observation = build(:observation, observation_type: :intervention, intervention_type: intervention_type, involved_pupils: true, description: "<div><figure></figure></div>")
+      observation.save
+      expect(observation.points).to eq(75)
+    end
+
+    it 'does not set a score if pupils not involved' do
       observation = build(:observation, observation_type: :intervention, intervention_type: intervention_type, involved_pupils: false)
       observation.save
       expect(observation.points).to eq(nil)

--- a/spec/models/observation_spec.rb
+++ b/spec/models/observation_spec.rb
@@ -40,6 +40,7 @@ describe Observation do
         ClimateControl.modify FEATURE_FLAG_ACTIVITIES_2023: 'true' do
           activity = create(:activity, description: "<div><figure></figure></div>")
           SiteSettings.current.update(photo_bonus_points: 15)
+          # Notes: see ActivityCreator where observation points are assigned for activities
           observation = build(:observation, observation_type: :activity, activity: activity, points: 10)
           observation.save
           expect(observation.points).to eq(25)
@@ -50,6 +51,7 @@ describe Observation do
         ClimateControl.modify FEATURE_FLAG_ACTIVITIES_2023: 'true' do
           activity = create(:activity, description: "<div></div>")
           SiteSettings.current.update(photo_bonus_points: 15)
+          # Notes: see ActivityCreator where observation points are assigned for activities
           observation = build(:observation, observation_type: :activity, activity: activity, description: "<div><figure></figure></div>", points: 10)
           observation.save
           expect(observation.points).to eq(25)
@@ -60,7 +62,11 @@ describe Observation do
         ClimateControl.modify FEATURE_FLAG_ACTIVITIES_2023: 'true' do
           activity = create(:activity, description: "<div><figure></figure></div>")
           SiteSettings.current.update(photo_bonus_points: 15)
-          observation = build(:observation, observation_type: :activity, activity: activity)
+          # Notes: see ActivityCreator where observation points are assigned for activities
+          observation = build(:observation, observation_type: :activity, activity: activity, points: 0)
+          observation.save
+          expect(observation.points).to eq(0)
+          observation = build(:observation, observation_type: :activity, activity: activity, points: nil)
           observation.save
           expect(observation.points).to eq(nil)
         end
@@ -73,6 +79,9 @@ describe Observation do
           observation = build(:observation, observation_type: :activity, activity: activity, description: "<div><figure></figure></div>")
           observation.save
           expect(observation.points).to eq(nil)
+          observation = build(:observation, observation_type: :activity, activity: activity, description: "<div><figure></figure></div>", points: 0)
+          observation.save
+          expect(observation.points).to eq(0)
         end
       end
 
@@ -106,6 +115,9 @@ describe Observation do
           observation = build(:observation, observation_type: :intervention, intervention_type: intervention_type, involved_pupils: false, description: "<div></div>")
           observation.save
           expect(observation.points).to eq(nil)
+          observation = build(:observation, observation_type: :intervention, intervention_type: intervention_type, involved_pupils: false, description: "<div></div>", points: 0)
+          observation.save
+          expect(observation.points).to eq(0)
         end
       end
 


### PR DESCRIPTION
This PR changes the scoring system for both pupil and adult lead activities so that bonus points are awarded if the school adds one or more photos to the description.  

- [x] Adds a new system wide setting for default bonus points for adding images to activities and actions
- [x] Adds a note to form field to both forms to indicate bonus points
- [x] Revises logic to ensure bonus points are recorded correctly