### PR TITLE
Return error if require param is missing

### DIFF
--- a/app/controllers/school_groups_controller.rb
+++ b/app/controllers/school_groups_controller.rb
@@ -28,6 +28,8 @@ class SchoolGroupsController < ApplicationController
     respond_to do |format|
       format.html {}
       format.csv do
+        head :bad_request and return unless params['advice_page_keys']
+
         filename = "#{@school_group.name}-#{I18n.t('school_groups.titles.comparisons')}-#{Time.zone.now.strftime('%Y-%m-%d')}".parameterize + ".csv"
         send_data SchoolGroups::ComparisonsCsvGenerator.new(school_group: @school_group, advice_page_keys: params['advice_page_keys'], include_cluster: include_cluster).export,
         filename: filename

--- a/spec/system/school_groups_spec.rb
+++ b/spec/system/school_groups_spec.rb
@@ -355,7 +355,12 @@ describe 'school groups', :school_groups, type: :system do
             end
           end
 
-          it 'allows a csv download of all priority actions for a school group' do
+          it 'returns 400 for an invalid request' do
+            visit comparisons_school_group_path(school_group, format: :csv)
+            expect(page.status_code).to eq 400
+          end
+
+          it 'allows a csv download of all comparison for a school group' do
             visit comparisons_school_group_path(school_group)
             first(:link, 'Download as CSV', id: 'download-comparisons-school-csv-baseload').click
             header = page.response_headers['Content-Disposition']


### PR DESCRIPTION
We seem to have crawlers or bots hitting the school group comparison page to download CSV, but not adding the parameter for the advice page key. This is adding a bunch of errors to Rollbar.

Update the controller plus add spec to return a 400 error if the parameter isn't replied. This should hopefully discourage them!