### PR TITLE
Fix sort order on tariffs table

### DIFF
--- a/app/models/energy_tariff.rb
+++ b/app/models/energy_tariff.rb
@@ -67,7 +67,7 @@ class EnergyTariff < ApplicationRecord
 
   #Sorts with null start date first, then start date, then end date
   scope :by_start_and_end, -> {
-    order(Arel.sql("(CASE WHEN start_date is NULL THEN 0 ELSE 1 END) DESC, start_date asc, end_date asc"))
+    order(Arel.sql("(CASE WHEN start_date is NULL THEN 0 ELSE 1 END) ASC, start_date asc, end_date asc"))
   }
 
   scope :count_by_school_group, -> { enabled.joins(:school_group).group(:slug).count(:id) }

--- a/spec/models/energy_tariff_spec.rb
+++ b/spec/models/energy_tariff_spec.rb
@@ -451,4 +451,18 @@ describe EnergyTariff do
     end
 
   end
+
+  context '.by_start_and_end' do
+    let(:energy_tariff_open_start) {
+      create(:energy_tariff, tariff_holder: tariff_holder, start_date: nil, end_date: Date.new(2022,3,31))
+    }
+    let(:energy_tariff_open_end) {
+      create(:energy_tariff, tariff_holder: tariff_holder, start_date: Date.new(2022,3,31), end_date: nil)
+    }
+    it 'sorts as expected' do
+      tariffs = tariff_holder.energy_tariffs.by_start_and_end
+      #using eq not match_array as we're expecting exactly this order
+      expect(tariffs).to eq([energy_tariff_open_start, energy_tariff, energy_tariff_open_end])
+    end
+  end
 end


### PR DESCRIPTION
I didn't add a test for this originally and then tweaked the SQL before committing which broke the ordering.

Have fixed the SQL and added a basic test.