### PR TITLE
Create OneDayAMRReading when loading readings

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,8 +22,8 @@ gem 'closed_struct'
 gem 'pg_search'
 
 # Dashboard analytics
-gem 'energy-sparks_analytics', git: 'https://github.com/Energy-Sparks/energy-sparks_analytics.git', tag: '4.0.3'
-#gem 'energy-sparks_analytics', git: 'https://github.com/Energy-Sparks/energy-sparks_analytics.git', branch: 'optimise-usage-breakdown'
+#gem 'energy-sparks_analytics', git: 'https://github.com/Energy-Sparks/energy-sparks_analytics.git', tag: '4.0.3'
+gem 'energy-sparks_analytics', git: 'https://github.com/Energy-Sparks/energy-sparks_analytics.git', branch: 'allow-passing-of-readings'
 #gem 'energy-sparks_analytics', path: '../energy-sparks_analytics'
 
 # Using master due to it having a patch which doesn't override Enumerable#sum if it's already defined

--- a/Gemfile
+++ b/Gemfile
@@ -22,8 +22,8 @@ gem 'closed_struct'
 gem 'pg_search'
 
 # Dashboard analytics
-#gem 'energy-sparks_analytics', git: 'https://github.com/Energy-Sparks/energy-sparks_analytics.git', tag: '4.0.3'
-gem 'energy-sparks_analytics', git: 'https://github.com/Energy-Sparks/energy-sparks_analytics.git', branch: 'allow-passing-of-readings'
+gem 'energy-sparks_analytics', git: 'https://github.com/Energy-Sparks/energy-sparks_analytics.git', tag: '4.0.4'
+#gem 'energy-sparks_analytics', git: 'https://github.com/Energy-Sparks/energy-sparks_analytics.git', branch: 'allow-passing-of-readings'
 #gem 'energy-sparks_analytics', path: '../energy-sparks_analytics'
 
 # Using master due to it having a patch which doesn't override Enumerable#sum if it's already defined

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/Energy-Sparks/energy-sparks_analytics.git
-  revision: d41c90baad101f211894f10cdae68cf35aa83b32
-  branch: allow-passing-of-readings
+  revision: 2d568d7503a6247cce03902b278f30c75db613f6
+  tag: 4.0.4
   specs:
     energy-sparks_analytics (1.2.1)
       activesupport (>= 6.0, < 7.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/Energy-Sparks/energy-sparks_analytics.git
-  revision: 9be58bb910ddb0e37c9a2b1682af9dfb3b426c99
-  tag: 4.0.3
+  revision: d41c90baad101f211894f10cdae68cf35aa83b32
+  branch: allow-passing-of-readings
   specs:
     energy-sparks_analytics (1.2.1)
       activesupport (>= 6.0, < 7.1)

--- a/app/services/amr/analytics_unvalidated_amr_data_factory.rb
+++ b/app/services/amr/analytics_unvalidated_amr_data_factory.rb
@@ -27,22 +27,24 @@ module Amr
       readings = AmrDataFeedReading.order(created_at: :asc)
         .where(meter_id: active_record_meter.id)
         .pluck(:amr_data_feed_config_id, :reading_date, :created_at, :readings).map do |reading|
-                reading_if_valid(reading, hash_of_date_formats)
+                reading_if_valid(active_record_meter.mpan_mprn, reading, hash_of_date_formats)
       end
 
       Amr::AnalyticsMeterFactory.new(active_record_meter).build(readings.compact)
     end
 
-    def reading_if_valid(reading, hash_of_date_formats)
+    def reading_if_valid(meter_id, reading, hash_of_date_formats)
       return if reading_invalid?(reading)
       reading_date = date_from_string_using_date_format(reading, hash_of_date_formats)
       return if reading_date.nil?
-      {
-        reading_date: reading_date,
-        type: 'ORIG',
-        upload_datetime: reading[2],
-        kwh_data_x48: reading[3].map(&:to_f)
-      }
+      OneDayAMRReading.new(
+        meter_id,
+        reading_date,
+        'ORIG',
+        nil,
+        reading[2],
+        reading[3].map(&:to_f)
+      )
     end
 
     def reading_invalid?(reading)

--- a/app/services/amr/analytics_validated_amr_data_factory.rb
+++ b/app/services/amr/analytics_validated_amr_data_factory.rb
@@ -7,15 +7,15 @@ module Amr
     def build_meter_data(active_record_meter)
       validated_reading_array = AmrValidatedReading.where(meter_id: active_record_meter.id).pluck(:reading_date, :status, :substitute_date, :upload_datetime, :kwh_data_x48)
       readings = validated_reading_array.map do |reading|
-        {
-          reading_date: reading[0],
-          type: reading[1],
-          substitute_date: reading[2],
-          upload_datetime: reading[3],
-          kwh_data_x48: reading[4].map(&:to_f)
-        }
+        OneDayAMRReading.new(
+          active_record_meter.mpan_mprn,
+          reading[0],
+          reading[1],
+          reading[2],
+          reading[3],
+          reading[4].map(&:to_f)
+        )
       end
-
       Amr::AnalyticsMeterFactory.new(active_record_meter).build(readings)
     end
   end

--- a/spec/services/amr/analytics_unvalidated_amr_data_factory_spec.rb
+++ b/spec/services/amr/analytics_unvalidated_amr_data_factory_spec.rb
@@ -20,14 +20,14 @@ module Amr
       expect(first_electricity_meter[:identifier]).to eq e_meter.mpan_mprn
       expect(first_electricity_meter[:dcc_meter]).to be false
       expect(first_electricity_meter[:readings].size).to eq 2
-      expect(first_electricity_meter[:readings].map { |reading| reading[:kwh_data_x48] }).to match_array e_meter.amr_data_feed_readings.map { |reading| reading.readings.map(&:to_f) }
+      expect(first_electricity_meter[:readings].map { |reading| reading.kwh_data_x48 }).to match_array e_meter.amr_data_feed_readings.map { |reading| reading.readings.map(&:to_f) }
 
       first_gas_meter = amr_data[:heat_meters].first
 
       expect(first_gas_meter[:identifier]).to eq g_meter.mpan_mprn
       expect(first_gas_meter[:dcc_meter]).to be true
-      expect(first_gas_meter[:readings].first[:reading_date]).to eq Date.parse(g_meter.amr_data_feed_readings.first.reading_date)
-      expect(first_gas_meter[:readings].first[:kwh_data_x48]).to eq g_meter.amr_data_feed_readings.first.readings.map(&:to_f)
+      expect(first_gas_meter[:readings].first.date).to eq Date.parse(g_meter.amr_data_feed_readings.first.reading_date)
+      expect(first_gas_meter[:readings].first.kwh_data_x48).to eq g_meter.amr_data_feed_readings.first.readings.map(&:to_f)
     end
 
     it 'fallsback to date parse where the specified format does not work' do
@@ -36,7 +36,7 @@ module Amr
       expect(e_meter.amr_data_feed_readings.count).to be 3
       amr_data = AnalyticsUnvalidatedAmrDataFactory.new(heat_meters: [g_meter], electricity_meters: [e_meter]).build
       expect(amr_data[:electricity_meters].first[:readings].size).to eq 3
-      expect(amr_data[:electricity_meters].first[:readings].map{|reading| reading[:reading_date]}).to include Date.tomorrow
+      expect(amr_data[:electricity_meters].first[:readings].map{|reading| reading.date}).to include Date.tomorrow
     end
 
     it 'skips invalid date formats' do
@@ -63,9 +63,9 @@ module Amr
 
       amr_data = AnalyticsUnvalidatedAmrDataFactory.new(heat_meters: [], electricity_meters: [e_meter]).build
 
-      expect(amr_data[:electricity_meters].last[:readings].last[:kwh_data_x48][0]).to be 1.23
-      expect(amr_data[:electricity_meters].last[:readings].last[:kwh_data_x48][1]).to be 0.0
-      expect(amr_data[:electricity_meters].last[:readings].last[:kwh_data_x48][47]).to be 0.0
+      expect(amr_data[:electricity_meters].last[:readings].last.kwh_data_x48[0]).to be 1.23
+      expect(amr_data[:electricity_meters].last[:readings].last.kwh_data_x48[1]).to be 0.0
+      expect(amr_data[:electricity_meters].last[:readings].last.kwh_data_x48[47]).to be 0.0
     end
 
     context 'with custom_tariffs' do

--- a/spec/services/amr/analytics_validated_amr_data_factory_spec.rb
+++ b/spec/services/amr/analytics_validated_amr_data_factory_spec.rb
@@ -19,14 +19,14 @@ module Amr
 
       expect(first_electricity_meter[:identifier]).to eq e_meter.mpan_mprn
       expect(first_electricity_meter[:readings].size).to eq 2
-      expect(first_electricity_meter[:readings].first[:reading_date]).to eq e_meter.amr_validated_readings.first.reading_date
-      expect(first_electricity_meter[:readings].first[:kwh_data_x48]).to eq e_meter.amr_validated_readings.first.kwh_data_x48.map(&:to_f)
+      expect(first_electricity_meter[:readings].first.date).to eq e_meter.amr_validated_readings.first.reading_date
+      expect(first_electricity_meter[:readings].first.kwh_data_x48).to eq e_meter.amr_validated_readings.first.kwh_data_x48.map(&:to_f)
 
       first_gas_meter = amr_data[:heat_meters].first
 
       expect(first_gas_meter[:identifier]).to eq g_meter.mpan_mprn
-      expect(first_gas_meter[:readings].first[:reading_date]).to eq g_meter.amr_validated_readings.first.reading_date
-      expect(first_gas_meter[:readings].first[:kwh_data_x48]).to eq g_meter.amr_validated_readings.first.kwh_data_x48.map(&:to_f)
+      expect(first_gas_meter[:readings].first.date).to eq g_meter.amr_validated_readings.first.reading_date
+      expect(first_gas_meter[:readings].first.kwh_data_x48).to eq g_meter.amr_validated_readings.first.kwh_data_x48.map(&:to_f)
     end
   end
 end


### PR DESCRIPTION
Currently when we load the unvalidated and validated readings from the database we build a hash for each reading, for each meter.

This is passed to a second factory in the analytics (`MeterCollectionFactory`) which then turns the hash of meter data into `Dashboard::Meter` and `AMRData` objects populated with `OneDayAMRReading` values.

This PR alters this so that the application just creates the `OneDayAMRReading` objects as it reads data from the dashboard. This saves on creating potentially thousands of Hash objects which are just immediately thrown away. So should be more memory efficient.

There's no other benefits to the indirection as elsewhere we just create the analytics objects directly. Having clearer dependencies also helps understand how and where data is created. Suspect this code is a hold-over from earlier version of the application.