### PR TITLE
Allow meters to be edited on School tariffs (2)

### DIFF
--- a/app/controllers/energy_tariffs/energy_tariffs_controller.rb
+++ b/app/controllers/energy_tariffs/energy_tariffs_controller.rb
@@ -56,6 +56,8 @@ module EnergyTariffs
     end
 
     def edit_meters
+      redirect_to energy_tariffs_path(@energy_tariff) and return if @energy_tariff.dcc?
+
       if @energy_tariff.electricity?
         @meters = @tariff_holder.meters.electricity
       elsif @energy_tariff.gas?

--- a/app/views/energy_tariffs/energy_tariffs/show.html.erb
+++ b/app/views/energy_tariffs/energy_tariffs/show.html.erb
@@ -40,12 +40,14 @@
       <div>
         <h4><%= t('schools.user_tariffs.show.meters') %></h4>
       </div>
-      <div>
-        <%= link_to t('common.labels.edit'),
-            energy_tariffs_path(@energy_tariff, [], { action: :edit_meters }),
-            class: 'btn', id: 'edit_meters'
-        %>
-      </div>
+      <% unless @energy_tariff.dcc? %>
+        <div>
+          <%= link_to t('common.labels.edit'),
+              energy_tariffs_path(@energy_tariff, [], { action: :edit_meters }),
+              class: 'btn', id: 'edit_meters'
+          %>
+        </div>
+      <% end %>
     </div>
     <table class="table table-charges">
       <tbody>


### PR DESCRIPTION
- [x] don't allow/show meter edit functionality if the energy tariff has a source of dcc