### PR TITLE
Update existing SiteSettings record

### DIFF
--- a/app/controllers/admin/settings_controller.rb
+++ b/app/controllers/admin/settings_controller.rb
@@ -1,12 +1,13 @@
 module Admin
   class SettingsController < AdminController
+    before_action :load_site_settings
+
     def show
-      @settings = SiteSettings.current
       @temperature_setting_months = temperature_setting_months
     end
 
     def update
-      SiteSettings.create!(site_settings_params)
+      @settings.update!(site_settings_params)
       if EnergySparks::FeatureFlags.active?(:use_site_settings_current_prices)
         BenchmarkMetrics.set_current_prices(prices: SiteSettings.current_prices)
       end
@@ -14,6 +15,10 @@ module Admin
     end
 
   private
+
+    def load_site_settings
+      @settings = SiteSettings.current
+    end
 
     def site_settings_params
       formatted_settings_params = settings_params

--- a/spec/system/admin/settings_spec.rb
+++ b/spec/system/admin/settings_spec.rb
@@ -10,31 +10,80 @@ describe 'site-wide settings' do
     click_on 'Admin'
   end
 
-  it 'allows admins to update site settings with the site settings pricing feature flag enabled' do
-    ClimateControl.modify FEATURE_FLAG_USE_SITE_SETTINGS_CURRENT_PRICES: 'true' do
-      BenchmarkMetrics.set_current_prices(prices: BenchmarkMetrics.default_prices)
-      expect(SiteSettings.current.electricity_price).to eq(nil)
-      click_on 'Site Settings'
-      uncheck 'Message for no contacts'
-      uncheck 'October'
-      check 'May'
-      fill_in "Electricity price", with: 0.99
-      fill_in "Solar export price", with: 0.98
-      fill_in "Gas price", with: 0.97
-      expect(BenchmarkMetrics.pricing).to eq(BenchmarkMetrics.default_prices)
-      click_on 'Update settings'
-      expect(SiteSettings.current.message_for_no_contacts).to eq(false)
-      expect(SiteSettings.current.temperature_recording_month_numbers).to match_array([11, 12, 1, 2, 3, 4, 5])
-      expect(SiteSettings.current.electricity_price).to eq(0.99)
-      expect(SiteSettings.current.solar_export_price).to eq(0.98)
-      expect(SiteSettings.current.gas_price).to eq(0.97)
-      expect(BenchmarkMetrics.pricing).not_to eq(BenchmarkMetrics.default_prices)
-      expect(BenchmarkMetrics.pricing).to eq(OpenStruct.new(gas_price: 0.97, electricity_price: 0.99, solar_export_price: 0.98))
+  context 'with pricing feature flag enabled' do
+    around do |example|
+      ClimateControl.modify FEATURE_FLAG_USE_SITE_SETTINGS_CURRENT_PRICES: 'true' do
+        example.run
+      end
     end
+
+    context 'with no existing site settings' do
+      it 'allows admins to update site settings with prices' do
+        BenchmarkMetrics.set_current_prices(prices: BenchmarkMetrics.default_prices)
+        click_on 'Site Settings'
+        uncheck 'Message for no contacts'
+        uncheck 'October'
+        check 'May'
+        fill_in "Electricity price", with: 0.99
+        fill_in "Solar export price", with: 0.98
+        fill_in "Gas price", with: 0.97
+        expect(BenchmarkMetrics.pricing).to eq(BenchmarkMetrics.default_prices)
+        click_on 'Update settings'
+        expect(SiteSettings.count).to eq 1
+        expect(SiteSettings.current.message_for_no_contacts).to eq(false)
+        expect(SiteSettings.current.temperature_recording_month_numbers).to match_array([11, 12, 1, 2, 3, 4, 5])
+        expect(SiteSettings.current.electricity_price).to eq(0.99)
+        expect(SiteSettings.current.solar_export_price).to eq(0.98)
+        expect(SiteSettings.current.gas_price).to eq(0.97)
+        expect(BenchmarkMetrics.pricing).not_to eq(BenchmarkMetrics.default_prices)
+        expect(BenchmarkMetrics.pricing).to eq(OpenStruct.new(gas_price: 0.97, electricity_price: 0.99, solar_export_price: 0.98))
+      end
+    end
+
+    context 'with site settings' do
+      before do
+        SiteSettings.create!(message_for_no_contacts: false, electricity_price: 1.2, gas_price: 0.2, solar_export_price: 0.1, temperature_recording_months: [1, 2, 3, 4, 5])
+      end
+      it 'updates price' do
+        click_on 'Site Settings'
+        check 'Message for no contacts'
+        fill_in "Electricity price", with: 0.99
+        fill_in "Solar export price", with: 0.98
+        fill_in "Gas price", with: 0.97
+        click_on 'Update settings'
+        expect(SiteSettings.count).to eq 1
+        expect(SiteSettings.current.electricity_price).to eq(0.99)
+        expect(SiteSettings.current.solar_export_price).to eq(0.98)
+        expect(SiteSettings.current.gas_price).to eq(0.97)
+        expect(SiteSettings.current.message_for_no_contacts).to eq(true)
+        expect(SiteSettings.current.temperature_recording_month_numbers).to match_array([1, 2, 3, 4, 5])
+      end
+
+      context 'that have tariffs' do
+        let!(:tariff)   { create(:energy_tariff, :with_flat_price, tariff_holder: SiteSettings.current)}
+
+        it 'updates price' do
+          click_on 'Site Settings'
+          fill_in "Electricity price", with: 0.99
+          click_on 'Update settings'
+          expect(SiteSettings.count).to eq 1
+          expect(SiteSettings.current.electricity_price).to eq(0.99)
+          expect(SiteSettings.current.energy_tariffs.first).to eq tariff
+        end
+
+      end
+    end
+
   end
 
-  it 'allows admins to update site settings with the site settings pricing feature flag disabled' do
-    ClimateControl.modify FEATURE_FLAG_USE_SITE_SETTINGS_CURRENT_PRICES: 'false' do
+  context 'with pricing feature flag disabled' do
+    around do |example|
+      ClimateControl.modify FEATURE_FLAG_USE_SITE_SETTINGS_CURRENT_PRICES: 'false' do
+        example.run
+      end
+    end
+
+    it 'allows admins to update site settings but no prices' do
       BenchmarkMetrics.set_current_prices(prices: BenchmarkMetrics.default_prices)
       expect(SiteSettings.current.electricity_price).to eq(nil)
       click_on 'Site Settings'
@@ -53,5 +102,8 @@ describe 'site-wide settings' do
       expect(SiteSettings.current.gas_price).to eq(nil)
       expect(BenchmarkMetrics.pricing).to eq(BenchmarkMetrics.default_prices)
     end
+
   end
+
+
 end


### PR DESCRIPTION
The admin site settings controller currently creates a new record when settings are updated, rather than updating the existing record. This works because we use `SiteSettings.current` to access the settings, so older records are ignored.

However, now that the energy tariffs are linked to the SiteSettings record creating a new record means we lose the association with tariffs, which causes a major problem with regenerating schools.

I think the intention is that the SiteSettings is meant to be a "singleton" rather than maintaining a history (which we don't need as we don't display or report on the history). So I've updated the controller to do a more conventional update to the existing record rather than creating a new one.

The PR has a small change to the controller and revisions to the system spec to explicitly test for updates when there is an existing record.