### PR TITLE
Add I18N key constants

### DIFF
--- a/app/models/chart_data_values.rb
+++ b/app/models/chart_data_values.rb
@@ -141,8 +141,8 @@ class ChartDataValues
       I18n.t('analytics.series_data_manager.series_name.storage_heaters') => STORAGE_HEATER,
       '£' => MONEY,
       I18n.t("analytics.series_data_manager.series_name.#{SolarPVPanels::SOLAR_PV_ONSITE_ELECTRIC_CONSUMPTION_METER_NAME_I18N_KEY}") => GREEN,
-      I18n.t("analytics.series_data_manager.series_name.#{SolarPVPanels::ELECTRIC_CONSUMED_FROM_MAINS_METER_NAME}") => DARK_ELECTRICITY,
-      I18n.t("analytics.series_data_manager.series_name.#{SolarPVPanels::SOLAR_PV_EXPORTED_ELECTRIC_METER_NAME}") => LIGHT_GAS_LINE,
+      I18n.t("analytics.series_data_manager.series_name.#{SolarPVPanels::ELECTRIC_CONSUMED_FROM_MAINS_METER_NAME_I18N_KEY}") => DARK_ELECTRICITY,
+      I18n.t("analytics.series_data_manager.series_name.#{SolarPVPanels::SOLAR_PV_EXPORTED_ELECTRIC_METER_NAME_I18N_KEY}") => LIGHT_GAS_LINE,
       I18n.t('analytics.series_data_manager.y2_solar_label') => MIDDLE_GAS,
       I18n.t('analytics.series_data_manager.y2_rating') => '#232b49'
     }

--- a/spec/models/chart_data_values_spec.rb
+++ b/spec/models/chart_data_values_spec.rb
@@ -152,8 +152,9 @@ describe ChartDataValues do
 
   describe '#colour_lookup' do
     it 'returns a hash with colours assigned to chart series names' do
+      #pry
       expect(chart_data_values.colour_lookup).to eq(
-        {"Degree Days" => "#232b49", "Temperature" => "#232b49", "School Day Closed" => "#3bc0f0", "School Day Open" => "#5cb85c", "Holiday" => "#ff4500", "Weekend" => "#ffac21", "Heating on in cold weather" => "#3bc0f0", "Hot Water (& Kitchen)" => "#5cb85c", "Hot Water Usage" => "#3bc0f0", "Wasted Hot Water Usage" => "#ff4500", "Solar PV (consumed onsite)" => "#ffac21", "Electricity" => "#007EFF", "Gas" => "#FF8438", "Storage heaters" => "#501e74", "£" => "#232B49", "Electricity consumed from solar pv" => "#5cb85c", "translation missing: en.analytics.series_data_manager.series_name.Electricity consumed from mains" => "#007EFF", "translation missing: en.analytics.series_data_manager.series_name.Exported solar electricity (not consumed onsite)" => "#FCB43A", "Solar irradiance (brightness of sunshine)" => "#FFB138", "Rating" => "#232b49"}
+        {"Degree Days" => "#232b49", "Temperature" => "#232b49", "School Day Closed" => "#3bc0f0", "School Day Open" => "#5cb85c", "Holiday" => "#ff4500", "Weekend" => "#ffac21", "Heating on in cold weather" => "#3bc0f0", "Hot Water (& Kitchen)" => "#5cb85c", "Hot Water Usage" => "#3bc0f0", "Wasted Hot Water Usage" => "#ff4500", "Solar PV (consumed onsite)" => "#ffac21", "Electricity" => "#007EFF", "Gas" => "#FF8438", "Storage heaters" => "#501e74", "£" => "#232B49", "Electricity consumed from solar pv" => "#5cb85c", "Electricity consumed from mains" => "#007EFF", "Exported solar electricity (not consumed onsite)" => "#FCB43A", "Solar irradiance (brightness of sunshine)" => "#FFB138", "Rating" => "#232b49"}
       )
     end
   end


### PR DESCRIPTION
We have a number of dependabot PRs which are all failing with the same error:

https://github.com/Energy-Sparks/energy-sparks/actions/runs/5713575489/job/15900364828?pr=2939

```
       +"Translation missing: en.analytics.series_data_manager.series_name.Electricity consumed from mains" => "#007EFF",
       +"Translation missing: en.analytics.series_data_manager.series_name.Exported solar electricity (not consumed onsite)" =>        -"translation missing: en.analytics.series_data_manager.series_name.Electricity consumed from mains" => "#007EFF",
       -"translation missing: en.analytics.series_data_manager.series_name.Exported solar electricity (not consumed onsite)" =>      # ./spec/models/chart_data_values_spec.rb:155:in `block (3 levels) in <top (required)>'
```

Looks like somewhere in the recent dependency updates the formatting of the "Translation missing" text has changed. 

I'm not sure why we are checking for the translation missing text here in the spec, as it's a bug if the translation can't be found. Fix is to use the constants defined in the `SolarPVPanels` class. Maybe these were missed before.

This wasn't causing a visible application error as the missing colour code meant the charts have just been defaulting to a different colour. This fix will now apply the preferred colour to the exported solar series.

If we can merge this then we can get dependabot to rebase the other changes so we can merge.