### PR TITLE
Migrate school and meter tariffs

### DIFF
--- a/app/services/database/energy_tariff_migration_service.rb
+++ b/app/services/database/energy_tariff_migration_service.rb
@@ -133,7 +133,7 @@ module Database
             tariff_type: tariff_type,
             tnuos: false,
             vat_rate: nil,
-            energy_tariff_prices: energy_tariff_prices(attribute, tariff_type)
+            energy_tariff_prices: energy_tariff_prices(attribute.input_data['rates'], tariff_type)
           )
       end
     end
@@ -160,8 +160,8 @@ module Database
             tariff_type: tariff_type,
             tnuos: false,
             vat_rate: nil,
-            energy_tariff_prices: energy_tariff_prices(attribute, tariff_type),
-            energy_tariff_charges: energy_tariff_charges(attribute)
+            energy_tariff_prices: energy_tariff_prices(attribute.input_data['rates'], tariff_type),
+            energy_tariff_charges: energy_tariff_charges(attribute.input_data['rates'])
           )
       end
     end
@@ -186,86 +186,126 @@ module Database
             tariff_type: tariff_type,
             tnuos: false,
             vat_rate: nil,
-            energy_tariff_prices: energy_tariff_prices(attribute, tariff_type)
+            energy_tariff_prices: energy_tariff_prices(attribute.input_data['rates'], tariff_type)
           )
         end
       end
     end
 
     def self.migrate_meter_accounting_tariffs
-      MeterAttribute.where(
-        attribute_type: %w[accounting_tariff accounting_tariff_differential]).active.each do |attribute|
-          tariff_type = tariff_type(attribute)
-          EnergyTariff.create!(
-            ccl: false,
-            enabled: true,
-            end_date: date_or_nil(attribute.input_data['end_date']),
-            meter_type: attribute.meter.meter_type,
-            name: attribute.input_data['name'],
-            source: :manually_entered,
-            start_date: date_or_nil(attribute.input_data['start_date']),
-            tariff_holder: attribute.meter.school,
-            tariff_type: tariff_type,
-            tnuos: false,
-            vat_rate: nil,
-            energy_tariff_prices: energy_tariff_prices(attribute, tariff_type),
-            energy_tariff_charges: energy_tariff_charges(attribute),
-            meters: [attribute.meter]
-          )
+      ActiveRecord::Base.transaction do
+        MeterAttribute.where(
+          attribute_type: %w[accounting_tariff accounting_tariff_differential]).active.each do |attribute|
+            tariff_type = tariff_type(attribute)
+            EnergyTariff.create!(
+              ccl: false,
+              enabled: true,
+              end_date: date_or_nil(attribute.input_data['end_date']),
+              meter_type: attribute.meter.meter_type,
+              name: attribute.input_data['name'],
+              source: :manually_entered,
+              start_date: date_or_nil(attribute.input_data['start_date']),
+              tariff_holder: attribute.meter.school,
+              tariff_type: tariff_type,
+              tnuos: false,
+              vat_rate: nil,
+              energy_tariff_prices: energy_tariff_prices(attribute.input_data['rates'], tariff_type),
+              energy_tariff_charges: energy_tariff_charges(attribute.input_data['rates']),
+              meters: [attribute.meter]
+            )
+        end
+      end
+    end
+
+    def self.migrate_tariff_prices
+      ActiveRecord::Base.transaction do
+        Meter.dcc.each do |meter|
+          meter_attributes = meter.smart_meter_tariff_attributes
+          next if meter_attributes.nil?
+          #Note: this is an analytics meter attribute hash, not a MeterAttribute record
+          meter_attributes[:accounting_tariff_generic].each do |attribute|
+            tariff_type = if attribute[:rates][:flat_rate].present?
+                            :flat_rate
+                          else
+                            :differential
+                          end
+
+            EnergyTariff.create!(
+              ccl: false,
+              enabled: true,
+              end_date: attribute[:end_date],
+              meter_type: meter.meter_type,
+              name: attribute[:name],
+              source: :dcc,
+              start_date: attribute[:start_date],
+              tariff_holder: meter.school,
+              tariff_type: tariff_type,
+              tnuos: false,
+              vat_rate: nil,
+              energy_tariff_prices: energy_tariff_prices(attribute[:rates], tariff_type, true),
+              energy_tariff_charges: energy_tariff_charges(attribute[:rates]),
+              meters: [meter]
+            )
+          end
+        end
       end
     end
 
     #Generic method for creating prices for any type of tariff
-    def self.energy_tariff_prices(attribute, tariff_type)
+    def self.energy_tariff_prices(rates, tariff_type, dcc_tariff = false)
+      rates.deep_symbolize_keys!
       if tariff_type == :flat_rate
         [
           EnergyTariffPrice.new(
             start_time: Time.zone.parse('00:00'),
             end_time: Time.zone.parse('23:30'),
             units: 'kwh',
-            value: attribute.input_data['rates']['rate']['rate'].to_f
+            value: dcc_tariff ? rates[:flat_rate][:rate].to_f : rates[:rate][:rate].to_f
           )
         ]
+      elsif dcc_tariff
+        []
       else
         [
           EnergyTariffPrice.new(
-            start_time: time_for_rate_type_period(attribute, 'daytime_rate', 'from'),
-            end_time: time_for_rate_type_period(attribute, 'daytime_rate', 'to'),
+            start_time: time_for_rate_type_period(rates, :daytime_rate, :from),
+            end_time: time_for_rate_type_period(rates, :daytime_rate, :to),
             units: 'kwh',
-            value: attribute.input_data['rates']['daytime_rate']['rate'].to_f
+            value: rates[:daytime_rate][:rate].to_f
           ),
           EnergyTariffPrice.new(
-            start_time: time_for_rate_type_period(attribute, 'nighttime_rate', 'from'),
-            end_time: time_for_rate_type_period(attribute, 'nighttime_rate', 'to'),
+            start_time: time_for_rate_type_period(rates, :nighttime_rate, :from),
+            end_time: time_for_rate_type_period(rates, :nighttime_rate, :to),
             units: 'kwh',
-            value: attribute.input_data['rates']['nighttime_rate']['rate'].to_f
+            value: rates[:nighttime_rate][:rate].to_f
           ),
         ]
       end
     end
 
     #Create charges for accounting tariffs
-    def self.energy_tariff_charges(attribute)
+    def self.energy_tariff_charges(rates)
+      rates.deep_symbolize_keys!
       energy_tariff_charges = []
-      rates = attribute.input_data['rates']
       #iterate over the charges (any non-price related key) add those that
       #have a rate
-      ignored = %w[rate daytime_rate nighttime_rate]
+      ignored = %i[rate daytime_rate nighttime_rate]
       rates.each_key do |rate_type|
         next if ignored.include?(rate_type)
-        next if rates[rate_type]['rate'].blank?
+        next if rates[rate_type][:rate].blank?
         #charge has :per and :rate values
         charge = rates[rate_type]
         energy_tariff_charges << EnergyTariffCharge.new(
           charge_type: rate_type.to_sym,
-          units: charge['per'].to_sym,
-          value: charge['rate'].to_f
+          units: charge[:per].to_sym,
+          value: charge[:rate].to_f
         )
       end
       energy_tariff_charges
     end
 
     def self.date_or_nil(val)
+      return val if val.is_a?(Date)
       return nil if val.nil? || val.blank?
       Date.parse(val)
     end
@@ -300,25 +340,25 @@ module Database
       end
     end
 
-    def self.time_for_rate_type_period(attribute, rate_type = 'daytime_rate', range = 'from')
-      return nil unless attribute.input_data['rates'][rate_type].present?
-      return nil unless attribute.input_data['rates'][rate_type][range].present?
+    def self.time_for_rate_type_period(rates, rate_type = :daytime_rate, range = :from)
+      return nil unless rates[rate_type].present?
+      return nil unless rates[rate_type][range].present?
 
-      period = attribute.input_data['rates'][rate_type][range]
+      period = rates[rate_type][range]
 
       #meter attributes uses 24:00 as the final period of the day, for its
       #exclusive range. So spot this and return last half-hourly period
-      return "23:30" if range == 'to' && period['hour'] == '24'
+      return "23:30" if range == :to && period[:hour] == '24'
 
       #rubocop:disable Rails/Date
       #use the TimeOfDay class to convert to a time
-      time_of_day = TimeOfDay.new(period['hour'].to_i, period['minutes'].to_i).to_time
+      time_of_day = TimeOfDay.new(period[:hour].to_i, period[:minutes].to_i).to_time
       #rubocop:enable Rails/Date
 
       #roll back 30 minutes for the end of the tariff time range, as we're converting from
       #an exclusive range, to an inclusive range. Which means the end should be the
       #previous half-hourly period. Start ranges ("from") remain unchanged.
-      if range == 'to'
+      if range == :to
         time_of_day = time_of_day.advance(minutes: -30)
       end
       time_of_day.to_s(:time)

--- a/app/services/database/energy_tariff_migration_service.rb
+++ b/app/services/database/energy_tariff_migration_service.rb
@@ -248,10 +248,11 @@ module Database
     end
 
     def self.meter_type(attribute)
-      return :electricity if attribute.meter_types.include?('electricity')
-      return :gas if attribute.meter_types.include?('gas')
-      return :solar_pv if attribute.meter_types.include?('solar_pv', 'solar_pv_consumed_sub_meter')
-      return :exported_solar_pv if attribute.meter_types.include?('exported_solar_pv', 'solar_pv_exported_sub_meter')
+      meter_types = attribute.meter_types
+      return :electricity if meter_types.include?('electricity')
+      return :gas if meter_types.include?('gas')
+      return :solar_pv if meter_types.include?('solar_pv') || meter_types.include?('solar_pv_consumed_sub_meter')
+      return :exported_solar_pv if meter_types.include?('exported_solar_pv') || meter_types.include?('solar_pv_exported_sub_meter')
       raise "Unexpected meter type"
     end
 

--- a/spec/services/database/energy_tariff_migration_service_spec.rb
+++ b/spec/services/database/energy_tariff_migration_service_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.shared_examples 'the expected EnergyTariff' do
-  it 'with right default attributes' do
+  it 'with the right attributes' do
     expect(energy_tariff.start_date).to eq start_date
     expect(energy_tariff.end_date).to eq end_date
     expect(energy_tariff.name).to eq tariff_name

--- a/spec/services/database/energy_tariff_migration_service_spec.rb
+++ b/spec/services/database/energy_tariff_migration_service_spec.rb
@@ -50,12 +50,12 @@ RSpec.shared_examples "a migrated differential economic tariff" do
 
     daytime, nighttime = energy_tariff.energy_tariff_prices.order(start_time: :asc).to_a
     expect(daytime.start_time.to_s(:time)).to eq '00:00'
-    expect(daytime.end_time.to_s(:time)).to eq '06:30'
+    expect(daytime.end_time.to_s(:time)).to eq '07:00'
     expect(daytime.value).to eq rate * 2
     expect(daytime.units).to eq "kwh"
 
     expect(nighttime.start_time.to_s(:time)).to eq '07:00'
-    expect(nighttime.end_time.to_s(:time)).to eq '23:30'
+    expect(nighttime.end_time.to_s(:time)).to eq '00:00'
     expect(nighttime.value).to eq rate
     expect(nighttime.units).to eq "kwh"
   end
@@ -94,12 +94,12 @@ RSpec.shared_examples "a migrated differential accounting tariff" do
 
     daytime, nighttime = energy_tariff.energy_tariff_prices.order(start_time: :asc).to_a
     expect(daytime.start_time.to_s(:time)).to eq '00:00'
-    expect(daytime.end_time.to_s(:time)).to eq '06:30'
+    expect(daytime.end_time.to_s(:time)).to eq '07:00'
     expect(daytime.value).to eq rate * 2
     expect(daytime.units).to eq "kwh"
 
     expect(nighttime.start_time.to_s(:time)).to eq '07:00'
-    expect(nighttime.end_time.to_s(:time)).to eq '23:30'
+    expect(nighttime.end_time.to_s(:time)).to eq '00:00'
     expect(nighttime.value).to eq rate
     expect(nighttime.units).to eq "kwh"
   end
@@ -458,21 +458,19 @@ describe Database::EnergyTariffMigrationService do
         Database::EnergyTariffMigrationService.migrate_tariff_prices
       end
 
-      it_behaves_like 'a flat rate EnergyTariff'
-      it 'creates expected price'
-      it 'creates standing charge'
+      it_behaves_like 'a migrated flat rate accounting tariff'
     end
 
     context 'with differential tariff' do
-      let!(:tariff_price) { create(:tariff_price, :with_differential_tariff, meter: meter, tariff_date: end_date) }
+      let!(:tariff_price) { create(:tariff_price,
+        :with_differential_tariff, meter: meter, tariff_date: end_date,
+        tiered_rate: Array.new(14, rate * 2) + Array.new(34, rate)) }
 
       before(:each) do
         Database::EnergyTariffMigrationService.migrate_tariff_prices
       end
 
-      it_behaves_like 'a differential EnergyTariff'
-      it 'creates expected prices'
-      it 'creates standing charge'
+      it_behaves_like 'a migrated differential accounting tariff'
     end
 
   end

--- a/spec/services/database/energy_tariff_migration_service_spec.rb
+++ b/spec/services/database/energy_tariff_migration_service_spec.rb
@@ -1,43 +1,51 @@
 require 'rails_helper'
 
-RSpec.shared_examples 'an energy tariff' do
+RSpec.shared_examples 'the expected EnergyTariff' do
   it 'with right default attributes' do
     expect(energy_tariff.start_date).to eq start_date
     expect(energy_tariff.end_date).to eq end_date
     expect(energy_tariff.name).to eq tariff_name
     expect(energy_tariff.meter_type).to eq "electricity"
     expect(energy_tariff.source).to eq "manually_entered"
-    expect(energy_tariff.tariff_holder).to eq subject
+    expect(energy_tariff.tariff_holder).to eq tariff_holder
+  end
+end
+
+RSpec.shared_examples 'a differential EnergyTariff' do
+  it_behaves_like 'the expected EnergyTariff'
+  it 'has the right type' do
+    expect(energy_tariff.tariff_type).to eq "differential"
+  end
+end
+
+RSpec.shared_examples 'a flat rate EnergyTariff' do
+  it_behaves_like 'the expected EnergyTariff'
+  it 'has the right type' do
+    expect(energy_tariff.tariff_type).to eq "flat_rate"
   end
 end
 
 RSpec.shared_examples "a migrated flat rate economic tariff" do
-  it_behaves_like 'an energy tariff'
+  it_behaves_like 'a flat rate EnergyTariff'
 
-  it 'creates a flat rate energy tariff' do
-    expect(energy_tariff.tariff_type).to eq "flat_rate"
-  end
+  let(:price)   { energy_tariff.energy_tariff_prices.first }
 
-  it 'creates energy tariff price' do
+  it 'creates an single price' do
     expect(price.start_time.to_s(:time)).to eq '00:00'
     expect(price.end_time.to_s(:time)).to eq '23:30'
     expect(price.value).to eq 0.03
     expect(price.units).to eq "kwh"
   end
 
-  it 'creates no energy tariff charges' do
+  it 'creates no charges' do
     expect(energy_tariff.energy_tariff_charges.any?).to eq false
   end
 end
 
 RSpec.shared_examples "a migrated differential economic tariff" do
-  it_behaves_like 'an energy tariff'
+  it_behaves_like 'a differential EnergyTariff'
 
-  it 'the created energy tariff is differential' do
-    expect(energy_tariff.tariff_type).to eq "differential"
-  end
-
-  it 'creates energy tariff prices' do
+  it 'creates two prices' do
     expect(energy_tariff.energy_tariff_prices.count).to eq 2
 
     daytime, nighttime = energy_tariff.energy_tariff_prices.order(start_time: :asc).to_a
@@ -52,8 +60,55 @@ RSpec.shared_examples "a migrated differential economic tariff" do
     expect(nighttime.units).to eq "kwh"
   end
 
-  it 'creates no energy tariff charges' do
+  it 'creates no charges' do
     expect(energy_tariff.energy_tariff_charges.any?).to eq false
+  end
+end
+
+RSpec.shared_examples "a migrated flat rate accounting tariff" do
+  it_behaves_like 'a flat rate EnergyTariff'
+  let(:price)     { energy_tariff.energy_tariff_prices.first }
+  let(:charge)    { energy_tariff.energy_tariff_charges.first }
+
+  it 'creates a single price' do
+    expect(price.start_time.to_s(:time)).to eq '00:00'
+    expect(price.end_time.to_s(:time)).to eq '23:30'
+    expect(price.value).to eq 0.03
+    expect(price.units).to eq "kwh"
+  end
+
+  it 'creates charges' do
+    expect(energy_tariff.energy_tariff_charges.any?).to eq true
+    expect(charge.charge_type).to eq 'standing_charge'
+    expect(charge.value).to eq 0.6
+    expect(charge.units).to eq 'day'
+  end
+end
+
+RSpec.shared_examples "a migrated differential accounting tariff" do
+  it_behaves_like 'a differential EnergyTariff'
+  let(:charge)    { energy_tariff.energy_tariff_charges.first }
+
+  it 'creates two prices' do
+    expect(energy_tariff.energy_tariff_prices.count).to eq 2
+
+    daytime, nighttime = energy_tariff.energy_tariff_prices.order(start_time: :asc).to_a
+    expect(daytime.start_time.to_s(:time)).to eq '00:00'
+    expect(daytime.end_time.to_s(:time)).to eq '06:30'
+    expect(daytime.value).to eq rate * 2
+    expect(daytime.units).to eq "kwh"
+
+    expect(nighttime.start_time.to_s(:time)).to eq '07:00'
+    expect(nighttime.end_time.to_s(:time)).to eq '23:30'
+    expect(nighttime.value).to eq rate
+    expect(nighttime.units).to eq "kwh"
+  end
+
+  it 'creates charges' do
+    expect(energy_tariff.energy_tariff_charges.any?).to eq true
+    expect(charge.charge_type).to eq 'standing_charge'
+    expect(charge.value).to eq 0.6
+    expect(charge.units).to eq 'day'
   end
 end
 
@@ -118,9 +173,9 @@ describe Database::EnergyTariffMigrationService do
       let(:energy_tariff)       { EnergyTariff.first }
       let(:charge)              { energy_tariff.energy_tariff_charges.first }
       let(:price)               { energy_tariff.energy_tariff_prices.first }
-      let(:subject)             { user_tariff.school }
+      let(:tariff_holder)       { user_tariff.school }
 
-      it_behaves_like "an energy tariff"
+      it_behaves_like "the expected EnergyTariff"
 
       it 'creates a flat rate energy tariff' do
         expect(energy_tariff.tariff_type).to eq "flat_rate"
@@ -140,7 +195,7 @@ describe Database::EnergyTariffMigrationService do
   end
 
   context '#migrate_global_meter_attributes' do
-    let!(:subject)           { SiteSettings.create! }
+    let!(:tariff_holder)           { SiteSettings.create! }
 
     let!(:global_meter_attribute) {
       GlobalMeterAttribute.create(
@@ -150,7 +205,7 @@ describe Database::EnergyTariffMigrationService do
       )
     }
 
-    context 'migrates the global accounting tariff' do
+    context 'migrates a global accounting tariff' do
       let(:energy_tariff)       { EnergyTariff.first }
       let(:charge)              { energy_tariff.energy_tariff_charges.first }
       let(:price)               { energy_tariff.energy_tariff_prices.first }
@@ -159,35 +214,18 @@ describe Database::EnergyTariffMigrationService do
         Database::EnergyTariffMigrationService.migrate_global_meter_attributes
       end
 
-      it_behaves_like "an energy tariff"
-
-      it 'creates flat rate energy tariff' do
-        expect(energy_tariff.tariff_type).to eq "flat_rate"
-      end
-
-      it 'creates energy tariff price' do
-        expect(price.start_time.to_s(:time)).to eq '00:00'
-        expect(price.end_time.to_s(:time)).to eq '23:30'
-        expect(price.value).to eq 0.03
-        expect(price.units).to eq "kwh"
-      end
-      it 'creates energy tariff charge' do
-        expect(charge.charge_type).to eq "standing_charge"
-        expect(charge.units).to eq "day"
-        expect(charge.value).to eq 0.6
-      end
+      it_behaves_like "a migrated flat rate accounting tariff"
     end
   end
 
   it 'migrates global solar attributes'
 
   context '#migrate_school_group_economic_tariffs' do
-    let(:sytem_wide)    { false }
-    let(:subject)  { create(:school_group) }
+    let(:system_wide)    { false }
+    let(:tariff_holder)  { create(:school_group) }
 
     let!(:school_group_attribute) {
-      subject.meter_attributes.create(
-        school_group: subject,
+      tariff_holder.meter_attributes.create(
         attribute_type: "economic_tariff_change_over_time",
         input_data: input_data,
         meter_types: ["", "electricity", "aggregated_electricity"]
@@ -198,7 +236,7 @@ describe Database::EnergyTariffMigrationService do
     let(:price)               { energy_tariff.energy_tariff_prices.first }
 
     before(:each) do
-      Database::EnergyTariffMigrationService.migrate_school_group_economic_tariffs(subject)
+      Database::EnergyTariffMigrationService.migrate_school_group_economic_tariffs(tariff_holder)
     end
 
     context 'with only flat rate tariff' do
@@ -253,65 +291,38 @@ describe Database::EnergyTariffMigrationService do
   end
 
   context '#migrate_school_group_accounting_tariffs' do
-    let(:sytem_wide)    { false }
-    let(:school_group)  { create(:school_group) }
+    let(:system_wide)    { false }
+    let(:tariff_holder)  { create(:school_group) }
 
     let!(:school_group_attribute) {
-      school_group.meter_attributes.create(
-        school_group: school_group,
+      tariff_holder.meter_attributes.create(
         attribute_type: "accounting_tariff",
         input_data: input_data,
         meter_types: ["", "electricity", "aggregated_electricity"]
       )
     }
     let(:energy_tariff)        { EnergyTariff.first }
-    let(:charges)              { energy_tariff.energy_tariff_charges }
-    let(:prices)               { energy_tariff.energy_tariff_prices }
 
     before(:each) do
-      Database::EnergyTariffMigrationService.migrate_school_group_accounting_tariffs(school_group)
+      Database::EnergyTariffMigrationService.migrate_school_group_accounting_tariffs(tariff_holder)
     end
 
-    it 'creates energy tariff' do
-      expect(energy_tariff.tariff_holder).to eq school_group
-      expect(energy_tariff.start_date).to eq start_date
-      expect(energy_tariff.end_date).to eq end_date
-      expect(energy_tariff.name).to eq tariff_name
-      expect(energy_tariff.meter_type).to eq "electricity"
-      expect(energy_tariff.tariff_type).to eq "flat_rate"
-      expect(energy_tariff.source).to eq "manually_entered"
-    end
-
-    it 'creates energy tariff price' do
-      expect(prices.first.start_time.to_s(:time)).to eq '00:00'
-      expect(prices.first.end_time.to_s(:time)).to eq '23:30'
-      expect(prices.first.value).to eq 0.03
-      expect(prices.first.units).to eq "kwh"
-    end
-
-    it 'creates energy tariff charges' do
-      expect(charges.any?).to eq true
-      expect(charges.first.charge_type).to eq 'standing_charge'
-      expect(charges.first.value).to eq 0.6
-      expect(charges.first.units).to eq 'day'
-    end
+    it_behaves_like 'a migrated flat rate accounting tariff'
   end
 
   context '#migrate_school_economic_tariffs' do
-    let(:sytem_wide)    { false }
+    let(:system_wide)    { false }
     let(:default)       { false }
-    let(:subject)  { create(:school) }
+    let(:tariff_holder)  { create(:school) }
 
     let!(:school_attribute) {
-      subject.meter_attributes.create(
-        school: subject,
+      tariff_holder.meter_attributes.create(
         attribute_type: "economic_tariff_change_over_time",
         input_data: input_data,
         meter_types: ["", "electricity", "aggregated_electricity"]
       )
     }
     let(:energy_tariff)       { EnergyTariff.first }
-    let(:price)               { energy_tariff.energy_tariff_prices.first }
 
     before(:each) do
       Database::EnergyTariffMigrationService.migrate_school_economic_tariffs
@@ -367,4 +378,60 @@ describe Database::EnergyTariffMigrationService do
     end
   end
 
+  context '#migrate meter accounting tariffs' do
+    let(:sytem_wide)      { false }
+    let(:default)         { false }
+    let(:attribute_type)  { "accounting_tariff" }
+    let(:school)          { create(:school) }
+    let!(:meter)          { create(:electricity_meter, school: school) }
+    let!(:gas_meter)      { create(:gas_meter, school: school) }
+
+    let(:tariff_holder)       { school }
+
+    let!(:meter_attribute) {
+      meter.meter_attributes.create(
+        attribute_type: attribute_type,
+        input_data: input_data
+      )
+    }
+    let(:energy_tariff)        { EnergyTariff.first }
+
+    before(:each) do
+      Database::EnergyTariffMigrationService.migrate_meter_accounting_tariffs
+    end
+
+    it_behaves_like 'a migrated flat rate accounting tariff'
+
+    it 'associates tariff with meter' do
+      expect(energy_tariff.meters.first).to eq meter
+    end
+
+    context 'with differential tariff' do
+      let(:attribute_type) { "accounting_tariff_differential" }
+      it_behaves_like 'a migrated differential accounting tariff'
+
+      let(:rates) {
+        {
+          daytime_rate: {
+            from: { hour: '0', minutes: '0' },
+            to: { hour: '7', minutes: '0' },
+            per: :kwh,
+            rate: rate * 2
+          },
+          nighttime_rate: {
+            from: { hour: '7', minutes: '0' },
+            to: { hour: '24', minutes: '0' },
+            per: :kwh,
+            rate: rate
+          },
+          standing_charge: {
+            per: :day,
+            rate: standing_charge
+          }
+        }
+      }
+
+      it_behaves_like "a migrated differential accounting tariff"
+    end
+  end
 end

--- a/spec/services/database/energy_tariff_migration_service_spec.rb
+++ b/spec/services/database/energy_tariff_migration_service_spec.rb
@@ -1,5 +1,62 @@
 require 'rails_helper'
 
+RSpec.shared_examples 'an energy tariff' do
+  it 'with right default attributes' do
+    expect(energy_tariff.start_date).to eq start_date
+    expect(energy_tariff.end_date).to eq end_date
+    expect(energy_tariff.name).to eq tariff_name
+    expect(energy_tariff.meter_type).to eq "electricity"
+    expect(energy_tariff.source).to eq "manually_entered"
+    expect(energy_tariff.tariff_holder).to eq subject
+  end
+end
+
+RSpec.shared_examples "a migrated flat rate economic tariff" do
+  it_behaves_like 'an energy tariff'
+
+  it 'creates a flat rate energy tariff' do
+    expect(energy_tariff.tariff_type).to eq "flat_rate"
+  end
+
+  it 'creates energy tariff price' do
+    expect(price.start_time.to_s(:time)).to eq '00:00'
+    expect(price.end_time.to_s(:time)).to eq '23:30'
+    expect(price.value).to eq 0.03
+    expect(price.units).to eq "kwh"
+  end
+
+  it 'creates no energy tariff charges' do
+    expect(energy_tariff.energy_tariff_charges.any?).to eq false
+  end
+end
+
+RSpec.shared_examples "a migrated differential economic tariff" do
+  it_behaves_like 'an energy tariff'
+
+  it 'the created energy tariff is differential' do
+    expect(energy_tariff.tariff_type).to eq "differential"
+  end
+
+  it 'creates energy tariff prices' do
+    expect(energy_tariff.energy_tariff_prices.count).to eq 2
+
+    daytime, nighttime = energy_tariff.energy_tariff_prices.order(start_time: :asc).to_a
+    expect(daytime.start_time.to_s(:time)).to eq '00:00'
+    expect(daytime.end_time.to_s(:time)).to eq '06:30'
+    expect(daytime.value).to eq rate * 2
+    expect(daytime.units).to eq "kwh"
+
+    expect(nighttime.start_time.to_s(:time)).to eq '07:00'
+    expect(nighttime.end_time.to_s(:time)).to eq '23:30'
+    expect(nighttime.value).to eq rate
+    expect(nighttime.units).to eq "kwh"
+  end
+
+  it 'creates no energy tariff charges' do
+    expect(energy_tariff.energy_tariff_charges.any?).to eq false
+  end
+end
+
 describe Database::EnergyTariffMigrationService do
 
   let(:start_date)      { Date.new(2000,1,1) }
@@ -38,9 +95,9 @@ describe Database::EnergyTariffMigrationService do
     let!(:user_tariff)  do
       UserTariff.create(
         school: create(:school),
-        start_date: '2021-04-01',
-        end_date: '2022-03-31',
-        name: 'My First Tariff',
+        start_date: start_date,
+        end_date: end_date,
+        name: tariff_name,
         fuel_type: :electricity,
         flat_rate: true,
         vat_rate: '20%',
@@ -61,14 +118,12 @@ describe Database::EnergyTariffMigrationService do
       let(:energy_tariff)       { EnergyTariff.first }
       let(:charge)              { energy_tariff.energy_tariff_charges.first }
       let(:price)               { energy_tariff.energy_tariff_prices.first }
-      it 'creates energy tariff' do
-        expect(energy_tariff.tariff_holder).to eq user_tariff.school
-        expect(energy_tariff.start_date).to eq user_tariff.start_date
-        expect(energy_tariff.end_date).to eq user_tariff.end_date
-        expect(energy_tariff.name).to eq user_tariff.name
-        expect(energy_tariff.meter_type).to eq user_tariff.fuel_type
+      let(:subject)             { user_tariff.school }
+
+      it_behaves_like "an energy tariff"
+
+      it 'creates a flat rate energy tariff' do
         expect(energy_tariff.tariff_type).to eq "flat_rate"
-        expect(energy_tariff.source).to eq "manually_entered"
       end
       it 'creates energy tariff price' do
         expect(price.start_time).to eq user_tariff_price.start_time
@@ -85,12 +140,12 @@ describe Database::EnergyTariffMigrationService do
   end
 
   context '#migrate_global_meter_attributes' do
-    let!(:settings)           { SiteSettings.create! }
+    let!(:subject)           { SiteSettings.create! }
 
     let!(:global_meter_attribute) {
       GlobalMeterAttribute.create(
         attribute_type: 'accounting_tariff',
-        meter_types: ["", "gas", "aggregated_gas"],
+        meter_types: ["", "electricity", "aggregated_electricity"],
         input_data: input_data
       )
     }
@@ -104,15 +159,12 @@ describe Database::EnergyTariffMigrationService do
         Database::EnergyTariffMigrationService.migrate_global_meter_attributes
       end
 
-      it 'creates energy tariff' do
-        expect(energy_tariff.tariff_holder).to eq SiteSettings.current
-        expect(energy_tariff.start_date).to eq start_date
-        expect(energy_tariff.end_date).to eq end_date
-        expect(energy_tariff.name).to eq tariff_name
-        expect(energy_tariff.meter_type).to eq "gas"
+      it_behaves_like "an energy tariff"
+
+      it 'creates flat rate energy tariff' do
         expect(energy_tariff.tariff_type).to eq "flat_rate"
-        expect(energy_tariff.source).to eq "manually_entered"
       end
+
       it 'creates energy tariff price' do
         expect(price.start_time.to_s(:time)).to eq '00:00'
         expect(price.end_time.to_s(:time)).to eq '23:30'
@@ -131,11 +183,11 @@ describe Database::EnergyTariffMigrationService do
 
   context '#migrate_school_group_economic_tariffs' do
     let(:sytem_wide)    { false }
-    let(:school_group)  { create(:school_group) }
+    let(:subject)  { create(:school_group) }
 
     let!(:school_group_attribute) {
-      school_group.meter_attributes.create(
-        school_group: school_group,
+      subject.meter_attributes.create(
+        school_group: subject,
         attribute_type: "economic_tariff_change_over_time",
         input_data: input_data,
         meter_types: ["", "electricity", "aggregated_electricity"]
@@ -146,29 +198,11 @@ describe Database::EnergyTariffMigrationService do
     let(:price)               { energy_tariff.energy_tariff_prices.first }
 
     before(:each) do
-      Database::EnergyTariffMigrationService.migrate_school_group_economic_tariffs(school_group)
+      Database::EnergyTariffMigrationService.migrate_school_group_economic_tariffs(subject)
     end
 
     context 'with only flat rate tariff' do
-        it 'creates energy tariff' do
-          expect(energy_tariff.tariff_holder).to eq school_group
-          expect(energy_tariff.start_date).to eq start_date
-          expect(energy_tariff.end_date).to eq end_date
-          expect(energy_tariff.name).to eq tariff_name
-          expect(energy_tariff.meter_type).to eq "electricity"
-          expect(energy_tariff.tariff_type).to eq "flat_rate"
-          expect(energy_tariff.source).to eq "manually_entered"
-        end
-        it 'creates energy tariff price' do
-          expect(price.start_time.to_s(:time)).to eq '00:00'
-          expect(price.end_time.to_s(:time)).to eq '23:30'
-          expect(price.value).to eq 0.03
-          expect(price.units).to eq "kwh"
-        end
-
-        it 'creates no energy tariff charges' do
-          expect(energy_tariff.energy_tariff_charges.any?).to eq false
-        end
+      it_behaves_like "a migrated flat rate economic tariff"
     end
 
     context 'with differential tariff' do
@@ -189,35 +223,7 @@ describe Database::EnergyTariffMigrationService do
         }
       }
 
-      it 'creates energy tariff' do
-        expect(energy_tariff.tariff_holder).to eq school_group
-        expect(energy_tariff.start_date).to eq start_date
-        expect(energy_tariff.end_date).to eq end_date
-        expect(energy_tariff.name).to eq tariff_name
-        expect(energy_tariff.meter_type).to eq "electricity"
-        expect(energy_tariff.tariff_type).to eq "differential"
-        expect(energy_tariff.source).to eq "manually_entered"
-      end
-
-      it 'creates energy tariff prices' do
-        expect(energy_tariff.energy_tariff_prices.count).to eq 2
-
-        daytime, nighttime = energy_tariff.energy_tariff_prices.order(start_time: :asc).to_a
-        expect(daytime.start_time.to_s(:time)).to eq '00:00'
-        expect(daytime.end_time.to_s(:time)).to eq '06:30'
-        expect(daytime.value).to eq rate * 2
-        expect(daytime.units).to eq "kwh"
-
-        expect(nighttime.start_time.to_s(:time)).to eq '07:00'
-        expect(nighttime.end_time.to_s(:time)).to eq '23:30'
-        expect(nighttime.value).to eq rate
-        expect(nighttime.units).to eq "kwh"
-      end
-
-      it 'creates no energy tariff charges' do
-        expect(energy_tariff.energy_tariff_charges.any?).to eq false
-      end
-
+      it_behaves_like "a migrated differential economic tariff"
     end
 
     context 'with attribute that both flat and differential rates' do
@@ -225,7 +231,7 @@ describe Database::EnergyTariffMigrationService do
         {
           rate: {
             per: :kwh,
-            rate: rate
+            rate: 0
           },
           daytime_rate: {
             from: { hour: '0', minutes: '0' },
@@ -237,13 +243,11 @@ describe Database::EnergyTariffMigrationService do
             from: { hour: '7', minutes: '0' },
             to: { hour: '24', minutes: '0' },
             per: :kwh,
-            rate: rate * 2
+            rate: rate
           }
         }
       }
-      it 'still creates only a differential rate tariff' do
-        expect(energy_tariff.tariff_type).to eq "differential"
-      end
+      it_behaves_like "a migrated differential economic tariff"
     end
 
   end
@@ -296,14 +300,14 @@ describe Database::EnergyTariffMigrationService do
   context '#migrate_school_economic_tariffs' do
     let(:sytem_wide)    { false }
     let(:default)       { false }
-    let(:school)  { create(:school) }
+    let(:subject)  { create(:school) }
 
     let!(:school_attribute) {
-      school.meter_attributes.create(
-        school: school,
+      subject.meter_attributes.create(
+        school: subject,
         attribute_type: "economic_tariff_change_over_time",
         input_data: input_data,
-        meter_types: ["", "gas", "aggregated_gas"]
+        meter_types: ["", "electricity", "aggregated_electricity"]
       )
     }
     let(:energy_tariff)       { EnergyTariff.first }
@@ -314,25 +318,7 @@ describe Database::EnergyTariffMigrationService do
     end
 
     context 'with only flat rate tariff' do
-        it 'creates energy tariff' do
-          expect(energy_tariff.tariff_holder).to eq school
-          expect(energy_tariff.start_date).to eq start_date
-          expect(energy_tariff.end_date).to eq end_date
-          expect(energy_tariff.name).to eq tariff_name
-          expect(energy_tariff.meter_type).to eq "gas"
-          expect(energy_tariff.tariff_type).to eq "flat_rate"
-          expect(energy_tariff.source).to eq "manually_entered"
-        end
-        it 'creates energy tariff price' do
-          expect(price.start_time.to_s(:time)).to eq '00:00'
-          expect(price.end_time.to_s(:time)).to eq '23:30'
-          expect(price.value).to eq 0.03
-          expect(price.units).to eq "kwh"
-        end
-
-        it 'creates no energy tariff charges' do
-          expect(energy_tariff.energy_tariff_charges.any?).to eq false
-        end
+      it_behaves_like "a migrated flat rate economic tariff"
     end
 
     context 'with differential tariff' do
@@ -353,35 +339,7 @@ describe Database::EnergyTariffMigrationService do
         }
       }
 
-      it 'creates energy tariff' do
-        expect(energy_tariff.tariff_holder).to eq school
-        expect(energy_tariff.start_date).to eq start_date
-        expect(energy_tariff.end_date).to eq end_date
-        expect(energy_tariff.name).to eq tariff_name
-        expect(energy_tariff.meter_type).to eq "gas"
-        expect(energy_tariff.tariff_type).to eq "differential"
-        expect(energy_tariff.source).to eq "manually_entered"
-      end
-
-      it 'creates energy tariff prices' do
-        expect(energy_tariff.energy_tariff_prices.count).to eq 2
-
-        daytime, nighttime = energy_tariff.energy_tariff_prices.order(start_time: :asc).to_a
-        expect(daytime.start_time.to_s(:time)).to eq '00:00'
-        expect(daytime.end_time.to_s(:time)).to eq '06:30'
-        expect(daytime.value).to eq rate * 2
-        expect(daytime.units).to eq "kwh"
-
-        expect(nighttime.start_time.to_s(:time)).to eq '07:00'
-        expect(nighttime.end_time.to_s(:time)).to eq '23:30'
-        expect(nighttime.value).to eq rate
-        expect(nighttime.units).to eq "kwh"
-      end
-
-      it 'creates no energy tariff charges' do
-        expect(energy_tariff.energy_tariff_charges.any?).to eq false
-      end
-
+      it_behaves_like "a migrated differential economic tariff"
     end
 
     context 'with attribute that both flat and differential rates' do
@@ -389,7 +347,7 @@ describe Database::EnergyTariffMigrationService do
         {
           rate: {
             per: :kwh,
-            rate: rate
+            rate: 0
           },
           daytime_rate: {
             from: { hour: '0', minutes: '0' },
@@ -401,13 +359,11 @@ describe Database::EnergyTariffMigrationService do
             from: { hour: '7', minutes: '0' },
             to: { hour: '24', minutes: '0' },
             per: :kwh,
-            rate: rate * 2
+            rate: rate
           }
         }
       }
-      it 'still creates only a differential rate tariff' do
-        expect(energy_tariff.tariff_type).to eq "differential"
-      end
+      it_behaves_like "a migrated differential economic tariff"
     end
   end
 


### PR DESCRIPTION
Updates the Energy Tariff migration code to finalise the basic migration code for the following:

- [x] School time varying economic tariffs
- [x] Meter specific accounting tariffs (flat & differential)
- [x] TariffPrices and TariffStandingCharges populated from n3rgy
- [x] Global solar default economic tariffs
- [x] DRY up the migration service spec to use shared examples
- [x] add some extra specs for utility methods

In a follow-up PR I'll add:

- some code for running the set of migrations
- some code for doing some precondition checks to confirm that basic assumptions are correct prior to doing a migration

