### PR TITLE
Fix additional issues with tariff editor

### DIFF
--- a/app/controllers/energy_tariffs/energy_tariff_charges_controller.rb
+++ b/app/controllers/energy_tariffs/energy_tariff_charges_controller.rb
@@ -4,8 +4,8 @@ module EnergyTariffs
     include EnergyTariffable
     include EnergyTariffsHelper
 
-    load_and_authorize_resource :school
-    load_and_authorize_resource :school_group
+    load_and_authorize_resource :school, instance_name: 'tariff_holder'
+    load_and_authorize_resource :school_group, instance_name: 'tariff_holder'
     load_and_authorize_resource :energy_tariff
     before_action :admin_authorized?, if: :site_settings_resource?
     before_action :load_site_setting, if: :site_settings_resource?

--- a/app/controllers/energy_tariffs/energy_tariff_differential_prices_controller.rb
+++ b/app/controllers/energy_tariffs/energy_tariff_differential_prices_controller.rb
@@ -4,8 +4,8 @@ module EnergyTariffs
     include EnergyTariffable
     include EnergyTariffsHelper
 
-    load_and_authorize_resource :school
-    load_and_authorize_resource :school_group
+    load_and_authorize_resource :school, instance_name: 'tariff_holder'
+    load_and_authorize_resource :school_group, instance_name: 'tariff_holder'
     load_and_authorize_resource :energy_tariff
     before_action :admin_authorized?, if: :site_settings_resource?
     before_action :load_site_setting, if: :site_settings_resource?

--- a/app/controllers/energy_tariffs/energy_tariff_differential_prices_controller.rb
+++ b/app/controllers/energy_tariffs/energy_tariff_differential_prices_controller.rb
@@ -25,7 +25,7 @@ module EnergyTariffs
       @energy_tariff_price = @energy_tariff.energy_tariff_prices.build(energy_tariff_price_params.merge(units: 'kwh'))
       respond_to do |format|
         if @energy_tariff_price.save
-          format.html { redirect_to school_energy_tariff_energy_tariff_differential_prices_path(@school, @energy_tariff) }
+          format.html { redirect_to energy_tariffs_path(@energy_tariff, [:energy_tariff_differential_prices]) }
           format.js
         else
           format.html { render :new }

--- a/app/controllers/energy_tariffs/energy_tariff_flat_prices_controller.rb
+++ b/app/controllers/energy_tariffs/energy_tariff_flat_prices_controller.rb
@@ -4,8 +4,8 @@ module EnergyTariffs
     include EnergyTariffable
     include EnergyTariffsHelper
 
-    load_and_authorize_resource :school
-    load_and_authorize_resource :school_group
+    load_and_authorize_resource :school, instance_name: 'tariff_holder'
+    load_and_authorize_resource :school_group, instance_name: 'tariff_holder'
     load_and_authorize_resource :energy_tariff
     before_action :admin_authorized?, if: :site_settings_resource?
     before_action :load_site_setting, if: :site_settings_resource?

--- a/app/controllers/energy_tariffs/energy_tariff_prices_controller.rb
+++ b/app/controllers/energy_tariffs/energy_tariff_prices_controller.rb
@@ -4,8 +4,8 @@ module EnergyTariffs
     include EnergyTariffable
     include EnergyTariffsHelper
 
-    load_and_authorize_resource :school
-    load_and_authorize_resource :school_group
+    load_and_authorize_resource :school, instance_name: 'tariff_holder'
+    load_and_authorize_resource :school_group, instance_name: 'tariff_holder'
     load_and_authorize_resource :energy_tariff
     before_action :admin_authorized?, if: :site_settings_resource?
     before_action :load_site_setting, if: :site_settings_resource?

--- a/app/controllers/energy_tariffs/energy_tariff_prices_controller.rb
+++ b/app/controllers/energy_tariffs/energy_tariff_prices_controller.rb
@@ -20,9 +20,9 @@ module EnergyTariffs
 
     def new
       if @energy_tariff.tariff_type == 'flat_rate'
-        redirect_to new_school_energy_tariff_energy_tariff_flat_prices_path(@school, @energy_tariff)
+        redirect_to_new_energy_tariff_differential_prices_path
       else
-        redirect_to new_school_energy_tariff_energy_tariff_differential_prices_path(@school, @energy_tariff)
+        redirect_to_new_energy_tariff_differential_prices_path
       end
     end
 
@@ -35,6 +35,14 @@ module EnergyTariffs
     end
 
     private
+
+    def redirect_to_new_energy_tariff_differential_prices_path
+      redirect_to energy_tariffs_path(@energy_tariff, [:energy_tariff_differential_prices], { action: :new })
+    end
+
+    def redirect_to_new_energy_tariff_flat_prices_path
+      redirect_to energy_tariffs_path(@energy_tariff, [:energy_tariff_flat_prices], { action: :new })
+    end
 
     def redirect_to_edit_energy_tariff_differential_prices_path
       redirect_to energy_tariffs_path(@energy_tariff, [:energy_tariff_differential_prices], { action: :edit })

--- a/app/services/energy_tariff_default_prices_creator.rb
+++ b/app/services/energy_tariff_default_prices_creator.rb
@@ -5,14 +5,14 @@ class EnergyTariffDefaultPricesCreator
 
   def process
     return if @energy_tariff.flat_rate?
-    return if @energy_tariff.tariff_holder_type == 'School' && @energy_tariff.meters.empty?
     return if @energy_tariff.energy_tariff_prices.any?
 
-    night_times = case @energy_tariff.tariff_holder_type
-                  when 'School' then Economy7Times.times(@energy_tariff&.meters&.first&.mpan_mprn)
-                  when 'SchoolGroup' then Economy7Times::DEFAULT_TIMES
-                  when 'SiteSettings' then Economy7Times::DEFAULT_TIMES
+    night_times = if @energy_tariff.tariff_holder.school? && @energy_tariff.meters.any?
+                    Economy7Times.times(@energy_tariff&.meters&.first&.mpan_mprn)
+                  else
+                    Economy7Times::DEFAULT_TIMES
                   end
+
     day_times = night_times.last..night_times.first
 
     @energy_tariff.energy_tariff_prices.create!(energy_tariff_price_defaults(night_times.first.to_s, night_times.last.to_s, EnergyTariffPrice::NIGHT_RATE_DESCRIPTION))

--- a/app/views/energy_tariffs/energy_tariff_charges/index.html.erb
+++ b/app/views/energy_tariffs/energy_tariff_charges/index.html.erb
@@ -14,9 +14,9 @@
   <%= simple_form_for :energy_tariff_charges, url: form_url do |f| %>
 
     <% if @energy_tariff.gas? %>
-      <%= render 'charges_edit_gas', school: @tariff_holder, energy_tariff: @energy_tariff, energy_tariff_charges: @energy_tariff_charges, f: f %>
+      <%= render 'charges_edit_gas', energy_tariff: @energy_tariff, energy_tariff_charges: @energy_tariff_charges, f: f %>
     <% else %>
-      <%= render 'charges_edit_electricity', school: @tariff_holder, energy_tariff: @energy_tariff, energy_tariff_charges: @energy_tariff_charges, f: f %>
+      <%= render 'charges_edit_electricity', energy_tariff: @energy_tariff, energy_tariff_charges: @energy_tariff_charges, f: f %>
     <% end %>
 
     <br/>

--- a/app/views/energy_tariffs/energy_tariff_differential_prices/edit.html.erb
+++ b/app/views/energy_tariffs/energy_tariff_differential_prices/edit.html.erb
@@ -1,5 +1,5 @@
 <% url = energy_tariffs_path(@energy_tariff, [:energy_tariff_differential_price], { id: @energy_tariff_price.id }) %>
 
 <%= simple_form_for @energy_tariff_price, url: url, remote: true, method: :put do |f| %>
-  <%= render 'form', school: @tariff_holder, energy_tariff: @energy_tariff, energy_tariff_price: @energy_tariff_price, f: f %>
+  <%= render 'form', energy_tariff: @energy_tariff, energy_tariff_price: @energy_tariff_price, f: f %>
 <% end %>

--- a/app/views/energy_tariffs/energy_tariff_differential_prices/index.html.erb
+++ b/app/views/energy_tariffs/energy_tariff_differential_prices/index.html.erb
@@ -15,7 +15,7 @@
 
   <div id="modal-window" class="modal hide" role="dialog" aria-hidden="true" ></div>
 
-  <%= render 'energy_tariffs/energy_tariffs/rates_table', school: @tariff_holder, energy_tariff: @energy_tariff, allow_edits: true %>
+  <%= render 'energy_tariffs/energy_tariffs/rates_table', energy_tariff: @energy_tariff, allow_edits: true %>
 
   <br/>
 

--- a/app/views/energy_tariffs/energy_tariff_differential_prices/new.html.erb
+++ b/app/views/energy_tariffs/energy_tariff_differential_prices/new.html.erb
@@ -1,4 +1,4 @@
 <% url = energy_tariffs_path(@energy_tariff, [:energy_tariff_differential_prices]) %>
 <%= simple_form_for @energy_tariff_price, url: url, remote: true do |f| %>
-  <%= render 'form', school: @tariff_holder, energy_tariff: @energy_tariff, energy_tariff_price: @energy_tariff_price, f: f %>
+  <%= render 'form', energy_tariff: @energy_tariff, energy_tariff_price: @energy_tariff_price, f: f %>
 <% end %>

--- a/app/views/energy_tariffs/energy_tariff_flat_prices/edit.html.erb
+++ b/app/views/energy_tariffs/energy_tariff_flat_prices/edit.html.erb
@@ -11,7 +11,7 @@
 
   <% url = energy_tariffs_path(@energy_tariff, [:energy_tariff_flat_price], { id: @energy_tariff_price.id } ) %>
   <%= simple_form_for @energy_tariff_price, url: url, method: :put do |f| %>
-    <%= render 'form', school: @tariff_holder, energy_tariff: @energy_tariff, energy_tariff_price: @energy_tariff_price, f: f %>
+    <%= render 'form', energy_tariff: @energy_tariff, energy_tariff_price: @energy_tariff_price, f: f %>
 
     <br/>
     <% edit_path = energy_tariffs_path(@energy_tariff, [], { action: :edit }) %>

--- a/app/views/energy_tariffs/energy_tariff_flat_prices/new.html.erb
+++ b/app/views/energy_tariffs/energy_tariff_flat_prices/new.html.erb
@@ -11,7 +11,7 @@
   <br/>
   <% form_url = energy_tariffs_path(@energy_tariff, [:energy_tariff_flat_prices]) %>
   <%= simple_form_for @energy_tariff_price, url: form_url do |f| %>
-    <%= render 'form', school: @tariff_holder, energy_tariff: @energy_tariff, energy_tariff_price: @energy_tariff_price, f: f %>
+    <%= render 'form', energy_tariff: @energy_tariff, energy_tariff_price: @energy_tariff_price, f: f %>
     <br/>
     <% edit_path = energy_tariffs_path(@energy_tariff) %>
     <%= link_to t('common.labels.previous'), edit_path, class: 'btn' %>

--- a/app/views/energy_tariffs/energy_tariffs/_smart_meter_tariffs_tab_school.html.erb
+++ b/app/views/energy_tariffs/energy_tariffs/_smart_meter_tariffs_tab_school.html.erb
@@ -12,7 +12,7 @@
               </span>
               <%= t('schools.user_tariffs.index.electricity.header') %>
             </h4>
-            <%= render 'smart_meter_tariffs_summary_table_school', meters: @electricity_meters.dcc, school: @tariff_holder %>
+            <%= render 'smart_meter_tariffs_summary_table_school', meters: @electricity_meters.dcc %>
         </div>
       </div>
     <% end %>
@@ -26,7 +26,7 @@
               </span>
               <%= t('schools.user_tariffs.index.gas.header') %>
             </h4>
-            <%= render 'smart_meter_tariffs_summary_table_school', meters: @gas_meters.dcc, school: @tariff_holder %>
+            <%= render 'smart_meter_tariffs_summary_table_school', meters: @gas_meters.dcc %>
         </div>
       </div>
     <% end %>

--- a/app/views/energy_tariffs/energy_tariffs/show.html.erb
+++ b/app/views/energy_tariffs/energy_tariffs/show.html.erb
@@ -11,7 +11,7 @@
 
   <%= render 'energy_tariffs/energy_tariffs/header', energy_tariff: @energy_tariff %>
 
-  <h4>
+  <h4 id="consumption-charges">
     <%= t('schools.user_tariffs.show.consumption_charges') %>
     <%= link_to t('common.labels.edit'), energy_tariffs_path(@energy_tariff, [:energy_tariff_prices]), class: 'btn' %>
   </h4>
@@ -24,7 +24,7 @@
 
   <br/>
 
-  <h4>
+  <h4 id="standing-charges">
     <%= t('schools.user_tariffs.show.standing_charges') %>
     <%= link_to t('common.labels.edit'), energy_tariffs_path(@energy_tariff, [:energy_tariff_charges]), class: 'btn' %>
   </h4>

--- a/app/views/energy_tariffs/energy_tariffs/show.html.erb
+++ b/app/views/energy_tariffs/energy_tariffs/show.html.erb
@@ -13,13 +13,7 @@
 
   <h4>
     <%= t('schools.user_tariffs.show.consumption_charges') %>
-    <% if @energy_tariff.tariff_holder.school? %>
-      <%= link_to t('common.labels.edit'), school_energy_tariff_energy_tariff_prices_path(@tariff_holder, @energy_tariff), class: 'btn' %>
-    <% end %>
-
-    <% if @energy_tariff.tariff_holder.site_settings? %>
-      <%= link_to t('common.labels.edit'), admin_settings_energy_tariff_energy_tariff_prices_path(@energy_tariff), class: 'btn' %>
-    <% end %>
+    <%= link_to t('common.labels.edit'), energy_tariffs_path(@energy_tariff, [:energy_tariff_prices]), class: 'btn' %>
   </h4>
 
   <% if @energy_tariff.flat_rate? %>
@@ -32,13 +26,7 @@
 
   <h4>
     <%= t('schools.user_tariffs.show.standing_charges') %>
-    <% if @energy_tariff.tariff_holder.school? %>
-      <%= link_to t('common.labels.edit'), school_energy_tariff_energy_tariff_charges_path(@tariff_holder, @energy_tariff), class: 'btn' %>
-    <% end %>
-
-    <% if @energy_tariff.tariff_holder.site_settings? %>
-      <%= link_to t('common.labels.edit'), admin_settings_energy_tariff_energy_tariff_charges_path(@energy_tariff), class: 'btn' %>
-    <% end %>
+    <%= link_to t('common.labels.edit'), energy_tariffs_path(@energy_tariff, [:energy_tariff_charges]), class: 'btn' %>
   </h4>
 
   <%= render 'energy_tariffs/energy_tariffs/charges_table', energy_tariff: @energy_tariff, allow_edits: false %>

--- a/app/views/energy_tariffs/energy_tariffs/show.html.erb
+++ b/app/views/energy_tariffs/energy_tariffs/show.html.erb
@@ -23,9 +23,9 @@
   </h4>
 
   <% if @energy_tariff.flat_rate? %>
-    <%= render 'energy_tariffs/energy_tariffs/flat_rate', school: @tariff_holder, energy_tariff: @energy_tariff, allow_edits: false %>
+    <%= render 'energy_tariffs/energy_tariffs/flat_rate', energy_tariff: @energy_tariff, allow_edits: false %>
   <% else %>
-    <%= render 'energy_tariffs/energy_tariffs/rates_table', school: @tariff_holder, energy_tariff: @energy_tariff, allow_edits: false %>
+    <%= render 'energy_tariffs/energy_tariffs/rates_table', energy_tariff: @energy_tariff, allow_edits: false %>
   <% end %>
 
   <br/>
@@ -41,7 +41,7 @@
     <% end %>
   </h4>
 
-  <%= render 'energy_tariffs/energy_tariffs/charges_table', school: @tariff_holder, energy_tariff: @energy_tariff, allow_edits: false %>
+  <%= render 'energy_tariffs/energy_tariffs/charges_table', energy_tariff: @energy_tariff, allow_edits: false %>
 
   <br/>
   <br/>

--- a/spec/support/energy_tariff_shared_examples.rb
+++ b/spec/support/energy_tariff_shared_examples.rb
@@ -330,7 +330,7 @@ RSpec.shared_examples "an electricity tariff editor with meter selection" do
   let(:tariff_title)  { "My First Tariff for #{mpan_mprn}" }
   before              { click_link('Add electricity tariff') }
 
-  it 'can create a tariff and associate the meters' do
+  it 'can create a flat rate tariff and associate the meters' do
     #Meter selection
     expect(page).to have_content('Select meters for this tariff')
     check('specific_meters')
@@ -350,6 +350,68 @@ RSpec.shared_examples "an electricity tariff editor with meter selection" do
     expect(energy_tariff.tariff_holder_type).to eq('School')
     expect(energy_tariff.tariff_holder).to eq(school)
     expect(energy_tariff.meters).to match_array([meter])
+  end
+
+  it 'can create a differential tariff and associate the meters' do
+    #Meter selection
+    expect(page).to have_content('Select meters for this tariff')
+    check('specific_meters')
+    check(mpan_mprn)
+    click_button('Next')
+
+    fill_in 'Name', with: 'My First Diff Tariff'
+    click_button('Next')
+
+    click_button('Day/Night tariff')
+
+    expect(page).to have_content('Night rate (00:00 to 07:00)')
+    expect(page).to have_content('Day rate (07:00 to 00:00)')
+    expect(page).not_to have_link('Add rate')
+    expect(page).not_to have_link('Delete')
+
+    first('.energy-tariff-show-button').click
+
+    select '00', from: 'energy_tariff_price_start_time_4i'
+    select '30', from: 'energy_tariff_price_start_time_5i'
+    select '06', from: 'energy_tariff_price_end_time_4i'
+    select '30', from: 'energy_tariff_price_end_time_5i'
+
+    fill_in 'Rate in £/kWh', with: '1.5'
+    click_button('Save')
+
+    expect(page).to have_content('Night rate (00:30 to 06:30)')
+    expect(page).to have_content('Day rate (07:00 to 00:00)')
+    expect(page).to have_content('£1.50 per kWh')
+    expect(page).to have_content('£0.00 per kWh')
+
+    click_link('Next')
+    click_button('Next')
+
+    expect(page).to have_content('Tariff details')
+    expect(page).to have_content('£1.50 per kWh')
+    expect(page).not_to have_link('Delete')
+
+    click_link('Finished')
+    expect(page).to have_content('Manage and view tariffs')
+
+    energy_tariff = EnergyTariff.last
+    expect(energy_tariff.enabled).to be true
+    expect(energy_tariff.meter_type.to_sym).to eq(:electricity)
+    expect(energy_tariff.meters).to match_array([meter])
+    expect(energy_tariff.tariff_holder_type).to eq(tariff_holder_type)
+    expect(energy_tariff.tariff_holder).to eq(tariff_holder)
+    expect(energy_tariff.created_by).to eq(current_user)
+    expect(energy_tariff.updated_by).to eq(current_user)
+    energy_tariff_price = energy_tariff.energy_tariff_prices.first
+    expect(energy_tariff_price.start_time.to_s(:time)).to eq('00:30')
+    expect(energy_tariff_price.end_time.to_s(:time)).to eq('06:30')
+    expect(energy_tariff_price.value.to_s).to eq('1.5')
+    expect(energy_tariff_price.units).to eq('kwh')
+    energy_tariff_price = energy_tariff.energy_tariff_prices.last
+    expect(energy_tariff_price.start_time.to_s(:time)).to eq('07:00')
+    expect(energy_tariff_price.end_time.to_s(:time)).to eq('00:00')
+    expect(energy_tariff_price.value.to_s).to eq('0.0')
+    expect(energy_tariff_price.units).to eq('kwh')
   end
 
   it 'doesnt require a meter to be selected by default' do
@@ -402,6 +464,9 @@ RSpec.shared_examples "a school tariff editor" do
   context 'when creating electricity tariffs' do
     let(:meter)       { electricity_meter }
     let(:mpan_mprn)   { electricity_meter.mpan_mprn.to_s }
+    let(:tariff_holder)       { school }
+    let(:tariff_holder_type)  { 'School' }
+
     it_behaves_like "an electricity tariff editor with meter selection"
   end
 

--- a/spec/support/energy_tariff_shared_examples.rb
+++ b/spec/support/energy_tariff_shared_examples.rb
@@ -80,6 +80,14 @@ RSpec.shared_examples "a gas tariff editor with no meter selection" do
     expect(page).to have_content('£4.56 per month')
     expect(page).not_to have_link('Delete')
 
+    within('#consumption-charges') do
+      expect(page).to have_link("Edit")
+    end
+
+    within('#standing-charges') do
+      expect(page).to have_link("Edit")
+    end
+
     click_link('Finished')
     expect(page).to have_content('Manage and view tariffs')
     expect(page).to have_content('My First Gas Tariff')
@@ -178,6 +186,14 @@ RSpec.shared_examples "an electricity tariff editor with no meter selection" do
     expect(page).to have_content('£1.50 per kWh')
     expect(page).not_to have_link('Delete')
 
+    within('#consumption-charges') do
+      expect(page).to have_link("Edit")
+    end
+
+    within('#standing-charges') do
+      expect(page).to have_link("Edit")
+    end
+
     click_link('Finished')
     expect(page).to have_content('Manage and view tariffs')
 
@@ -232,6 +248,14 @@ RSpec.shared_examples "an electricity tariff editor with no meter selection" do
     expect(page).to have_content('Tariff details')
     expect(page).to have_content('£1.50 per kWh')
     expect(page).not_to have_link('Delete')
+
+    within('#consumption-charges') do
+      expect(page).to have_link("Edit")
+    end
+
+    within('#standing-charges') do
+      expect(page).to have_link("Edit")
+    end
 
     click_link('Finished')
     expect(page).to have_content('Manage and view tariffs')
@@ -295,6 +319,14 @@ RSpec.shared_examples "an electricity tariff editor with no meter selection" do
 
     click_button('Next')
     expect(page).to have_content('Tariff details')
+
+    within('#consumption-charges') do
+      expect(page).to have_link("Edit")
+    end
+
+    within('#standing-charges') do
+      expect(page).to have_link("Edit")
+    end
 
     energy_tariff = EnergyTariff.last
     expect(energy_tariff.enabled).to be true
@@ -390,6 +422,14 @@ RSpec.shared_examples "an electricity tariff editor with meter selection" do
     expect(page).to have_content('Tariff details')
     expect(page).to have_content('£1.50 per kWh')
     expect(page).not_to have_link('Delete')
+
+    within('#consumption-charges') do
+      expect(page).to have_link("Edit")
+    end
+
+    within('#standing-charges') do
+      expect(page).to have_link("Edit")
+    end
 
     click_link('Finished')
     expect(page).to have_content('Manage and view tariffs')


### PR DESCRIPTION
There were several issues with the tariff editor:

- Differential Prices weren't being added for School tariffs if there were no meters. Fixed the logic to use the defaults in that case
- There were a lot of partials that were called with a `school: @school` variable but the variable wasn't being used in the partials. So have removed that to avoid confusion and clarify the interface to the partials
- Updated the other tariff controllers to use `tariff_holder` as the instance name for the loaded model
- Fixed some redirect routes in controllers. One of which was stopping prices being edited for School Group tariffs
- Fix up the tariff show page to ensure that the Edit links for Prices and Charges are displayed for all tariff holder types (they were missing for School Group) and added a spec for this