### PR TITLE
Add school group to admin email

### DIFF
--- a/app/mailers/onboarding_mailer.rb
+++ b/app/mailers/onboarding_mailer.rb
@@ -13,9 +13,10 @@ class OnboardingMailer < LocaleMailer
   def completion_email
     @school_onboarding = params[:school_onboarding]
     @title = @school_onboarding.school_name
+    @school_group_name = @school_onboarding.school&.school_group&.name
     if @school_onboarding.created_by
       make_bootstrap_mail(to: 'operations@energysparks.uk', subject:
-        default_i18n_subject(school: @school_onboarding.school_name, school_group: @school_onboarding.school.school_group.name))
+        default_i18n_subject(school: @school_onboarding.school_name, school_group: @school_group_name))
     end
   end
 

--- a/app/mailers/onboarding_mailer.rb
+++ b/app/mailers/onboarding_mailer.rb
@@ -15,7 +15,7 @@ class OnboardingMailer < LocaleMailer
     @title = @school_onboarding.school_name
     if @school_onboarding.created_by
       make_bootstrap_mail(to: 'operations@energysparks.uk', subject:
-        default_i18n_subject(school: @school_onboarding.school_name))
+        default_i18n_subject(school: @school_onboarding.school_name, school_group: @school_onboarding.school.school_group.name))
     end
   end
 

--- a/app/views/onboarding_mailer/completion_email.html.erb
+++ b/app/views/onboarding_mailer/completion_email.html.erb
@@ -1,3 +1,3 @@
-<h1 class="mb-3"><%= t('onboarding_mailer.completion_email.title', school_name: @school_onboarding.school_name, school_group: @school_onboarding.school.school_group.name) %></h1>
+<h1 class="mb-3"><%= t('onboarding_mailer.completion_email.title', school_name: @school_onboarding.school_name, school_group: @school_group_name) %></h1>
 
 <%= link_to t('onboarding_mailer.completion_email.find_them_on_energy_sparks'), school_url(@school_onboarding.school), class: 'btn btn-primary mb-3 mb-3'%>

--- a/app/views/onboarding_mailer/completion_email.html.erb
+++ b/app/views/onboarding_mailer/completion_email.html.erb
@@ -1,3 +1,3 @@
-<h1 class="mb-3"><%= t('onboarding_mailer.completion_email.title', school_name: @school_onboarding.school_name) %></h1>
+<h1 class="mb-3"><%= t('onboarding_mailer.completion_email.title', school_name: @school_onboarding.school_name, school_group: @school_onboarding.school.school_group.name) %></h1>
 
 <%= link_to t('onboarding_mailer.completion_email.find_them_on_energy_sparks'), school_url(@school_onboarding.school), class: 'btn btn-primary mb-3 mb-3'%>

--- a/config/locales/mailers/mailer.yml
+++ b/config/locales/mailers/mailer.yml
@@ -90,8 +90,8 @@ en:
       the_energy_sparks_team: The Energy Sparks Team
     completion_email:
       find_them_on_energy_sparks: Find them on Energy Sparks
-      subject: "%{school} has completed the onboarding process"
-      title: "%{school_name} has completed the automatic setup process"
+      subject: "%{school} (%{school_group}) has completed the onboarding process"
+      title: "%{school_name} (%{school_group}) has completed the automatic setup process"
     data_enabled_email:
       explore_data: Explore your data
       get_in_touch_html: <a href="%{contact_url}">Get in touch</a> if you have any further questions.

--- a/spec/mailers/onboarding_mailer_spec.rb
+++ b/spec/mailers/onboarding_mailer_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe OnboardingMailer do
-  let(:school)            { create(:school, name: 'Test School') }
+  let(:school)            { create(:school, name: 'Test School', school_group: create(:school_group)) }
   let(:preferred_locale)  { :cy }
   let(:user)              { create(:onboarding_user, school: school, preferred_locale: preferred_locale) }
   let(:country)           { 'wales' }
@@ -69,9 +69,9 @@ RSpec.describe OnboardingMailer do
   describe '#completion_email' do
     it 'sends the completion email' do
       OnboardingMailer.with(school_onboarding: school_onboarding).completion_email.deliver_now
-      expect(email.subject).to eq(I18n.t('onboarding_mailer.completion_email.subject').gsub('%{school}', school.name))
+      expect(email.subject).to eq(I18n.t('onboarding_mailer.completion_email.subject').gsub('%{school}', school.name).gsub('%{school_group}', school.area_name))
       I18n.t('onboarding_mailer.completion_email').except(:subject).values.each do |email_content|
-        expect(email.body.to_s).to include(email_content.gsub('%{school_name}', school.name))
+        expect(email.body.to_s).to include(email_content.gsub('%{school_name}', school.name).gsub('%{school_group}', school.area_name))
       end
     end
   end

--- a/spec/mailers/previews/onboarding_mailer_preview.rb
+++ b/spec/mailers/previews/onboarding_mailer_preview.rb
@@ -1,0 +1,30 @@
+class OnboardingMailerPreview < ActionMailer::Preview
+  def onboarding_email
+    OnboardingMailer.with(school_onboarding: SchoolOnboarding.complete.first).onboarding_email
+  end
+
+  def completion_email
+    OnboardingMailer.with(school_onboarding: SchoolOnboarding.complete.first).completion_email
+  end
+
+  def reminder_email
+    OnboardingMailer.with(school_onboarding: SchoolOnboarding.complete.first).reminder_email
+  end
+
+  def activation_email
+    OnboardingMailer.with(school: School.visible.first, users: School.visible.first.users.school_admin).activation_email
+  end
+
+  def onboarded_email
+    OnboardingMailer.with(school: School.visible.first, users: School.visible.first.users.school_admin).onboarded_email
+  end
+
+  def data_enabled_email
+    OnboardingMailer.with(school: School.visible.first, users: School.visible.first.users.school_admin, target_prompt: true).data_enabled_email
+  end
+
+  def welcome_email
+    OnboardingMailer.with(school: School.visible.first, users: School.visible.first.users.school_admin).welcome_email
+  end
+
+end

--- a/spec/support/admin_school_group_onboardings.rb
+++ b/spec/support/admin_school_group_onboardings.rb
@@ -6,7 +6,6 @@ RSpec.shared_examples "admin school group onboardings" do
   end
 
   context "selectable actions" do
-
     let(:school_group_onboardings) { 3.times.collect { create :school_onboarding, :with_school, school_group: school_group, created_by: admin } }
     let(:setup_data) { school_group_onboardings }
 
@@ -50,7 +49,7 @@ RSpec.shared_examples "admin school group onboardings" do
             it "sends onboarding complete email" do
               email = ActionMailer::Base.deliveries.first
               expect(email.to).to include('operations@energysparks.uk')
-              expect(email.subject).to eq("#{onboarding.school.name} has completed the onboarding process")
+              expect(email.subject).to eq("#{onboarding.school.name} () has completed the onboarding process")
             end
             it "sends school live email" do
               email = ActionMailer::Base.deliveries.second

--- a/spec/system/admin/school_onboarding_spec.rb
+++ b/spec/system/admin/school_onboarding_spec.rb
@@ -148,7 +148,7 @@ RSpec.describe "onboarding", :schools, type: :system do
 
         email = ActionMailer::Base.deliveries.first
         expect(email.to).to include('operations@energysparks.uk')
-        expect(email.subject).to eq("#{school_onboarding.school.name} has completed the onboarding process")
+        expect(email.subject).to eq("#{school_onboarding.school.name} () has completed the onboarding process")
 
         email = ActionMailer::Base.deliveries.second
         expect(email.to).to include(school_onboarding.created_user.email)

--- a/spec/system/school_onboarding_spec.rb
+++ b/spec/system/school_onboarding_spec.rb
@@ -404,8 +404,8 @@ RSpec.describe "onboarding", :schools, type: :system do
 
           it 'sends an email after completion' do
             click_on "Complete setup", match: :first
-            email = ActionMailer::Base.deliveries[-2]
-            expect(email.subject).to include("#{school_name} has completed the onboarding process")
+            email = ActionMailer::Base.deliveries.first
+            expect(email.subject).to include("#{school_name} (#{school.area_name}) has completed the onboarding process")
             expect(email.to).to include('operations@energysparks.uk')
           end
 


### PR DESCRIPTION
Small request from ops team: add the school group name to the internal emails sent when schools have completed onboarding.

The PR also adds mailer previews for all the onboarding emails.