### PR TITLE
Fix error when reporting tariffs have changed

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ gem 'pg_search'
 gem 'calculate_in_group'
 
 # Dashboard analytics
-gem 'energy-sparks_analytics', git: 'https://github.com/Energy-Sparks/energy-sparks_analytics.git', tag: '3.0.1'
+gem 'energy-sparks_analytics', git: 'https://github.com/Energy-Sparks/energy-sparks_analytics.git', tag: '3.0.2'
 #gem 'energy-sparks_analytics', git: 'https://github.com/Energy-Sparks/energy-sparks_analytics.git', branch: 'additional-tariff-code-tests-and-refactoring'
 #gem 'energy-sparks_analytics', path: '../energy-sparks_analytics'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/Energy-Sparks/energy-sparks_analytics.git
-  revision: c256458bf1a2fca743a6add7d5a667e8b89af012
-  tag: 3.0.1
+  revision: f991dba69e5e6011ebe7e741132f9dace645c58a
+  tag: 3.0.2
   specs:
     energy-sparks_analytics (1.2.1)
       activesupport (>= 6.0, < 7.1)

--- a/app/services/energy_tariff_default_prices_creator.rb
+++ b/app/services/energy_tariff_default_prices_creator.rb
@@ -8,9 +8,9 @@ class EnergyTariffDefaultPricesCreator
     return if @energy_tariff.energy_tariff_prices.any?
 
     night_times = if @energy_tariff.tariff_holder.school? && @energy_tariff.meters.any?
-                    Economy7Times.times(@energy_tariff&.meters&.first&.mpan_mprn)
+                    Meters::Economy7Times.times(@energy_tariff&.meters&.first&.mpan_mprn)
                   else
-                    Economy7Times::DEFAULT_TIMES
+                    Meters::Economy7Times::DEFAULT_TIMES
                   end
 
     day_times = night_times.last..night_times.first

--- a/app/services/meters/economy7_times.rb
+++ b/app/services/meters/economy7_times.rb
@@ -1,0 +1,36 @@
+module Meters
+  class Economy7Times
+    def self.times(mprn)
+      region = (mprn / 100_000_000_000).to_i
+      if NIGHTTIME.key?(region) && NIGHTTIME[region][:times].is_a?(Range)
+        NIGHTTIME[region][:times]
+      else
+        DEFAULT_TIMES
+      end
+    end
+
+    # https://www.electricityprices.org.uk/economy-7/
+    # https://www.businessjuice.co.uk/energy-guides/economy-7-times/
+    # https://sse.co.uk/help/energy/daylight-saving-time states economy 7 stays on GMT all year round?
+    DEFAULT_TIMES = (TimeOfDay.new(0, 0)..TimeOfDay.new(7, 0)).freeze
+
+    NIGHTTIME = { # there seems to be some ambiguity, varies between suppliers?
+      10 => { times: TimeOfDay.new(23,  0)..TimeOfDay.new(7,  0), region: :eastern },
+      11 => { times: TimeOfDay.new(23,  0)..TimeOfDay.new(7,  0), region: :east_midlands },
+      12 => { times: TimeOfDay.new(23,  0)..TimeOfDay.new(7,  0), region: :london },
+      13 => { times: TimeOfDay.new(0,  0)..TimeOfDay.new(8, 0), region: :merseyside_north_wales },
+      14 => { times: TimeOfDay.new(23, 30)..TimeOfDay.new(8, 0), region: :midlands },
+      15 => { times: TimeOfDay.new(0, 30)..TimeOfDay.new(7, 30), region: :north_east },
+      16 => { times: TimeOfDay.new(0, 30)..TimeOfDay.new(7, 30), region: :north_west },
+      17 => { varies_between_meter: true, region: :north_scotland },
+      18 => { times: TimeOfDay.new(22,  0)..TimeOfDay.new(8,  0), region: :south_scotland },
+      19 => { times: [TimeOfDay.new(23, 30)..TimeOfDay.new(0, 30),
+                      TimeOfDay.new(2, 30)..TimeOfDay.new(7, 30)], region: :south_east },
+      20 => { times:  { gmt: TimeOfDay.new(23, 30)..TimeOfDay.new(6, 30),
+                        bst: TimeOfDay.new(0, 30)..TimeOfDay.new(7, 30) }, region: :southern },
+      21 => { varies_between_meter: true, region: :south_wales },
+      22 => { varies_between_meter: true, region: :south_west },
+      24 => { times: TimeOfDay.new(0, 30)..TimeOfDay.new(7, 30), region: :yorkshire },
+      }.freeze
+  end
+end


### PR DESCRIPTION
Update to new version of analytics with fix to tariff manager that stops an error on pages where we display the "tariff  caveats".