### PR TITLE
Add back in adult dashboard prompts

### DIFF
--- a/app/assets/javascripts/schools.js
+++ b/app/assets/javascripts/schools.js
@@ -4,12 +4,4 @@ $(document).ready(function() {
   $('a[data-toggle="tab"]').on('shown.bs.tab', function(e) {
     window.dispatchEvent(new Event('resize'));
   })
-  if($('.more-alerts').length){
-    $('.more-alerts').on('click', function(e) {
-      $('.act-on-energy-usage .alert').show();
-      $(this).hide();
-      event.preventDefault();
-    });
-    $(".act-on-energy-usage .alert:not(:first)").hide();
-  }
 });

--- a/app/components/info_bar_component/info_bar_component.html.erb
+++ b/app/components/info_bar_component/info_bar_component.html.erb
@@ -1,5 +1,5 @@
 <%= component 'notice', status: status, classes: 'mb-4' do %>
-  <div class="row">
+  <div class="row align-items-center">
     <div class="col-md-1 d-flex justify-content-center align-content-center">
       <div class="d-flex align-content-center flex-wrap">
         <%= icon %>

--- a/app/controllers/concerns/dashboard_alerts.rb
+++ b/app/controllers/concerns/dashboard_alerts.rb
@@ -1,7 +1,7 @@
 module DashboardAlerts
   extend ActiveSupport::Concern
 
-  def setup_alerts(alerts, content_field, limit: 3)
+  def setup_alerts(alerts, content_field, limit: 2)
     alerts.includes(:content_version, :find_out_more).by_priority.limit(limit).map do |dashboard_alert|
       TemplateInterpolation.new(
         dashboard_alert.content_version,

--- a/app/views/schools/_engagement_prompts.html.erb
+++ b/app/views/schools/_engagement_prompts.html.erb
@@ -1,0 +1,13 @@
+<%= component 'info_bar',
+    status: :neutral,
+    title: t('schools.show.complete_activities'),
+    icon: fa_icon('chalkboard-teacher fa-3x'),
+    buttons: { t('schools.show.record_pupil_activity') => activity_categories_path }
+%>
+
+<%= component 'info_bar',
+    status: :neutral,
+    title: t('schools.show.complete_interventions'),
+    icon: fa_icon('school fa-3x'),
+    buttons: { t('schools.show.record_action') => intervention_type_groups_path }
+%>

--- a/app/views/schools/show.html.erb
+++ b/app/views/schools/show.html.erb
@@ -54,6 +54,10 @@
   <%= render 'management/schools/targets/set_new_target', school: @school %>
 <% end %>
 
+<% if @show_standard_prompts %>
+  <%= render 'schools/engagement_prompts', school: @school %>
+<% end %>
+
 <% if @add_pupils %>
   <%= render 'management/schools/add_pupils', school: @school %>
 <% end %>

--- a/app/views/shared/_dashboard_alerts.html.erb
+++ b/app/views/shared/_dashboard_alerts.html.erb
@@ -15,9 +15,7 @@
     <% if dashboard_alerts.size > 1 && !local_assigns[:show_all] %>
       <div class="row">
         <div class="col text-center">
-          <a href="#" class="btn btn-rounded more-alerts">
-            <%= t('dashboard_alerts.show_more_alerts', count: dashboard_alerts.size - 1) %>
-          </a>
+          <%= link_to t('advice_pages.index.alerts.title'), alerts_school_advice_path(school), class: 'btn btn-rounded' %>
         </div>
       </div>
     <% end %>

--- a/config/locales/cy/views/schools/schools.yml
+++ b/config/locales/cy/views/schools/schools.yml
@@ -530,6 +530,10 @@ cy:
       explore_data: Archwilio data
       review_energy_analysis: Adolygu dadansoddiad ynni
     show:
+      record_action: Cofnodi gweithred
+      record_pupil_activity: Cofnodi gweithgaredd disgybl
+      complete_activities: Dysgwch ddisgyblion am ynni a newid hinsawdd o fewn cyd-destun eich ysgol eich hun drwy gwblhau ein gweithgareddau sydd ar gael am ddim
+      complete_interventions: Cofnodi camau arbed ynni a wneir gan staff ysgol a rheolwyr cyfleusterau i helpu i olrhain a yw eich ymyriadau wedi arbed ynni.
       act_on_energy_usage: Gweithredu ar y defnydd o ynni
       add_alert_contacts: Ychwanegu cysylltiadau rhybuddio
       add_consumption_estimate: Ychwanegwch amcangyfrif o'ch defnydd %{fuels} blynyddol fel y gallwn ddarparu adroddiad cynnydd manylach i'ch helpu i gyrraedd eich targedau

--- a/config/locales/cy/views/shared/shared.yml
+++ b/config/locales/cy/views/shared/shared.yml
@@ -45,12 +45,6 @@ cy:
         <li>rhoi gwybod i chi os ydych yn gwneud yn dda o gymharu ag ysgolion eraill a'ch perfformiad yn y gorffennol</li>
       </ul>
     title: 'Rhybuddion Sbarcynni:'
-  dashboard_alerts:
-    show_more_alerts:
-      one: Dangos 1 rhybudd arall
-      two: Dangos %{count} rybudd arall
-      many: Dangos %{count} o rybuddion eraill
-      other: Dangos %{count} o rybuddion eraill
   dashboards:
     adult_dashboard: Dangosfwrdd oedolion
     pupil_dashboard: Dangosfwrdd disgyblion

--- a/config/locales/views/schools/schools.yml
+++ b/config/locales/views/schools/schools.yml
@@ -546,6 +546,8 @@ en:
       add_consumption_estimate: Add an estimate of your annual %{fuels} consumption so we can provide you with a more detailed progress report to help you achieve your targets
       add_estimate: Add an estimate
       coming_soon: Coming Soon
+      complete_activities: Teach pupils about energy and climate change within the context of your own school by completing our freely available activities
+      complete_interventions: Record energy saving actions made by school staff and facilities management to help to track whether your interventions have saved energy.
       configuring_data_access: We're configuring access to your energy data and will notify you when it's ready to explore
       create_pupil_account: Create a pupil account
       dashboard_title: Adult dashboard for %{school_name}
@@ -563,6 +565,8 @@ en:
       print_view: Print view
       recent_energy_audit: The Energy Sparks team have recently completed an energy audit for this school
       recent_energy_usage: Recent energy usage
+      record_action: Record an action
+      record_pupil_activity: Record a pupil activity
       review_audit: Review audit
       review_progress: Review progress
       review_target: Review your target

--- a/config/locales/views/shared/shared.yml
+++ b/config/locales/views/shared/shared.yml
@@ -44,10 +44,6 @@ en:
         <li>let you know if you are doing well compared to other schools and your past performance</li>
       </ul>
     title: 'Energy Sparks alerts:'
-  dashboard_alerts:
-    show_more_alerts:
-      one: Show 1 more alert
-      other: Show %{count} more alerts
   dashboards:
     adult_dashboard: Adult dashboard
     pupil_dashboard: Pupil dashboard

--- a/spec/components/info_bar_component_spec.rb
+++ b/spec/components/info_bar_component_spec.rb
@@ -3,29 +3,60 @@
 require "rails_helper"
 
 RSpec.describe InfoBarComponent, type: :component do
-  it "renders a three colum info bar with an icon, title text, and some optional buttons" do
-    expect(
-      render_inline(described_class.new(icon: '<i class="fas fa-school fa-3x"></i>'.html_safe, title: 'This is an info bar', buttons: { "Click me" => "http://www.example.com" })).to_html
-    ).to include(
-      <<~HTML.chomp
-        <div class="p-4 notice-component neutral mb-4">
-          
-          <div class="row">
-            <div class="col-md-1 d-flex justify-content-center align-content-center">
-              <div class="d-flex align-content-center flex-wrap">
-                <i class="fas fa-school fa-3x"></i>
-              </div>
-            </div>
-              <div class="col-md-8">
-                This is an info bar
-              </div>
-                <div class="col-md-3 d-flex justify-content-end">
-                  <a class="btn btn-light btn rounded-pill font-weight-bold" style="height: fit-content;" href="http://www.example.com">Click me</a>
-                </div>
-          </div>
-        
-        </div>
-      HTML
-    )
+  let(:title)         { 'This is an info bar' }
+  let(:button_title)  { 'Click me' }
+  let(:button_link)   { 'http://www.example.com' }
+  let(:icon)          { '<i class="fas fa-school fa-3x"></i>' }
+  let(:status)        { :neutral }
+  let(:params)        {
+    {
+      icon: icon.html_safe,
+      title: title,
+      buttons: { button_title => button_link }
+    }
+  }
+
+  let(:component) { InfoBarComponent.new(**params) }
+
+  let(:html) do
+    render_inline(component)
+  end
+
+  it 'renders a notice' do
+    expect(html).to have_css('.notice-component')
+  end
+
+  it 'renders the right status' do
+    expect(html).to have_css('.neutral')
+  end
+
+  it 'centers the items in the row' do
+    expect(html).to have_css('.row.align-items-center')
+  end
+
+  it 'centers the icon in the column' do
+    expect(html).to have_css('.col-md-1.justify-content-center')
+  end
+
+  it 'right aligns the button link' do
+    expect(html).to have_css('.col-md-3.justify-content-end')
+  end
+
+  it 'includes icon' do
+    within('.row .col-md-1') do
+      expect(html).to have_css('.fa-school')
+    end
+  end
+
+  it 'includes the title' do
+    within('.row .col-md-8') do
+      expect(html).to have_content(title)
+    end
+  end
+
+  it 'includes the link' do
+    within('.row .col-md-3') do
+      expect(html).to have_link(button_title, href: button_link)
+    end
   end
 end


### PR DESCRIPTION
Until we have implemented the rest of the new engagement options, add back in the prompts to record adult and pupil lead activities on the dashboard.

Also, rather than have a dynamic section with up to 3 alerts on the dashboard, we will now show 2 by default and then a link to all of the "Recent alerts" in the advice pages.