### PR TITLE
Change feature flag name for new tariff editor

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ gem 'pg_search'
 gem 'calculate_in_group'
 
 # Dashboard analytics
-gem 'energy-sparks_analytics', git: 'https://github.com/Energy-Sparks/energy-sparks_analytics.git', tag: '3.0.0'
+gem 'energy-sparks_analytics', git: 'https://github.com/Energy-Sparks/energy-sparks_analytics.git', tag: '3.0.1'
 #gem 'energy-sparks_analytics', git: 'https://github.com/Energy-Sparks/energy-sparks_analytics.git', branch: 'additional-tariff-code-tests-and-refactoring'
 #gem 'energy-sparks_analytics', path: '../energy-sparks_analytics'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/Energy-Sparks/energy-sparks_analytics.git
-  revision: 31bfbeb02d9e95587d602ffd46c06be74c78fede
-  tag: 3.0.0
+  revision: c256458bf1a2fca743a6add7d5a667e8b89af012
+  tag: 3.0.1
   specs:
     energy-sparks_analytics (1.2.1)
       activesupport (>= 6.0, < 7.1)

--- a/app/models/global_meter_attribute.rb
+++ b/app/models/global_meter_attribute.rb
@@ -36,7 +36,7 @@ class GlobalMeterAttribute < ApplicationRecord
   end
 
   def self.for(meter)
-    if EnergySparks::FeatureFlags.active?(:use_new_energy_tariffs)
+    if EnergySparks::FeatureFlags.active?(:new_energy_tariff_editor)
       where('meter_types ? :meter_type', meter_type: meter.meter_type).where.not(attribute_type: GlobalMeterAttribute::TARIFF_ATTRIBUTE_TYPES).active
     else
       where('meter_types ? :meter_type', meter_type: meter.meter_type).active
@@ -54,7 +54,7 @@ class GlobalMeterAttribute < ApplicationRecord
   end
 
   def self.filtered_attributes
-    if EnergySparks::FeatureFlags.active?(:use_new_energy_tariffs)
+    if EnergySparks::FeatureFlags.active?(:new_energy_tariff_editor)
       where.not(attribute_type: GlobalMeterAttribute::TARIFF_ATTRIBUTE_TYPES).active
     else
       active

--- a/app/models/meter.rb
+++ b/app/models/meter.rb
@@ -222,7 +222,7 @@ class Meter < ApplicationRecord
   end
 
   def active_meter_attributes
-    if EnergySparks::FeatureFlags.active?(:use_new_energy_tariffs)
+    if EnergySparks::FeatureFlags.active?(:new_energy_tariff_editor)
       meter_attributes.where.not(attribute_type: GlobalMeterAttribute::TARIFF_ATTRIBUTE_TYPES).active
     else
       meter_attributes.active
@@ -231,7 +231,7 @@ class Meter < ApplicationRecord
 
   def energy_tariff_meter_attributes
     attributes = []
-    if EnergySparks::FeatureFlags.active?(:use_new_energy_tariffs)
+    if EnergySparks::FeatureFlags.active?(:new_energy_tariff_editor)
       school_attributes = school.all_energy_tariff_attributes(meter_type)
       attributes += school_attributes unless school_attributes.nil?
     end

--- a/app/models/parent_meter_attribute_holder.rb
+++ b/app/models/parent_meter_attribute_holder.rb
@@ -2,7 +2,7 @@ module ParentMeterAttributeHolder
   extend ActiveSupport::Concern
 
   def meter_attributes_for(meter)
-    if EnergySparks::FeatureFlags.active?(:use_new_energy_tariffs)
+    if EnergySparks::FeatureFlags.active?(:new_energy_tariff_editor)
       meter_attributes.where('meter_types ? :meter_type', meter_type: meter.meter_type).where.not(attribute_type: GlobalMeterAttribute::TARIFF_ATTRIBUTE_TYPES).active
     else
       meter_attributes.where('meter_types ? :meter_type', meter_type: meter.meter_type).active
@@ -22,7 +22,7 @@ module ParentMeterAttributeHolder
   private
 
   def filtered_meter_attributes
-    if EnergySparks::FeatureFlags.active?(:use_new_energy_tariffs)
+    if EnergySparks::FeatureFlags.active?(:new_energy_tariff_editor)
       meter_attributes.where.not(attribute_type: GlobalMeterAttribute::TARIFF_ATTRIBUTE_TYPES)
     else
       meter_attributes

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -532,7 +532,7 @@ class School < ApplicationRecord
       end
       collection
     end
-    if EnergySparks::FeatureFlags.active?(:use_new_energy_tariffs)
+    if EnergySparks::FeatureFlags.active?(:new_energy_tariff_editor)
       all_attributes[:aggregated_electricity] = all_energy_tariff_attributes(:electricity)
       all_attributes[:aggregated_gas] = all_energy_tariff_attributes(:gas)
       all_attributes[:solar_pv_consumed_sub_meter] = all_energy_tariff_attributes(:solar_pv)

--- a/spec/models/meter_spec.rb
+++ b/spec/models/meter_spec.rb
@@ -324,12 +324,12 @@ describe 'Meter', :meters do
     let(:feature_flag)    { 'false' }
 
     around do |example|
-      ClimateControl.modify FEATURE_FLAG_USE_NEW_ENERGY_TARIFFS: feature_flag do
+      ClimateControl.modify FEATURE_FLAG_NEW_ENERGY_TARIFF_EDITOR: feature_flag do
         example.run
       end
     end
 
-    context 'with :use_new_energy_tariffs enabled' do
+    context 'with :new_energy_tariff_editor enabled' do
       let(:feature_flag) { 'true' }
 
       let(:all_meter_attributes)          { meter.all_meter_attributes }

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -770,12 +770,12 @@ describe School do
     let(:feature_flag)    { 'false' }
 
     around do |example|
-      ClimateControl.modify FEATURE_FLAG_USE_NEW_ENERGY_TARIFFS: feature_flag do
+      ClimateControl.modify FEATURE_FLAG_NEW_ENERGY_TARIFF_EDITOR: feature_flag do
         example.run
       end
     end
 
-    context 'with :use_new_energy_tariffs enabled' do
+    context 'with :new_energy_tariff_editor enabled' do
       let(:feature_flag) { 'true' }
 
       let(:all_pseudo_meter_attributes) { school.all_pseudo_meter_attributes }

--- a/spec/system/admin/settings/energy_tariffs_spec.rb
+++ b/spec/system/admin/settings/energy_tariffs_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe 'site settings energy tariffs', type: :system do
   around do |example|
-    ClimateControl.modify FEATURE_FLAG_USE_NEW_ENERGY_TARIFFS: 'true' do
+    ClimateControl.modify FEATURE_FLAG_NEW_ENERGY_TARIFF_EDITOR: 'true' do
       example.run
     end
   end

--- a/spec/system/school_groups/energy_tariffs_spec.rb
+++ b/spec/system/school_groups/energy_tariffs_spec.rb
@@ -4,7 +4,7 @@ describe 'school group energy tariffs', type: :system do
   let!(:school_group) { create(:school_group, public: true) }
 
   around do |example|
-    ClimateControl.modify FEATURE_FLAG_USE_NEW_ENERGY_TARIFFS: 'true' do
+    ClimateControl.modify FEATURE_FLAG_NEW_ENERGY_TARIFF_EDITOR: 'true' do
       ClimateControl.modify FEATURE_FLAG_ENHANCED_SCHOOL_GROUP_DASHBOARD: "true" do
         example.run
       end

--- a/spec/system/schools/energy_tariffs_spec.rb
+++ b/spec/system/schools/energy_tariffs_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe 'school energy tariffs', type: :system do
 
   around do |example|
-    ClimateControl.modify FEATURE_FLAG_USE_NEW_ENERGY_TARIFFS: 'true' do
+    ClimateControl.modify FEATURE_FLAG_NEW_ENERGY_TARIFF_EDITOR: 'true' do
       example.run
     end
   end


### PR DESCRIPTION
Switch to use `FEATURE_FLAG_NEW_ENERGY_TARIFF_EDITOR` / `:new_energy_tariff_editor`

Includes a bump to the analytics as the feature flag is in use there too.