### PR TITLE
Properly lock accounts when school is deleted

### DIFF
--- a/app/controllers/admin/school_groups/users_controller.rb
+++ b/app/controllers/admin/school_groups/users_controller.rb
@@ -13,6 +13,12 @@ module Admin
         end
       end
 
+      def unlock
+        user = User.find(params['user_id'])
+        user.unlock_access!
+        redirect_to admin_school_group_users_path(@school_group), notice: "User '#{user.email}' was successfully unlocked."
+      end
+
       private
 
       def filename(school_group)
@@ -39,7 +45,8 @@ module Admin
             'Confirmed',
             'Last signed in',
             'Alerts',
-            'Language'
+            'Language',
+            'Locked'
           ]
           group_admins.each do |user|
             add_user_to_csv(csv, school_group, nil, user)
@@ -63,7 +70,8 @@ module Admin
           y_n(user.confirmed?),
           display_last_signed_in_as(user),
           user.group_admin? ? 'N/A' : y_n(user.contact_for_school),
-          I18n.t("languages.#{user.preferred_locale}")
+          I18n.t("languages.#{user.preferred_locale}"),
+          y_n(user.access_locked?)
         ]
       end
     end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,5 +1,6 @@
 module Admin
   class UsersController < AdminController
+    include ApplicationHelper
     load_and_authorize_resource
 
     def index
@@ -41,6 +42,12 @@ module Admin
     def destroy
       @user.destroy
       redirect_to admin_users_path, notice: 'User was successfully destroyed.'
+    end
+
+    def unlock
+      user = User.find(params['user_id'])
+      user.unlock_access!
+      redirect_to admin_users_path, notice: "User '#{user.email}' was successfully unlocked."
     end
 
   private

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -86,7 +86,8 @@ module Admin
           'Name',
           'Email',
           'Role',
-          'Staff Role'
+          'Staff Role',
+          'Locked'
         ]
         User.where.not(role: :pupil).where.not(role: :admin).order(:email).each do |user|
           csv << [
@@ -97,6 +98,7 @@ module Admin
             user.email,
             user.role.titleize,
             user.staff_role&.title,
+            y_n(user.access_locked?)
           ]
         end
       end

--- a/app/views/admin/school_groups/users/show.html.erb
+++ b/app/views/admin/school_groups/users/show.html.erb
@@ -23,6 +23,7 @@
         <th>Confirmed?</th>
         <th>Last signed in</th>
         <th>Language</th>
+        <th>Locked?</th>
         <th></th>
       </tr>
     </thead>
@@ -34,14 +35,14 @@
           <td><%= y_n(user.confirmed?) %></td>
           <td data-order="<%=user.last_sign_in_at.iso8601 if user.last_sign_in_at %>"><%= display_last_signed_in_as(user) %></td>
           <td><%= I18n.t("languages.#{user.preferred_locale}") %></td>
+          <td><%= y_n(user.access_locked?) %></td>
           <td>
             <div class="btn-group">
               <%= link_to 'Edit', edit_admin_user_path(user), class: 'btn btn-primary btn-sm' %>
               <%= link_to 'Delete', admin_user_path(user), method: :delete, data: { confirm: 'Are you sure?' }, class: 'btn btn-danger btn-sm' %>
             </div>
-            <% unless user.confirmed? %>
-              <%= button_to 'Resend confirmation', admin_user_confirmation_path(user), class: 'btn btn-warning btn-sm' %>
-            <% end %>
+            <%= button_to 'Resend confirmation', admin_user_confirmation_path(user), class: 'btn btn-warning btn-sm' unless user.confirmed? %>
+            <%= link_to 'Unlock', unlock_admin_school_group_users_path(user_id: user.id), class: 'btn btn-warning btn-sm' if user.access_locked? %>
           </td>
         </tr>
       <% end %>
@@ -63,6 +64,7 @@
       <th>Last signed in</th>
       <th>Alerts</th>
       <th>Language</th>
+      <th>Locked?</th>
       <th></th>
     </tr>
   </thead>
@@ -79,14 +81,14 @@
           <td data-order="<%=user.last_sign_in_at.iso8601 if user.last_sign_in_at %>"><%= display_last_signed_in_as(user) %></td>
           <td><%= y_n(user.contact_for_school) %></td>
           <td><%= I18n.t("languages.#{user.preferred_locale}") %></td>
+          <td><%= y_n(user.access_locked?) %></td>
           <td>
             <div class="btn-group">
               <%= link_to 'Edit', edit_admin_user_path(user), class: 'btn btn-primary btn-sm' %>
               <%= link_to 'Delete', admin_user_path(user), method: :delete, data: { confirm: 'Are you sure?' }, class: 'btn btn-danger btn-sm' %>
             </div>
-            <% unless user.confirmed? %>
-              <%= button_to 'Resend confirmation', admin_user_confirmation_path(user), class: 'btn btn-warning btn-sm' %>
-            <% end %>
+            <%= button_to 'Resend confirmation', admin_user_confirmation_path(user), class: 'btn btn-warning btn-sm' unless user.confirmed? %>
+            <%= link_to 'Unlock', unlock_admin_school_group_users_path(user_id: user.id), class: 'btn btn-warning btn-sm' if user.access_locked? %>
           </td>
         </tr>
       <% end %>

--- a/app/views/admin/users/_other_users.html.erb
+++ b/app/views/admin/users/_other_users.html.erb
@@ -8,6 +8,7 @@
       <th>Role</th>
       <th>Confirmed</th>
       <th>Last sign in</th>
+      <th>Locked?</th>
       <th></th>
     </tr>
   </thead>
@@ -19,13 +20,13 @@
         <td><%= user.role.titleize %></td>
         <td><%= y_n(user.confirmed?) %></td>
         <td data-order="<%=user.last_sign_in_at.iso8601 if user.last_sign_in_at %>"><%= display_last_signed_in_as(user) %></td>
+        <td><%= y_n(user.access_locked?) %></td>
         <td>
           <div class="btn-group">
             <%= link_to 'Edit', edit_admin_user_path(user), class: 'btn btn-primary btn-sm' %>
             <%= link_to 'Delete', admin_user_path(user), method: :delete, data: { confirm: 'Are you sure?' }, class: 'btn btn-danger btn-sm' %>
-            <% unless user.confirmed? %>
-              <%= button_to 'Resend confirmation', admin_user_confirmation_path(user), class: 'btn btn-warning btn-sm' %>
-            <% end %>
+            <%= button_to 'Resend confirmation', admin_user_confirmation_path(user), class: 'btn btn-warning btn-sm' unless user.confirmed? %>
+            <%= link_to 'Unlock', admin_user_unlock_path(user_id: user.id), class: 'btn btn-warning btn-sm' if user.access_locked? %>
           </div>
         </td>
       </tr>

--- a/app/views/admin/users/_user_search.html.erb
+++ b/app/views/admin/users/_user_search.html.erb
@@ -22,6 +22,7 @@
         <th>Confirmed</th>
         <th>Last signed in</th>
         <th>Language</th>
+        <th>Locked?</th>
         <th></th>
       </tr>
     </thead>
@@ -39,15 +40,15 @@
           </td>
           <td><%= user.role.titleize %></td>
           <td><%= y_n(user.confirmed?) %></td>
+          <td><%= y_n(user.access_locked?) %></td>
           <td data-order="<%=user.last_sign_in_at.iso8601 if user.last_sign_in_at %>"><%= display_last_signed_in_as(user) %></td>
           <td><%= I18n.t("languages.#{user.preferred_locale}") %></td>
           <td>
             <div class="btn-group">
               <%= link_to 'Edit', edit_admin_user_path(user), class: 'btn btn-primary btn-sm' %>
               <%= link_to 'Delete', admin_user_path(user), method: :delete, data: { confirm: 'Are you sure?' }, class: 'btn btn-danger btn-sm' %>
-              <% unless user.confirmed? %>
-                <%= button_to 'Resend confirmation', admin_user_confirmation_path(user), class: 'btn btn-warning btn-sm' %>
-              <% end %>
+              <%= button_to 'Resend confirmation', admin_user_confirmation_path(user), class: 'btn btn-warning btn-sm' unless user.confirmed? %>
+              <%= link_to 'Unlock', admin_user_unlock_path(user_id: user.id), class: 'btn btn-warning btn-sm' if user.access_locked? %>
             </div>
           </td>
         </tr>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -180,14 +180,11 @@ Devise.setup do |config|
   # :time  = Re-enables login after a certain amount of time (see :unlock_in below)
   # :both  = Enables both strategies
   # :none  = No unlock strategy. You should handle unlocking by yourself.
-  config.unlock_strategy = :both
+  config.unlock_strategy = :email
 
   # Number of authentication tries before locking an account if lock_strategy
   # is failed attempts.
   config.maximum_attempts = 5
-
-  # Time interval to unlock the account if :time is enabled as unlock_strategy.
-  config.unlock_in = 1.hour
 
   # Warn on the last attempt before the account is locked.
   config.last_attempt_warning = true

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -428,7 +428,9 @@ Rails.application.routes.draw do
             post :make_visible
           end
         end
-        resource :users, only: [:show]
+        resource :users, only: [:show] do
+          get 'unlock', to: 'users#unlock'
+        end
         resource :partners, only: [:show, :update]
         resource :meter_report, only: [:show] do
           post :deliver, on: :member

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -388,6 +388,7 @@ Rails.application.routes.draw do
     concerns :issueable
     resources :funders
     resources :users do
+      get 'unlock', to: 'users#unlock'
       scope module: :users do
         resource :confirmation, only: [:create], controller: 'confirmation'
       end


### PR DESCRIPTION
The `SchoolRemover` tries to lock user accounts using the Devise locking feature. However the current Devise config allows locks to automatically expire after an hour.  This PR

- [x] revises the config so any locked accounts must request an unlock email, rather than being timed out
- [x] ensures the admin views of user lists indicate whether an account is locked, with an option to manually unlock