### PR TITLE
Add visual cues to tariffs table

### DIFF
--- a/app/components/energy_tariff_table_component.rb
+++ b/app/components/energy_tariff_table_component.rb
@@ -66,4 +66,9 @@ class EnergyTariffTableComponent < ViewComponent::Base
   def table_sorted
     @tariffs.length > 1 ? 'table-sorted' : ''
   end
+
+  def class_for_tariff(energy_tariff)
+    return "table-secondary" unless energy_tariff.enabled
+    return "table-danger" unless energy_tariff.usable?
+  end
 end

--- a/app/components/energy_tariff_table_component/energy_tariff_table_component.html.erb
+++ b/app/components/energy_tariff_table_component/energy_tariff_table_component.html.erb
@@ -16,7 +16,7 @@
   </thead>
   <tbody>
     <% @tariffs.each do |energy_tariff| %>
-      <tr class="<%= class_for_tariff(energy_tariff) %>">
+      <tr class="<%= class_for_tariff(energy_tariff) %>" id="energy-tariff-<%=energy_tariff.id%>">
         <td class="text-right" data-order="<%= start_date_sortable(energy_tariff) %>"><%= start_date(energy_tariff) %></td>
         <td class="text-right" data-order="<%= end_date_sortable(energy_tariff) %>"><%= end_date(energy_tariff) %></td>
         <td class="text-left" >

--- a/app/components/energy_tariff_table_component/energy_tariff_table_component.html.erb
+++ b/app/components/energy_tariff_table_component/energy_tariff_table_component.html.erb
@@ -16,7 +16,7 @@
   </thead>
   <tbody>
     <% @tariffs.each do |energy_tariff| %>
-      <tr >
+      <tr class="<%= class_for_tariff(energy_tariff) %>">
         <td class="text-right" data-order="<%= start_date_sortable(energy_tariff) %>"><%= start_date(energy_tariff) %></td>
         <td class="text-right" data-order="<%= end_date_sortable(energy_tariff) %>"><%= end_date(energy_tariff) %></td>
         <td class="text-left" >

--- a/app/components/energy_tariffs_component.rb
+++ b/app/components/energy_tariffs_component.rb
@@ -22,4 +22,12 @@ class EnergyTariffsComponent < ViewComponent::Base
       "#{meter_type}-tariffs-table"
     end
   end
+
+  def sorted_tariffs(meter_type)
+    if @default_tariffs
+      @tariff_holder.energy_tariffs.where(meter_type: meter_type, source: @source, enabled: true).by_start_and_end.by_name.select(&:usable?)
+    else
+      @tariff_holder.energy_tariffs.where(meter_type: meter_type, source: @source).by_start_and_end.by_name
+    end
+  end
 end

--- a/app/components/energy_tariffs_component/energy_tariffs_component.html.erb
+++ b/app/components/energy_tariffs_component/energy_tariffs_component.html.erb
@@ -11,11 +11,11 @@
               </span>
               <%= t("schools.user_tariffs.index.#{meter_type}.header") %>
             </h4>
-            <% if @tariff_holder.any_tariffs_of_type?(meter_type, @source) %>
+            <% if @tariff_holder.any_tariffs_of_type?(meter_type, @source, only_enabled: @default_tariffs) %>
               <%= component 'energy_tariff_table',
                 id: table_id(meter_type),
                 tariff_holder: @tariff_holder,
-                tariffs: sorted_tariffs(@tariff_holder, meter_type, @source),
+                tariffs: sorted_tariffs(meter_type),
                 show_actions: @show_actions %>
             <% else %>
               <p>

--- a/app/helpers/energy_tariffs_helper.rb
+++ b/app/helpers/energy_tariffs_helper.rb
@@ -42,10 +42,6 @@ module EnergyTariffsHelper
     show_all ? EnergyTariff.meter_types.keys : Meter::MAIN_METER_TYPES
   end
 
-  def sorted_tariffs(tariff_holder, meter_type, source = :manually_entered)
-    tariff_holder.energy_tariffs.where(meter_type: meter_type, source: source).by_start_and_end.by_name
-  end
-
   def site_settings_page?
     request.path.start_with?('/admin/settings')
   end

--- a/app/models/concerns/energy_tariff_holder.rb
+++ b/app/models/concerns/energy_tariff_holder.rb
@@ -27,8 +27,12 @@ module EnergyTariffHolder
   end
 
   #Does it currently have any of that type
-  def any_tariffs_of_type?(meter_type, source = :manually_entered)
-    energy_tariffs.where(meter_type: meter_type, source: source).any?
+  def any_tariffs_of_type?(meter_type, source = :manually_entered, only_enabled: false)
+    if only_enabled
+      energy_tariffs.where(meter_type: meter_type, source: source, enabled: true).any?
+    else
+      energy_tariffs.where(meter_type: meter_type, source: source).any?
+    end
   end
 
   #Can if have tariffs of a type

--- a/app/models/energy_tariff.rb
+++ b/app/models/energy_tariff.rb
@@ -5,12 +5,12 @@
 #  ccl                :boolean          default(FALSE)
 #  created_at         :datetime         not null
 #  created_by_id      :bigint(8)
-#  enabled            :boolean          default(FALSE)
+#  enabled            :boolean          default(TRUE)
 #  end_date           :date
 #  id                 :bigint(8)        not null, primary key
 #  meter_type         :integer          default("electricity"), not null
 #  name               :text             not null
-#  source             :integer          default("manual"), not null
+#  source             :integer          default("manually_entered"), not null
 #  start_date         :date
 #  tariff_holder_id   :bigint(8)
 #  tariff_holder_type :string
@@ -18,7 +18,7 @@
 #  tnuos              :boolean          default(FALSE)
 #  updated_at         :datetime         not null
 #  updated_by_id      :bigint(8)
-#  vat_rate           :float
+#  vat_rate           :integer
 #
 # Indexes
 #

--- a/app/models/energy_tariff_charge.rb
+++ b/app/models/energy_tariff_charge.rb
@@ -6,7 +6,7 @@
 #  created_at       :datetime         not null
 #  energy_tariff_id :bigint(8)        not null
 #  id               :bigint(8)        not null, primary key
-#  units            :text             not null
+#  units            :text
 #  updated_at       :datetime         not null
 #  value            :decimal(, )      not null
 #

--- a/app/models/energy_tariff_price.rb
+++ b/app/models/energy_tariff_price.rb
@@ -4,10 +4,10 @@
 #
 #  created_at       :datetime         not null
 #  description      :text
-#  end_time         :text             not null
+#  end_time         :time             default(Sat, 01 Jan 2000 23:30:00 UTC +00:00), not null
 #  energy_tariff_id :bigint(8)        not null
 #  id               :bigint(8)        not null, primary key
-#  start_time       :text             not null
+#  start_time       :time             default(Sat, 01 Jan 2000 00:00:00 UTC +00:00), not null
 #  units            :text
 #  updated_at       :datetime         not null
 #  value            :decimal(, )      default(0.0), not null

--- a/app/views/energy_tariffs/energy_tariffs/show.html.erb
+++ b/app/views/energy_tariffs/energy_tariffs/show.html.erb
@@ -2,6 +2,26 @@
 <h1><%= @energy_tariff.name %></h1>
 
 <div class="energy_tariff">
+  <% if @energy_tariff.usable? %>
+    <% if @energy_tariff.tariff_holder.school? %>
+      <%= component 'notice', classes: 'mb-2', status: :neutral do |c| %>
+        <p>
+          <%= t('schools.user_tariffs.show.introduction_html', analysis_path: analysis_page_finder_path(urn: @tariff_holder.urn, analysis_class: cost_analysis_class_for(@energy_tariff.meter_type)), meter_type: t("common.#{@energy_tariff.meter_type}").downcase) %>.
+        </p>
+      <% end %>
+    <% end %>
+  <% else %>
+    <%= component 'notice', classes: 'mb-2', status: :negative do |c| %>
+      <div class="d-flex justify-content-between">
+        <%= t('schools.user_tariffs.show.not_usable') %>
+        <%= link_to t('common.labels.edit'),
+          energy_tariff_prices_path(@energy_tariff),
+          class: 'btn btn-primary' unless @energy_tariff.dcc?
+        %>
+      </div>
+    <% end %>
+  <% end %>
+
   <% if @energy_tariff.dcc? %>
     <%= component 'notice', classes: 'mb-2', status: :neutral do |c| %>
       <div class="d-flex justify-content-between">
@@ -10,13 +30,6 @@
           energy_tariffs_path(@energy_tariff, [:energy_tariff_charges]),
           class: 'btn btn-primary' %>
       </div>
-    <% end %>
-  <% end %>
-  <% if @energy_tariff.tariff_holder.school? %>
-    <%= component 'notice', classes: 'mb-2', status: :neutral do |c| %>
-      <p>
-        <%= t('schools.user_tariffs.show.introduction_html', analysis_path: analysis_page_finder_path(urn: @tariff_holder.urn, analysis_class: cost_analysis_class_for(@energy_tariff.meter_type)), meter_type: t("common.#{@energy_tariff.meter_type}").downcase) %>.
-      </p>
     <% end %>
   <% end %>
 

--- a/app/views/energy_tariffs/energy_tariffs/toggle_enabled.js.erb
+++ b/app/views/energy_tariffs/energy_tariffs/toggle_enabled.js.erb
@@ -1,2 +1,3 @@
 $("#energy-tariff-<%= @energy_tariff.id %>-toggle").html("<%== @energy_tariff.enabled ? t('common.labels.disable') : t('common.labels.enable') %>")
+$("#energy-tariff-<%= @energy_tariff.id %>").toggleClass('table-secondary', <%== !@energy_tariff.enabled %>)
 $("#energy-tariff-<%= @energy_tariff.id %>-delete").toggle()

--- a/config/locales/views/schools/user_tariffs.yml
+++ b/config/locales/views/schools/user_tariffs.yml
@@ -157,6 +157,7 @@ en:
         meter_attribute_view: Meter attribute view (admin only)
         meters: Meters
         no_standing_charges: No standing charges have been added
+        not_usable: This tariff has missing or incomplete prices and so is not yet usable.
         notes_html: Notes <small>(admin only)</small>
         standing_charges: Standing charges
         updated_at: Date last updated

--- a/spec/components/energy_tariffs_table_component_spec.rb
+++ b/spec/components/energy_tariffs_table_component_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe EnergyTariffTableComponent, type: :component do
   let(:tariff_holder)     { SiteSettings.current }
   let(:enabled)           { true }
   let(:source)            { :manually_entered }
-  let(:energy_tariffs)    { [create(:energy_tariff, tariff_holder: tariff_holder, meter_type: :electricity, enabled: enabled, source: source)] }
+  let(:energy_tariffs)    { [create(:energy_tariff, :with_flat_price, tariff_holder: tariff_holder, meter_type: :electricity, enabled: enabled, source: source)] }
   let(:show_actions)      { true }
   let(:show_prices)       { true }
 
@@ -87,6 +87,10 @@ RSpec.describe EnergyTariffTableComponent, type: :component do
       expect(html).to have_css('#tariff-table')
     end
 
+    it 'does not treat tariff as not usable' do
+      expect(html).to_not have_css('tr.table-danger')
+    end
+
     it 'includes the tariff details' do
       within('#tariff-table tbody tr[1]') do
         expect(html).to have_content(energy_tariffs.first.name)
@@ -147,6 +151,17 @@ RSpec.describe EnergyTariffTableComponent, type: :component do
         expect(html).to have_link('Enable')
         expect(html).to have_link('Delete')
       end
+      it 'styles the row' do
+        expect(html).to have_css("tr.table-secondary")
+      end
+    end
+
+    context 'with unusable tariff' do
+      #no prices
+      let(:energy_tariffs)    { [create(:energy_tariff, tariff_holder: tariff_holder, meter_type: :electricity, enabled: enabled, source: source)] }
+      it 'styles the row' do
+        expect(html).to have_css("tr.table-danger")
+      end
     end
 
     context 'with dcc tariff' do
@@ -165,8 +180,10 @@ RSpec.describe EnergyTariffTableComponent, type: :component do
           expect(html).to have_link('Edit charges')
           expect(html).to have_link('Enable')
         end
+        it 'styles the row' do
+          expect(html).to have_css("tr.table-secondary")
+        end
       end
-
     end
 
     context 'with non-authorised user' do

--- a/spec/support/energy_tariff_shared_examples.rb
+++ b/spec/support/energy_tariff_shared_examples.rb
@@ -103,6 +103,8 @@ RSpec.shared_examples "a gas tariff editor with no meter selection" do
     expect(page).to have_content('End date')
     expect(page).to have_content('16/08/2023')
 
+    expect(page).to_not have_content(I18n.t('schools.user_tariffs.show.not_usable'))
+
     find('#edit_dates').click
     expect(page).to have_content('Name')
     expect(page).to have_content('Start date')
@@ -203,6 +205,9 @@ RSpec.shared_examples "an electricity tariff editor with no meter selection" do
     visit tariff_index_path
 
     expect(page).to have_content('My First Tariff')
+
+    click_on('My First Tariff')
+    expect(page).to have_content(I18n.t('schools.user_tariffs.show.not_usable'))
   end
 
   it 'can create a flat rate tariff with just a price' do
@@ -252,6 +257,8 @@ RSpec.shared_examples "an electricity tariff editor with no meter selection" do
     expect(page).to have_content('15/08/2023')
     expect(page).to have_content('End date')
     expect(page).to have_content('16/08/2023')
+
+    expect(page).to_not have_content(I18n.t('schools.user_tariffs.show.not_usable'))
 
     find('#edit_dates').click
     expect(page).to have_content('Name')
@@ -410,6 +417,9 @@ RSpec.shared_examples "an electricity tariff editor with no meter selection" do
     expect(page).to have_content('Manage and view tariffs')
 
     click_link(energy_tariff.name)
+    #previous flow leaves a zero charge
+    expect(page).to have_content(I18n.t('schools.user_tariffs.show.not_usable'))
+
     expect(page).to have_content('My First Diff Tariff')
     expect(page).to have_content('Dates')
     expect(page).to have_content('Start date')
@@ -514,6 +524,8 @@ RSpec.shared_examples "an electricity tariff editor with no meter selection" do
     else
       expect(page).not_to have_content('Notes (admin only)')
     end
+
+    expect(page).to_not have_content(I18n.t('schools.user_tariffs.show.not_usable'))
 
     expect(energy_tariff.enabled).to be true
     expect(energy_tariff.meter_type.to_sym).to eq(:electricity)


### PR DESCRIPTION
If a tariff is disabled then

* Flag the table row in a different colour
* Do not include it in the list of default tariffs

If a tariff is not usable

* Flag the table row in a different colour
* Add a notice to the tariff page with a link to edit the prices
