### PR TITLE
Allow user to change tariff to all meters

### DIFF
--- a/app/views/energy_tariffs/energy_tariffs/_form_meter_choices.html.erb
+++ b/app/views/energy_tariffs/energy_tariffs/_form_meter_choices.html.erb
@@ -1,10 +1,31 @@
-<div class="form-check meter-choices">
-  <%= f.collection_check_boxes(:meter_ids, @meters, :id, :mpan_mprn) do |b|  %>
-    <div class="custom-control custom-checkbox">
-      <%= b.check_box(class: "custom-control-input") %>
-      <%= b.label(class: "custom-control-label spaced") do %>
-        <%= b.object.display_summary(display_data_source: false) %>
+<div class="row">
+  <div class="col-md-12">
+    <p>
+      <%= t('schools.user_tariffs.choose_meters.specific_meters_prompt', fuel_type: meter_type) %>
+    </p>
+    <div class="form-check">
+      <div class="custom-control custom-checkbox">
+        <%= check_box_tag :specific_meters, 'yes', specific_meters, {class: 'specific-meters custom-control-input', data: {reveals: '.meter-choices'}} %>
+        <%= label_tag :specific_meters, t('schools.user_tariffs.choose_meters.specific_meters_label'), class: 'custom-control-label' %>
+      </div>
+    </div>
+  </div>
+</div>
+<div class="row mt-4 meter-choices" data-revealed-by='.specific-meters'>
+  <div class="col-md-12">
+    <p>
+      <%= t('schools.user_tariffs.choose_meters.which_meters_will_this_tariff_apply_to') %>
+    </p>
+    <div class="form-check meter-choices">
+      <%= f.collection_check_boxes(:meter_ids, @meters, :id, :mpan_mprn) do |b|  %>
+        <div class="custom-control custom-checkbox">
+          <%= b.check_box(class: "custom-control-input") %>
+          <%= b.label(class: "custom-control-label spaced") do %>
+            <%= b.object.display_summary(display_data_source: false) %>
+          <% end %>
+        </div>
       <% end %>
     </div>
-  <% end %>
+  </div>
 </div>
+<br/>

--- a/app/views/energy_tariffs/energy_tariffs/choose_meters.html.erb
+++ b/app/views/energy_tariffs/energy_tariffs/choose_meters.html.erb
@@ -3,28 +3,7 @@
 <div class="energy_tariff">
   <%= simple_form_for :energy_tariff, url: new_school_energy_tariff_path(@tariff_holder), method: :get do |f| %>
     <%= f.hidden_field :meter_type, value: params[:meter_type] %>
-    <div class="row">
-      <div class="col-md-12">
-        <p>
-          <%= t('schools.user_tariffs.choose_meters.specific_meters_prompt', fuel_type: params[:meter_type]) %>
-        </p>
-        <div class="form-check">
-          <div class="custom-control custom-checkbox">
-            <%= check_box_tag :specific_meters, 'yes', false, {class: 'specific-meters custom-control-input', data: {reveals: '.meter-choices'}} %>
-            <%= label_tag :specific_meters, t('schools.user_tariffs.choose_meters.specific_meters_label'), class: 'custom-control-label' %>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div class="row mt-4 meter-choices" data-revealed-by='.specific-meters'>
-      <div class="col-md-12">
-        <p>
-          <%= t('schools.user_tariffs.choose_meters.which_meters_will_this_tariff_apply_to') %>
-        </p>
-        <%= render 'form_meter_choices', f: f %>
-      </div>
-    </div>
-    <br/>
+    <%= render 'form_meter_choices', f: f, meter_type: params[:meter_type], specific_meters: false %>
     <%= submit_tag t('common.labels.next'), class: 'btn btn-info' %>
   <% end %>
 </div>

--- a/app/views/energy_tariffs/energy_tariffs/edit_meters.html.erb
+++ b/app/views/energy_tariffs/energy_tariffs/edit_meters.html.erb
@@ -10,14 +10,8 @@
   <div class="col-md-12">
     <div class="energy_tariff">
       <%= simple_form_for :energy_tariff, url: energy_tariffs_path(@energy_tariff, [], { action: :update_meters }), method: :post do |f| %>
-        <div class="col-md-12">
-          <p>
-            <%= t('schools.user_tariffs.choose_meters.which_meters_will_this_tariff_apply_to') %>
-          </p>
-          <%= render 'form_meter_choices', f: f %>
-        </div>
-        <br/>
-        <%= submit_tag t('common.labels.submit'), class: 'btn btn-info' %>
+        <%= render 'form_meter_choices', f: f, meter_type: @energy_tariff.meter_type, specific_meters: @energy_tariff.meters.any? %>
+        <%= submit_tag t('common.labels.next'), class: 'btn btn-info' %>
       <% end %>
     </div>
   </div>

--- a/spec/support/energy_tariff_shared_examples.rb
+++ b/spec/support/energy_tariff_shared_examples.rb
@@ -622,7 +622,7 @@ RSpec.shared_examples "an electricity tariff editor with meter selection" do
     find('#edit_meters').click
     expect(page).to have_content('Select meters for this tariff')
     uncheck(mpan_mprn)
-    click_button('Submit')
+    click_button('Next')
     expect(page).to have_content('My Updated First Diff Tariff')
     expect(page).to have_content('Dates')
     expect(page).to have_content('Start date')


### PR DESCRIPTION
Revises the "edit meters" flow so that it uses the same form as the "choose meters" step. I've retained the routes and form due to the different contexts (with and without a tariff).