### PR TITLE
Remove unused index on amr_validated_readings

### DIFF
--- a/db/migrate/20231009123308_remove_unused_validated_reading_index.rb
+++ b/db/migrate/20231009123308_remove_unused_validated_reading_index.rb
@@ -1,0 +1,5 @@
+class RemoveUnusedValidatedReadingIndex < ActiveRecord::Migration[6.0]
+  def change
+    remove_index "amr_validated_readings", column: [:meter_id], name: "index_amr_validated_readings_on_meter_id"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_09_22_131629) do
+ActiveRecord::Schema.define(version: 2023_10_09_123308) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
@@ -471,7 +471,6 @@ ActiveRecord::Schema.define(version: 2023_09_22_131629) do
     t.datetime "upload_datetime"
     t.index ["meter_id", "one_day_kwh"], name: "index_amr_validated_readings_on_meter_id_and_one_day_kwh"
     t.index ["meter_id", "reading_date"], name: "unique_amr_meter_validated_readings", unique: true
-    t.index ["meter_id"], name: "index_amr_validated_readings_on_meter_id"
     t.index ["reading_date"], name: "index_amr_validated_readings_on_reading_date"
   end
 


### PR DESCRIPTION
Checking [the statistics in `pg_stat_all_indexes` table](https://www.postgresql.org/docs/current/monitoring-stats.html#MONITORING-PG-STAT-ALL-INDEXES-VIEW) shows that there is an index on the `amr_validated_readings` table on the `meter_id` column which is unused. The stats have zero reads using that index.

Looks like postgres prefers to use the compound, unique index when doing all loads.

This PR removes the index, which will reclaim space and avoid need to maintain the index during inserts, vacuums, etc.
