### PR TITLE
Tidy up tariff specs

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -75,7 +75,7 @@ class Ability
         end
         can :read, [:my_school_menu]
         can :switch, School
-        can :manage, EnergyTariff, tariff_holder_id: user.school.id
+        can :manage, EnergyTariff, tariff_holder: user.school
       end
       #allow users from schools in same group to access dashboards
       if user.school.present?

--- a/app/views/energy_tariffs/energy_tariffs/_energy_tariffs_summary_table.html.erb
+++ b/app/views/energy_tariffs/energy_tariffs/_energy_tariffs_summary_table.html.erb
@@ -1,4 +1,4 @@
-<table class="table advice-table">
+<table class="table advice-table" id="<%=meter_type%><%= local_assigns[:default] ? '-default' : '' %>-tariffs-table">
   <thead>
     <tr>
       <th><%= t('schools.user_tariffs.name') %></th>

--- a/app/views/energy_tariffs/energy_tariffs/_energy_tariffs_tab_school.html.erb
+++ b/app/views/energy_tariffs/energy_tariffs/_energy_tariffs_tab_school.html.erb
@@ -16,7 +16,7 @@
             </h4>
 
             <% if @electricity_tariffs&.any? %>
-              <%= render 'energy_tariffs_summary_table', tariffs: @electricity_tariffs %>
+              <%= render 'energy_tariffs_summary_table', meter_type: :electricity, tariffs: @electricity_tariffs %>
             <% else %>
               <p><%= t('schools.user_tariffs.index.electricity.there_are_no_electricity_tariffs_set_up_yet') %></p>
               <p>
@@ -44,7 +44,7 @@
               <%= t('schools.user_tariffs.index.gas.header') %>
             </h4>
             <% if @gas_tariffs.any? %>
-              <%= render 'energy_tariffs_summary_table', tariffs: @gas_tariffs %>
+              <%= render 'energy_tariffs_summary_table', meter_type: :gas, tariffs: @gas_tariffs %>
             <% else %>
               <p><%= t('schools.user_tariffs.index.gas.there_are_no_gas_tariffs_set_up_yet') %></p>
               <p>

--- a/app/views/energy_tariffs/energy_tariffs/_energy_tariffs_tab_school_groups.html.erb
+++ b/app/views/energy_tariffs/energy_tariffs/_energy_tariffs_tab_school_groups.html.erb
@@ -9,7 +9,7 @@
             </span>
             <%= t("schools.user_tariffs.index.#{meter_type}.header") %>
           </h4>
-          <%= render 'energy_tariffs_summary_table', tariffs: @school_group.energy_tariffs.where(meter_type: meter_type) %>
+          <%= render 'energy_tariffs_summary_table', meter_type: meter_type, tariffs: @school_group.energy_tariffs.where(meter_type: meter_type) %>
           <div class="mt-4">
             <%= link_to t("schools.user_tariffs.index.#{meter_type}.add_label"), new_school_group_energy_tariff_path(meter_type: meter_type), class: 'btn btn-success' %>
           </div>

--- a/app/views/energy_tariffs/energy_tariffs/_energy_tariffs_tab_site_settings.html.erb
+++ b/app/views/energy_tariffs/energy_tariffs/_energy_tariffs_tab_site_settings.html.erb
@@ -9,7 +9,7 @@
             </span>
             <%= t("schools.user_tariffs.index.#{meter_type}.header") %>
           </h4>
-          <%= render 'energy_tariffs_summary_table', tariffs: SiteSettings.current.energy_tariffs.where(meter_type: meter_type) %>
+          <%= render 'energy_tariffs_summary_table', default: true, meter_type: meter_type, tariffs: SiteSettings.current.energy_tariffs.where(meter_type: meter_type) %>
           <% if site_settings_page? %>
             <div class="mt-4">
               <%= link_to t("schools.user_tariffs.index.#{meter_type}.add_label"), new_admin_settings_energy_tariff_path(meter_type: meter_type), class: 'btn btn-success' %>

--- a/app/views/energy_tariffs/energy_tariffs/_energy_tariffs_tab_site_settings.html.erb
+++ b/app/views/energy_tariffs/energy_tariffs/_energy_tariffs_tab_site_settings.html.erb
@@ -9,7 +9,7 @@
             </span>
             <%= t("schools.user_tariffs.index.#{meter_type}.header") %>
           </h4>
-          <%= render 'energy_tariffs_summary_table', default: true, meter_type: meter_type, tariffs: SiteSettings.current.energy_tariffs.where(meter_type: meter_type) %>
+          <%= render 'energy_tariffs_summary_table', default: default, meter_type: meter_type, tariffs: SiteSettings.current.energy_tariffs.where(meter_type: meter_type) %>
           <% if site_settings_page? %>
             <div class="mt-4">
               <%= link_to t("schools.user_tariffs.index.#{meter_type}.add_label"), new_admin_settings_energy_tariff_path(meter_type: meter_type), class: 'btn btn-success' %>

--- a/app/views/energy_tariffs/energy_tariffs/index.html.erb
+++ b/app/views/energy_tariffs/energy_tariffs/index.html.erb
@@ -24,7 +24,7 @@
   <div id="nav-user-tariffs" role="tabpanel" aria-labelledby="nav-user-tariffs-tab" class="tab-pane fade show active">
     <%= render 'energy_tariffs_tab_school' if @school %>
     <%= render 'energy_tariffs_tab_school_groups' if @school_group %>
-    <%= render 'energy_tariffs_tab_site_settings' if @site_setting %>
+    <%= render 'energy_tariffs_tab_site_settings', default: false if @site_setting %>
   </div>
   <% if @school && any_smart_meters?(@school) %>
     <div id="nav-smart-meter-tariffs" role="tabpanel" aria-labelledby="nav-smart-meter-tariffs-tab" class="tab-pane fade">
@@ -34,7 +34,7 @@
   <% if @school || @school_group %>
     <div id="nav-default-tariffs" role="tabpanel" aria-labelledby="nav-default-tariffs-tab" class="tab-pane fade">
       <%= render 'default_tariffs_tab_school' if @school %>
-      <%= render 'energy_tariffs_tab_site_settings' if @school_group %>
+      <%= render 'energy_tariffs_tab_site_settings', default: true if @school_group %>
     </div>
   <% end %>
 </div>

--- a/spec/factories/users_factory.rb
+++ b/spec/factories/users_factory.rb
@@ -14,6 +14,7 @@ FactoryBot.define do
     factory :pupil do
       role { :pupil }
       pupil_password { 'test' }
+      school
     end
 
     factory :staff do
@@ -37,6 +38,7 @@ FactoryBot.define do
     factory :volunteer do
       name { "Volunteer"}
       role { :volunteer }
+      school
     end
 
     factory :analytics do

--- a/spec/support/energy_tariff_shared_examples.rb
+++ b/spec/support/energy_tariff_shared_examples.rb
@@ -121,7 +121,7 @@ RSpec.shared_examples "an electricity tariff editor with no meter selection" do
     click_button('Next')
     click_button('Simple')
 
-    visit school_group_energy_tariffs_path(school_group)
+    visit tariff_index_path
 
     expect(page).to have_content('My First Tariff')
   end
@@ -378,280 +378,6 @@ RSpec.shared_examples "a school tariff editor" do
 
 end
 
-RSpec.shared_examples "the site settings energy tariff forms well navigated" do
-  before(:each) { sign_in(current_user) }
-
-  context 'checks current user role' do
-    it 'expects the current user to be an admin' do
-      expect(['admin', 'analyst']).to include(current_user.role)
-    end
-  end
-
-  context 'has navigation links' do
-    it 'from admin page to site settings energy tariffs index' do
-      visit admin_path
-      expect(current_path).to eq("/admin")
-      click_link('Energy Tariffs')
-      expect(current_path).to eq("/admin/settings/energy_tariffs")
-      expect(page).to have_content(I18n.t('schools.user_tariffs.index.title'))
-      expect(page).not_to have_link('cost analysis pages')
-    end
-  end
-
-  context 'creating flat rate site setting gas tariffs' do
-    it 'can create a tariff and add prices and charges' do
-      visit admin_settings_energy_tariffs_path
-      expect(current_path).to eq("/admin/settings/energy_tariffs")
-      expect(page).to have_content('Manage and view tariffs')
-      expect(page).not_to have_content('My First Gas Tariff')
-
-      click_link('Add gas tariff')
-
-      expect(page).not_to have_content('Select meters for this tariff')
-      expect(page).to have_content('Choose a name and date range')
-
-      fill_in 'Name', with: 'My First Gas Tariff'
-      click_button('Next')
-
-      expect(page).to have_content('My First Gas Tariff')
-
-      fill_in "energy_tariff_price[value]", with: '1.5'
-      click_button('Next')
-
-      expect(page).to have_content('Add standing charges')
-      expect(page).to have_content('My First Gas Tariff')
-
-      fill_in "energy_tariff_charges[fixed_charge][value]", with: '4.56'
-      select 'month', from: 'energy_tariff_charges[fixed_charge][units]'
-      check 'energy_tariff_charges[energy_tariff][ccl]'
-      select '5', from: 'energy_tariff_charges[energy_tariff][vat_rate]'
-
-      click_button('Next')
-
-      expect(page).to have_content('Tariff details')
-      expect(page).to have_content('5')
-      expect(page).to have_content('Flat rate tariff')
-      expect(page).to have_content('£1.50 per kWh')
-      expect(page).to have_content('£4.56 per month')
-      expect(page).not_to have_link('Delete')
-
-      click_link('Finished')
-      expect(page).to have_content('Manage and view tariffs')
-      expect(page).to have_content('My First Gas Tariff')
-
-      energy_tariff = EnergyTariff.last
-      expect(energy_tariff.tariff_holder_type).to eq('SiteSettings')
-      expect(energy_tariff.tariff_holder).to eq(SiteSettings.current)
-      expect(energy_tariff.created_by).to eq(current_user)
-      expect(energy_tariff.updated_by).to eq(nil)
-
-      expect(energy_tariff.meters).to match_array([])
-      expect(energy_tariff.vat_rate).to eq(5)
-      expect(energy_tariff.ccl).to be_truthy
-      energy_tariff_price = energy_tariff.energy_tariff_prices.first
-      expect(energy_tariff_price.start_time.to_s(:time)).to eq('00:00')
-      expect(energy_tariff_price.end_time.to_s(:time)).to eq('23:30')
-      expect(energy_tariff_price.units).to eq('kwh')
-    end
-  end
-
-  context 'creating flat rate electricity tariffs' do
-    it 'can handle partially created tariff with bits missing' do
-      visit admin_settings_energy_tariffs_path
-      expect(current_path).to eq("/admin/settings/energy_tariffs")
-      expect(page).to have_content(I18n.t('schools.user_tariffs.index.title'))
-
-      click_link('Add electricity tariff')
-
-      expect(page).not_to have_content('Select meters for this tariff')
-
-      click_button('Next')
-
-      expect(page).to have_content('Choose a name and date range')
-      fill_in 'Name', with: 'My First Flat Tariff'
-      click_button('Next')
-      click_button('Simple')
-
-      visit admin_settings_energy_tariffs_path
-
-      expect(page).to have_content(I18n.t('schools.user_tariffs.index.title'))
-    end
-
-    it 'can create a flat rate tariff with price' do
-      visit admin_settings_energy_tariffs_path
-      expect(current_path).to eq("/admin/settings/energy_tariffs")
-      click_link('Add electricity tariff')
-
-      fill_in 'Name', with: 'My First Flat Tariff'
-      click_button('Next')
-
-      click_button('Simple')
-
-      fill_in "energy_tariff_price[value]", with: '1.5'
-      click_button('Next')
-
-      click_button('Next')
-
-      expect(page).to have_content('Tariff details')
-      expect(page).to have_content('Flat rate tariff')
-      expect(page).to have_content('£1.50 per kWh')
-      expect(page).not_to have_link('Delete')
-
-      click_link('Finished')
-      expect(page).to have_content('Manage and view tariffs')
-
-      energy_tariff = EnergyTariff.last
-      expect(energy_tariff.tariff_holder_type).to eq('SiteSettings')
-      expect(energy_tariff.tariff_holder).to eq(SiteSettings.current)
-      expect(energy_tariff.created_by).to eq(current_user)
-      expect(energy_tariff.updated_by).to eq(current_user)
-
-      expect(energy_tariff.meters).to match_array([])
-      expect(energy_tariff.tariff_type == 'flat_rate').to be_truthy
-      expect(energy_tariff.vat_rate).to eq(nil)
-      expect(energy_tariff.ccl).to be_falsey
-      energy_tariff_price = energy_tariff.energy_tariff_prices.first
-      expect(energy_tariff_price.start_time.to_s(:time)).to eq('00:00')
-      expect(energy_tariff_price.end_time.to_s(:time)).to eq('23:30')
-      expect(energy_tariff_price.value.to_s).to eq('1.5')
-      expect(energy_tariff_price.units).to eq('kwh')
-    end
-  end
-
-  context 'creating differential electricity tariffs' do
-    it 'can create a tariff and add prices and charges' do
-      visit admin_settings_energy_tariffs_path
-      expect(current_path).to eq("/admin/settings/energy_tariffs")
-      click_link('Add electricity tariff')
-
-      fill_in 'Name', with: 'My First Diff Tariff'
-      click_button('Next')
-
-      click_button('Day/Night tariff')
-
-      expect(page).to have_content('Night rate (00:00 to 07:00)')
-      expect(page).to have_content('Day rate (07:00 to 00:00)')
-      expect(page).not_to have_link('Add rate')
-      expect(page).not_to have_link('Delete')
-
-      first('.energy-tariff-show-button').click
-
-      select '00', from: 'energy_tariff_price_start_time_4i'
-      select '30', from: 'energy_tariff_price_start_time_5i'
-      select '06', from: 'energy_tariff_price_end_time_4i'
-      select '30', from: 'energy_tariff_price_end_time_5i'
-
-      fill_in 'Rate in £/kWh', with: '1.5'
-      click_button('Save')
-
-      expect(page).to have_content('Night rate (00:30 to 06:30)')
-      expect(page).to have_content('Day rate (07:00 to 00:00)')
-      expect(page).to have_content('£1.50 per kWh')
-      expect(page).to have_content('£0.00 per kWh')
-
-      click_link('Next')
-      click_button('Next')
-
-      expect(page).to have_content('Tariff details')
-      expect(page).to have_content('£1.50 per kWh')
-      expect(page).not_to have_link('Delete')
-
-      click_link('Finished')
-      expect(page).to have_content('Manage and view tariffs')
-
-      energy_tariff = EnergyTariff.last
-      expect(energy_tariff.tariff_holder_type).to eq('SiteSettings')
-      expect(energy_tariff.tariff_holder).to eq(SiteSettings.current)
-      expect(energy_tariff.created_by).to eq(current_user)
-      expect(energy_tariff.updated_by).to eq(current_user)
-      expect(energy_tariff.meters).to match_array([])
-      energy_tariff_price = energy_tariff.energy_tariff_prices.first
-      expect(energy_tariff_price.start_time.to_s(:time)).to eq('00:30')
-      expect(energy_tariff_price.end_time.to_s(:time)).to eq('06:30')
-      expect(energy_tariff_price.value.to_s).to eq('1.5')
-      expect(energy_tariff_price.units).to eq('kwh')
-      energy_tariff_price = energy_tariff.energy_tariff_prices.last
-      expect(energy_tariff_price.start_time.to_s(:time)).to eq('07:00')
-      expect(energy_tariff_price.end_time.to_s(:time)).to eq('00:00')
-      expect(energy_tariff_price.value.to_s).to eq('0.0')
-      expect(energy_tariff_price.units).to eq('kwh')
-    end
-  end
-
-  context 'adding electricity standing charges' do
-    it 'can create a tariff and add charges' do
-      visit admin_settings_energy_tariffs_path
-      expect(current_path).to eq("/admin/settings/energy_tariffs")
-
-      click_link('Add electricity tariff')
-
-      fill_in 'Name', with: 'My First Diff Tariff'
-      click_button('Next')
-
-      click_button('Simple')
-
-      fill_in "energy_tariff_price[value]", with: '1.5'
-      click_button('Next')
-
-      fill_in "energy_tariff_charges[fixed_charge][value]", with: '1.11'
-      select 'day', from: 'energy_tariff_charges[fixed_charge][units]'
-
-      fill_in "energy_tariff_charges[site_fee][value]", with: '2.22'
-      select 'month', from: 'energy_tariff_charges[site_fee][units]'
-
-      fill_in "energy_tariff_charges[duos_red][value]", with: '3.33'
-      fill_in "energy_tariff_charges[duos_amber][value]", with: '4.44'
-      fill_in "energy_tariff_charges[duos_green][value]", with: '5.55'
-
-      fill_in "energy_tariff_charges[agreed_availability_charge][value]", with: '6.66'
-      fill_in "energy_tariff_charges[excess_availability_charge][value]", with: '7.77'
-      fill_in "energy_tariff_charges[asc_limit_kw][value]", with: '8.88'
-
-      fill_in "energy_tariff_charges[reactive_power_charge][value]", with: '9.99'
-      fill_in "energy_tariff_charges[feed_in_tariff_levy][value]", with: '9.87'
-
-      fill_in "energy_tariff_charges[settlement_agency_fee][value]", with: '6.54'
-      fill_in "energy_tariff_charges[meter_asset_provider_charge][value]", with: '3.21'
-      fill_in "energy_tariff_charges[nhh_metering_agent_charge][value]", with: '1.9'
-
-      fill_in "energy_tariff_charges[nhh_automatic_meter_reading_charge][value]", with: '.12'
-      fill_in "energy_tariff_charges[data_collection_dcda_agent_charge][value]", with: '.34'
-
-      check 'energy_tariff_charges[energy_tariff][tnuos]'
-      check 'energy_tariff_charges[energy_tariff][ccl]'
-      select '20', from: 'energy_tariff_charges[energy_tariff][vat_rate]'
-
-      click_button('Next')
-      expect(page).to have_content('Tariff details')
-
-      energy_tariff = EnergyTariff.last
-      expect(energy_tariff.tariff_holder_type).to eq('SiteSettings')
-      expect(energy_tariff.tariff_holder).to eq(SiteSettings.current)
-      expect(energy_tariff.created_by).to eq(current_user)
-      expect(energy_tariff.updated_by).to eq(current_user)
-      expect(energy_tariff.tnuos).to be_truthy
-      expect(energy_tariff.ccl).to be_truthy
-      expect(energy_tariff.vat_rate).to eq(20)
-
-      expect(energy_tariff.value_for_charge(:fixed_charge)).to eq('1.11')
-      expect(energy_tariff.value_for_charge(:site_fee)).to eq('2.22')
-      expect(energy_tariff.value_for_charge(:duos_red)).to eq('3.33')
-      expect(energy_tariff.value_for_charge(:duos_amber)).to eq('4.44')
-      expect(energy_tariff.value_for_charge(:duos_green)).to eq('5.55')
-      expect(energy_tariff.value_for_charge(:agreed_availability_charge)).to eq('6.66')
-      expect(energy_tariff.value_for_charge(:excess_availability_charge)).to eq('7.77')
-      expect(energy_tariff.value_for_charge(:asc_limit_kw)).to eq('8.88')
-      expect(energy_tariff.value_for_charge(:reactive_power_charge)).to eq('9.99')
-      expect(energy_tariff.value_for_charge(:feed_in_tariff_levy)).to eq('9.87')
-      expect(energy_tariff.value_for_charge(:settlement_agency_fee)).to eq('6.54')
-      expect(energy_tariff.value_for_charge(:meter_asset_provider_charge)).to eq('3.21')
-      expect(energy_tariff.value_for_charge(:nhh_metering_agent_charge)).to eq('1.9')
-      expect(energy_tariff.value_for_charge(:nhh_automatic_meter_reading_charge)).to eq('0.12')
-      expect(energy_tariff.value_for_charge(:data_collection_dcda_agent_charge)).to eq('0.34')
-    end
-  end
-end
-
 RSpec.shared_examples "a school group energy tariff editor" do
   before(:each) { sign_in(current_user) }
 
@@ -666,12 +392,34 @@ RSpec.shared_examples "a school group energy tariff editor" do
   end
 
   context 'when creating tariffs' do
+    let(:tariff_index_path)   { school_group_energy_tariffs_path(school_group) }
     let(:tariff_holder)       { school_group }
     let(:tariff_holder_type)  { 'SchoolGroup' }
 
     before(:each) do
-      visit school_group_energy_tariffs_path(school_group)
+      visit tariff_index_path
     end
+
+    it_behaves_like "a gas tariff editor with no meter selection"
+    it_behaves_like "an electricity tariff editor with no meter selection"
+  end
+end
+
+RSpec.shared_examples "the site settings energy tariff editor" do
+  before(:each) do
+    visit admin_path
+    click_link('Energy Tariffs')
+  end
+
+  it 'has expected contents' do
+    expect(page).to have_content(I18n.t('schools.user_tariffs.index.title'))
+    expect(page).not_to have_link('cost analysis pages')
+  end
+
+  context 'when creating tariffs' do
+    let(:tariff_index_path)   { admin_settings_energy_tariffs_path }
+    let(:tariff_holder)       { SiteSettings.current }
+    let(:tariff_holder_type)  { 'SiteSettings' }
 
     it_behaves_like "a gas tariff editor with no meter selection"
     it_behaves_like "an electricity tariff editor with no meter selection"

--- a/spec/support/energy_tariff_shared_examples.rb
+++ b/spec/support/energy_tariff_shared_examples.rb
@@ -1,342 +1,336 @@
-RSpec.shared_examples "the school energy tariff forms well navigated" do
-  before(:each) { sign_in(current_user) }
+RSpec.shared_examples "the user does not have access to the tariff editor" do
+  it 'redirects away from the editor' do
+    visit school_energy_tariffs_path(school)
+    if current_user && current_user.school
+      expect(current_path).to eq("/schools/#{current_user.school.slug}")
+    else
+      expect(current_path).to eq('/users/sign_in')
+    end
+  end
+end
 
-  context 'checks current user role' do
-    it 'expects the current user to be either an admin or a school admin' do
-      expect(%w[admin analytics school_admin]).to include(current_user.role)
+RSpec.shared_examples "a gas tariff editor" do
+  let(:tariff_title)  { "My First Tariff for #{mpan_mprn}" }
+  before { click_link('Add gas tariff') }
+
+  it 'can create a flat rate tariff and add prices and charges' do
+    #Meter selection
+    expect(page).to have_content('Select meters for this tariff')
+    check(mpan_mprn)
+    click_button('Next')
+
+    #Name and dates
+    expect(page).to have_content('Choose a name and date range')
+    expect(page).to have_content(mpan_mprn)
+
+    fill_in 'Name', with: tariff_title
+    click_button('Next')
+
+    expect(page).to have_content('Add consumption charges')
+    expect(page).to have_content("01/04/2021 to 31/03/2022 : " + tariff_title)
+    expect(page).to have_content(mpan_mprn)
+
+    fill_in "energy_tariff_price[value]", with: '1.5'
+    click_button('Next')
+
+    expect(page).to have_content('Add standing charges')
+    expect(page).to have_content("01/04/2021 to 31/03/2022 : " + tariff_title)
+    expect(page).to have_content(mpan_mprn)
+
+    fill_in "energy_tariff_charges[fixed_charge][value]", with: '4.56'
+    select 'month', from: 'energy_tariff_charges[fixed_charge][units]'
+    check 'energy_tariff_charges[energy_tariff][ccl]'
+    select '5', from: 'energy_tariff_charges[energy_tariff][vat_rate]'
+
+    click_button('Next')
+
+    expect(page).to have_content('Tariff details')
+    expect(page).to have_content(mpan_mprn)
+    expect(page).to have_content('5')
+    expect(page).to have_content('Flat rate tariff')
+    expect(page).to have_content('£1.50 per kWh')
+    expect(page).to have_content('£4.56 per month')
+    expect(page).not_to have_link('Delete')
+
+    click_link('Finished')
+    expect(page).to have_content('Manage tariffs')
+    expect(page).to have_content(mpan_mprn)
+
+    energy_tariff = EnergyTariff.last
+    expect(energy_tariff.tariff_holder_type).to eq('School')
+    expect(energy_tariff.tariff_holder).to eq(school)
+    expect(energy_tariff.created_by).to eq(current_user)
+    expect(energy_tariff.updated_by).to eq(nil)
+
+    expect(energy_tariff.meters).to match_array([meter])
+    expect(energy_tariff.vat_rate).to eq(5)
+    expect(energy_tariff.ccl).to be_truthy
+    energy_tariff_price = energy_tariff.energy_tariff_prices.first
+    expect(energy_tariff_price.start_time.to_s(:time)).to eq('00:00')
+    expect(energy_tariff_price.end_time.to_s(:time)).to eq('23:30')
+    expect(energy_tariff_price.units).to eq('kwh')
+  end
+end
+
+RSpec.shared_examples "an electricity tariff editor" do
+  let(:tariff_title)  { "My First Tariff for #{mpan_mprn}" }
+  before { click_link('Add electricity tariff') }
+  it 'can create a flat rate tariff with just a price' do
+    expect(page).to have_content('Select meters for this tariff')
+
+    check('specific_meters')
+    check(mpan_mprn)
+    click_button('Next')
+
+    expect(page).to have_content('Choose a name and date range')
+    expect(page).to have_content(mpan_mprn)
+
+    fill_in 'Name', with: 'My First Flat Tariff'
+    click_button('Next')
+
+    expect(page).to have_content('Choose the type of this tariff')
+    click_button('Simple')
+
+    expect(page).to have_content('Add consumption charges for this tariff')
+    fill_in "energy_tariff_price[value]", with: '1.5'
+    click_button('Next')
+
+    click_button('Next')
+
+    expect(page).to have_content('Tariff details')
+    expect(page).to have_content('Flat rate tariff')
+    expect(page).to have_content('£1.50 per kWh')
+    expect(page).not_to have_link('Delete')
+
+    click_link('Finished')
+    expect(page).to have_content('Manage tariffs')
+    expect(page).to have_content('12345678901234')
+
+    energy_tariff = EnergyTariff.last
+    expect(energy_tariff.tariff_holder_type).to eq('School')
+    expect(energy_tariff.tariff_holder).to eq(school)
+    expect(energy_tariff.created_by).to eq(current_user)
+    expect(energy_tariff.updated_by).to eq(current_user)
+
+    expect(energy_tariff.meters).to match_array([meter])
+    expect(energy_tariff.tariff_type == 'flat_rate').to be_truthy
+    expect(energy_tariff.vat_rate).to eq(nil)
+    expect(energy_tariff.ccl).to be_falsey
+    energy_tariff_price = energy_tariff.energy_tariff_prices.first
+    expect(energy_tariff_price.start_time.to_s(:time)).to eq('00:00')
+    expect(energy_tariff_price.end_time.to_s(:time)).to eq('23:30')
+    expect(energy_tariff_price.value.to_s).to eq('1.5')
+    expect(energy_tariff_price.units).to eq('kwh')
+  end
+
+  it 'can create a flat rate tariff and add all the charges' do
+    check('specific_meters')
+    check(mpan_mprn)
+    click_button('Next')
+
+    fill_in 'Name', with: 'My First Tariff'
+    click_button('Next')
+
+    click_button('Simple')
+
+    fill_in "energy_tariff_price[value]", with: '1.5'
+    click_button('Next')
+
+    fill_in "energy_tariff_charges[fixed_charge][value]", with: '1.11'
+    select 'day', from: 'energy_tariff_charges[fixed_charge][units]'
+
+    fill_in "energy_tariff_charges[site_fee][value]", with: '2.22'
+    select 'month', from: 'energy_tariff_charges[site_fee][units]'
+
+    fill_in "energy_tariff_charges[duos_red][value]", with: '3.33'
+    fill_in "energy_tariff_charges[duos_amber][value]", with: '4.44'
+    fill_in "energy_tariff_charges[duos_green][value]", with: '5.55'
+
+    fill_in "energy_tariff_charges[agreed_availability_charge][value]", with: '6.66'
+    fill_in "energy_tariff_charges[excess_availability_charge][value]", with: '7.77'
+    fill_in "energy_tariff_charges[asc_limit_kw][value]", with: '8.88'
+
+    fill_in "energy_tariff_charges[reactive_power_charge][value]", with: '9.99'
+    fill_in "energy_tariff_charges[feed_in_tariff_levy][value]", with: '9.87'
+
+    fill_in "energy_tariff_charges[settlement_agency_fee][value]", with: '6.54'
+    fill_in "energy_tariff_charges[meter_asset_provider_charge][value]", with: '3.21'
+    fill_in "energy_tariff_charges[nhh_metering_agent_charge][value]", with: '1.9'
+
+    fill_in "energy_tariff_charges[nhh_automatic_meter_reading_charge][value]", with: '.12'
+    fill_in "energy_tariff_charges[data_collection_dcda_agent_charge][value]", with: '.34'
+
+    check 'energy_tariff_charges[energy_tariff][tnuos]'
+    check 'energy_tariff_charges[energy_tariff][ccl]'
+    select '20', from: 'energy_tariff_charges[energy_tariff][vat_rate]'
+
+    click_button('Next')
+    expect(page).to have_content('Tariff details')
+
+    energy_tariff = EnergyTariff.last
+    expect(energy_tariff.tariff_holder_type).to eq('School')
+    expect(energy_tariff.tariff_holder).to eq(school)
+    expect(energy_tariff.created_by).to eq(current_user)
+    expect(energy_tariff.updated_by).to eq(current_user)
+    expect(energy_tariff.tnuos).to be_truthy
+    expect(energy_tariff.ccl).to be_truthy
+    expect(energy_tariff.vat_rate).to eq(20)
+
+    expect(energy_tariff.value_for_charge(:fixed_charge)).to eq('1.11')
+    expect(energy_tariff.value_for_charge(:site_fee)).to eq('2.22')
+    expect(energy_tariff.value_for_charge(:duos_red)).to eq('3.33')
+    expect(energy_tariff.value_for_charge(:duos_amber)).to eq('4.44')
+    expect(energy_tariff.value_for_charge(:duos_green)).to eq('5.55')
+    expect(energy_tariff.value_for_charge(:agreed_availability_charge)).to eq('6.66')
+    expect(energy_tariff.value_for_charge(:excess_availability_charge)).to eq('7.77')
+    expect(energy_tariff.value_for_charge(:asc_limit_kw)).to eq('8.88')
+    expect(energy_tariff.value_for_charge(:reactive_power_charge)).to eq('9.99')
+    expect(energy_tariff.value_for_charge(:feed_in_tariff_levy)).to eq('9.87')
+    expect(energy_tariff.value_for_charge(:settlement_agency_fee)).to eq('6.54')
+    expect(energy_tariff.value_for_charge(:meter_asset_provider_charge)).to eq('3.21')
+    expect(energy_tariff.value_for_charge(:nhh_metering_agent_charge)).to eq('1.9')
+    expect(energy_tariff.value_for_charge(:nhh_automatic_meter_reading_charge)).to eq('0.12')
+    expect(energy_tariff.value_for_charge(:data_collection_dcda_agent_charge)).to eq('0.34')
+  end
+
+  it 'can create a differential tariff and add both prices and charges' do
+    check('specific_meters')
+    check(mpan_mprn)
+    click_button('Next')
+
+    fill_in 'Name', with: 'My First Diff Tariff'
+    click_button('Next')
+
+    click_button('Day/Night tariff')
+
+    expect(page).to have_content('Night rate (00:00 to 07:00)')
+    expect(page).to have_content('Day rate (07:00 to 00:00)')
+    expect(page).not_to have_link('Add rate')
+    expect(page).not_to have_link('Delete')
+
+    first('.energy-tariff-show-button').click
+
+    select '00', from: 'energy_tariff_price_start_time_4i'
+    select '30', from: 'energy_tariff_price_start_time_5i'
+    select '06', from: 'energy_tariff_price_end_time_4i'
+    select '30', from: 'energy_tariff_price_end_time_5i'
+
+    fill_in 'Rate in £/kWh', with: '1.5'
+    click_button('Save')
+
+    expect(page).to have_content('Night rate (00:30 to 06:30)')
+    expect(page).to have_content('Day rate (07:00 to 00:00)')
+    expect(page).to have_content('£1.50 per kWh')
+    expect(page).to have_content('£0.00 per kWh')
+
+    click_link('Next')
+    click_button('Next')
+
+    expect(page).to have_content('Tariff details')
+    expect(page).to have_content('£1.50 per kWh')
+    expect(page).not_to have_link('Delete')
+
+    click_link('Finished')
+    expect(page).to have_content('Manage tariffs')
+    expect(page).to have_content('12345678901234')
+
+    energy_tariff = EnergyTariff.last
+    expect(energy_tariff.tariff_holder_type).to eq('School')
+    expect(energy_tariff.tariff_holder).to eq(school)
+
+    expect(energy_tariff.created_by).to eq(current_user)
+    expect(energy_tariff.updated_by).to eq(current_user)
+    expect(energy_tariff.meters).to match_array([meter])
+    energy_tariff_price = energy_tariff.energy_tariff_prices.first
+    expect(energy_tariff_price.start_time.to_s(:time)).to eq('00:30')
+    expect(energy_tariff_price.end_time.to_s(:time)).to eq('06:30')
+    expect(energy_tariff_price.value.to_s).to eq('1.5')
+    expect(energy_tariff_price.units).to eq('kwh')
+    energy_tariff_price = energy_tariff.energy_tariff_prices.last
+    expect(energy_tariff_price.start_time.to_s(:time)).to eq('07:00')
+    expect(energy_tariff_price.end_time.to_s(:time)).to eq('00:00')
+    expect(energy_tariff_price.value.to_s).to eq('0.0')
+    expect(energy_tariff_price.units).to eq('kwh')
+  end
+end
+
+RSpec.shared_examples "a school tariff editor" do
+
+  before(:each) do
+    sign_in(current_user)
+    visit school_path(school)
+    within '#manage_school_menu' do
+      click_on 'Manage tariffs'
     end
   end
 
-  context 'has navigation links' do
-    it 'from meters page to user tariffs index' do
-      visit school_meters_path(school)
-      click_link('Manage School')
-      click_link('Manage tariffs')
-      expect(current_path).to eq("/schools/#{school.slug}/energy_tariffs")
-      expect(page).to have_content(I18n.t('schools.user_tariffs.index.title'))
-      expect(page).to have_link('cost analysis pages')
-    end
+  it 'is navigable from the manage school menu' do
+    expect(current_path).to eq("/schools/#{school.slug}/energy_tariffs")
+    expect(page).to have_content(I18n.t('schools.user_tariffs.index.title'))
+    expect(page).to have_link('cost analysis pages')
   end
 
-  context 'creating flat rate gas tariffs' do
-    it 'can create a tariff and add prices and charges' do
-      visit school_path(school)
-      click_link('Manage tariffs')
-      expect(current_path).to eq("/schools/#{school.slug}/energy_tariffs")
+  it 'can handle partially created tariff with bits missing' do
+    click_link('Add electricity tariff')
 
-      expect(page).to have_content('Manage tariffs')
+    expect(page).to have_content('Select meters for this tariff')
+    check('specific_meters')
+    check(electricity_meter.mpan_mprn.to_s)
+    expect(page).not_to have_content(gas_meter.mpan_mprn)
 
-      click_link('Add gas tariff')
+    click_button('Next')
 
-      expect(page).to have_content('Select meters for this tariff')
-      check('999888777')
-      click_button('Next')
+    expect(page).to have_content(electricity_meter.mpan_mprn)
+    expect(page).to have_content('Choose a name and date range')
+    fill_in 'Name', with: 'My First Flat Tariff'
+    click_button('Next')
+    click_button('Simple')
 
-      expect(page).to have_content('999888777')
-      expect(page).to have_content('Choose a name and date range')
+    visit school_energy_tariffs_path(school)
 
-      fill_in 'Name', with: 'My First Gas Tariff'
-      click_button('Next')
-
-      expect(page).to have_content('Add consumption charges')
-      expect(page).to have_content('01/04/2021 to 31/03/2022 : My First Gas Tariff')
-      expect(page).to have_content('999888777')
-
-      fill_in "energy_tariff_price[value]", with: '1.5'
-      click_button('Next')
-
-      expect(page).to have_content('Add standing charges')
-      expect(page).to have_content('01/04/2021 to 31/03/2022 : My First Gas Tariff')
-      expect(page).to have_content('999888777')
-
-      fill_in "energy_tariff_charges[fixed_charge][value]", with: '4.56'
-      select 'month', from: 'energy_tariff_charges[fixed_charge][units]'
-      check 'energy_tariff_charges[energy_tariff][ccl]'
-      select '5', from: 'energy_tariff_charges[energy_tariff][vat_rate]'
-
-      click_button('Next')
-
-      expect(page).to have_content('Tariff details')
-      expect(page).to have_content('999888777')
-      expect(page).to have_content('5')
-      expect(page).to have_content('Flat rate tariff')
-      expect(page).to have_content('£1.50 per kWh')
-      expect(page).to have_content('£4.56 per month')
-      expect(page).not_to have_link('Delete')
-
-      click_link('Finished')
-      expect(page).to have_content('Manage tariffs')
-      expect(page).to have_content('999888777')
-
-      energy_tariff = EnergyTariff.last
-      expect(energy_tariff.tariff_holder_type).to eq('School')
-      expect(energy_tariff.tariff_holder).to eq(school)
-      expect(energy_tariff.created_by).to eq(current_user)
-      expect(energy_tariff.updated_by).to eq(nil)
-
-      expect(energy_tariff.meters).to match_array([gas_meter])
-      expect(energy_tariff.vat_rate).to eq(5)
-      expect(energy_tariff.ccl).to be_truthy
-      energy_tariff_price = energy_tariff.energy_tariff_prices.first
-      expect(energy_tariff_price.start_time.to_s(:time)).to eq('00:00')
-      expect(energy_tariff_price.end_time.to_s(:time)).to eq('23:30')
-      expect(energy_tariff_price.units).to eq('kwh')
-    end
+    expect(page).to have_content(I18n.t('schools.user_tariffs.index.title'))
   end
 
-  context 'creating flat rate electricity tariffs' do
-    before(:each) do
-      visit school_path(school)
-      click_link('Manage tariffs')
-    end
+  it 'doesnt require a meter to be selected by default' do
+    expect(current_path).to eq("/schools/#{school.slug}/energy_tariffs")
 
-    it 'doesnt require a meter to be selected by default' do
-      expect(current_path).to eq("/schools/#{school.slug}/energy_tariffs")
+    click_link('Add electricity tariff')
+    expect(page).to have_content('Select meters for this tariff')
+    expect(page).to have_unchecked_field('specific_meters')
+    click_button('Next')
 
-      click_link('Add electricity tariff')
-      expect(page).to have_content('Select meters for this tariff')
-      expect(page).to have_unchecked_field('specific_meters')
-      click_button('Next')
-
-      expect(page).to have_content('Choose a name and date range')
-    end
-
-    it 'requires a meter to be selected if we check the box' do
-      expect(current_path).to eq("/schools/#{school.slug}/energy_tariffs")
-
-      click_link('Add electricity tariff')
-      expect(page).to have_content('Select meters for this tariff')
-      expect(page).to have_content('Will this tariff apply to all electricity meters at the school or just specific meters?')
-
-      check('specific_meters')
-      uncheck(electricity_meter.mpan_mprn.to_s)
-
-      click_button('Next')
-
-      expect(page).to have_content('Please select at least one meter for this tariff. Or uncheck option to apply tariff to all meters')
-      expect(page).to have_content('Select meters for this tariff')
-      expect(page).to have_content('Please select at least one meter')
-    end
-
-    it 'can handle partially created tariff with bits missing' do
-      expect(page).to have_content(I18n.t('schools.user_tariffs.index.title'))
-
-      click_link('Add electricity tariff')
-
-      expect(page).to have_content('Select meters for this tariff')
-      check('specific_meters')
-      check(electricity_meter.mpan_mprn.to_s)
-      expect(page).not_to have_content(gas_meter.mpan_mprn)
-
-      click_button('Next')
-
-      expect(page).to have_content(electricity_meter.mpan_mprn)
-      expect(page).to have_content('Choose a name and date range')
-      fill_in 'Name', with: 'My First Flat Tariff'
-      click_button('Next')
-      click_button('Simple')
-
-      visit school_energy_tariffs_path(school)
-
-      expect(page).to have_content(I18n.t('schools.user_tariffs.index.title'))
-    end
-
-    it 'can create a flat rate tariff with price' do
-      click_link('Add electricity tariff')
-
-      check('specific_meters')
-
-      check('12345678901234')
-      click_button('Next')
-
-      fill_in 'Name', with: 'My First Flat Tariff'
-      click_button('Next')
-
-      click_button('Simple')
-
-      fill_in "energy_tariff_price[value]", with: '1.5'
-      click_button('Next')
-
-      click_button('Next')
-
-      expect(page).to have_content('Tariff details')
-      expect(page).to have_content('Flat rate tariff')
-      expect(page).to have_content('£1.50 per kWh')
-      expect(page).not_to have_link('Delete')
-
-      click_link('Finished')
-      expect(page).to have_content('Manage tariffs')
-      expect(page).to have_content('12345678901234')
-
-      energy_tariff = EnergyTariff.last
-      expect(energy_tariff.tariff_holder_type).to eq('School')
-      expect(energy_tariff.tariff_holder).to eq(school)
-      expect(energy_tariff.created_by).to eq(current_user)
-      expect(energy_tariff.updated_by).to eq(current_user)
-
-      expect(energy_tariff.meters).to match_array([electricity_meter])
-      expect(energy_tariff.tariff_type == 'flat_rate').to be_truthy
-      expect(energy_tariff.vat_rate).to eq(nil)
-      expect(energy_tariff.ccl).to be_falsey
-      energy_tariff_price = energy_tariff.energy_tariff_prices.first
-      expect(energy_tariff_price.start_time.to_s(:time)).to eq('00:00')
-      expect(energy_tariff_price.end_time.to_s(:time)).to eq('23:30')
-      expect(energy_tariff_price.value.to_s).to eq('1.5')
-      expect(energy_tariff_price.units).to eq('kwh')
-    end
+    expect(page).to have_content('Choose a name and date range')
   end
 
-  context 'creating differential electricity tariffs' do
-    before(:each) do
-      visit school_path(school)
-      click_link('Manage tariffs')
-    end
+  it 'requires a meter to be selected if we check the box' do
+    expect(current_path).to eq("/schools/#{school.slug}/energy_tariffs")
 
-    it 'can create a tariff and add prices and charges' do
-      expect(current_path).to eq("/schools/#{school.slug}/energy_tariffs")
-      click_link('Add electricity tariff')
+    click_link('Add electricity tariff')
+    expect(page).to have_content('Select meters for this tariff')
+    expect(page).to have_content('Will this tariff apply to all electricity meters at the school or just specific meters?')
 
-      check('specific_meters')
+    check('specific_meters')
+    uncheck(electricity_meter.mpan_mprn.to_s)
 
-      check('12345678901234')
-      click_button('Next')
+    click_button('Next')
 
-      fill_in 'Name', with: 'My First Diff Tariff'
-      click_button('Next')
-
-      click_button('Day/Night tariff')
-
-      expect(page).to have_content('Night rate (00:00 to 07:00)')
-      expect(page).to have_content('Day rate (07:00 to 00:00)')
-      expect(page).not_to have_link('Add rate')
-      expect(page).not_to have_link('Delete')
-
-      first('.energy-tariff-show-button').click
-
-      select '00', from: 'energy_tariff_price_start_time_4i'
-      select '30', from: 'energy_tariff_price_start_time_5i'
-      select '06', from: 'energy_tariff_price_end_time_4i'
-      select '30', from: 'energy_tariff_price_end_time_5i'
-
-      fill_in 'Rate in £/kWh', with: '1.5'
-      click_button('Save')
-
-      expect(page).to have_content('Night rate (00:30 to 06:30)')
-      expect(page).to have_content('Day rate (07:00 to 00:00)')
-      expect(page).to have_content('£1.50 per kWh')
-      expect(page).to have_content('£0.00 per kWh')
-
-      click_link('Next')
-      click_button('Next')
-
-      expect(page).to have_content('Tariff details')
-      expect(page).to have_content('£1.50 per kWh')
-      expect(page).not_to have_link('Delete')
-
-      click_link('Finished')
-      expect(page).to have_content('Manage tariffs')
-      expect(page).to have_content('12345678901234')
-
-      energy_tariff = EnergyTariff.last
-      expect(energy_tariff.tariff_holder_type).to eq('School')
-      expect(energy_tariff.tariff_holder).to eq(school)
-
-      expect(energy_tariff.created_by).to eq(current_user)
-      expect(energy_tariff.updated_by).to eq(current_user)
-      expect(energy_tariff.meters).to match_array([electricity_meter])
-      energy_tariff_price = energy_tariff.energy_tariff_prices.first
-      expect(energy_tariff_price.start_time.to_s(:time)).to eq('00:30')
-      expect(energy_tariff_price.end_time.to_s(:time)).to eq('06:30')
-      expect(energy_tariff_price.value.to_s).to eq('1.5')
-      expect(energy_tariff_price.units).to eq('kwh')
-      energy_tariff_price = energy_tariff.energy_tariff_prices.last
-      expect(energy_tariff_price.start_time.to_s(:time)).to eq('07:00')
-      expect(energy_tariff_price.end_time.to_s(:time)).to eq('00:00')
-      expect(energy_tariff_price.value.to_s).to eq('0.0')
-      expect(energy_tariff_price.units).to eq('kwh')
-    end
+    expect(page).to have_content('Please select at least one meter for this tariff. Or uncheck option to apply tariff to all meters')
+    expect(page).to have_content('Select meters for this tariff')
+    expect(page).to have_content('Please select at least one meter')
   end
 
-  context 'adding electricity standing charges' do
-    before(:each) do
-      visit school_path(school)
-      click_link('Manage tariffs')
-    end
-
-    it 'can create a tariff and add charges' do
-      expect(current_path).to eq("/schools/#{school.slug}/energy_tariffs")
-
-      click_link('Add electricity tariff')
-
-      check('specific_meters')
-      check('12345678901234')
-      click_button('Next')
-
-      fill_in 'Name', with: 'My First Diff Tariff'
-      click_button('Next')
-
-      click_button('Simple')
-
-      fill_in "energy_tariff_price[value]", with: '1.5'
-      click_button('Next')
-
-      fill_in "energy_tariff_charges[fixed_charge][value]", with: '1.11'
-      select 'day', from: 'energy_tariff_charges[fixed_charge][units]'
-
-      fill_in "energy_tariff_charges[site_fee][value]", with: '2.22'
-      select 'month', from: 'energy_tariff_charges[site_fee][units]'
-
-      fill_in "energy_tariff_charges[duos_red][value]", with: '3.33'
-      fill_in "energy_tariff_charges[duos_amber][value]", with: '4.44'
-      fill_in "energy_tariff_charges[duos_green][value]", with: '5.55'
-
-      fill_in "energy_tariff_charges[agreed_availability_charge][value]", with: '6.66'
-      fill_in "energy_tariff_charges[excess_availability_charge][value]", with: '7.77'
-      fill_in "energy_tariff_charges[asc_limit_kw][value]", with: '8.88'
-
-      fill_in "energy_tariff_charges[reactive_power_charge][value]", with: '9.99'
-      fill_in "energy_tariff_charges[feed_in_tariff_levy][value]", with: '9.87'
-
-      fill_in "energy_tariff_charges[settlement_agency_fee][value]", with: '6.54'
-      fill_in "energy_tariff_charges[meter_asset_provider_charge][value]", with: '3.21'
-      fill_in "energy_tariff_charges[nhh_metering_agent_charge][value]", with: '1.9'
-
-      fill_in "energy_tariff_charges[nhh_automatic_meter_reading_charge][value]", with: '.12'
-      fill_in "energy_tariff_charges[data_collection_dcda_agent_charge][value]", with: '.34'
-
-      check 'energy_tariff_charges[energy_tariff][tnuos]'
-      check 'energy_tariff_charges[energy_tariff][ccl]'
-      select '20', from: 'energy_tariff_charges[energy_tariff][vat_rate]'
-
-      click_button('Next')
-      expect(page).to have_content('Tariff details')
-
-      energy_tariff = EnergyTariff.last
-      expect(energy_tariff.tariff_holder_type).to eq('School')
-      expect(energy_tariff.tariff_holder).to eq(school)
-      expect(energy_tariff.created_by).to eq(current_user)
-      expect(energy_tariff.updated_by).to eq(current_user)
-      expect(energy_tariff.tnuos).to be_truthy
-      expect(energy_tariff.ccl).to be_truthy
-      expect(energy_tariff.vat_rate).to eq(20)
-
-      expect(energy_tariff.value_for_charge(:fixed_charge)).to eq('1.11')
-      expect(energy_tariff.value_for_charge(:site_fee)).to eq('2.22')
-      expect(energy_tariff.value_for_charge(:duos_red)).to eq('3.33')
-      expect(energy_tariff.value_for_charge(:duos_amber)).to eq('4.44')
-      expect(energy_tariff.value_for_charge(:duos_green)).to eq('5.55')
-      expect(energy_tariff.value_for_charge(:agreed_availability_charge)).to eq('6.66')
-      expect(energy_tariff.value_for_charge(:excess_availability_charge)).to eq('7.77')
-      expect(energy_tariff.value_for_charge(:asc_limit_kw)).to eq('8.88')
-      expect(energy_tariff.value_for_charge(:reactive_power_charge)).to eq('9.99')
-      expect(energy_tariff.value_for_charge(:feed_in_tariff_levy)).to eq('9.87')
-      expect(energy_tariff.value_for_charge(:settlement_agency_fee)).to eq('6.54')
-      expect(energy_tariff.value_for_charge(:meter_asset_provider_charge)).to eq('3.21')
-      expect(energy_tariff.value_for_charge(:nhh_metering_agent_charge)).to eq('1.9')
-      expect(energy_tariff.value_for_charge(:nhh_automatic_meter_reading_charge)).to eq('0.12')
-      expect(energy_tariff.value_for_charge(:data_collection_dcda_agent_charge)).to eq('0.34')
-    end
+  context 'when creating gas tariffs' do
+    let(:meter)       { gas_meter }
+    let(:mpan_mprn)   { gas_meter.mpan_mprn.to_s }
+    it_behaves_like "a gas tariff editor"
   end
+
+  context 'when creating electricity tariffs' do
+    let(:meter)       { electricity_meter }
+    let(:mpan_mprn)   { electricity_meter.mpan_mprn.to_s }
+    it_behaves_like "an electricity tariff editor"
+  end
+
 end
 
 RSpec.shared_examples "the site settings energy tariff forms well navigated" do

--- a/spec/support/energy_tariff_shared_examples.rb
+++ b/spec/support/energy_tariff_shared_examples.rb
@@ -343,27 +343,6 @@ RSpec.shared_examples "a school tariff editor" do
     expect(page).to have_link('cost analysis pages')
   end
 
-  it 'can handle a user quitting the forms early' do
-    click_link('Add electricity tariff')
-
-    expect(page).to have_content('Select meters for this tariff')
-    check('specific_meters')
-    check(electricity_meter.mpan_mprn.to_s)
-    expect(page).not_to have_content(gas_meter.mpan_mprn)
-
-    click_button('Next')
-
-    expect(page).to have_content(electricity_meter.mpan_mprn)
-    expect(page).to have_content('Choose a name and date range')
-    fill_in 'Name', with: 'My First Flat Tariff'
-    click_button('Next')
-    click_button('Simple')
-
-    visit school_energy_tariffs_path(school)
-
-    expect(page).to have_content('My First Flat Tariff')
-  end
-
   context 'when creating gas tariffs' do
     let(:meter)       { gas_meter }
     let(:mpan_mprn)   { gas_meter.mpan_mprn.to_s }
@@ -411,7 +390,7 @@ RSpec.shared_examples "the site settings energy tariff editor" do
     click_link('Energy Tariffs')
   end
 
-  it 'has expected contents' do
+  it 'has expected index' do
     expect(page).to have_content(I18n.t('schools.user_tariffs.index.title'))
     expect(page).not_to have_link('cost analysis pages')
   end

--- a/spec/support/energy_tariff_shared_examples.rb
+++ b/spec/support/energy_tariff_shared_examples.rb
@@ -1,8 +1,12 @@
 RSpec.shared_examples "the user does not have access to the tariff editor" do
   it 'redirects away from the editor' do
-    visit school_energy_tariffs_path(school)
+    visit path
     if current_user && current_user.school
-      expect(current_path).to eq("/schools/#{current_user.school.slug}")
+      if current_user.pupil?
+        expect(current_path).to eq("/pupils/schools/#{current_user.school.slug}")
+      else
+        expect(current_path).to eq("/schools/#{current_user.school.slug}")
+      end
     else
       expect(current_path).to eq('/users/sign_in')
     end

--- a/spec/support/energy_tariff_shared_examples.rb
+++ b/spec/support/energy_tariff_shared_examples.rb
@@ -17,6 +17,38 @@ RSpec.shared_examples "the user does not have access to the tariff editor" do
   end
 end
 
+RSpec.shared_examples "a tariff editor index" do
+  it 'has buttons to create new tariffs' do
+    expect(page).to have_link("Add gas tariff")
+    expect(page).to have_link("Add electricity tariff")
+  end
+
+  context 'when there are existing tariffs' do
+    include_context "with flat price electricity and gas tariffs"
+    before { refresh }
+    it 'displays the gas tariff' do
+      within '#gas-tariffs-table' do
+        expect(page).to have_content(gas_tariff.name)
+        expect(page).to have_content(gas_tariff.start_date.to_s(:es_compact))
+        expect(page).to have_content(gas_tariff.end_date.to_s(:es_compact))
+        expect(page).to have_link("Full details")
+        expect(page).to have_link("Edit")
+        expect(page).to have_link("Delete")
+      end
+    end
+    it 'displays the electricity tariff' do
+      within '#electricity-tariffs-table' do
+        expect(page).to have_content(electricity_tariff.name)
+        expect(page).to have_content(electricity_tariff.start_date.to_s(:es_compact))
+        expect(page).to have_content(electricity_tariff.end_date.to_s(:es_compact))
+        expect(page).to have_link("Full details")
+        expect(page).to have_link("Edit")
+        expect(page).to have_link("Delete")
+      end
+    end
+  end
+end
+
 RSpec.shared_examples "a gas tariff editor with no meter selection" do
   before { click_link('Add gas tariff') }
   it 'can create a flat rate tariff and add prices and charges' do
@@ -337,6 +369,12 @@ RSpec.shared_examples "a school tariff editor" do
     end
   end
 
+  context 'when viewing index' do
+    let(:tariff_holder)   { school }
+    before { visit school_energy_tariffs_path(school) }
+    it_behaves_like "a tariff editor index"
+  end
+
   it 'is navigable from the manage school menu' do
     expect(current_path).to eq("/schools/#{school.slug}/energy_tariffs")
     expect(page).to have_content(I18n.t('schools.user_tariffs.index.title'))
@@ -370,6 +408,12 @@ RSpec.shared_examples "a school group energy tariff editor" do
     end
   end
 
+  context 'when viewing index' do
+    let(:tariff_holder)   { school_group }
+    before { visit school_group_energy_tariffs_path(school_group) }
+    it_behaves_like "a tariff editor index"
+  end
+
   context 'when creating tariffs' do
     let(:tariff_index_path)   { school_group_energy_tariffs_path(school_group) }
     let(:tariff_holder)       { school_group }
@@ -388,6 +432,12 @@ RSpec.shared_examples "the site settings energy tariff editor" do
   before(:each) do
     visit admin_path
     click_link('Energy Tariffs')
+  end
+
+  context 'when viewing index' do
+    let(:tariff_holder)   { SiteSettings.current }
+    before { visit admin_settings_energy_tariffs_path }
+    it_behaves_like "a tariff editor index"
   end
 
   it 'has expected index' do

--- a/spec/support/energy_tariffs_shared_contexts.rb
+++ b/spec/support/energy_tariffs_shared_contexts.rb
@@ -4,7 +4,7 @@ RSpec.shared_context "a school with meters" do
   let!(:gas_meter)          { create(:gas_meter, school: school, mpan_mprn: '999888777') }
 end
 
-RSpec.shared_context "a school with a flat price electricity tariff" do
-  let!(:school)             { create_active_school() }
-  let!(:energy_tariff)      { create(:energy_tariff, :with_flat_price, tariff_holder: school, fuel_type: :electricity)}
+RSpec.shared_context "with flat price electricity and gas tariffs" do
+  let!(:gas_tariff)         { create(:energy_tariff, :with_flat_price, start_date: Date.new(2022,1,1), end_date: Date.new(2022,12,31), tariff_holder: tariff_holder, meter_type: :gas)}
+  let!(:electricity_tariff)   { create(:energy_tariff, :with_flat_price, start_date: Date.new(2023,1,1), end_date: Date.new(2023,12,31), tariff_holder: tariff_holder, meter_type: :electricity)}
 end

--- a/spec/support/energy_tariffs_shared_contexts.rb
+++ b/spec/support/energy_tariffs_shared_contexts.rb
@@ -1,0 +1,10 @@
+RSpec.shared_context "a school with meters" do
+  let!(:school)             { create_active_school() }
+  let!(:electricity_meter)  { create(:electricity_meter, school: school, mpan_mprn: '12345678901234') }
+  let!(:gas_meter)          { create(:gas_meter, school: school, mpan_mprn: '999888777') }
+end
+
+RSpec.shared_context "a school with a flat price electricity tariff" do
+  let!(:school)             { create_active_school() }
+  let!(:energy_tariff)      { create(:energy_tariff, :with_flat_price, tariff_holder: school, fuel_type: :electricity)}
+end

--- a/spec/system/admin/settings/energy_tariffs_spec.rb
+++ b/spec/system/admin/settings/energy_tariffs_spec.rb
@@ -1,8 +1,6 @@
 require 'rails_helper'
 
 describe 'site settings energy tariffs', type: :system do
-  let!(:school) { create_active_school(name: "Big School")}
-
   around do |example|
     ClimateControl.modify FEATURE_FLAG_USE_NEW_ENERGY_TARIFFS: 'true' do
       example.run
@@ -12,119 +10,67 @@ describe 'site settings energy tariffs', type: :system do
   context 'as an admin user' do
     let!(:current_user) { create(:admin) }
     before(:each) { sign_in(current_user) }
-
-    context 'allows access to the admin site settings energy tariffs page' do
-      it 'redirects to the school index page' do
-        visit admin_settings_energy_tariffs_path
-        expect(current_path).to eq("/admin/settings/energy_tariffs")
-      end
-
-      it_behaves_like "the site settings energy tariff forms well navigated"
-    end
+    it_behaves_like "the site settings energy tariff editor"
   end
 
   context 'as an analytics user' do
     let!(:current_user) { create(:admin) }
     before(:each) { sign_in(current_user) }
-
-    context 'allows access to the admin site settings energy tariffs page' do
-      it 'redirects to the school index page' do
-        visit admin_settings_energy_tariffs_path
-        expect(current_path).to eq("/admin/settings/energy_tariffs")
-      end
-
-      it_behaves_like "the site settings energy tariff forms well navigated"
-    end
+    it_behaves_like "the site settings energy tariff editor"
   end
 
   context 'as a group_admin user' do
     let!(:current_user) { create(:group_admin) }
-
-    context 'does not allow access to the energy tariffs page' do
-      it 'redirects to the school index page' do
-        visit admin_settings_energy_tariffs_path
-        expect(current_path).to eq("/users/sign_in")
-      end
-    end
+    let(:path)          { admin_settings_energy_tariffs_path }
+    before              { sign_in(current_user) }
+    it_behaves_like "the user does not have access to the tariff editor"
   end
 
   context 'as a guest user' do
     let!(:current_user) { create(:guest) }
-
-    context 'does not allow access to the energy tariffs page' do
-      it 'redirects to the school index page' do
-        visit admin_settings_energy_tariffs_path
-        expect(current_path).to eq("/users/sign_in")
-      end
-    end
+    let(:path)          { admin_settings_energy_tariffs_path }
+    before              { sign_in(current_user) }
+    it_behaves_like "the user does not have access to the tariff editor"
   end
 
   context 'as a pupil user' do
-    let!(:current_user) { create(:pupil, school: school) }
-    before(:each) { sign_in(current_user) }
-
-    context 'does not allow access to the energy tariffs page' do
-      it 'redirects to the school index page' do
-        visit admin_settings_energy_tariffs_path
-        expect(current_path).to eq("/pupils/schools/#{school.slug}")
-      end
-    end
+    let!(:current_user) { create(:pupil) }
+    let(:path)          { admin_settings_energy_tariffs_path }
+    before              { sign_in(current_user) }
+    it_behaves_like "the user does not have access to the tariff editor"
   end
 
   context 'as a school admin user' do
-    let!(:current_user) { create(:school_admin, school: school) }
-    before(:each) { sign_in(current_user) }
-
-    context 'does not allow access to the energy tariffs page' do
-      it 'redirects to the school index page' do
-        visit admin_settings_energy_tariffs_path
-        expect(current_path).to eq("/schools/#{school.slug}")
-      end
-    end
+    let!(:current_user) { create(:school_admin) }
+    let(:path)          { admin_settings_energy_tariffs_path }
+    before              { sign_in(current_user) }
+    it_behaves_like "the user does not have access to the tariff editor"
   end
 
   context 'as a school_onboarding user' do
-    let!(:current_user) { create(:onboarding_user, school: school) }
-    before(:each) { sign_in(current_user) }
-
-    context 'does not allow access to the energy tariffs page' do
-      it 'redirects to the school index page' do
-        visit admin_settings_energy_tariffs_path
-        expect(current_path).to eq("/schools/#{school.slug}")
-      end
-    end
+    let!(:current_user) { create(:onboarding_user) }
+    let(:path)          { admin_settings_energy_tariffs_path }
+    before              { sign_in(current_user) }
+    it_behaves_like "the user does not have access to the tariff editor"
   end
 
   context 'as a staff user' do
-    let!(:current_user) { create(:staff, school: school) }
-    before(:each) { sign_in(current_user) }
-
-    context 'does not allow access to the energy tariffs page' do
-      it 'redirects to the school index page' do
-        visit admin_settings_energy_tariffs_path
-        expect(current_path).to eq("/schools/#{school.slug}")
-      end
-    end
+    let!(:current_user) { create(:staff) }
+    let(:path)          { admin_settings_energy_tariffs_path }
+    before              { sign_in(current_user) }
+    it_behaves_like "the user does not have access to the tariff editor"
   end
 
   context 'as a volunteer user' do
-    let!(:current_user) { create(:volunteer, school: school) }
-    before(:each) { sign_in(current_user) }
-
-    context 'does not allow access to the energy tariffs page' do
-      it 'redirects to the school index page' do
-        visit admin_settings_energy_tariffs_path
-        expect(current_path).to eq("/schools/#{school.slug}")
-      end
-    end
+    let!(:current_user) { create(:volunteer) }
+    let(:path)          { admin_settings_energy_tariffs_path }
+    before              { sign_in(current_user) }
+    it_behaves_like "the user does not have access to the tariff editor"
   end
 
   context 'with no signed in user' do
-    context 'does not allow access to the energy tariffs page' do
-      it 'redirects to the sign in page' do
-        visit admin_settings_energy_tariffs_path
-        expect(current_path).to eq('/users/sign_in')
-      end
-    end
+    let!(:current_user) { nil }
+    let(:path)          { admin_settings_energy_tariffs_path }
+    it_behaves_like "the user does not have access to the tariff editor"
   end
 end

--- a/spec/system/school_groups/energy_tariffs_spec.rb
+++ b/spec/system/school_groups/energy_tariffs_spec.rb
@@ -2,8 +2,6 @@ require 'rails_helper'
 
 describe 'school group energy tariffs', type: :system do
   let!(:school_group) { create(:school_group, public: true) }
-  let!(:school_group_2) { create(:school_group, public: true) }
-  let!(:school) { create(:school, name: 'Big School', school_group: school_group, number_of_pupils: 10, floor_area: 200.0, data_enabled: true, visible: true, active: true) }
 
   around do |example|
     ClimateControl.modify FEATURE_FLAG_USE_NEW_ENERGY_TARIFFS: 'true' do
@@ -18,118 +16,74 @@ describe 'school group energy tariffs', type: :system do
   context 'as an admin user' do
     let!(:current_user) { create(:admin) }
 
-    it_behaves_like "the school group energy tariff forms well navigated"
+    it_behaves_like "a school group energy tariff editor"
   end
 
   context 'as an analytics user' do
     let!(:current_user) { create(:analytics) }
 
-    it_behaves_like "the school group energy tariff forms well navigated"
+    it_behaves_like "a school group energy tariff editor"
   end
 
   context 'as a group_admin user' do
     let(:current_user) { create(:user, role: :group_admin, school_group: school_group)}
 
-    it_behaves_like "the school group energy tariff forms well navigated"
+    it_behaves_like "a school group energy tariff editor"
   end
 
   context 'as a group_admin user of a different group' do
+    let!(:school_group_2) { create(:school_group, public: true) }
     let(:current_user) { create(:user, role: :group_admin, school_group: school_group_2)}
-
+    let(:path)          { school_group_energy_tariffs_path(school_group) }
     before(:each) { sign_in(current_user) }
-
-    context 'does not allow access to the energy tariffs page' do
-      it 'redirects to the school index page' do
-        visit school_group_energy_tariffs_path(school_group)
-        expect(current_path).to eq("/school_groups/#{school_group_2.slug}")
-      end
-    end
+    it_behaves_like "the user does not have access to the tariff editor"
   end
 
   context 'as a guest user' do
     let!(:current_user) { create(:guest) }
-
-    before(:each) { sign_in(current_user) }
-
-    context 'does not allow access to the energy tariffs page' do
-      it 'redirects to the school index page' do
-        visit school_group_energy_tariffs_path(school_group)
-        expect(current_path).to eq("/schools")
-      end
-    end
+    let(:path)          { school_group_energy_tariffs_path(school_group) }
+    before(:each)       { sign_in(current_user) }
+    it_behaves_like "the user does not have access to the tariff editor"
   end
 
   context 'as a pupil user' do
-    let!(:current_user) { create(:pupil, school: school) }
-
+    let!(:current_user) { create(:pupil) }
+    let(:path)          { school_group_energy_tariffs_path(school_group) }
     before(:each) { sign_in(current_user) }
-
-    context 'does not allow access to the energy tariffs page' do
-      it 'redirects to the school index page' do
-        visit school_group_energy_tariffs_path(school_group)
-        expect(current_path).to eq("/pupils/schools/#{school.slug}")
-      end
-    end
+    it_behaves_like "the user does not have access to the tariff editor"
   end
 
   context 'as a school admin user' do
-    let!(:current_user) { create(:school_admin, school: school) }
-
-    before(:each) { sign_in(current_user) }
-
-    context 'does not allow access to the energy tariffs page' do
-      it 'redirects to the school index page' do
-        visit school_group_energy_tariffs_path(school_group)
-        expect(current_path).to eq("/schools/#{school.slug}")
-      end
-    end
+    let!(:current_user) { create(:school_admin) }
+    let(:path)          { school_group_energy_tariffs_path(school_group) }
+    before              { sign_in(current_user) }
+    it_behaves_like "the user does not have access to the tariff editor"
   end
 
   context 'as a school_onboarding user' do
-    let!(:current_user) { create(:onboarding_user, school: school) }
-
-    before(:each) { sign_in(current_user) }
-
-    context 'does not allow access to the energy tariffs page' do
-      it 'redirects to the school index page' do
-        visit school_group_energy_tariffs_path(school_group)
-        expect(current_path).to eq("/schools/#{school.slug}")
-      end
-    end
+    let!(:current_user) { create(:onboarding_user) }
+    let(:path)          { school_group_energy_tariffs_path(school_group) }
+    before(:each)       { sign_in(current_user) }
+    it_behaves_like "the user does not have access to the tariff editor"
   end
 
   context 'as a staff user' do
-    let!(:current_user) { create(:staff, school: school) }
-
-    before(:each) { sign_in(current_user) }
-
-    context 'does not allow access to the energy tariffs page' do
-      it 'redirects to the school index page' do
-        visit school_group_energy_tariffs_path(school_group)
-        expect(current_path).to eq("/schools/#{school.slug}")
-      end
-    end
+    let!(:current_user) { create(:staff) }
+    let(:path)          { school_group_energy_tariffs_path(school_group) }
+    before(:each)       { sign_in(current_user) }
+    it_behaves_like "the user does not have access to the tariff editor"
   end
 
   context 'as a volunteer user' do
-    let!(:current_user) { create(:volunteer, school: school) }
-
-    before(:each) { sign_in(current_user) }
-
-    context 'does not allow access to the energy tariffs page' do
-      it 'redirects to the school index page' do
-        visit school_group_energy_tariffs_path(school_group)
-        expect(current_path).to eq("/schools/#{school.slug}")
-      end
-    end
+    let!(:current_user) { create(:volunteer) }
+    let(:path)          { school_group_energy_tariffs_path(school_group) }
+    before(:each)       { sign_in(current_user) }
+    it_behaves_like "the user does not have access to the tariff editor"
   end
 
   context 'with no signed in user' do
-    context 'does not allow access to the energy tariffs page' do
-      it 'redirects to the school index page' do
-        visit school_group_energy_tariffs_path(school_group)
-        expect(current_path).to eq("/users/sign_in")
-      end
-    end
+    let!(:current_user) { nil }
+    let(:path)          { school_group_energy_tariffs_path(school_group) }
+    it_behaves_like "the user does not have access to the tariff editor"
   end
 end

--- a/spec/system/schools/energy_tariffs_spec.rb
+++ b/spec/system/schools/energy_tariffs_spec.rb
@@ -21,6 +21,11 @@ describe 'school energy tariff editor', type: :system do
       it_behaves_like "a school tariff editor"
     end
 
+    context 'as a school admin user' do
+      let!(:current_user) { create(:school_admin, school: school) }
+      it_behaves_like "a school tariff editor"
+    end
+
     context 'as a group_admin user' do
       let!(:current_user) { create(:group_admin) }
 
@@ -34,46 +39,36 @@ describe 'school energy tariff editor', type: :system do
 
     context 'as a guest user' do
       let!(:current_user) { create(:guest) }
-
-      context 'does not allow access to the energy tariffs page' do
-        it 'redirects to the school index page' do
-          visit school_energy_tariffs_path(school)
-          expect(current_path).to eq("/users/sign_in")
-        end
-      end
+      let(:path)          { school_energy_tariffs_path(school) }
+      it_behaves_like "the user does not have access to the tariff editor"
     end
 
     context 'as a pupil user' do
       let!(:current_user) { create(:pupil, school: school) }
       before(:each) { sign_in(current_user) }
-
-      context 'does not allow access to the energy tariffs page' do
-        it 'redirects to the school index page' do
-          visit school_energy_tariffs_path(school)
-          expect(current_path).to eq("/pupils/schools/#{school.slug}")
-        end
-      end
-    end
-
-    context 'as a school admin user' do
-      let!(:current_user) { create(:school_admin, school: school) }
-      it_behaves_like "a school tariff editor"
+      let(:path)          { school_energy_tariffs_path(school) }
+      it_behaves_like "the user does not have access to the tariff editor"
     end
 
     context 'as a school_onboarding user' do
       let!(:current_user) { create(:onboarding_user, school: school) }
+      let(:path)          { school_energy_tariffs_path(school) }
       before(:each)       { sign_in(current_user) }
       it_behaves_like "the user does not have access to the tariff editor"
     end
 
     context 'as a staff user' do
       let!(:current_user) { create(:staff, school: school) }
+      let(:path)          { school_energy_tariffs_path(school) }
+
       before(:each)       { sign_in(current_user) }
       it_behaves_like "the user does not have access to the tariff editor"
     end
 
     context 'as a volunteer user' do
       let!(:current_user) { create(:volunteer, school: school) }
+      let(:path)          { school_energy_tariffs_path(school) }
+
       before(:each)       { sign_in(current_user) }
       it_behaves_like "the user does not have access to the tariff editor"
     end
@@ -81,6 +76,7 @@ describe 'school energy tariff editor', type: :system do
     context 'as a non school user' do
       let!(:school_2)     { create_active_school() }
       let!(:current_user) { create(:user, school: school_2) }
+      let(:path)          { school_energy_tariffs_path(school) }
       before(:each)       { sign_in(current_user) }
       it_behaves_like "the user does not have access to the tariff editor"
     end
@@ -88,12 +84,14 @@ describe 'school energy tariff editor', type: :system do
     context 'as a non school admin user' do
       let!(:school_2)     { create_active_school() }
       let!(:current_user) { create(:school_admin, school: school_2) }
+      let(:path)          { school_energy_tariffs_path(school) }
       before(:each)       { sign_in(current_user) }
       it_behaves_like "the user does not have access to the tariff editor"
     end
 
     context 'with no signed in user' do
       let!(:current_user) { nil }
+      let(:path)          { school_energy_tariffs_path(school) }
       it_behaves_like "the user does not have access to the tariff editor"
     end
 

--- a/spec/system/schools/energy_tariffs_spec.rb
+++ b/spec/system/schools/energy_tariffs_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe 'school energy tariff editor', type: :system do
+describe 'school energy tariffs', type: :system do
 
   around do |example|
     ClimateControl.modify FEATURE_FLAG_USE_NEW_ENERGY_TARIFFS: 'true' do
@@ -40,12 +40,13 @@ describe 'school energy tariff editor', type: :system do
     context 'as a guest user' do
       let!(:current_user) { create(:guest) }
       let(:path)          { school_energy_tariffs_path(school) }
+      before(:each)       { sign_in(current_user) }
       it_behaves_like "the user does not have access to the tariff editor"
     end
 
     context 'as a pupil user' do
       let!(:current_user) { create(:pupil, school: school) }
-      before(:each) { sign_in(current_user) }
+      before(:each)       { sign_in(current_user) }
       let(:path)          { school_energy_tariffs_path(school) }
       it_behaves_like "the user does not have access to the tariff editor"
     end
@@ -60,7 +61,6 @@ describe 'school energy tariff editor', type: :system do
     context 'as a staff user' do
       let!(:current_user) { create(:staff, school: school) }
       let(:path)          { school_energy_tariffs_path(school) }
-
       before(:each)       { sign_in(current_user) }
       it_behaves_like "the user does not have access to the tariff editor"
     end
@@ -68,7 +68,6 @@ describe 'school energy tariff editor', type: :system do
     context 'as a volunteer user' do
       let!(:current_user) { create(:volunteer, school: school) }
       let(:path)          { school_energy_tariffs_path(school) }
-
       before(:each)       { sign_in(current_user) }
       it_behaves_like "the user does not have access to the tariff editor"
     end

--- a/spec/system/schools/energy_tariffs_spec.rb
+++ b/spec/system/schools/energy_tariffs_spec.rb
@@ -1,10 +1,6 @@
 require 'rails_helper'
 
-describe 'school energy tariffs', type: :system do
-  let!(:school) { create_active_school(name: "Big School")}
-  let!(:school_2)                   { create_active_school(name: "Small School")}
-  let!(:electricity_meter)        { create(:electricity_meter, school: school, mpan_mprn: '12345678901234') }
-  let!(:gas_meter)                { create(:gas_meter, school: school, mpan_mprn: '999888777') }
+describe 'school energy tariff editor', type: :system do
 
   around do |example|
     ClimateControl.modify FEATURE_FLAG_USE_NEW_ENERGY_TARIFFS: 'true' do
@@ -12,121 +8,94 @@ describe 'school energy tariffs', type: :system do
     end
   end
 
-  context 'as an admin user' do
-    let!(:current_user) { create(:admin) }
-    it_behaves_like "the school energy tariff forms well navigated"
-  end
+  describe 'when creating tariffs' do
+    include_context "a school with meters"
 
-  context 'as an analytics user' do
-    let!(:current_user) { create(:analytics) }
-    it_behaves_like "the school energy tariff forms well navigated"
-  end
+    context 'as an admin user' do
+      let!(:current_user) { create(:admin) }
+      it_behaves_like "a school tariff editor"
+    end
 
-  context 'as a group_admin user' do
-    let!(:current_user) { create(:group_admin) }
+    context 'as an analytics user' do
+      let!(:current_user) { create(:analytics) }
+      it_behaves_like "a school tariff editor"
+    end
 
-    context 'does not allow access to the energy tariffs page' do
-      it 'redirects to the school index page' do
-        visit school_energy_tariffs_path(school)
-        expect(current_path).to eq("/users/sign_in")
+    context 'as a group_admin user' do
+      let!(:current_user) { create(:group_admin) }
+
+      context 'does not allow access to the energy tariffs page' do
+        it 'redirects to the school index page' do
+          visit school_energy_tariffs_path(school)
+          expect(current_path).to eq("/users/sign_in")
+        end
       end
     end
-  end
 
-  context 'as a guest user' do
-    let!(:current_user) { create(:guest) }
+    context 'as a guest user' do
+      let!(:current_user) { create(:guest) }
 
-    context 'does not allow access to the energy tariffs page' do
-      it 'redirects to the school index page' do
-        visit school_energy_tariffs_path(school)
-        expect(current_path).to eq("/users/sign_in")
+      context 'does not allow access to the energy tariffs page' do
+        it 'redirects to the school index page' do
+          visit school_energy_tariffs_path(school)
+          expect(current_path).to eq("/users/sign_in")
+        end
       end
     end
-  end
 
-  context 'as a pupil user' do
-    let!(:current_user) { create(:pupil, school: school) }
-    before(:each) { sign_in(current_user) }
+    context 'as a pupil user' do
+      let!(:current_user) { create(:pupil, school: school) }
+      before(:each) { sign_in(current_user) }
 
-    context 'does not allow access to the energy tariffs page' do
-      it 'redirects to the school index page' do
-        visit school_energy_tariffs_path(school)
-        expect(current_path).to eq("/pupils/schools/#{school.slug}")
+      context 'does not allow access to the energy tariffs page' do
+        it 'redirects to the school index page' do
+          visit school_energy_tariffs_path(school)
+          expect(current_path).to eq("/pupils/schools/#{school.slug}")
+        end
       end
     end
-  end
 
-  context 'as a school admin user' do
-    let!(:current_user) { create(:school_admin, school: school) }
-    it_behaves_like "the school energy tariff forms well navigated"
-  end
-
-  context 'as a school_onboarding user' do
-    let!(:current_user) { create(:onboarding_user, school: school) }
-    before(:each) { sign_in(current_user) }
-
-    context 'does not allow access to the energy tariffs page' do
-      it 'redirects to the school index page' do
-        visit school_energy_tariffs_path(school)
-        expect(current_path).to eq("/schools/#{school.slug}")
-      end
+    context 'as a school admin user' do
+      let!(:current_user) { create(:school_admin, school: school) }
+      it_behaves_like "a school tariff editor"
     end
-  end
 
-  context 'as a staff user' do
-    let!(:current_user) { create(:staff, school: school) }
-    before(:each) { sign_in(current_user) }
-
-    context 'does not allow access to the energy tariffs page' do
-      it 'redirects to the school index page' do
-        visit school_energy_tariffs_path(school)
-        expect(current_path).to eq("/schools/#{school.slug}")
-      end
+    context 'as a school_onboarding user' do
+      let!(:current_user) { create(:onboarding_user, school: school) }
+      before(:each)       { sign_in(current_user) }
+      it_behaves_like "the user does not have access to the tariff editor"
     end
-  end
 
-  context 'as a volunteer user' do
-    let!(:current_user) { create(:volunteer, school: school) }
-    before(:each) { sign_in(current_user) }
-
-    context 'does not allow access to the energy tariffs page' do
-      it 'redirects to the school index page' do
-        visit school_energy_tariffs_path(school)
-        expect(current_path).to eq("/schools/#{school.slug}")
-      end
+    context 'as a staff user' do
+      let!(:current_user) { create(:staff, school: school) }
+      before(:each)       { sign_in(current_user) }
+      it_behaves_like "the user does not have access to the tariff editor"
     end
-  end
 
-  context 'as a non school user' do
-    let!(:current_user) { create(:user, school: school_2) }
-    before(:each) { sign_in(current_user) }
-
-    context 'does not allow access to the energy tariffs page' do
-      it 'redirects to the school index page' do
-        visit school_energy_tariffs_path(school)
-        expect(current_path).to eq("/schools/#{school_2.slug}")
-      end
+    context 'as a volunteer user' do
+      let!(:current_user) { create(:volunteer, school: school) }
+      before(:each)       { sign_in(current_user) }
+      it_behaves_like "the user does not have access to the tariff editor"
     end
-  end
 
-  context 'as a non school admin user' do
-    let!(:current_user) { create(:school_admin, school: school_2) }
-    before(:each) { sign_in(current_user) }
-
-    context 'does not allow access to the energy tariffs page' do
-      it 'redirects to the school index page' do
-        visit school_energy_tariffs_path(school)
-        expect(current_path).to eq("/schools/#{school_2.slug}")
-      end
+    context 'as a non school user' do
+      let!(:school_2)     { create_active_school() }
+      let!(:current_user) { create(:user, school: school_2) }
+      before(:each)       { sign_in(current_user) }
+      it_behaves_like "the user does not have access to the tariff editor"
     end
-  end
 
-  context 'with no signed in user' do
-    context 'does not allow access to the energy tariffs page' do
-      it 'redirects to the sign in page' do
-        visit school_energy_tariffs_path(school)
-        expect(current_path).to eq('/users/sign_in')
-      end
+    context 'as a non school admin user' do
+      let!(:school_2)     { create_active_school() }
+      let!(:current_user) { create(:school_admin, school: school_2) }
+      before(:each)       { sign_in(current_user) }
+      it_behaves_like "the user does not have access to the tariff editor"
     end
+
+    context 'with no signed in user' do
+      let!(:current_user) { nil }
+      it_behaves_like "the user does not have access to the tariff editor"
+    end
+
   end
 end


### PR DESCRIPTION
This PR tries to DRY up the tariff editor specs a bit more by:

- introducing some shared context
- removing `let` calls variables where they are not required, or can be defaulted
- refactoring the specs to make more use of shared examples

It also fixes an issue with the ability file which as causing an intermittent test failure.