### PR TITLE
Optimise generation of out of hours usage benchmark

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,8 +22,8 @@ gem 'closed_struct'
 gem 'pg_search'
 
 # Dashboard analytics
-gem 'energy-sparks_analytics', git: 'https://github.com/Energy-Sparks/energy-sparks_analytics.git', tag: '4.0.2'
-#gem 'energy-sparks_analytics', git: 'https://github.com/Energy-Sparks/energy-sparks_analytics.git', branch: 'clean-up-advice-classes'
+gem 'energy-sparks_analytics', git: 'https://github.com/Energy-Sparks/energy-sparks_analytics.git', tag: '4.0.3'
+#gem 'energy-sparks_analytics', git: 'https://github.com/Energy-Sparks/energy-sparks_analytics.git', branch: 'optimise-usage-breakdown'
 #gem 'energy-sparks_analytics', path: '../energy-sparks_analytics'
 
 # Using master due to it having a patch which doesn't override Enumerable#sum if it's already defined

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/Energy-Sparks/energy-sparks_analytics.git
-  revision: 5cd278bb0ee2ecfbfb7c9f50fa2858f1a0c61779
-  tag: 4.0.2
+  revision: 9be58bb910ddb0e37c9a2b1682af9dfb3b426c99
+  tag: 4.0.3
   specs:
     energy-sparks_analytics (1.2.1)
       activesupport (>= 6.0, < 7.1)

--- a/app/services/schools/advice_page_benchmarks/out_of_hours_usage_benchmark_generator.rb
+++ b/app/services/schools/advice_page_benchmarks/out_of_hours_usage_benchmark_generator.rb
@@ -9,11 +9,11 @@ module Schools
       private
 
       def benchmark_usage
-        annual_usage_breakdown = usage_service.usage_breakdown
+        annual_out_of_hours_kwh = usage_service.annual_out_of_hours_kwh
         Schools::Comparison.new(
-          school_value: annual_usage_breakdown.out_of_hours.kwh,
-          benchmark_value: (annual_usage_breakdown.total.kwh * BenchmarkMetrics::BENCHMARK_OUT_OF_HOURS_USE_PERCENT_ELECTRICITY),
-          exemplar_value: (annual_usage_breakdown.total.kwh * BenchmarkMetrics::EXEMPLAR_OUT_OF_HOURS_USE_PERCENT_ELECTRICITY),
+          school_value: annual_out_of_hours_kwh[:out_of_hours],
+          benchmark_value: (annual_out_of_hours_kwh[:total_annual] * BenchmarkMetrics::BENCHMARK_OUT_OF_HOURS_USE_PERCENT_ELECTRICITY),
+          exemplar_value: (annual_out_of_hours_kwh[:total_annual] * BenchmarkMetrics::EXEMPLAR_OUT_OF_HOURS_USE_PERCENT_ELECTRICITY),
           unit: :kwh
         )
       end

--- a/spec/services/schools/advice_page_benchmarks/out_of_hours_usage_benchmark_generator_spec.rb
+++ b/spec/services/schools/advice_page_benchmarks/out_of_hours_usage_benchmark_generator_spec.rb
@@ -9,28 +9,14 @@ RSpec.describe Schools::AdvicePageBenchmarks::OutOfHoursUsageBenchmarkGenerator,
 
   context '#benchmark_school' do
     let(:enough_data) { true }
-    let(:usage) {
-      CombinedUsageMetric.new(
-        £: 12.0,
-        kwh: 12.0,
-        co2: 12.0,
-        percent: 0.4
-      )
-    }
     before(:each) do
       allow_any_instance_of(Usage::AnnualUsageBreakdownService).to receive(:enough_data?).and_return(enough_data)
-      allow_any_instance_of(Usage::AnnualUsageBreakdownService).to receive(:usage_breakdown) do
-        Usage::AnnualUsageCategoryBreakdown.new(
-          holiday: usage,
-          school_day_closed: usage,
-          school_day_open: usage,
-          weekend: usage,
-          out_of_hours: usage,
-          community: usage,
-          fuel_type: :electricity
-        )
+      allow_any_instance_of(Usage::AnnualUsageBreakdownService).to receive(:annual_out_of_hours_kwh) do
+        {
+          out_of_hours: 12,
+          total_annual: 40
+        }
       end
-      allow_any_instance_of(Usage::AnnualUsageCategoryBreakdown).to receive(:potential_savings) { usage }
     end
 
     context 'not enough data' do


### PR DESCRIPTION
This PR updates the out of hours usage benchmark generator to use a new method on `AnnualUsageBreakdownService` in the analytics. It avoids generating additional variables (co2, £, £current) when we only need the kwh values for the benchmark assessment.

This PR relies on this change: https://github.com/Energy-Sparks/energy-sparks_analytics/pull/606. 

Cannot be merged until we have a new tagged version of the analytics.

