### PR TITLE
Add tariff holder and creation date to tariff meter attribute

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ gem 'pg_search'
 gem 'calculate_in_group'
 
 # Dashboard analytics
-gem 'energy-sparks_analytics', git: 'https://github.com/Energy-Sparks/energy-sparks_analytics.git', tag: '2.9.0'
+gem 'energy-sparks_analytics', git: 'https://github.com/Energy-Sparks/energy-sparks_analytics.git', tag: '2.9.1'
 #gem 'energy-sparks_analytics', git: 'https://github.com/Energy-Sparks/energy-sparks_analytics.git', branch: 'aws-eb-test'
 #gem 'energy-sparks_analytics', path: '../energy-sparks_analytics'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/Energy-Sparks/energy-sparks_analytics.git
-  revision: 1cc809ede30a885665f0d4e85c4b02f7e401333e
-  tag: 2.9.0
+  revision: 4950b97f178f513826dc55db7a18e8acc496f361
+  tag: 2.9.1
   specs:
     energy-sparks_analytics (1.2.1)
       activesupport (>= 6.0, < 7.1)

--- a/app/models/energy_tariff.rb
+++ b/app/models/energy_tariff.rb
@@ -77,7 +77,9 @@ class EnergyTariff < ApplicationRecord
       rates: rates,
       vat: vat_rate.nil? ? nil : "#{vat_rate}%",
       climate_change_levy: ccl,
-      asc_limit_kw: (value_for_charge(:asc_limit_kw) if rates_has_availability_charge?(rates))
+      asc_limit_kw: (value_for_charge(:asc_limit_kw) if rates_has_availability_charge?(rates)),
+      tariff_holder: tariff_holder_symbol,
+      created_at: created_at.to_datetime
     }.compact
   end
 
@@ -88,6 +90,10 @@ class EnergyTariff < ApplicationRecord
   end
 
   private
+
+  def tariff_holder_symbol
+    meters.any? ? :meter : tariff_holder_type.underscore.to_sym
+  end
 
   def rates_attrs
     attrs = {}

--- a/app/views/shared/meter_attributes/_date_time.html.erb
+++ b/app/views/shared/meter_attributes/_date_time.html.erb
@@ -1,0 +1,1 @@
+<%= form.input field_name, as: :tempus_dominus_date, default_date: value.blank? ? '' : Date.parse(value), required: field.required?, label: label.try(:to_s).try(:humanize), hint: field.hint, input_html: {required: field.required?, data: { allow_input_toggle: false }} %>

--- a/spec/models/energy_tariff_spec.rb
+++ b/spec/models/energy_tariff_spec.rb
@@ -109,6 +109,8 @@ describe EnergyTariff do
       expect(meter_attribute[:accounting_tariff_generic][0][:source]).to eq(:manually_entered)
       expect(meter_attribute[:accounting_tariff_generic][0][:type]).to eq(:flat)
       expect(meter_attribute[:accounting_tariff_generic][0][:vat]).to eq(:"5%")
+      expect(meter_attribute[:accounting_tariff_generic][0][:tariff_holder]).to eq :school
+      expect(meter_attribute[:accounting_tariff_generic][0][:created_at].iso8601).to eq energy_tariff.created_at.to_datetime.iso8601
     end
   end
 

--- a/spec/models/energy_tariff_spec.rb
+++ b/spec/models/energy_tariff_spec.rb
@@ -2,15 +2,17 @@ require 'rails_helper'
 
 describe EnergyTariff do
 
+  let(:tariff_holder)         { create(:school) }
   let(:tariff_type)           { :flat_rate }
   let(:vat_rate)              { 5 }
 
   let(:energy_tariff_prices)  { [] }
   let(:energy_tariff_charges) { [] }
+  let(:meters)                { [] }
 
   let(:energy_tariff)  do
     EnergyTariff.create(
-      tariff_holder: create(:school),
+      tariff_holder: tariff_holder,
       start_date: '2021-04-01',
       end_date: '2022-03-31',
       name: 'My First Tariff',
@@ -18,7 +20,8 @@ describe EnergyTariff do
       tariff_type: tariff_type,
       vat_rate: vat_rate,
       energy_tariff_prices: energy_tariff_prices,
-      energy_tariff_charges: energy_tariff_charges
+      energy_tariff_charges: energy_tariff_charges,
+      meters: meters
       )
   end
 
@@ -124,6 +127,27 @@ describe EnergyTariff do
       expect(attributes[:source]).to eq(:manually_entered)
       expect(attributes[:sub_type]).to eq('')
       expect(attributes[:vat]).to eq('5%')
+      expect(attributes[:created_at].iso8601).to eq energy_tariff.created_at.to_datetime.iso8601
+    end
+
+    context 'when adding tariff holder' do
+      context 'with school' do
+        it "should identify tariff holder" do
+          expect(attributes[:tariff_holder]).to eq :school
+        end
+      end
+      context 'when attached to a meter' do
+        let(:meters)  { [create(:electricity_meter)] }
+        it "should identify tariff holder as a meter" do
+          expect(attributes[:tariff_holder]).to eq :meter
+        end
+      end
+      context 'with school_group' do
+        let(:tariff_holder) { create(:school_group) }
+        it "should identify tariff holder" do
+          expect(attributes[:tariff_holder]).to eq :school_group
+        end
+      end
     end
 
     it "should include ccl" do


### PR DESCRIPTION
Updates the EnergyTariff model so that when it serialises as a meter attribute it identifies the type of tariff holder and the date that the tariff was created.

Requires updates to analytics from this PR: https://github.com/Energy-Sparks/energy-sparks_analytics/pull/580. Until then tests will fail.