### PR TITLE
Reduce clutter on adult dashboard

### DIFF
--- a/app/controllers/schools_controller.rb
+++ b/app/controllers/schools_controller.rb
@@ -153,7 +153,7 @@ private
     if can?(:show_management_dash, @school)
       @add_contacts = site_settings.message_for_no_contacts && @school.contacts.empty? && can?(:manage, Contact)
       @add_pupils = site_settings.message_for_no_pupil_accounts && @school.users.pupil.empty? && can?(:manage_users, @school)
-      @prompt_training = !@show_data_enabled_features || current_user.confirmed_at < 60.days.ago
+      @prompt_training = @show_data_enabled_features && current_user.confirmed_at > 30.days.ago
       @prompt_for_bill = @school.bill_requested && can?(:index, ConsentDocument)
     end
   end

--- a/app/views/schools/show.html.erb
+++ b/app/views/schools/show.html.erb
@@ -54,16 +54,6 @@
   <%= render 'management/schools/targets/set_new_target', school: @school %>
 <% end %>
 
-<% if @show_standard_prompts %>
-  <%= render 'management/schools/complete_programmes', school: @school %>
-
-  <%= render 'management/schools/record_activity', school: @school %>
-
-  <%= render 'management/schools/record_intervention', school: @school %>
-
-  <%= render 'schools/dashboard/transport_surveys', school: @school %>
-<% end %>
-
 <% if @add_pupils %>
   <%= render 'management/schools/add_pupils', school: @school %>
 <% end %>

--- a/spec/system/schools/dashboard/prompts_spec.rb
+++ b/spec/system/schools/dashboard/prompts_spec.rb
@@ -5,22 +5,6 @@ RSpec.shared_examples "dashboard prompts" do
     visit school_path(test_school, switch: true)
   end
 
-  it 'has prompt to view programmes' do
-    expect(page).to have_content("Take the next step towards completing one of our short programmes of activity to increase your impact and score points for your school")
-  end
-
-  it 'has prompt to record activity' do
-    expect(page).to have_content("Teach pupils about energy and climate change within the context of your own school by completing our freely available activities")
-  end
-
-  it 'has prompt to record an action' do
-    expect(page).to have_content("Record energy saving actions made by school staff and facilities management to help to track whether your interventions have saved energy.")
-  end
-
-  it 'has prompt to start survey' do
-    expect(page).to have_content("Start a transport survey so that you can find out how much carbon your school community generates by travelling to school")
-  end
-
   it 'has school group dashboard message' do
     expect(page).to have_content("School group message")
   end
@@ -40,22 +24,6 @@ RSpec.describe "adult dashboard prompts", type: :system do
       visit school_path(school)
     end
 
-    it 'does not have prompt to view programmes' do
-      expect(page).to_not have_content("Take the next step towards completing one of our short programmes of activity to increase your impact and score points for your school")
-    end
-
-    it 'does not have prompt to record activity' do
-      expect(page).to_not have_content("Teach pupils about energy and climate change within the context of your own school by completing our freely available activities")
-    end
-
-    it 'does not have prompt to record an action' do
-      expect(page).to_not have_content("Record energy saving actions made by school staff and facilities management to help to track whether your interventions have saved energy.")
-    end
-
-    it 'does not have prompt to start survey' do
-      expect(page).to_not have_content("Start a transport survey so that you can find out how much carbon your school community generates by travelling to school")
-    end
-
     it 'does not display school group dashboard message' do
       expect(page).to_not have_content("School group message")
     end
@@ -66,22 +34,6 @@ RSpec.describe "adult dashboard prompts", type: :system do
     let(:user)    { create(:staff, school: school2) }
     before(:each) do
       visit school_path(school)
-    end
-
-    it 'does not have prompt to view programmes' do
-      expect(page).to_not have_content("Take the next step towards completing one of our short programmes of activity to increase your impact and score points for your school")
-    end
-
-    it 'does not have prompt to record activity' do
-      expect(page).to_not have_content("Teach pupils about energy and climate change within the context of your own school by completing our freely available activities")
-    end
-
-    it 'does not have prompt to record an action' do
-      expect(page).to_not have_content("Record energy saving actions made by school staff and facilities management to help to track whether your interventions have saved energy.")
-    end
-
-    it 'does not have prompt to start survey' do
-      expect(page).to_not have_content("Start a transport survey so that you can find out how much carbon your school community generates by travelling to school")
     end
 
     it 'does not display school group dashboard message' do

--- a/spec/system/schools/dashboard/prompts_spec.rb
+++ b/spec/system/schools/dashboard/prompts_spec.rb
@@ -1,80 +1,111 @@
 require 'rails_helper'
 
-RSpec.shared_examples "dashboard prompts" do
-  before(:each) do
-    visit school_path(test_school, switch: true)
+shared_examples "a dashboard showing dashboard messages" do
+  it { expect(page).to have_content("School group message") }
+  it { expect(page).to have_content("School message") }
+end
+
+shared_examples "a dashboard not showing dashboard messages" do
+  it { expect(page).to_not have_content("School group message") }
+  it { expect(page).to_not have_content("School message") }
+end
+
+shared_examples "a dashboard showing training prompt" do
+  it { expect(page).to have_content("New to Energy Sparks? Sign up to one of our upcoming free online training courses to help you get the most from the service.") }
+end
+
+shared_examples "a dashboard not showing training prompt" do
+  it { expect(page).to_not have_content("New to Energy Sparks? Sign up to one of our upcoming free online training courses to help you get the most from the service.") }
+end
+
+shared_examples "a dashboard training prompt" do
+  context "school is data enabled" do
+    let(:data_enabled) { true }
+    context "and user confirmed in the last 30 days" do
+      let(:confirmed_at) { 2.days.ago }
+
+      it_behaves_like "a dashboard showing training prompt"
+    end
+    context "and user confirmed more than 30 days ago" do
+      let(:confirmed_at) { 31.days.ago }
+
+      it_behaves_like "a dashboard not showing training prompt"
+    end
   end
 
-  it 'has school group dashboard message' do
-    expect(page).to have_content("School group message")
+  context "school is not data enabled" do
+    let(:data_enabled) { false }
+    it_behaves_like "a dashboard not showing training prompt"
+    context "and user confirmed more than 30 days ago" do
+      let(:confirmed_at) { 31.days.ago }
+
+      it_behaves_like "a dashboard not showing training prompt"
+    end
+    context "and user confirmed in the last 30 days" do
+      let(:confirmed_at) { 2.days.ago }
+
+      it_behaves_like "a dashboard not showing training prompt"
+    end
   end
 end
 
+########### TESTS START HERE ###########
+
 RSpec.describe "adult dashboard prompts", type: :system do
-  let(:school)             { create(:school, :with_school_group) }
-  let!(:dashboard_message) { school.school_group.create_dashboard_message(message: "School group message") }
+  let(:data_enabled)                    { true }
+  let(:confirmed_at)                    { 1.day.ago }
+  let(:school)                          { create(:school, :with_school_group, data_enabled: data_enabled) }
+  let!(:school_group_dashboard_message) { school.school_group.create_dashboard_message(message: "School group message") }
+  let!(:school_dashboard_message)       { school.create_dashboard_message(message: "School message") }
 
   before(:each) do
     sign_in(user) if user.present?
+    visit school_path(school, switch: true) # don't redirect pupils to pupil dashboard
   end
 
   context 'as guest' do
-    let(:user)                { nil }
-    before(:each) do
-      visit school_path(school)
-    end
+    let(:user)          { nil }
+    it_behaves_like "a dashboard not showing dashboard messages"
+    it_behaves_like "a dashboard not showing training prompt"
 
-    it 'does not display school group dashboard message' do
-      expect(page).to_not have_content("School group message")
-    end
   end
 
   context 'as user from another school' do
     let(:school2) { create(:school) }
     let(:user)    { create(:staff, school: school2) }
-    before(:each) do
-      visit school_path(school)
-    end
-
-    it 'does not display school group dashboard message' do
-      expect(page).to_not have_content("School group message")
-    end
+    it_behaves_like "a dashboard not showing dashboard messages"
+    it_behaves_like "a dashboard not showing training prompt"
   end
 
   context 'as pupil' do
-    let(:user)          { create(:pupil, school: school) }
-    include_examples "dashboard prompts" do
-      let(:test_school) { school }
-    end
+    let(:user)  { create(:pupil, school: school, confirmed_at: confirmed_at) }
+    it_behaves_like "a dashboard showing dashboard messages"
+    it_behaves_like "a dashboard training prompt"
   end
 
   context 'as staff' do
-    let(:user)   { create(:staff, school: school) }
-    include_examples "dashboard prompts" do
-      let(:test_school) { school }
-    end
+    let(:user)  { create(:staff, school: school, confirmed_at: confirmed_at) }
+    it_behaves_like "a dashboard showing dashboard messages"
+    it_behaves_like "a dashboard training prompt"
   end
 
   context 'as school admin' do
-    let(:user)  { create(:school_admin, school: school) }
-    include_examples "dashboard prompts" do
-      let(:test_school) { school }
-    end
+    let(:user)  { create(:school_admin, school: school, confirmed_at: confirmed_at) }
+    it_behaves_like "a dashboard showing dashboard messages"
+    it_behaves_like "a dashboard training prompt"
   end
 
   context 'as group admin' do
     let(:school_group)  { create(:school_group) }
-    let(:school)        { create(:school, school_group: school_group) }
-    let(:user)          { create(:group_admin, school_group: school_group, school: school) }
-    include_examples "dashboard prompts" do
-      let(:test_school) { school }
-    end
+    let(:school)        { create(:school, school_group: school_group, data_enabled: data_enabled) }
+    let(:user)          { create(:group_admin, school_group: school_group, school: school, confirmed_at: confirmed_at) }
+    it_behaves_like "a dashboard showing dashboard messages"
+    it_behaves_like "a dashboard training prompt"
   end
 
   context 'as admin' do
-    let(:user)  { create(:admin) }
-    include_examples "dashboard prompts" do
-      let(:test_school) { school }
-    end
+    let(:user)  { create(:admin, confirmed_at: confirmed_at) }
+    it_behaves_like "a dashboard showing dashboard messages"
+    it_behaves_like "a dashboard showing training prompt"
   end
 end


### PR DESCRIPTION
Logic for training prompt should be: if we are showing the data enabled features (and so its worth the school attending training) then prompt the user to sign up if they confirmed their account in the last 60 days. Currently it always seems to be displaying? Also suggest we reduce the window for the training prompt to 30 days.

Refactored the rspec after removing the standard prompts spec - now also includes spec for school dashboard messages (as well as school group dashboard messages), along with spec for the training prompt.