### PR TITLE
Add premailer-rails

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -114,7 +114,7 @@ gem 'delegated_type'
 gem 'roo'
 gem 'roo-xls'
 
-# Used to handle CSS style processing for
+# Used to handle mail processing for the admin mailer
 gem 'premailer-rails'
 
 group :development, :test do

--- a/Gemfile
+++ b/Gemfile
@@ -114,6 +114,9 @@ gem 'delegated_type'
 gem 'roo'
 gem 'roo-xls'
 
+# Used to handle CSS style processing for
+gem 'premailer-rails'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platform: :mri

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -395,6 +395,10 @@ GEM
     multipart-post (2.0.0)
     mustache (1.1.1)
     nenv (0.3.0)
+    net-protocol (0.2.1)
+      timeout
+    net-smtp (0.4.0)
+      net-protocol
     netrc (0.11.0)
     nio4r (2.5.8)
     nokogiri (1.15.4)
@@ -434,6 +438,10 @@ GEM
       addressable
       css_parser (>= 1.6.0)
       htmlentities (>= 4.0.0)
+    premailer-rails (1.12.0)
+      actionmailer (>= 3)
+      net-smtp
+      premailer (~> 1.7, >= 1.7.9)
     pry (0.14.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -652,6 +660,7 @@ GEM
     thread_safe (0.3.6)
     tilt (2.0.10)
     timecop (0.9.5)
+    timeout (0.4.0)
     trix-rails (2.3.0)
       rails (> 4.1, < 7.0)
     twilio-ruby (6.6.0)
@@ -760,6 +769,7 @@ DEPENDENCIES
   pagy
   pg
   pg_search
+  premailer-rails
   pry
   pry-byebug (~> 3.10.1)
   puma (= 6.4.0)

--- a/app/helpers/premailer_override_helper.rb
+++ b/app/helpers/premailer_override_helper.rb
@@ -1,0 +1,20 @@
+module PremailerOverrideHelper
+  #We use bootstrap-email to process all outgoing email to users. But, due to
+  #a performance issue, we don't use it for some admin mailers.
+  #
+  #For the admin mailers we rely on premailer and the premailer-rails gem.
+  #By default premailer-rails will process all email using premailer.
+  #
+  #But we dont want that behaviour for emails that will be processed using
+  #bootstrap-email. So we have to explicitly disable the premailer integration
+  #here when calling make_bootstrap_mail.
+  #
+  #The bootstrap-email code still ends up calling premailer, but in a different
+  #way after doing some pre- and post- processing of the generated email.
+  #
+  #Overidding the method here avoids having to add this argument to all non-admin
+  #mailers. It also ensures that our localised emails work correctly.
+  def make_bootstrap_mail(**kwargs, &block)
+    super(kwargs.merge({ skip_premailer: true }), &block)
+  end
+end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,5 +1,6 @@
 class ApplicationMailer < ActionMailer::Base
   include DefaultUrlOptionsHelper
+  include PremailerOverrideHelper
 
   default from: 'Energy Sparks <hello@energysparks.uk>'
   layout 'mailer'
@@ -12,24 +13,5 @@ class ApplicationMailer < ActionMailer::Base
 
   def user_emails(users)
     users.map(&:email)
-  end
-
-  #We use bootstrap-email to process all outgoing email to users. But, due to
-  #a performance issue, we don't use it for some admin mailers.
-  #
-  #For the admin mailers we rely on premailer and the premailer-rails gem.
-  #By default premailer-rails will process all email using premailer.
-  #
-  #But we dont want that behaviour for emails that will be processed using
-  #bootstrap-email. So we have to explicitly disable the premailer integration
-  #here when calling make_bootstrap_mail.
-  #
-  #The bootstrap-email code still ends up calling premailer, but in a different
-  #way after doing some pre- and post- processing of the generated email.
-  #
-  #Overidding the method here avoids having to add this argument to all non-admin
-  #mailers. It also ensures that our localised emails work correctly.
-  def make_bootstrap_mail(**kwargs)
-    super(kwargs.merge({ skip_premailer: true }))
   end
 end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -13,4 +13,23 @@ class ApplicationMailer < ActionMailer::Base
   def user_emails(users)
     users.map(&:email)
   end
+
+  #We use bootstrap-email to process all outgoing email to users. But, due to
+  #a performance issue, we don't use it for some admin mailers.
+  #
+  #For the admin mailers we rely on premailer and the premailer-rails gem.
+  #By default premailer-rails will process all email using premailer.
+  #
+  #But we dont want that behaviour for emails that will be processed using
+  #bootstrap-email. So we have to explicitly disable the premailer integration
+  #here when calling make_bootstrap_mail.
+  #
+  #The bootstrap-email code still ends up calling premailer, but in a different
+  #way after doing some pre- and post- processing of the generated email.
+  #
+  #Overidding the method here avoids having to add this argument to all non-admin
+  #mailers. It also ensures that our localised emails work correctly.
+  def make_bootstrap_mail(**kwargs)
+    super(kwargs.merge({ skip_premailer: true }))
+  end
 end

--- a/app/mailers/energy_sparks_devise_mailer.rb
+++ b/app/mailers/energy_sparks_devise_mailer.rb
@@ -3,6 +3,7 @@ class EnergySparksDeviseMailer < Devise::Mailer
   include Devise::Controllers::UrlHelpers
   include DefaultUrlOptionsHelper
   include LocaleMailerHelper
+  include PremailerOverrideHelper
 
   default template_path: 'devise/mailer'
 

--- a/config/initializers/premailer.rb
+++ b/config/initializers/premailer.rb
@@ -1,0 +1,2 @@
+#Ensure premailer uses the optimised adapter
+Premailer::Adapter.use = :nokogiri_fast


### PR DESCRIPTION
A follow-up to https://github.com/Energy-Sparks/energy-sparks/pull/3133.

While the previous PR appeared to work fine, with emails showing up as styled in mailcatcher and rails previews, this is because the browser was rendering the styles. They weren't actually being inlined into the emails.

To make this work correctly we also need to add `premailer-rails`. This automatically processes ALL outgoing emails using premailer. This helps fix styling on the admin emails but interferes with the bootstrap-email gem, so as part of customising we force the premailer processing to be disabled there.