### PR TITLE
Remove use of bootstrap-email for admin mailers

### DIFF
--- a/app/mailers/admin_mailer.rb
+++ b/app/mailers/admin_mailer.rb
@@ -1,5 +1,6 @@
 class AdminMailer < ApplicationMailer
   helper :application, :issues
+  layout 'admin_mailer'
 
   def school_data_source_report
     to, data_source_id = params.values_at(:to, :data_source_id)
@@ -7,7 +8,7 @@ class AdminMailer < ApplicationMailer
     title = "#{t('common.application')}-#{@data_source.name}-meters-#{Time.zone.now.iso8601}".parameterize
     attachments[(title + '.csv')] = { mime_type: 'text/csv', content: @data_source.to_csv }
 
-    make_bootstrap_mail(to: to, subject: subject(title))
+    mail(to: to, subject: subject(title))
   end
 
   def school_procurement_route_report
@@ -16,7 +17,7 @@ class AdminMailer < ApplicationMailer
     title = "#{t('common.application')}-#{@procurement_route.organisation_name}-meters-#{Time.zone.now.iso8601}".parameterize
     attachments[(title + '.csv')] = { mime_type: 'text/csv', content: @procurement_route.to_csv }
 
-    make_bootstrap_mail(to: to, subject: subject(title))
+    mail(to: to, subject: subject(title))
   end
 
   def school_group_meters_report
@@ -29,7 +30,7 @@ class AdminMailer < ApplicationMailer
     title += @all_meters ? " - all meters" : " - active meters"
     attachments[meter_report.csv_filename] = { mime_type: 'text/csv', content: meter_report.csv }
 
-    make_bootstrap_mail(to: to, subject: subject(title))
+    mail(to: to, subject: subject(title))
   end
 
   def issues_report
@@ -39,7 +40,7 @@ class AdminMailer < ApplicationMailer
 
     if @issues.any?
       attachments['issues_report.csv'] = { mime_type: 'text/csv', content: build_issues_csv_for(@issues) }
-      make_bootstrap_mail(to: @user.email, subject: subject(title))
+      mail(to: @user.email, subject: subject(title))
     end
   end
 
@@ -47,7 +48,7 @@ class AdminMailer < ApplicationMailer
     to, funder_report = params.values_at(:to, :funder_report)
     title = "Funder allocation report #{Time.zone.today.iso8601}"
     attachments[funder_report.csv_filename] = { mime_type: 'text/csv', content: funder_report.csv }
-    make_bootstrap_mail(to: to, subject: subject(title))
+    mail(to: to, subject: subject(title))
   end
 
   private

--- a/app/mailers/import_mailer.rb
+++ b/app/mailers/import_mailer.rb
@@ -1,5 +1,6 @@
 class ImportMailer < ApplicationMailer
   helper :application, :issues
+  layout 'admin_mailer'
 
   def import_summary
     @meters_running_behind = params[:meters_running_behind]
@@ -9,7 +10,7 @@ class ImportMailer < ApplicationMailer
     environment_identifier = ENV['ENVIRONMENT_IDENTIFIER'] || 'unknown'
     subject = "[energy-sparks-#{environment_identifier}] Energy Sparks #{subject_description}: #{Time.zone.today.strftime('%d/%m/%Y')}"
     attachments[subject + '.csv'] = { mime_type: 'text/csv', content: to_csv }
-    make_bootstrap_mail(to: 'operations@energysparks.uk', subject: subject)
+    mail(to: 'operations@energysparks.uk', subject: subject)
   end
 
   private

--- a/app/views/admin_mailer/issues_report.html.erb
+++ b/app/views/admin_mailer/issues_report.html.erb
@@ -18,7 +18,7 @@
   </thead>
   <tbody>
     <% @issues.each do |issue| %>
-      <tr class="bg-light">
+      <tr>
         <td title="<%= issue.issue_type %>"><%= issue_type_image(issue.issue_type) %></td>
         <td><%= render 'admin/issues/issueable', issueable: issue.try(:issueable), email: true %></td>
         <td>

--- a/app/views/admin_mailer/school_group_meters_report.html.erb
+++ b/app/views/admin_mailer/school_group_meters_report.html.erb
@@ -3,19 +3,8 @@
 <%= render 'shared/school_group_meter_report', email: true, all_meters: @all_meters %>
 
 <h3>Loader Legend</h3>
-<div class="row p-2">
-  <div class="col-2 table-danger"></div>
-  <div class="col-10">No reading for 30 days</div>
-</div>
-<div class="row p-2">
-  <div class="col-2 table-warning"></div>
-  <div class="col-10">No reading for 5 days</div>
-</div>
-<div class="row p-2">
-  <div class="col-2 table-success"></div>
-  <div class="col-10">Recent reading</div>
-</div>
-
-<h2>Downloads</h2>
-<p>You can download the individual meter collections (unvalidated, validated and aggregated) for each school</p>
-<p><%= link_to "Download meter collections", admin_schools_meter_collections_url(anchor: "school-group-#{@school_group.id}") %>
+<ul>
+  <li><span class="table-danger">No reading for 30 days</span></li>
+  <li><span class="table-warning">No reading for 5 days</span></li>
+  <li><span class="table-success">Recent reading</span></li>
+</ul>

--- a/app/views/import_mailer/import_summary.html.erb
+++ b/app/views/import_mailer/import_summary.html.erb
@@ -1,7 +1,7 @@
 <h2>Data issues</h2>
 
-<table class="table mt-3 mb-5">
-  <thead class="thead-light">
+<table class="table">
+  <thead>
     <tr>
       <th>Area</th>
       <th>Meter type</th>
@@ -17,24 +17,24 @@
     </tr>
   </thead>
   <% if @meters_running_behind.any? %>
-    <thead class="thead-light">
-      <tr>
+    <thead>
+      <tr align="left">
         <th colspan="8">Meters with stale data</th>
       </tr>
     <thead>
     <%= render 'meter_table', meters: @meters_running_behind %>
   <% end %>
   <% if @meters_with_blank_data.any? %>
-    <thead class="thead-light">
-      <tr>
+    <thead>
+      <tr align="left">
         <th colspan="8">Meters with blank readings (whole day)</th>
       </tr>
     <thead>
     <%= render 'meter_table', meters: @meters_with_blank_data %>
   <% end %>
   <% if @meters_with_zero_data.any? %>
-    <thead class="thead-light">
-      <tr>
+    <thead>
+      <tr align="left">
         <th colspan="8">Zero data imports (whole day)</th>
       </tr>
     <thead>

--- a/app/views/layouts/admin_mailer.html.erb
+++ b/app/views/layouts/admin_mailer.html.erb
@@ -1,0 +1,114 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html>
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <style>
+      .table-primary { background-color: #b8daff; }
+      .table-secondary { background-color: #d6d8db; }
+      .table-light { background-color: #fdfdfe; }
+      .table-dark { background-color: #32383e; }
+      .table-success { background-color: #c3e6cb; }
+      .table-warning { background-color: #ffeeba; }
+      .table-danger { background-color: #f5c6cb; }
+      .table-info { background-color: #bee5eb; }
+
+      .bg-light { background-color: #f7fafc; }
+      .bg-primary { background-color: #0d6efd; }
+      .bg-secondary { background-color: #718096; }
+      .bg-success { background-color: #198754; }
+      .bg-danger { background-color: #dc3545; }
+      .bg-warning { background-color: #ffc107; }
+      .bg-black { background-color: #000000; }
+
+      .bg-dark-blue { background-color: #232b49; }
+      .new-yellow { color: #FCB43A; }
+
+      .text-white { color: #ffffff; }
+      .text-dark { color: #343a40; }
+      .text-decoration-none { text-decoration: none; }
+      .font-weight-normal { font-weight: normal; }
+      .no-wrap { white-space: nowrap; }
+      .rounded { border-radius: 4px; }
+      .rounded-full { border-radius: 9999px; }
+
+      .badge {
+        display: inline-block;
+        padding: 4px 6.4px;
+        font-size: 75%;
+        font-weight: 700;
+        line-height: 1;
+        text-align: center;
+        white-space: nowrap;
+        vertical-align: baseline;
+        border-radius: 4px;
+      }
+
+      body {
+        font-family: 'Quicksand', sans-serif;
+        font-weight: 500;
+        font-size: 21.6px;
+        margin-top: 18px;
+        overflow-x: hidden;
+      }
+
+      .table {
+        border-width: 0
+        box-sizing: border-box;
+        -moz-box-sizing: border-box;
+        -webkit-box-sizing: border-box;
+        color: #000000;
+        font-family: Helvetica, Arial, sans-serif;
+        font-weight: normal;
+        font-size: 16px;
+        -webkit-text-size-adjust: 100%;
+        -ms-text-size-adjust: 100%;
+        height: 100%;
+        line-height: 24px;
+        margin: 0;
+        min-width: 100%;
+        outline: 0;
+        padding: 0;
+        width: 100%;
+        border-spacing: 0px;
+        border-collapse: separate;
+      }
+      thead tr {
+        text-align: left;
+      }
+
+      tr:nth-child(even) {
+        background-color: #f2f2f2;
+      }
+
+      th {
+        line-height: 24px;
+        font-size: 16px;
+        border-bottom-width: 2px;
+        border-bottom-color: #e2e8f0;
+        border-bottom-style: solid;
+        border-top-width: 1px;
+        border-top-color: #e2e8f0;
+        border-top-style: solid;
+        margin: 0;
+        padding: 12px;
+      }
+      td {
+        line-height: 24px;
+        font-size: 16px;
+        border-top-width: 1px;
+        border-top-color: #e2e8f0;
+        border-top-style: solid;
+        margin: 0;
+        padding: 12px;
+      }
+      a {
+        text-decoration: none;
+      }
+    </style>
+  </head>
+  <body>
+    <div>
+      <%= yield %>
+    </div>
+  </body>
+</html>

--- a/app/views/shared/_school_group_meter_report.html.erb
+++ b/app/views/shared/_school_group_meter_report.html.erb
@@ -1,5 +1,5 @@
 <div class="row">
-  <table class="table table-striped">
+  <table class="table">
     <thead>
       <tr>
         <th>School</th>
@@ -61,4 +61,3 @@
     </tbody>
   </table>
 </div>
-

--- a/spec/mailers/previews/admin_mailer_preview.rb
+++ b/spec/mailers/previews/admin_mailer_preview.rb
@@ -1,0 +1,5 @@
+class AdminMailerPreview < ActionMailer::Preview
+  def issues_report
+    AdminMailer.with(email_address: 'test@blah.com', user: User.admin.last).issues_report
+  end
+end


### PR DESCRIPTION
This PR removes the use of `bootstrap-email` for the admin mailers.

Internally `bootstrap-email` delegates to `premailer` which seems to be the standard Rails gem for inlining CSS into HTML emails. Premailer has some optimisations to work around performance issues for large emails. This poor performance is particularly bad for emails with tables and manifests itself as very high CPU usage

Bootstrap uses a lot of CSS selectors that cannot be optimised by Premailer. This results in very slow performance. That performance is actually due to nokogiri/libxml2 being slow at searching larger DOMs. 

So there doesn't seem to be another workaround for our high CPU issues other than removing bootstrap-email.

This PR:

* Adds a new custom layout for the `AdminMailer` and `ImportMailer`
* Removes references to the `application_mailer.css` file from that layout and inlines a number of CSS styles from bootstrap. This includes some basic styling for tables and some utility classes.
* The mailers have then been updated to just call `mail` rather than `make_bootstrap_mail`

I've chosen to inline the CSS classes for now as it avoids adding SCSS compilation to the email generation. It at least keeps the styles where they are used.

The admin mails that are affected don't look too bad in the new styles. The most obvious change is removal of the header and footer which wasn't necessary for an internal email. We can always improve styling in later PRs.

As a side effect of this change, the specs that test these mailers will likely run faster!