### PR TITLE
Fix missing route and add conditions around text

### DIFF
--- a/app/controllers/admin/schools_controller.rb
+++ b/app/controllers/admin/schools_controller.rb
@@ -16,14 +16,14 @@ module Admin
 
     def archive_meters
       remove_meters(archive: true)
-      redirect_back fallback_location: root_path, notice: "Meters have been deactivated and only validated data removed"
+      redirect_back fallback_location: root_path, notice: "Meters have been archived and validated data removed"
     rescue => e
       redirect_back fallback_location: root_path, notice: e.message
     end
 
     def delete_meters
       remove_meters(archive: false)
-      redirect_back fallback_location: root_path, notice: "Meters have been deactivated and all data removed"
+      redirect_back fallback_location: root_path, notice: "Meters have been deactivated and validated data removed"
     rescue => e
       redirect_back fallback_location: root_path, notice: e.message
     end

--- a/app/views/admin/schools/removal.html.erb
+++ b/app/views/admin/schools/removal.html.erb
@@ -9,8 +9,10 @@
   <h1>Removing <%= @school.name %></h1>
   <% if @school.users.any? %>
     <h2>User status</h2>
-    <%= component 'notice', status: :negative, classes: 'mb-4' do %>
-      <p>School cannot be removed while it has active users.</p>
+    <% unless @school_remover.users_ready? %>
+      <%= component 'notice', status: :negative, classes: 'mb-4' do %>
+        <p>School cannot be removed while it has active users.</p>
+      <% end %>
     <% end %>
     <p>Current users:</p>
     <ol>
@@ -30,8 +32,10 @@
 
   <% if @school.meters.any? %>
     <h2>Meter status</h2>
-    <%= component 'notice', status: :negative, classes: 'mb-4' do %>
-      <p>School cannot be removed while it has active meters</p>
+    <% unless @school_remover.meters_ready? %>
+      <%= component 'notice', status: :negative, classes: 'mb-4' do %>
+        <p>School cannot be removed while it has active meters</p>
+      <% end %>
     <% end %>
     <p>Current meters:</p>
     <ol>
@@ -43,14 +47,14 @@
 
   <% unless @school_remover.meters_ready? %>
     <div class="mt-4">
-      <p>Archiving meters will mark them all as inactive, remove validated data but leave unvalidated
-        data intact</p>
-      <%= button_to 'Archive meters', deactivate_meters_admin_school_path(@school), method: :post, class: 'btn btn-success'%>
+      <p>Archiving meters will mark them all as inactive. Validated data will be removed, but unvalidated
+        data will remain linked to the meter.</p>
+      <%= button_to 'Archive meters', archive_meters_admin_school_path(@school), method: :post, class: 'btn btn-success'%>
     </div>
     <div class="mt-4">
       <p>
-        Deactivating and deleting meter data, will mark meters as inactive, and remove both the validated
-        and unvalidated data.
+        Deactivating and deleting meter data, will mark meters as inactive. Validated data will be removed and
+        the unvalidated data will be unlinked from the meter.
       </p>
       <%= button_to 'Deactivate all meters and delete data', delete_meters_admin_school_path(@school), method: :post, class: 'btn btn-success'%>
     </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -591,12 +591,12 @@ Rails.application.routes.draw do
         resource :target_data, only: :show
       end
       member do
-        get :removal
-        post :deactivate_meters
+        post :archive
+        post :archive_meters
         post :delete_meters
         post :deactivate_users
         post :reenable
-        post :archive
+        get :removal
         post :delete
       end
       concerns :issueable

--- a/spec/system/admin/school_removal_spec.rb
+++ b/spec/system/admin/school_removal_spec.rb
@@ -35,12 +35,23 @@ RSpec.describe "school removal", :schools, type: :system do
     end
     context 'and there are meters' do
       let!(:electricity_meter)  { create(:electricity_meter, school: school) }
-      before do
-        refresh
-        click_button 'Deactivate all meters and delete data'
+      context 'when deactivating them' do
+        before do
+          refresh
+          click_button 'Deactivate all meters and delete data'
+        end
+        it 'removes the meters' do
+          expect(page).to have_content('Meters have been deactivated')
+        end
       end
-      it 'removes the meters' do
-        expect(page).to have_content('Meters have been deactivated')
+      context 'when archiving them' do
+        before do
+          refresh
+          click_button 'Archive meters'
+        end
+        it 'removes the meters' do
+          expect(page).to have_content('Meters have been archived')
+        end
       end
     end
     context 'when the school is ready for removal' do


### PR DESCRIPTION
Previous PR for school removal had some bugs:

* incorrect route, which wasn't caught because of missing spec. Have fixed route and added extra spec
* the noticed were always appearing, so these are now wrapped in conditional blocks

plus a couple of text tweaks.