### PR TITLE
Customise message for smart meters

### DIFF
--- a/app/components/energy_tariffs_component/energy_tariffs_component.html.erb
+++ b/app/components/energy_tariffs_component/energy_tariffs_component.html.erb
@@ -19,7 +19,9 @@
                 show_actions: @show_actions %>
             <% else %>
               <p>
-                <% if @default_tariffs %>
+                <% if @source == :dcc %>
+                <%= t('schools.user_tariffs.index.no_smart_meter_tariffs', meter_type: meter_type) %>
+                <% elsif @default_tariffs %>
                   <%= t('schools.user_tariffs.index.no_defaults', meter_type: meter_type) %>
                 <% else %>
                   <%= t("schools.user_tariffs.index.#{meter_type}.there_are_no_#{meter_type}_tariffs_set_up_yet") %>

--- a/config/locales/views/schools/user_tariffs.yml
+++ b/config/locales/views/schools/user_tariffs.yml
@@ -122,6 +122,7 @@ en:
             To add a a new tariff you will need to know the prices and, optionally, the range of standing charges that are included in your energy contract.
           </p>
         no_defaults: We have no default tariffs for your %{meter_type} meters.
+        no_smart_meter_tariffs: We have not imported any tariffs from your %{meter_type} meters.
         note_about_defaults: If we do not have your real tariff information, then we will estimate your costs using our default tariffs.
         note_about_smart_meter_tariffs: We are currently using tariffs automatically imported from your smart meters.
         solar_pv:

--- a/spec/components/energy_tariffs_component_spec.rb
+++ b/spec/components/energy_tariffs_component_spec.rb
@@ -9,14 +9,17 @@ RSpec.describe EnergyTariffsComponent, type: :component do
   let!(:exp_solar_pv_tariffs){ create_list(:energy_tariff, 1, tariff_holder: tariff_holder, meter_type: :exported_solar_pv)}
 
   let(:tariff_types)         { Meter::MAIN_METER_TYPES }
-
   let(:show_add_button)      { true }
+  let(:source)               { :manually_entered }
+  let(:default_tariffs)      { false }
 
   let(:params) {
     {
       tariff_holder: tariff_holder,
       tariff_types: tariff_types,
-      show_add_button: show_add_button
+      source: source,
+      show_add_button: show_add_button,
+      default_tariffs: default_tariffs
     }
   }
 
@@ -40,6 +43,24 @@ RSpec.describe EnergyTariffsComponent, type: :component do
         expect(html).to have_css('#gas-tariffs-table')
         expect(html).to have_css('#solar_pv-tariffs-table')
         expect(html).to have_css('#exported_solar_pv-tariffs-table')
+      end
+    end
+    context 'with smart meter tariffs' do
+      let(:source)               { :dcc }
+      context 'and no gas meters' do
+        let!(:gas_tariffs)         { nil }
+        it 'adds correct message' do
+          expect(html).to have_content(I18n.t('schools.user_tariffs.index.no_smart_meter_tariffs', meter_type: :gas))
+        end
+      end
+    end
+    context 'with default tariffs' do
+      let(:default_tariffs)      { true }
+      context 'and no gas meters' do
+        let!(:gas_tariffs)         { nil }
+        it 'adds correct message' do
+          expect(html).to have_content(I18n.t('schools.user_tariffs.index.no_defaults', meter_type: :gas))
+        end
       end
     end
   end


### PR DESCRIPTION
Tweak the message for when we're displaying a list of smart meter tariffs and there aren't any for a specific meter type.