### PR TITLE
Tweak admin good jobs report

### DIFF
--- a/app/controllers/admin/reports/good_jobs_controller.rb
+++ b/app/controllers/admin/reports/good_jobs_controller.rb
@@ -10,7 +10,6 @@ module Admin
 
       def export
         @jobs = find_jobs_per_queue_and_job_class
-
         respond_to do |format|
           format.csv do
             response.headers['Content-Type'] = 'text/csv'
@@ -30,6 +29,7 @@ module Admin
           serialized_params->>'arguments' as school_id,
           performed_at,
           finished_at,
+          date_trunc('day', performed_at) as run_date,
           extract(EPOCH from (finished_at - performed_at)) as time_to_completion_in_seconds
           from good_jobs
         SQL
@@ -47,6 +47,7 @@ module Admin
             serialized_params->>'job_id' as job_id,
             (finished_at - performed_at) as time_to_completion
             from good_jobs
+            where performed_at > (current_date - interval '2 days')
             group by queue_name, serialized_params->>'job_class', serialized_params->>'job_id', (finished_at - performed_at)
             order by (finished_at - performed_at) desc
           ) jobs

--- a/app/views/admin/reports/good_jobs/export.csv.erb
+++ b/app/views/admin/reports/good_jobs/export.csv.erb
@@ -1,12 +1,13 @@
-<%- headers = ['queue_name', 'job_class', 'job_id', 'school_id', 'performed_at', 'finished_at', 'time_to_completion_in_seconds'] -%>
+<%- headers = ['queue_name', 'job_class', 'run_date', 'school_id', 'job_id', 'performed_at', 'finished_at', 'time_to_completion_in_seconds'] -%>
 <%= CSV.generate_line headers %>
 <%- @jobs.each do |job| -%>
 <%= CSV.generate_line(
   [
     job['queue_name'],
     job['job_class'],
-    job['job_id'],
+    job['run_date'].strftime('%Y-%m-%d'),
     job['school_id']&.match(/(?<=energy-sparks\/School\/)(.*)(?="})/)&.to_s, # Extract school id from argument
+    job['job_id'],
     job['performed_at'],
     job['finished_at'],
     job['time_to_completion_in_seconds']

--- a/app/views/admin/reports/good_jobs/index.html.erb
+++ b/app/views/admin/reports/good_jobs/index.html.erb
@@ -33,7 +33,7 @@
   </table>
 </div>
 <div class='pt-4'>
-  <h3>Slowest jobs in the last 24 hours per queue and job class</h3>
+  <h3>Slowest jobs in the last 48 hours per queue and job class</h3>
   <table class="table">
     <thead>
       <tr>


### PR DESCRIPTION
Reviewing the job times I noticed there was a small bug on the admin report. It should be showing the slowest jobs in last 24 hours, but is actually showing slowest jobs in the database (which is up to 30 days).

This PR tweaks the query to limit to the last 48 hours instead.

Also modify the CSV download to adjust the columns and add a date. Makes it easier to work with in a spreadsheet.