### PR TITLE
Remove use of previous next buttons

### DIFF
--- a/app/components/energy_tariff_table_component/energy_tariff_table_component.html.erb
+++ b/app/components/energy_tariff_table_component/energy_tariff_table_component.html.erb
@@ -65,7 +65,7 @@
               %>
             <% else %>
               <%= link_to t('common.labels.edit'),
-                  energy_tariffs_path(energy_tariff, [], { action: :edit }),
+                  energy_tariffs_path(energy_tariff),
                   class: 'btn btn-sm'
               %>
             <% end %>

--- a/app/controllers/energy_tariffs/energy_tariff_charges_controller.rb
+++ b/app/controllers/energy_tariffs/energy_tariff_charges_controller.rb
@@ -13,7 +13,7 @@ module EnergyTariffs
           @energy_tariff.energy_tariff_charges.destroy_all
           @energy_tariff_charges.each(&:save!)
         end
-
+        @energy_tariff.update!(updated_by: current_user)
         redirect_to energy_tariffs_path(@energy_tariff)
       else
         render :index

--- a/app/controllers/energy_tariffs/energy_tariff_differential_prices_controller.rb
+++ b/app/controllers/energy_tariffs/energy_tariff_differential_prices_controller.rb
@@ -3,6 +3,7 @@ module EnergyTariffs
     before_action :redirect_if_dcc
 
     def index
+      EnergyTariffDefaultPricesCreator.new(@energy_tariff).process unless params[:editing]
     end
 
     def new
@@ -55,7 +56,7 @@ module EnergyTariffs
 
     def destroy
       @energy_tariff.energy_tariff_prices.find(params[:id]).destroy
-      redirect_to energy_tariffs_path(@energy_tariff, [:energy_tariff_differential_prices])
+      redirect_to energy_tariffs_path(@energy_tariff, [:energy_tariff_differential_prices], { editing: true })
     end
 
     def reset

--- a/app/controllers/energy_tariffs/energy_tariff_differential_prices_controller.rb
+++ b/app/controllers/energy_tariffs/energy_tariff_differential_prices_controller.rb
@@ -17,6 +17,7 @@ module EnergyTariffs
       @energy_tariff_price = @energy_tariff.energy_tariff_prices.build(energy_tariff_price_params.merge(units: 'kwh'))
       respond_to do |format|
         if @energy_tariff_price.save
+          @energy_tariff.update!(updated_by: current_user)
           format.html { redirect_to energy_tariffs_path(@energy_tariff, [:energy_tariff_differential_prices]) }
           format.js
         else

--- a/app/controllers/energy_tariffs/energy_tariff_flat_prices_controller.rb
+++ b/app/controllers/energy_tariffs/energy_tariff_flat_prices_controller.rb
@@ -17,7 +17,7 @@ module EnergyTariffs
     def create
       @energy_tariff_price = @energy_tariff.energy_tariff_prices.build(energy_tariff_price_params.merge(default_attributes))
       if @energy_tariff_price.save
-        redirect_to_energy_tariff_charges_path
+        redirect_to energy_tariffs_path(@energy_tariff)
       else
         render :new
       end
@@ -30,7 +30,8 @@ module EnergyTariffs
     def update
       @energy_tariff_price = @energy_tariff.energy_tariff_prices.find(params[:id])
       if @energy_tariff_price.update(energy_tariff_price_params)
-        redirect_to_energy_tariff_charges_path
+        @energy_tariff.update!(updated_by: current_user)
+        redirect_to energy_tariffs_path(@energy_tariff)
       else
         render :edit
       end

--- a/app/controllers/energy_tariffs/energy_tariff_flat_prices_controller.rb
+++ b/app/controllers/energy_tariffs/energy_tariff_flat_prices_controller.rb
@@ -39,10 +39,6 @@ module EnergyTariffs
 
     private
 
-    def redirect_to_energy_tariff_charges_path
-      redirect_to energy_tariffs_path(@energy_tariff, [:energy_tariff_charges])
-    end
-
     def redirect_to_edit_energy_tariff_flat_price_path
       redirect_to energy_tariffs_path(@energy_tariff, [:energy_tariff_flat_price], { id: @energy_tariff.energy_tariff_prices.first, action: :edit })
     end

--- a/app/controllers/energy_tariffs/energy_tariffs_controller.rb
+++ b/app/controllers/energy_tariffs/energy_tariffs_controller.rb
@@ -11,16 +11,11 @@ module EnergyTariffs
       end
     end
 
-    def new
-      @energy_tariff = if @tariff_holder.school?
-                         @tariff_holder.energy_tariffs.build(default_params.merge(energy_tariff_params))
-                       else
-                         @tariff_holder.energy_tariffs.build(default_params.merge({ meter_type: params[:meter_type] }))
-                       end
+    def show
+    end
 
-      if require_meters?
-        redirect_back fallback_location: school_energy_tariffs_path(@tariff_holder), notice: I18n.t('schools.user_tariffs.choose_meters.missing_meters')
-      end
+    def new
+      @energy_tariff = @tariff_holder.energy_tariffs.build(default_params.merge({ meter_type: params[:meter_type] }))
     end
 
     def create
@@ -32,13 +27,11 @@ module EnergyTariffs
       end
     end
 
-    def choose_meters
-      if params[:meter_type] == 'electricity'
-        @meters = @tariff_holder.meters.electricity
-      elsif params[:meter_type] == 'gas'
-        @meters = @tariff_holder.meters.gas
+    def update
+      if @energy_tariff.update(energy_tariff_params.merge(updated_by: current_user))
+        redirect_to energy_tariffs_path(@energy_tariff)
       else
-        @meters = []
+        render :edit
       end
     end
 
@@ -53,7 +46,9 @@ module EnergyTariffs
     end
 
     def update_meters
-      if @energy_tariff.update(energy_tariff_params.merge(updated_by: current_user))
+      if require_meters?
+        redirect_back fallback_location: school_energy_tariffs_path(@tariff_holder), notice: I18n.t('schools.user_tariffs.choose_meters.missing_meters')
+      elsif @energy_tariff.update(energy_tariff_params.merge(updated_by: current_user))
         redirect_to energy_tariffs_path(@energy_tariff)
       else
         render :edit_meters
@@ -63,21 +58,17 @@ module EnergyTariffs
     def choose_type
     end
 
-    def update
+    def update_type
       if @energy_tariff.update(energy_tariff_params.merge(updated_by: current_user))
-        #EnergyTariffDefaultPricesCreator.new(@energy_tariff).process
-        #redirect_to energy_tariff_prices_path(@energy_tariff)
+        @energy_tariff.energy_tariff_prices.destroy_all
         redirect_to energy_tariffs_path(@energy_tariff)
       else
-        render :edit
+        render :choose_type
       end
     end
 
     def toggle_enabled
       @energy_tariff.toggle!(:enabled)
-    end
-
-    def show
     end
 
     def destroy
@@ -89,11 +80,7 @@ module EnergyTariffs
     private
 
     def require_meters?
-      params[:specific_meters] && @energy_tariff.meter_ids.empty? && @tariff_holder.school?
-    end
-
-    def redirect_to_choose_type_energy_tariff_path
-      redirect_to energy_tariffs_path(@energy_tariff, [], { action: :choose_type })
+      params[:specific_meters] && params[:energy_tariff][:meter_ids].reject(&:empty?).empty?
     end
 
     def default_params

--- a/app/controllers/energy_tariffs/energy_tariffs_controller.rb
+++ b/app/controllers/energy_tariffs/energy_tariffs_controller.rb
@@ -26,11 +26,7 @@ module EnergyTariffs
     def create
       @energy_tariff = @tariff_holder.energy_tariffs.build(energy_tariff_params.merge(created_by: current_user))
       if @energy_tariff.save
-        if @energy_tariff.gas?
-          redirect_to energy_tariff_prices_path(@energy_tariff)
-        else
-          redirect_to_choose_type_energy_tariff_path
-        end
+        redirect_to energy_tariffs_path(@energy_tariff)
       else
         render :new
       end
@@ -69,8 +65,9 @@ module EnergyTariffs
 
     def update
       if @energy_tariff.update(energy_tariff_params.merge(updated_by: current_user))
-        EnergyTariffDefaultPricesCreator.new(@energy_tariff).process
-        redirect_to energy_tariff_prices_path(@energy_tariff)
+        #EnergyTariffDefaultPricesCreator.new(@energy_tariff).process
+        #redirect_to energy_tariff_prices_path(@energy_tariff)
+        redirect_to energy_tariffs_path(@energy_tariff)
       else
         render :edit
       end

--- a/app/helpers/energy_tariffs_helper.rb
+++ b/app/helpers/energy_tariffs_helper.rb
@@ -15,11 +15,7 @@ module EnergyTariffsHelper
   end
 
   def new_energy_tariff_path(tariff_holder, options = {})
-    if tariff_holder.school?
-      choose_meters_school_energy_tariffs_path(tariff_holder, options)
-    else
-      polymorphic_path(tariff_holder_route(tariff_holder) + [:energy_tariff], options.merge!({ action: :new }))
-    end
+    polymorphic_path(tariff_holder_route(tariff_holder) + [:energy_tariff], options.merge!({ action: :new }))
   end
 
   def energy_tariff_prices_path(energy_tariff, options = {})

--- a/app/views/energy_tariffs/energy_tariff_charges/index.html.erb
+++ b/app/views/energy_tariffs/energy_tariff_charges/index.html.erb
@@ -38,8 +38,7 @@
 
         <br/>
 
-        <%= link_to t('common.labels.previous'), energy_tariff_prices_path(@energy_tariff), class: 'btn' %>
-        <%= f.submit t('common.labels.next'), class: 'btn btn-primary' %>
+        <%= f.submit t('common.labels.continue'), class: 'btn btn-primary' %>
 
       <% end %>
     </div>

--- a/app/views/energy_tariffs/energy_tariff_differential_prices/index.html.erb
+++ b/app/views/energy_tariffs/energy_tariff_differential_prices/index.html.erb
@@ -50,10 +50,8 @@
 
       <div class="d-flex justify-content-between mb-2 mt-2">
         <div>
-          <% edit_path = energy_tariffs_path(@energy_tariff, [], { action: :edit }) %>
-          <%= link_to t('common.labels.previous'), edit_path, class: 'btn' %>
           <% next_path = energy_tariffs_path(@energy_tariff, [:energy_tariff_charges]) %>
-          <%= link_to t('common.labels.next'), next_path, class: "btn#{@energy_tariff.usable? ? '' : ' disabled' }" %>
+          <%= link_to t('common.labels.continue'), energy_tariffs_path(@energy_tariff), class: "btn#{@energy_tariff.usable? ? '' : ' disabled' }" %>
         </div>
         <div>
           <%= link_to t('schools.user_tariff_differential_prices.index.reset_to_default'),

--- a/app/views/energy_tariffs/energy_tariff_flat_prices/edit.html.erb
+++ b/app/views/energy_tariffs/energy_tariff_flat_prices/edit.html.erb
@@ -19,9 +19,7 @@
         <%= render 'form', energy_tariff: @energy_tariff, energy_tariff_price: @energy_tariff_price, f: f %>
 
         <br/>
-        <% edit_path = energy_tariffs_path(@energy_tariff, [], { action: :edit }) %>
-        <%= link_to t('common.labels.previous'), edit_path, class: 'btn' %>
-        <%= f.submit t('common.labels.next'), class: 'btn btn-primary' %>
+        <%= f.submit t('common.labels.continue'), class: 'btn btn-primary' %>
       <% end %>
     </div>
   </div>

--- a/app/views/energy_tariffs/energy_tariff_flat_prices/new.html.erb
+++ b/app/views/energy_tariffs/energy_tariff_flat_prices/new.html.erb
@@ -17,9 +17,7 @@
       <%= simple_form_for @energy_tariff_price, url: form_url do |f| %>
         <%= render 'form', energy_tariff: @energy_tariff, energy_tariff_price: @energy_tariff_price, f: f %>
         <br/>
-        <% edit_path = energy_tariffs_path(@energy_tariff) %>
-        <%= link_to t('common.labels.previous'), edit_path, class: 'btn' %>
-        <%= f.submit t('common.labels.next'), class: 'btn btn-primary' %>
+        <%= f.submit t('common.labels.continue'), class: 'btn btn-primary' %>
       <% end %>
     </div>
   </div>

--- a/app/views/energy_tariffs/energy_tariffs/_form.html.erb
+++ b/app/views/energy_tariffs/energy_tariffs/_form.html.erb
@@ -16,4 +16,4 @@
     <%= component 'date_picker_form', form: f, field_name: :end_date, value: @energy_tariff.end_date&.strftime('%d/%m/%Y'), default_if_nil: '', errors: @energy_tariff.errors.messages[:end_date].to_sentence %>
   </div>
 </div>
-<%= f.submit t('common.labels.next'), class: 'btn'%>
+<%= f.submit t('common.labels.continue'), class: 'btn'%>

--- a/app/views/energy_tariffs/energy_tariffs/choose_meters.html.erb
+++ b/app/views/energy_tariffs/energy_tariffs/choose_meters.html.erb
@@ -1,9 +1,0 @@
-<h1><%= t('schools.user_tariffs.choose_meters.title') %></h1>
-
-<div class="energy_tariff">
-  <%= simple_form_for :energy_tariff, url: new_school_energy_tariff_path(@tariff_holder), method: :get do |f| %>
-    <%= f.hidden_field :meter_type, value: params[:meter_type] %>
-    <%= render 'form_meter_choices', f: f, meter_type: params[:meter_type], specific_meters: false %>
-    <%= submit_tag t('common.labels.next'), class: 'btn btn-info' %>
-  <% end %>
-</div>

--- a/app/views/energy_tariffs/energy_tariffs/choose_type.html.erb
+++ b/app/views/energy_tariffs/energy_tariffs/choose_type.html.erb
@@ -10,8 +10,8 @@
     <div class="energy_tariff">
       <p><%= t('schools.user_tariffs.choose_type.is_this_a_flat_rate') %></p>
 
-      <% form_url = energy_tariffs_path(@energy_tariff) %>
-      <%= simple_form_for @energy_tariff, url: form_url do |f| %>
+      <% form_url = energy_tariffs_path(@energy_tariff, [], { action: :update_type }) %>
+      <%= simple_form_for @energy_tariff, url: form_url, method: :post do |f| %>
         <%= f.hidden_field :tariff_type, value: 'flat_rate' %>
         <%= submit_tag t('schools.user_tariffs.choose_type.flat_rate'), class: 'btn btn-info' %>
       <% end %>
@@ -21,7 +21,7 @@
 
       <p><%= t('schools.user_tariffs.choose_type.or_a_rate_which_varies_by_time_of_day') %></p>
 
-      <%= simple_form_for @energy_tariff, url: form_url do |f| %>
+      <%= simple_form_for @energy_tariff, url: form_url, method: :post do |f| %>
         <%= f.hidden_field :tariff_type, value: 'differential' %>
         <%= submit_tag t('schools.user_tariffs.choose_type.differential_tariff'), class: 'btn btn-info' %>
       <% end %>

--- a/app/views/energy_tariffs/energy_tariffs/edit_meters.html.erb
+++ b/app/views/energy_tariffs/energy_tariffs/edit_meters.html.erb
@@ -11,7 +11,7 @@
     <div class="energy_tariff">
       <%= simple_form_for :energy_tariff, url: energy_tariffs_path(@energy_tariff, [], { action: :update_meters }), method: :post do |f| %>
         <%= render 'form_meter_choices', f: f, meter_type: @energy_tariff.meter_type, specific_meters: @energy_tariff.meters.any? %>
-        <%= submit_tag t('common.labels.next'), class: 'btn btn-info' %>
+        <%= submit_tag t('common.labels.continue'), class: 'btn btn-info' %>
       <% end %>
     </div>
   </div>

--- a/app/views/energy_tariffs/energy_tariffs/show.html.erb
+++ b/app/views/energy_tariffs/energy_tariffs/show.html.erb
@@ -102,7 +102,7 @@
     <tbody>
       <tr>
         <td class="description"><%= t('schools.user_tariffs.tariff_partial.type') %></td>
-        <td class="value"><%= @energy_tariff.flat_rate? ? t('schools.user_tariffs.tariff_partial.simple_tariff') : t('schools.user_tariffs.tariff_partial.differential_tariff') %></td>
+        <td class="value"><%= @energy_tariff.flat_rate? ? t('schools.user_tariffs.tariff_partial.flat_rate_tariff') : t('schools.user_tariffs.tariff_partial.differential_tariff') %></td>
       </tr>
     </tbody>
   </table>

--- a/app/views/energy_tariffs/energy_tariffs/show.html.erb
+++ b/app/views/energy_tariffs/energy_tariffs/show.html.erb
@@ -33,14 +33,14 @@
     <% end %>
   <% end %>
 
-  <div class="d-flex justify-content-between">
+  <div class="d-flex justify-content-between" id="tariff-metadata">
     <div>
       <h4><%= t('schools.user_tariffs.show.dates.title') %></h4>
     </div>
     <div>
       <%= link_to t('common.labels.edit'),
           energy_tariffs_path(@energy_tariff, [], { action: :edit }),
-          class: 'btn', id: 'edit_dates' unless @energy_tariff.dcc?
+          class: 'btn', id: 'edit-dates' unless @energy_tariff.dcc?
       %>
     </div>
   </div>
@@ -58,14 +58,14 @@
   </table>
 
   <% if @energy_tariff.school? %>
-    <div class="mt-4 d-flex justify-content-between">
+    <div class="mt-4 d-flex justify-content-between" id="tariff-meters">
       <div>
         <h4><%= t('schools.user_tariffs.show.meters') %></h4>
       </div>
       <div>
         <%= link_to t('common.labels.edit'),
             energy_tariffs_path(@energy_tariff, [], { action: :edit_meters }),
-            class: 'btn', id: 'edit_meters' unless @energy_tariff.dcc?
+            class: 'btn', id: 'choose-meters' unless @energy_tariff.dcc?
         %>
       </div>
     </div>
@@ -87,6 +87,27 @@
     </table>
   <% end %>
 
+  <div class="mt-4 d-flex justify-content-between" id="tariff-type">
+    <div>
+      <h4><%= t('schools.user_tariffs.choose_type.breadcrumb_title') %></h4>
+    </div>
+    <div>
+      <%= link_to t('common.labels.edit'),
+          energy_tariffs_path(@energy_tariff, [], { action: :choose_type }),
+          class: 'btn', id: 'choose-type' unless (@energy_tariff.gas? || @energy_tariff.dcc?)
+      %>
+    </div>
+  </div>
+  <table class="table table-charges">
+    <tbody>
+      <tr>
+        <td class="description"><%= t('schools.user_tariffs.tariff_partial.type') %></td>
+        <td class="value"><%= @energy_tariff.flat_rate? ? t('schools.user_tariffs.tariff_partial.simple_tariff') : t('schools.user_tariffs.tariff_partial.differential_tariff') %></td>
+      </tr>
+    </tbody>
+  </table>
+
+
   <div class="mt-4 d-flex justify-content-between" id="consumption-charges">
     <div>
       <h4><%= t('schools.user_tariffs.show.consumption_charges') %></h4>
@@ -94,7 +115,7 @@
     <div>
       <%= link_to t('common.labels.edit'),
         energy_tariff_prices_path(@energy_tariff),
-        class: 'btn' unless @energy_tariff.dcc?
+        class: 'btn', id: 'edit-prices' unless @energy_tariff.dcc?
       %>
     </div>
   </div>
@@ -111,7 +132,7 @@
     <div>
       <%= link_to t('common.labels.edit'),
         energy_tariffs_path(@energy_tariff, [:energy_tariff_charges]),
-        class: 'btn' unless @energy_tariff.dcc? %>
+        class: 'btn', id: 'edit-charges' unless @energy_tariff.dcc? %>
     </div>
   </div>
   <%= render 'energy_tariffs/energy_tariffs/charges_table', energy_tariff: @energy_tariff, allow_edits: false %>
@@ -151,13 +172,5 @@
   <br/>
   <br/>
 
-  <%= link_to t('common.labels.previous'), energy_tariffs_path(@energy_tariff, [:energy_tariff_charges]), class: 'btn' %>
   <%= link_to t('common.labels.finished'), energy_tariffs_path(@energy_tariff, [], { energy_tariff_index: true }), class: 'btn' %>
-
-  <div class="hidden">
-    <% if can? :download, EnergyTariff %>
-      <h4><%= t('schools.user_tariffs.show.meter_attribute_view') %></h4>
-      <%= print_meter_attribute(@energy_tariff.meter_attribute) %>
-    <% end %>
-  </div>
 </div>

--- a/config/locales/common.yml
+++ b/config/locales/common.yml
@@ -21,6 +21,7 @@ en:
       back: Back
       cancel: Cancel
       close: Close
+      continue: Continue
       create: Create
       created: Created
       deactivate: Deactivate

--- a/config/locales/cy/views/schools/user_tariffs.yml
+++ b/config/locales/cy/views/schools/user_tariffs.yml
@@ -94,7 +94,6 @@ cy:
       show:
         consumption_charges: Costau defnydd
         introduction_html: Bydd unrhyw newidiadau i'r tariff yn cael eu hadlewyrchu yn y tudalennau <a href='%{electricity_analysis_path}'>dadansoddiad cost trydan</a> a <a href='%{gas_analysis_path}'>dadansoddiad cost nwy</a> a fydd yn diweddaru dros nos
-        meter_attribute_view: Gwedd priodoledd mesurydd (gweinyddwr yn unig)
         standing_charges: Costau sefydlog
       smart_meter_tariffs:
         introduction_html: |-

--- a/config/locales/views/schools/user_tariffs.yml
+++ b/config/locales/views/schools/user_tariffs.yml
@@ -165,7 +165,6 @@ en:
           start_date: Start date
           title: Dates
         introduction_html: Any changes to the tariff will be reflected in the <a href='%{analysis_path}'>%{meter_type} cost analysis</a> page which will update overnight
-        meter_attribute_view: Meter attribute view (admin only)
         meters: Meters
         no_standing_charges: No standing charges have been added
         not_usable: This tariff has missing or incomplete prices and so is not yet usable.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -83,6 +83,7 @@ Rails.application.routes.draw do
         get :choose_type, to: 'energy_tariffs#choose_type'
         get :edit_meters, to: 'energy_tariffs#edit_meters'
         post :update_meters, to: 'energy_tariffs#update_meters'
+        post :update_type, to: 'energy_tariffs#update_type'
         post :toggle_enabled, to: 'energy_tariffs#toggle_enabled'
       end
     end

--- a/spec/support/energy_tariff_editors_shared_examples.rb
+++ b/spec/support/energy_tariff_editors_shared_examples.rb
@@ -1,0 +1,335 @@
+RSpec.shared_examples "a basic gas tariff editor" do
+  let(:meter_type) { :gas }
+  context 'when adding a new tariff' do
+    before { click_link('Add gas tariff') }
+    include_examples 'the user can create a tariff'
+  end
+
+  context 'with an existing tariff' do
+    let!(:energy_tariff)         { create(:energy_tariff, :with_flat_price, start_date: Date.new(2022,1,1), end_date: Date.new(2022,12,31), tariff_holder: tariff_holder, meter_type: meter_type)}
+    before do
+      #assumes staring from tariff index
+      refresh
+      click_on energy_tariff.name
+    end
+
+    include_examples "the user can edit the tariff"
+
+    it 'does not offer option to edit the type of tariff' do
+      expect(page).to_not have_css('#choose-type')
+    end
+  end
+end
+
+RSpec.shared_examples "a basic electricity tariff editor" do
+  let(:meter_type) { :electricity }
+  context 'when adding a new tariff' do
+    before { click_link('Add electricity tariff') }
+    include_examples 'the user can create a tariff'
+  end
+
+  context 'with an existing tariff' do
+    let!(:energy_tariff)         { create(:energy_tariff, :with_flat_price, start_date: Date.new(2022,1,1), end_date: Date.new(2022,12,31), tariff_holder: tariff_holder, meter_type: meter_type)}
+    before do
+      #assumes staring from tariff index
+      refresh
+      click_on energy_tariff.name
+    end
+
+    include_examples "the user can edit the tariff"
+    include_examples 'the user can change the type of tariff'
+
+    it 'allows adding all the charges' do
+      find('#edit-charges').click
+
+      fill_in "energy_tariff_charges[fixed_charge][value]", with: '1.11'
+      select 'day', from: 'energy_tariff_charges[fixed_charge][units]'
+
+      fill_in "energy_tariff_charges[site_fee][value]", with: '2.22'
+      select 'month', from: 'energy_tariff_charges[site_fee][units]'
+
+      fill_in "energy_tariff_charges[duos_red][value]", with: '3.33'
+      fill_in "energy_tariff_charges[duos_amber][value]", with: '4.44'
+      fill_in "energy_tariff_charges[duos_green][value]", with: '5.55'
+
+      fill_in "energy_tariff_charges[agreed_availability_charge][value]", with: '6.66'
+      fill_in "energy_tariff_charges[excess_availability_charge][value]", with: '7.77'
+      fill_in "energy_tariff_charges[asc_limit_kw][value]", with: '8.88'
+
+      fill_in "energy_tariff_charges[reactive_power_charge][value]", with: '9.99'
+      fill_in "energy_tariff_charges[feed_in_tariff_levy][value]", with: '9.87'
+
+      fill_in "energy_tariff_charges[settlement_agency_fee][value]", with: '6.54'
+      fill_in "energy_tariff_charges[meter_asset_provider_charge][value]", with: '3.21'
+      fill_in "energy_tariff_charges[nhh_metering_agent_charge][value]", with: '1.9'
+
+      fill_in "energy_tariff_charges[nhh_automatic_meter_reading_charge][value]", with: '.12'
+      fill_in "energy_tariff_charges[data_collection_dcda_agent_charge][value]", with: '.34'
+
+      check 'energy_tariff_charges[energy_tariff][tnuos]'
+      check 'energy_tariff_charges[energy_tariff][ccl]'
+      select '20', from: 'energy_tariff_charges[energy_tariff][vat_rate]'
+
+      click_button('Continue')
+
+      energy_tariff = EnergyTariff.last
+
+      expect(energy_tariff.updated_by).to eq(current_user)
+      expect(energy_tariff.tnuos).to be_truthy
+      expect(energy_tariff.ccl).to be_truthy
+      expect(energy_tariff.vat_rate).to eq(20)
+
+      expect(energy_tariff.value_for_charge(:fixed_charge)).to eq('1.11')
+      expect(energy_tariff.value_for_charge(:site_fee)).to eq('2.22')
+      expect(energy_tariff.value_for_charge(:duos_red)).to eq('3.33')
+      expect(energy_tariff.value_for_charge(:duos_amber)).to eq('4.44')
+      expect(energy_tariff.value_for_charge(:duos_green)).to eq('5.55')
+      expect(energy_tariff.value_for_charge(:agreed_availability_charge)).to eq('6.66')
+      expect(energy_tariff.value_for_charge(:excess_availability_charge)).to eq('7.77')
+      expect(energy_tariff.value_for_charge(:asc_limit_kw)).to eq('8.88')
+      expect(energy_tariff.value_for_charge(:reactive_power_charge)).to eq('9.99')
+      expect(energy_tariff.value_for_charge(:feed_in_tariff_levy)).to eq('9.87')
+      expect(energy_tariff.value_for_charge(:settlement_agency_fee)).to eq('6.54')
+      expect(energy_tariff.value_for_charge(:meter_asset_provider_charge)).to eq('3.21')
+      expect(energy_tariff.value_for_charge(:nhh_metering_agent_charge)).to eq('1.9')
+      expect(energy_tariff.value_for_charge(:nhh_automatic_meter_reading_charge)).to eq('0.12')
+      expect(energy_tariff.value_for_charge(:data_collection_dcda_agent_charge)).to eq('0.34')
+    end
+  end
+
+  context 'with an existing differential tariff' do
+    let!(:energy_tariff)         { create(:energy_tariff, tariff_type: :differential, tariff_holder: tariff_holder, meter_type: meter_type)}
+
+    before do
+      #assumes staring from tariff index
+      refresh
+      click_on energy_tariff.name
+    end
+
+    it 'can create a differential tariff and add, edit, delete, and reset prices and charges' do
+      find('#edit-prices').click()
+      expect(page).to have_content('Rate from 00:00 to 07:00')
+      expect(page).to have_content('Rate from 07:00 to 00:00')
+      expect(page).to have_link('Add rate')
+      expect(page).to have_content('Please add valid prices for all marked rates')
+
+      page.all('.energy-tariff-show-button')[0].click
+
+      select '00', from: 'energy_tariff_price_start_time_4i'
+      select '30', from: 'energy_tariff_price_start_time_5i'
+      select '06', from: 'energy_tariff_price_end_time_4i'
+      select '30', from: 'energy_tariff_price_end_time_5i'
+
+      fill_in 'Rate in £/kWh', with: '1.5'
+      click_button('Save')
+
+      expect(page).to have_content('Rate from 00:30 to 06:30')
+      expect(page).to have_content('Rate from 07:00 to 00:00')
+      expect(page).to have_content('£1.50 per kWh')
+      expect(page).to have_content('£ per kWh')
+
+      expect(page).to have_content('Please add valid prices for all marked rates.')
+      first('.energy-tariff-show-button').click
+
+      fill_in 'Rate in £/kWh', with: '1.5'
+      click_button('Save')
+
+      expect(page).to have_content('Please add valid prices for all marked rates.')
+      first('.energy-tariff-show-button').click
+
+      select '00', from: 'energy_tariff_price_start_time_4i'
+      select '00', from: 'energy_tariff_price_start_time_5i'
+      select '07', from: 'energy_tariff_price_end_time_4i'
+      select '00', from: 'energy_tariff_price_end_time_5i'
+      click_button('Save')
+
+      expect(page).to have_content('Please add valid prices for all marked rates.')
+      expect(page).not_to have_content('Incomplete 24 hour coverage. Please add another rate.')
+      expect(page).not_to have_content('A differential tariff must have at least 2 prices, e.g. a day time and a night-time rate. Please add prices, or reset to default.')
+      expect(find("a", text: "Add rate")[:class]).to eq('btn disabled')
+      expect(find("a", text: "Reset to default")[:class]).to eq('btn disabled')
+
+      click_link("Delete", match: :first)
+
+      expect(page).not_to have_content('Rate from 00:30 to 06:30')
+      expect(page).to have_content('Rate from 07:00 to 00:00')
+      expect(page).not_to have_content('£1.50 per kWh')
+      expect(page).to have_content('£ per kWh')
+
+      expect(page).not_to have_content('Complete 24 hour coverage.')
+      expect(page).to have_content('Please add valid prices for all marked rates.')
+      expect(page).not_to have_content('A differential tariff must have at least 2 prices, e.g. a day time and a night-time rate. Please add prices, or reset to default.')
+      expect(find("a", text: "Add rate")[:class]).to eq('btn')
+      expect(find("a", text: "Reset to default")[:class]).to eq('btn')
+
+      click_link("Delete", match: :first)
+
+      expect(page).not_to have_content('Rate from 00:30 to 06:30')
+      expect(page).not_to have_content('Rate from 07:00 to 00:00')
+      expect(page).not_to have_content('£1.50 per kWh')
+      expect(page).not_to have_content('£ per kWh')
+
+      expect(page).not_to have_content('Please add valid prices for all marked rates.')
+      expect(page).not_to have_content('Incomplete 24 hour coverage. Please add another rate.')
+      expect(page).to have_content('A differential tariff must have at least 2 prices, e.g. a day time and a night-time rate. Please add prices, or reset to default.')
+      expect(find("a", text: "Add rate")[:class]).to eq('btn')
+      expect(find("a", text: "Reset to default")[:class]).to eq('btn')
+
+      click_link('Reset to default')
+
+      expect(page).to have_content('Rate from 00:00 to 07:00')
+      expect(page).to have_content('Rate from 07:00 to 00:00')
+      expect(page).to have_content('£ per kWh')
+      expect(page).to have_content('£ per kWh')
+
+      find("#energy-tariff-show-button-#{energy_tariff.energy_tariff_prices.first.id}").click
+
+      fill_in 'Rate in £/kWh', with: '1.5'
+      click_button('Save')
+
+      expect(page).to have_content('Rate from 00:00 to 07:00')
+      expect(page).to have_content('Rate from 07:00 to 00:00')
+      expect(page).to have_content('£1.50 per kWh')
+      expect(page).to have_content('£ per kWh')
+
+      expect(find("a", text: "Continue")[:class]).to eq('btn disabled')
+
+      find("#energy-tariff-show-button-#{energy_tariff.energy_tariff_prices.last.id}").click
+
+      fill_in 'Rate in £/kWh', with: '2.5'
+      click_button('Save')
+
+      expect(page).to have_content('Rate from 00:00 to 07:00 ')
+      expect(page).to have_content('Rate from 07:00 to 00:00')
+      expect(page).to have_content('£1.50 per kWh')
+      expect(page).to have_content('£2.50 per kWh')
+
+      expect(page).to have_content('Complete 24 hour coverage.')
+      expect(page).not_to have_content('Incomplete 24 hour coverage. Please add another rate.')
+      expect(page).not_to have_content('A differential tariff must have at least 2 prices, e.g. a day time and a night-time rate. Please add prices, or reset to default.')
+      expect(find("a", text: "Add rate")[:class]).to eq('btn disabled')
+      expect(find("a", text: "Reset to default")[:class]).to eq('btn disabled')
+
+      click_link('Continue')
+
+      expect(page).to_not have_content(I18n.t('schools.user_tariffs.show.not_usable'))
+
+      energy_tariff_price = energy_tariff.energy_tariff_prices.first
+      expect(energy_tariff_price.start_time.to_s(:time)).to eq('00:00')
+      expect(energy_tariff_price.end_time.to_s(:time)).to eq('07:00')
+      expect(energy_tariff_price.value.to_s).to eq('1.5')
+      expect(energy_tariff_price.units).to eq('kwh')
+      energy_tariff_price = energy_tariff.energy_tariff_prices.last
+      expect(energy_tariff_price.start_time.to_s(:time)).to eq('07:00')
+      expect(energy_tariff_price.end_time.to_s(:time)).to eq('00:00')
+      expect(energy_tariff_price.value.to_s).to eq('2.5')
+      expect(energy_tariff_price.units).to eq('kwh')
+    end
+  end
+end
+
+RSpec.shared_examples "a school tariff editor" do
+  let(:tariff_holder)       { school }
+  let(:tariff_holder_type)  { 'School' }
+
+  before(:each) do
+    sign_in(current_user)
+    visit school_path(school)
+    within '#manage_school_menu' do
+      click_on 'Manage tariffs'
+    end
+  end
+
+  context 'when viewing index' do
+    let(:tariff_holder) { school }
+    before { visit school_energy_tariffs_path(school) }
+    it_behaves_like "a tariff editor index"
+  end
+
+  it 'is navigable from the manage school menu' do
+    expect(current_path).to eq("/schools/#{school.slug}/energy_tariffs")
+    expect(page).to have_content(I18n.t('schools.user_tariffs.index.title'))
+    expect(page).to have_link('cost analysis pages')
+  end
+
+  context 'when creating tariffs' do
+    context 'for electricity meters' do
+      include_examples 'a basic electricity tariff editor'
+    end
+    context 'for gas meters' do
+      include_examples 'a basic gas tariff editor'
+    end
+  end
+
+  context 'when editing a school tariff' do
+    let(:meter)           { electricity_meter }
+    let(:mpan_mprn)       { electricity_meter.mpan_mprn.to_s }
+    let(:meter_type)      { :electricity }
+    let!(:energy_tariff)  { create(:energy_tariff, :with_flat_price, start_date: Date.new(2022,1,1), end_date: Date.new(2022,12,31), tariff_holder: tariff_holder, meter_type: meter_type)}
+    before(:each) do
+      refresh
+      click_on(energy_tariff.name)
+    end
+    include_examples "the user can select the meters"
+  end
+end
+
+RSpec.shared_examples "a school group energy tariff editor" do
+  before(:each) { sign_in(current_user) }
+
+  context 'has navigation links', skip: "Group tariff editor is temporarily admin only.  This skip can be removed when the group sub nav template is updated" do
+    it 'from school group page to energy tariffs index' do
+      visit school_group_path(school_group)
+      click_link('Manage Group')
+      click_link('Manage tariffs')
+      expect(current_path).to eq("/school_groups/#{school_group.slug}/energy_tariffs")
+      expect(page).to have_content(I18n.t('schools.user_tariffs.index.title'))
+    end
+  end
+
+  context 'when viewing index' do
+    let(:tariff_holder) { school_group }
+    before { visit school_group_energy_tariffs_path(school_group) }
+    it_behaves_like "a tariff editor index"
+  end
+
+  context 'when creating tariffs' do
+    let(:tariff_index_path)   { school_group_energy_tariffs_path(school_group) }
+    let(:tariff_holder)       { school_group }
+    let(:tariff_holder_type)  { 'SchoolGroup' }
+
+    before(:each) do
+      visit tariff_index_path
+    end
+
+    it_behaves_like 'a basic gas tariff editor'
+    it_behaves_like 'a basic electricity tariff editor'
+  end
+end
+
+RSpec.shared_examples "the site settings energy tariff editor" do
+  before(:each) do
+    visit admin_path
+    click_link('Energy Tariffs')
+  end
+
+  context 'when viewing index' do
+    let(:tariff_holder) { SiteSettings.current }
+    before { visit admin_settings_energy_tariffs_path }
+    it_behaves_like "a tariff editor index"
+  end
+
+  it 'has expected index' do
+    expect(page).to have_content(I18n.t('schools.user_tariffs.index.title'))
+    expect(page).not_to have_link('cost analysis pages')
+  end
+
+  context 'when creating tariffs' do
+    let(:tariff_index_path)   { admin_settings_energy_tariffs_path }
+    let(:tariff_holder)       { SiteSettings.current }
+    let(:tariff_holder_type)  { 'SiteSettings' }
+
+    it_behaves_like 'a basic gas tariff editor'
+    it_behaves_like 'a basic electricity tariff editor'
+  end
+end

--- a/spec/system/admin/settings/energy_tariffs_spec.rb
+++ b/spec/system/admin/settings/energy_tariffs_spec.rb
@@ -10,61 +10,61 @@ describe 'site settings energy tariffs', type: :system do
   context 'as an admin user' do
     let!(:current_user) { create(:admin) }
     before(:each) { sign_in(current_user) }
-    it_behaves_like "the site settings energy tariff editor"
+    include_examples "the site settings energy tariff editor"
   end
 
   context 'as a group_admin user' do
     let!(:current_user) { create(:group_admin) }
     let(:path)          { admin_settings_energy_tariffs_path }
     before              { sign_in(current_user) }
-    it_behaves_like "the user does not have access to the tariff editor"
+    include_examples "the user does not have access to the tariff editor"
   end
 
   context 'as a guest user' do
     let!(:current_user) { create(:guest) }
     let(:path)          { admin_settings_energy_tariffs_path }
     before              { sign_in(current_user) }
-    it_behaves_like "the user does not have access to the tariff editor"
+    include_examples "the user does not have access to the tariff editor"
   end
 
   context 'as a pupil user' do
     let!(:current_user) { create(:pupil) }
     let(:path)          { admin_settings_energy_tariffs_path }
     before              { sign_in(current_user) }
-    it_behaves_like "the user does not have access to the tariff editor"
+    include_examples "the user does not have access to the tariff editor"
   end
 
   context 'as a school admin user' do
     let!(:current_user) { create(:school_admin) }
     let(:path)          { admin_settings_energy_tariffs_path }
     before              { sign_in(current_user) }
-    it_behaves_like "the user does not have access to the tariff editor"
+    include_examples "the user does not have access to the tariff editor"
   end
 
   context 'as a school_onboarding user' do
     let!(:current_user) { create(:onboarding_user) }
     let(:path)          { admin_settings_energy_tariffs_path }
     before              { sign_in(current_user) }
-    it_behaves_like "the user does not have access to the tariff editor"
+    include_examples "the user does not have access to the tariff editor"
   end
 
   context 'as a staff user' do
     let!(:current_user) { create(:staff) }
     let(:path)          { admin_settings_energy_tariffs_path }
     before              { sign_in(current_user) }
-    it_behaves_like "the user does not have access to the tariff editor"
+    include_examples "the user does not have access to the tariff editor"
   end
 
   context 'as a volunteer user' do
     let!(:current_user) { create(:volunteer) }
     let(:path)          { admin_settings_energy_tariffs_path }
     before              { sign_in(current_user) }
-    it_behaves_like "the user does not have access to the tariff editor"
+    include_examples "the user does not have access to the tariff editor"
   end
 
   context 'with no signed in user' do
     let!(:current_user) { nil }
     let(:path)          { admin_settings_energy_tariffs_path }
-    it_behaves_like "the user does not have access to the tariff editor"
+    include_examples "the user does not have access to the tariff editor"
   end
 end

--- a/spec/system/admin/settings/energy_tariffs_spec.rb
+++ b/spec/system/admin/settings/energy_tariffs_spec.rb
@@ -13,12 +13,6 @@ describe 'site settings energy tariffs', type: :system do
     it_behaves_like "the site settings energy tariff editor"
   end
 
-  context 'as an analytics user' do
-    let!(:current_user) { create(:admin) }
-    before(:each) { sign_in(current_user) }
-    it_behaves_like "the site settings energy tariff editor"
-  end
-
   context 'as a group_admin user' do
     let!(:current_user) { create(:group_admin) }
     let(:path)          { admin_settings_energy_tariffs_path }

--- a/spec/system/school_groups/energy_tariffs_spec.rb
+++ b/spec/system/school_groups/energy_tariffs_spec.rb
@@ -16,13 +16,13 @@ describe 'school group energy tariffs', type: :system do
   context 'as an admin user' do
     let!(:current_user) { create(:admin) }
 
-    it_behaves_like "a school group energy tariff editor"
+    include_examples "a school group energy tariff editor"
   end
 
   context 'as a group_admin user' do
     let(:current_user) { create(:user, role: :group_admin, school_group: school_group)}
 
-    it_behaves_like "a school group energy tariff editor"
+    include_examples "a school group energy tariff editor"
   end
 
   context 'as a group_admin user of a different group' do
@@ -30,54 +30,54 @@ describe 'school group energy tariffs', type: :system do
     let(:current_user) { create(:user, role: :group_admin, school_group: school_group_2)}
     let(:path)          { school_group_energy_tariffs_path(school_group) }
     before(:each) { sign_in(current_user) }
-    it_behaves_like "the user does not have access to the tariff editor"
+    include_examples "the user does not have access to the tariff editor"
   end
 
   context 'as a guest user' do
     let!(:current_user) { create(:guest) }
     let(:path)          { school_group_energy_tariffs_path(school_group) }
     before(:each)       { sign_in(current_user) }
-    it_behaves_like "the user does not have access to the tariff editor"
+    include_examples "the user does not have access to the tariff editor"
   end
 
   context 'as a pupil user' do
     let!(:current_user) { create(:pupil) }
     let(:path)          { school_group_energy_tariffs_path(school_group) }
     before(:each) { sign_in(current_user) }
-    it_behaves_like "the user does not have access to the tariff editor"
+    include_examples "the user does not have access to the tariff editor"
   end
 
   context 'as a school admin user' do
     let!(:current_user) { create(:school_admin) }
     let(:path)          { school_group_energy_tariffs_path(school_group) }
     before              { sign_in(current_user) }
-    it_behaves_like "the user does not have access to the tariff editor"
+    include_examples "the user does not have access to the tariff editor"
   end
 
   context 'as a school_onboarding user' do
     let!(:current_user) { create(:onboarding_user) }
     let(:path)          { school_group_energy_tariffs_path(school_group) }
     before(:each)       { sign_in(current_user) }
-    it_behaves_like "the user does not have access to the tariff editor"
+    include_examples "the user does not have access to the tariff editor"
   end
 
   context 'as a staff user' do
     let!(:current_user) { create(:staff) }
     let(:path)          { school_group_energy_tariffs_path(school_group) }
     before(:each)       { sign_in(current_user) }
-    it_behaves_like "the user does not have access to the tariff editor"
+    include_examples "the user does not have access to the tariff editor"
   end
 
   context 'as a volunteer user' do
     let!(:current_user) { create(:volunteer) }
     let(:path)          { school_group_energy_tariffs_path(school_group) }
     before(:each)       { sign_in(current_user) }
-    it_behaves_like "the user does not have access to the tariff editor"
+    include_examples "the user does not have access to the tariff editor"
   end
 
   context 'with no signed in user' do
     let!(:current_user) { nil }
     let(:path)          { school_group_energy_tariffs_path(school_group) }
-    it_behaves_like "the user does not have access to the tariff editor"
+    include_examples "the user does not have access to the tariff editor"
   end
 end

--- a/spec/system/school_groups/energy_tariffs_spec.rb
+++ b/spec/system/school_groups/energy_tariffs_spec.rb
@@ -19,12 +19,6 @@ describe 'school group energy tariffs', type: :system do
     it_behaves_like "a school group energy tariff editor"
   end
 
-  context 'as an analytics user' do
-    let!(:current_user) { create(:analytics) }
-
-    it_behaves_like "a school group energy tariff editor"
-  end
-
   context 'as a group_admin user' do
     let(:current_user) { create(:user, role: :group_admin, school_group: school_group)}
 

--- a/spec/system/schools/energy_tariffs_spec.rb
+++ b/spec/system/schools/energy_tariffs_spec.rb
@@ -13,17 +13,12 @@ describe 'school energy tariffs', type: :system do
 
     context 'as an admin user' do
       let!(:current_user) { create(:admin) }
-      it_behaves_like "a school tariff editor"
-    end
-
-    context 'as an analytics user' do
-      let!(:current_user) { create(:analytics) }
-      it_behaves_like "a school tariff editor"
+      include_examples "a school tariff editor"
     end
 
     context 'as a school admin user' do
       let!(:current_user) { create(:school_admin, school: school) }
-      it_behaves_like "a school tariff editor"
+      include_examples "a school tariff editor"
     end
 
     context 'as a group_admin user' do
@@ -41,35 +36,35 @@ describe 'school energy tariffs', type: :system do
       let!(:current_user) { create(:guest) }
       let(:path)          { school_energy_tariffs_path(school) }
       before(:each)       { sign_in(current_user) }
-      it_behaves_like "the user does not have access to the tariff editor"
+      include_examples "the user does not have access to the tariff editor"
     end
 
     context 'as a pupil user' do
       let!(:current_user) { create(:pupil, school: school) }
       before(:each)       { sign_in(current_user) }
       let(:path)          { school_energy_tariffs_path(school) }
-      it_behaves_like "the user does not have access to the tariff editor"
+      include_examples "the user does not have access to the tariff editor"
     end
 
     context 'as a school_onboarding user' do
       let!(:current_user) { create(:onboarding_user, school: school) }
       let(:path)          { school_energy_tariffs_path(school) }
       before(:each)       { sign_in(current_user) }
-      it_behaves_like "the user does not have access to the tariff editor"
+      include_examples "the user does not have access to the tariff editor"
     end
 
     context 'as a staff user' do
       let!(:current_user) { create(:staff, school: school) }
       let(:path)          { school_energy_tariffs_path(school) }
       before(:each)       { sign_in(current_user) }
-      it_behaves_like "the user does not have access to the tariff editor"
+      include_examples "the user does not have access to the tariff editor"
     end
 
     context 'as a volunteer user' do
       let!(:current_user) { create(:volunteer, school: school) }
       let(:path)          { school_energy_tariffs_path(school) }
       before(:each)       { sign_in(current_user) }
-      it_behaves_like "the user does not have access to the tariff editor"
+      include_examples "the user does not have access to the tariff editor"
     end
 
     context 'as a non school user' do
@@ -77,7 +72,7 @@ describe 'school energy tariffs', type: :system do
       let!(:current_user) { create(:user, school: school_2) }
       let(:path)          { school_energy_tariffs_path(school) }
       before(:each)       { sign_in(current_user) }
-      it_behaves_like "the user does not have access to the tariff editor"
+      include_examples "the user does not have access to the tariff editor"
     end
 
     context 'as a non school admin user' do
@@ -85,13 +80,13 @@ describe 'school energy tariffs', type: :system do
       let!(:current_user) { create(:school_admin, school: school_2) }
       let(:path)          { school_energy_tariffs_path(school) }
       before(:each)       { sign_in(current_user) }
-      it_behaves_like "the user does not have access to the tariff editor"
+      include_examples "the user does not have access to the tariff editor"
     end
 
     context 'with no signed in user' do
       let!(:current_user) { nil }
       let(:path)          { school_energy_tariffs_path(school) }
-      it_behaves_like "the user does not have access to the tariff editor"
+      include_examples "the user does not have access to the tariff editor"
     end
 
   end


### PR DESCRIPTION
This is a large refactor of the editor flow and the associated specs.

The key changes are to:

* Remove the "wizard" style interface with previous and next buttons in favour of providing an initial form, then allowing the user to navigate from the energy tariff page to add specific elements
* Use this to refactor the specs to allow more reuse and make it easier to test specific parts of the editor interface
* Allow the type of tariff to be changed, e.g. switch between flat rate and differential, although this requires removing prices

Along the way I also fixed an issue with the EnergyTariff.last_updated_by not updating if we just edit tariffs and charges.

Following this, there's a need to do UX tidy, but this is the basic changes.