### PR TITLE
Add option to show prices

### DIFF
--- a/app/components/energy_tariff_table_component.rb
+++ b/app/components/energy_tariff_table_component.rb
@@ -5,39 +5,20 @@ class EnergyTariffTableComponent < ViewComponent::Base
 
   delegate :can?, :cannot?, to: :helpers
 
-  def initialize(id: 'tariff-table', tariff_holder:, tariffs:, show_actions: true)
+  def initialize(id: 'tariff-table', tariff_holder:, tariffs:, show_actions: true, show_prices: true)
     @id = id
     @tariff_holder = tariff_holder
     @tariffs = tariffs
     @show_actions = show_actions
+    @show_prices = show_prices
+  end
+
+  def show_prices?
+    @show_prices
   end
 
   def show_meters?
     @tariff_holder.school?
-  end
-
-  def flat_rate_label(energy_tariff)
-    energy_tariff.flat_rate? ? t('schools.user_tariffs.tariff_partial.simple_tariff') : t('schools.user_tariffs.tariff_partial.day_night_tariff')
-  end
-
-  def start_date(energy_tariff)
-    energy_tariff.start_date ? energy_tariff.start_date&.to_s(:es_compact) : t('schools.user_tariffs.summary_table.no_start_date')
-  end
-
-  def start_date_sortable(energy_tariff)
-    energy_tariff.start_date&.iso8601
-  end
-
-  def end_date_sortable(energy_tariff)
-    energy_tariff.end_date&.iso8601
-  end
-
-  def table_sorted
-    @tariffs.length > 1 ? 'table-sorted' : ''
-  end
-
-  def end_date(energy_tariff)
-    energy_tariff.end_date ? energy_tariff.end_date&.to_s(:es_compact) : t('schools.user_tariffs.summary_table.no_end_date')
   end
 
   def can_toggle_status?(energy_tariff)
@@ -52,5 +33,37 @@ class EnergyTariffTableComponent < ViewComponent::Base
 
   def show_actions?
     @show_actions
+  end
+
+  def start_time(price)
+    price.start_time.to_s(:time)
+  end
+
+  def end_time(price)
+    price.start_time.to_s(:time)
+  end
+
+  def flat_rate_label(energy_tariff)
+    energy_tariff.flat_rate? ? t('schools.user_tariffs.tariff_partial.simple_tariff') : t('schools.user_tariffs.tariff_partial.day_night_tariff')
+  end
+
+  def start_date(energy_tariff)
+    energy_tariff.start_date ? energy_tariff.start_date&.to_s(:es_compact) : t('schools.user_tariffs.summary_table.no_start_date')
+  end
+
+  def start_date_sortable(energy_tariff)
+    energy_tariff.start_date&.iso8601
+  end
+
+  def end_date(energy_tariff)
+    energy_tariff.end_date ? energy_tariff.end_date&.to_s(:es_compact) : t('schools.user_tariffs.summary_table.no_end_date')
+  end
+
+  def end_date_sortable(energy_tariff)
+    energy_tariff.end_date&.iso8601
+  end
+
+  def table_sorted
+    @tariffs.length > 1 ? 'table-sorted' : ''
   end
 end

--- a/app/components/energy_tariff_table_component.rb
+++ b/app/components/energy_tariff_table_component.rb
@@ -40,7 +40,7 @@ class EnergyTariffTableComponent < ViewComponent::Base
   end
 
   def end_time(price)
-    price.start_time.to_s(:time)
+    price.end_time.to_s(:time)
   end
 
   def flat_rate_label(energy_tariff)

--- a/app/components/energy_tariff_table_component/energy_tariff_table_component.html.erb
+++ b/app/components/energy_tariff_table_component/energy_tariff_table_component.html.erb
@@ -5,6 +5,9 @@
       <th><%= t('schools.user_tariffs.tariff_partial.end_date') %></th>
       <th><%= t('schools.user_tariffs.name') %></th>
       <th><%= t('schools.user_tariffs.tariff_partial.type') %></th>
+      <% if show_prices? %>
+        <th><%= t('schools.user_tariffs.tariff_partial.consumption_charges') %></th>
+      <% end %>
       <% if show_meters? %>
         <th data-orderable="false"><%= t('schools.user_tariffs.meters.meter_list') %></th>
       <% end %>
@@ -22,6 +25,20 @@
         <td>
           <%= flat_rate_label(energy_tariff) %>
         </td>
+        <% if show_prices? %>
+          <td>
+            <ul style="list-style: none; padding-left: 0px;">
+              <% energy_tariff.energy_tariff_prices.order(start_time: :asc).each do |price| %>
+                <li>
+                  <% if energy_tariff.differential? %>
+                    <%= t('schools.user_tariffs.tariff_partial.price_from_to', price_start_time: start_time(price), price_end_time: end_time(price)) %>
+                  <% end %>
+                  <%= t('schools.user_tariffs.rates_table.price_per_kwh', price_value: convert_value_to_long_currency(price.value)) %>
+                </li>
+              <% end %>
+            </ul>
+          </td>
+        <% end %>
         <% if show_meters? %>
           <td>
             <% if energy_tariff.meters.any? %>

--- a/app/components/energy_tariff_table_component/energy_tariff_table_component.html.erb
+++ b/app/components/energy_tariff_table_component/energy_tariff_table_component.html.erb
@@ -1,32 +1,36 @@
 <table class="table advice-table <%=table_sorted%>" id="<%= @id %>">
   <thead>
     <tr>
-      <th><%= t('schools.user_tariffs.tariff_partial.start_date') %></th>
-      <th><%= t('schools.user_tariffs.tariff_partial.end_date') %></th>
-      <th><%= t('schools.user_tariffs.name') %></th>
-      <th><%= t('schools.user_tariffs.tariff_partial.type') %></th>
+      <th class="col-1 text-right"><%= t('schools.user_tariffs.tariff_partial.start_date') %></th>
+      <th class="col-1 text-right"><%= t('schools.user_tariffs.tariff_partial.end_date') %></th>
+      <th class="col-3 text-left"><%= t('schools.user_tariffs.name') %></th>
+      <th class="col-1 text-left"><%= t('schools.user_tariffs.tariff_partial.type') %></th>
       <% if show_prices? %>
-        <th><%= t('schools.user_tariffs.tariff_partial.consumption_charges') %></th>
+        <th class="col-3 text-right" data-orderable="false"><%= t('schools.user_tariffs.tariff_partial.consumption_charges') %></th>
       <% end %>
       <% if show_meters? %>
-        <th data-orderable="false"><%= t('schools.user_tariffs.meters.meter_list') %></th>
+        <th class="col-1 text-left" data-orderable="false"><%= t('schools.user_tariffs.meters.meter_list') %></th>
       <% end %>
-      <% if @show_actions %>
-        <th data-orderable="false"></th>
-      <% end %>
+      <th class="col-2 text-right" data-orderable="false"></th>
     </tr>
   </thead>
   <tbody>
     <% @tariffs.each do |energy_tariff| %>
-      <tr>
-        <td data-order="<%= start_date_sortable(energy_tariff) %>"><%= start_date(energy_tariff) %></td>
-        <td data-order="<%= end_date_sortable(energy_tariff) %>"><%= end_date(energy_tariff) %></td>
-        <td><%= energy_tariff.name %></td>
-        <td>
+      <tr >
+        <td class="text-right" data-order="<%= start_date_sortable(energy_tariff) %>"><%= start_date(energy_tariff) %></td>
+        <td class="text-right" data-order="<%= end_date_sortable(energy_tariff) %>"><%= end_date(energy_tariff) %></td>
+        <td class="text-left" >
+          <% if show_actions? && can?(:manage, energy_tariff) %>
+            <%= link_to energy_tariff.name, energy_tariffs_path(energy_tariff)  %>
+          <% else %>
+            <%= energy_tariff.name %>
+          <% end %>
+        </td>
+        <td class="text-left" >
           <%= flat_rate_label(energy_tariff) %>
         </td>
         <% if show_prices? %>
-          <td>
+          <td class="text-right" >
             <ul style="list-style: none; padding-left: 0px;">
               <% energy_tariff.energy_tariff_prices.order(start_time: :asc).each do |price| %>
                 <li>
@@ -40,7 +44,7 @@
           </td>
         <% end %>
         <% if show_meters? %>
-          <td>
+          <td class="text-left" >
             <% if energy_tariff.meters.any? %>
               <ul style="list-style: none; padding-left: 0px;">
                 <% energy_tariff.meters.each do |meter| %>
@@ -53,11 +57,7 @@
           </td>
         <% end %>
         <% if show_actions? && can?(:manage, energy_tariff) %>
-          <td>
-            <%= link_to t('schools.user_tariffs.tariff_partial.full_details'),
-                energy_tariffs_path(energy_tariff),
-                class: 'btn btn-sm'
-            %>
+          <td class="text-right">
             <% if energy_tariff.dcc? %>
               <%= link_to t('schools.user_tariff_charges.edit_charges'),
                   energy_tariffs_path(energy_tariff, [:energy_tariff_charges]),

--- a/app/components/energy_tariffs_component/energy_tariffs_component.html.erb
+++ b/app/components/energy_tariffs_component/energy_tariffs_component.html.erb
@@ -27,7 +27,7 @@
               <div class="mt-4">
                 <%= link_to t("schools.user_tariffs.index.#{meter_type}.add_label"),
                   new_energy_tariff_path(@tariff_holder, meter_type: meter_type),
-                  class: 'btn btn-success' %>
+                  class: 'btn btn-sm btn-success' %>
               </div>
             <% end %>
           </div>

--- a/config/locales/cy/views/schools/user_tariffs.yml
+++ b/config/locales/cy/views/schools/user_tariffs.yml
@@ -112,12 +112,14 @@ cy:
             Bydd ychwanegu tariff newydd â llaw yn eich galluogi i ddarparu rhagor o wybodaeth am eich taliadau sefydlog am gyfnod penodol.
           </p>
       tariff_partial:
+        consumption_charges: Costau defnydd
         day_night_tariff: Tariff dydd/nos
         end_date: Dyddiad gorffen
         full_details: Manylion llawn
         simple_tariff: Tariff syml
         start_date: Dyddiad cychwyn
         type: Math
+        price_from_to: "%{price_start_time} i %{price_end_time}:"
       title_partial:
         heading: Tariff
       view_and_manage_tariffs_html: <a href="%{user_tariffs_path}">Gweld a rheoli tariffau eich ysgol</a>

--- a/config/locales/cy/views/schools/user_tariffs.yml
+++ b/config/locales/cy/views/schools/user_tariffs.yml
@@ -115,7 +115,6 @@ cy:
         consumption_charges: Costau defnydd
         day_night_tariff: Tariff dydd/nos
         end_date: Dyddiad gorffen
-        full_details: Manylion llawn
         simple_tariff: Tariff syml
         start_date: Dyddiad cychwyn
         type: Math

--- a/config/locales/views/schools/user_tariffs.yml
+++ b/config/locales/views/schools/user_tariffs.yml
@@ -170,7 +170,6 @@ en:
         consumption_charges: Consumption charges
         day_night_tariff: Day/night tariff
         end_date: End date
-        full_details: View details
         price_from_to: "%{price_start_time} to %{price_end_time}:"
         simple_tariff: Simple tariff
         start_date: Start date

--- a/config/locales/views/schools/user_tariffs.yml
+++ b/config/locales/views/schools/user_tariffs.yml
@@ -167,9 +167,11 @@ en:
         no_end_date: No end date
         no_start_date: No start date
       tariff_partial:
+        consumption_charges: Consumption charges
         day_night_tariff: Day/night tariff
         end_date: End date
         full_details: View details
+        price_from_to: "%{price_start_time} to %{price_end_time}:"
         simple_tariff: Simple tariff
         start_date: Start date
         type: Type

--- a/spec/components/energy_tariffs_table_component_spec.rb
+++ b/spec/components/energy_tariffs_table_component_spec.rb
@@ -133,7 +133,7 @@ RSpec.describe EnergyTariffTableComponent, type: :component do
 
   context 'action buttons' do
     it 'includes the actions' do
-      expect(html).to have_link('View details')
+      expect(html).to have_link(energy_tariffs.first.name)
       expect(html).to have_link('Edit')
       expect(html).to have_link('Disable')
       expect(html).to_not have_link('Delete')
@@ -142,7 +142,7 @@ RSpec.describe EnergyTariffTableComponent, type: :component do
     context 'with disabled site settings tariff' do
       let(:enabled)   { false }
       it 'includes all the actions' do
-        expect(html).to have_link('View details')
+        expect(html).to have_link(energy_tariffs.first.name)
         expect(html).to have_link('Edit')
         expect(html).to have_link('Enable')
         expect(html).to have_link('Delete')
@@ -152,7 +152,7 @@ RSpec.describe EnergyTariffTableComponent, type: :component do
     context 'with dcc tariff' do
       let(:source)  { :dcc }
       it 'includes the actions' do
-        expect(html).to have_link('View details')
+        expect(html).to have_link(energy_tariffs.first.name)
         expect(html).to have_link('Edit charges')
         expect(html).to have_link('Disable')
         expect(html).to_not have_link('Delete')
@@ -161,7 +161,7 @@ RSpec.describe EnergyTariffTableComponent, type: :component do
       context 'that is disabled' do
         let(:enabled)   { false }
         it 'includes the expected actions' do
-          expect(html).to have_link('View details')
+          expect(html).to have_link(energy_tariffs.first.name)
           expect(html).to have_link('Edit charges')
           expect(html).to have_link('Enable')
         end
@@ -173,7 +173,7 @@ RSpec.describe EnergyTariffTableComponent, type: :component do
       let(:current_user)  { create(:school_admin) }
 
       it 'does not include the actions' do
-        expect(html).to_not have_link('View details')
+        expect(html).to_not have_link(energy_tariffs.first.name)
         expect(html).to_not have_link('Edit')
         expect(html).to_not have_link('Disable')
         expect(html).to_not have_link('Delete')

--- a/spec/components/energy_tariffs_table_component_spec.rb
+++ b/spec/components/energy_tariffs_table_component_spec.rb
@@ -8,12 +8,14 @@ RSpec.describe EnergyTariffTableComponent, type: :component do
   let(:source)            { :manually_entered }
   let(:energy_tariffs)    { [create(:energy_tariff, tariff_holder: tariff_holder, meter_type: :electricity, enabled: enabled, source: source)] }
   let(:show_actions)      { true }
+  let(:show_prices)       { true }
 
   let(:params) {
     {
       tariff_holder: tariff_holder,
       tariffs: energy_tariffs,
-      show_actions: show_actions
+      show_actions: show_actions,
+      show_prices: show_prices
     }
   }
 
@@ -91,6 +93,16 @@ RSpec.describe EnergyTariffTableComponent, type: :component do
         expect(html).to have_content('schools.user_tariffs.tariff_partial.simple_tariff')
         expect(html).to have_content(energy_tariffs.first.start_date.to_s(:es_compact))
         expect(html).to have_content(energy_tariffs.first.end_date.to_s(:es_compact))
+        expect(html).to have_content(energy_tariffs.first.energy_tariff_price.first)
+      end
+    end
+
+    context 'with show no prices option' do
+      let(:show_prices)       { true }
+      it 'doesnt show price' do
+        within('#tariff-table tbody tr[1]') do
+          expect(html).to_not have_content(energy_tariffs.first.energy_tariff_price.first)
+        end
       end
     end
 

--- a/spec/support/energy_tariff_shared_examples.rb
+++ b/spec/support/energy_tariff_shared_examples.rb
@@ -28,20 +28,18 @@ RSpec.shared_examples "a tariff editor index" do
     before { refresh }
     it 'displays the gas tariff' do
       within '#gas-tariffs-table' do
-        expect(page).to have_content(gas_tariff.name)
         expect(page).to have_content(gas_tariff.start_date.to_s(:es_compact))
         expect(page).to have_content(gas_tariff.end_date.to_s(:es_compact))
-        expect(page).to have_link("View details")
+        expect(page).to have_link(gas_tariff.name)
         expect(page).to have_link("Edit")
         expect(page).to have_link("Delete") if !tariff_holder.site_settings?
       end
     end
     it 'displays the electricity tariff' do
       within '#electricity-tariffs-table' do
-        expect(page).to have_content(electricity_tariff.name)
         expect(page).to have_content(electricity_tariff.start_date.to_s(:es_compact))
         expect(page).to have_content(electricity_tariff.end_date.to_s(:es_compact))
-        expect(page).to have_link("View details")
+        expect(page).to have_link(electricity_tariff.name)
         expect(page).to have_link("Edit")
         expect(page).to have_link("Delete") if !tariff_holder.site_settings?
       end
@@ -97,7 +95,7 @@ RSpec.shared_examples "a gas tariff editor with no meter selection" do
     expect(page).to have_content('Manage and view tariffs')
     expect(page).to have_content('My First Gas Tariff')
 
-    click_link('View details')
+    click_link(energy_tariff.name)
     expect(page).to have_content('My First Gas Tariff')
     expect(page).to have_content('Dates')
     expect(page).to have_content('Start date')
@@ -245,7 +243,7 @@ RSpec.shared_examples "an electricity tariff editor with no meter selection" do
     click_link('Finished')
     expect(page).to have_content('Manage and view tariffs')
 
-    click_link('View details')
+    click_link(energy_tariff.name)
     expect(page).to have_content('My First Flat Tariff')
     expect(page).to have_content('Dates')
     expect(page).to have_content('Start date')
@@ -346,7 +344,7 @@ RSpec.shared_examples "an electricity tariff editor with no meter selection" do
     click_link('Finished')
     expect(page).to have_content('Manage and view tariffs')
 
-    click_link('View details')
+    click_link(energy_tariff.name)
     expect(page).to have_content('My First Diff Tariff')
     expect(page).to have_content('Dates')
     expect(page).to have_content('Start date')
@@ -569,7 +567,7 @@ RSpec.shared_examples "an electricity tariff editor with meter selection" do
     click_link('Finished')
     expect(page).to have_content('Manage and view tariffs')
 
-    click_link('View details')
+    click_link(energy_tariff.name)
     expect(page).to have_content('My First Diff Tariff')
     expect(page).to have_content('Dates')
     expect(page).to have_content('Start date')


### PR DESCRIPTION
When people are reviewing and editing tariffs the most common things to do will be to check dates and prices.

This PR updates the tariff table component to:

- include consumption charges column (but these can be switched off as an option)
- remove the "View details" link in favour of making the tariff name a link
- tidy up the table alignment by adding some `col-x` and text alignment classes