### PR TITLE
Update selenium and webdriver gems, unpin driver

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -163,7 +163,7 @@ group :test do
   gem 'capybara-email'
   gem 'selenium-webdriver'
   gem 'database_cleaner'
-  gem "webdrivers", '>= 5.2.0'
+  gem "webdrivers", '>= 5.3.0'
   gem 'simplecov', :require => false, :group => :test
   gem 'shoulda-matchers'
   gem 'timecop'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -656,10 +656,10 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
-    webdrivers (5.2.0)
+    webdrivers (5.3.1)
       nokogiri (~> 1.6)
       rubyzip (>= 1.3.0)
-      selenium-webdriver (~> 4.0)
+      selenium-webdriver (~> 4.0, < 4.11)
     webmock (3.14.0)
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
@@ -778,7 +778,7 @@ DEPENDENCIES
   uglifier
   view_component
   web-console
-  webdrivers (>= 5.2.0)
+  webdrivers (>= 5.3.0)
   webmock
   webpacker
   wisper (= 2.0.0)

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -17,10 +17,6 @@ require 'capybara/email/rspec'
 require 'cancan/matchers'
 require 'wisper/rspec/matchers'
 
-#Pin version of Chrome driver. A workaround for this issue:
-# https://github.com/titusfortner/webdrivers/issues/247
-Webdrivers::Chromedriver.required_version = "114.0.5735.90"
-
 # Add additional requires below this line. Rails is not loaded until this point!
 
 # Requires supporting ruby files with custom matchers and macros, etc, in


### PR DESCRIPTION
This should fix the issues with builds failing because of newer version of Chrome being available.