### PR TITLE
Pin version of chrome driver

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -11,10 +11,16 @@ require 'rspec/rails'
 require 'pry'
 require 'view_component/test_helpers'
 require 'capybara/rspec'
-require 'webdrivers'
+require 'selenium-webdriver'
+#require 'webdrivers'
 require 'capybara/email/rspec'
 require 'cancan/matchers'
 require 'wisper/rspec/matchers'
+
+#Pin version of Chrome driver. A workaround for this issue:
+# https://github.com/titusfortner/webdrivers/issues/247
+Webdrivers::Chromedriver.required_version = "114.0.5735.90"
+
 # Add additional requires below this line. Rails is not loaded until this point!
 
 # Requires supporting ruby files with custom matchers and macros, etc, in


### PR DESCRIPTION
Fix for an issue with incorrect Chrome driver version being used.

Issue described here: https://github.com/titusfortner/webdrivers/issues/247

For the moment pinning the version looks like best approach, as switching to use Selenium only has other issues (a number of deprecations and latest version of the gem isn't available for our version of Ruby).