### PR TITLE
Improve error reporting on tariff forms

### DIFF
--- a/app/helpers/energy_tariffs_helper.rb
+++ b/app/helpers/energy_tariffs_helper.rb
@@ -100,6 +100,17 @@ module EnergyTariffsHelper
     settings(charge_type).fetch(:units, []).map { |k| [EnergyTariffCharge.charge_type_units[k], k] }
   end
 
+  #If user provides a value that cant be cast to underlying type,
+  #e.g. a string when a number is expected, you cant read the attribute
+  #value. This checks for errors and retrieves the original.
+  def value_allowing_for_errors(model, attribute = :value)
+    if model.errors.any?
+      model.read_attribute_before_type_cast(attribute)
+    else
+      model.read_attribute(attribute)
+    end
+  end
+
   def energy_tariff_charge_value(energy_tariff_charge)
     if energy_tariff_charge.units
       I18n.t(

--- a/app/views/energy_tariffs/energy_tariff_charges/_charge_basic_row.html.erb
+++ b/app/views/energy_tariffs/energy_tariff_charges/_charge_basic_row.html.erb
@@ -1,5 +1,3 @@
-<%= render 'shared/errors', subject: energy_tariff_charge, subject_name: 'charge' %>
-
 <tr>
   <td class="description">
     <%= energy_tariff_charge_type_description(energy_tariff_charge.charge_type) %>
@@ -11,7 +9,10 @@
     <%= energy_tariff_charge_type_value_label(energy_tariff_charge.charge_type) %>
   </td>
   <td class="value">
-    <%= f.input :value, pattern: '[0-9.]+', label: false, input_html: { value: energy_tariff_charge.value}.merge(local_assigns.slice(:data, :title)), required: false %>
+    <%= f.input :value, as: :decimal, pattern: '[0-9.]+', label: false,
+      input_html: { value: value_allowing_for_errors(energy_tariff_charge) }.merge(local_assigns.slice(:data, :title)),
+      error: energy_tariff_charge.errors.any? ? energy_tariff_charge.errors.full_messages.first : nil,
+      required: false %>
   </td>
   <td class="units">
     <% if energy_tariff_charge_type_units_for(energy_tariff_charge.charge_type).any? %>

--- a/app/views/energy_tariffs/energy_tariff_flat_prices/_form.html.erb
+++ b/app/views/energy_tariffs/energy_tariff_flat_prices/_form.html.erb
@@ -1,5 +1,3 @@
-<%= render 'shared/errors', subject: energy_tariff_price, subject_name: 'price' %>
-
 <table class="table table-charges">
   <tbody>
   <tr>
@@ -9,7 +7,10 @@
     <td class="value">
     </td>
     <td class="value">
-      <%= f.input :value, as: :string, pattern: '[0-9.]+', label: false, input_html: { value: energy_tariff_price.value }, required: false %>
+      <%= f.input :value, pattern: '[0-9.]+', label: false,
+        input_html: { value: value_allowing_for_errors(energy_tariff_price) },
+        error: energy_tariff_price.errors.any? ? energy_tariff_price.errors.full_messages.first : nil,
+        required: false %>
     </td>
     <td class="units">
       <%= t('schools.user_tariff_flat_prices.form.per_gbp_kwh') %>


### PR DESCRIPTION
Improves the display of errors on the flat rate price and charges forms.

Originally the errors were just using a default error block. I've updated the form fields to check for errors and then provide a custom error message via the SimpleForm `error` attribute on the field.

I've also fixed an issue with form values not displaying properly if they don't match the underlying type. See the `value_allowing_for_errors` helper. This was mainly to catch problems with a user typing a string into the field.

However I also noticed that while we were adding `pattern` to the form fields they were being ignored in some cases. So I've tweaked the fields to be numeric which means you can no longer enter anything except a number. 

So the `value_allowing_for_errors` helper is probably not needed, but have left it in place for now.

The form validation on the editing to name/dates and on the differential prices was already fine.