### PR TITLE
New common data model for storing energy tariffs

### DIFF
--- a/app/models/energy_tariff.rb
+++ b/app/models/energy_tariff.rb
@@ -1,0 +1,128 @@
+# == Schema Information
+#
+# Table name: energy_tariffs
+#
+#  ccl                :boolean          default(FALSE)
+#  created_at         :datetime         not null
+#  created_by_id      :bigint(8)
+#  enabled            :boolean          default(FALSE)
+#  end_date           :date
+#  id                 :bigint(8)        not null, primary key
+#  meter_type         :integer          default("electricity"), not null
+#  name               :text             not null
+#  source             :integer          default("manual"), not null
+#  start_date         :date
+#  tariff_holder_id   :bigint(8)
+#  tariff_holder_type :string
+#  tariff_type        :integer          default("flat_rate"), not null
+#  tnuos              :boolean          default(FALSE)
+#  updated_at         :datetime         not null
+#  updated_by_id      :bigint(8)
+#  vat_rate           :float
+#
+# Indexes
+#
+#  index_energy_tariffs_on_created_by_id                            (created_by_id)
+#  index_energy_tariffs_on_tariff_holder_type_and_tariff_holder_id  (tariff_holder_type,tariff_holder_id)
+#  index_energy_tariffs_on_updated_by_id                            (updated_by_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (created_by_id => users.id)
+#  fk_rails_...  (updated_by_id => users.id)
+#
+class EnergyTariff < ApplicationRecord
+  belongs_to :tariff_holder, polymorphic: true
+
+  delegated_type :tariff_holder, types: %w[School SchoolGroup]
+
+  has_many :energy_tariff_prices, inverse_of: :energy_tariff
+  has_many :energy_tariff_charges, inverse_of: :energy_tariff
+
+  #only populated if tariff_holder is school
+  has_and_belongs_to_many :meters, inverse_of: :energy_tariffs
+
+  belongs_to :created_by, class_name: 'User'
+  belongs_to :updated_by, class_name: 'User'
+
+  enum source: [:manually_entered, :dcc]
+  enum meter_type: [:electricity, :gas, :solar_pv, :exported_solar_pv]
+  enum tariff_type: [:flat_rate, :differential]
+
+  validates :name, presence: true
+
+  scope :enabled, -> { where(enabled: true) }
+  scope :disabled, -> { where(enabled: false) }
+
+  scope :has_prices, -> { where(id: EnergyTariffPrice.select(:energy_tariff_id)) }
+  scope :has_charges, -> { where(id: EnergyTariffCharge.select(:energy_tariff_id)) }
+  scope :complete, -> { has_prices.or(has_charges) }
+
+  def meter_attribute
+    MeterAttribute.new(attribute_type: :accounting_tariff_generic, input_data: to_hash)
+  end
+
+  def to_hash
+    rates = rates_attrs
+    {
+      start_date: start_date.to_s(:es_compact),
+      end_date: end_date.to_s(:es_compact),
+      source: source.to_sym,
+      name: name,
+      type: flat_rate? ? :flat : :differential,
+      sub_type: '',
+      rates: rates,
+      vat: "#{vat_rate}%",
+      climate_change_levy: ccl,
+      asc_limit_kw: (value_for_charge(:asc_limit_kw) if rates_has_availability_charge?(rates))
+    }.compact
+  end
+
+  def value_for_charge(type)
+    if (charge = energy_tariff_charges.for_type(type).first)
+      charge.value.to_s
+    end
+  end
+
+  private
+
+  def rates_attrs
+    attrs = {}
+    if flat_rate?
+      if (first_price = energy_tariff_prices.first)
+        attrs[:flat_rate] = { rate: first_price.value.to_s, per: first_price.units.to_s }
+      end
+    else
+      energy_tariff_prices.each_with_index do |price, idx|
+        attrs["rate#{idx}".to_sym] = { rate: price.value.to_s, per: price.units.to_s, from: hour_minutes(price.start_time), to: hour_minutes(price.end_time.advance(minutes: -30)) }
+      end
+    end
+    energy_tariff_charges.select { |c| c.units.present? }.each do |charge|
+      charge_value = { rate: charge.value.to_s, per: charge.units.to_s }
+      charge_type = charge.charge_type.to_sym
+      #only add these charges if we also have an asc limit
+      if charge.is_type?([:agreed_availability_charge, :excess_availability_charge])
+        attrs[charge_type] = charge_value if value_for_charge(:asc_limit_kw).present?
+      else
+        attrs[charge_type] = charge_value
+      end
+    end
+    energy_tariff_charges.select { |c| c.is_type?([:duos_red, :duos_amber, :duos_green]) }.each do |charge|
+      attrs[charge.charge_type.to_sym] = charge.value.to_s
+    end
+    attrs[:tnuos] = tnuos
+    attrs
+  end
+
+  def rates_has_availability_charge?(rates)
+    rates.key?(:agreed_availability_charge) || rates.key?(:excess_availability_charge)
+  end
+
+  def hour_minutes(time)
+    hm = time.to_s(:time).split(':')
+    {
+      hour: hm.first,
+      minutes: hm.last
+    }
+  end
+end

--- a/app/models/energy_tariff.rb
+++ b/app/models/energy_tariff.rb
@@ -42,8 +42,8 @@ class EnergyTariff < ApplicationRecord
   #only populated if tariff_holder is school
   has_and_belongs_to_many :meters, inverse_of: :energy_tariffs
 
-  belongs_to :created_by, class_name: 'User'
-  belongs_to :updated_by, class_name: 'User'
+  belongs_to :created_by, optional: true, class_name: 'User'
+  belongs_to :updated_by, optional: true, class_name: 'User'
 
   enum source: [:manually_entered, :dcc]
   enum meter_type: [:electricity, :gas, :solar_pv, :exported_solar_pv]

--- a/app/models/energy_tariff_charge.rb
+++ b/app/models/energy_tariff_charge.rb
@@ -1,0 +1,116 @@
+# == Schema Information
+#
+# Table name: energy_tariff_charges
+#
+#  charge_type      :text             not null
+#  created_at       :datetime         not null
+#  energy_tariff_id :bigint(8)        not null
+#  id               :bigint(8)        not null, primary key
+#  units            :text             not null
+#  updated_at       :datetime         not null
+#  value            :decimal(, )      not null
+#
+# Indexes
+#
+#  index_energy_tariff_charges_on_energy_tariff_id  (energy_tariff_id)
+#
+class EnergyTariffCharge < ApplicationRecord
+  belongs_to :energy_tariff, inverse_of: :energy_tariff_charges
+
+  validates :charge_type, :value, presence: true
+  validates :value, numericality: true
+
+  scope :for_type, ->(type) { where('charge_type = ?', type.to_s) }
+
+  def self.charge_type_units
+    {
+      kwh: I18n.t('charge_type_units.kwh'),
+      kva: I18n.t('charge_type_units.kva'),
+      day: I18n.t('charge_type_units.day'),
+      month: I18n.t('charge_type_units.month'),
+      quarter: I18n.t('charge_type_units.quarter')
+    }.freeze
+  end
+
+  def self.charge_types
+    {
+      standing_charge: {
+        units: [:day, :month, :quarter]
+      },
+      asc_limit_kw: {
+        units: [],
+        label: 'kVA',
+        name: I18n.t('user_tariff_charge.available_capacity')
+      },
+      renewable_energy_obligation: {
+        units: [:kwh]
+      },
+      feed_in_tariff_levy: {
+        units: [:kwh]
+      },
+      agreed_capacity: {
+        units: [:day, :month, :quarter]
+      },
+      agreed_availability_charge: {
+        units: [:kva],
+        tip: I18n.t('user_tariff_charge.available_capacity_tip')
+      },
+      excess_availability_charge: {
+        units: [:kva],
+        tip: I18n.t('user_tariff_charge.available_capacity_tip')
+      },
+      settlement_agency_fee: {
+        units: [:day, :month, :quarter]
+      },
+      reactive_power_charge: {
+        units: [:kva]
+      },
+      half_hourly_data_charge: {
+        units: [:day, :month, :quarter]
+      },
+      fixed_charge: {
+        units: [:day, :month, :quarter]
+      },
+      nhh_metering_agent_charge: {
+        units: [:kwh, :day, :month, :quarter],
+        name: I18n.t('user_tariff_charge.nhh_metering_agent_charge')
+      },
+      nhh_automatic_meter_reading_charge: {
+        units: [:kwh, :day, :month, :quarter],
+        name: I18n.t('user_tariff_charge.nhh_automatic_meter_reading_charge')
+      },
+      meter_asset_provider_charge: {
+        units: [:day, :month, :quarter]
+      },
+      data_collection_dcda_agent_charge: {
+        units: [:day, :month, :quarter],
+        name: I18n.t('user_tariff_charge.data_collection_dcda_agent_charge')
+      },
+      site_fee: {
+        units: [:day, :month, :quarter]
+      },
+      duos_red: {
+        units: [],
+        name: I18n.t('user_tariff_charge.unit_rate_charge_red'),
+        label: I18n.t('user_tariff_charge.rate')
+      },
+      duos_amber: {
+        units: [],
+        name: I18n.t('user_tariff_charge.unit_rate_charge_amber'),
+        label: I18n.t('user_tariff_charge.rate')
+      },
+      duos_green: {
+        units: [],
+        name: I18n.t('user_tariff_charge.unit_rate_charge_green'),
+        label: I18n.t('user_tariff_charge.rate')
+      },
+      other: {
+        units: [:kwh, :day, :month, :quarter]
+      },
+    }.freeze
+  end
+
+  def is_type?(types)
+    types.map(&:to_sym).include?(charge_type.to_sym)
+  end
+end

--- a/app/models/energy_tariff_price.rb
+++ b/app/models/energy_tariff_price.rb
@@ -1,0 +1,51 @@
+# == Schema Information
+#
+# Table name: energy_tariff_prices
+#
+#  created_at       :datetime         not null
+#  description      :text
+#  end_time         :text             not null
+#  energy_tariff_id :bigint(8)        not null
+#  id               :bigint(8)        not null, primary key
+#  start_time       :text             not null
+#  units            :text
+#  updated_at       :datetime         not null
+#  value            :decimal(, )      default(0.0), not null
+#
+# Indexes
+#
+#  index_energy_tariff_prices_on_energy_tariff_id  (energy_tariff_id)
+#
+class EnergyTariffPrice < ApplicationRecord
+  belongs_to :energy_tariff, inverse_of: :energy_tariff_prices
+
+  enum units: [:kwh]
+
+  validates :start_time, :end_time, :value, :units, presence: true
+  validates :value, numericality: true
+  validate :no_time_overlaps
+  validate :time_range_given
+
+  scope :by_start_time, -> { order(start_time: :asc) }
+
+  NIGHT_RATE_DESCRIPTION = 'Night rate'.freeze
+  DAY_RATE_DESCRIPTION = 'Day rate'.freeze
+
+  def time_range
+    last_time = end_time < start_time ? end_time + 1.day : end_time
+    start_time + 1.minute..last_time - 1.minute
+  end
+
+  private
+
+  def no_time_overlaps
+    energy_tariff.energy_tariff_prices.without(self).each do |other_price|
+      errors.add(:start_time, 'overlaps with another time range') if other_price.time_range.include?(start_time)
+      errors.add(:end_time, 'overlaps with another time range') if other_price.time_range.include?(end_time)
+    end
+  end
+
+  def time_range_given
+    errors.add(:start_time, "can't be the same as end time") if start_time == end_time
+  end
+end

--- a/app/models/energy_tariff_price.rb
+++ b/app/models/energy_tariff_price.rb
@@ -19,8 +19,6 @@
 class EnergyTariffPrice < ApplicationRecord
   belongs_to :energy_tariff, inverse_of: :energy_tariff_prices
 
-  enum units: [:kwh]
-
   validates :start_time, :end_time, :value, :units, presence: true
   validates :value, numericality: true
   validate :no_time_overlaps

--- a/app/models/meter.rb
+++ b/app/models/meter.rb
@@ -64,6 +64,7 @@ class Meter < ApplicationRecord
 
   has_one :school_group, through: :school
   has_and_belongs_to_many :user_tariffs, inverse_of: :meters
+  has_and_belongs_to_many :energy_tariffs, inverse_of: :meters
 
   CREATABLE_METER_TYPES = [:electricity, :gas, :solar_pv, :exported_solar_pv].freeze
   MAIN_METER_TYPES = [:electricity, :gas].freeze

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -147,6 +147,8 @@ class School < ApplicationRecord
 
   has_many :advice_page_school_benchmarks
 
+  has_many :energy_tariffs, as: :tariff_holder, dependent: :destroy
+
   belongs_to :calendar, optional: true
   belongs_to :template_calendar, optional: true, class_name: 'Calendar'
   belongs_to :school_group_cluster, optional: true

--- a/app/models/school_group.rb
+++ b/app/models/school_group.rb
@@ -82,6 +82,8 @@ class SchoolGroup < ApplicationRecord
 
   has_many :meter_attributes, inverse_of: :school_group, class_name: 'SchoolGroupMeterAttribute'
 
+  has_many :energy_tariffs, as: :tariff_holder, dependent: :destroy
+
   has_many :clusters, class_name: 'SchoolGroupCluster', dependent: :destroy
   scope :by_name, -> { order(name: :asc) }
   scope :is_public, -> { where(public: true) }

--- a/app/models/user_tariff.rb
+++ b/app/models/user_tariff.rb
@@ -53,7 +53,7 @@ class UserTariff < ApplicationRecord
     {
       start_date: start_date.to_s(:es_compact),
       end_date: end_date.to_s(:es_compact),
-      source: :manually_entered,
+      source: source.to_sym,
       name: name,
       type: flat_rate ? :flat : :differential,
       sub_type: '',

--- a/app/models/user_tariff.rb
+++ b/app/models/user_tariff.rb
@@ -53,7 +53,7 @@ class UserTariff < ApplicationRecord
     {
       start_date: start_date.to_s(:es_compact),
       end_date: end_date.to_s(:es_compact),
-      source: source.to_sym,
+      source: :manually_entered,
       name: name,
       type: flat_rate ? :flat : :differential,
       sub_type: '',

--- a/db/migrate/20230724142054_create_energy_tariffs.rb
+++ b/db/migrate/20230724142054_create_energy_tariffs.rb
@@ -32,7 +32,7 @@ class CreateEnergyTariffs < ActiveRecord::Migration[6.0]
       t.text          :units, null: true
       t.timestamps
     end
-    create_table :meters_energy_tariffs, id: false do |t|
+    create_table :energy_tariffs_meters, id: false do |t|
       t.belongs_to :meter
       t.belongs_to :energy_tariff
     end

--- a/db/migrate/20230724142054_create_energy_tariffs.rb
+++ b/db/migrate/20230724142054_create_energy_tariffs.rb
@@ -1,0 +1,40 @@
+class CreateEnergyTariffs < ActiveRecord::Migration[6.0]
+  def change
+    create_table :energy_tariffs do |t|
+      t.references    :tariff_holder, polymorphic: true, null: true, index: true
+      t.integer       :source, null: false, default: 0
+      t.integer       :meter_type, null: false, default: 0
+      t.integer       :tariff_type, null: false, default: 0
+      t.text          :name, null: false
+      t.date          :start_date, null: true
+      t.date          :end_date, null: true
+      t.boolean       :enabled, default: false
+      t.boolean       :ccl, default: false
+      t.boolean       :tnuos, default: false
+      t.integer       :vat_rate, null: true
+      t.references    :created_by, foreign_key: { to_table: 'users' }, null: true
+      t.references    :updated_by, foreign_key: { to_table: 'users' }, null: true
+      t.timestamps
+    end
+    create_table :energy_tariff_prices do |t|
+      t.references    :energy_tariff, null: false, index: true
+      t.time          :start_time, null: false, default: '00:00:00'
+      t.time          :end_time, null: false, default: '23:30:00'
+      t.decimal       :value, null: false, default: 0
+      t.text          :units, null: true
+      t.text          :description, null: true
+      t.timestamps
+    end
+    create_table :energy_tariff_charges do |t|
+      t.references    :energy_tariff, null: false, index: true
+      t.text          :charge_type, null: false
+      t.decimal       :value, null: false
+      t.text          :units, null: false
+      t.timestamps
+    end
+    create_table :meters_energy_tariffs, id: false do |t|
+      t.belongs_to :meter
+      t.belongs_to :energy_tariff
+    end
+  end
+end

--- a/db/migrate/20230724142054_create_energy_tariffs.rb
+++ b/db/migrate/20230724142054_create_energy_tariffs.rb
@@ -29,7 +29,7 @@ class CreateEnergyTariffs < ActiveRecord::Migration[6.0]
       t.references    :energy_tariff, null: false, index: true
       t.text          :charge_type, null: false
       t.decimal       :value, null: false
-      t.text          :units, null: false
+      t.text          :units, null: true
       t.timestamps
     end
     create_table :meters_energy_tariffs, id: false do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -778,7 +778,7 @@ ActiveRecord::Schema.define(version: 2023_07_24_142054) do
     t.bigint "energy_tariff_id", null: false
     t.text "charge_type", null: false
     t.decimal "value", null: false
-    t.text "units", null: false
+    t.text "units"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["energy_tariff_id"], name: "index_energy_tariff_charges_on_energy_tariff_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_07_20_152127) do
+ActiveRecord::Schema.define(version: 2023_07_24_142054) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
@@ -774,6 +774,50 @@ ActiveRecord::Schema.define(version: 2023_07_20_152127) do
     t.index ["contact_id"], name: "index_emails_on_contact_id"
   end
 
+  create_table "energy_tariff_charges", force: :cascade do |t|
+    t.bigint "energy_tariff_id", null: false
+    t.text "charge_type", null: false
+    t.decimal "value", null: false
+    t.text "units", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["energy_tariff_id"], name: "index_energy_tariff_charges_on_energy_tariff_id"
+  end
+
+  create_table "energy_tariff_prices", force: :cascade do |t|
+    t.bigint "energy_tariff_id", null: false
+    t.time "start_time", default: "2000-01-01 00:00:00", null: false
+    t.time "end_time", default: "2000-01-01 23:30:00", null: false
+    t.decimal "value", default: "0.0", null: false
+    t.text "units"
+    t.text "description"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["energy_tariff_id"], name: "index_energy_tariff_prices_on_energy_tariff_id"
+  end
+
+  create_table "energy_tariffs", force: :cascade do |t|
+    t.string "tariff_holder_type"
+    t.bigint "tariff_holder_id"
+    t.integer "source", default: 0, null: false
+    t.integer "meter_type", default: 0, null: false
+    t.integer "tariff_type", default: 0, null: false
+    t.text "name", null: false
+    t.date "start_date"
+    t.date "end_date"
+    t.boolean "enabled", default: false
+    t.boolean "ccl", default: false
+    t.boolean "tnuos", default: false
+    t.integer "vat_rate"
+    t.bigint "created_by_id"
+    t.bigint "updated_by_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["created_by_id"], name: "index_energy_tariffs_on_created_by_id"
+    t.index ["tariff_holder_type", "tariff_holder_id"], name: "index_energy_tariffs_on_tariff_holder_type_and_tariff_holder_id"
+    t.index ["updated_by_id"], name: "index_energy_tariffs_on_updated_by_id"
+  end
+
   create_table "equivalence_type_content_versions", force: :cascade do |t|
     t.bigint "equivalence_type_id", null: false
     t.bigint "replaced_by_id"
@@ -854,13 +898,13 @@ ActiveRecord::Schema.define(version: 2023_07_20_152127) do
     t.index ["replaced_by_id"], name: "index_global_meter_attributes_on_replaced_by_id"
   end
 
-  create_table "good_job_processes", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "good_job_processes", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.jsonb "state"
   end
 
-  create_table "good_job_settings", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "good_job_settings", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.text "key"
@@ -868,7 +912,7 @@ ActiveRecord::Schema.define(version: 2023_07_20_152127) do
     t.index ["key"], name: "index_good_job_settings_on_key", unique: true
   end
 
-  create_table "good_jobs", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "good_jobs", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.text "queue_name"
     t.integer "priority"
     t.jsonb "serialized_params"
@@ -1112,6 +1156,13 @@ ActiveRecord::Schema.define(version: 2023_07_20_152127) do
     t.index ["procurement_route_id"], name: "index_meters_on_procurement_route_id"
     t.index ["school_id"], name: "index_meters_on_school_id"
     t.index ["solar_edge_installation_id"], name: "index_meters_on_solar_edge_installation_id"
+  end
+
+  create_table "meters_energy_tariffs", id: false, force: :cascade do |t|
+    t.bigint "meter_id"
+    t.bigint "energy_tariff_id"
+    t.index ["energy_tariff_id"], name: "index_meters_energy_tariffs_on_energy_tariff_id"
+    t.index ["meter_id"], name: "index_meters_energy_tariffs_on_meter_id"
   end
 
   create_table "meters_user_tariffs", id: false, force: :cascade do |t|
@@ -1568,8 +1619,8 @@ ActiveRecord::Schema.define(version: 2023_07_20_152127) do
     t.integer "management_priorities_page_limit", default: 10
     t.boolean "message_for_no_pupil_accounts", default: true
     t.jsonb "temperature_recording_months", default: ["10", "11", "12", "1", "2", "3", "4"]
-    t.jsonb "prices"
     t.integer "default_import_warning_days", default: 10
+    t.jsonb "prices"
     t.integer "photo_bonus_points", default: 0
   end
 
@@ -1943,6 +1994,8 @@ ActiveRecord::Schema.define(version: 2023_07_20_152127) do
   add_foreign_key "dashboard_alerts", "content_generation_runs", on_delete: :cascade
   add_foreign_key "dashboard_alerts", "find_out_mores", on_delete: :nullify
   add_foreign_key "emails", "contacts", on_delete: :cascade
+  add_foreign_key "energy_tariffs", "users", column: "created_by_id"
+  add_foreign_key "energy_tariffs", "users", column: "updated_by_id"
   add_foreign_key "equivalence_type_content_versions", "equivalence_type_content_versions", column: "replaced_by_id", on_delete: :nullify
   add_foreign_key "equivalence_type_content_versions", "equivalence_types", on_delete: :cascade
   add_foreign_key "equivalences", "equivalence_type_content_versions", on_delete: :cascade

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -818,6 +818,13 @@ ActiveRecord::Schema.define(version: 2023_07_24_142054) do
     t.index ["updated_by_id"], name: "index_energy_tariffs_on_updated_by_id"
   end
 
+  create_table "energy_tariffs_meters", id: false, force: :cascade do |t|
+    t.bigint "meter_id"
+    t.bigint "energy_tariff_id"
+    t.index ["energy_tariff_id"], name: "index_energy_tariffs_meters_on_energy_tariff_id"
+    t.index ["meter_id"], name: "index_energy_tariffs_meters_on_meter_id"
+  end
+
   create_table "equivalence_type_content_versions", force: :cascade do |t|
     t.bigint "equivalence_type_id", null: false
     t.bigint "replaced_by_id"
@@ -898,13 +905,13 @@ ActiveRecord::Schema.define(version: 2023_07_24_142054) do
     t.index ["replaced_by_id"], name: "index_global_meter_attributes_on_replaced_by_id"
   end
 
-  create_table "good_job_processes", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "good_job_processes", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.jsonb "state"
   end
 
-  create_table "good_job_settings", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "good_job_settings", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.text "key"
@@ -912,7 +919,7 @@ ActiveRecord::Schema.define(version: 2023_07_24_142054) do
     t.index ["key"], name: "index_good_job_settings_on_key", unique: true
   end
 
-  create_table "good_jobs", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "good_jobs", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.text "queue_name"
     t.integer "priority"
     t.jsonb "serialized_params"
@@ -1156,13 +1163,6 @@ ActiveRecord::Schema.define(version: 2023_07_24_142054) do
     t.index ["procurement_route_id"], name: "index_meters_on_procurement_route_id"
     t.index ["school_id"], name: "index_meters_on_school_id"
     t.index ["solar_edge_installation_id"], name: "index_meters_on_solar_edge_installation_id"
-  end
-
-  create_table "meters_energy_tariffs", id: false, force: :cascade do |t|
-    t.bigint "meter_id"
-    t.bigint "energy_tariff_id"
-    t.index ["energy_tariff_id"], name: "index_meters_energy_tariffs_on_energy_tariff_id"
-    t.index ["meter_id"], name: "index_meters_energy_tariffs_on_meter_id"
   end
 
   create_table "meters_user_tariffs", id: false, force: :cascade do |t|

--- a/spec/factories/energy_tariffs.rb
+++ b/spec/factories/energy_tariffs.rb
@@ -1,0 +1,13 @@
+FactoryBot.define do
+  factory :energy_tariff do
+    sequence(:name) {|n| "Energy Tariff #{n}"}
+    start_date { '2020-01-01' }
+    end_date { '2022-12-31' }
+    meter_type { :electricity }
+    source { :manually_entered }
+    tariff_type { :flat_rate }
+    tariff_holder { create(:school) }
+    created_by { association :user }
+    updated_by { association :user }
+  end
+end

--- a/spec/models/energy_tariff_spec.rb
+++ b/spec/models/energy_tariff_spec.rb
@@ -4,262 +4,34 @@ describe EnergyTariff do
 
   let(:school) { create(:school) }
 
-  context 'with only basic fields' do
+  let(:energy_tariff_prices)  { [] }
+  let(:energy_tariff_charges) { [] }
+  let(:tariff_type)           { :flat_rate }
+  let(:vat_rate)              { 5 }
 
-    let(:energy_tariff)  do
-      EnergyTariff.create(
-        tariff_holder: school,
-        start_date: '2021-04-01',
-        end_date: '2022-03-31',
-        name: 'My Empty Tariff',
-        source: :manually_entered,
-        meter_type: :electricity,
-        tariff_type: :flat_rate,
-        vat_rate: 0,
-        )
-    end
-
-    it "should create valid analytics meter attribute" do
-      meter_attribute = MeterAttribute.to_analytics([energy_tariff.meter_attribute])
-
-      expect(meter_attribute[:accounting_tariff_generic][0][:name]).to eq('My Empty Tariff')
-      expect(meter_attribute[:accounting_tariff_generic][0][:source]).to eq(:manually_entered)
-      expect(meter_attribute[:accounting_tariff_generic][0][:type]).to eq(:flat)
-      expect(meter_attribute[:accounting_tariff_generic][0][:vat]).to eq(:"0%")
-    end
+  let(:energy_tariff)  do
+    EnergyTariff.create(
+      tariff_holder: school,
+      start_date: '2021-04-01',
+      end_date: '2022-03-31',
+      name: 'My First Tariff',
+      meter_type: :electricity,
+      tariff_type: tariff_type,
+      vat_rate: vat_rate,
+      energy_tariff_prices: energy_tariff_prices,
+      energy_tariff_charges: energy_tariff_charges
+      )
   end
 
-  context 'with flat rate electricity tariff' do
-
-    let(:energy_tariff)  do
-      EnergyTariff.create(
-        tariff_holder: school,
-        start_date: '2021-04-01',
-        end_date: '2022-03-31',
-        name: 'My First Tariff',
-        meter_type: :electricity,
-        tariff_type: :flat_rate,
-        source: :manually_entered,
-        vat_rate: 20,
-        energy_tariff_prices: energy_tariff_prices,
-        energy_tariff_charges: energy_tariff_charges,
-        created_by: nil,
-        updated_by: nil
-        )
-    end
-    let(:attributes) { energy_tariff.to_hash }
-
-    let(:energy_tariff_price)  { EnergyTariffPrice.new(start_time: '00:00', end_time: '23:30', value: 1.23, units: :kwh) }
-    let(:energy_tariff_charge)  { EnergyTariffCharge.new(charge_type: :fixed_charge, value: 4.56, units: :month) }
-
-    let(:energy_tariff_prices)  { [energy_tariff_price] }
-    let(:energy_tariff_charges)  { [energy_tariff_charge] }
-
-    it "should include basic fields" do
-      expect(attributes[:name]).to eq('My First Tariff')
-      expect(attributes[:start_date]).to eq('01/04/2021')
-      expect(attributes[:end_date]).to eq('31/03/2022')
-      expect(attributes[:source]).to eq(:manually_entered)
-      expect(attributes[:type]).to eq(:flat)
-      expect(attributes[:sub_type]).to eq('')
-      expect(attributes[:vat]).to eq('20%')
-    end
-
-    it "should include standing charges" do
-      rates = attributes[:rates]
-      expect(rates[:fixed_charge]).to eq({per: 'month', rate: '4.56'})
-    end
-
-    it "should include rate" do
-      rates = attributes[:rates]
-      expect(rates[:flat_rate][:per]).to eq('kwh')
-      expect(rates[:flat_rate][:rate]).to eq('1.23')
-    end
-
-    it "should create valid analytics meter attribute" do
-      meter_attribute = MeterAttribute.to_analytics([energy_tariff.meter_attribute])
-
-      expect(meter_attribute[:accounting_tariff_generic][0][:name]).to eq('My First Tariff')
-      expect(meter_attribute[:accounting_tariff_generic][0][:source]).to eq(:manually_entered)
-      expect(meter_attribute[:accounting_tariff_generic][0][:type]).to eq(:flat)
-    end
-
-    context '#complete' do
-      context 'with prices and charges' do
-        it "should include tariff" do
-          expect(EnergyTariff.complete).to include(energy_tariff)
-        end
-      end
-      context 'without prices or charges' do
-        let(:energy_tariff_prices)  { [] }
-        let(:energy_tariff_charges)  { [] }
-        it "should not include tariff" do
-          expect(EnergyTariff.complete).not_to include(energy_tariff)
-        end
-      end
-      context 'without prices' do
-        let(:energy_tariff_prices)  { [] }
-        it "should include tariff" do
-          expect(EnergyTariff.complete).to include(energy_tariff)
-        end
-      end
-      context 'without charges' do
-        let(:energy_tariff_charges)  { [] }
-        it "should include tariff" do
-          expect(EnergyTariff.complete).to include(energy_tariff)
-        end
-      end
-    end
-  end
-
-  context 'with differential electricity tariff' do
-    let(:energy_tariff)  do
-      EnergyTariff.create(
-        tariff_holder: school,
-        start_date: '2021-04-01',
-        end_date: '2022-03-31',
-        name: 'My First Tariff',
-        meter_type: :electricity,
-        tariff_type: :differential,
-        vat_rate: 5,
-        energy_tariff_prices: energy_tariff_prices,
-        energy_tariff_charges: energy_tariff_charges,
-        )
-    end
-
-    let(:attributes) { energy_tariff.to_hash }
-
+  context 'validations' do
     let(:energy_tariff_price_1)  { EnergyTariffPrice.new(start_time: '00:00', end_time: '03:30', value: 1.23, units: 'kwh') }
     let(:energy_tariff_price_2)  { EnergyTariffPrice.new(start_time: '04:00', end_time: '23:30', value: 2.46, units: 'kwh') }
+
     let(:energy_tariff_charge_1)  { EnergyTariffCharge.new(charge_type: :fixed_charge, value: 4.56, units: :month) }
     let(:energy_tariff_charge_2)  { EnergyTariffCharge.new(charge_type: :agreed_availability_charge, value: 6.78, units: :kva) }
 
     let(:energy_tariff_prices)  { [energy_tariff_price_1, energy_tariff_price_2] }
     let(:energy_tariff_charges) { [energy_tariff_charge_1, energy_tariff_charge_2] }
-    let(:asc_limit_kw_charge) { EnergyTariffCharge.create(charge_type: :asc_limit_kw, value: 5.43) }
-
-    it "should include basic fields" do
-      expect(attributes[:name]).to eq('My First Tariff')
-      expect(attributes[:start_date]).to eq('01/04/2021')
-      expect(attributes[:end_date]).to eq('31/03/2022')
-      expect(attributes[:source]).to eq(:manually_entered)
-      expect(attributes[:type]).to eq(:differential)
-      expect(attributes[:sub_type]).to eq('')
-      expect(attributes[:vat]).to eq('5%')
-    end
-
-    it "should include duos" do
-      energy_tariff.energy_tariff_charges << EnergyTariffCharge.create(charge_type: :duos_red, value: 6.78)
-
-      expect(attributes[:rates][:duos_red]).to eq('6.78')
-    end
-
-    context "with asc limit kw" do
-      context "agreed_availability_charge and excess_availability_charge not present" do
-        let(:energy_tariff_charges) { [asc_limit_kw_charge] }
-        it "should not be included" do
-          expect(attributes).to_not have_key(:asc_limit_kw)
-        end
-      end
-
-      context "and agreed_availability_charge is present" do
-        let(:agreed_availability_charge)  { EnergyTariffCharge.create(charge_type: :agreed_availability_charge, value: 6.78, units: :kva) }
-        let(:energy_tariff_charges) { [asc_limit_kw_charge, agreed_availability_charge] }
-        it "should be included" do
-          expect(attributes[:asc_limit_kw]).to eq('5.43')
-        end
-        it 'should include the charge' do
-          expect(attributes[:rates]).to have_key(:agreed_availability_charge)
-        end
-      end
-
-      context "and excess_availability_charge is present" do
-        let(:excess_availability_charge)  { EnergyTariffCharge.create(charge_type: :excess_availability_charge, value: 6.78, units: :kva) }
-        let(:energy_tariff_charges) { [asc_limit_kw_charge, excess_availability_charge] }
-        it "should be included" do
-          expect(attributes[:asc_limit_kw]).to eq('5.43')
-        end
-        it 'should include the charge' do
-          expect(attributes[:rates]).to have_key(:excess_availability_charge)
-        end
-      end
-
-      context 'only agreed availability charge is present' do
-        let(:agreed_availability_charge)  { EnergyTariffCharge.create(charge_type: :agreed_availability_charge, value: 6.78, units: :kva) }
-        let(:energy_tariff_charges) { [agreed_availability_charge] }
-        it "should not be included" do
-          expect(attributes[:rates]).to_not have_key(:asc_limit_kw)
-        end
-        it 'should not include the charge' do
-          expect(attributes[:rates]).to_not have_key(:agreed_availability_charge)
-        end
-      end
-
-      context 'only excess_availability_charge charge is present' do
-        let(:excess_availability_charge)  { EnergyTariffCharge.create(charge_type: :excess_availability_charge, value: 6.78, units: :kva) }
-        let(:energy_tariff_charges) { [excess_availability_charge] }
-        it "should not be included" do
-          expect(attributes).to_not have_key(:asc_limit_kw)
-        end
-        it 'should not include the charge' do
-          expect(attributes[:rates]).to_not have_key(:excess_availability_charge)
-        end
-      end
-
-      context 'all charges are present' do
-        let(:agreed_availability_charge)  { EnergyTariffCharge.create(charge_type: :agreed_availability_charge, value: 6.78, units: :kva) }
-        let(:excess_availability_charge)  { EnergyTariffCharge.create(charge_type: :excess_availability_charge, value: 6.78, units: :kva) }
-        let(:energy_tariff_charges) { [asc_limit_kw_charge, agreed_availability_charge, excess_availability_charge] }
-        it "should be included" do
-          expect(attributes).to have_key(:asc_limit_kw)
-        end
-        it 'should include the charges' do
-          expect(attributes[:rates][:agreed_availability_charge]).to eq({:per => 'kva', :rate => '6.78'})
-          expect(attributes[:rates][:excess_availability_charge]).to eq({:per => 'kva', :rate => '6.78'})
-        end
-      end
-    end
-
-    it "should include ccl" do
-      expect(attributes[:climate_change_levy]).to be_falsey
-
-      energy_tariff.update(ccl: true)
-      attributes = energy_tariff.to_hash
-      expect(attributes[:climate_change_levy]).to be_truthy
-    end
-
-    it "should include tnuos" do
-      expect(attributes[:rates][:tnuos]).to be_falsey
-
-      energy_tariff.update(tnuos: true)
-      attributes = energy_tariff.to_hash
-      expect(attributes[:rates][:tnuos]).to be_truthy
-    end
-
-    it "should include standing charges" do
-      rates = attributes[:rates]
-      expect(rates[:fixed_charge]).to eq({:per => 'month', :rate => '4.56'})
-    end
-
-    it "should include rates with adjusted end times" do
-      rates = attributes[:rates]
-      expect(rates[:rate0][:per]).to eq('kwh')
-      expect(rates[:rate0][:rate]).to eq('1.23')
-      expect(rates[:rate0][:from]).to eq({hour: "00", minutes: "00"})
-      expect(rates[:rate0][:to]).to eq({hour: "03", minutes: "00"})
-      expect(rates[:rate1][:per]).to eq('kwh')
-      expect(rates[:rate1][:rate]).to eq('2.46')
-      expect(rates[:rate1][:from]).to eq({hour: "04", minutes: "00"})
-      expect(rates[:rate1][:to]).to eq({hour: "23", minutes: "00"})
-    end
-
-    it "should create valid analytics meter attribute" do
-      meter_attribute = MeterAttribute.to_analytics([energy_tariff.meter_attribute])
-
-      expect(meter_attribute[:accounting_tariff_generic][0][:name]).to eq('My First Tariff')
-      expect(meter_attribute[:accounting_tariff_generic][0][:source]).to eq(:manually_entered)
-      expect(meter_attribute[:accounting_tariff_generic][0][:type]).to eq(:differential)
-    end
 
     it "should prevent same start and end time" do
       expect(energy_tariff).to be_valid
@@ -294,6 +66,211 @@ describe EnergyTariff do
       energy_tariff_price_2.update(start_time: '07:00', end_time: '00:00')
       energy_tariff_price_1.update(start_time: '08:00', end_time: '09:00')
       expect(energy_tariff_price_1).not_to be_valid
+    end
+  end
+
+  context '#complete' do
+
+    let(:energy_tariff_price)  { EnergyTariffPrice.new(start_time: '00:00', end_time: '23:30', value: 1.23, units: :kwh) }
+    let(:energy_tariff_charge)  { EnergyTariffCharge.new(charge_type: :fixed_charge, value: 4.56, units: :month) }
+
+    context 'with both prices and charges' do
+      let(:energy_tariff_prices)  { [energy_tariff_price] }
+      let(:energy_tariff_charges)  { [energy_tariff_charge] }
+      it "should include tariff" do
+        expect(EnergyTariff.complete).to include(energy_tariff)
+      end
+    end
+    context 'without prices or charges' do
+      let(:energy_tariff_prices)  { [] }
+      let(:energy_tariff_charges)  { [] }
+      it "should not include tariff" do
+        expect(EnergyTariff.complete).not_to include(energy_tariff)
+      end
+    end
+    context 'with only charges' do
+      let(:energy_tariff_charges)  { [energy_tariff_charge] }
+      it "should include tariff" do
+        expect(EnergyTariff.complete).to include(energy_tariff)
+      end
+    end
+    context 'with only prices' do
+      let(:energy_tariff_prices)  { [energy_tariff_price] }
+      it "should include tariff" do
+        expect(EnergyTariff.complete).to include(energy_tariff)
+      end
+    end
+  end
+
+  context '.meter_attribute' do
+    let(:meter_attribute) { MeterAttribute.to_analytics([energy_tariff.meter_attribute]) }
+
+    it "should create valid analytics meter attribute" do
+      expect(meter_attribute[:accounting_tariff_generic][0][:name]).to eq('My First Tariff')
+      expect(meter_attribute[:accounting_tariff_generic][0][:source]).to eq(:manually_entered)
+      expect(meter_attribute[:accounting_tariff_generic][0][:type]).to eq(:flat)
+      expect(meter_attribute[:accounting_tariff_generic][0][:vat]).to eq(:"5%")
+    end
+  end
+
+  context '.to_hash' do
+    let(:attributes)      { energy_tariff.to_hash }
+
+    it "should include basic fields" do
+      expect(attributes[:name]).to eq('My First Tariff')
+      expect(attributes[:start_date]).to eq('01/04/2021')
+      expect(attributes[:end_date]).to eq('31/03/2022')
+      expect(attributes[:source]).to eq(:manually_entered)
+      expect(attributes[:sub_type]).to eq('')
+      expect(attributes[:vat]).to eq('5%')
+    end
+
+    it "should include ccl" do
+      expect(attributes[:climate_change_levy]).to be_falsey
+
+      energy_tariff.update(ccl: true)
+      attributes = energy_tariff.to_hash
+      expect(attributes[:climate_change_levy]).to be_truthy
+    end
+
+    it "should include tnuos" do
+      expect(attributes[:rates][:tnuos]).to be_falsey
+
+      energy_tariff.update(tnuos: true)
+      attributes = energy_tariff.to_hash
+      expect(attributes[:rates][:tnuos]).to be_truthy
+    end
+
+    context 'with flat rate electricity tariff' do
+      let(:tariff_type)     { :flat_rate }
+
+      let(:energy_tariff_price)   { EnergyTariffPrice.new(start_time: '00:00', end_time: '23:30', value: 1.23, units: :kwh) }
+      let(:energy_tariff_charge)  { EnergyTariffCharge.new(charge_type: :fixed_charge, value: 4.56, units: :month) }
+
+      let(:energy_tariff_prices)  { [energy_tariff_price] }
+      let(:energy_tariff_charges) { [energy_tariff_charge] }
+
+      it "should have right type" do
+        expect(attributes[:type]).to eq(:flat)
+      end
+
+      it "should include standing charges" do
+        rates = attributes[:rates]
+        expect(rates[:fixed_charge]).to eq({per: 'month', rate: '4.56'})
+      end
+
+      it "should include rate" do
+        rates = attributes[:rates]
+        expect(rates[:flat_rate][:per]).to eq('kwh')
+        expect(rates[:flat_rate][:rate]).to eq('1.23')
+      end
+
+    end
+
+    context 'with differential electricity tariff' do
+      let(:tariff_type)     { :differential }
+
+      let(:energy_tariff_price_1)  { EnergyTariffPrice.new(start_time: '00:00', end_time: '03:30', value: 1.23, units: 'kwh') }
+      let(:energy_tariff_price_2)  { EnergyTariffPrice.new(start_time: '04:00', end_time: '23:30', value: 2.46, units: 'kwh') }
+      let(:energy_tariff_charge_1)  { EnergyTariffCharge.new(charge_type: :fixed_charge, value: 4.56, units: :month) }
+      let(:energy_tariff_charge_2)  { EnergyTariffCharge.new(charge_type: :agreed_availability_charge, value: 6.78, units: :kva) }
+
+      let(:energy_tariff_prices)  { [energy_tariff_price_1, energy_tariff_price_2] }
+      let(:energy_tariff_charges) { [energy_tariff_charge_1, energy_tariff_charge_2] }
+
+      it "should have right type" do
+        expect(attributes[:type]).to eq(:differential)
+      end
+
+      it "should include duos" do
+        energy_tariff.energy_tariff_charges << EnergyTariffCharge.create(charge_type: :duos_red, value: 6.78)
+        expect(attributes[:rates][:duos_red]).to eq('6.78')
+      end
+
+      context "with asc limit kw" do
+        let(:asc_limit_kw_charge) { EnergyTariffCharge.create(charge_type: :asc_limit_kw, value: 5.43) }
+
+        context "agreed_availability_charge and excess_availability_charge not present" do
+          let(:energy_tariff_charges) { [asc_limit_kw_charge] }
+          it "should not be included" do
+            expect(attributes).to_not have_key(:asc_limit_kw)
+          end
+        end
+
+        context "and agreed_availability_charge is present" do
+          let(:agreed_availability_charge)  { EnergyTariffCharge.create(charge_type: :agreed_availability_charge, value: 6.78, units: :kva) }
+          let(:energy_tariff_charges) { [asc_limit_kw_charge, agreed_availability_charge] }
+          it "should be included" do
+            expect(attributes[:asc_limit_kw]).to eq('5.43')
+          end
+          it 'should include the charge' do
+            expect(attributes[:rates]).to have_key(:agreed_availability_charge)
+          end
+        end
+
+        context "and excess_availability_charge is present" do
+          let(:excess_availability_charge)  { EnergyTariffCharge.create(charge_type: :excess_availability_charge, value: 6.78, units: :kva) }
+          let(:energy_tariff_charges) { [asc_limit_kw_charge, excess_availability_charge] }
+          it "should be included" do
+            expect(attributes[:asc_limit_kw]).to eq('5.43')
+          end
+          it 'should include the charge' do
+            expect(attributes[:rates]).to have_key(:excess_availability_charge)
+          end
+        end
+
+        context 'only agreed availability charge is present' do
+          let(:agreed_availability_charge)  { EnergyTariffCharge.create(charge_type: :agreed_availability_charge, value: 6.78, units: :kva) }
+          let(:energy_tariff_charges) { [agreed_availability_charge] }
+          it "should not be included" do
+            expect(attributes[:rates]).to_not have_key(:asc_limit_kw)
+          end
+          it 'should not include the charge' do
+            expect(attributes[:rates]).to_not have_key(:agreed_availability_charge)
+          end
+        end
+
+        context 'only excess_availability_charge charge is present' do
+          let(:excess_availability_charge)  { EnergyTariffCharge.create(charge_type: :excess_availability_charge, value: 6.78, units: :kva) }
+          let(:energy_tariff_charges) { [excess_availability_charge] }
+          it "should not be included" do
+            expect(attributes).to_not have_key(:asc_limit_kw)
+          end
+          it 'should not include the charge' do
+            expect(attributes[:rates]).to_not have_key(:excess_availability_charge)
+          end
+        end
+
+        context 'all charges are present' do
+          let(:agreed_availability_charge)  { EnergyTariffCharge.create(charge_type: :agreed_availability_charge, value: 6.78, units: :kva) }
+          let(:excess_availability_charge)  { EnergyTariffCharge.create(charge_type: :excess_availability_charge, value: 6.78, units: :kva) }
+          let(:energy_tariff_charges) { [asc_limit_kw_charge, agreed_availability_charge, excess_availability_charge] }
+          it "should be included" do
+            expect(attributes).to have_key(:asc_limit_kw)
+          end
+          it 'should include the charges' do
+            expect(attributes[:rates][:agreed_availability_charge]).to eq({:per => 'kva', :rate => '6.78'})
+            expect(attributes[:rates][:excess_availability_charge]).to eq({:per => 'kva', :rate => '6.78'})
+          end
+        end
+      end
+
+      it "should include standing charges" do
+        rates = attributes[:rates]
+        expect(rates[:fixed_charge]).to eq({:per => 'month', :rate => '4.56'})
+      end
+
+      it "should include rates with adjusted end times" do
+        rates = attributes[:rates]
+        expect(rates[:rate0][:per]).to eq('kwh')
+        expect(rates[:rate0][:rate]).to eq('1.23')
+        expect(rates[:rate0][:from]).to eq({hour: "00", minutes: "00"})
+        expect(rates[:rate0][:to]).to eq({hour: "03", minutes: "00"})
+        expect(rates[:rate1][:per]).to eq('kwh')
+        expect(rates[:rate1][:rate]).to eq('2.46')
+        expect(rates[:rate1][:from]).to eq({hour: "04", minutes: "00"})
+        expect(rates[:rate1][:to]).to eq({hour: "23", minutes: "00"})
+      end
     end
   end
 end

--- a/spec/models/energy_tariff_spec.rb
+++ b/spec/models/energy_tariff_spec.rb
@@ -1,0 +1,299 @@
+require 'rails_helper'
+
+describe EnergyTariff do
+
+  let(:school) { create(:school) }
+
+  context 'with only basic fields' do
+
+    let(:energy_tariff)  do
+      EnergyTariff.create(
+        tariff_holder: school,
+        start_date: '2021-04-01',
+        end_date: '2022-03-31',
+        name: 'My Empty Tariff',
+        source: :manually_entered,
+        meter_type: :electricity,
+        tariff_type: :flat_rate,
+        vat_rate: 0,
+        )
+    end
+
+    it "should create valid analytics meter attribute" do
+      meter_attribute = MeterAttribute.to_analytics([energy_tariff.meter_attribute])
+
+      expect(meter_attribute[:accounting_tariff_generic][0][:name]).to eq('My Empty Tariff')
+      expect(meter_attribute[:accounting_tariff_generic][0][:source]).to eq(:manually_entered)
+      expect(meter_attribute[:accounting_tariff_generic][0][:type]).to eq(:flat)
+      expect(meter_attribute[:accounting_tariff_generic][0][:vat]).to eq(:"0%")
+    end
+  end
+
+  context 'with flat rate electricity tariff' do
+
+    let(:energy_tariff)  do
+      EnergyTariff.create(
+        tariff_holder: school,
+        start_date: '2021-04-01',
+        end_date: '2022-03-31',
+        name: 'My First Tariff',
+        meter_type: :electricity,
+        tariff_type: :flat_rate,
+        source: :manually_entered,
+        vat_rate: 20,
+        energy_tariff_prices: energy_tariff_prices,
+        energy_tariff_charges: energy_tariff_charges,
+        created_by: nil,
+        updated_by: nil
+        )
+    end
+    let(:attributes) { energy_tariff.to_hash }
+
+    let(:energy_tariff_price)  { EnergyTariffPrice.new(start_time: '00:00', end_time: '23:30', value: 1.23, units: :kwh) }
+    let(:energy_tariff_charge)  { EnergyTariffCharge.new(charge_type: :fixed_charge, value: 4.56, units: :month) }
+
+    let(:energy_tariff_prices)  { [energy_tariff_price] }
+    let(:energy_tariff_charges)  { [energy_tariff_charge] }
+
+    it "should include basic fields" do
+      expect(attributes[:name]).to eq('My First Tariff')
+      expect(attributes[:start_date]).to eq('01/04/2021')
+      expect(attributes[:end_date]).to eq('31/03/2022')
+      expect(attributes[:source]).to eq(:manually_entered)
+      expect(attributes[:type]).to eq(:flat)
+      expect(attributes[:sub_type]).to eq('')
+      expect(attributes[:vat]).to eq('20%')
+    end
+
+    it "should include standing charges" do
+      rates = attributes[:rates]
+      expect(rates[:fixed_charge]).to eq({per: 'month', rate: '4.56'})
+    end
+
+    it "should include rate" do
+      rates = attributes[:rates]
+      expect(rates[:flat_rate][:per]).to eq('kwh')
+      expect(rates[:flat_rate][:rate]).to eq('1.23')
+    end
+
+    it "should create valid analytics meter attribute" do
+      meter_attribute = MeterAttribute.to_analytics([energy_tariff.meter_attribute])
+
+      expect(meter_attribute[:accounting_tariff_generic][0][:name]).to eq('My First Tariff')
+      expect(meter_attribute[:accounting_tariff_generic][0][:source]).to eq(:manually_entered)
+      expect(meter_attribute[:accounting_tariff_generic][0][:type]).to eq(:flat)
+    end
+
+    context '#complete' do
+      context 'with prices and charges' do
+        it "should include tariff" do
+          expect(EnergyTariff.complete).to include(energy_tariff)
+        end
+      end
+      context 'without prices or charges' do
+        let(:energy_tariff_prices)  { [] }
+        let(:energy_tariff_charges)  { [] }
+        it "should not include tariff" do
+          expect(EnergyTariff.complete).not_to include(energy_tariff)
+        end
+      end
+      context 'without prices' do
+        let(:energy_tariff_prices)  { [] }
+        it "should include tariff" do
+          expect(EnergyTariff.complete).to include(energy_tariff)
+        end
+      end
+      context 'without charges' do
+        let(:energy_tariff_charges)  { [] }
+        it "should include tariff" do
+          expect(EnergyTariff.complete).to include(energy_tariff)
+        end
+      end
+    end
+  end
+
+  context 'with differential electricity tariff' do
+    let(:energy_tariff)  do
+      EnergyTariff.create(
+        tariff_holder: school,
+        start_date: '2021-04-01',
+        end_date: '2022-03-31',
+        name: 'My First Tariff',
+        meter_type: :electricity,
+        tariff_type: :flat_rate,
+        vat_rate: 0.05,
+        energy_tariff_prices: energy_tariff_prices,
+        energy_tariff_charges: energy_tariff_charges,
+        )
+    end
+
+    let(:attributes) { energy_tariff.to_hash }
+
+    let(:energy_tariff_price_1)  { EnergyTariffPrice.new(start_time: '00:00', end_time: '03:30', value: 1.23, units: 'kwh') }
+    let(:energy_tariff_price_2)  { EnergyTariffPrice.new(start_time: '04:00', end_time: '23:30', value: 2.46, units: 'kwh') }
+    let(:energy_tariff_charge_1)  { EnergyTariffCharge.new(charge_type: :fixed_charge, value: 4.56, units: :month) }
+    let(:energy_tariff_charge_2)  { EnergyTariffCharge.new(charge_type: :agreed_availability_charge, value: 6.78, units: :kva) }
+
+    let(:energy_tariff_prices)  { [energy_tariff_price_1, energy_tariff_price_2] }
+    let(:energy_tariff_charges) { [energy_tariff_charge_1, energy_tariff_charge_2] }
+    let(:asc_limit_kw_charge) { EnergyTariffCharge.create(charge_type: :asc_limit_kw, value: 5.43) }
+
+    it "should include basic fields" do
+      expect(attributes[:name]).to eq('My First Tariff')
+      expect(attributes[:start_date]).to eq('01/04/2021')
+      expect(attributes[:end_date]).to eq('31/03/2022')
+      expect(attributes[:source]).to eq(:manual)
+      expect(attributes[:type]).to eq(:differential)
+      expect(attributes[:sub_type]).to eq('')
+      expect(attributes[:vat]).to eq('5%')
+    end
+
+    it "should include duos" do
+      energyr_tariff.energy_tariff_charges << EnergyTariffCharge.create(charge_type: :duos_red, value: 6.78)
+
+      expect(attributes[:rates][:duos_red]).to eq('6.78')
+    end
+
+    context "with asc limit kw" do
+      context "agreed_availability_charge and excess_availability_charge not present" do
+        let(:energy_tariff_charges) { [asc_limit_kw_charge] }
+        it "should not be included" do
+          expect(attributes).to_not have_key(:asc_limit_kw)
+        end
+      end
+
+      context "and agreed_availability_charge is present" do
+        let(:agreed_availability_charge)  { EnergyTariffCharge.create(charge_type: :agreed_availability_charge, value: 6.78, units: :kva) }
+        let(:energy_tariff_charges) { [asc_limit_kw_charge, agreed_availability_charge] }
+        it "should be included" do
+          expect(attributes[:asc_limit_kw]).to eq('5.43')
+        end
+        it 'should include the charge' do
+          expect(attributes[:rates]).to have_key(:agreed_availability_charge)
+        end
+      end
+
+      context "and excess_availability_charge is present" do
+        let(:excess_availability_charge)  { EnergyTariffCharge.create(charge_type: :excess_availability_charge, value: 6.78, units: :kva) }
+        let(:energy_tariff_charges) { [asc_limit_kw_charge, excess_availability_charge] }
+        it "should be included" do
+          expect(attributes[:asc_limit_kw]).to eq('5.43')
+        end
+        it 'should include the charge' do
+          expect(attributes[:rates]).to have_key(:excess_availability_charge)
+        end
+      end
+
+      context 'only agreed availability charge is present' do
+        let(:agreed_availability_charge)  { EnergyTariffCharge.create(charge_type: :agreed_availability_charge, value: 6.78, units: :kva) }
+        let(:energy_tariff_charges) { [agreed_availability_charge] }
+        it "should not be included" do
+          expect(attributes[:rates]).to_not have_key(:asc_limit_kw)
+        end
+        it 'should not include the charge' do
+          expect(attributes[:rates]).to_not have_key(:agreed_availability_charge)
+        end
+      end
+
+      context 'only excess_availability_charge charge is present' do
+        let(:excess_availability_charge)  { EnergyTariffCharge.create(charge_type: :excess_availability_charge, value: 6.78, units: :kva) }
+        let(:energy_tariff_charges) { [excess_availability_charge] }
+        it "should not be included" do
+          expect(attributes).to_not have_key(:asc_limit_kw)
+        end
+        it 'should not include the charge' do
+          expect(attributes[:rates]).to_not have_key(:excess_availability_charge)
+        end
+      end
+
+      context 'all charges are present' do
+        let(:agreed_availability_charge)  { EnergyTariffCharge.create(charge_type: :agreed_availability_charge, value: 6.78, units: :kva) }
+        let(:excess_availability_charge)  { EnergyTariffCharge.create(charge_type: :excess_availability_charge, value: 6.78, units: :kva) }
+        let(:energy_tariff_charges) { [asc_limit_kw_charge, agreed_availability_charge, excess_availability_charge] }
+        it "should be included" do
+          expect(attributes).to have_key(:asc_limit_kw)
+        end
+        it 'should include the charges' do
+          expect(attributes[:rates][:agreed_availability_charge]).to eq({:per => 'kva', :rate => '6.78'})
+          expect(attributes[:rates][:excess_availability_charge]).to eq({:per => 'kva', :rate => '6.78'})
+        end
+      end
+    end
+
+    it "should include ccl" do
+      expect(attributes[:climate_change_levy]).to be_falsey
+
+      energy_tariff.update(ccl: true)
+      attributes = energy_tariff.to_hash
+      expect(attributes[:climate_change_levy]).to be_truthy
+    end
+
+    it "should include tnuos" do
+      expect(attributes[:rates][:tnuos]).to be_falsey
+
+      energy_tariff.update(tnuos: true)
+      attributes = energy_tariff.to_hash
+      expect(attributes[:rates][:tnuos]).to be_truthy
+    end
+
+    it "should include standing charges" do
+      rates = attributes[:rates]
+      expect(rates[:fixed_charge]).to eq({:per => 'month', :rate => '4.56'})
+    end
+
+    it "should include rates with adjusted end times" do
+      rates = attributes[:rates]
+      expect(rates[:rate0][:per]).to eq('kwh')
+      expect(rates[:rate0][:rate]).to eq('1.23')
+      expect(rates[:rate0][:from]).to eq({hour: "00", minutes: "00"})
+      expect(rates[:rate0][:to]).to eq({hour: "03", minutes: "00"})
+      expect(rates[:rate1][:per]).to eq('kwh')
+      expect(rates[:rate1][:rate]).to eq('2.46')
+      expect(rates[:rate1][:from]).to eq({hour: "04", minutes: "00"})
+      expect(rates[:rate1][:to]).to eq({hour: "23", minutes: "00"})
+    end
+
+    it "should create valid analytics meter attribute" do
+      meter_attribute = MeterAttribute.to_analytics([energy_tariff.meter_attribute])
+
+      expect(meter_attribute[:accounting_tariff_generic][0][:name]).to eq('My First Tariff')
+      expect(meter_attribute[:accounting_tariff_generic][0][:source]).to eq(:manually_entered)
+      expect(meter_attribute[:accounting_tariff_generic][0][:type]).to eq(:differential)
+    end
+
+    it "should prevent same start and end time" do
+      expect(energy_tariff).to be_valid
+      energy_tariff_price_1.update(end_time: energy_tariff_price_1.start_time)
+      expect(energy_tariff_price_1).not_to be_valid
+      expect(energy_tariff_price_1.errors[:start_time]).to include("can't be the same as end time")
+    end
+
+    it "should allow end time of one range to be start time of next" do
+      expect(energy_tariff).to be_valid
+      energy_tariff_price_1.update(end_time: energy_tariff_price_2.start_time)
+      expect(energy_tariff_price_1).to be_valid
+      expect(energy_tariff).to be_valid
+    end
+
+    it "should prevent overlapping start time" do
+      expect(energy_tariff).to be_valid
+      energy_tariff_price_2.update(start_time: energy_tariff_price_1.end_time - 1.minute)
+      expect(energy_tariff_price_2).not_to be_valid
+      expect(energy_tariff_price_2.errors[:start_time]).to include("overlaps with another time range")
+    end
+
+    it "should prevent overlapping end time" do
+      expect(energy_tariff).to be_valid
+      energy_tariff_price_1.update(end_time: energy_tariff_price_2.start_time + 1.minute)
+      expect(energy_tariff_price_1).not_to be_valid
+      expect(energy_tariff_price_1.errors[:end_time]).to include("overlaps with another time range")
+    end
+
+    it "should handle midnight end time as next day" do
+      expect(energy_tariff).to be_valid
+      energy_tariff_price_2.update(start_time: '07:00', end_time: '00:00')
+      energy_tariff_price_1.update(start_time: '08:00', end_time: '09:00')
+      expect(energy_tariff_price_1).not_to be_valid
+    end
+  end
+end

--- a/spec/models/energy_tariff_spec.rb
+++ b/spec/models/energy_tariff_spec.rb
@@ -2,16 +2,15 @@ require 'rails_helper'
 
 describe EnergyTariff do
 
-  let(:school) { create(:school) }
-
-  let(:energy_tariff_prices)  { [] }
-  let(:energy_tariff_charges) { [] }
   let(:tariff_type)           { :flat_rate }
   let(:vat_rate)              { 5 }
 
+  let(:energy_tariff_prices)  { [] }
+  let(:energy_tariff_charges) { [] }
+
   let(:energy_tariff)  do
     EnergyTariff.create(
-      tariff_holder: school,
+      tariff_holder: create(:school),
       start_date: '2021-04-01',
       end_date: '2022-03-31',
       name: 'My First Tariff',

--- a/spec/models/energy_tariff_spec.rb
+++ b/spec/models/energy_tariff_spec.rb
@@ -120,8 +120,8 @@ describe EnergyTariff do
         end_date: '2022-03-31',
         name: 'My First Tariff',
         meter_type: :electricity,
-        tariff_type: :flat_rate,
-        vat_rate: 0.05,
+        tariff_type: :differential,
+        vat_rate: 5,
         energy_tariff_prices: energy_tariff_prices,
         energy_tariff_charges: energy_tariff_charges,
         )
@@ -142,14 +142,14 @@ describe EnergyTariff do
       expect(attributes[:name]).to eq('My First Tariff')
       expect(attributes[:start_date]).to eq('01/04/2021')
       expect(attributes[:end_date]).to eq('31/03/2022')
-      expect(attributes[:source]).to eq(:manual)
+      expect(attributes[:source]).to eq(:manually_entered)
       expect(attributes[:type]).to eq(:differential)
       expect(attributes[:sub_type]).to eq('')
       expect(attributes[:vat]).to eq('5%')
     end
 
     it "should include duos" do
-      energyr_tariff.energy_tariff_charges << EnergyTariffCharge.create(charge_type: :duos_red, value: 6.78)
+      energy_tariff.energy_tariff_charges << EnergyTariffCharge.create(charge_type: :duos_red, value: 6.78)
 
       expect(attributes[:rates][:duos_red]).to eq('6.78')
     end


### PR DESCRIPTION
This PR creates a new set of data models and relationships for managing energy tariffs.

It builds on the existing "user tariff" models used by the tariff editor, but generalises them so they are a bit more flexible and extensible. Specifically it allows tariffs to be owned by any `tariff_holder` model which will include the system, groups and schools.

This PR will just add the models, a later PR will include some data migration code.

* [x] Create migration for new tables
* [x] Copy over validations and meter attribute code from original models (UserTariff, UserTariffCharge, UserTariffPrice)
* [x] Revise rspecs to allow for model differences
* [x] Refactor and tidy up tests