### PR TITLE
Remove meter id check in unvalidated meter report spec

### DIFF
--- a/spec/system/admin/reports/unvalidated_readings_spec.rb
+++ b/spec/system/admin/reports/unvalidated_readings_spec.rb
@@ -21,7 +21,6 @@ describe "unvalidated readings", type: :system do
 
     it "displays report" do
       expect(page).to have_content reading.mpan_mprn
-      expect(page).to have_content reading.meter.id
       expect(page).to have_content config.identifier
       expect(page).to have_content config.description
       expect(page).to have_content '2023-06-23'


### PR DESCRIPTION
The spec is checking for the meter id to be present, although that's no longer included on the page.

I think this is sometimes passing when the meter id matches another value on the page. But this is seems to be regularly failing in builds:

https://github.com/Energy-Sparks/energy-sparks/actions/runs/5726381033/job/15516710682