### PR TITLE
Tariff editor text updates

### DIFF
--- a/app/components/date_picker_form_component.rb
+++ b/app/components/date_picker_form_component.rb
@@ -1,13 +1,14 @@
 # frozen_string_literal: true
 
 class DatePickerFormComponent < ViewComponent::Base
-  attr_reader :form_object_name, :field_name, :value, :errors
+  attr_reader :form_object_name, :field_name, :value, :errors, :hint
 
-  def initialize(form:, field_name:, value: nil, errors: '')
+  def initialize(form:, field_name:, value: nil, errors: '', hint: '')
     @form_object_name = form.object_name
     @field_name = field_name
     @value = value || DateTime.now.strftime('%d/%m/%Y')
     @errors = errors
+    @hint = hint
   end
 
   def id

--- a/app/components/date_picker_form_component/date_picker_form_component.html.erb
+++ b/app/components/date_picker_form_component/date_picker_form_component.html.erb
@@ -3,9 +3,13 @@
   <div class="input-group-append" data-target="#<%= datetime_picker_id %>" data-toggle="datetimepicker">
     <div class="input-group-text"><i class="fa fa-calendar"></i></div>
   </div>
+
   <% if errors.present? %>
     <div class="invalid-feedback">
       <%= errors %>
     </div>
   <% end %>
 </div>
+<% if hint.present? %>
+  <small class='class="form-text text-muted'><%= hint %></small>
+<% end %>

--- a/app/components/date_picker_form_component/date_picker_form_component.html.erb
+++ b/app/components/date_picker_form_component/date_picker_form_component.html.erb
@@ -3,7 +3,6 @@
   <div class="input-group-append" data-target="#<%= datetime_picker_id %>" data-toggle="datetimepicker">
     <div class="input-group-text"><i class="fa fa-calendar"></i></div>
   </div>
-
   <% if errors.present? %>
     <div class="invalid-feedback">
       <%= errors %>

--- a/app/components/energy_tariff_form_title_component.rb
+++ b/app/components/energy_tariff_form_title_component.rb
@@ -17,7 +17,7 @@ class EnergyTariffFormTitleComponent < ViewComponent::Base
   end
 
   def type_label
-    @energy_tariff.flat_rate? ? t('schools.user_tariffs.tariff_partial.simple_tariff') : t('schools.user_tariffs.tariff_partial.differential_tariff')
+    @energy_tariff.flat_rate? ? t('schools.user_tariffs.tariff_partial.flat_rate_tariff') : t('schools.user_tariffs.tariff_partial.differential_tariff')
   end
 
   def dates

--- a/app/components/energy_tariff_table_component.rb
+++ b/app/components/energy_tariff_table_component.rb
@@ -44,7 +44,7 @@ class EnergyTariffTableComponent < ViewComponent::Base
   end
 
   def flat_rate_label(energy_tariff)
-    energy_tariff.flat_rate? ? t('schools.user_tariffs.tariff_partial.simple_tariff') : t('schools.user_tariffs.tariff_partial.differential_tariff')
+    energy_tariff.flat_rate? ? t('schools.user_tariffs.tariff_partial.flat_rate_tariff') : t('schools.user_tariffs.tariff_partial.differential_tariff')
   end
 
   def start_date(energy_tariff)

--- a/app/components/energy_tariffs_component/energy_tariffs_component.html.erb
+++ b/app/components/energy_tariffs_component/energy_tariffs_component.html.erb
@@ -20,11 +20,11 @@
             <% else %>
               <p>
                 <% if @source == :dcc %>
-                  <%= t('schools.user_tariffs.index.no_smart_meter_tariffs', meter_type: meter_type) %>
+                  <%= t('schools.user_tariffs.index.no_smart_meter_tariffs', meter_type: meter_type) %>.
                 <% elsif @default_tariffs %>
-                  <%= t('schools.user_tariffs.index.no_defaults', meter_type: meter_type) %>
+                  <%= t('schools.user_tariffs.index.no_defaults', meter_type: meter_type) %>.
                 <% else %>
-                  <%= t("schools.user_tariffs.index.#{meter_type}.there_are_no_#{meter_type}_tariffs_set_up_yet") %>
+                  <%= t("schools.user_tariffs.index.#{meter_type}.there_are_no_#{meter_type}_tariffs_set_up_yet") %>.
                 <% end %>
               </p>
               <%= footer %>

--- a/app/views/energy_tariffs/energy_tariff_charges/_charge_ccl.html.erb
+++ b/app/views/energy_tariffs/energy_tariff_charges/_charge_ccl.html.erb
@@ -5,6 +5,10 @@
   <tr>
     <td class="description">
       <%= t('schools.user_tariff_charges.charge_ccl.climate_charge_levy') %>
+      <br />
+      <small class="text-muted">
+        <%= t('schools.user_tariff_charges.tick_this_box_if_you_pay_this_charge') %>
+      </small>
     </td>
     <td class="value">
     </td>

--- a/app/views/energy_tariffs/energy_tariff_charges/_charge_tnuos.html.erb
+++ b/app/views/energy_tariffs/energy_tariff_charges/_charge_tnuos.html.erb
@@ -5,6 +5,10 @@
   <tr>
     <td class="description">
       <%= t('schools.user_tariff_charges.charge_tnuos.tnuos_transmission_network_use_of_system') %>
+      <br />
+      <small class="text-muted">
+        <%= t('schools.user_tariff_charges.tick_this_box_if_you_pay_this_charge') %>
+      </small>
     </td>
     <td class="value">
     </td>

--- a/app/views/energy_tariffs/energy_tariff_charges/index.html.erb
+++ b/app/views/energy_tariffs/energy_tariff_charges/index.html.erb
@@ -1,7 +1,7 @@
 <%= component 'energy_tariff_form_title',
   energy_tariff: @energy_tariff do |c| %>
   <% c.with_page_title do %>
-    <h1><%= t('schools.user_tariff_charges.index.title') %></h1>
+    <h1><%= t('schools.user_tariff_charges.index.title', fuel_type: t("common.#{@energy_tariff.meter_type}").downcase) %></h1>
   <% end %>
   <% c.with_notice do %>
     <%= component 'notice', status: :neutral do |c| %>

--- a/app/views/energy_tariffs/energy_tariff_differential_prices/index.html.erb
+++ b/app/views/energy_tariffs/energy_tariff_differential_prices/index.html.erb
@@ -1,7 +1,7 @@
 <%= component 'energy_tariff_form_title',
   energy_tariff: @energy_tariff do |c| %>
   <% c.with_page_title do %>
-    <h1><%= t('schools.user_tariff_differential_prices.index.title') %></h1>
+    <h1><%= t('schools.user_tariff_differential_prices.index.title', fuel_type: t("common.#{@energy_tariff.meter_type}").downcase) %></h1>
   <% end %>
 <% end %>
 

--- a/app/views/energy_tariffs/energy_tariff_flat_prices/edit.html.erb
+++ b/app/views/energy_tariffs/energy_tariff_flat_prices/edit.html.erb
@@ -1,7 +1,7 @@
 <%= component 'energy_tariff_form_title',
   energy_tariff: @energy_tariff do |c| %>
   <% c.with_page_title do %>
-    <h1><%= t('schools.user_tariff_flat_prices.edit.title') %></h1>
+    <h1><%= t('schools.user_tariff_flat_prices.edit.title', fuel_type: t("common.#{@energy_tariff.meter_type}").downcase) %></h1>
   <% end %>
 <% end %>
 

--- a/app/views/energy_tariffs/energy_tariff_flat_prices/new.html.erb
+++ b/app/views/energy_tariffs/energy_tariff_flat_prices/new.html.erb
@@ -1,7 +1,7 @@
 <%= component 'energy_tariff_form_title',
   energy_tariff: @energy_tariff do |c| %>
   <% c.with_page_title do %>
-    <h1><%= t('schools.user_tariff_flat_prices.new.title') %></h1>
+    <h1><%= t('schools.user_tariff_flat_prices.new.title', fuel_type: t("common.#{@energy_tariff.meter_type}").downcase) %></h1>
   <% end %>
 <% end %>
 

--- a/app/views/energy_tariffs/energy_tariffs/_energy_tariffs_tab.html.erb
+++ b/app/views/energy_tariffs/energy_tariffs/_energy_tariffs_tab.html.erb
@@ -6,7 +6,9 @@
   default_tariffs: default_tariffs do |c| %>
   <% c.with_header do %>
     <%= t('schools.user_tariffs.index.introduction_html', advice_pages: school_advice_path(tariff_holder)) if tariff_holder.school? %>
-    <% unless default_tariffs %>
+    <% if default_tariffs %>
+      <div><p><%= t('schools.user_tariffs.index.default_tariffs_message') %></p></div>
+    <% else %>
       <p><%= t('schools.user_tariffs.index.changes_to_cost_calculations_message') %></p>
     <% end %>
   <% end %>

--- a/app/views/energy_tariffs/energy_tariffs/_energy_tariffs_tab.html.erb
+++ b/app/views/energy_tariffs/energy_tariffs/_energy_tariffs_tab.html.erb
@@ -7,15 +7,15 @@
   <% c.with_header do %>
     <%= t('schools.user_tariffs.index.introduction_html', advice_pages: school_advice_path(tariff_holder)) if tariff_holder.school? %>
     <% if default_tariffs %>
-      <div><p><%= t('schools.user_tariffs.index.default_tariffs_message') %></p></div>
+      <div><p><%= t('schools.user_tariffs.index.default_tariffs_message') %>.</p></div>
     <% else %>
-      <p><%= t('schools.user_tariffs.index.changes_to_cost_calculations_message') %></p>
+      <p><%= t('schools.user_tariffs.index.changes_to_cost_calculations_message') %>.</p>
     <% end %>
   <% end %>
   <% c.with_footer do %>
     <p>
       <% if tariff_holder.school? && @electricity_meters&.dcc&.any? %>
-        <%= t('schools.user_tariffs.index.note_about_smart_meter_tariffs') %>
+        <%= t('schools.user_tariffs.index.note_about_smart_meter_tariffs') %>.
       <% else %>
         <%= t('schools.user_tariffs.index.note_about_defaults') unless default_tariffs %>
       <% end %>

--- a/app/views/energy_tariffs/energy_tariffs/_form.html.erb
+++ b/app/views/energy_tariffs/energy_tariffs/_form.html.erb
@@ -7,13 +7,13 @@
 <div class="form-row">
   <div class="form-group col-md-6">
     <%= f.label :start_date %>
-    <%= component 'date_picker_form', form: f, field_name: :start_date, value: @energy_tariff.start_date&.strftime('%d/%m/%Y'), errors: @energy_tariff.errors.messages[:start_date].to_sentence %>
+    <%= component 'date_picker_form', form: f, field_name: :start_date, value: @energy_tariff.start_date&.strftime('%d/%m/%Y'), errors: @energy_tariff.errors.messages[:start_date].to_sentence, hint: t('schools.user_tariffs.form.hints.start_date') %>
   </div>
 </div>
 <div class="form-row">
   <div class="form-group col-md-6">
     <%= f.label :end_date %>
-    <%= component 'date_picker_form', form: f, field_name: :end_date, value: @energy_tariff.end_date&.strftime('%d/%m/%Y'), errors: @energy_tariff.errors.messages[:end_date].to_sentence %>
+    <%= component 'date_picker_form', form: f, field_name: :end_date, value: @energy_tariff.end_date&.strftime('%d/%m/%Y'), errors: @energy_tariff.errors.messages[:end_date].to_sentence, hint: t('schools.user_tariffs.form.hints.end_date') %>
   </div>
 </div>
 <%= f.submit t('common.labels.next'), class: 'btn'%>

--- a/app/views/energy_tariffs/energy_tariffs/choose_type.html.erb
+++ b/app/views/energy_tariffs/energy_tariffs/choose_type.html.erb
@@ -8,12 +8,12 @@
 <div class="row mt-4">
   <div class="col-md-12">
     <div class="energy_tariff">
-      <p><%= t('schools.user_tariffs.choose_type.is_this_a_simple_flat_rate') %></p>
+      <p><%= t('schools.user_tariffs.choose_type.is_this_a_flat_rate') %></p>
 
       <% form_url = energy_tariffs_path(@energy_tariff) %>
       <%= simple_form_for @energy_tariff, url: form_url do |f| %>
         <%= f.hidden_field :tariff_type, value: 'flat_rate' %>
-        <%= submit_tag t('schools.user_tariffs.choose_type.simple'), class: 'btn btn-info' %>
+        <%= submit_tag t('schools.user_tariffs.choose_type.flat_rate'), class: 'btn btn-info' %>
       <% end %>
 
       <br/>

--- a/app/views/energy_tariffs/energy_tariffs/choose_type.html.erb
+++ b/app/views/energy_tariffs/energy_tariffs/choose_type.html.erb
@@ -1,7 +1,7 @@
 <%= component 'energy_tariff_form_title',
   energy_tariff: @energy_tariff do |c| %>
   <% c.with_page_title do %>
-    <h1><%= t('schools.user_tariffs.choose_type.title') %></h1>
+    <h1><%= t('schools.user_tariffs.choose_type.title', fuel_type: t("common.#{@energy_tariff.meter_type}").downcase) %></h1>
   <% end %>
 <% end %>
 

--- a/app/views/energy_tariffs/energy_tariffs/edit.html.erb
+++ b/app/views/energy_tariffs/energy_tariffs/edit.html.erb
@@ -2,7 +2,7 @@
   energy_tariff: @energy_tariff,
   skip_fields: [:name, :dates] do |c| %>
   <% c.with_page_title do %>
-    <h1><%= t('schools.user_tariffs.edit.title', fuel_type: @energy_tariff.meter_type) %></h1>
+    <h1><%= t('schools.user_tariffs.edit.title', fuel_type: t("common.#{@energy_tariff.meter_type}").downcase) %></h1>
   <% end %>
 <% end %>
 

--- a/app/views/energy_tariffs/energy_tariffs/index.html.erb
+++ b/app/views/energy_tariffs/energy_tariffs/index.html.erb
@@ -5,7 +5,11 @@
     <a class="nav-item nav-link active"
       id="nav-user-tariffs-tab" data-toggle="tab"
       href="#nav-user-tariffs" role="tab" aria-controls="nav-user-tariffs" aria-selected="true">
-      <%= t('schools.user_tariffs.index.tabs.user_tariffs') %>
+      <% if @tariff_holder.site_settings? %>
+        <%= t('schools.user_tariffs.index.tabs.system_default_tariffs') %>
+      <% else %>
+        <%= t('schools.user_tariffs.index.tabs.user_tariffs') %>
+      <% end %>
     </a>
     <% if @tariff_holder.school? && any_smart_meters?(@tariff_holder) %>
       <a class="nav-item nav-link"

--- a/app/views/energy_tariffs/energy_tariffs/new.html.erb
+++ b/app/views/energy_tariffs/energy_tariffs/new.html.erb
@@ -1,11 +1,4 @@
-<%= component 'energy_tariff_form_title',
-  energy_tariff: @energy_tariff,
-  skip_fields: [:name, :dates] do |c| %>
-  <% c.with_page_title do %>
-    <h1><%= t('schools.user_tariffs.new.title', fuel_type: t("common.#{@energy_tariff.meter_type}")) %></h1>
-  <% end %>
-<% end %>
-
+<h1><%= t('schools.user_tariffs.new.title', fuel_type: t("common.#{@energy_tariff.meter_type}").downcase) %></h1>
 <div class="row mt-4">
   <div class="col-md-12">
     <div class="energy_tariff">

--- a/config/locales/cy/views/schools/user_tariffs.yml
+++ b/config/locales/cy/views/schools/user_tariffs.yml
@@ -52,9 +52,7 @@ cy:
         title: Dewiswch fesuryddion ar gyfer y tariff hwn
         which_meters_will_this_tariff_apply_to: I ba fesuryddion y bydd y tariff hwn yn berthnasol?
       choose_type:
-        is_this_a_simple_flat_rate: Ai cyfradd unffurf syml yw hon?
         or_a_rate_which_varies_by_time_of_day: Neu gyfradd sy’n amrywio yn ôl amser o’r dydd (e.e. tariff Dydd/Nos, Economi7)
-        simple: Syml
         title: Dewiswch y math o'r tariff hwn
       edit:
         title: Golygu'r enw a'r ystod dyddiad ar gyfer y tariff %{fuel_type} hwn
@@ -113,7 +111,6 @@ cy:
       tariff_partial:
         consumption_charges: Costau defnydd
         end_date: Dyddiad gorffen
-        simple_tariff: Tariff syml
         start_date: Dyddiad cychwyn
         type: Math
         price_from_to: "%{price_start_time} i %{price_end_time}:"

--- a/config/locales/views/schools/user_tariffs.yml
+++ b/config/locales/views/schools/user_tariffs.yml
@@ -107,7 +107,7 @@ en:
           end_date: Leave blank if there is no end date
           start_date: Leave blank if there is no start date
       index:
-        changes_to_cost_calculations_message: To add a new tariff, you will need to know the rate you are charged. You will also have the option to add any standing charges that you pay. Details of your rate and standing charges should be listed on a recent bill.
+        changes_to_cost_calculations_message: The cost calculations based on these tariffs will update overnight
         default_tariffs_message: These tariffs will apply to any periods not covered by user supplied tariffs or any tariffs imported from your smart meters
         electricity:
           add_label: Add electricity tariff
@@ -126,7 +126,7 @@ en:
             You can improve the accuracy of the calculations on your <a href="%{advice_pages}">cost analysis pages</a> by adding details about your real tariffs.
           </p>
           <p>
-            To add a a new tariff you will need to know the prices and, optionally, the range of standing charges that are included in your energy contract.
+            To add a new tariff, you will need to know the rate you are charged. You will also have the option to add any standing charges that you pay. Details of your rate and standing charges should be listed on a recent bill.
           </p>
         no_defaults: We have no default tariffs for your %{meter_type} meters.
         no_smart_meter_tariffs: We have not imported any tariffs from your %{meter_type} meters.

--- a/config/locales/views/schools/user_tariffs.yml
+++ b/config/locales/views/schools/user_tariffs.yml
@@ -133,6 +133,7 @@ en:
         tabs:
           default_tariffs: Default tariffs
           smart_meter_tariffs: Smart meter tariffs
+          system_default_tariffs: System default tariffs
           user_tariffs: User supplied tariffs
         title: Manage and view tariffs
       meters:

--- a/config/locales/views/schools/user_tariffs.yml
+++ b/config/locales/views/schools/user_tariffs.yml
@@ -107,6 +107,7 @@ en:
           start_date: Leave blank if there is no start date
       index:
         changes_to_cost_calculations_message: The cost calculations based on these tariffs will update overnight
+        default_tariffs_message: These tariffs will apply to any periods not covered by user supplied tariffs or any tariffs imported from your smart meters
         electricity:
           add_label: Add electricity tariff
           header: Electricity

--- a/config/locales/views/schools/user_tariffs.yml
+++ b/config/locales/views/schools/user_tariffs.yml
@@ -27,12 +27,13 @@ en:
       edit_charges: Edit charges
       index:
         breadcrumb_title: Add standing charges for this tariff
-        introduction_school: Using your bill, please provide as much detail as you can about the standing charges associated with this tariff
-        introduction_school_group: Using your bill, please provide as much detail as you can about the standing charges associated with this tariff
+        introduction_school: Please provide as much detail as you can about the standing charges associated with this tariff. You can find details about the standing charges by looking at a recent bill
+        introduction_school_group: Please provide as much detail as you can about the standing charges associated with this tariff. You can find details about the standing charges by looking at a recent bill
         introduction_site_settings: Please provide as much detail as you can about the standing charges associated with this tariff
-        notice: Adding standing charges to this tariff will allow us to provide you with more detailed cost analysis. But this step is optional.
+        notice: This step is optional and if you do not have this information, you can skip it.
         skip_to_final_step: Skip to final step
-        title: Add standing charges for this tariff
+        title: Add standing charges for this %{fuel_type} tariff
+      tick_this_box_if_you_pay_this_charge: Tick this box if you pay this charge
     user_tariff_differential_prices:
       form:
         labels:

--- a/config/locales/views/schools/user_tariffs.yml
+++ b/config/locales/views/schools/user_tariffs.yml
@@ -86,7 +86,7 @@ en:
         is_this_a_simple_flat_rate: Is this a simple flat rate?
         or_a_rate_which_varies_by_time_of_day: Or a rate which varies by time of day (e.g. Day/Night tariff, Economy7)
         simple: Simple
-        title: Choose the type of this tariff
+        title: Choose the type of this %{fuel_type} tariff
       edit:
         breadcrumb_title: Edit the name and date range
         title: Edit the name and date range for this %{fuel_type} tariff

--- a/config/locales/views/schools/user_tariffs.yml
+++ b/config/locales/views/schools/user_tariffs.yml
@@ -84,9 +84,9 @@ en:
       choose_type:
         breadcrumb_title: Choose tariff type
         differential_tariff: Differential tariff
-        is_this_a_simple_flat_rate: Is this a simple flat rate?
+        flat_rate: Flat rate tariff
+        is_this_a_flat_rate: Is this a flat rate tariff?
         or_a_rate_which_varies_by_time_of_day: Or a rate which varies by time of day (e.g. Day/Night tariff, Economy7)
-        simple: Simple
         title: Choose the type of this %{fuel_type} tariff
       edit:
         breadcrumb_title: Edit the name and date range
@@ -106,7 +106,7 @@ en:
           end_date: Leave blank if there is no end date
           start_date: Leave blank if there is no start date
       index:
-        changes_to_cost_calculations_message: The cost calculations based on these tariffs will update overnight
+        changes_to_cost_calculations_message: To add a new tariff, you will need to know the rate you are charged. You will also have the option to add any standing charges that you pay. Details of your rate and standing charges should be listed on a recent bill.
         default_tariffs_message: These tariffs will apply to any periods not covered by user supplied tariffs or any tariffs imported from your smart meters
         electricity:
           add_label: Add electricity tariff
@@ -187,8 +187,8 @@ en:
         consumption_charges: Consumption charges
         differential_tariff: Differential tariff
         end_date: End date
+        flat_rate_tariff: Flat rate tariff
         price_from_to: "%{price_start_time} to %{price_end_time}:"
-        simple_tariff: Simple tariff
         start_date: Start date
         type: Type
       title_partial:

--- a/config/locales/views/schools/user_tariffs.yml
+++ b/config/locales/views/schools/user_tariffs.yml
@@ -101,6 +101,9 @@ en:
           dates:
             start_and_end_date_can_not_both_be_empty: start and end date can't both be empty
             start_date_must_be_earlier_than_or_equal_to_end_date: start date must be earlier than or equal to end date
+        hints:
+          end_date: Leave blank if there is no end date
+          start_date: Leave blank if there is no start date
       index:
         changes_to_cost_calculations_message: The cost calculations based on these tariffs will update overnight
         electricity:

--- a/config/locales/views/schools/user_tariffs.yml
+++ b/config/locales/views/schools/user_tariffs.yml
@@ -53,14 +53,14 @@ en:
         introduction_site_settings: Please provide as much detail as you can about the consumption charges associated with this tariff
         invalid_values_message: Please add valid prices for all marked rates
         reset_to_default: Reset to default
-        title: Add consumption charges for each time period for this tariff
+        title: Add consumption charges for each time period for this %{fuel_type} tariff
     user_tariff_flat_prices:
       edit:
         breadcrumb_title: Edit the consumption charges for this tariff
         introduction_school: Using your bill, please provide as much detail as you can about the consumption charges associated with this tariff
         introduction_school_group: Using your bill, please provide as much detail as you can about the consumption charges associated with this tariff
         introduction_site_settings: Please provide as much detail as you can about the consumption charges associated with this tariff
-        title: Edit the consumption charges for this tariff
+        title: Edit the consumption charges for this %{fuel_type} tariff
       form:
         per_gbp_kwh: per £/kWh
         rate: Rate
@@ -69,7 +69,7 @@ en:
         introduction_school: Using your bill, please provide as much detail as you can about the consumption charges associated with this tariff
         introduction_school_group: Using your bill, please provide as much detail as you can about the consumption charges associated with this tariff
         introduction_site_settings: Please provide as much detail as you can about the consumption charges associated with this tariff
-        title: Add consumption charges for this tariff
+        title: Add consumption charges for this %{fuel_type} tariff
     user_tariffs:
       charges_table:
         climate_charge_levy: Climate charge levy

--- a/spec/components/date_picker_form_component_spec.rb
+++ b/spec/components/date_picker_form_component_spec.rb
@@ -38,7 +38,8 @@ RSpec.describe DatePickerFormComponent, type: :component do
         form: OpenStruct.new(object_name: 'job'),
         field_name: :start_date,
         value: value,
-        default_if_nil: ''
+        default_if_nil: '',
+        hint: ''
         }
       }
       it 'uses that default' do

--- a/spec/components/energy_tariffs_table_component_spec.rb
+++ b/spec/components/energy_tariffs_table_component_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe EnergyTariffTableComponent, type: :component do
 
   context '.flat_rate_label' do
     it 'returns expected label' do
-      expect(component.flat_rate_label(energy_tariffs.first)).to eq I18n.t('schools.user_tariffs.tariff_partial.simple_tariff')
+      expect(component.flat_rate_label(energy_tariffs.first)).to eq I18n.t('schools.user_tariffs.tariff_partial.flat_rate_tariff')
     end
     context 'with differential tariff' do
       let(:energy_tariffs) { [create(:energy_tariff, tariff_type: :differential)]}
@@ -94,7 +94,7 @@ RSpec.describe EnergyTariffTableComponent, type: :component do
     it 'includes the tariff details' do
       within('#tariff-table tbody tr[1]') do
         expect(html).to have_content(energy_tariffs.first.name)
-        expect(html).to have_content('schools.user_tariffs.tariff_partial.simple_tariff')
+        expect(html).to have_content('schools.user_tariffs.tariff_partial.flat_rate_tariff')
         expect(html).to have_content(energy_tariffs.first.start_date.to_s(:es_compact))
         expect(html).to have_content(energy_tariffs.first.end_date.to_s(:es_compact))
         expect(html).to have_content(energy_tariffs.first.energy_tariff_price.first)

--- a/spec/support/energy_tariff_shared_examples.rb
+++ b/spec/support/energy_tariff_shared_examples.rb
@@ -114,7 +114,7 @@ RSpec.shared_examples "a gas tariff editor with no meter selection" do
     fill_in 'Start date', with: '13/08/2023'
     fill_in 'End date', with: '14/08/2023'
     click_on('Next')
-    expect(page).to have_content('Edit the consumption charges for this tariff')
+    expect(page).to have_content('Edit the consumption charges for this gas tariff')
     click_on('Next')
     expect(page).to have_content('Add standing charges for this tariff')
     click_on('Next')
@@ -154,7 +154,6 @@ RSpec.shared_examples "a gas tariff editor with meter selection" do
 
     #Name and dates
     expect(page).to have_content('Choose a name and date range')
-    expect(page).to have_content(mpan_mprn)
 
     fill_in 'Name', with: tariff_title
     fill_in 'Start date', with: '15/08/2023'
@@ -200,7 +199,7 @@ RSpec.shared_examples "an electricity tariff editor with no meter selection" do
     fill_in 'End date', with: '16/08/2023'
 
     click_button('Next')
-    click_button('Simple')
+    click_button('Flat rate tariff')
 
     visit tariff_index_path
 
@@ -217,7 +216,7 @@ RSpec.shared_examples "an electricity tariff editor with no meter selection" do
 
     click_button('Next')
 
-    click_button('Simple')
+    click_button('Flat rate tariff')
 
     fill_in "energy_tariff_price[value]", with: '1.5'
     click_button('Next')
@@ -269,7 +268,7 @@ RSpec.shared_examples "an electricity tariff editor with no meter selection" do
     fill_in 'Start date', with: '13/08/2023'
     fill_in 'End date', with: '14/08/2023'
     click_on('Next')
-    expect(page).to have_content('Edit the consumption charges for this tariff')
+    expect(page).to have_content('Edit the consumption charges for this electricity tariff')
     click_on('Next')
     expect(page).to have_content('Add standing charges for this tariff')
     click_on('Next')
@@ -452,7 +451,7 @@ RSpec.shared_examples "an electricity tariff editor with no meter selection" do
     fill_in 'Start date', with: '13/08/2023'
     fill_in 'End date', with: '14/08/2023'
     click_on('Next')
-    expect(page).to have_content('Add consumption charges for each time period for this tariff')
+    expect(page).to have_content('Add consumption charges for each time period for this electricity tariff')
     click_on('Next')
     expect(page).to have_content('Add standing charges for this tariff')
     click_on('Next')
@@ -489,7 +488,7 @@ RSpec.shared_examples "an electricity tariff editor with no meter selection" do
 
     click_button('Next')
 
-    click_button('Simple')
+    click_button('Flat rate tariff')
 
     fill_in "energy_tariff_price[value]", with: '1.5'
     click_button('Next')
@@ -584,7 +583,6 @@ RSpec.shared_examples "an electricity tariff editor with meter selection" do
 
     #Name and dates
     expect(page).to have_content('Choose a name and date range')
-    expect(page).to have_content(mpan_mprn)
 
     fill_in 'Name', with: tariff_title
     fill_in 'Start date', with: '15/08/2023'
@@ -680,7 +678,7 @@ RSpec.shared_examples "an electricity tariff editor with meter selection" do
     fill_in 'Start date', with: '13/08/2023'
     fill_in 'End date', with: '14/08/2023'
     click_on('Next')
-    expect(page).to have_content('Add consumption charges for each time period for this tariff')
+    expect(page).to have_content('Add consumption charges for each time period for this electricity tariff')
     click_on('Next')
     expect(page).to have_content('Add standing charges for this tariff')
     click_on('Next')


### PR DESCRIPTION
**Site Setting Tariffs**
- [x] On this page, change the tab name from “User supplied tariffs” to “System default tariffs”



**New and Edit Tariff forms**
- [x] Title should use lower case names, e.g. “electricity” not “Electricity”
- [x] The edit form is not using a translation key
- [x] Skip adding the Energy Tariff Form Title component on the new form. And just add the page title and content_for sections directly as user has not yet chosen meters or a tariff type.
- [x] Add note below “Start date” and “End date” label to say “Leave blank if there is no start date” (or end date as appropriate)



**Choose tariff type form**
- [x] Make title consistent with the new/edit form, e.g. “Choose the type of this %{meter_type} tariff”, with lower case names



**Standing charges form**
- [x] As above, make title consistent by adding fuel type
- [x] Change notice so that the final sentence is “This step is optional and if you do not have this information, you can skip it”
- [x] Update text in body of page to read “Please provide as much detail as you can about the standing charges associated with this tariff. You can find details about the standing charges by looking at a recent bill.”
- [x] Below the TnUos and Climate Charge Levy charges add a note to say “Tick this box if you pay this charge”. Place the text below the form label similar to the notes we have for agreed availability charge, etc



**Default tariffs tab**
- [x] Add a note to the top of the page: “These tariffs will apply to any periods not covered by user supplied tariffs or any tariffs imported from your smart meters”.



**User supplied tariffs tab**
- [x] Revise text to say “To add a new tariff, you will need to know the rate you are charged. You will also have the option to add any standing charges that you pay. Details of your rate and standing charges should be listed on a recent bill.”
- [x] Add full stop after “overnight”
- [x] Add a full stop after the text thats displayed when there are no meters  of a specific type



**All energy tariff forms/pages:**
- [x] Change “Simple tariff” to “Flat rate tariff”
- [x] Ensure that we refer to “Flat rate tariff” everywhere, not “simple tariff” or “simple flat tariff” or “flat tariff”