### PR TITLE
Attempt to regenerate following validation failure

### DIFF
--- a/spec/services/schools/school_regeneration_service_spec.rb
+++ b/spec/services/schools/school_regeneration_service_spec.rb
@@ -17,14 +17,31 @@ describe Schools::SchoolRegenerationService, type: :service do
   end
 
   context '#perform' do
-    before do
-      expect_any_instance_of(Amr::ValidateAndPersistReadingsService).to receive(:perform).and_return(meter_collection)
-      expect_any_instance_of(AggregateDataService).to receive(:aggregate_heat_and_electricity_meters)
-      expect_any_instance_of(AggregateSchoolService).to receive(:cache)
-      expect_any_instance_of(Schools::SchoolMetricsGeneratorService).to receive(:perform)
+
+    context 'when there are no errors' do
+      it 'calls validate, update cache and regenerate metrics ' do
+        expect_any_instance_of(Amr::ValidateAndPersistReadingsService).to receive(:perform).and_return(meter_collection)
+        expect_any_instance_of(Amr::AnalyticsMeterCollectionFactory).to_not receive(:validated)
+        expect_any_instance_of(AggregateDataService).to receive(:aggregate_heat_and_electricity_meters)
+        expect_any_instance_of(AggregateSchoolService).to receive(:cache)
+        expect_any_instance_of(Schools::SchoolMetricsGeneratorService).to receive(:perform)
+
+        service.perform
+      end
     end
-    it 'calls validate, update cache and regenerate metrics ' do
-      service.perform
+
+    context 'when validation fails' do
+      before do
+        allow_any_instance_of(Amr::ValidateAndPersistReadingsService).to receive(:perform).and_raise
+      end
+
+      it 'continues with the other steps' do
+        expect_any_instance_of(Amr::AnalyticsMeterCollectionFactory).to receive(:validated).and_return(meter_collection)
+        expect_any_instance_of(AggregateDataService).to receive(:aggregate_heat_and_electricity_meters)
+        expect_any_instance_of(AggregateSchoolService).to receive(:cache)
+        expect_any_instance_of(Schools::SchoolMetricsGeneratorService).to receive(:perform)
+        service.perform
+      end
     end
   end
 end


### PR DESCRIPTION
Testing the updated school regeneration workflow highlighted that if the validation stage failed, then we end up with further downstream failures.

The previous workflow would have raised an error but would have continued to regenerate the school using the existing validated readings (if any).

This PR adds a fallback step if an exception is thrown by the validation process. In that case we build a new meter collection, using the existing validated data in the database, and then continue processing. 

This ensures that the school is properly regenerated any will see warnings about out of date data, etc. The 

