### PR TITLE
Remove duplicate dcc tariffs and charges

### DIFF
--- a/app/components/energy_tariffs_component/energy_tariffs_component.html.erb
+++ b/app/components/energy_tariffs_component/energy_tariffs_component.html.erb
@@ -11,7 +11,7 @@
               </span>
               <%= t("schools.user_tariffs.index.#{meter_type}.header") %>
             </h4>
-            <% if @tariff_holder.any_tariffs_of_type?(meter_type) %>
+            <% if @tariff_holder.any_tariffs_of_type?(meter_type, @source) %>
               <%= component 'energy_tariff_table',
                 id: table_id(meter_type),
                 tariff_holder: @tariff_holder,

--- a/app/models/tariff_price.rb
+++ b/app/models/tariff_price.rb
@@ -27,7 +27,7 @@ class TariffPrice < ApplicationRecord
 
   def self.delete_duplicates_for_meter!(meter)
     last_price = nil
-    meter.tariff_prices.order(created_at: :asc).each do |tariff_price|
+    meter.tariff_prices.order(tariff_date: :asc).each do |tariff_price|
       last_price = tariff_price if last_price.nil? || last_price.prices != tariff_price.prices
       tariff_price.destroy if tariff_price != last_price && tariff_price.prices == last_price.prices
     end

--- a/app/models/tariff_price.rb
+++ b/app/models/tariff_price.rb
@@ -24,4 +24,12 @@ class TariffPrice < ApplicationRecord
   belongs_to :tariff_import_log, inverse_of: :tariff_prices
 
   serialize :prices
+
+  def self.delete_duplicates_for_meter!(meter)
+    last_price = nil
+    meter.tariff_prices.order(created_at: :asc).each do |tariff_price|
+      last_price = tariff_price if last_price.nil? || last_price.prices != tariff_price.prices
+      tariff_price.destroy if tariff_price != last_price && tariff_price.prices == last_price.prices
+    end
+  end
 end

--- a/app/models/tariff_standing_charge.rb
+++ b/app/models/tariff_standing_charge.rb
@@ -24,4 +24,12 @@ class TariffStandingCharge < ApplicationRecord
   belongs_to :tariff_import_log, inverse_of: :tariff_standing_charges
 
   attribute :value, :float
+
+  def self.delete_duplicates_for_meter!(meter)
+    last_charge = nil
+    meter.tariff_standing_charges.order(created_at: :asc).each do |tariff_standing_charge|
+      last_charge = tariff_standing_charge if last_charge.nil? || last_charge.value != tariff_standing_charge.value
+      tariff_standing_charge.destroy if tariff_standing_charge != last_charge && tariff_standing_charge.value == last_charge.value
+    end
+  end
 end

--- a/app/models/tariff_standing_charge.rb
+++ b/app/models/tariff_standing_charge.rb
@@ -27,7 +27,7 @@ class TariffStandingCharge < ApplicationRecord
 
   def self.delete_duplicates_for_meter!(meter)
     last_charge = nil
-    meter.tariff_standing_charges.order(created_at: :asc).each do |tariff_standing_charge|
+    meter.tariff_standing_charges.order(start_date: :asc).each do |tariff_standing_charge|
       last_charge = tariff_standing_charge if last_charge.nil? || last_charge.value != tariff_standing_charge.value
       tariff_standing_charge.destroy if tariff_standing_charge != last_charge && tariff_standing_charge.value == last_charge.value
     end

--- a/lib/tasks/deployment/20230821130012_remove_duplicate_dcc_tariffs.rake
+++ b/lib/tasks/deployment/20230821130012_remove_duplicate_dcc_tariffs.rake
@@ -1,0 +1,18 @@
+namespace :after_party do
+  desc 'Deployment task: remove_duplicate_dcc_tariffs'
+  task remove_duplicate_dcc_tariffs: :environment do
+    puts "Running deploy task 'remove_duplicate_dcc_tariffs'"
+
+    ActiveRecord::Base.transaction do
+      Meter.dcc.each do |meter|
+        TariffPrice.delete_duplicates_for_meter!(meter)
+        TariffStandingCharge.delete_duplicates_for_meter!(meter)
+      end
+    end
+
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord
+      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+  end
+end

--- a/spec/models/tariff_standing_charge_spec.rb
+++ b/spec/models/tariff_standing_charge_spec.rb
@@ -17,4 +17,37 @@ describe TariffStandingCharge do
     expect(@tariff_standing_charge.value).to eq(0.123)
     expect(@tariff_standing_charge.value.class).to eq(Float)
   end
+
+  describe '#delete_duplicates_for_meter!' do
+    let(:charge)   { 0.1 }
+    let!(:first)   { create(:tariff_standing_charge, meter: meter, start_date: Date.new(2023,1,1), value: charge) }
+    let!(:second)  { create(:tariff_standing_charge, meter: meter, start_date: Date.new(2023,1,2), value: 0.3 ) }
+
+    it 'doesnt delete if not duplicates' do
+      expect { TariffStandingCharge.delete_duplicates_for_meter!(meter) }.not_to change {TariffStandingCharge.count}
+    end
+
+    context 'with duplicates on following day' do
+      let!(:second)  { create(:tariff_standing_charge, meter: meter, start_date: Date.new(2023,1,2), value: charge ) }
+      it 'deletes duplicates' do
+        expect { TariffStandingCharge.delete_duplicates_for_meter!(meter) }.to change {TariffStandingCharge.count}.by(-1)
+      end
+    end
+
+    context 'with many duplicates' do
+      let!(:duplicates)  { create_list(:tariff_standing_charge, 10, meter: meter, value: charge) }
+      it 'deletes duplicates' do
+        #should remove all but one of the 10
+        expect { TariffStandingCharge.delete_duplicates_for_meter!(meter) }.to change {TariffStandingCharge.count}.by(-9)
+      end
+    end
+
+    context 'with duplicates on different days' do
+      let!(:third)  { create(:tariff_standing_charge, meter: meter, start_date: Date.new(2023,1,3), value: charge) }
+      it 'does not delete duplicates' do
+        expect { TariffStandingCharge.delete_duplicates_for_meter!(meter) }.not_to change {TariffStandingCharge.count}
+      end
+    end
+  end
+
 end


### PR DESCRIPTION
Removes duplicate TariffPrice and TariffStandingCharge records if they are the same as the previous record for that meter.

Also fixes a bug in display of migrated smart meter tariffs