### PR TITLE
Add code for migrating school group tariffs

### DIFF
--- a/app/services/database/energy_tariff_migration_service.rb
+++ b/app/services/database/energy_tariff_migration_service.rb
@@ -88,32 +88,140 @@ module Database
       end
     end
 
+    def self.migrate_school_group_meter_attributes
+      ActiveRecord::Base.transaction do
+        SchoolGroup.all.order(:id).each do |school_group|
+          #If a school group has any time-varying economic tariffs (there are 11 of these) then
+          #we will use these to create new EnergyTariff records and their accounting tariffs
+          #will be ignored. This is because the team is creating economic tariffs and not
+          #accounting tariffs, so these records provide better initial defaults
+          if has_time_varying_economic_tariffs?(school_group)
+            migrate_school_group_economic_tariffs(school_group)
+          else
+            #If a group does not have time-varying economic tariffs, but has accounting tariffs
+            #(e.g. Bath, Futura Learning) then we will create new EnergyTariff records from
+            #those tariffs
+            #
+            #Need to translate both accounting_tariff and accounting_tariff_differential
+            migrate_school_grouo_accounting_tariffs(school_group)
+          end
+        end
+      end
+    end
+
+    #Economic tariffs don't have any charges, so we just need to migrate the prices
+    #and ensure we're using the right type of tariff
+    def self.migrate_school_group_economic_tariffs(school_group)
+      school_group.meter_attributes.where(attribute_type: 'economic_tariff_change_over_time').active.each do |attribute|
+          #If a time varying tariff has day/time time rates we can ignore the flat rate. The team
+          #are currently required to add this for validation reasons.
+          tariff_type = tariff_type(attribute)
+          #There are some invalid/incorrect differential economic tariffs for Swansea (school group 11)
+          #So in this case, just use the flat rate
+          tariff_type = :flat_rate if school_group.slug == "swansea-abertawe"
+          meter_type = meter_type(attribute)
+
+          EnergyTariff.create!(
+            ccl: false,
+            enabled: true,
+            end_date: Date.parse(attribute.input_data['end_date']),
+            meter_type: meter_type,
+            name: attribute.input_data['name'],
+            source: :manually_entered,
+            start_date: Date.parse(attribute.input_data['start_date']),
+            tariff_holder: school_group,
+            tariff_type: tariff_type,
+            tnuos: false,
+            vat_rate: nil,
+            energy_tariff_prices: energy_tariff_prices(attribute, tariff_type)
+          )
+      end
+    end
+
+    #meter_types are gas, electricity, or aggregated. Aggregate always existing with fuel type
+    def self.migrate_school_group_accounting_tariffs(school_group)
+      return unless has_accounting_tariffs?(school_group)
+      school_group.meter_attributes.where(
+        attribute_type: %w[accounting_tariff accounting_tariff_differential]).active.each do |attribute|
+          #account tariffs don't have day/night rates, so this returns the right results
+          #regardless of attribute_type
+          tariff_type = tariff_type(attribute)
+          meter_type = meter_type(attribute)
+
+          EnergyTariff.create!(
+            ccl: false,
+            enabled: true,
+            end_date: Date.parse(attribute.input_data['end_date']),
+            meter_type: meter_type,
+            name: attribute.input_data['name'],
+            source: :manually_entered,
+            start_date: Date.parse(attribute.input_data['start_date']),
+            tariff_holder: school_group,
+            tariff_type: tariff_type,
+            tnuos: false,
+            vat_rate: nil,
+            energy_tariff_prices: energy_tariff_prices(attribute, tariff_type),
+            energy_tariff_charges: energy_tariff_charges(attribute)
+          )
+      end
+    end
+
+    #Generic method for creating prices for any type of tariff
+    def self.energy_tariff_prices(attribute, tariff_type)
+      if tariff_type == :flat_rate
+        [
+          EnergyTariffPrice.new(
+            start_time: Time.zone.parse('00:00'),
+            end_time: Time.zone.parse('23:30'),
+            units: 'kwh',
+            value: attribute.input_data['rates']['rate']['rate'].to_f
+          )
+        ]
+      else
+        [
+          EnergyTariffPrice.new(
+            start_time: time_for_rate_type_period(attribute, 'daytime_rate', 'from'),
+            end_time: time_for_rate_type_period(attribute, 'daytime_rate', 'to'),
+            units: 'kwh',
+            value: attribute.input_data['rates']['daytime_rate']['rate'].to_f
+          ),
+          EnergyTariffPrice.new(
+            start_time: time_for_rate_type_period(attribute, 'nighttime_rate', 'from'),
+            end_time: time_for_rate_type_period(attribute, 'nighttime_rate', 'to'),
+            units: 'kwh',
+            value: attribute.input_data['rates']['nighttime_rate']['rate'].to_f
+          ),
+        ]
+      end
+    end
+
+    #Create charges for accounting tariffs
+    def self.energy_tariff_charges(attribute)
+      energy_tariff_charges = []
+      rates = attribute.input_data['rates']
+      #iterate over the charges (any non-price related key) add those that
+      #have a rate
+      ignored = %w[rate daytime_rate nighttime_rate]
+      rates.each_key do |rate_type|
+        next if ignored.include?(rate_type)
+        next if rates[rate_type]['rate'].blank?
+        #charge has :per and :rate values
+        charge = rates[rate_type]
+        energy_tariff_charges << EnergyTariffCharge.new(
+          charge_type: rate_type.to_sym,
+          units: charge['per'].to_sym,
+          value: charge['rate'].to_f
+        )
+      end
+      energy_tariff_charges
+    end
+
     def self.meter_type(attribute)
       return :electricity if attribute.meter_types.include?('electricity')
       return :gas if attribute.meter_types.include?('gas')
       return :solar_pv if attribute.meter_types.include?('solar_pv', 'solar_pv_consumed_sub_meter')
       return :exported_solar_pv if attribute.meter_types.include?('exported_solar_pv', 'solar_pv_exported_sub_meter')
       raise "Unexpected meter type"
-    end
-
-    def self.migrate_school_group_meter_attributes
-      ActiveRecord::Base.transaction do
-        SchoolGroup.all.order(:id).each do |school_group|
-        #If a school group has any time-varying economic tariffs (there are 11 of these) then
-        #we will use these to create new EnergyTariff records and their accounting tariffs
-        #will be ignored.
-        if has_time_varying_economic_tariffs?(school_group)
-          migrate_school_group_economic_tariffs(school_group)
-        else
-          #If a group does not have time-varying economic tariffs, but has accounting tariffs
-          #(e.g. Bath, Futura Learning) then we will create new EnergyTariff records from the
-          #accounting tariffs as described below
-          #
-          #Need to translate both accounting_tariff and accounting_tariff_differential
-          migrate_school_grouo_accounting_tariffs(school_group)
-        end
-        end
-      end
     end
 
     #Does the group have any time varying tariffs?
@@ -135,66 +243,6 @@ module Database
       else
         :flat_rate
       end
-    end
-
-    #Economic tariffs don't have any charges, so we just need to migrate the prices
-    #and ensure we're using the right type of tariff
-    def self.migrate_school_group_economic_tariffs(school_group)
-      school_group.meter_attributes.where(attribute_type: 'economic_tariff_change_over_time').active.each do |attribute|
-          #If a time varying tariff has day/time time rates we can ignore the flat rate. The team
-          #are currently required to add this for validation reasons.
-          tariff_type = tariff_type(attribute)
-          #There are some invalid/incorrect differential economic tariffs for Swansea (school group 11)
-          #So in this case, just use the flat rate
-          tariff_type = :flat_rate if school_group.slug == "swansea-abertawe"
-          meter_type = meter_type(attribute)
-
-          if tariff_type == :flat_rate
-            energy_tariff_prices = [
-              EnergyTariffPrice.new(
-                start_time: Time.zone.parse('00:00'),
-                end_time: Time.zone.parse('23:30'),
-                units: 'kwh',
-                value: attribute.input_data['rates']['rate']['rate'].to_f
-              )
-            ]
-          else
-            energy_tariff_prices = [
-              EnergyTariffPrice.new(
-                start_time: time_for_rate_type_period(attribute, 'daytime_rate', 'from'),
-                end_time: time_for_rate_type_period(attribute, 'daytime_rate', 'to'),
-                units: 'kwh',
-                value: attribute.input_data['rates']['daytime_rate']['rate'].to_f
-              ),
-              EnergyTariffPrice.new(
-                start_time: time_for_rate_type_period(attribute, 'nighttime_rate', 'from'),
-                end_time: time_for_rate_type_period(attribute, 'nighttime_rate', 'to'),
-                units: 'kwh',
-                value: attribute.input_data['rates']['nighttime_rate']['rate'].to_f
-              ),
-            ]
-          end
-
-          EnergyTariff.create!(
-            ccl: false,
-            enabled: true,
-            end_date: Date.parse(attribute.input_data['end_date']),
-            meter_type: meter_type,
-            name: attribute.input_data['name'],
-            source: :manually_entered,
-            start_date: Date.parse(attribute.input_data['start_date']),
-            tariff_holder: school_group,
-            tariff_type: tariff_type,
-            tnuos: false,
-            vat_rate: nil,
-            energy_tariff_prices: energy_tariff_prices
-          )
-      end
-    end
-
-    #meter_types are gas, electricity, or aggregated. Aggregate always existing with fuel type
-    def self.migrate_school_group_accounting_tariffs(school_group)
-      return unless has_accounting_tariffs?(school_group)
     end
 
     def self.time_for_rate_type_period(attribute, rate_type = 'daytime_rate', range = 'from')

--- a/app/services/database/energy_tariff_migration_service.rb
+++ b/app/services/database/energy_tariff_migration_service.rb
@@ -103,7 +103,7 @@ module Database
             #those tariffs
             #
             #Need to translate both accounting_tariff and accounting_tariff_differential
-            migrate_school_grouo_accounting_tariffs(school_group)
+            migrate_school_group_accounting_tariffs(school_group)
           end
         end
       end
@@ -124,11 +124,11 @@ module Database
           EnergyTariff.create!(
             ccl: false,
             enabled: true,
-            end_date: Date.parse(attribute.input_data['end_date']),
+            end_date: date_or_nil(attribute.input_data['end_date']),
             meter_type: meter_type,
             name: attribute.input_data['name'],
             source: :manually_entered,
-            start_date: Date.parse(attribute.input_data['start_date']),
+            start_date: date_or_nil(attribute.input_data['start_date']),
             tariff_holder: school_group,
             tariff_type: tariff_type,
             tnuos: false,
@@ -151,11 +151,11 @@ module Database
           EnergyTariff.create!(
             ccl: false,
             enabled: true,
-            end_date: Date.parse(attribute.input_data['end_date']),
+            end_date: date_or_nil(attribute.input_data['end_date']),
             meter_type: meter_type,
             name: attribute.input_data['name'],
             source: :manually_entered,
-            start_date: Date.parse(attribute.input_data['start_date']),
+            start_date: date_or_nil(attribute.input_data['start_date']),
             tariff_holder: school_group,
             tariff_type: tariff_type,
             tnuos: false,
@@ -214,6 +214,11 @@ module Database
         )
       end
       energy_tariff_charges
+    end
+
+    def self.date_or_nil(val)
+      return nil if val.nil? || val.blank?
+      Date.parse(val)
     end
 
     def self.meter_type(attribute)

--- a/app/services/database/energy_tariff_migration_service.rb
+++ b/app/services/database/energy_tariff_migration_service.rb
@@ -95,5 +95,130 @@ module Database
       return :exported_solar_pv if attribute.meter_types.include?('exported_solar_pv', 'solar_pv_exported_sub_meter')
       raise "Unexpected meter type"
     end
+
+    def self.migrate_school_group_meter_attributes
+      ActiveRecord::Base.transaction do
+        SchoolGroup.all.order(:id).each do |school_group|
+        #If a school group has any time-varying economic tariffs (there are 11 of these) then
+        #we will use these to create new EnergyTariff records and their accounting tariffs
+        #will be ignored.
+        if has_time_varying_economic_tariffs?(school_group)
+          migrate_school_group_economic_tariffs(school_group)
+        else
+          #If a group does not have time-varying economic tariffs, but has accounting tariffs
+          #(e.g. Bath, Futura Learning) then we will create new EnergyTariff records from the
+          #accounting tariffs as described below
+          #
+          #Need to translate both accounting_tariff and accounting_tariff_differential
+          migrate_school_grouo_accounting_tariffs(school_group)
+        end
+        end
+      end
+    end
+
+    #Does the group have any time varying tariffs?
+    def self.has_time_varying_economic_tariffs?(school_group)
+      school_group.meter_attributes.where(
+        attribute_type: 'economic_tariff_change_over_time').active.any?
+    end
+
+    #Does the group have any accounting tariffs?
+    def self.has_accounting_tariffs?(school_group)
+      school_group.meter_attributes.where(
+        attribute_type: %w[accounting_tariff accounting_tariff_differential]).active.any?
+    end
+
+    #Determine tariff type from accounting tariff / accounting tariff differential attribute
+    def self.tariff_type(attribute)
+      if attribute.input_data['rates']['daytime_rate'].present?
+        :differential
+      else
+        :flat_rate
+      end
+    end
+
+    #Economic tariffs don't have any charges, so we just need to migrate the prices
+    #and ensure we're using the right type of tariff
+    def self.migrate_school_group_economic_tariffs(school_group)
+      school_group.meter_attributes.where(attribute_type: 'economic_tariff_change_over_time').active.each do |attribute|
+          #If a time varying tariff has day/time time rates we can ignore the flat rate. The team
+          #are currently required to add this for validation reasons.
+          tariff_type = tariff_type(attribute)
+          #There are some invalid/incorrect differential economic tariffs for Swansea (school group 11)
+          #So in this case, just use the flat rate
+          tariff_type = :flat_rate if school_group.slug == "swansea-abertawe"
+          meter_type = meter_type(attribute)
+
+          if tariff_type == :flat_rate
+            energy_tariff_prices = [
+              EnergyTariffPrice.new(
+                start_time: Time.zone.parse('00:00'),
+                end_time: Time.zone.parse('23:30'),
+                units: 'kwh',
+                value: attribute.input_data['rates']['rate']['rate'].to_f
+              )
+            ]
+          else
+            energy_tariff_prices = [
+              EnergyTariffPrice.new(
+                start_time: time_for_rate_type_period(attribute, 'daytime_rate', 'from'),
+                end_time: time_for_rate_type_period(attribute, 'daytime_rate', 'to'),
+                units: 'kwh',
+                value: attribute.input_data['rates']['daytime_rate']['rate'].to_f
+              ),
+              EnergyTariffPrice.new(
+                start_time: time_for_rate_type_period(attribute, 'nighttime_rate', 'from'),
+                end_time: time_for_rate_type_period(attribute, 'nighttime_rate', 'to'),
+                units: 'kwh',
+                value: attribute.input_data['rates']['nighttime_rate']['rate'].to_f
+              ),
+            ]
+          end
+
+          EnergyTariff.create!(
+            ccl: false,
+            enabled: true,
+            end_date: Date.parse(attribute.input_data['end_date']),
+            meter_type: meter_type,
+            name: attribute.input_data['name'],
+            source: :manually_entered,
+            start_date: Date.parse(attribute.input_data['start_date']),
+            tariff_holder: school_group,
+            tariff_type: tariff_type,
+            tnuos: false,
+            vat_rate: nil,
+            energy_tariff_prices: energy_tariff_prices
+          )
+      end
+    end
+
+    #meter_types are gas, electricity, or aggregated. Aggregate always existing with fuel type
+    def self.migrate_school_group_accounting_tariffs(school_group)
+      return unless has_accounting_tariffs?(school_group)
+    end
+
+    def self.time_for_rate_type_period(attribute, rate_type = 'daytime_rate', range = 'from')
+      return nil unless attribute.input_data['rates'][rate_type].present?
+      return nil unless attribute.input_data['rates'][rate_type][range].present?
+
+      period = attribute.input_data['rates'][rate_type][range]
+
+      #meter attributes uses 24:00 as the final period of the day, for its
+      #exclusive range. So spot this and return last half-hourly period
+      return "23:30" if range == 'to' && period['hour'] == '24'
+
+      #rubocop:disable Rails/Date
+      #use the TimeOfDay class to convert to a time
+      time_of_day = TimeOfDay.new(period['hour'].to_i, period['minutes'].to_i).to_time
+      #rubocop:enable Rails/Date
+
+      #roll back 30 minutes for the end of the tariff time range, as we're converting from
+      #an exclusive range, to an inclusive range. Which means the end should be the
+      #previous half-hourly period. Start ranges ("from") remain unchanged.
+      if range == 'to'
+        time_of_day = time_of_day.advance(minutes: -30)
+      end
+      time_of_day.to_s(:time)
+    end
   end
 end


### PR DESCRIPTION
This PR adds extra code to migrate SchoolGroup meter attributes to the new tariff data model.

The main entry point is the `migrate_school_group_meter_attributes` method. This decides whether to migrate the group's economic tariffs or accounting tariffs.

As the team are currently prioritising populating the economic tariffs to follow latest prices, we use those over the accounting tariffs which may be incomplete or out of date. 

When migrating the economic tariffs if the tariff specifies both flat and differential rates, then we just migrate the differential rates. This is because the MeterAttribute editor has the flat rate marked as a required field. But we won't need both tariff types once migrated.

As economic tariffs don't have charges, we just migrate the prices.

If a school group has accounting tariffs then we'll migrate those as a fallback. The code handles both flat rate and differential accounting tariffs with all known charge types.

One note about time ranges for differential tariffs:

The time ranges on the meter attributes are *exclusive* time ranges, so a range of 00:00 to 07:00 means any consumption up until 07:00. However the time ranges in the new energy tariff model are *inclusive* so when migrating we need to turn this period into 00:00 to 06:30 to be consistent. The differences are due to the analytics handling these time ranges differently across different attribute types.