### PR TITLE
Prevent prices of £1 and above being saved & widen field

### DIFF
--- a/app/assets/stylesheets/energy_tariffs.scss
+++ b/app/assets/stylesheets/energy_tariffs.scss
@@ -10,6 +10,9 @@
     td.value {
       width: 10%
     }
+    td.value input {
+      width: 7em;
+    }
     td.units {
       width: 10%
     }
@@ -38,4 +41,5 @@
   .energy_tariff-show-button {
     margin-top: -5px
   }
+
 }

--- a/app/models/energy_tariff_price.rb
+++ b/app/models/energy_tariff_price.rb
@@ -18,14 +18,16 @@
 #
 class EnergyTariffPrice < ApplicationRecord
   MINIMUM_VALUE = 0.0
+  MAXIMUM_VALUE = 1.0
 
   belongs_to :energy_tariff, inverse_of: :energy_tariff_prices
 
   validates :start_time, :end_time, :units, presence: true
   validates :value, presence: true, on: :update
 
-  validates :value, numericality: { greater_than: MINIMUM_VALUE }, allow_nil: true, on: :create
-  validates :value, numericality: { greater_than: MINIMUM_VALUE }, on: :update
+  validates :value, numericality: { greater_than: MINIMUM_VALUE, less_than: MAXIMUM_VALUE }, allow_nil: true, on: :create
+  validates :value, numericality: { greater_than: MINIMUM_VALUE, less_than: MAXIMUM_VALUE }, on: :update
+
   validate :no_time_overlaps
   validate :time_range_given
 

--- a/app/views/energy_tariffs/energy_tariff_flat_prices/_form.html.erb
+++ b/app/views/energy_tariffs/energy_tariff_flat_prices/_form.html.erb
@@ -9,7 +9,7 @@
     </td>
     <td class="value align-middle">
       <%= f.input :value, pattern: '[0-9.]+', label: false,
-        input_html: { value: value_allowing_for_errors(energy_tariff_price) },
+        input_html: { value: value_allowing_for_errors(energy_tariff_price), style:"width: 8em" },
         error: energy_tariff_price.errors.any? ? energy_tariff_price.errors.full_messages.first : nil,
         required: false %>
     </td>

--- a/app/views/energy_tariffs/energy_tariff_flat_prices/_form.html.erb
+++ b/app/views/energy_tariffs/energy_tariff_flat_prices/_form.html.erb
@@ -9,7 +9,7 @@
     </td>
     <td class="value align-middle">
       <%= f.input :value, pattern: '[0-9.]+', label: false,
-        input_html: { value: value_allowing_for_errors(energy_tariff_price), style:"width: 8em" },
+        input_html: { value: value_allowing_for_errors(energy_tariff_price), step: 0.01 },
         error: energy_tariff_price.errors.any? ? energy_tariff_price.errors.full_messages.first : nil,
         required: false %>
     </td>

--- a/spec/factories/energy_tariffs.rb
+++ b/spec/factories/energy_tariffs.rb
@@ -14,7 +14,7 @@ FactoryBot.define do
 
     trait :with_flat_price do
       transient do
-        value { 1 }
+        value { 0.1 }
       end
       after(:create) do |energy_tariff, evaluator|
         create(:energy_tariff_price, energy_tariff: energy_tariff, value: evaluator.value)

--- a/spec/models/energy_tariff_price_spec.rb
+++ b/spec/models/energy_tariff_price_spec.rb
@@ -5,6 +5,7 @@ describe EnergyTariffPrice do
   it { should validate_presence_of(:end_time) }
   it { should validate_presence_of(:units) }
   it { should validate_numericality_of(:value).is_greater_than(EnergyTariffPrice::MINIMUM_VALUE) }
+  it { should validate_numericality_of(:value).is_less_than(EnergyTariffPrice::MAXIMUM_VALUE) }
 
   describe '#time_duration' do
     it 'calculates the time duration in minutes between the start and end date' do

--- a/spec/models/energy_tariff_spec.rb
+++ b/spec/models/energy_tariff_spec.rb
@@ -26,8 +26,8 @@ describe EnergyTariff do
   end
 
   context 'validations' do
-    let(:energy_tariff_price_1)  { EnergyTariffPrice.new(start_time: '00:00', end_time: '03:30', value: 1.23, units: 'kwh') }
-    let(:energy_tariff_price_2)  { EnergyTariffPrice.new(start_time: '04:00', end_time: '23:30', value: 2.46, units: 'kwh') }
+    let(:energy_tariff_price_1)  { EnergyTariffPrice.new(start_time: '00:00', end_time: '03:30', value: 0.23, units: 'kwh') }
+    let(:energy_tariff_price_2)  { EnergyTariffPrice.new(start_time: '04:00', end_time: '23:30', value: 0.46, units: 'kwh') }
 
     let(:energy_tariff_charge_1)  { EnergyTariffCharge.new(charge_type: :fixed_charge, value: 4.56, units: :month) }
     let(:energy_tariff_charge_2)  { EnergyTariffCharge.new(charge_type: :agreed_availability_charge, value: 6.78, units: :kva) }
@@ -221,7 +221,7 @@ describe EnergyTariff do
     context 'with flat rate electricity tariff' do
       let(:tariff_type)     { :flat_rate }
 
-      let(:energy_tariff_price)   { EnergyTariffPrice.new(start_time: '00:00', end_time: '23:30', value: 1.23, units: :kwh) }
+      let(:energy_tariff_price)   { EnergyTariffPrice.new(start_time: '00:00', end_time: '23:30', value: 0.23, units: :kwh) }
       let(:energy_tariff_charge)  { EnergyTariffCharge.new(charge_type: :fixed_charge, value: 4.56, units: :month) }
 
       let(:energy_tariff_prices)  { [energy_tariff_price] }
@@ -239,7 +239,7 @@ describe EnergyTariff do
       it "should include rate" do
         rates = attributes[:rates]
         expect(rates[:flat_rate][:per]).to eq('kwh')
-        expect(rates[:flat_rate][:rate]).to eq('1.23')
+        expect(rates[:flat_rate][:rate]).to eq('0.23')
       end
 
     end
@@ -247,8 +247,8 @@ describe EnergyTariff do
     context 'with differential electricity tariff' do
       let(:tariff_type)     { :differential }
 
-      let(:energy_tariff_price_1)  { EnergyTariffPrice.new(start_time: '00:00', end_time: '03:30', value: 1.23, units: 'kwh') }
-      let(:energy_tariff_price_2)  { EnergyTariffPrice.new(start_time: '04:00', end_time: '23:30', value: 2.46, units: 'kwh') }
+      let(:energy_tariff_price_1)  { EnergyTariffPrice.new(start_time: '00:00', end_time: '03:30', value: 0.23, units: 'kwh') }
+      let(:energy_tariff_price_2)  { EnergyTariffPrice.new(start_time: '04:00', end_time: '23:30', value: 0.46, units: 'kwh') }
       let(:energy_tariff_charge_1)  { EnergyTariffCharge.new(charge_type: :fixed_charge, value: 4.56, units: :month) }
       let(:energy_tariff_charge_2)  { EnergyTariffCharge.new(charge_type: :agreed_availability_charge, value: 6.78, units: :kva) }
 
@@ -340,11 +340,11 @@ describe EnergyTariff do
       it "should include rates with adjusted end times" do
         rates = attributes[:rates]
         expect(rates[:rate0][:per]).to eq('kwh')
-        expect(rates[:rate0][:rate]).to eq('1.23')
+        expect(rates[:rate0][:rate]).to eq('0.23')
         expect(rates[:rate0][:from]).to eq({hour: "00", minutes: "00"})
         expect(rates[:rate0][:to]).to eq({hour: "03", minutes: "00"})
         expect(rates[:rate1][:per]).to eq('kwh')
-        expect(rates[:rate1][:rate]).to eq('2.46')
+        expect(rates[:rate1][:rate]).to eq('0.46')
         expect(rates[:rate1][:from]).to eq({hour: "04", minutes: "00"})
         expect(rates[:rate1][:to]).to eq({hour: "23", minutes: "00"})
       end

--- a/spec/support/energy_tariff_editors_shared_examples.rb
+++ b/spec/support/energy_tariff_editors_shared_examples.rb
@@ -124,18 +124,18 @@ RSpec.shared_examples "a basic electricity tariff editor" do
       select '06', from: 'energy_tariff_price_end_time_4i'
       select '30', from: 'energy_tariff_price_end_time_5i'
 
-      fill_in 'Rate in £/kWh', with: '1.5'
+      fill_in 'Rate in £/kWh', with: '0.15'
       click_button('Save')
 
       expect(page).to have_content('Rate from 00:30 to 06:30')
       expect(page).to have_content('Rate from 07:00 to 00:00')
-      expect(page).to have_content('£1.50 per kWh')
+      expect(page).to have_content('£0.15 per kWh')
       expect(page).to have_content('£ per kWh')
 
       expect(page).to have_content('Please add valid prices for all marked rates.')
       first('.energy-tariff-show-button').click
 
-      fill_in 'Rate in £/kWh', with: '1.5'
+      fill_in 'Rate in £/kWh', with: '0.15'
       click_button('Save')
 
       expect(page).to have_content('Please add valid prices for all marked rates.')
@@ -157,7 +157,7 @@ RSpec.shared_examples "a basic electricity tariff editor" do
 
       expect(page).not_to have_content('Rate from 00:30 to 06:30')
       expect(page).to have_content('Rate from 07:00 to 00:00')
-      expect(page).not_to have_content('£1.50 per kWh')
+      expect(page).not_to have_content('£0.15 per kWh')
       expect(page).to have_content('£ per kWh')
 
       expect(page).not_to have_content('Complete 24 hour coverage.')
@@ -170,7 +170,7 @@ RSpec.shared_examples "a basic electricity tariff editor" do
 
       expect(page).not_to have_content('Rate from 00:30 to 06:30')
       expect(page).not_to have_content('Rate from 07:00 to 00:00')
-      expect(page).not_to have_content('£1.50 per kWh')
+      expect(page).not_to have_content('£0.15 per kWh')
       expect(page).not_to have_content('£ per kWh')
 
       expect(page).not_to have_content('Please add valid prices for all marked rates.')
@@ -188,25 +188,25 @@ RSpec.shared_examples "a basic electricity tariff editor" do
 
       find("#energy-tariff-show-button-#{energy_tariff.energy_tariff_prices.first.id}").click
 
-      fill_in 'Rate in £/kWh', with: '1.5'
+      fill_in 'Rate in £/kWh', with: '0.15'
       click_button('Save')
 
       expect(page).to have_content('Rate from 00:00 to 07:00')
       expect(page).to have_content('Rate from 07:00 to 00:00')
-      expect(page).to have_content('£1.50 per kWh')
+      expect(page).to have_content('£0.15 per kWh')
       expect(page).to have_content('£ per kWh')
 
       expect(find("a", text: "Continue")[:class]).to eq('btn disabled')
 
       find("#energy-tariff-show-button-#{energy_tariff.energy_tariff_prices.last.id}").click
 
-      fill_in 'Rate in £/kWh', with: '2.5'
+      fill_in 'Rate in £/kWh', with: '0.25'
       click_button('Save')
 
       expect(page).to have_content('Rate from 00:00 to 07:00 ')
       expect(page).to have_content('Rate from 07:00 to 00:00')
-      expect(page).to have_content('£1.50 per kWh')
-      expect(page).to have_content('£2.50 per kWh')
+      expect(page).to have_content('£0.15 per kWh')
+      expect(page).to have_content('£0.25 per kWh')
 
       expect(page).to have_content('Complete 24 hour coverage.')
       expect(page).not_to have_content('Incomplete 24 hour coverage. Please add another rate.')
@@ -221,12 +221,12 @@ RSpec.shared_examples "a basic electricity tariff editor" do
       energy_tariff_price = energy_tariff.energy_tariff_prices.first
       expect(energy_tariff_price.start_time.to_s(:time)).to eq('00:00')
       expect(energy_tariff_price.end_time.to_s(:time)).to eq('07:00')
-      expect(energy_tariff_price.value.to_s).to eq('1.5')
+      expect(energy_tariff_price.value.to_s).to eq('0.15')
       expect(energy_tariff_price.units).to eq('kwh')
       energy_tariff_price = energy_tariff.energy_tariff_prices.last
       expect(energy_tariff_price.start_time.to_s(:time)).to eq('07:00')
       expect(energy_tariff_price.end_time.to_s(:time)).to eq('00:00')
-      expect(energy_tariff_price.value.to_s).to eq('2.5')
+      expect(energy_tariff_price.value.to_s).to eq('0.25')
       expect(energy_tariff_price.units).to eq('kwh')
     end
   end

--- a/spec/support/energy_tariffs_shared_examples.rb
+++ b/spec/support/energy_tariffs_shared_examples.rb
@@ -118,9 +118,9 @@ RSpec.shared_examples "the user can create a tariff" do
     #Add price
     find("#prices-section-edit").click
 
-    fill_in "energy_tariff_price[value]", with: '1.5'
+    fill_in "energy_tariff_price[value]", with: '0.15'
     click_button('Continue')
-    expect(page).to have_content('£1.50 per kWh')
+    expect(page).to have_content('£0.15 per kWh')
 
     #Add charges
     find("#charges-section-edit").click
@@ -145,7 +145,7 @@ RSpec.shared_examples "the user can create a tariff" do
     energy_tariff_price = energy_tariff.energy_tariff_prices.first
     expect(energy_tariff_price.start_time.to_s(:time)).to eq('00:00')
     expect(energy_tariff_price.end_time.to_s(:time)).to eq('23:30')
-    expect(energy_tariff_price.value).to eq(1.5)
+    expect(energy_tariff_price.value).to eq(0.15)
     expect(energy_tariff_price.units).to eq('kwh')
 
     expect(energy_tariff.value_for_charge(:standing_charge)).to eq('1.11')
@@ -155,11 +155,11 @@ end
 RSpec.shared_examples "the user can edit the tariff" do
   it 'allows me to edit price' do
     find("#prices-section-edit").click
-    expect(page).to have_field('energy_tariff_price[value]', with: '1.0')
+    expect(page).to have_field('energy_tariff_price[value]', with: '0.1')
 
-    fill_in "energy_tariff_price[value]", with: '1.5'
+    fill_in "energy_tariff_price[value]", with: '0.15'
     click_button('Continue')
-    expect(page).to have_content('£1.50 per kWh')
+    expect(page).to have_content('£0.15 per kWh')
     expect(page).to_not have_content(I18n.t('schools.user_tariffs.show.not_usable'))
   end
 
@@ -212,15 +212,15 @@ RSpec.shared_examples "the user can change the type of tariff" do
     find("#prices-section-edit").click
     expect(energy_tariff.energy_tariff_prices.count).to eq(2)
     find("#energy-tariff-show-button-#{energy_tariff.energy_tariff_prices.first.id}").click
-    fill_in 'Rate in £/kWh', with: '1.5'
+    fill_in 'Rate in £/kWh', with: '0.5'
     click_button('Save')
     find("#energy-tariff-show-button-#{energy_tariff.energy_tariff_prices.last.id}").click
-    fill_in 'Rate in £/kWh', with: '2.5'
+    fill_in 'Rate in £/kWh', with: '0.25'
     click_button('Save')
     click_link(energy_tariff.name)
     expect(page).to have_content('Differential tariff')
-    expect(page).to have_content('£1.50 per kWh')
-    expect(page).to have_content('£2.50 per kWh')
+    expect(page).to have_content('£0.50 per kWh')
+    expect(page).to have_content('£0.25 per kWh')
 
     # Selecting the existing tariff type should retain all energy tariff prices
     find('#tariff-type-section-edit').click()
@@ -228,8 +228,8 @@ RSpec.shared_examples "the user can change the type of tariff" do
     click_button('Differential tariff')
     expect(energy_tariff.reload.energy_tariff_prices.count).to eq(2)
     expect(page).to have_content('Differential tariff')
-    expect(page).to have_content('£1.50 per kWh')
-    expect(page).to have_content('£2.50 per kWh')
+    expect(page).to have_content('£0.50 per kWh')
+    expect(page).to have_content('£0.25 per kWh')
 
     # Switching tariff types should delete all energy tariff prices associated with the previous tariff type
     find('#tariff-type-section-edit').click()
@@ -239,17 +239,17 @@ RSpec.shared_examples "the user can change the type of tariff" do
 
     # Add some flat rate consumption charges
     find("#prices-section-edit").click
-    fill_in "energy_tariff_price[value]", with: '1.5'
+    fill_in "energy_tariff_price[value]", with: '0.15'
     click_button('Continue')
     expect(energy_tariff.reload.energy_tariff_prices.count).to eq(1)
-    expect(page).to have_content('£1.50 per kWh')
+    expect(page).to have_content('£0.15 per kWh')
 
     # Selecting the existing tariff type should retain all energy tariff prices
     find('#tariff-type-section-edit').click()
     click_button('Flat rate tariff')
     expect(page).to have_content('Flat rate tariff')
     expect(energy_tariff.reload.energy_tariff_prices.count).to eq(1)
-    expect(page).to have_content('£1.50 per kWh')
+    expect(page).to have_content('£0.15 per kWh')
   end
 end
 


### PR DESCRIPTION
Also widens field, as previously, any longer numbers were being partially covered by the up/down arrows: 

![Screenshot 2023-09-26 at 15 08 26](https://github.com/Energy-Sparks/energy-sparks/assets/6051/3e337c30-383f-40d6-9ce9-aedccbf9e529)

After PR changes:

![Screenshot 2023-09-26 at 15 08 02](https://github.com/Energy-Sparks/energy-sparks/assets/6051/320c0696-431c-40dd-be09-8aec8d4e3ab3)
