### PR TITLE
Remove unused meter consolidation alerts

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ gem 'pg_search'
 gem 'calculate_in_group'
 
 # Dashboard analytics
-gem 'energy-sparks_analytics', git: 'https://github.com/Energy-Sparks/energy-sparks_analytics.git', tag: '2.8.8'
+gem 'energy-sparks_analytics', git: 'https://github.com/Energy-Sparks/energy-sparks_analytics.git', tag: '2.8.9'
 #gem 'energy-sparks_analytics', git: 'https://github.com/Energy-Sparks/energy-sparks_analytics.git', branch: 'aws-eb-test'
 #gem 'energy-sparks_analytics', path: '../energy-sparks_analytics'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/Energy-Sparks/energy-sparks_analytics.git
-  revision: 812c7ef01c739e7af415f6533e26d444c26662e0
-  tag: 2.8.8
+  revision: e3616281e43773d764a847d36c90996457779530
+  tag: 2.8.9
   specs:
     energy-sparks_analytics (1.2.1)
       activesupport (>= 6.0, < 7.1)

--- a/app/views/shared/meter_attributes/_new_select.html.erb
+++ b/app/views/shared/meter_attributes/_new_select.html.erb
@@ -1,6 +1,6 @@
 
 <%= form_tag create_path, method: :get do %>
-  <%= select_tag :type, options_for_select(available_meter_attributes.map{|id, attribute_type| [attribute_type.attribute_name, id]}.sort_by(&:last))%>
+  <%= select_tag :type, options_for_select(available_meter_attributes.map{|id, attribute_type| [attribute_type.attribute_name, id]}.sort_by(&:first))%>
   <%= hidden_field_tag(:meter_id, meter_id) if local_assigns[:meter_id] %>
   <%=  submit_tag 'New attribute', class: 'btn btn-sm'%>
 <% end %>

--- a/lib/tasks/deployment/20230725161734_remove_meter_consolidation_alert.rake
+++ b/lib/tasks/deployment/20230725161734_remove_meter_consolidation_alert.rake
@@ -1,0 +1,23 @@
+namespace :after_party do
+  desc 'Deployment task: remove_meter_consolidation_alert'
+  task remove_meter_consolidation_alert: :environment do
+    puts "Running deploy task 'remove_meter_consolidation_alert'"
+
+    #Delete unneeded attributes
+    GlobalMeterAttribute.where(attribute_type: "indicative_standing_charge").destroy_all
+
+    ["AlertGasMeterConsolidationOpportunity", "AlertElectricityMeterConsolidationOpportunity"].each do |class_name|
+      alert_type = AlertType.find_by_class_name(class_name)
+      #remove all the alert records where we've run this, as it was still enabled for running
+      #but not display
+      Alert.where(alert_type: alert_type).destroy_all
+      #remove the alert type from the database
+      alert_type.destroy
+    end
+
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord
+      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+  end
+end


### PR DESCRIPTION
Removes the meter consolidation alerts:

* [x] Update to new version of analytics with alert removed (https://github.com/Energy-Sparks/energy-sparks_analytics/pull/576)
* [x] Remove the unused meter attributes
* [x] Remove the alerts
* [x] Remove the alert type