### PR TITLE
Make checkbox align left on mobile (not centre as it was doing)

### DIFF
--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -36,7 +36,7 @@
             <div class="form-group row">
               <%= f.label t('devise.sessions.new.remember_me'), class: "col-sm-4 col-form-label" %>
               <div class="col-sm-6">
-                <%= f.check_box :remember_me, class: "form-control col-sm-1" %>
+                <%= f.check_box :remember_me, class: "form-control col-1" %>
               </div>
             </div>
           <% end -%>


### PR DESCRIPTION
Small change to checkbox css that was merged earlier...