### PR TITLE
Hide table if we dont have an average start time

### DIFF
--- a/app/views/schools/advice/heating_control/_heating_timings.html.erb
+++ b/app/views/schools/advice/heating_control/_heating_timings.html.erb
@@ -1,61 +1,63 @@
 <%= render 'schools/advice/section_title', section_id: 'heating-timings', section_title: t('advice_pages.heating_control.analysis.heating_timings.title') %>
 
-<%= t('advice_pages.heating_control.analysis.heating_timings.intro_html') %>
-
 <%= t('advice_pages.heating_control.analysis.heating_timings.estimated_savings_html',
   estimated_saving: format_unit(estimated_savings.£, :£),
   percent: format_unit(percentage_of_annual_gas, :percent)) %>
 
-<table class="table advice-table">
-  <thead>
-    <tr>
-      <th></th>
-      <th></th>
-      <th colspan="2"><%= t('advice_pages.heating_control.tables.columns.heating_time') %></th>
-      <th></th>
-      <th colspan="3"><%= t('advice_pages.heating_control.tables.columns.potential_saving') %></th>
-    </tr>
-    <tr>
-      <th><%= t('advice_pages.heating_control.tables.columns.date') %></th>
-      <th><%= t('advice_pages.heating_control.tables.columns.overnight_temperature') %></th>
-      <th><%= t('advice_pages.heating_control.tables.columns.heating_on_time') %></th>
-      <th><%= t('advice_pages.heating_control.tables.columns.recommended_time') %></th>
-      <th><%= t('advice_pages.heating_control.tables.columns.assessment') %></th>
-      <th><%= t('advice_pages.heating_control.tables.columns.potential_saving_kwh') %></th>
-      <th><%= t('advice_pages.heating_control.tables.columns.potential_saving_gbp') %></th>
-      <th><%= t('advice_pages.heating_control.tables.columns.potential_saving_co2') %></th>
-    </tr>
-  </thead>
-  <tbody>
-    <% last_week_start_times.days.each do |day| %>
+<% if @last_week_start_times.average_start_time.present? %>
+  <%= t('advice_pages.heating_control.analysis.heating_timings.intro_html') %>
+
+  <table class="table advice-table" id='heating-start-times'>
+    <thead>
       <tr>
-        <td><%= day.date.to_s(:es_full) %></td>
-        <td><%= day.temperature %></td>
-        <% if day.heating_start_time.present? %>
-          <td><%= day.heating_start_time %></td>
-          <td><%= day.recommended_time %></td>
-          <td class="<%= heating_time_class(day.heating_start_time, day.recommended_time) %>">
-            <%= heating_time_assessment(day.heating_start_time, day.recommended_time) %>
-          </td>
-          <% if day.heating_start_time < day.recommended_time %>
-            <td><%= format_unit(day.saving.kwh, :kwh) %></td>
-            <td><%= format_unit(day.saving.£, :£) %></td>
-            <td><%= format_unit(day.saving.co2, :co2) %></td>
+        <th></th>
+        <th></th>
+        <th colspan="2"><%= t('advice_pages.heating_control.tables.columns.heating_time') %></th>
+        <th></th>
+        <th colspan="3"><%= t('advice_pages.heating_control.tables.columns.potential_saving') %></th>
+      </tr>
+      <tr>
+        <th><%= t('advice_pages.heating_control.tables.columns.date') %></th>
+        <th><%= t('advice_pages.heating_control.tables.columns.overnight_temperature') %></th>
+        <th><%= t('advice_pages.heating_control.tables.columns.heating_on_time') %></th>
+        <th><%= t('advice_pages.heating_control.tables.columns.recommended_time') %></th>
+        <th><%= t('advice_pages.heating_control.tables.columns.assessment') %></th>
+        <th><%= t('advice_pages.heating_control.tables.columns.potential_saving_kwh') %></th>
+        <th><%= t('advice_pages.heating_control.tables.columns.potential_saving_gbp') %></th>
+        <th><%= t('advice_pages.heating_control.tables.columns.potential_saving_co2') %></th>
+      </tr>
+    </thead>
+    <tbody>
+      <% last_week_start_times.days.each do |day| %>
+        <tr>
+          <td><%= day.date.to_s(:es_full) %></td>
+          <td><%= day.temperature %></td>
+          <% if day.heating_start_time.present? %>
+            <td><%= day.heating_start_time %></td>
+            <td><%= day.recommended_time %></td>
+            <td class="<%= heating_time_class(day.heating_start_time, day.recommended_time) %>">
+              <%= heating_time_assessment(day.heating_start_time, day.recommended_time) %>
+            </td>
+            <% if day.heating_start_time < day.recommended_time %>
+              <td><%= format_unit(day.saving.kwh, :kwh) %></td>
+              <td><%= format_unit(day.saving.£, :£) %></td>
+              <td><%= format_unit(day.saving.co2, :co2) %></td>
+            <% else %>
+              <td>-</td>
+              <td>-</td>
+              <td>-</td>
+            <% end %>
           <% else %>
+            <td>-</td>
+            <td>-</td>
+            <td colspan="1"><%= t('analytics.modelling.heating.no_heating') %></td>
             <td>-</td>
             <td>-</td>
             <td>-</td>
           <% end %>
-        <% else %>
-          <td>-</td>
-          <td>-</td>
-          <td colspan="1"><%= t('analytics.modelling.heating.no_heating') %></td>
-          <td>-</td>
-          <td>-</td>
-          <td>-</td>
-        <% end %>
-      </tr>
-    <% end %>
-  </tbody>
-</table>
-<%= render 'schools/advice/how_have_we_analysed_your_data_table_caption', data_target: "how-have-we-analysed-your-data-footnotes" %>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+  <%= render 'schools/advice/how_have_we_analysed_your_data_table_caption', data_target: "how-have-we-analysed-your-data-footnotes" %>
+<% end %>

--- a/app/views/schools/advice/heating_control/_insights.html.erb
+++ b/app/views/schools/advice/heating_control/_insights.html.erb
@@ -7,14 +7,16 @@
 
 <%= component 'alerts', school: @school, dashboard_alerts: @dashboard_alerts, alert_types: alert_types_for_class(AlertHeatingSensitivityAdvice), show_links: false, show_icons: false %>
 
-<p>
-  <%= t('advice_pages.heating_control.insights.controls.average_start_time',
-  time: @last_week_start_times.average_start_time) %>
-</p>
-
 <%= t('advice_pages.heating_control.analysis.heating_timings.estimated_savings_html',
   estimated_saving: format_unit(@estimated_savings.£, :£),
   percent: format_unit(@percentage_of_annual_gas, :percent)) %>
+
+<% if @last_week_start_times.average_start_time.present? %>
+  <p>
+    <%= t('advice_pages.heating_control.insights.controls.average_start_time',
+    time: @last_week_start_times.average_start_time) %>
+  </p>
+<% end %>
 
 <p>
   <%= t('advice_pages.heating_control.insights.view_our_analysis_html', href: analysis_school_advice_heating_control_path(@school, anchor: 'heating-timings')) %>

--- a/spec/system/schools/advice_pages/heating_control_spec.rb
+++ b/spec/system/schools/advice_pages/heating_control_spec.rb
@@ -61,9 +61,17 @@ RSpec.describe "heating control advice page", type: :system do
       end
 
       it 'includes expected data' do
+        expect(page).to have_content('the average start time for your heating')
         expect(page).to have_content("04:00")
         expect(page).to have_content("£1,234")
         expect(page).to have_content("42")
+      end
+
+      context 'and theres is no average start time' do
+        let(:last_week_start_times) { Heating::HeatingStartTimes.new(days: [day, day, day], average_start_time: nil) }
+        it 'does not show that text' do
+          expect(page).to_not have_content('the average start time for your heating')
+        end
       end
     end
     context "clicking the 'Analysis' tab" do
@@ -82,6 +90,7 @@ RSpec.describe "heating control advice page", type: :system do
       end
 
       it 'includes expected data in table' do
+        expect(page).to have_css('#heating-start-times')
         expect(page).to have_content(date.to_s(:es_short))
         expect(page).to have_content("05:00")
         expect(page).to have_content("06:00")
@@ -91,6 +100,14 @@ RSpec.describe "heating control advice page", type: :system do
       it 'includes expected data in seasonal analysis' do
         expect(page).to have_content("£1,234")
         expect(page).to have_content("42")
+      end
+
+      context 'and theres is no average start time' do
+        let(:last_week_start_times) { Heating::HeatingStartTimes.new(days: [day, day, day], average_start_time: nil) }
+        it 'does not show the table' do
+          expect(page).to_not have_content(I18n.t('advice_pages.heating_control.analysis.heating_timings.intro_html '))
+          expect(page).to_not have_css('#heating-start-times')
+        end
       end
     end
     context "clicking the 'Learn More' tab" do


### PR DESCRIPTION
This PR updates the heating control page to hide some sections if we aren't able to determine an average heating start time for the last 7 days:

- remove text on the insights page which shows the time
- hide text and table on the analysis page 

The text for the average annual saving is left in place, providing some useful feedback during the summer/early autumn.