### PR TITLE
Fix tariff type migration issue

### DIFF
--- a/app/services/database/energy_tariff_migration_service.rb
+++ b/app/services/database/energy_tariff_migration_service.rb
@@ -42,6 +42,21 @@ module Database
       end
     end
 
+    #Doesn't include user tariffs as that is being migrated via an
+    #after party task
+    def self.migrate_all
+      migrate_all_meter_attributes
+      migrate_tariff_prices
+    end
+
+    def self.migrate_all_meter_attributes
+      migrate_global_meter_attributes
+      migrate_global_solar_meter_attributes
+      migrate_school_group_meter_attributes
+      migrate_school_economic_tariffs
+      migrate_meter_accounting_tariffs
+    end
+
     #Turns the Global Meter Attributes that are accounting tariffs into
     #EnergyTariffs.
     def self.migrate_global_meter_attributes
@@ -384,7 +399,7 @@ module Database
 
     #Determine tariff type from accounting tariff / accounting tariff differential attribute
     def self.tariff_type(attribute)
-      if attribute.input_data['rates']['daytime_rate'].present?
+      if attribute.input_data['rates']['daytime_rate'].present? && attribute.input_data['rates']['daytime_rate']['rate'].present?
         :differential
       else
         :flat_rate


### PR DESCRIPTION
Fixes an issue with migration meter attributes to EnergyTariffs.

The tariff type wasn't being correctly converted, so added a check for the actual `daytime_rate` (to check for differential tariffs) rather than just presence of the key.

The PR also adds a couple of methods to the migration service to run all the migrations, except for the user tariffs which will already have been run.