### PR TITLE
Admin report for school group tariffs

### DIFF
--- a/app/controllers/admin/reports/energy_tariffs_controller.rb
+++ b/app/controllers/admin/reports/energy_tariffs_controller.rb
@@ -1,0 +1,9 @@
+module Admin
+  module Reports
+    class EnergyTariffsController < AdminController
+      def index
+        @count_by_school_group = EnergyTariff.count_by_school_group
+      end
+    end
+  end
+end

--- a/app/views/admin/index.html.erb
+++ b/app/views/admin/index.html.erb
@@ -39,15 +39,16 @@
 
   </div>
   <div class="col">
-    <h2>Data feeds and meter attributes</h2>
+    <h2>Data, Tariffs, Meter attributes</h2>
     <ul>
-      <li><%= link_to "Global Meter Attributes", admin_global_meter_attributes_path %></li>
       <li><%= link_to "AMR Data feed configuration", admin_amr_data_feed_configs_path %></li>
+      <li><%= link_to "Energy Tariffs", admin_settings_energy_tariffs_path %></li>
       <li><%= link_to "Dark Sky Areas", admin_dark_sky_areas_path %></li>
       <li><%= link_to "Solar PV Areas", admin_solar_pv_tuos_areas_path %></li>
       <li><%= link_to "Weather Stations", admin_weather_stations_path %></li>
       <li><%= link_to "Data Sources", admin_data_sources_path %></li>
       <li><%= link_to "Procurement Routes", admin_procurement_routes_path %></li>
+      <li><%= link_to "Global Meter Attributes", admin_global_meter_attributes_path %></li>
     </ul>
 
     <h2>Alerts and Equivalences</h2>
@@ -65,7 +66,6 @@
       <li><%= link_to "Partners", admin_partners_path %></li>
       <li><%= link_to "Resources", admin_resource_files_path %></li>
       <li><%= link_to "Site Settings", admin_settings_path %></li>
-      <li><%= link_to "Energy Tariffs", admin_settings_energy_tariffs_path %></li>
       <li><%= link_to "Team members", admin_team_members_path %></li>
       <li><%= link_to "Transport Types", admin_transport_types_path %></li>
       <li><%= link_to "Videos", admin_videos_path %></li>

--- a/app/views/admin/reports/energy_tariffs/index.html.erb
+++ b/app/views/admin/reports/energy_tariffs/index.html.erb
@@ -1,0 +1,44 @@
+<% content_for :page_title, 'Energy tariffs report' %>
+
+<h1>Energy tariffs overview</h1>
+
+<p>
+The following table summarises the energy tariffs currently configured in the system.
+</p>
+
+<p>
+ It only counts tariffs that are currently enabled and in-use. As well as a count
+ of how many tariffs for each school group, it lists how many schools in those groups
+ have their own tariffs, either manually entered or imported via their smart meters.
+</p>
+
+<table class="advice-table mt-4 table table-sm table-sorted">
+  <thead>
+    <tr>
+      <th>School Group</th>
+      <th>Tariffs</th>
+      <th>Schools with Tariffs</th>
+      <th>Schools with DCC Tariffs</th>
+    </tr>
+  </thead>
+  <tbody>
+    <% SchoolGroup.all.order(:name).each do |school_group| %>
+      <tr>
+        <td><%= link_to school_group.name, school_group_energy_tariffs_path(school_group) %></td>
+        <td><%= @count_by_school_group[school_group.slug].present? ? link_to(@count_by_school_group[school_group.slug], school_group_energy_tariffs_path(school_group)) : '-' %></td>
+        <td>
+          <% count = EnergyTariff.count_schools_with_tariff_by_group(school_group) %>
+          <%= count != 0 ? count : '' %>
+        </td>
+        <td>
+          <% count = EnergyTariff.count_schools_with_tariff_by_group(school_group, :dcc) %>
+          <% if count > 0 %>
+            <%= link_to count, admin_reports_tariffs_path(anchor: school_group.name.parameterize) %>
+          <% else %>
+            -
+          <% end %>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/admin/reports/index.html.erb
+++ b/app/views/admin/reports/index.html.erb
@@ -33,19 +33,23 @@
   </div>
 
   <div class="col">
-    <h3>Data & Tariffs</h3>
+    <h3>Data</h3>
     <ul>
       <li><%= link_to "Unvalidated readings", admin_reports_unvalidated_readings_path %></li>
       <li><%= link_to "Recent manual imports", admin_reports_data_loads_path %></li>
       <li><%= link_to "AMR File imports report", admin_reports_amr_data_feed_import_logs_path %></li>
       <li><%= link_to "School group meter reports", admin_reports_meter_reports_path %></li>
       <li><%= link_to "DCC Meter Status", admin_reports_dcc_status_index_path %></li>
-      <li><%= link_to "Tariff imports report", admin_reports_tariff_import_logs_path %></li>
-      <li><%= link_to "Tariffs report", admin_reports_tariffs_path %></li>
       <li><%= link_to "PROB data report", admin_prob_data_reports_path %></li>
       <li><%= link_to "Solar Panels", admin_reports_solar_panels_path %></li>
     </ul>
 
+    <h3>Tariffs</h3>
+    <ul>
+      <li><%= link_to 'Energy Tariffs', admin_reports_energy_tariffs_path %></li>
+      <li><%= link_to "DCC Tariff imports report", admin_reports_tariff_import_logs_path %></li>
+      <li><%= link_to "DCC Tariffs report", admin_reports_tariffs_path %></li>
+    </ul>
     <h3>Transifex</h3>
     <ul>
       <li><%= link_to "Transifex Content Loads", admin_reports_transifex_loads_path %></li>

--- a/app/views/admin/reports/tariffs/index.html.erb
+++ b/app/views/admin/reports/tariffs/index.html.erb
@@ -18,7 +18,8 @@
     </thead>
     <tbody>
     <% @group_meters.each do |school_group_name, school_meters| %>
-      <tr class='table-active'><td colspan="8"><strong><%= school_group_name || 'Ungrouped' %></strong></td></tr>
+      <% name = school_group_name || 'Ungrouped' %>
+      <tr class='table-active' id='<%=name.parameterize%>' ><td colspan="8"><strong><%= name %></strong></td></tr>
       <% school_meters.each do |school, meters| %>
         <% meters.each do |meter| %>
           <tr>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -556,6 +556,7 @@ Rails.application.routes.draw do
       resource :funder_allocations, only: [:show] do
         post :deliver
       end
+      get 'energy_tariffs', to: 'energy_tariffs#index', as: :energy_tariffs
     end
 
     resource :settings, only: [:show, :update]

--- a/spec/factories/energy_tariffs.rb
+++ b/spec/factories/energy_tariffs.rb
@@ -9,6 +9,7 @@ FactoryBot.define do
     tariff_holder { create(:school) }
     created_by { association :user }
     updated_by { association :user }
+    enabled { true }
 
     trait :with_flat_price do
       after(:create) do |energy_tariff, evaluator|

--- a/spec/models/energy_tariff_spec.rb
+++ b/spec/models/energy_tariff_spec.rb
@@ -305,4 +305,45 @@ describe EnergyTariff do
       end
     end
   end
+
+  context '#for_schools_in_group' do
+    let!(:school_group)     { create(:school_group) }
+    let!(:school)           { create(:school, school_group: school_group)}
+    let!(:energy_tariff)    { create(:energy_tariff, tariff_holder: school)}
+    let!(:energy_tariff_2)  { create(:energy_tariff, tariff_holder: school, enabled: false)}
+    let!(:energy_tariff_3)  { create(:energy_tariff)}
+    let!(:energy_tariff_4)  { create(:energy_tariff, tariff_holder: school_group)}
+
+    it 'returns expected schools' do
+      expect(EnergyTariff.for_schools_in_group(school.school_group)).to match_array([energy_tariff])
+    end
+  end
+
+  context '#count_schools_with_tariff_by_group' do
+    let!(:school)           { create(:school, school_group: create(:school_group))}
+    let!(:energy_tariff)    { create(:energy_tariff, tariff_holder: school)}
+    let!(:energy_tariff_2)  { create(:energy_tariff)}
+
+    it 'returns expected count' do
+      expect(EnergyTariff.count_schools_with_tariff_by_group(school.school_group)).to eq 1
+    end
+  end
+
+  context '#count_by_school_group' do
+    let!(:school_group_1)     { create(:school_group) }
+    let!(:school_group_2)     { create(:school_group) }
+    let!(:school_group_3)     { create(:school_group) }
+
+    let!(:energy_tariff)      { create(:energy_tariff, tariff_holder: school_group_1)}
+    let!(:energy_tariff_2)    { create(:energy_tariff, tariff_holder: school_group_2)}
+    let!(:energy_tariff_3)    { create(:energy_tariff, tariff_holder: school_group_2)}
+
+    let(:counts)              { EnergyTariff.count_by_school_group }
+
+    it 'returns expected counts' do
+      expect(counts[school_group_1.slug]).to eq 1
+      expect(counts[school_group_2.slug]).to eq 2
+      expect(counts[school_group_3.slug]).to be_nil
+    end
+  end
 end

--- a/spec/system/admin/reports/energy_tariffs_report_spec.rb
+++ b/spec/system/admin/reports/energy_tariffs_report_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+describe 'TariffsReport', type: :system do
+
+  let(:admin)                    { create(:admin) }
+  let!(:school_group)            { create(:school_group) }
+  let!(:school)                  { create(:school, school_group: school_group) }
+  let!(:school_2)                { create(:school, school_group: school_group) }
+
+  let!(:group_tariffs)           { create_list(:energy_tariff, 3, tariff_holder: school_group) }
+  let!(:school_tariff)           { create(:energy_tariff, tariff_holder: school, source: :manually_entered) }
+  let!(:school_tariff_2)         { create(:energy_tariff, tariff_holder: school_2, source: :manually_entered) }
+
+  let!(:school_dcc_tariff)       { create(:energy_tariff, tariff_holder: school, source: :dcc) }
+
+  before(:each) do
+    sign_in(admin)
+    visit root_path
+    click_on 'Manage'
+    click_on 'Reports'
+  end
+
+  it 'displays a report' do
+    click_on 'Energy Tariffs'
+    expect(page).to have_link(school_group.name, href: school_group_energy_tariffs_path(school_group))
+    expect(page).to have_link("3", href: school_group_energy_tariffs_path(school_group))
+    expect(page).to have_link("1", href: admin_reports_tariffs_path(anchor: school_group.name.parameterize))
+    expect(page).to have_content("2")
+  end
+end


### PR DESCRIPTION
Creates a new report for admins that lists:

- which school groups have Energy Tariffs configured
- how many schools in those groups have their own school level tariffs
- how many schools in those groups have DCC tariffs

...along with links to more information where currently available. This is intended to give an overview of current state of tariffs. The individual group and school pages will provide more information.

The PR declares two new associations on EnergyTariffs which makes it possible to do:

```
EnergyTariff.joins(:school)
EnergyTariff.joins(:school_groups)
```

Which allows joining against those models when doing queries.