### PR TITLE
Add net-http gem

### DIFF
--- a/.github/workflows/rubyonrails.yml
+++ b/.github/workflows/rubyonrails.yml
@@ -36,13 +36,13 @@ jobs:
         run: bin/rails db:schema:load
       # Precompile assets
       - name: Precompile assets
-        run: bundle exec rake assets:precompile
+        run: bundle exec bin/rake assets:precompile
       # Fail early if we have issues with translation keys
       - name: Run i18n-tasks
         run: bundle exec i18n-tasks health
       # Add or replace test runners here
       - name: Run tests
-        run: bundle exec rspec --exclude-pattern "spec/system/**/*_spec.rb"
+        run: bundle exec bin/rspec --exclude-pattern "spec/system/**/*_spec.rb"
   test-system:
     runs-on: ubuntu-latest
     services:

--- a/Gemfile
+++ b/Gemfile
@@ -116,7 +116,9 @@ gem 'roo-xls'
 
 # Used to handle mail processing for the admin mailer
 gem 'premailer-rails'
+
 gem 'net-http'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platform: :mri

--- a/Gemfile
+++ b/Gemfile
@@ -116,7 +116,7 @@ gem 'roo-xls'
 
 # Used to handle mail processing for the admin mailer
 gem 'premailer-rails'
-
+gem 'net-http'
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platform: :mri

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -395,6 +395,8 @@ GEM
     multipart-post (2.0.0)
     mustache (1.1.1)
     nenv (0.3.0)
+    net-http (0.3.2)
+      uri
     net-protocol (0.2.1)
       timeout
     net-smtp (0.4.0)
@@ -676,6 +678,7 @@ GEM
     unf_ext (0.0.8)
     unicode-display_width (1.8.0)
     uniform_notifier (1.14.2)
+    uri (0.12.2)
     view_component (3.6.0)
       activesupport (>= 5.2.0, < 8.0)
       concurrent-ruby (~> 1.0)
@@ -764,6 +767,7 @@ DEPENDENCIES
   mobility-actiontext (~> 1.1.1)
   momentjs-rails
   mustache (~> 1.0)
+  net-http
   oj
   overcommit
   pagy


### PR DESCRIPTION
Since adding `premailer-rails` I've been getting these warnings from rails, rails console, rspec, etc:

```
/usr/share/rvm/rubies/ruby-2.7.6/lib/ruby/2.7.0/net/protocol.rb:66: warning: already initialized constant Net::ProtocRetryError
/home/ldodds/.rvm/gems/ruby-2.7.6/gems/net-protocol-0.2.1/lib/net/protocol.rb:68: warning: previous definition of ProtocRetryError was here
/usr/share/rvm/rubies/ruby-2.7.6/lib/ruby/2.7.0/net/protocol.rb:206: warning: already initialized constant Net::BufferedIO::BUFSIZE
/home/ldodds/.rvm/gems/ruby-2.7.6/gems/net-protocol-0.2.1/lib/net/protocol.rb:214: warning: previous definition of BUFSIZE was here
/usr/share/rvm/rubies/ruby-2.7.6/lib/ruby/2.7.0/net/protocol.rb:503: warning: already initialized constant Net::NetPrivate::Socket
/home/ldodds/.rvm/gems/ruby-2.7.6/gems/net-protocol-0.2.1/lib/net/protocol.rb:541: warning: previous definition of Socket was here
```

There are [various](https://github.com/ruby/net-imap/issues/16) [suggestions](https://stackoverflow.com/questions/67773514/getting-warning-already-initialized-constant-on-assets-precompile-at-the-time) that adding net-http gem will fix this. Problem appears due to some dependency issues.

PR explicitly adds net-http gem to our Gemfile. 