### PR TITLE
Allow meters to be optional on School tariff editor

### DIFF
--- a/app/controllers/energy_tariffs/energy_tariffs_controller.rb
+++ b/app/controllers/energy_tariffs/energy_tariffs_controller.rb
@@ -16,9 +16,9 @@ module EnergyTariffs
 
       if @school
         @electricity_meters = @school.meters.electricity
-        @electricity_tariffs = @school.energy_tariffs.electricity.by_start_date.by_name
+        @electricity_tariffs = @school.energy_tariffs.electricity.manually_entered.by_start_date.by_name
         @gas_meters = @school.meters.gas
-        @gas_tariffs = @school.energy_tariffs.gas.by_start_date.by_name
+        @gas_tariffs = @school.energy_tariffs.gas.manually_entered.by_start_date.by_name
       end
     end
 
@@ -30,8 +30,9 @@ module EnergyTariffs
                        elsif @site_setting
                          @site_setting.energy_tariffs.build(meter_type: params[:meter_type])
                        end
-      if @energy_tariff.meter_ids.empty? && @school
-        redirect_back fallback_location: school_energy_tariffs_path(@school), notice: "Please select at least one meter for this tariff"
+
+      if require_meters?
+        redirect_back fallback_location: school_energy_tariffs_path(@school), notice: "Please select at least one meter for this tariff. Or uncheck option to apply tariff to all meters"
       end
     end
 
@@ -96,6 +97,10 @@ module EnergyTariffs
     end
 
     private
+
+    def require_meters?
+      params[:specific_meters] && @energy_tariff.meter_ids.empty? && @school
+    end
 
     def redirect_to_choose_type_energy_tariff_path
       case @energy_tariff.tariff_holder_type

--- a/app/controllers/energy_tariffs/energy_tariffs_controller.rb
+++ b/app/controllers/energy_tariffs/energy_tariffs_controller.rb
@@ -32,7 +32,7 @@ module EnergyTariffs
                        end
 
       if require_meters?
-        redirect_back fallback_location: school_energy_tariffs_path(@school), notice: "Please select at least one meter for this tariff. Or uncheck option to apply tariff to all meters"
+        redirect_back fallback_location: school_energy_tariffs_path(@school), notice: I18n.t('schools.user_tariffs.choose_meters.missing_meters')
       end
     end
 

--- a/app/models/meter.rb
+++ b/app/models/meter.rb
@@ -181,6 +181,10 @@ class Meter < ApplicationRecord
     name.present? ? name : mpan_mprn.to_s
   end
 
+  def mpan_mprn_and_name
+    name.present? ? "#{mpan_mprn} - #{name}" : mpan_mprn
+  end
+
   def display_name
     name.present? ? "#{display_meter_mpan_mprn} (#{name})" : display_meter_mpan_mprn
   end

--- a/app/views/energy_tariffs/energy_tariffs/choose_meters.html.erb
+++ b/app/views/energy_tariffs/energy_tariffs/choose_meters.html.erb
@@ -4,16 +4,30 @@
   <%= simple_form_for :energy_tariff, url: new_school_energy_tariff_path(@school), method: :get do |f| %>
     <%= f.hidden_field :meter_type, value: params[:meter_type] %>
     <div class="row">
-      <div class="col-md-4">
-        <p><%= t('schools.user_tariffs.choose_meters.which_meters_will_this_tariff_apply_to') %></p>
-      </div>
-      <div class="col-md-3 right">
+      <div class="col-md-12">
+        <p>
+          Will this tariff apply to all <%= params[:meter_type] %> meters at the school or
+          just specific meters?
+        </p>
         <div class="form-check">
+          <div class="custom-control custom-checkbox">
+            <%= check_box_tag :specific_meters, 'yes', false, {class: 'specific-meters custom-control-input', data: {reveals: '.meter-choices'}} %>
+            <%= label_tag :specific_meters, "Just specific meters. (Tick to choose them)", class: 'custom-control-label' %>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="row mt-4 meter-choices" data-revealed-by='.specific-meters'>
+      <div class="col-md-12">
+        <p>
+          <%= t('schools.user_tariffs.choose_meters.which_meters_will_this_tariff_apply_to') %>
+        </p>
+        <div class="form-check meter-choices">
           <%= f.collection_check_boxes(:meter_ids, @meters, :id, :mpan_mprn) do |b|  %>
             <div class="custom-control custom-checkbox">
-              <%= b.check_box(checked: @meters.first == b.object, class: "custom-control-input") %>
+              <%= b.check_box(class: "custom-control-input") %>
               <%= b.label(class: "custom-control-label spaced") do %>
-                <%= b.object.mpan_mprn %>
+                <%= b.object.display_summary(display_data_source: false) %>
               <% end %>
             </div>
           <% end %>
@@ -24,4 +38,3 @@
     <%= submit_tag t('common.labels.next'), class: 'btn btn-info' %>
   <% end %>
 </div>
-

--- a/app/views/energy_tariffs/energy_tariffs/choose_meters.html.erb
+++ b/app/views/energy_tariffs/energy_tariffs/choose_meters.html.erb
@@ -6,13 +6,12 @@
     <div class="row">
       <div class="col-md-12">
         <p>
-          Will this tariff apply to all <%= params[:meter_type] %> meters at the school or
-          just specific meters?
+          <%= t('schools.user_tariffs.choose_meters.specific_meters_prompt', fuel_type: params[:meter_type]) %>
         </p>
         <div class="form-check">
           <div class="custom-control custom-checkbox">
             <%= check_box_tag :specific_meters, 'yes', false, {class: 'specific-meters custom-control-input', data: {reveals: '.meter-choices'}} %>
-            <%= label_tag :specific_meters, "Just specific meters. (Tick to choose them)", class: 'custom-control-label' %>
+            <%= label_tag :specific_meters, t('schools.user_tariffs.choose_meters.specific_meters_label'), class: 'custom-control-label' %>
           </div>
         </div>
       </div>

--- a/config/locales/views/schools/user_tariffs.yml
+++ b/config/locales/views/schools/user_tariffs.yml
@@ -56,6 +56,9 @@ en:
         tnuos: TNUoS (Transmission Network Use of System)
         vat_rate: VAT rate
       choose_meters:
+        missing_meters: Please select at least one meter for this tariff. Or uncheck option to apply tariff to all meters
+        specific_meters_label: Just specific meters. (Tick to choose them)
+        specific_meters_prompt: Will this tariff apply to all %{fuel_type} meters at the school or just specific meters?
         title: Select meters for this tariff
         which_meters_will_this_tariff_apply_to: Which meters will this tariff apply to?
       choose_type:

--- a/spec/support/energy_tariff_shared_examples.rb
+++ b/spec/support/energy_tariff_shared_examples.rb
@@ -106,12 +106,14 @@ RSpec.shared_examples "the school energy tariff forms well navigated" do
 
       click_link('Add electricity tariff')
       expect(page).to have_content('Select meters for this tariff')
+      expect(page).to have_content('Will this tariff apply to all electricity meters at the school or just specific meters?')
 
       check('specific_meters')
       uncheck(electricity_meter.mpan_mprn.to_s)
 
       click_button('Next')
 
+      expect(page).to have_content('Please select at least one meter for this tariff. Or uncheck option to apply tariff to all meters')
       expect(page).to have_content('Select meters for this tariff')
       expect(page).to have_content('Please select at least one meter')
     end

--- a/spec/support/energy_tariff_shared_examples.rb
+++ b/spec/support/energy_tariff_shared_examples.rb
@@ -32,6 +32,7 @@ RSpec.shared_examples "the school energy tariff forms well navigated" do
       check('999888777')
       click_button('Next')
 
+      expect(page).to have_content('999888777')
       expect(page).to have_content('Choose a name and date range')
 
       fill_in 'Name', with: 'My First Gas Tariff'
@@ -89,14 +90,26 @@ RSpec.shared_examples "the school energy tariff forms well navigated" do
       click_link('Manage tariffs')
     end
 
-    it 'requires a meter to be selected' do
+    it 'doesnt require a meter to be selected by default' do
       expect(current_path).to eq("/schools/#{school.slug}/energy_tariffs")
 
       click_link('Add electricity tariff')
-
       expect(page).to have_content('Select meters for this tariff')
-      expect(page).to have_content(electricity_meter.mpan_mprn)
+      expect(page).to have_unchecked_field('specific_meters')
+      click_button('Next')
+
+      expect(page).to have_content('Choose a name and date range')
+    end
+
+    it 'requires a meter to be selected if we check the box' do
+      expect(current_path).to eq("/schools/#{school.slug}/energy_tariffs")
+
+      click_link('Add electricity tariff')
+      expect(page).to have_content('Select meters for this tariff')
+
+      check('specific_meters')
       uncheck(electricity_meter.mpan_mprn.to_s)
+
       click_button('Next')
 
       expect(page).to have_content('Select meters for this tariff')
@@ -109,11 +122,13 @@ RSpec.shared_examples "the school energy tariff forms well navigated" do
       click_link('Add electricity tariff')
 
       expect(page).to have_content('Select meters for this tariff')
-      expect(page).to have_content(electricity_meter.mpan_mprn)
+      check('specific_meters')
+      check(electricity_meter.mpan_mprn.to_s)
       expect(page).not_to have_content(gas_meter.mpan_mprn)
 
       click_button('Next')
 
+      expect(page).to have_content(electricity_meter.mpan_mprn)
       expect(page).to have_content('Choose a name and date range')
       fill_in 'Name', with: 'My First Flat Tariff'
       click_button('Next')
@@ -126,6 +141,8 @@ RSpec.shared_examples "the school energy tariff forms well navigated" do
 
     it 'can create a flat rate tariff with price' do
       click_link('Add electricity tariff')
+
+      check('specific_meters')
 
       check('12345678901234')
       click_button('Next')
@@ -176,6 +193,8 @@ RSpec.shared_examples "the school energy tariff forms well navigated" do
     it 'can create a tariff and add prices and charges' do
       expect(current_path).to eq("/schools/#{school.slug}/energy_tariffs")
       click_link('Add electricity tariff')
+
+      check('specific_meters')
 
       check('12345678901234')
       click_button('Next')
@@ -247,6 +266,7 @@ RSpec.shared_examples "the school energy tariff forms well navigated" do
 
       click_link('Add electricity tariff')
 
+      check('specific_meters')
       check('12345678901234')
       click_button('Next')
 


### PR DESCRIPTION
Currently we require users to choose one or more meters when creating a School tariff.

But we want to allow the creation and editing of tariffs that apply to all meters of a type at a school, not just specific meters.

This PR updates the "choose meters" stage of tariff creation to allow user to decide whether to add meters.

- add a check box to the form to prompt user whether they want to add meters, default is now that a tariff is for any meter
- update validation check to be aware of users choice
- update specs to check for validation changes and selections
- add missing translation for error message and new translations for extra form text.