### PR TITLE
Show benchmark flag on description

### DIFF
--- a/app/views/admin/alert_types/show.html.erb
+++ b/app/views/admin/alert_types/show.html.erb
@@ -17,6 +17,9 @@
   <dt class="col-md-2">Frequency</dt>
   <dd class="col-md-10"><%= @alert_type.frequency.humanize %></dd>
 
+  <dt class="col-md-2">Benchmark?</dt>
+  <dd class="col-md-10"><%= y_n(@alert_type.benchmark) %></dd>
+
   <dt class="col-md-2">Advice Page</dt>
   <dd class="col-md-10">
     <% if @alert_type.advice_page.present? %>


### PR DESCRIPTION
Trivial change to add an `AlertType` flag to the show page.

Helps identify whether an alert type is used to also generate benchmark metrics. If not, and we've not set up any ratings then its safe to disable.

Adding this flag will make it easier to review the settings.