### PR TITLE
Provide better default tariff dates

### DIFF
--- a/app/controllers/energy_tariffs/energy_tariffs_controller.rb
+++ b/app/controllers/energy_tariffs/energy_tariffs_controller.rb
@@ -22,9 +22,9 @@ module EnergyTariffs
 
     def new
       @energy_tariff = if @tariff_holder.school?
-                         @tariff_holder.energy_tariffs.build(energy_tariff_params.merge(default_params))
+                         @tariff_holder.energy_tariffs.build(default_params.merge(energy_tariff_params))
                        else
-                         @tariff_holder.energy_tariffs.build(meter_type: params[:meter_type])
+                         @tariff_holder.energy_tariffs.build(default_params.merge({ meter_type: params[:meter_type] }))
                        end
 
       if require_meters?
@@ -91,7 +91,12 @@ module EnergyTariffs
     end
 
     def default_params
-      { start_date: Date.parse('2021-04-01'), end_date: Date.parse('2022-03-31'), tariff_type: :flat_rate }
+      default_start_date = @tariff_holder.default_tariff_start_date(@energy_tariff.meter_type)
+      default_end_date = default_start_date + 1.year
+      {
+        start_date: default_start_date,
+        end_date: default_end_date
+      }
     end
 
     def energy_tariff_params

--- a/app/models/concerns/energy_tariff_holder.rb
+++ b/app/models/concerns/energy_tariff_holder.rb
@@ -40,6 +40,15 @@ module EnergyTariffHolder
     self.class.name.underscore&.to_sym
   end
 
+  def default_tariff_start_date(meter_type, source = :manually_entered)
+    latest_with_fixed_dates = energy_tariffs.latest_with_fixed_end_date(meter_type, source).first
+    if latest_with_fixed_dates.present?
+      latest_with_fixed_dates.end_date + 1.day
+    else
+      Time.zone.today
+    end
+  end
+
   def all_energy_tariff_attributes(meter_type = EnergyTariff.meter_types.keys)
     attributes = []
     parent = parent_tariff_holder

--- a/app/models/energy_tariff.rb
+++ b/app/models/energy_tariff.rb
@@ -75,6 +75,8 @@ class EnergyTariff < ApplicationRecord
     for_schools_in_group(school_group, source).select(:tariff_holder_id).distinct.count
   }
 
+  scope :latest_with_fixed_end_date, ->(meter_type, source = :manually_entered) { where(meter_type: meter_type, source: source).where.not(end_date: nil).order(end_date: :desc) }
+
   def flat_rate?
     tariff_type == 'flat_rate'
   end

--- a/spec/models/concerns/energy_tariff_holder_spec.rb
+++ b/spec/models/concerns/energy_tariff_holder_spec.rb
@@ -93,7 +93,22 @@ describe EnergyTariffHolder do
         expect(attributes.size).to eq 1
         expect(attributes[0].input_data['tariff_holder']).to eq 'school_group'
       end
+    end
+  end
 
+  context '.default_tariff_start_date' do
+    let(:tariff_holder) { SiteSettings.current }
+    it 'defaults to one day later' do
+      expect(tariff_holder.default_tariff_start_date(:electricity)).to eq energy_tariff.end_date + 1.day
+    end
+
+    it 'defaults to today otherwise' do
+      EnergyTariff.destroy_all
+      expect(tariff_holder.default_tariff_start_date(:electricity)).to eq Time.zone.today
+    end
+
+    it 'checks source when provided' do
+      expect(tariff_holder.default_tariff_start_date(:electricity, :dcc)).to eq Time.zone.today
     end
   end
 end


### PR DESCRIPTION
Switches from using hard-coded default tariff start and end dates to using something more sensible.

If the tariff holder has any existing tariffs with a fixed end date, then we default to using the day after the latest end date.