### PR TITLE
Update net.core.somaxconn system setting on deploy

### DIFF
--- a/.ebextensions/00_sysctl.config
+++ b/.ebextensions/00_sysctl.config
@@ -1,0 +1,3 @@
+commands:
+    set_sysctl_options:
+        command: "sysctl -w net.core.somaxconn=512"


### PR DESCRIPTION
We had some 502 errors from the application yesterday afternoon. There were no obvious issues with the application or database, but there were a large number of requests from a crawler.

The application log had no 502 errors, but nginx and the load balancer both logged them. This suggests requests were being rejected before being received by the application.

This PR updates the net.core.somaxconn OS setting to increase the number of connections above the nginx default, as noted here:

* https://www.nginx.com/blog/tuning-nginx/
* https://www.getpagespeed.com/server-setup/nginx/maximizing-nginx-performance-a-comprehensive-guide-to-tuning-the-backlog-and-net-core-somaxconn-parameters

This could cause other problems, e.g. more load on the application, but we don't want users to see rejected requests either, so accepting more requests during busy periods is important.

The setting is updated using the `sysctl` command triggered during the deploy using an EBS customization.