### PR TITLE
Add migration for global meter attributes

### DIFF
--- a/app/models/energy_tariff.rb
+++ b/app/models/energy_tariff.rb
@@ -34,7 +34,7 @@
 class EnergyTariff < ApplicationRecord
   belongs_to :tariff_holder, polymorphic: true
 
-  delegated_type :tariff_holder, types: %w[School SchoolGroup]
+  delegated_type :tariff_holder, types: %w[SiteSettings School SchoolGroup]
 
   has_many :energy_tariff_prices, inverse_of: :energy_tariff, dependent: :destroy
   has_many :energy_tariff_charges, inverse_of: :energy_tariff, dependent: :destroy

--- a/app/models/site_settings.rb
+++ b/app/models/site_settings.rb
@@ -20,6 +20,8 @@ class SiteSettings < ApplicationRecord
   validates :photo_bonus_points, numericality: { greater_than_or_equal_to: 0 }
   validates :audit_activities_bonus_points, numericality: { greater_than_or_equal_to: 0 }
 
+  has_many :energy_tariffs, as: :tariff_holder, dependent: :destroy
+
   after_save :delete_current_prices_cache
 
   CURRENT_PRICES_CACHE_KEY = 'site_settings_current_prices'.freeze

--- a/app/services/database/energy_tariff_migration_service.rb
+++ b/app/services/database/energy_tariff_migration_service.rb
@@ -1,0 +1,99 @@
+module Database
+  class EnergyTariffMigrationService
+    def self.migrate_user_tariffs
+      ActiveRecord::Base.transaction do
+        UserTariff.all.order(:id).each do |ut|
+          energy_tariff_prices = ut.user_tariff_prices.map do |utp|
+            EnergyTariffPrice.new(
+              start_time: utp.start_time,
+              end_time: utp.end_time,
+              units: utp.units,
+              value: utp.value,
+              description: utp.description
+            )
+          end
+
+          energy_tariff_charges = ut.user_tariff_charges.map do |utc|
+            EnergyTariffCharge.new(
+              charge_type: utc.charge_type,
+              units: utc.units,
+              value: utc.value
+            )
+          end
+          vat_rate = ut.vat_rate.nil? ? nil : ut.vat_rate.gsub(/\D/, '').to_i
+          EnergyTariff.create!(
+            ccl: ut.ccl,
+            enabled: true,
+            end_date: ut.end_date,
+            meter_type: ut.fuel_type.to_sym,
+            name: ut.name,
+            source: :manually_entered,
+            start_date: ut.start_date,
+            tariff_holder_id: ut.school.id,
+            tariff_holder_type: School,
+            tariff_type: ut.flat_rate? ? :flat_rate : :differential,
+            tnuos: ut.tnuos,
+            vat_rate: vat_rate,
+            meters: ut.meters,
+            energy_tariff_charges: energy_tariff_charges,
+            energy_tariff_prices: energy_tariff_prices
+          )
+        end
+      end
+    end
+
+    #Turns the Global Meter Attributes that are for accounting tariffs into
+    #EnergyTariffs. We will be ignoring the economic tariffs as they aren't needed.
+    def self.migrate_global_meter_attributes
+      ActiveRecord::Base.transaction do
+        GlobalMeterAttribute.where(attribute_type: 'accounting_tariff',
+          replaced_by: nil, deleted_by: nil).each do |attribute|
+            #either :electricity or :gas
+            meter_type = meter_type(attribute)
+
+            #global attributes only have standing charges
+            energy_tariff_charges = [
+              EnergyTariffCharge.new(
+                charge_type: :standing_charge,
+                units: :day,
+                value: attribute.input_data['rates']['standing_charge']['rate'].to_f
+              )
+            ]
+            #global attributes are flat rate only
+            energy_tariff_prices = [
+              EnergyTariffPrice.new(
+                start_time: Time.zone.parse('00:00'),
+                end_time: Time.zone.parse('23:30'),
+                units: 'kwh',
+                value: attribute.input_data['rates']['rate']['rate'].to_f
+              )
+            ]
+
+            EnergyTariff.create!(
+              ccl: false,
+              enabled: true,
+              end_date: Date.parse(attribute.input_data['end_date']),
+              meter_type: meter_type,
+              name: attribute.input_data['name'],
+              source: :manually_entered,
+              start_date: Date.parse(attribute.input_data['start_date']),
+              tariff_holder: SiteSettings.current,
+              tariff_type: :flat_rate,
+              tnuos: false,
+              vat_rate: nil,
+              energy_tariff_charges: energy_tariff_charges,
+              energy_tariff_prices: energy_tariff_prices
+            )
+        end
+      end
+    end
+
+    def self.meter_type(attribute)
+      return :electricity if attribute.meter_types.include?('electricity')
+      return :gas if attribute.meter_types.include?('gas')
+      return :solar_pv if attribute.meter_types.include?('solar_pv', 'solar_pv_consumed_sub_meter')
+      return :exported_solar_pv if attribute.meter_types.include?('exported_solar_pv', 'solar_pv_exported_sub_meter')
+      raise "Unexpected meter type"
+    end
+  end
+end

--- a/lib/tasks/deployment/20230725132841_migrate_to_energy_tariffs.rake
+++ b/lib/tasks/deployment/20230725132841_migrate_to_energy_tariffs.rake
@@ -3,49 +3,7 @@ namespace :after_party do
   task migrate_to_energy_tariffs: :environment do
     puts "Running deploy task 'migrate_to_energy_tariffs'"
 
-    ActiveRecord::Base.transaction do
-      EnergyTariff.destroy_all
-
-      UserTariff.all.order(:id).each do |ut|
-        energy_tariff_prices = ut.user_tariff_prices.map do |utp|
-          EnergyTariffPrice.new(
-            start_time: utp.start_time,
-            end_time: utp.end_time,
-            units: utp.units,
-            value: utp.value,
-            description: utp.description
-          )
-        end
-
-        energy_tariff_charges = ut.user_tariff_charges.map do |utc|
-          EnergyTariffCharge.new(
-            charge_type: utc.charge_type,
-            units: utc.units,
-            value: utc.value
-          )
-        end
-
-        vat_rate = ut.vat_rate.nil? ? nil : ut.vat_rate.gsub(/\D/, '').to_i
-
-        EnergyTariff.create!(
-          ccl: ut.ccl,
-          enabled: true,
-          end_date: ut.end_date,
-          meter_type: ut.fuel_type.to_sym,
-          name: ut.name,
-          source: :manually_entered,
-          start_date: ut.start_date,
-          tariff_holder_id: ut.school.id,
-          tariff_holder_type: School,
-          tariff_type: ut.flat_rate? ? :flat_rate : :differential,
-          tnuos: ut.tnuos,
-          vat_rate: vat_rate,
-          meters: ut.meters,
-          energy_tariff_charges: energy_tariff_charges,
-          energy_tariff_prices: energy_tariff_prices
-        )
-      end
-    end
+    Database::EnergyTariffMigrationService.migrate_user_tariffs
 
     # Update task as completed.  If you remove the line below, the task will
     # run with every deploy (or every time you call after_party:run).

--- a/spec/services/database/energy_tariff_migration_service_spec.rb
+++ b/spec/services/database/energy_tariff_migration_service_spec.rb
@@ -1,0 +1,113 @@
+require 'rails_helper'
+
+describe Database::EnergyTariffMigrationService do
+
+  context '#migrate_user_tariffs' do
+    let!(:user_tariff)  do
+      UserTariff.create(
+        school: create(:school),
+        start_date: '2021-04-01',
+        end_date: '2022-03-31',
+        name: 'My First Tariff',
+        fuel_type: :electricity,
+        flat_rate: true,
+        vat_rate: '20%',
+        user_tariff_prices: user_tariff_prices,
+        user_tariff_charges: user_tariff_charges,
+        )
+    end
+    let(:user_tariff_price)  { UserTariffPrice.new(start_time: '00:00', end_time: '23:30', value: 1.23, units: 'kwh') }
+    let(:user_tariff_charge)  { UserTariffCharge.new(charge_type: :fixed_charge, value: 4.56, units: :month) }
+
+    let(:user_tariff_prices)  { [user_tariff_price] }
+    let(:user_tariff_charges)  { [user_tariff_charge] }
+
+    context 'it migrates flat rate tariffs' do
+      before do
+        Database::EnergyTariffMigrationService.migrate_user_tariffs
+      end
+      let(:energy_tariff)       { EnergyTariff.first }
+      let(:charge)              { energy_tariff.energy_tariff_charges.first }
+      let(:price)               { energy_tariff.energy_tariff_prices.first }
+      it 'creates energy tariff' do
+        expect(energy_tariff.tariff_holder).to eq user_tariff.school
+        expect(energy_tariff.start_date).to eq user_tariff.start_date
+        expect(energy_tariff.end_date).to eq user_tariff.end_date
+        expect(energy_tariff.name).to eq user_tariff.name
+        expect(energy_tariff.meter_type).to eq user_tariff.fuel_type
+        expect(energy_tariff.tariff_type).to eq "flat_rate"
+        expect(energy_tariff.source).to eq "manually_entered"
+      end
+      it 'creates energy tariff price' do
+        expect(price.start_time).to eq user_tariff_price.start_time
+        expect(price.end_time).to eq user_tariff_price.end_time
+        expect(price.value).to eq user_tariff_price.value
+        expect(price.units).to eq user_tariff_price.units
+      end
+      it 'creates energy tariff charge' do
+        expect(charge.charge_type).to eq user_tariff_charge.charge_type
+        expect(charge.units).to eq user_tariff_charge.units
+        expect(charge.value).to eq user_tariff_charge.value
+      end
+    end
+  end
+
+  context '#migrate_global_meter_attributes' do
+    let!(:settings)           { SiteSettings.create! }
+
+    let!(:global_meter_attribute) {
+      GlobalMeterAttribute.create(
+        attribute_type: 'accounting_tariff',
+        meter_types: ["", "gas", "aggregated_gas"],
+        input_data: {
+            start_date: "01/01/2000",
+            end_date: "01/01/2050",
+            name: "System Wide Gas Accounting Tariff",
+            default: true,
+            system_wide: true,
+            rates: {
+              rate: {
+                per: :kwh,
+                rate: 0.03
+              },
+            standing_charge: {
+                per: :day,
+                rate: 0.6
+                }
+            }
+        }
+      )
+    }
+
+    context 'migrates the global accounting tariff' do
+      let(:energy_tariff)       { EnergyTariff.first }
+      let(:charge)              { energy_tariff.energy_tariff_charges.first }
+      let(:price)               { energy_tariff.energy_tariff_prices.first }
+
+      before do
+        Database::EnergyTariffMigrationService.migrate_global_meter_attributes
+      end
+
+      it 'creates energy tariff' do
+        expect(energy_tariff.tariff_holder).to eq SiteSettings.current
+        expect(energy_tariff.start_date).to eq Date.new(2000,1,1)
+        expect(energy_tariff.end_date).to eq Date.new(2050,1,1)
+        expect(energy_tariff.name).to eq "System Wide Gas Accounting Tariff"
+        expect(energy_tariff.meter_type).to eq "gas"
+        expect(energy_tariff.tariff_type).to eq "flat_rate"
+        expect(energy_tariff.source).to eq "manually_entered"
+      end
+      it 'creates energy tariff price' do
+        expect(price.start_time.to_s(:time)).to eq '00:00'
+        expect(price.end_time.to_s(:time)).to eq '23:30'
+        expect(price.value).to eq 0.03
+        expect(price.units).to eq "kwh"
+      end
+      it 'creates energy tariff charge' do
+        expect(charge.charge_type).to eq "standing_charge"
+        expect(charge.units).to eq "day"
+        expect(charge.value).to eq 0.6
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR adds another step to the data migration for tariffs:

* Creates a separate service to do the migration of user tariffs and global meter attributes. This makes it easier to test and possibly re-run the migration
* Update the after party task to call this step, but remove the "delete all", so we're a little more cautious when doing the migration
* Allows EnergyTariff to be owned by SiteSettings
* Adds some basic specs for the initial migration steps

I'll do the migration of SchoolGroup and School attributes in a later PR. This is a little more involved as we need to selectively migrate some attributes and finesse some of the time ranges.