### PR TITLE
Add an meter system options to Energy Tariff

### DIFF
--- a/app/controllers/schools/meters_controller.rb
+++ b/app/controllers/schools/meters_controller.rb
@@ -113,7 +113,7 @@ module Schools
     end
 
     def meter_params
-      params.require(:meter).permit(:mpan_mprn, :meter_type, :name, :meter_serial_number, :dcc_meter, :sandbox, :earliest_available_data, :data_source_id, :procurement_route_id, :admin_meter_statuses_id, :system_type)
+      params.require(:meter).permit(:mpan_mprn, :meter_type, :name, :meter_serial_number, :dcc_meter, :sandbox, :earliest_available_data, :data_source_id, :procurement_route_id, :admin_meter_statuses_id, :meter_system)
     end
   end
 end

--- a/app/controllers/schools/meters_controller.rb
+++ b/app/controllers/schools/meters_controller.rb
@@ -113,7 +113,7 @@ module Schools
     end
 
     def meter_params
-      params.require(:meter).permit(:mpan_mprn, :meter_type, :name, :meter_serial_number, :dcc_meter, :sandbox, :earliest_available_data, :data_source_id, :procurement_route_id, :admin_meter_statuses_id, :half_hourly)
+      params.require(:meter).permit(:mpan_mprn, :meter_type, :name, :meter_serial_number, :dcc_meter, :sandbox, :earliest_available_data, :data_source_id, :procurement_route_id, :admin_meter_statuses_id, :system_type)
     end
   end
 end

--- a/app/mailers/import_mailer.rb
+++ b/app/mailers/import_mailer.rb
@@ -30,7 +30,7 @@ class ImportMailer < ApplicationMailer
       'Meter type',
       'School',
       'MPAN/MPRN',
-      'Half-Hourly',
+      'Meter system',
       'Data source',
       'Procurement route',
       'Last validated reading date',

--- a/app/mailers/import_mailer.rb
+++ b/app/mailers/import_mailer.rb
@@ -48,7 +48,7 @@ class ImportMailer < ApplicationMailer
       meter.meter_type.to_s.humanize,
       meter.school.name,
       meter.mpan_mprn,
-      (meter.half_hourly ? 'Yes' : 'No'),
+      meter.t_meter_system,
       meter.data_source&.name,
       meter.procurement_route&.organisation_name,
       meter.last_validated_reading&.strftime('%d/%m/%Y'),

--- a/app/models/data_source.rb
+++ b/app/models/data_source.rb
@@ -37,7 +37,7 @@ class DataSource < ApplicationRecord
           meter&.mpan_mprn,
           meter&.meter_type&.humanize,
           meter&.active,
-          (meter.half_hourly ? 'Yes' : 'No'),
+          meter.t_meter_system,
           meter&.first_validated_reading,
           meter&.last_validated_reading,
           meter&.admin_meter_status_label,

--- a/app/models/energy_tariff.rb
+++ b/app/models/energy_tariff.rb
@@ -52,6 +52,11 @@ class EnergyTariff < ApplicationRecord
   enum source: [:manually_entered, :dcc]
   enum meter_type: [:electricity, :gas, :solar_pv, :exported_solar_pv]
   enum tariff_type: [:flat_rate, :differential]
+
+  # When use as an all_energy_tariff_attributes filter:
+  # :half_hourly applies to meters which have a :meter_system of :hh
+  # :non_half_hourly applies to meters which have a :meter_system of :nhh_amr, :nhh or :smets2_smart
+  # :both applies to meters with all meter :system_type values
   enum applies_to: [:both, :half_hourly, :non_half_hourly]
 
   validates :name, presence: true

--- a/app/models/meter.rb
+++ b/app/models/meter.rb
@@ -98,8 +98,10 @@ class Meter < ApplicationRecord
            COUNT(1) FILTER (WHERE one_day_kwh = 0.0) AS zero_reading_days_count")
   }
 
-  # If adding a new one, add to the amr_validated_reading case statement for downloading data
+  # If adding a new meter_type, add to the amr_validated_reading case statement for downloading data
   enum meter_type: [:electricity, :gas, :solar_pv, :exported_solar_pv]
+  # The Meter's meter sytem defaults to NHH AMR (Non Half-Hourly Automatic Meter Reading)
+  # Other options are: NHH (Non Half-Hourly), HH (Half-Hourly), and SMETS2/smart (SMETS2 Smart Meters)
   enum meter_system: [:nhh_amr, :nhh, :hh, :smets2_smart]
 
   delegate :area_name, to: :school

--- a/app/models/meter.rb
+++ b/app/models/meter.rb
@@ -122,6 +122,10 @@ class Meter < ApplicationRecord
     school.name
   end
 
+  def t_meter_system
+    I18n.t("meter.meter_system.#{meter_system}")
+  end
+
   def admin_meter_status_label
     for_fuel_type = (fuel_type == :exported_solar_pv ? :solar_pv : fuel_type)
     admin_meter_status&.label || school&.school_group&.send(:"admin_meter_status_#{for_fuel_type}")&.label || ''

--- a/app/models/meter.rb
+++ b/app/models/meter.rb
@@ -100,6 +100,7 @@ class Meter < ApplicationRecord
 
   # If adding a new one, add to the amr_validated_reading case statement for downloading data
   enum meter_type: [:electricity, :gas, :solar_pv, :exported_solar_pv]
+  enum meter_system: [:nhh_amr, :nhh, :hh, :smets2_smart]
 
   delegate :area_name, to: :school
 

--- a/app/models/procurement_route.rb
+++ b/app/models/procurement_route.rb
@@ -31,7 +31,7 @@ class ProcurementRoute < ApplicationRecord
           meter&.mpan_mprn,
           meter&.meter_type&.humanize,
           meter&.active,
-          (meter.half_hourly ? 'Yes' : 'No'),
+          meter.t_meter_system,
           meter&.first_validated_reading,
           meter&.last_validated_reading,
           meter&.admin_meter_status_label,

--- a/app/services/school_groups/meter_report.rb
+++ b/app/services/school_groups/meter_report.rb
@@ -45,7 +45,7 @@ module SchoolGroups
             meter.meter_type,
             meter.mpan_mprn,
             meter.name,
-            meter.half_hourly ? 'Yes' : 'No',
+            meter.t_meter_system,
             meter.data_source.try(:name) || '',
             meter.admin_meter_status_label,
             meter.procurement_route.try(:organisation_name) || '',

--- a/app/views/admin_mailer/school_data_source_report.html.erb
+++ b/app/views/admin_mailer/school_data_source_report.html.erb
@@ -35,7 +35,7 @@
         </td>
         <td><%= meter&.meter_type&.humanize %></td>
         <td><%= meter&.active %></td>
-        <td><%= meter.half_hourly ? 'Yes' : 'No' %></td>
+        <td><%= meter.t_meter_system %></td>
         <td><%= meter&.first_validated_reading %></td>
         <td><%= meter&.last_validated_reading %></td>
         <td><%= meter&.admin_meter_status_label %></td>

--- a/app/views/import_mailer/_meter_table.html.erb
+++ b/app/views/import_mailer/_meter_table.html.erb
@@ -5,7 +5,7 @@
       <td><%= meter.meter_type.to_s.humanize %></td>
       <td><%= link_to meter.school.name, school_url(meter.school) %></td>
       <td><%= link_to meter.mpan_mprn, school_meter_url(meter.school, meter) %></td>
-      <td><%= meter.half_hourly ? 'Yes' : 'No' %></td>
+      <td><%= meter.t_meter_system %></td>
       <td><%= link_to meter.data_source.name, admin_data_source_url(meter.data_source) if meter.data_source %></td>
       <td><%= link_to meter.procurement_route&.organisation_name, admin_procurement_route_url(meter.procurement_route) if meter.procurement_route %></td>
       <td><%= nice_dates(meter.last_validated_reading) %></td>

--- a/app/views/schools/meters/_active_meters.html.erb
+++ b/app/views/schools/meters/_active_meters.html.erb
@@ -7,7 +7,7 @@
     <td><%= meter.name %></td>
     <% if current_user.admin? %>
       <td>
-        <%= meter.half_hourly ? t('common.labels.yes_label') : t('common.labels.no_label') %>
+        <%= meter.t_meter_system %>
       </td>
       <td>
         <%= link_to meter.data_source.try(:name), admin_data_source_path(meter.data_source) if meter.data_source %>

--- a/app/views/schools/meters/_form.html.erb
+++ b/app/views/schools/meters/_form.html.erb
@@ -37,8 +37,8 @@
   <% if current_user.admin? %>
     <div class="form-group">
       <div class="custom-control custom-checkbox">
-        <%= form.check_box :half_hourly, checked: meter.half_hourly, class: "custom-control-input" %>
-        <%= form.label :half_hourly, t('schools.meters.form.half_hourly'), class: "custom-control-label" %>
+        <%= form.label :meter_system, t('schools.meters.form.data_source') %>
+        <%= form.select(:meter_system, Meter.meter_systems.keys.map { |meter_system| [I18n.t("meter.meter_system.#{meter_system}"), meter_system] }, { include_blank: true }, class: 'form-control') %>
       </div>
     </div>
     <div class="form-group">

--- a/app/views/schools/meters/_form.html.erb
+++ b/app/views/schools/meters/_form.html.erb
@@ -37,7 +37,7 @@
   <% if current_user.admin? %>
     <div class="form-group">
       <div class="custom-control custom-checkbox">
-        <%= form.label :meter_system, t('schools.meters.form.data_source') %>
+        <%= form.label :meter_system, t('schools.meters.form.meter_system') %>
         <%= form.select(:meter_system, Meter.meter_systems.keys.map { |meter_system| [I18n.t("meter.meter_system.#{meter_system}"), meter_system] }, { include_blank: true }, class: 'form-control') %>
       </div>
     </div>

--- a/app/views/schools/meters/_inactive_meters.html.erb
+++ b/app/views/schools/meters/_inactive_meters.html.erb
@@ -7,7 +7,7 @@
     <td><%= meter.name %></td>
     <% if current_user.admin? %>
       <td>
-        <%= meter.half_hourly ? t('common.labels.yes_label') : t('common.labels.no_label') %>
+        <%= meter.t_meter_system %>
       </td>
       <td>
         <%= link_to meter.data_source.try(:name), admin_data_source_path(meter.data_source) if meter.data_source %>

--- a/app/views/schools/meters/index.html.erb
+++ b/app/views/schools/meters/index.html.erb
@@ -65,7 +65,7 @@
       <th scope="col"><%= t('schools.meters.index.meter') %></th>
       <th scope="col"><%= t('schools.meters.index.name') %></th>
       <% if current_user.admin? %>
-        <th scope="col"><%= t('schools.meters.index.half_hourly') %></th>
+        <th scope="col"><%= t('schools.meters.index.meter_system') %></th>
         <th scope="col"><%= t('schools.meters.index.data_source') %></th>
         <th scope="col"><%= t('schools.meters.index.procurement_route') %></th>
         <th scope="col"><%= t('schools.meters.index.admin_meter_status') %></th>

--- a/app/views/shared/_school_group_meter_report.html.erb
+++ b/app/views/shared/_school_group_meter_report.html.erb
@@ -27,7 +27,7 @@
           <td>
             <%= link_to(meter.mpan_mprn, school_meter_url(meter.school, meter)) %>
           </td>
-          <td><%= meter.half_hourly ? t('common.labels.yes_label') : t('common.labels.no_label') %></td>
+          <td><%= meter.t_meter_system %></td>
           <td><%= link_to(meter.name.present? ? meter.name : meter.meter_type.to_s.humanize, admin_reports_amr_validated_reading_url(meter)) if AmrValidatedReading.where(meter_id: meter.id).any? %></td>
           <% if local_assigns[:all_meters] %>
             <td><%= meter.active ? 'Active' : 'Deprecated' %></td>

--- a/config/locales/models/meter.yml
+++ b/config/locales/models/meter.yml
@@ -1,0 +1,8 @@
+---
+en:
+  meter:
+    meter_system:
+      hh: HH
+      nhh: NHH
+      nhh_amr: NHH AMR
+      smets2_smart: SMETS2/smart

--- a/config/locales/views/schools/schools.yml
+++ b/config/locales/views/schools/schools.yml
@@ -247,9 +247,9 @@ en:
         dcc_smart_meter: DCC Smart Meter
         earliest_available_data: Earliest available data
         editing_disabled_for_pseudo_meters: Editing disabled for pseudo meters
-        half_hourly: Half-Hourly
         leave_this_blank_message: Leave this blank for new meters and system will check it is registered with n3rgy
         meter_point_number: Meter Point Number
+        meter_system: Meter system
         name: Name
         only_check_if_adding_an_n3rgy_test_meter: Only check if you're adding an n3rgy test meter, not used for live schools
         procurement_route: Procurement route
@@ -266,7 +266,6 @@ en:
         data_processing_turned_on_message: Data processing must be turned on for this school before meter readings can be validated
         data_source: Data source
         first: First
-        half_hourly: Half-Hourly
         imported: Imported
         inactive_meters: Inactive meters
         large_gaps: Large gaps
@@ -274,6 +273,7 @@ en:
         manage_solar_api_feeds: Manage Solar API feeds
         meter: Meter
         meter_reviews: Completed DCC meter reviews
+        meter_system: Meter system
         mpan_warning_message: There are electricity meters with MPANs that don't appear to have the correct check digit
         name: Name
         no_active_meters: No active meters

--- a/db/migrate/20230907122423_add_meter_system_to_meter.rb
+++ b/db/migrate/20230907122423_add_meter_system_to_meter.rb
@@ -1,0 +1,5 @@
+class AddMeterSystemToMeter < ActiveRecord::Migration[6.0]
+  def change
+    add_column :meters, :meter_system, :integer, default: 0 # enum defaults to :nhh_amr
+  end
+end

--- a/db/migrate/20230907123002_remove_half_hourly_column_from_meter.rb
+++ b/db/migrate/20230907123002_remove_half_hourly_column_from_meter.rb
@@ -1,0 +1,5 @@
+class RemoveHalfHourlyColumnFromMeter < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :meters, :half_hourly
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_09_05_155308) do
+ActiveRecord::Schema.define(version: 2023_09_07_123002) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
@@ -1160,7 +1160,7 @@ ActiveRecord::Schema.define(version: 2023_09_05_155308) do
     t.bigint "data_source_id"
     t.bigint "admin_meter_statuses_id"
     t.bigint "procurement_route_id"
-    t.boolean "half_hourly", default: false
+    t.integer "meter_system", default: 0
     t.index ["data_source_id"], name: "index_meters_on_data_source_id"
     t.index ["low_carbon_hub_installation_id"], name: "index_meters_on_low_carbon_hub_installation_id"
     t.index ["meter_review_id"], name: "index_meters_on_meter_review_id"
@@ -1627,8 +1627,8 @@ ActiveRecord::Schema.define(version: 2023_09_05_155308) do
     t.integer "management_priorities_page_limit", default: 10
     t.boolean "message_for_no_pupil_accounts", default: true
     t.jsonb "temperature_recording_months", default: ["10", "11", "12", "1", "2", "3", "4"]
-    t.jsonb "prices"
     t.integer "default_import_warning_days", default: 10
+    t.jsonb "prices"
     t.integer "photo_bonus_points", default: 0
     t.integer "audit_activities_bonus_points", default: 0
   end

--- a/spec/mailers/import_mailer_spec.rb
+++ b/spec/mailers/import_mailer_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe ImportMailer, include_application_helper: true do
       attachments = email.attachments[0]
       expect(attachments.content_type).to include('text/csv')
       expect(attachments.filename).to eq("[energy-sparks-unknown] Energy Sparks import report: #{Date.today.strftime('%d/%m/%Y')}.csv")
-      expect(attachments.body.raw_source).to eq("\"\",Area,Meter type,School,MPAN/MPRN,Half-Hourly,Data source,Procurement route,Last validated reading date,Admin meter status,Issues,Notes,Group admin name\r\nMeter with stale data,#{sheffield_school.school_group.name},Gas,Sheffield School,#{meter_1.mpan_mprn},No,#{meter_1.data_source.name},,#{meter_1.last_validated_reading&.strftime('%d/%m/%Y')},\"\",0,0,Admin Two\r\nMeter with stale data,#{bath_school.school_group.name},Gas,Bath School,#{meter_2.mpan_mprn},No,#{meter_2.data_source.name},,#{meter_2.last_validated_reading&.strftime('%d/%m/%Y')},\"\",0,0,Admin One\r\n")
+      expect(attachments.body.raw_source).to eq("\"\",Area,Meter type,School,MPAN/MPRN,Meter system,Data source,Procurement route,Last validated reading date,Admin meter status,Issues,Notes,Group admin name\r\nMeter with stale data,#{sheffield_school.school_group.name},Gas,Sheffield School,#{meter_1.mpan_mprn},NHH AMR,#{meter_1.data_source.name},,#{meter_1.last_validated_reading&.strftime('%d/%m/%Y')},\"\",0,0,Admin Two\r\nMeter with stale data,#{bath_school.school_group.name},Gas,Bath School,#{meter_2.mpan_mprn},NHH AMR,#{meter_2.data_source.name},,#{meter_2.last_validated_reading&.strftime('%d/%m/%Y')},\"\",0,0,Admin One\r\n")
     end
   end
 end

--- a/spec/models/data_source_spec.rb
+++ b/spec/models/data_source_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe DataSource, type: :model do
                 meters[i].mpan_mprn,
                 meters[i].meter_type.humanize,
                 meters[i].active,
-                (meters[i].half_hourly ? 'Yes' : 'No'),
+                meters[i].t_meter_system,
                 first_reading_date,
                 last_reading_date,
                 admin_meter_status.label,

--- a/spec/models/procurement_route_spec.rb
+++ b/spec/models/procurement_route_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe ProcurementRoute, type: :model do
                 meters[i].mpan_mprn,
                 meters[i].meter_type.humanize,
                 meters[i].active,
-                (meters[i].half_hourly ? 'Yes' : 'No'),
+                meters[i].t_meter_system,
                 first_reading_date,
                 last_reading_date,
                 admin_meter_status.label,


### PR DESCRIPTION
- [x] Removes the old `half_hourly` flag from `Meter`
- [x] Adds a new `meter_system` integer/enum with possible values `HH` & `NHH AMR`,`NHH`, `SMETS2/smart` that defaults with `NHH AMR`
- [x] Replace `half_hourly` (Yes/No) with the meter_system value on the Admin Meter show page.
- [x] Replace the `half_hourly` column on the school group meter report with the meter_system value
- [x] Replace the `half_hourly` column on the data source report with the meter_system value
- [x] Replace the `half_hourly` column on the procurement route report with the meter_system value
- [x] Replace the `half_hourly` column on the daily imports email and its attachment with the meter_system value
