### PR TITLE
Allow tariffs dates to be empty

### DIFF
--- a/app/components/date_picker_form_component.rb
+++ b/app/components/date_picker_form_component.rb
@@ -3,10 +3,10 @@
 class DatePickerFormComponent < ViewComponent::Base
   attr_reader :form_object_name, :field_name, :value, :errors
 
-  def initialize(form:, field_name:, value: nil, errors: '')
+  def initialize(form:, field_name:, value: nil, default_if_nil: DateTime.now.strftime('%d/%m/%Y'), errors: '')
     @form_object_name = form.object_name
     @field_name = field_name
-    @value = value || DateTime.now.strftime('%d/%m/%Y')
+    @value = value || default_if_nil
     @errors = errors
   end
 

--- a/app/views/energy_tariffs/energy_tariffs/_form.html.erb
+++ b/app/views/energy_tariffs/energy_tariffs/_form.html.erb
@@ -7,13 +7,13 @@
 <div class="form-row">
   <div class="form-group col-md-6">
     <%= f.label :start_date %>
-    <%= component 'date_picker_form', form: f, field_name: :start_date, value: @energy_tariff.start_date&.strftime('%d/%m/%Y'), errors: @energy_tariff.errors.messages[:start_date].to_sentence %>
+    <%= component 'date_picker_form', form: f, field_name: :start_date, value: @energy_tariff.start_date&.strftime('%d/%m/%Y'), default_if_nil: '', errors: @energy_tariff.errors.messages[:start_date].to_sentence %>
   </div>
 </div>
 <div class="form-row">
   <div class="form-group col-md-6">
     <%= f.label :end_date %>
-    <%= component 'date_picker_form', form: f, field_name: :end_date, value: @energy_tariff.end_date&.strftime('%d/%m/%Y'), errors: @energy_tariff.errors.messages[:end_date].to_sentence %>
+    <%= component 'date_picker_form', form: f, field_name: :end_date, value: @energy_tariff.end_date&.strftime('%d/%m/%Y'), default_if_nil: '', errors: @energy_tariff.errors.messages[:end_date].to_sentence %>
   </div>
 </div>
 <%= f.submit t('common.labels.next'), class: 'btn'%>

--- a/spec/components/date_picker_form_component_spec.rb
+++ b/spec/components/date_picker_form_component_spec.rb
@@ -3,9 +3,53 @@
 require "rails_helper"
 
 RSpec.describe DatePickerFormComponent, type: :component do
+  let(:value)         { '01/12/2022' }
+  let(:params)    {
+    {
+    form: OpenStruct.new(object_name: 'job'),
+    field_name: :start_date,
+    value: value,
+    }
+  }
+
+  let(:component) { DatePickerFormComponent.new(**params) }
+
+  let(:html) {
+    render_inline(component)
+  }
+
+  it "renders expected field" do
+    expect(html).to have_css('#job_start_date')
+  end
+
+  it "renders expected value" do
+    expect(html).to have_field('job[start_date]', with: value)
+  end
+
+  context 'with empty value' do
+    let(:value) { nil }
+    it 'defaults to today' do
+      expect(html).to have_field('job[start_date]', with: Date.today.strftime("%d/%m/%Y"))
+    end
+
+    context 'and a default supplied' do
+      let(:params)    {
+        {
+        form: OpenStruct.new(object_name: 'job'),
+        field_name: :start_date,
+        value: value,
+        default_if_nil: ''
+        }
+      }
+      it 'uses that default' do
+        expect(html).to have_field('job[start_date]', with: '')
+      end
+    end
+  end
+
   it "renders a datepicker form component" do
     expect(
-      ActionController::Base.render DatePickerFormComponent.new(form: OpenStruct.new(object_name: 'job'), field_name: :start_date, value: '01/12/2022')
+      ActionController::Base.render component
     ).to eq(
       <<~HTML.chomp
         <div class="input-group date" id="datepickerformcomponent_start_date" data-target-input="nearest">


### PR DESCRIPTION
The DateTimePicker component currently defaults to today's date if a value isn't provided.

This isn't the intended behaviour when editing tariffs, where an empty date should remain unpopulated. Rather than set a default in the form I've made the default value configurable on the component.

This preserves behaviour elsewhere in the application but allows an empty value to be provided on the tariff form.