### PR TITLE
Disable use of preferences on the pupil analysis charts only

### DIFF
--- a/app/helpers/chart_helper.rb
+++ b/app/helpers/chart_helper.rb
@@ -62,10 +62,10 @@ module ChartHelper
     Charts::YAxisSelectionService.new(school, chart_name).select_y_axis || default
   end
 
-  def create_chart_config(school, chart_name, mpan_mprn = nil, export_title: '', export_subtitle: '')
+  def create_chart_config(school, chart_name, mpan_mprn = nil, apply_preferred_units: true, export_title: '', export_subtitle: '')
     config = {}
     config[:mpan_mprn] = mpan_mprn if mpan_mprn.present?
-    y_axis = select_y_axis(school, chart_name)
+    y_axis = apply_preferred_units ? select_y_axis(school, chart_name) : nil
     config[:y_axis_units] = y_axis if y_axis.present?
     config[:export_title] = export_title
     config[:export_subtitle] = export_subtitle

--- a/app/views/pupils/analysis/show.html.erb
+++ b/app/views/pupils/analysis/show.html.erb
@@ -11,5 +11,5 @@
       <h5></h5>
   </div>
   <%= render 'shared/analysis_controls', chart_type: @chart_type.to_s, analysis_controls: true %>
-  <%= chart_tag(@school, @chart_type.to_s, no_zoom: true, wrap: false, chart_config: create_chart_config(@school, @chart_type)) %>
+  <%= chart_tag(@school, @chart_type.to_s, no_zoom: true, wrap: false, chart_config: create_chart_config(@school, @chart_type, apply_preferred_units: false)) %>
 </div>

--- a/spec/helpers/chart_helper_spec.rb
+++ b/spec/helpers/chart_helper_spec.rb
@@ -15,4 +15,31 @@ describe ChartHelper do
       expect(result['456']).to eq('Electricity baseload from 01 Jun 2018 to 01 Jun 2021 for 456')
     end
   end
+
+  describe '.create_chart_config' do
+    let(:chart_name)  { :pupil_dashboard_group_by_week_electricity_£ }
+    let(:school)      { create(:school) }
+
+    it 'returns hash' do
+      expect( helper.create_chart_config(school, chart_name) ).to eq({export_title: '', export_subtitle: ''})
+    end
+
+    it 'adds mpan' do
+      expect( helper.create_chart_config(school, chart_name, '1234') ).to eq({mpan_mprn: '1234', export_title: '', export_subtitle: ''})
+    end
+
+    it 'adds export details' do
+      expect( helper.create_chart_config(school, chart_name, export_title: 'title', export_subtitle: 'subtitle') ).to eq({export_title: 'title', export_subtitle: 'subtitle'})
+    end
+
+    context 'when adding y-axis' do
+      let(:school)      { create(:school, chart_preference: :usage) }
+      it 'uses school preference when set' do
+        expect( helper.create_chart_config(school, chart_name) ).to eq({y_axis_units: :kwh, export_title: '', export_subtitle: ''})
+      end
+      it 'the preference can be overridden' do
+        expect( helper.create_chart_config(school, chart_name, apply_preferred_units: false) ).to eq({export_title: '', export_subtitle: ''})
+      end
+    end
+  end
 end


### PR DESCRIPTION
Schools can set their default preferences for how we display charts.

However some of the pupil pages involve exploring the data, allowing users to request specific views. At the moment, for some of these charts (those on the "pupil analysis" pages) the school level preference is overriding what the user has requested to see.

Some of these charts also currently have hard-coded titles and descriptions that refer to costs. 

This PR fixes that bug by displaying use of the preference for just those charts. Other charts will use the school preference.