### PR TITLE
Change autovacuum delay for amr_validated_readings

### DIFF
--- a/lib/tasks/deployment/20231002081435_validated_reading_vacuum.rake
+++ b/lib/tasks/deployment/20231002081435_validated_reading_vacuum.rake
@@ -1,0 +1,13 @@
+namespace :after_party do
+  desc 'Deployment task: Change autovacuum settings for amr_validated_readings'
+  task validated_reading_vacuum: :environment do
+    puts "Running deploy task 'validated_reading_vacuum'"
+
+    ActiveRecord::Base.connection.execute("ALTER TABLE amr_validated_readings SET (autovacuum_vacuum_cost_delay = 0)")
+
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord
+      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+  end
+end


### PR DESCRIPTION
Changes the `autovacuum_vacuum_cost_delay` parameter on the `amr_validated_readings` table to zero.

This should ensure that a vacuum runs as fast as possible, with minimal timeout. Hoping this reduces the "Timeout:VacuumDelay" waits we're seeing in the database and ensure that when a vacuum is required its done as quickly as possible. At the moment it looks like the system is timing out trying to complete timeouts, so the period when performance is slow / space has not been recovered is longer.

https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/wait-event.timeoutvacuumdelay.html
https://www.cybertec-postgresql.com/en/tuning-autovacuum-postgresql/

