### PR TITLE
Tidy up wording on SiteSettings version of Tariff editor

### DIFF
--- a/app/helpers/energy_tariffs_helper.rb
+++ b/app/helpers/energy_tariffs_helper.rb
@@ -33,12 +33,20 @@ module EnergyTariffsHelper
     start_date = energy_tariff&.start_date&.to_s(:es_compact)
     end_date = energy_tariff&.end_date&.to_s(:es_compact)
 
-    title = I18n.t(
-      'schools.tariffs_helper.user_tariff_title',
-      start_date: start_date,
-      end_date: end_date
-    )
-    title += " : #{energy_tariff&.name} " if energy_tariff&.name&.present?
+    title = ''
+
+    if start_date && end_date
+      title += I18n.t(
+        'schools.tariffs_helper.user_tariff_title',
+        start_date: start_date,
+        end_date: end_date
+      )
+      title += ' : '
+    elsif start_date || end_date
+      title = start_date.to_s + end_date.to_s + ' : '
+    end
+
+    title += "#{energy_tariff&.name} " if energy_tariff&.name&.present?
 
     if energy_tariff.meters.any? && with_mpxn
       if energy_tariff.gas?

--- a/app/views/energy_tariffs/energy_tariff_charges/index.html.erb
+++ b/app/views/energy_tariffs/energy_tariff_charges/index.html.erb
@@ -2,7 +2,13 @@
 
 <div class="energy_tariff">
 
-  <p><%= t('schools.user_tariff_charges.index.using_your_bill_introduction') %>.</p>
+  <p>
+    <%= case @energy_tariff.tariff_holder_type
+        when 'School' then t('schools.user_tariff_charges.index.introduction')
+        when 'SiteSettings' then t('schools.user_tariff_charges.index.introduction_site_settings')
+        end
+    %>.
+  </p>
   <br/>
 
   <%= render 'energy_tariffs/energy_tariffs/header', energy_tariff: @energy_tariff %>

--- a/app/views/energy_tariffs/energy_tariff_differential_prices/index.html.erb
+++ b/app/views/energy_tariffs/energy_tariff_differential_prices/index.html.erb
@@ -2,7 +2,13 @@
 
 <div class="energy_tariff">
 
-  <p><%= t('schools.user_tariff_differential_prices.index.using_your_bill_introduction') %>.</p>
+  <p>
+    <%= case @energy_tariff.tariff_holder_type
+        when 'School' then t('schools.user_tariff_differential_prices.index.introduction')
+        when 'SiteSettings' then t('schools.user_tariff_differential_prices.index.introduction_site_settings')
+        end
+    %>.
+  </p>
   <br/>
 
   <%= render 'energy_tariffs/energy_tariffs/header', energy_tariff: @energy_tariff %>

--- a/app/views/energy_tariffs/energy_tariff_flat_prices/edit.html.erb
+++ b/app/views/energy_tariffs/energy_tariff_flat_prices/edit.html.erb
@@ -2,7 +2,13 @@
 
 <div class="energy_tariff">
 
-  <p><%= t('schools.user_tariff_flat_prices.edit.introduction') %>.</p>
+  <p>
+    <%= case @energy_tariff.tariff_holder_type
+        when 'School' then t('schools.user_tariff_flat_prices.edit.introduction')
+        when 'SiteSettings' then t('schools.user_tariff_flat_prices.edit.introduction_site_settings')
+        end
+    %>.
+  </p>
   <br/>
 
   <%= render 'energy_tariffs/energy_tariffs/header', energy_tariff: @energy_tariff %>

--- a/app/views/energy_tariffs/energy_tariff_flat_prices/new.html.erb
+++ b/app/views/energy_tariffs/energy_tariff_flat_prices/new.html.erb
@@ -2,13 +2,17 @@
 
 <div class="energy_tariff">
 
-  <p><%= t('schools.user_tariff_flat_prices.new.introduction') %>.</p>
+  <p>
+    <%= case @energy_tariff.tariff_holder_type
+        when 'School' then t('schools.user_tariff_flat_prices.new.introduction')
+        when 'SiteSettings' then t('schools.user_tariff_flat_prices.new.introduction_site_settings')
+        end
+    %>.
+  </p>
   <br/>
 
   <%= render 'energy_tariffs/energy_tariffs/header', energy_tariff: @energy_tariff %>
-
   <br/>
-
   <%
     form_url = case @energy_tariff.tariff_holder_type
                when 'School' then school_energy_tariff_energy_tariff_flat_prices_path(@school, @energy_tariff)

--- a/app/views/energy_tariffs/energy_tariffs/_energy_tariffs_summary_table.html.erb
+++ b/app/views/energy_tariffs/energy_tariffs/_energy_tariffs_summary_table.html.erb
@@ -27,8 +27,8 @@
         <td>
           <%= energy_tariff.tariff_type == 'flat_rate' ? t('schools.user_tariffs.tariff_partial.simple_tariff') : t('schools.user_tariffs.tariff_partial.day_night_tariff') %>
         </td>
-        <td><%= energy_tariff.start_date&.to_s(:es_compact) %></td>
-        <td><%= energy_tariff.end_date&.to_s(:es_compact) %></td>
+        <td><%= energy_tariff.start_date ? energy_tariff.start_date&.to_s(:es_compact) : t('schools.user_tariffs.summary_table.no_start_date') %></td>
+        <td><%= energy_tariff.end_date ? energy_tariff.end_date&.to_s(:es_compact) : t('schools.user_tariffs.summary_table.no_end_date') %></td>
         <td>
           <% if energy_tariff.tariff_holder_type == 'School' %>
             <%= link_to t('schools.user_tariffs.tariff_partial.full_details'), school_energy_tariff_path(school, energy_tariff), class: 'btn' if can? :download, UserTariff  %>

--- a/app/views/energy_tariffs/energy_tariffs/_header.html.erb
+++ b/app/views/energy_tariffs/energy_tariffs/_header.html.erb
@@ -1,4 +1,7 @@
 <%= render 'energy_tariffs/energy_tariffs/title', energy_tariff: energy_tariff %>
-<%= render 'energy_tariffs/energy_tariffs/meters', energy_tariff: energy_tariff %>
-
+<% if energy_tariff.tariff_holder_type == 'SiteSettings' %>
+  <%= t('schools.user_tariffs.meters.this_tariff_applies_to_all_meters', meter_type: t("common.#{@energy_tariff.meter_type}")) %>
+<% else %>
+  <%= render 'energy_tariffs/energy_tariffs/meters', energy_tariff: energy_tariff %>
+<% end %>
 <br/>

--- a/app/views/energy_tariffs/energy_tariffs/_meters.html.erb
+++ b/app/views/energy_tariffs/energy_tariffs/_meters.html.erb
@@ -1,3 +1,6 @@
+<p><%= t('schools.user_tariffs.there_should_only_be_one_tariff_message') %>.</p>
+<br/>
+
 <% if energy_tariff.meters.present? %>
   <div class="row">
     <div class="col-md-3">

--- a/app/views/energy_tariffs/energy_tariffs/_meters.html.erb
+++ b/app/views/energy_tariffs/energy_tariffs/_meters.html.erb
@@ -1,4 +1,10 @@
-<p><%= t('schools.user_tariffs.there_should_only_be_one_tariff_message') %>.</p>
+<p>
+  <%= case energy_tariff.tariff_holder_type
+      when 'School' then t('schools.user_tariffs.there_should_only_be_one_tariff_message')
+      when 'SiteSettings' then t('schools.user_tariffs.there_should_only_be_one_tariff_message_site_settings')
+      end
+  %>.
+</p>
 <br/>
 
 <% if energy_tariff.meters.present? %>

--- a/app/views/energy_tariffs/energy_tariffs/edit.html.erb
+++ b/app/views/energy_tariffs/energy_tariffs/edit.html.erb
@@ -2,7 +2,13 @@
 
 <div class="energy_tariff">
 
-  <p><%= t('schools.user_tariffs.there_should_only_be_one_tariff_message') %>.</p>
+  <p>
+    <%= case @energy_tariff.tariff_holder_type
+        when 'School' then t('schools.user_tariffs.there_should_only_be_one_tariff_message')
+        when 'SiteSettings' then t('schools.user_tariffs.there_should_only_be_one_tariff_message_site_settings')
+        end
+    %>.
+  </p>
   <br/>
 
   <%= render 'energy_tariffs/energy_tariffs/header', energy_tariff: @energy_tariff %>

--- a/app/views/energy_tariffs/energy_tariffs/new.html.erb
+++ b/app/views/energy_tariffs/energy_tariffs/new.html.erb
@@ -1,10 +1,6 @@
-<h1><%= t('schools.user_tariffs.new.title', fuel_type: @energy_tariff.meter_type) %></h1>
+<h1><%= t('schools.user_tariffs.new.title', fuel_type: t("common.#{@energy_tariff.meter_type}")) %></h1>
 
 <div class="energy_tariff">
-
-  <p><%= t('schools.user_tariffs.there_should_only_be_one_tariff_message') %>.</p>
-  <br/>
-
   <%= render 'energy_tariffs/energy_tariffs/meters', energy_tariff: @energy_tariff if @energy_tariff.tariff_holder_type == 'School' %>
   <br/>
 

--- a/app/views/schools/user_tariff_charges/index.html.erb
+++ b/app/views/schools/user_tariff_charges/index.html.erb
@@ -2,7 +2,8 @@
 
 <div class="user_tariff">
 
-  <p><%= t('schools.user_tariff_charges.index.using_your_bill_introduction') %>.</p>
+  <p>
+    <%= t('schools.user_tariff_charges.index.introduction') %>.</p>
   <br/>
 
   <%= render 'schools/user_tariffs/header', user_tariff: @user_tariff %>

--- a/app/views/schools/user_tariff_differential_prices/index.html.erb
+++ b/app/views/schools/user_tariff_differential_prices/index.html.erb
@@ -2,7 +2,7 @@
 
 <div class="user_tariff">
 
-  <p><%= t('schools.user_tariff_differential_prices.index.using_your_bill_introduction') %>.</p>
+  <p><%= t('schools.user_tariff_differential_prices.index.introduction') %>.</p>
   <br/>
 
   <%= render 'schools/user_tariffs/header', user_tariff: @user_tariff %>

--- a/config/locales/common.yml
+++ b/config/locales/common.yml
@@ -10,6 +10,7 @@ en:
     electricity: Electricity
     electricity_and_solar_pv: Electricity and Solar PV
     email_us: email us
+    exported_solar_pv: Exported Solar PV
     gas: Gas
     labels:
       actions: Actions

--- a/config/locales/cy/views/schools/user_tariffs.yml
+++ b/config/locales/cy/views/schools/user_tariffs.yml
@@ -24,7 +24,7 @@ cy:
         other_charges: Costau eraill
       index:
         title: Ychwanegu taliadau sefydlog ar gyfer y tariff hwn
-        using_your_bill_introduction: Gan ddefnyddio'ch bil, rhowch gymaint o fanylion ag y gallwch am y taliadau sefydlog sy'n gysylltiedig â'r tariff hwn
+        introduction: Gan ddefnyddio'ch bil, rhowch gymaint o fanylion ag y gallwch am y taliadau sefydlog sy'n gysylltiedig â'r tariff hwn
     user_tariff_differential_prices:
       form:
         labels:
@@ -34,7 +34,7 @@ cy:
       index:
         consumption_charges: Costau defnydd
         title: Ychwanegu costau defnydd ar gyfer pob cyfnod amser ar gyfer y tariff hwn
-        using_your_bill_introduction: Gan ddefnyddio'ch bil, rhowch gymaint o fanylion ag y gallwch am y costau defnydd sy'n gysylltiedig â'r tariff hwn
+        introduction: Gan ddefnyddio'ch bil, rhowch gymaint o fanylion ag y gallwch am y costau defnydd sy'n gysylltiedig â'r tariff hwn
     user_tariff_flat_prices:
       edit:
         introduction: Gan ddefnyddio'ch bil, rhowch gymaint o fanylion ag y gallwch am y costau defnydd sy'n gysylltiedig â'r tariff hwn

--- a/config/locales/views/schools/user_tariffs.yml
+++ b/config/locales/views/schools/user_tariffs.yml
@@ -24,8 +24,9 @@ en:
         consumption_and_supply_charges: Consumption and supply charges
         other_charges: Other charges
       index:
+        introduction: Using your bill, please provide as much detail as you can about the standing charges associated with this tariff
+        introduction_site_settings: Please provide as much detail as you can about the standing charges associated with this tariff
         title: Add standing charges for this tariff
-        using_your_bill_introduction: Using your bill, please provide as much detail as you can about the standing charges associated with this tariff
     user_tariff_differential_prices:
       form:
         labels:
@@ -34,17 +35,20 @@ en:
           value: Rate in £/kWh
       index:
         consumption_charges: Consumption charges
+        introduction: Using your bill, please provide as much detail as you can about the consumption charges associated with this tariff
+        introduction_site_settings: Please provide as much detail as you can about the consumption charges associated with this tariff
         title: Add consumption charges for each time period for this tariff
-        using_your_bill_introduction: Using your bill, please provide as much detail as you can about the consumption charges associated with this tariff
     user_tariff_flat_prices:
       edit:
         introduction: Using your bill, please provide as much detail as you can about the consumption charges associated with this tariff
+        introduction_site_settings: Please provide as much detail as you can about the consumption charges associated with this tariff
         title: Edit the consumption charges for this tariff
       form:
         per_gbp_kwh: per £/kWh
         rate: Rate
       new:
         introduction: Using your bill, please provide as much detail as you can about the consumption charges associated with this tariff
+        introduction_site_settings: Please provide as much detail as you can about the consumption charges associated with this tariff
         title: Add consumption charges for this tariff
     user_tariffs:
       charges_table:
@@ -172,6 +176,7 @@ en:
         start_date: Start date
         type: Type
       there_should_only_be_one_tariff_message: There should only be one tariff for each date period, for each meter
+      there_should_only_be_one_tariff_message_site_settings: There should only be one tariff for each date period
       title_partial:
         heading: Tariff
       view_and_manage_tariffs_html: <a href="%{user_tariffs_path}">View and manage your school tariffs</a>

--- a/config/locales/views/schools/user_tariffs.yml
+++ b/config/locales/views/schools/user_tariffs.yml
@@ -131,6 +131,7 @@ en:
         meter_list: Meters
         meters_associated_with_this_tariff: Meters associated with this tariff
         there_are_no_meters_associated_with_this_tariff: There are no meters associated with this tariff
+        this_tariff_applies_to_all_meters: This tariff applies to all %{meter_type} meters
       name: Name
       new:
         title: Choose a name and date range for this %{fuel_type} tariff

--- a/config/locales/views/schools/user_tariffs.yml
+++ b/config/locales/views/schools/user_tariffs.yml
@@ -159,6 +159,9 @@ en:
           per_day: "%{charge} per day"
         tariff_types:
           differential_tiered: Differential tiered tariff
+      summary_table:
+        no_end_date: No end date
+        no_start_date: No start date
       tariff_partial:
         consumption_charges: Consumption charges
         day_night_tariff: Day/night tariff


### PR DESCRIPTION
This PR tidies up some of the wording on the SiteSettings version of the Energy Tariff editor: 
- [x] “Choose a name and date range for this exported_solar_pv tariff” – uses a symbol name
- [x] “There should only be one tariff for each date period, for each meter.” – no need to say “for each meter” if tariff is not tied to a meter
- [x] “There are no meters associated with this tariff” – wording should instead say something like “This tariff applies to all electricity meters” depending on fuel type
- [x] If there’s no dates then the labelling is wrong: “to : a”
- [x] If there are no dates, then the overview page has nothing in the start/end date columns. Might be better to say something like “No start date”?
- [x] “Using your bill, please provide as much detail as you can about the consumption charges associated with this tariff.” – maybe remove “Using your bill,” for system tariffs