### PR TITLE
Remove reference to deleted service in after party task

### DIFF
--- a/lib/tasks/deployment/20230725132841_migrate_to_energy_tariffs.rake
+++ b/lib/tasks/deployment/20230725132841_migrate_to_energy_tariffs.rake
@@ -3,7 +3,8 @@ namespace :after_party do
   task migrate_to_energy_tariffs: :environment do
     puts "Running deploy task 'migrate_to_energy_tariffs'"
 
-    Database::EnergyTariffMigrationService.migrate_user_tariffs
+    # This service has since been removed
+    # Database::EnergyTariffMigrationService.migrate_user_tariffs
 
     # Update task as completed.  If you remove the line below, the task will
     # run with every deploy (or every time you call after_party:run).


### PR DESCRIPTION
Database::EnergyTariffMigrationService.migrate_user_tariffs was removed in this PR: https://github.com/Energy-Sparks/energy-sparks/pull/3025, however it is still referenced by 20230725132841_migrate_to_energy_tariffs.rake which I've just been trying to run.

I have removed the reference for now as it was tricky to unpickle otherwise (think I would have needed to rollback irreversible migrations). Is really only is me that it will affect for now, just means I could run all the other after_party tasks.

I might need to grab a database dump at some point though with the migrated user tariffs in, assuming that's what it does.