### PR TITLE
Add prompt to complete programme

### DIFF
--- a/app/services/programmes/progress.rb
+++ b/app/services/programmes/progress.rb
@@ -19,6 +19,7 @@ module Programmes
         activity_types_count: activity_types_count,
         activity_types_uncompleted_count: activity_types_uncompleted_count,
         activity_types_total_scores: activity_types_total_scores,
+        activity_types_uncompleted_scores: activity_types_uncompleted_scores,
         programme_points_for_completion: programme_points_for_completion
       ).html_safe
     end
@@ -45,6 +46,14 @@ module Programmes
 
     def activity_types_completed
       programme.activity_types_completed
+    end
+
+    def activity_types_completed_scores
+      programme.activity_types_completed.sum(&:score)
+    end
+
+    def activity_types_uncompleted_scores
+      activity_types_total_scores - activity_types_completed_scores
     end
 
     def activity_types_uncompleted_count

--- a/app/services/programmes/progress.rb
+++ b/app/services/programmes/progress.rb
@@ -17,7 +17,7 @@ module Programmes
         programme_type_title: programme_type_title,
         programme_activities_count: programme_activities_count,
         activity_types_count: activity_types_count,
-        activity_types_uncompleted_count: activity_types_uncompleted_count,
+        count: activity_types_uncompleted_count,
         activity_types_total_scores: activity_types_total_scores,
         activity_types_uncompleted_scores: activity_types_uncompleted_scores,
         programme_points_for_completion: programme_points_for_completion

--- a/app/services/programmes/progress.rb
+++ b/app/services/programmes/progress.rb
@@ -13,21 +13,22 @@ module Programmes
     delegate :count, to: :activity_types_completed, prefix: :activity_types_completed
 
     def notification_text
-      I18n.t('schools.programme.progress.notification',
+      I18n.t('schools.programme.progress.notification_html',
         programme_type_title: programme_type_title,
         programme_activities_count: programme_activities_count,
         activity_types_count: activity_types_count,
         activity_types_uncompleted_count: activity_types_uncompleted_count,
-        total_points: total_points
-      )
-    end
-
-    def total_points
-      activity_types.sum(:score) + programme.points_for_completion
+        activity_types_total_scores: activity_types_total_scores,
+        programme_points_for_completion: programme_points_for_completion
+      ).html_safe
     end
 
     def activity_types_total_scores
       activity_types.sum(:score)
+    end
+
+    def programme_points_for_completion
+      programme.points_for_completion
     end
 
     def programme_type_title

--- a/app/views/schools/_prompt_to_complete_program.html.erb
+++ b/app/views/schools/_prompt_to_complete_program.html.erb
@@ -1,5 +1,5 @@
-<% if @programmes_to_prompt.present? %>
-  <% @programmes_to_prompt.each do |programme| %>
+<% if local_assigns[:programmes_to_prompt].try(:any?) %>
+  <% programmes_to_prompt.each do |programme| %>
     <%= component 'info_bar',
         status: :neutral,
         title: Programmes::Progress.new(programme).notification_text,

--- a/app/views/schools/recommendations/index.html.erb
+++ b/app/views/schools/recommendations/index.html.erb
@@ -4,6 +4,8 @@
 
 <p>Scope: <%= @scope %></p>
 
+<%= render('schools/prompt_to_complete_program', programmes_to_prompt: @school.programmes.started.order(started_on: :desc)) %>
+
 <%= component 'recommendations', title: t("schools.recommendations.more_ideas.title"), description: t("schools.recommendations.more_ideas.description"), classes: 'pb-4', id: 'more-ideas', max_lg: 4 do |c| %>
   <% c.with_item(name: t("schools.recommendations.more_ideas.programme"), href: programme_types_path, image: 'recommendations/get-energised.png') %>
   <% c.with_item(name: t("schools.recommendations.more_ideas.activities", count: ActivityType.count), href: activity_categories_path, image: 'recommendations/opt-in.png') %>

--- a/config/locales/views/schools/schools.yml
+++ b/config/locales/views/schools/schools.yml
@@ -339,7 +339,7 @@ en:
     programme:
       progress:
         choose_a_new_programme_message: It's time to choose a new programme of activities. What challenge will you take on next?
-        notification_html: You have completed <strong>%{programme_activities_count}/%{activity_types_count}</strong> of the activities in the <strong>%{programme_type_title}</strong> programme. Complete the final <strong>%{activity_types_uncompleted_count}</strong> activities now to score <span class="badge badge-success">%{activity_types_total_scores}</span> points and <span class="badge badge-success">%{programme_points_for_completion}</span> bonus points
+        notification_html: You have completed <strong>%{programme_activities_count}/%{activity_types_count}</strong> of the activities in the <strong>%{programme_type_title}</strong> programme. Complete the final <strong>%{activity_types_uncompleted_count}</strong> activities now to score <span class="badge badge-success">%{activity_types_uncompleted_scores}</span> points and <span class="badge badge-success">%{programme_points_for_completion}</span> bonus points for completing the programme
         start_a_new_programme: Start a new programme
         view_now: View now
     pupils:

--- a/config/locales/views/schools/schools.yml
+++ b/config/locales/views/schools/schools.yml
@@ -339,7 +339,9 @@ en:
     programme:
       progress:
         choose_a_new_programme_message: It's time to choose a new programme of activities. What challenge will you take on next?
-        notification_html: You have completed <strong>%{programme_activities_count}/%{activity_types_count}</strong> of the activities in the <strong>%{programme_type_title}</strong> programme. Complete the final <strong>%{activity_types_uncompleted_count}</strong> activities now to score <span class="badge badge-success">%{activity_types_uncompleted_scores}</span> points and <span class="badge badge-success">%{programme_points_for_completion}</span> bonus points for completing the programme
+        notification_html:
+          one: You have completed <strong>%{programme_activities_count}/%{activity_types_count}</strong> of the activities in the <strong>%{programme_type_title}</strong> programme. Complete the final activity now to score <span class="badge badge-success">%{activity_types_uncompleted_scores}</span> points and <span class="badge badge-success">%{programme_points_for_completion}</span> bonus points for completing the programme
+          other: You have completed <strong>%{programme_activities_count}/%{activity_types_count}</strong> of the activities in the <strong>%{programme_type_title}</strong> programme. Complete the final <strong>%{count}</strong> activities now to score <span class="badge badge-success">%{activity_types_uncompleted_scores}</span> points and <span class="badge badge-success">%{programme_points_for_completion}</span> bonus points for completing the programme
         start_a_new_programme: Start a new programme
         view_now: View now
     pupils:

--- a/config/locales/views/schools/schools.yml
+++ b/config/locales/views/schools/schools.yml
@@ -339,7 +339,7 @@ en:
     programme:
       progress:
         choose_a_new_programme_message: It's time to choose a new programme of activities. What challenge will you take on next?
-        notification: You have completed %{programme_activities_count}/%{activity_types_count} of the activities in the %{programme_type_title} programme. Complete the final %{activity_types_uncompleted_count} activities now to score %{total_points} points
+        notification_html: You have completed <strong>%{programme_activities_count}/%{activity_types_count}</strong> of the activities in the <strong>%{programme_type_title}</strong> programme. Complete the final <strong>%{activity_types_uncompleted_count}</strong> activities now to score <span class="badge badge-success">%{activity_types_total_scores}</span> points and <span class="badge badge-success">%{programme_points_for_completion}</span> bonus points
         start_a_new_programme: Start a new programme
         view_now: View now
     pupils:

--- a/spec/services/programmes/progress_spec.rb
+++ b/spec/services/programmes/progress_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe Programmes::Progress do
   let(:school) { create(:school) }
   let(:programme_type) { create(:programme_type_with_activity_types, bonus_score: 12) }
-  let(:programme) { Programme.create!(programme_type: programme_type, started_on: '2020-01-01', school: school) }
+  let(:programme) { create(:programme, programme_type: programme_type, started_on: '2020-01-01', school: school) }
 
   let(:service) { Programmes::Progress.new(programme) }
 

--- a/spec/services/programmes/progress_spec.rb
+++ b/spec/services/programmes/progress_spec.rb
@@ -1,92 +1,104 @@
 require 'rails_helper'
 
 describe Programmes::Progress do
-  let(:school) { create(:school) }
-  let(:programme_type) { create(:programme_type_with_activity_types, bonus_score: 12) }
-  let(:programme) { create(:programme, programme_type: programme_type, started_on: '2020-01-01', school: school) }
+  let!(:school) { create(:school) }
+  let!(:activity_types) { create_list(:activity_type, 3, score: 25) }
+  let!(:programme_type) { create(:programme_type, activity_types: activity_types, bonus_score: 12) }
+  let!(:programme) { create(:programme, programme_type: programme_type, started_on: '2020-01-01', school: school) }
 
   let(:service) { Programmes::Progress.new(programme) }
 
-  describe '#notification_text' do
-    context 'when the programme is completed within the same academic year as started' do
+  context "no activities completed yet" do
+    describe '#notification_text' do
       it 'returns the full notification text used on the school dashboard' do
         allow_any_instance_of(School).to receive(:academic_year_for) { OpenStruct.new(current?: true) }
-        expect(service.notification_text).to eq("You have completed <strong>0/3</strong> of the activities in the <strong>#{programme_type.title}</strong> programme. Complete the final <strong>3</strong> activities now to score <span class=\"badge badge-success\">75</span> points and <span class=\"badge badge-success\">12</span> bonus points")
+        expect(service.notification_text).to eq("You have completed <strong>0/3</strong> of the activities in the <strong>#{programme_type.title}</strong> programme. Complete the final <strong>3</strong> activities now to score <span class=\"badge badge-success\">75</span> points and <span class=\"badge badge-success\">12</span> bonus points for completing the programme")
+      end
+    end
+  end
+
+  context "a programme activity has been completed" do
+    let(:activity) { build(:activity, school: school, activity_type: activity_types.first, happened_on: Date.yesterday) }
+
+    before do
+      ActivityCreator.new(activity).process
+    end
+
+    describe '#notification_text' do
+      context 'when the programme is completed within the same academic year as started' do
+        it 'returns the full notification text used on the school dashboard' do
+          allow_any_instance_of(School).to receive(:academic_year_for) { OpenStruct.new(current?: true) }
+          expect(service.notification_text).to eq("You have completed <strong>1/3</strong> of the activities in the <strong>#{programme_type.title}</strong> programme. Complete the final <strong>2</strong> activities now to score <span class=\"badge badge-success\">50</span> points and <span class=\"badge badge-success\">12</span> bonus points for completing the programme")
+        end
+      end
+
+      context 'when the programme is completed outside of the academic year as started' do
+        it 'returns the full notification text used on the school dashboard' do
+          allow_any_instance_of(School).to receive(:academic_year_for) { OpenStruct.new(current?: false) }
+          expect(service.notification_text).to eq("You have completed <strong>1/3</strong> of the activities in the <strong>#{programme_type.title}</strong> programme. Complete the final <strong>2</strong> activities now to score <span class=\"badge badge-success\">50</span> points and <span class=\"badge badge-success\">0</span> bonus points for completing the programme")
+        end
       end
     end
 
-    context 'when the programme is completed outside of the academic year as started' do
-      it 'returns the full notification text used on the school dashboard' do
+    describe "#programme_points_for_completion" do
+      it 'includes bonus points if the programme is completed within the same academic year as started' do
+        allow_any_instance_of(School).to receive(:academic_year_for) { OpenStruct.new(current?: true) }
+        expect(service.programme_points_for_completion).to eq(12)
+      end
+
+      it 'excludes bonus points if the programme is completed outside of the academic year as started' do
         allow_any_instance_of(School).to receive(:academic_year_for) { OpenStruct.new(current?: false) }
-        expect(service.notification_text).to eq("You have completed <strong>0/3</strong> of the activities in the <strong>#{programme_type.title}</strong> programme. Complete the final <strong>3</strong> activities now to score <span class=\"badge badge-success\">75</span> points and <span class=\"badge badge-success\">0</span> bonus points")
+        expect(service.programme_points_for_completion).to eq(0)
       end
     end
-  end
 
-  describe "#programme_points_for_completion" do
-    it 'includes bonus points if the programme is completed within the same academic year as started' do
-      allow_any_instance_of(School).to receive(:academic_year_for) { OpenStruct.new(current?: true) }
-      expect(service.programme_points_for_completion).to eq(12)
+    describe '#activity_types_total_scores' do
+      it 'sums the scores of all activity types associated with the programmes programme type' do
+        expect(service.activity_types_total_scores).to eq(programme.programme_type.activity_types.sum(:score))
+      end
     end
 
-    it 'excludes bonus points if the programme is completed outside of the academic year as started' do
-      allow_any_instance_of(School).to receive(:academic_year_for) { OpenStruct.new(current?: false) }
-      expect(service.programme_points_for_completion).to eq(0)
+    describe '#programme_type_title' do
+      it 'returns the programmes programme_type title' do
+        expect(service.programme_type_title).to eq(programme_type.title)
+      end
     end
-  end
 
-  describe '#activity_types_total_scores' do
-    it 'sums the scores of all activity types associated with the programmes programme type' do
-      expect(service.activity_types_total_scores).to eq(programme.programme_type.activity_types.sum(:score))
+    describe '#programme_activities' do
+      it 'returns the programmes activities' do
+        expect(service.programme_activities).to match_array(programme.activities)
+      end
     end
-  end
 
-  describe '#programme_type_title' do
-    it 'returns the programmes programme_type title' do
-      expect(service.programme_type_title).to eq(programme_type.title)
+    describe '#programme_activities_count' do
+      it 'returns the count of the programmes activities which is the number of activities, of the programme, that the school has completed' do
+        expect(service.programme_activities_count).to eq(1)
+      end
     end
-  end
 
-  describe '#programme_activities' do
-    it 'returns the programmes activities' do
-      expect(service.programme_activities).to match_array(programme.activities)
+    describe '#activity_types' do
+      it 'returns the programmes programme types activity types' do
+        expect(service.activity_types).to match_array(programme.programme_type.activity_types)
+      end
     end
-  end
 
-  describe '#programme_activities_count' do
-    it 'returns the count of the programmes activities which is the number of activities, of the programme, that the school has completed' do
-      expect(service.programme_activities_count).to eq(0)
+    describe '#activity_types_count' do
+      it 'returns the count programmes programme types activity types which is the number of different activity types associated with the programme' do
+        expect(service.activity_types_count).to eq(3)
+      end
     end
-  end
 
-  describe '#activity_types' do
-    it 'returns the programmes programme types activity types' do
-      expect(service.activity_types).to match_array(programme.programme_type.activity_types)
+    describe '#activity_types_completed' do
+      it 'returns all activity types that have been completed for the programme' do
+        expect(service.activity_types_completed).to match_array(programme.activity_types_completed)
+      end
     end
-  end
 
-  describe '#activity_types_count' do
-    it 'returns the count programmes programme types activity types which is the number of different activity types associated with the programme' do
-      expect(service.activity_types_count).to eq(3)
-    end
-  end
-
-  describe '#activity_types_completed' do
-    it 'returns all activity types that have been completed for the programme' do
-      expect(service.activity_types_completed).to match_array(programme.activity_types_completed)
-    end
-  end
-
-  describe '#activity_types_completed_count' do
-    it 'returns the count of all activity types that have been completed for the programme' do
-      expect(service.activity_types_completed).to match_array(programme.activity_types_completed)
-    end
-  end
-
-  describe '#activity_types_uncompleted_count' do
-    it 'returns the difference between the number of activity types for the programme and those completed' do
-      allow_any_instance_of(Programme).to receive(:activity_types_completed) { programme.programme_type.activity_types.limit(1) }
-      expect(service.activity_types_uncompleted_count).to eq(2)
+    describe '#activity_types_uncompleted_count' do
+      it 'returns the difference between the number of activity types for the programme and those completed' do
+        allow_any_instance_of(Programme).to receive(:activity_types_completed) { programme.programme_type.activity_types.limit(1) }
+        expect(service.activity_types_uncompleted_count).to eq(2)
+      end
     end
   end
 end

--- a/spec/services/programmes/progress_spec.rb
+++ b/spec/services/programmes/progress_spec.rb
@@ -11,27 +11,27 @@ describe Programmes::Progress do
     context 'when the programme is completed within the same academic year as started' do
       it 'returns the full notification text used on the school dashboard' do
         allow_any_instance_of(School).to receive(:academic_year_for) { OpenStruct.new(current?: true) }
-        expect(service.notification_text).to eq("You have completed 0/3 of the activities in the #{programme_type.title} programme. Complete the final 3 activities now to score 87 points")
+        expect(service.notification_text).to eq("You have completed <strong>0/3</strong> of the activities in the <strong>#{programme_type.title}</strong> programme. Complete the final <strong>3</strong> activities now to score <span class=\"badge badge-success\">75</span> points and <span class=\"badge badge-success\">12</span> bonus points")
       end
     end
 
     context 'when the programme is completed outside of the academic year as started' do
       it 'returns the full notification text used on the school dashboard' do
         allow_any_instance_of(School).to receive(:academic_year_for) { OpenStruct.new(current?: false) }
-        expect(service.notification_text).to eq("You have completed 0/3 of the activities in the #{programme_type.title} programme. Complete the final 3 activities now to score 75 points")
+        expect(service.notification_text).to eq("You have completed <strong>0/3</strong> of the activities in the <strong>#{programme_type.title}</strong> programme. Complete the final <strong>3</strong> activities now to score <span class=\"badge badge-success\">75</span> points and <span class=\"badge badge-success\">0</span> bonus points")
       end
     end
   end
 
-  describe "#total_points" do
+  describe "#programme_points_for_completion" do
     it 'includes bonus points if the programme is completed within the same academic year as started' do
       allow_any_instance_of(School).to receive(:academic_year_for) { OpenStruct.new(current?: true) }
-      expect(service.total_points).to eq(87)
+      expect(service.programme_points_for_completion).to eq(12)
     end
 
     it 'excludes bonus points if the programme is completed outside of the academic year as started' do
       allow_any_instance_of(School).to receive(:academic_year_for) { OpenStruct.new(current?: false) }
-      expect(service.total_points).to eq(75)
+      expect(service.programme_points_for_completion).to eq(0)
     end
   end
 

--- a/spec/system/schools/recommendations_spec.rb
+++ b/spec/system/schools/recommendations_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 describe 'Recommendations Page', type: :system, include_application_helper: true do
   let!(:school) { create :school, name: "School Name" }
+  let!(:setup_data) {}
 
   before do
     # later we should simulate navigating here
@@ -18,6 +19,15 @@ describe 'Recommendations Page', type: :system, include_application_helper: true
 
   it "has the intro" do
     expect(page).to have_content("Find your next energy saving activity to score points for your school, reduce your energy usage and learn more about energy and climate change")
+  end
+
+  context "with prompts" do
+    let(:programme_type) { create(:programme_type_with_activity_types, bonus_score: 12) }
+    let(:setup_data) { create(:programme, programme_type: programme_type, started_on: Time.zone.today, school: school) }
+
+    it "has prompts to complete programme" do
+      expect(page).to have_content("You have completed 0/3 of the activities in the #{programme_type.title} programme. Complete the final 3 activities now to score 75 points and 12 bonus points")
+    end
   end
 
   context "more ideas section" do

--- a/spec/system/schools/recommendations_spec.rb
+++ b/spec/system/schools/recommendations_spec.rb
@@ -26,7 +26,7 @@ describe 'Recommendations Page', type: :system, include_application_helper: true
     let(:setup_data) { create(:programme, programme_type: programme_type, started_on: Time.zone.today, school: school) }
 
     it "has prompts to complete programme" do
-      expect(page).to have_content("You have completed 0/3 of the activities in the #{programme_type.title} programme. Complete the final 3 activities now to score 75 points and 12 bonus points")
+      expect(page).to have_content("You have completed 0/3 of the activities in the #{programme_type.title} programme. Complete the final 3 activities now to score 75 points and 12 bonus points for completing the programme")
     end
   end
 


### PR DESCRIPTION
Add prompts to complete programmes to recommendations page - now looks like this:
![image](https://github.com/Energy-Sparks/energy-sparks/assets/6051/889bc7b2-99d4-4239-ae63-e32412d2952e)

* Changed points logic to only display points remaining
* Added some styling
* Present singular text for when there is only one activity left