### PR TITLE
Add a note if there are no standing charges

### DIFF
--- a/app/models/energy_tariff.rb
+++ b/app/models/energy_tariff.rb
@@ -121,6 +121,12 @@ class EnergyTariff < ApplicationRecord
     tariff_holder.site_settings? || tariff_holder.school_group? || meters.empty?
   end
 
+  #Used to the show page to decide whether there's content for the standing
+  #charge section which groups these together
+  def has_any_standing_charges?
+    energy_tariff_charges.any? || tnuos? || vat_rate.present? || ccl?
+  end
+
   private
 
   def start_and_end_date_are_not_both_blank

--- a/app/views/energy_tariffs/energy_tariffs/_charges_table.html.erb
+++ b/app/views/energy_tariffs/energy_tariffs/_charges_table.html.erb
@@ -1,30 +1,37 @@
 <table class="table table-charges">
   <tbody>
-  <% if energy_tariff.energy_tariff_charges.any? %>
-    <% energy_tariff.energy_tariff_charges.each do |energy_tariff_charge| %>
+    <% if energy_tariff.has_any_standing_charges? %>
+      <% if energy_tariff.energy_tariff_charges.any? %>
+        <% energy_tariff.energy_tariff_charges.each do |energy_tariff_charge| %>
+          <tr>
+            <td class="description"><%= energy_tariff_charge_type_description(energy_tariff_charge.charge_type) %></td>
+            <td class="value"><%= energy_tariff_charge_value(energy_tariff_charge) %></td>
+          </tr>
+        <% end %>
+      <% end %>
+      <% if energy_tariff.tnuos? %>
+        <tr>
+          <td class="description"><%= t('schools.user_tariffs.charges_table.tnuos') %></td>
+          <td class="value"><%= y_n(energy_tariff.tnuos?)  %></td>
+        </tr>
+      <% end %>
+      <% if energy_tariff.vat_rate %>
+        <tr>
+          <td class="description"><%= t('schools.user_tariffs.charges_table.vat_rate') %></td>
+          <td class="value"><%= energy_tariff.vat_rate  %></td>
+        </tr>
+      <% end %>
+      <% if energy_tariff.ccl? %>
+        <tr>
+          <td class="description"><%= t('schools.user_tariffs.charges_table.climate_charge_levy') %></td>
+          <td class="value"><%= y_n(energy_tariff.ccl?)  %></td>
+        </tr>
+      <% end %>
+    <% else %>
       <tr>
-        <td class="description"><%= energy_tariff_charge_type_description(energy_tariff_charge.charge_type) %></td>
-        <td class="value"><%= energy_tariff_charge_value(energy_tariff_charge) %></td>
+        <td class="description"><%= t('schools.user_tariffs.show.no_standing_charges') %></td>
+        <td class="value"></td>
       </tr>
     <% end %>
-  <% end %>
-  <% if energy_tariff.tnuos? %>
-    <tr>
-      <td class="description"><%= t('schools.user_tariffs.charges_table.tnuos') %></td>
-      <td class="value"><%= y_n(energy_tariff.tnuos?)  %></td>
-    </tr>
-  <% end %>
-  <% if energy_tariff.vat_rate %>
-    <tr>
-      <td class="description"><%= t('schools.user_tariffs.charges_table.vat_rate') %></td>
-      <td class="value"><%= energy_tariff.vat_rate  %></td>
-    </tr>
-  <% end %>
-  <% if energy_tariff.ccl? %>
-    <tr>
-      <td class="description"><%= t('schools.user_tariffs.charges_table.climate_charge_levy') %></td>
-      <td class="value"><%= y_n(energy_tariff.ccl?)  %></td>
-    </tr>
-  <% end %>
   </tbody>
 </table>

--- a/app/views/energy_tariffs/energy_tariffs/_charges_table.html.erb
+++ b/app/views/energy_tariffs/energy_tariffs/_charges_table.html.erb
@@ -1,13 +1,11 @@
 <table class="table table-charges">
   <tbody>
     <% if energy_tariff.has_any_standing_charges? %>
-      <% if energy_tariff.energy_tariff_charges.any? %>
-        <% energy_tariff.energy_tariff_charges.each do |energy_tariff_charge| %>
-          <tr>
-            <td class="description"><%= energy_tariff_charge_type_description(energy_tariff_charge.charge_type) %></td>
-            <td class="value"><%= energy_tariff_charge_value(energy_tariff_charge) %></td>
-          </tr>
-        <% end %>
+      <% energy_tariff.energy_tariff_charges.each do |energy_tariff_charge| %>
+        <tr>
+          <td class="description"><%= energy_tariff_charge_type_description(energy_tariff_charge.charge_type) %></td>
+          <td class="value"><%= energy_tariff_charge_value(energy_tariff_charge) %></td>
+        </tr>
       <% end %>
       <% if energy_tariff.tnuos? %>
         <tr>

--- a/app/views/energy_tariffs/energy_tariffs/show.html.erb
+++ b/app/views/energy_tariffs/energy_tariffs/show.html.erb
@@ -1,7 +1,7 @@
+<% content_for :page_title, @energy_tariff.name %>
 <h1><%= @energy_tariff.name %></h1>
 
 <div class="energy_tariff">
-
   <% if @energy_tariff.dcc? %>
     <%= component 'notice', classes: 'mb-2', status: :neutral do |c| %>
       <div class="d-flex justify-content-between">
@@ -31,7 +31,6 @@
       %>
     </div>
   </div>
-
   <table class="table table-charges">
     <tbody>
       <tr>
@@ -45,9 +44,8 @@
     </tbody>
   </table>
 
-  <br/>
   <% if @energy_tariff.school? %>
-    <div class="d-flex justify-content-between">
+    <div class="mt-4 d-flex justify-content-between">
       <div>
         <h4><%= t('schools.user_tariffs.show.meters') %></h4>
       </div>
@@ -74,10 +72,9 @@
         <% end %>
       </tbody>
     </table>
-    <br/>
   <% end %>
 
-  <div class="d-flex justify-content-between" id="consumption-charges">
+  <div class="mt-4 d-flex justify-content-between" id="consumption-charges">
     <div>
       <h4><%= t('schools.user_tariffs.show.consumption_charges') %></h4>
     </div>
@@ -88,16 +85,13 @@
       %>
     </div>
   </div>
-
   <% if @energy_tariff.flat_rate? %>
     <%= render 'energy_tariffs/energy_tariffs/flat_rate', energy_tariff: @energy_tariff, allow_edits: false %>
   <% else %>
     <%= render 'energy_tariffs/energy_tariffs/rates_table', energy_tariff: @energy_tariff, allow_edits: false %>
   <% end %>
 
-  <br/>
-
-  <div class="d-flex justify-content-between" id="standing-charges">
+  <div class="mt-4 d-flex justify-content-between" id="standing-charges">
     <div>
       <h4><%= t('schools.user_tariffs.show.standing_charges') %></h4>
     </div>
@@ -107,12 +101,10 @@
         class: 'btn' unless @energy_tariff.dcc? %>
     </div>
   </div>
-
   <%= render 'energy_tariffs/energy_tariffs/charges_table', energy_tariff: @energy_tariff, allow_edits: false %>
-  <br />
 
   <% if current_user.admin? %>
-    <div class="d-flex justify-content-between">
+    <div class="mt-4 d-flex justify-content-between">
       <div>
         <h4><%= t('schools.user_tariffs.show.notes_html') %></h4>
       </div>

--- a/config/locales/views/schools/user_tariffs.yml
+++ b/config/locales/views/schools/user_tariffs.yml
@@ -149,6 +149,7 @@ en:
         introduction_html: Any changes to the tariff will be reflected in the <a href='%{analysis_path}'>%{meter_type} cost analysis</a> page which will update overnight
         meter_attribute_view: Meter attribute view (admin only)
         meters: Meters
+        no_standing_charges: No standing charges have been added
         notes_html: Notes <small>(admin only)</small>
         standing_charges: Standing charges
         updated_at: Date last updated

--- a/spec/support/energy_tariff_shared_examples.rb
+++ b/spec/support/energy_tariff_shared_examples.rb
@@ -224,6 +224,8 @@ RSpec.shared_examples "an electricity tariff editor with no meter selection" do
     energy_tariff = EnergyTariff.last
 
     expect(page).to have_content(energy_tariff.name)
+    expect(page).to have_content(I18n.t('schools.user_tariffs.show.no_standing_charges'))
+
     if current_user.admin?
       expect(page).to have_content('Notes (admin only)')
     else


### PR DESCRIPTION
Adds a note to to say if there's no standing charges configured, rather than leaving an empty space.

Also adds a proper page title and replaces use of `<br/>` with bootstrap spacers.