### PR TITLE
Allow archiving of schools

### DIFF
--- a/app/controllers/admin/schools_controller.rb
+++ b/app/controllers/admin/schools_controller.rb
@@ -14,20 +14,52 @@ module Admin
       redirect_back fallback_location: root_path, notice: e.message
     end
 
-    def deactivate_meters
-      service = SchoolRemover.new(@school)
-      service.remove_meters!
-      redirect_back fallback_location: root_path, notice: "Meters have been deactivated and data removed"
+    def archive_meters
+      remove_meters(archive: true)
+      redirect_back fallback_location: root_path, notice: "Meters have been deactivated and only validated data removed"
     rescue => e
       redirect_back fallback_location: root_path, notice: e.message
     end
 
-    def deactivate
+    def delete_meters
+      remove_meters(archive: false)
+      redirect_back fallback_location: root_path, notice: "Meters have been deactivated and all data removed"
+    rescue => e
+      redirect_back fallback_location: root_path, notice: e.message
+    end
+
+    def reenable
       service = SchoolRemover.new(@school)
-      service.remove_school!
+      service.reenable_school!
+      redirect_back fallback_location: root_path, notice: "School has been re-enabled"
+    rescue => e
+      redirect_back fallback_location: root_path, notice: e.message
+    end
+
+    def archive
+      remove_school(archive: true)
+      redirect_back fallback_location: root_path, notice: "School has been archived"
+    rescue => e
+      redirect_back fallback_location: root_path, notice: e.message
+    end
+
+    def delete
+      remove_school(archive: false)
       redirect_back fallback_location: root_path, notice: "School has been removed"
     rescue => e
       redirect_back fallback_location: root_path, notice: e.message
+    end
+
+    private
+
+    def remove_school(archive: true)
+      service = SchoolRemover.new(@school, archive: archive)
+      service.remove_school!
+    end
+
+    def remove_meters(archive: true)
+      service = SchoolRemover.new(@school, archive: archive)
+      service.remove_meters!
     end
   end
 end

--- a/app/controllers/schools_controller.rb
+++ b/app/controllers/schools_controller.rb
@@ -24,7 +24,9 @@ class SchoolsController < ApplicationController
   end
 
   #Redirect users associated with this school to a holding page, if its not
-  #visible yet. Other users will end up getting an access denied error
+  #visible yet.
+  #Admins will be sent to removal page
+  #Other users will end up getting an access denied error
   before_action :redirect_if_not_visible, only: [:show]
 
   #Redirect pupil accounts associated with this school to the pupil dashboard
@@ -131,6 +133,7 @@ private
 
   def redirect_if_not_visible
     redirect_to school_inactive_path(@school) if user_signed_in_and_linked_to_school? && !@school.visible?
+    redirect_to removal_admin_school_path(@school) if !@school.active && can?(:remove_school, @school)
   end
 
   def redirect_pupils

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -180,14 +180,18 @@ class School < ApplicationRecord
   enum funding_status: [:state_school, :private_school]
   enum region: [:north_east, :north_west, :yorkshire_and_the_humber, :east_midlands, :west_midlands, :east_of_england, :london, :south_east, :south_west]
 
-  scope :active,             -> { where(active: true) }
-  scope :inactive,           -> { where(active: false) }
-  scope :visible,            -> { active.where(visible: true) }
-  scope :not_visible,        -> { active.where(visible: false) }
-  scope :process_data,       -> { active.where(process_data: true) }
-  scope :data_enabled,       -> { active.where(data_enabled: true) }
-  scope :without_group,      -> { active.where(school_group_id: nil) }
-  scope :without_scoreboard, -> { active.where(scoreboard_id: nil) }
+  #active flag is a soft-delete, those with a removal date are deleted, others
+  #are archived, with chance of returning if we receive funding
+  scope :active,              -> { where(active: true) }
+  scope :inactive,            -> { where(active: false) }
+  scope :deleted,             -> { inactive.where.not(removal_date: nil)}
+  scope :archived,            -> { inactive.where(removal_date: nil)}
+  scope :visible,             -> { active.where(visible: true) }
+  scope :not_visible,         -> { active.where(visible: false) }
+  scope :process_data,        -> { active.where(process_data: true) }
+  scope :data_enabled,        -> { active.where(data_enabled: true) }
+  scope :without_group,       -> { active.where(school_group_id: nil) }
+  scope :without_scoreboard,  -> { active.where(scoreboard_id: nil) }
   scope :awaiting_activation, -> { active.where("visible = ? or data_enabled = ?", false, false) }
   scope :data_visible,        -> { data_enabled.visible }
 
@@ -231,6 +235,14 @@ class School < ApplicationRecord
   # Note that saved_change_to_activation_date? is a magic ActiveRecord method
   # https://api.rubyonrails.org/classes/ActiveRecord/AttributeMethods/Dirty.html#method-i-will_save_change_to_attribute-3F
   after_save :add_joining_observation, if: proc { saved_change_to_activation_date?(from: nil) }
+
+  def deleted?
+    !active and removal_date.present?
+  end
+
+  def archived?
+    !active && removal_date.nil?
+  end
 
   def minimum_reading_date
     return unless amr_validated_readings.present?

--- a/app/services/meter_management.rb
+++ b/app/services/meter_management.rb
@@ -102,12 +102,12 @@ class MeterManagement
     result
   end
 
-  def remove_data!
+  def remove_data!(archive: false)
     result = true
     @meter.transaction do
       @meter.tariff_prices.delete_all
       @meter.tariff_standing_charges.delete_all
-      @meter.amr_data_feed_readings.delete_all
+      @meter.amr_data_feed_readings.delete_all unless archive
       @meter.amr_validated_readings.delete_all
     end
     result

--- a/app/services/school_groups/meter_report.rb
+++ b/app/services/school_groups/meter_report.rb
@@ -70,7 +70,7 @@ module SchoolGroups
       scope = Meter.all
         .joins(:school)
         .joins(:school_group)
-        .where(schools: { school_group: school_group })
+        .where(schools: { school_group: school_group, active: true })
         .with_zero_reading_days_and_dates
         .order("schools.name", :mpan_mprn)
       scope = all_meters ? scope : scope.active

--- a/app/services/school_remover.rb
+++ b/app/services/school_remover.rb
@@ -68,6 +68,6 @@ class SchoolRemover
   def remove_meter(meter)
     service = MeterManagement.new(meter)
     service.deactivate_meter!
-    service.remove_data!
+    service.remove_data!(archive: @archive)
   end
 end

--- a/app/views/admin/school_groups/_removed_schools.html.erb
+++ b/app/views/admin/school_groups/_removed_schools.html.erb
@@ -3,6 +3,7 @@
     <tr>
       <th>Name</th>
       <th>Funder</th>
+      <th>Archived?</th>
       <th>Removal date</th>
       <th class="no-sort"></th>
     </tr>
@@ -12,6 +13,7 @@
       <tr class="bg-light">
         <td><%= link_to school.name, school_path(school) %></td>
         <td><%= school.funder&.name || school&.school_group&.funder&.name %></td>
+        <td><%= y_n(school.archived?) %></td>
         <td><%= nice_dates(school.removal_date) %></td>
         <td class="nowrap text-right">
           <%= link_to issue_type_icons(school.issues, label: 'Issues'), admin_school_issues_path(school), class: 'btn btn-sm' %>

--- a/app/views/admin/schools/removal.html.erb
+++ b/app/views/admin/schools/removal.html.erb
@@ -1,44 +1,76 @@
-<h1><%= @school.name %><%= @school.active? ? " REMOVAL" : " (INACTIVE)"  %></h1>
-
-<% if @school_remover.school_ready? %>
-
-  <h2>Users</h2>
-
-  <ol>
-    <% @school.users.each do |user| %>
-      <li><%= user.email %><%= user.access_locked? ? ' (LOCKED)' : '' %></li>
+<% if @school.deleted? %>
+  <h1><%= @school.name %></h1>
+  <p>This school was deleted on <%= @school.removal_date %></p>
+<% elsif @school.archived? %>
+  <h1><%= @school.name %></h1>
+  <p>This school has been archived.</p>
+  <%= link_to 'Reenable school', reenable_admin_school_path(@school), method: :post, class: 'btn btn-success' %>
+<% elsif @school_remover.school_ready? %>
+  <h1>Removing <%= @school.name %></h1>
+  <% if @school.users.any? %>
+    <h2>User status</h2>
+    <%= component 'notice', status: :negative, classes: 'mb-4' do %>
+      <p>School cannot be removed while it has active users.</p>
     <% end %>
-  </ol>
-
-  <% unless @school_remover.users_ready? %>
-    <p>School cannot be removed while it has active users</p>
-    <%= button_to 'Remove users', deactivate_users_admin_school_path(@school), method: :post, class: 'btn btn-success'%>
+    <p>Current users:</p>
+    <ol>
+      <% @school.users.each do |user| %>
+        <li><%= user.email %><%= user.access_locked? ? ' (LOCKED)' : '' %></li>
+      <% end %>
+    </ol>
+    <% unless @school_remover.users_ready? %>
+      <div class="mt-4">
+        <p>Locking a user account will prevent the user from logging in again. If they are
+        linked to other schools, they'll still be able to login but will be removed from
+        this school.</p>
+        <%= button_to 'Lock user accounts', deactivate_users_admin_school_path(@school), method: :post, class: 'btn btn-success'%>
+      </div>
+    <% end %>
   <% end %>
 
-
-  <h2>Meters</h2>
-
-  <ol>
-    <% @school.meters.each do |meter| %>
-      <li><%= meter.mpan_mprn %><%= meter.active? ? '' : ' (INACTIVE)' %></li>
+  <% if @school.meters.any? %>
+    <h2>Meter status</h2>
+    <%= component 'notice', status: :negative, classes: 'mb-4' do %>
+      <p>School cannot be removed while it has active meters</p>
     <% end %>
-  </ol>
+    <p>Current meters:</p>
+    <ol>
+      <% @school.meters.each do |meter| %>
+        <li><%= meter.mpan_mprn %><%= meter.active? ? '' : ' (INACTIVE)' %></li>
+      <% end %>
+    </ol>
+  <% end %>
 
   <% unless @school_remover.meters_ready? %>
-    <p>School cannot be removed while it has active meters</p>
-    <%= button_to 'Remove meters', deactivate_meters_admin_school_path(@school), method: :post, class: 'btn btn-success'%>
+    <div class="mt-4">
+      <p>Archiving meters will mark them all as inactive, remove validated data but leave unvalidated
+        data intact</p>
+      <%= button_to 'Archive meters', deactivate_meters_admin_school_path(@school), method: :post, class: 'btn btn-success'%>
+    </div>
+    <div class="mt-4">
+      <p>
+        Deactivating and deleting meter data, will mark meters as inactive, and remove both the validated
+        and unvalidated data.
+      </p>
+      <%= button_to 'Deactivate all meters and delete data', delete_meters_admin_school_path(@school), method: :post, class: 'btn btn-success'%>
+    </div>
   <% end %>
 
-
   <% if @school.active && @school_remover.can_remove_school? %>
-    <br/>
-    <%= button_to 'Remove school', deactivate_admin_school_path(@school), method: :post, class: 'btn btn-success'%>
+    <h2>School ready for removal</h2>
+    <div class="mt-4">
+      <p>Archiving a school will mark it as inactive and disable data processing. An archive school can be later
+      re-enabled</p>
+      <%= button_to 'Archive school', archive_admin_school_path(@school), method: :post, class: 'btn btn-success'%>
+    </div>
+    <div class="mt-4">
+      <p>Deleting a school will do the same, but also flag the school as deleted. A deleted school cannot be re-enabled.</p>
+      <%= button_to 'Delete school', delete_admin_school_path(@school), method: :post, class: 'btn btn-success'%>
+    </div>
   <% end %>
 
 <% else %>
-
-  <h2>Visibility</h2>
-
-  <p>School cannot be removed while still visible</p>
-
+  <h1><%= @school.name %></h1>
+  <p>This school is still visible so cannot be deleted or archived.</p>
+  <p>Mark school has not visible to hide it from the website.</p>
 <% end %>

--- a/app/views/admin/schools/removals/index.html.erb
+++ b/app/views/admin/schools/removals/index.html.erb
@@ -4,6 +4,7 @@
   <thead>
     <tr>
       <th>Name</th>
+      <th>Archived?</th>
       <th>Removal date</th>
       <th>Meters</th>
     </tr>
@@ -12,6 +13,7 @@
   <% @schools.each do |school| %>
     <tr>
       <td><%= link_to school.name, admin_school_path(school) %></td>
+      <td><%= y_n(school.archived?) %></td>
       <td><%= nice_dates(school.removal_date) %></td>
       <td>
         <% school.meters.each do |meter| %>

--- a/app/views/shared/_school_status_buttons.html.erb
+++ b/app/views/shared/_school_status_buttons.html.erb
@@ -1,5 +1,4 @@
 <% if can?(:change_visibility, school) %>
-
   <% if school.visible? %>
     <%= link_to 'Visible', school_visibility_path(school), class: 'badge badge-pill badge-success', method: :delete, data: { confirm: 'Are you sure?' } %>
   <% else %>

--- a/app/views/shared/_sub_nav.html.erb
+++ b/app/views/shared/_sub_nav.html.erb
@@ -1,8 +1,12 @@
 <nav class="navbar navbar-expand-lg navbar-custom fixed-top fixed-top-sub-nav sub-navbar">
   <div class="container">
-    <div>
-      <%= render 'shared/school_status_buttons', school: school %>
-    </div>
+    <% if school.active %>
+      <div id="school-status-buttons">
+        <%= render 'shared/school_status_buttons', school: school %>
+      </div>
+    <% else %>
+      <div></div>
+    <% end %>
     <div>
       <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#subnavbarNavDropdown" aria-controls="subnavbarNavDropdown" aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon"></span>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -593,8 +593,11 @@ Rails.application.routes.draw do
       member do
         get :removal
         post :deactivate_meters
+        post :delete_meters
         post :deactivate_users
-        post :deactivate
+        post :reenable
+        post :archive
+        post :delete
       end
       concerns :issueable
     end

--- a/spec/services/school_groups/meter_report_spec.rb
+++ b/spec/services/school_groups/meter_report_spec.rb
@@ -10,8 +10,9 @@ RSpec.describe SchoolGroups::MeterReport do
   let(:all_meters) { false }
   subject(:meter_report) { SchoolGroups::MeterReport.new(school_group, all_meters: all_meters) }
 
-  let!(:active_meter) { create :gas_meter, active: true, school: create(:school, school_group: school_group) }
-  let!(:inactive_meter) { create :gas_meter, active: false, school: create(:school, school_group: school_group) }
+  let!(:school)       { create(:school, school_group: school_group) }
+  let!(:active_meter) { create :gas_meter, active: true, school: school }
+  let!(:inactive_meter) { create :gas_meter, active: false, school: school }
 
   let(:header) { 'School,Supply,Number,Meter,Half-Hourly,Data source,Admin meter status,Procurement route,Active,First validated reading,Last validated reading,Large gaps (last 2 years),Modified readings (last 2 years),Zero reading days' }
 
@@ -32,10 +33,15 @@ RSpec.describe SchoolGroups::MeterReport do
 
     context "only active meters" do
       let(:all_meters) { false }
-
       it { expect(csv.lines.first.chomp).to eq(header) }
       it { expect(csv.lines.count).to eq(2) }
       it { expect(csv.lines.second).to include(active_meter.school_name) }
+
+      context 'and the school is inactive' do
+        let!(:school)       { create(:school, school_group: school_group, active: false) }
+        it { expect(csv.lines.first.chomp).to eq(header) }
+        it { expect(csv.lines.count).to eq(1) }
+      end
     end
 
     context "all meters" do
@@ -46,5 +52,7 @@ RSpec.describe SchoolGroups::MeterReport do
       it { expect(csv).to include(active_meter.school_name) }
       it { expect(csv).to include(inactive_meter.school_name) }
     end
+
+
   end
 end

--- a/spec/services/school_remover_spec.rb
+++ b/spec/services/school_remover_spec.rb
@@ -98,8 +98,8 @@ describe SchoolRemover, :schools, type: :service do
       it 'removes the validated data' do
         expect(AmrValidatedReading.count).to eq 0
       end
-      it 'dissociates the unvalidated data' do
-        expect(AmrDataFeedReading.first.meter).to be_nil
+      it 'does not unlink the unvalidated data' do
+        expect(AmrDataFeedReading.first.meter).to_not be_nil
       end
     end
   end

--- a/spec/services/school_remover_spec.rb
+++ b/spec/services/school_remover_spec.rb
@@ -2,11 +2,15 @@ require 'rails_helper'
 
 describe SchoolRemover, :schools, type: :service do
 
-  let(:school) { create(:school, visible: false) }
-  let!(:school_admin) { create(:school_admin, school: school) }
-  let!(:meter) { create(:electricity_meter, school: school) }
+  let(:school)              { create(:school, visible: false) }
+  let!(:school_admin)       { create(:school_admin, school: school) }
+  let!(:contact)            { create(:contact_with_name_email_phone, school: school, user: school_admin)}
 
-  let(:service) { SchoolRemover.new(school) }
+  let!(:electricity_meter) { create(:electricity_meter_with_validated_reading, school: school) }
+  let!(:gas_meter)         { create(:gas_meter, :with_unvalidated_readings, school: school)}
+
+  let(:archive) { false }
+  let(:service) { SchoolRemover.new(school, archive: archive) }
 
   describe '#remove_school!' do
     it 'marks the school as inactive and sets removal date' do
@@ -22,33 +26,83 @@ describe SchoolRemover, :schools, type: :service do
         service.remove_school!
       }.to raise_error(SchoolRemover::Error)
     end
+
+    context 'when archive flag set' do
+      let(:archive) { true }
+      it 'marks the school as inactive but with no removal date' do
+        service.remove_school!
+        expect(school.active).to be_falsey
+        expect(school.process_data).to be_falsey
+        expect(school.removal_date).to be_nil
+      end
+    end
   end
 
   describe '#remove_users!' do
-    it 'locks the user account if only for that school' do
-      service.remove_users!
+    let(:remove)    { service.remove_users! }
+    it 'locks the user accounts' do
+      remove
       expect(school.users.all?(&:access_locked?)).to be_truthy
     end
 
-    it 'switches user to other school if available' do
-      other_school = create(:school)
-      school_admin.add_cluster_school(other_school)
-      service.remove_users!
-      school_admin.reload
-      expect(school_admin.access_locked?).to be_falsey
-      expect(school_admin.school).to eq(other_school)
+    it 'removes alert contacts' do
+      remove
+      expect(Contact.count).to eq 0
     end
+
+    context 'when archiving' do
+      let(:archive) { true }
+      it 'keeps the alert contacts' do
+        remove
+        expect(Contact.count).to eq 1
+      end
+    end
+    context 'when user is linked to other schools' do
+      let(:other_school)  { create(:school) }
+      before do
+        school_admin.add_cluster_school(other_school)
+        remove
+      end
+      it 'does not lock user and switches them to the other school' do
+        school_admin.reload
+        expect(school_admin.access_locked?).to be_falsey
+        expect(school_admin.school).to eq(other_school)
+      end
+    end
+
+    context
   end
 
   describe '#remove_meters!' do
-    it 'deactivates the meters' do
-      expect_any_instance_of(MeterManagement).to receive_messages([:deactivate_meter!, :remove_data!])
+    before(:each) do
       service.remove_meters!
     end
-  end
 
-  # remove school from user cluster schools
-  # remove alert contacts
+    it 'deactivates the meters' do
+      electricity_meter.reload
+      expect(electricity_meter.active).to eq false
+      gas_meter.reload
+      expect(gas_meter.active).to eq false
+    end
+
+    it 'removes the validated data' do
+      expect(AmrValidatedReading.count).to eq 0
+    end
+
+    it 'dissociates the unvalidated data' do
+      expect(AmrDataFeedReading.first.meter).to be_nil
+    end
+
+    context 'when archive flag is set' do
+      let(:archive) { true }
+      it 'removes the validated data' do
+        expect(AmrValidatedReading.count).to eq 0
+      end
+      it 'dissociates the unvalidated data' do
+        expect(AmrDataFeedReading.first.meter).to be_nil
+      end
+    end
+  end
 
   # remove onboarding?
   # remove calendars?

--- a/spec/system/admin/school_removal_spec.rb
+++ b/spec/system/admin/school_removal_spec.rb
@@ -2,48 +2,77 @@ require 'rails_helper'
 
 RSpec.describe "school removal", :schools, type: :system do
 
+  let(:visible) { true }
+  let(:school)  { create(:school, name: 'My High School', visible: visible) }
+
   let(:admin)  { create(:admin) }
 
   before(:each) do
     sign_in(admin)
+    visit school_path(school)
+    click_on 'Remove school'
   end
 
   context 'if school still visible' do
-
-    let(:school) { create(:school, name: 'My High School', visible: true) }
-
     it 'shows message' do
-      visit school_path(school)
-      click_on 'Remove school'
-      expect(page).to have_content('My High School REMOVAL')
-      expect(page).to have_content('School cannot be removed while still visible')
+      expect(page).to have_content('My High School')
+      expect(page).to have_content('This school is still visible so cannot be deleted or archived.')
     end
   end
 
   context 'if school not visible' do
+    let(:visible) { false }
 
-    let(:school) { create(:school, name: 'My High School', visible: false) }
-    let!(:school_admin)  { create(:school_admin, school: school) }
-    let!(:electricity_meter)  { create(:electricity_meter, school: school) }
+    context 'and there are users' do
+      let!(:school_admin)  { create(:school_admin, school: school) }
+      before do
+        refresh
+        click_button 'Lock user accounts'
+      end
+      it 'removes the users' do
+        expect(page).to have_content('Users have been deactivated')
+      end
+    end
+    context 'and there are meters' do
+      let!(:electricity_meter)  { create(:electricity_meter, school: school) }
+      before do
+        refresh
+        click_button 'Deactivate all meters and delete data'
+      end
+      it 'removes the meters' do
+        expect(page).to have_content('Meters have been deactivated')
+      end
+    end
+    context 'when the school is ready for removal' do
+      it 'can be deleted' do
+        click_button 'Delete school'
+        expect(page).to have_content('School has been removed')
+        expect(page).to have_content('This school was deleted')
+      end
+      it 'can be archived' do
+        click_button 'Archive school'
+        expect(page).to have_content('School has been archived')
+        expect(page).to have_content('This school has been archived')
+        expect(page).to have_content('Reenable school')
+      end
+    end
 
-    it 'removes school and shows on removals list' do
-      visit school_path(school)
-      click_on 'Remove school'
-      expect(page).to have_content('My High School REMOVAL')
-      click_button 'Remove users'
-      expect(page).to have_content('Users have been deactivated')
-      click_button 'Remove meters'
-      expect(page).to have_content('Meters have been deactivated')
-      click_button 'Remove school'
-      expect(page).to have_content('School has been removed')
-      expect(page).to have_content('My High School (INACTIVE)')
+    context 'when a school has been removed' do
+      let(:school)  { create(:school, name: 'My High School', visible: false, active: false, removal_date: Time.zone.today) }
+      let!(:electricity_meter)  { create(:electricity_meter, school: school) }
 
-      visit admin_reports_path
-      click_on 'Schools removed'
+      it 'is shown in the admin report' do
+        visit admin_reports_path
+        click_on 'Schools removed'
+        expect(page).to have_content('My High School')
+        expect(page).to have_content(Time.zone.today.to_s(:es_full))
+        expect(page).to have_link(electricity_meter.mpan_mprn.to_s)
+      end
 
-      expect(page).to have_content('My High School')
-      expect(page).to have_content(Time.zone.today.to_s(:es_full))
-      expect(page).to have_link(electricity_meter.mpan_mprn.to_s)
+      it 'does not show status buttons' do
+        visit school_path(school)
+        expect(page).to_not have_css('#school-status-buttons')
+      end
     end
   end
 end


### PR DESCRIPTION
When we remove schools we do a soft delete, setting the `active` flag to false. The admin forms for doing this require user accounts to be locked and meters to be deactivated before the flag can be set.

This PR has some updates to the removal process to allow for "archiving" schools. If a school is archived, rather than deleted then we want to:

* retain the alert contacts for users, otherwise they can be deleted
* retain the links between the meters and the unvalidated readings, so when the school is re-enabled we can reload their data

When a school is deleted we should:

* remove alert contacts
* remove the links to the unvalidated readings

In both cases we want to:

* redirect admins to the removal page to clarify that the school has been removed
* disable use of the visibility, process data and other buttons
* indicate whether the school has been archived or removed on the existing school group and admin report
* filter those schools from the daily import emails and school group meter report

This PR has improvements to the removal page and implements the above behaviour. Further improvements can and will be made, but this provides the basic functionality to allow the admins to begin archiving schools.