### PR TITLE
Disable standing charge form fields for smart meter tariffs

### DIFF
--- a/app/views/energy_tariffs/energy_tariff_charges/_charge_basic.html.erb
+++ b/app/views/energy_tariffs/energy_tariff_charges/_charge_basic.html.erb
@@ -1,5 +1,5 @@
 <table class="table table-charges">
   <tbody>
-    <%= render 'charge_basic_row', energy_tariff_charge: energy_tariff_charge, f: f %>
+    <%= render 'charge_basic_row', energy_tariff_charge: energy_tariff_charge, f: f, disabled: local_assigns[:disabled] %>
   </tbody>
 </table>

--- a/app/views/energy_tariffs/energy_tariff_charges/_charge_basic_row.html.erb
+++ b/app/views/energy_tariffs/energy_tariff_charges/_charge_basic_row.html.erb
@@ -10,7 +10,7 @@
   </td>
   <td class="value">
     <%= f.input :value, as: :decimal, pattern: '[0-9.]+', label: false,
-      input_html: { value: value_allowing_for_errors(energy_tariff_charge) }.merge(local_assigns.slice(:data, :title)),
+      input_html: { disabled: local_assigns[:disabled] ? 'disabled' : nil, value: value_allowing_for_errors(energy_tariff_charge) }.merge(local_assigns.slice(:data, :title)),
       error: energy_tariff_charge.errors.any? ? energy_tariff_charge.errors.full_messages.first : nil,
       required: false %>
   </td>
@@ -21,7 +21,10 @@
   </td>
   <td class="units">
     <% if energy_tariff_charge_type_units_for(energy_tariff_charge.charge_type).any? %>
-      <%= f.select :units, options_for_select(energy_tariff_charge_type_units_for(energy_tariff_charge.charge_type), energy_tariff_charge.units), {required: :true}, { class: 'form-control' } %>
+      <%= f.select :units,
+       options_for_select(energy_tariff_charge_type_units_for(energy_tariff_charge.charge_type), energy_tariff_charge.units),
+       {required: :true},
+       { disabled: local_assigns[:disabled] ? 'disabled' : nil, class: 'form-control' } %>
     <% end %>
   </td>
 </tr>

--- a/app/views/energy_tariffs/energy_tariff_charges/_charges_edit_electricity.html.erb
+++ b/app/views/energy_tariffs/energy_tariff_charges/_charges_edit_electricity.html.erb
@@ -1,7 +1,7 @@
 <h4><%= t('schools.user_tariff_charges.charges_edit_electricity.consumption_and_supply_charges') %></h4>
 
 <%= f.fields_for :standing_charge do |ff| %>
-  <%= render 'charge_basic', energy_tariff_charge: energy_tariff_charge_for_type(energy_tariff_charges, :standing_charge), f: ff %>
+  <%= render 'charge_basic', energy_tariff_charge: energy_tariff_charge_for_type(energy_tariff_charges, :standing_charge), disabled: energy_tariff.dcc?, f: ff %>
 <% end %>
 
 <%= f.fields_for :fixed_charge do |ff| %>

--- a/app/views/energy_tariffs/energy_tariff_charges/_charges_edit_gas.html.erb
+++ b/app/views/energy_tariffs/energy_tariff_charges/_charges_edit_gas.html.erb
@@ -3,7 +3,7 @@
 
 <div class="fixed_charge">
   <%= f.fields_for :fixed_charge do |ff| %>
-    <%= render 'charge_basic', energy_tariff_charge: energy_tariff_charge_for_type(energy_tariff_charges, :fixed_charge), f: ff %>
+    <%= render 'charge_basic', energy_tariff_charge: energy_tariff_charge_for_type(energy_tariff_charges, :fixed_charge), disabled: energy_tariff.dcc?, f: ff %>
   <% end %>
 </div>
 

--- a/app/views/energy_tariffs/energy_tariff_charges/index.html.erb
+++ b/app/views/energy_tariffs/energy_tariff_charges/index.html.erb
@@ -6,7 +6,11 @@
   <% c.with_notice do %>
     <%= component 'notice', status: :neutral do |c| %>
       <div class="d-flex justify-content-between">
-        <%= t('schools.user_tariff_charges.index.notice') %>
+        <% if @energy_tariff.dcc? %>
+          <%= t('schools.user_tariff_charges.index.smart_meter_notice') %>
+        <% else %>
+          <%= t('schools.user_tariff_charges.index.notice') %>
+        <% end %>
         <%= link_to t('schools.user_tariff_charges.index.skip_to_final_step'), energy_tariffs_path(@energy_tariff), class: 'btn btn-primary' %>
       </div>
     <% end %>

--- a/config/locales/views/schools/user_tariffs.yml
+++ b/config/locales/views/schools/user_tariffs.yml
@@ -32,6 +32,7 @@ en:
         introduction_site_settings: Please provide as much detail as you can about the standing charges associated with this tariff
         notice: Adding standing charges to this tariff will allow us to provide you with more detailed cost analysis. But this step is optional.
         skip_to_final_step: Skip to final step
+        smart_meter_notice: You cannot edit the daily standing charge for this tariff but can edit the other charges.
         title: Add standing charges for this tariff
     user_tariff_differential_prices:
       form:
@@ -173,7 +174,7 @@ en:
           <p>
             You can choose to edit these tariffs to add more detailed standing charge information for each meter. If you have already added tariffs for the whole school, you can instead choose to disable these tariffs.
           </p>
-        limited_editing: This tariff information has been automatically imported from your smart meter. You may add details of standing charges but cannot edit any other information.
+        limited_editing: This tariff information has been automatically imported from your smart meter. You may add additional detail about your standing charges but cannot edit any other information.
       summary_table:
         no_end_date: No end date
         no_start_date: No start date


### PR DESCRIPTION
Smart meter tariffs, when imported have prices and a single type of standing charge.

We want to allow users to edit the other charges associated with the tariff but not the prices or that standing charge.

This PR fixes a bug with editing charges by disabling the form field for the `:standing_charge` `charge_type` but allows others types of charges to be updated.