### PR TITLE
Tweaks to loading and deleting readings

### DIFF
--- a/app/services/amr/analytics_validated_amr_data_factory.rb
+++ b/app/services/amr/analytics_validated_amr_data_factory.rb
@@ -5,7 +5,7 @@ module Amr
   private
 
     def build_meter_data(active_record_meter)
-      validated_reading_array = AmrValidatedReading.where(meter_id: active_record_meter.id).order(reading_date: :asc).pluck(:reading_date, :status, :substitute_date, :upload_datetime, :kwh_data_x48)
+      validated_reading_array = AmrValidatedReading.where(meter_id: active_record_meter.id).pluck(:reading_date, :status, :substitute_date, :upload_datetime, :kwh_data_x48)
       readings = validated_reading_array.map do |reading|
         {
           reading_date: reading[0],

--- a/app/services/amr/checking_validated_readings_for_a_meter.rb
+++ b/app/services/amr/checking_validated_readings_for_a_meter.rb
@@ -10,7 +10,11 @@ module Amr
       pp "Checking: #{@dashboard_meter} with mpan_mprn: #{@dashboard_meter.mpan_mprn} id: #{@dashboard_meter.external_meter_id}"
       amr_data = @dashboard_meter.amr_data
 
-      readings_to_delete = AmrValidatedReading.where(meter_id: @dashboard_meter.external_meter_id).where.not(reading_date: amr_data.keys)
+      #the analytic validation process always returns a full time series of data for each meter.
+      #See: ValidateAMR.do_validations which finishes by ensuring all gaps are filled.
+      #As there won't be any gaps rather than delete individual days, just remove anything before
+      #or after the amr_data start or end date for this meter
+      readings_to_delete = AmrValidatedReading.where(meter_id: @dashboard_meter.external_meter_id).where("reading_date < ? OR reading_date > ?", amr_data.start_date, amr_data.end_date)
 
       #this returns the number of rows affected, so no need for the count
       deleted_count = readings_to_delete.delete_all

--- a/spec/factories/dashboard_meters_factory.rb
+++ b/spec/factories/dashboard_meters_factory.rb
@@ -17,15 +17,14 @@ FactoryBot.define do
         reading_count       { 1 }
         start_reading_date  { Date.today - reading_count.days }
         config              { create(:amr_data_feed_config) }
+        actual_meter        { create(:gas_meter) }
       end
 
       after(:build) do |meter, evaluator|
-        actual_meter = create(:gas_meter)
-        meter.external_meter_id = actual_meter.id
+        meter.external_meter_id = evaluator.actual_meter.id
         readings = evaluator.reading_count.times.map { |index| build(:dashboard_one_day_amr_reading, dashboard_meter: meter, date: evaluator.start_reading_date + index) }
-        # meter.amr_data = readings.map { |a| [a.date, a]}.to_h
-        meter.amr_data=AMRData.new(:blah)
-        readings.each { |a| meter.amr_data[a.date] = a }
+        meter.amr_data=AMRData.new(:gas)
+        readings.each { |r| meter.amr_data.add(r.date, r) }
       end
     end
 
@@ -39,13 +38,14 @@ FactoryBot.define do
           reading_count       { 1 }
           start_reading_date  { Date.today - reading_count.days }
           config              { create(:amr_data_feed_config) }
+          actual_meter        { create(:electricity_meter) }
         end
 
         after(:build) do |meter, evaluator|
-          actual_meter = create(:electricity_meter)
-          meter.external_meter_id = actual_meter.id
+          meter.external_meter_id = evaluator.actual_meter.id
           readings = evaluator.reading_count.times.map { |index| build(:dashboard_one_day_amr_reading, dashboard_meter: meter, date: evaluator.start_reading_date + index) }
-          meter.amr_data = readings.map { |a| [a.date, a]}.to_h
+          meter.amr_data=AMRData.new(:electricity)
+          readings.each { |r| meter.amr_data.add(r.date, r) }
         end
       end
     end

--- a/spec/services/amr/checking_validated_readings_for_a_meter_spec.rb
+++ b/spec/services/amr/checking_validated_readings_for_a_meter_spec.rb
@@ -14,8 +14,9 @@ describe Amr::CheckingValidatedReadingsForAMeter do
 
     it 'removes data when appropriate' do
       expect(AmrValidatedReading.count).to be number_of_readings
+
       last_reading_date = gas_dashboard_meter.amr_data.keys.last
-      gas_dashboard_meter.amr_data.delete(last_reading_date)
+      gas_dashboard_meter.amr_data.set_end_date(last_reading_date - 1)
 
       upserted_meter_collection = upsert_gas_service.perform
       deleted = Amr::CheckingValidatedReadingsForAMeter.new(upserted_meter_collection).perform


### PR DESCRIPTION
Reviewing the code and logs for when we are processing validated readings I noticed that:

- we order readings when loading from the database, but these are later added to an `AmrData` object which is a hash. So the ordering is unnecessary
- when we delete readings we were deleting all the dates present in the `AmrData.keys`. This isn't necessary as the `AmrData` returned by the analytics is guaranteed to have a continuous time series between its start and end dates. So we only have to delete data before the `start_date` or after the `end_date`. 

This PR fixes both of those issues. These are unlikely to have a huge impact on performance, but might make some of the data processing slightly quicker.