### PR TITLE
Improve data load reports

### DIFF
--- a/app/controllers/admin/reports/amr_data_feed_import_logs_controller.rb
+++ b/app/controllers/admin/reports/amr_data_feed_import_logs_controller.rb
@@ -3,7 +3,7 @@ module Admin
     class AmrDataFeedImportLogsController < AdminController
       include Pagy::Backend
       before_action :set_log_counts
-      SUMMARY_PERIOD_IN_DAYS = 7
+      SUMMARY_PERIOD_IN_DAYS = 30
 
       def warnings
         render_for(:with_warnings)
@@ -31,9 +31,9 @@ module Admin
       end
 
       def set_log_counts
-        @successes_count = AmrDataFeedImportLog.successful.count
-        @warnings_count = AmrDataFeedImportLog.with_warnings.count
-        @errors_count = AmrDataFeedImportLog.errored.count
+        @successes_count = AmrDataFeedImportLog.successful.since(SUMMARY_PERIOD_IN_DAYS.days.ago).count
+        @warnings_count = AmrDataFeedImportLog.with_warnings.since(SUMMARY_PERIOD_IN_DAYS.days.ago).count
+        @errors_count = AmrDataFeedImportLog.errored.since(SUMMARY_PERIOD_IN_DAYS.days.ago).count
       end
     end
   end

--- a/app/controllers/admin/reports/data_loads_controller.rb
+++ b/app/controllers/admin/reports/data_loads_controller.rb
@@ -1,8 +1,10 @@
 module Admin
   module Reports
     class DataLoadsController < AdminController
+      include Pagy::Backend
       def index
-        @data_loads = ManualDataLoadRun.by_date.limit(50)
+        @all_data_loads = ManualDataLoadRun.by_date
+        @pagy, @data_loads = pagy(@all_data_loads, items: 20)
       end
     end
   end

--- a/app/models/amr_data_feed_import_log.rb
+++ b/app/models/amr_data_feed_import_log.rb
@@ -27,4 +27,5 @@ class AmrDataFeedImportLog < ApplicationRecord
   scope :errored,       -> { where.not(error_messages: nil) }
   scope :successful,    -> { where(error_messages: nil) }
   scope :with_warnings, -> { includes(:amr_reading_warnings).where.not(amr_reading_warnings: { id: nil }) }
+  scope :since,         ->(date) { where('import_time >= ?', date) }
 end

--- a/app/views/admin/reports/amr_data_feed_import_logs/index.html.erb
+++ b/app/views/admin/reports/amr_data_feed_import_logs/index.html.erb
@@ -3,7 +3,7 @@
 
 <h4>Summary of the last <%= Admin::Reports::AmrDataFeedImportLogsController::SUMMARY_PERIOD_IN_DAYS %> days</h4>
 
-<table class="table table-bordered text-center">
+<table class="table table-bordered text-center" id="import-summary-table">
   <thead>
     <tr>
       <th colspan=2></th>
@@ -25,8 +25,8 @@
   </thead>
   <tbody>
   <% @amr_data_feed_configs.each do |config| %>
-    <tr>
-    <% import_logs = config.amr_data_feed_import_logs.where('import_time >= ?', Date.today - Admin::Reports::AmrDataFeedImportLogsController::SUMMARY_PERIOD_IN_DAYS.days) %>
+    <tr class="<%= 'table-warning' unless config.enabled %>">
+    <% import_logs = config.amr_data_feed_import_logs.since(Admin::Reports::AmrDataFeedImportLogsController::SUMMARY_PERIOD_IN_DAYS.days.ago) %>
     <td class='text-left'><%= link_to config.description, admin_amr_data_feed_config_path(config) %></td>
     <td><%= import_logs.count %></td>
     <td><%= link_to import_logs.successful.count, admin_reports_amr_data_feed_import_logs_successes_path({config: {config_id: config.id}}) %></td>

--- a/app/views/admin/reports/data_loads/index.html.erb
+++ b/app/views/admin/reports/data_loads/index.html.erb
@@ -1,6 +1,6 @@
 <h1>Recent manual data loads</h1>
 
-<div class="d-flex justify-content-end pt-4">
+<div id="paging-top" class="d-flex justify-content-end pt-4">
   <%= render partial: 'shared/pagy/bootstrap_nav', locals: { pagy: @pagy } %>
 </div>
 
@@ -33,6 +33,6 @@
   </tbody>
 </table>
 
-<div class="d-flex justify-content-end pt-4">
+<div id="paging-bottom" class="d-flex justify-content-end pt-4">
   <%= render partial: 'shared/pagy/bootstrap_nav', locals: { pagy: @pagy } %>
 </div>

--- a/app/views/admin/reports/data_loads/index.html.erb
+++ b/app/views/admin/reports/data_loads/index.html.erb
@@ -1,6 +1,8 @@
 <h1>Recent manual data loads</h1>
 
-Listing the 50 most recent manual data loads and their status.
+<div class="d-flex justify-content-end pt-4">
+  <%= render partial: 'shared/pagy/bootstrap_nav', locals: { pagy: @pagy } %>
+</div>
 
 <table class="table table-striped table-sorted">
   <thead>
@@ -21,10 +23,16 @@ Listing the 50 most recent manual data loads and their status.
         <td><%= nice_date_times(manual_data_load_run.created_at) %></td>
         <td><%= manual_data_load_run.status %></td>
         <td>
-          <%= link_to "View", admin_amr_data_feed_config_amr_uploaded_reading_manual_data_load_run_path(manual_data_load_run.amr_uploaded_reading.amr_data_feed_config, manual_data_load_run.amr_uploaded_reading, manual_data_load_run), class: "btn btn-secondary" %>
-          <%= link_to "Delete", admin_amr_data_feed_config_amr_uploaded_reading_manual_data_load_run_path(manual_data_load_run.amr_uploaded_reading.amr_data_feed_config, manual_data_load_run.amr_uploaded_reading, manual_data_load_run), method: :delete, data: { confirm: 'Are you sure?' }, class: "btn btn-danger" %>
+          <div class="btn-group">
+            <%= link_to "View", admin_amr_data_feed_config_amr_uploaded_reading_manual_data_load_run_path(manual_data_load_run.amr_uploaded_reading.amr_data_feed_config, manual_data_load_run.amr_uploaded_reading, manual_data_load_run), class: "btn btn-sm btn-secondary" %>
+            <%= link_to "Delete", admin_amr_data_feed_config_amr_uploaded_reading_manual_data_load_run_path(manual_data_load_run.amr_uploaded_reading.amr_data_feed_config, manual_data_load_run.amr_uploaded_reading, manual_data_load_run), method: :delete, data: { confirm: 'Are you sure?' }, class: "btn btn-sm btn-danger" %>
+          </div>
         </td>
       </tr>
     <% end %>
   </tbody>
 </table>
+
+<div class="d-flex justify-content-end pt-4">
+  <%= render partial: 'shared/pagy/bootstrap_nav', locals: { pagy: @pagy } %>
+</div>

--- a/spec/factories/amr_data_feed_config_factory.rb
+++ b/spec/factories/amr_data_feed_config_factory.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :amr_data_feed_config do
     source_type                   { :email }
     date_format                   { "%b %e %Y %I:%M%p" }
-    description                   { |n| "Email data feed-#{n}" }
+    sequence(:description)        { |n| "Email data feed-#{n}" }
     mpan_mprn_field               { 'M1_Code1' }
     reading_date_field            { 'Date' }
     number_of_header_rows         { 1 }

--- a/spec/system/admin/manual_data_loading_spec.rb
+++ b/spec/system/admin/manual_data_loading_spec.rb
@@ -2,7 +2,6 @@ require 'rails_helper'
 
 describe "manual data load", type: :system do
   let!(:admin)               { create(:admin) }
-  let!(:runs)                { create_list(:manual_data_load_run, 22, status: :done) }
 
   before do
     sign_in(admin)
@@ -16,29 +15,33 @@ describe "manual data load", type: :system do
   end
 
   context 'view the manual data load report' do
-    let(:run)      { ManualDataLoadRun.first }
-    let(:last_run) { ManualDataLoadRun.last }
+    let!(:runs)           { create_list(:manual_data_load_run, 22, status: :done) }
+
+    let(:oldest_run)      { runs.first }
+    let(:newest_run)      { runs.last }
 
     before do
       click_on("Recent manual imports")
     end
 
     it 'lists the data loads' do
-      expect(page).to have_content(run.amr_uploaded_reading.file_name)
-      expect(page).not_to have_content(last_run.amr_uploaded_reading.file_name)
+      expect(page).to have_content(newest_run.amr_uploaded_reading.file_name)
+      expect(page).not_to have_content(oldest_run.amr_uploaded_reading.file_name)
     end
 
     it 'has paging' do
-      expect(page).to have_link('Next')
-      click_on('Next')
-      expect(page).not_to have_content(run.amr_uploaded_reading.file_name)
-      expect(page).to have_content(last_run.amr_uploaded_reading.file_name)
+      within '#paging-top' do
+        expect(page).to have_link('Next')
+        click_on('Next')
+      end
+      expect(page).not_to have_content(newest_run.amr_uploaded_reading.file_name)
+      expect(page).to have_content(oldest_run.amr_uploaded_reading.file_name)
     end
 
     it 'displays the status' do
-      click_on("View")
-      expect(page).to have_content(run.amr_uploaded_reading.amr_data_feed_config.description)
-      expect(page).to have_content(run.amr_uploaded_reading.file_name)
+      first(:link, text: 'View', exact_text: true).click
+      expect(page).to have_content(newest_run.amr_uploaded_reading.amr_data_feed_config.description)
+      expect(page).to have_content(newest_run.amr_uploaded_reading.file_name)
       expect(page).to have_content("done")
     end
   end

--- a/spec/system/admin/manual_data_loading_spec.rb
+++ b/spec/system/admin/manual_data_loading_spec.rb
@@ -1,32 +1,41 @@
 require 'rails_helper'
 
 describe "manual data load", type: :system do
-  let!(:admin)              { create(:admin) }
-
-  let!(:run)                { create(:manual_data_load_run, status: :done) }
+  let!(:admin)               { create(:admin) }
+  let!(:runs)                { create_list(:manual_data_load_run, 22, status: :done) }
 
   before do
     sign_in(admin)
     visit root_path
+    click_on("Reports")
   end
 
-  describe 'report' do
-    before do
-      click_on("Reports")
-    end
+  it 'links to report' do
+    click_on("Recent manual imports")
+    expect(page).to have_content("Recent manual data loads")
+  end
 
-    it 'links to report' do
+  context 'view the manual data load report' do
+    let(:run)      { ManualDataLoadRun.first }
+    let(:last_run) { ManualDataLoadRun.last }
+
+    before do
       click_on("Recent manual imports")
-      expect(page).to have_content("Recent manual data loads")
     end
 
     it 'lists the data loads' do
-      click_on("Recent manual imports")
       expect(page).to have_content(run.amr_uploaded_reading.file_name)
+      expect(page).not_to have_content(last_run.amr_uploaded_reading.file_name)
+    end
+
+    it 'has paging' do
+      expect(page).to have_link('Next')
+      click_on('Next')
+      expect(page).not_to have_content(run.amr_uploaded_reading.file_name)
+      expect(page).to have_content(last_run.amr_uploaded_reading.file_name)
     end
 
     it 'displays the status' do
-      click_on("Recent manual imports")
       click_on("View")
       expect(page).to have_content(run.amr_uploaded_reading.amr_data_feed_config.description)
       expect(page).to have_content(run.amr_uploaded_reading.file_name)

--- a/spec/system/admin/reports/amr_data_feed_import_logs_spec.rb
+++ b/spec/system/admin/reports/amr_data_feed_import_logs_spec.rb
@@ -1,8 +1,12 @@
 require 'rails_helper'
 
 describe AmrDataFeedImportLog, type: :system, include_application_helper: true do
-  let!(:admin)           { create(:admin) }
-  let(:sheffield_config) { create(:amr_data_feed_config, description: 'Sheffield') }
+  let!(:admin)            { create(:admin) }
+  let!(:config)           { create(:amr_data_feed_config) }
+  let!(:disabled_config)  { create(:amr_data_feed_config, description: 'Disabled', enabled: false) }
+  let!(:import_log_1)     { create(:amr_data_feed_import_log, amr_data_feed_config: config, error_messages: "oh no!", import_time: 1.day.ago) }
+  let!(:import_log_2)     { create(:amr_data_feed_import_log, amr_data_feed_config: config, records_imported: 200, import_time: 1.day.ago) }
+  let!(:import_log_3)     { create(:amr_data_feed_import_log, amr_data_feed_config: config, records_imported: 200, import_time: 31.days.ago) }
 
   before do
     sign_in(admin)
@@ -11,19 +15,35 @@ describe AmrDataFeedImportLog, type: :system, include_application_helper: true d
     click_on 'Reports'
   end
 
-  it 'shows an import log summary table' do
-    error_messages = "Oh no!"
-    create(:amr_data_feed_import_log, amr_data_feed_config: sheffield_config, error_messages: error_messages, import_time: 1.day.ago)
-    create(:amr_data_feed_import_log, amr_data_feed_config: sheffield_config, records_imported: 200, import_time: 1.day.ago)
+  context 'when viewing summary report' do
+    before do
+      click_on 'AMR File imports report'
+    end
 
-    click_on 'AMR File imports report'
-    expect(page).to have_content('Data Feed Import Logs')
-    expect(page).to have_content('Summary of the last 7 days')
+    it 'has the expected title' do
+      expect(page).to have_content('Data Feed Import Logs')
+      expect(page).to have_content('Summary of the last 30 days')
+    end
 
-    expect(page).to have_content('Successes 1')
-    expect(page).to have_content('Warnings 0')
-    expect(page).to have_content('Errors 1')
+    it 'includes summary counts in tabs' do
+      within '.nav-tabs' do
+        expect(page).to have_content('Successes 1')
+        expect(page).to have_content('Warnings 0')
+        expect(page).to have_content('Errors 1')
+      end
+    end
 
-    expect(page).to have_content('Feed')
+    it 'lists all the configs' do
+      within '#import-summary-table' do
+        expect(page).to have_content(config.description)
+        expect(page).to have_content(disabled_config.description)
+      end
+    end
+
+    it 'highlights disabled configs' do
+      within '#import-summary-table tbody tr.table-warning' do
+        expect(page).to have_content(disabled_config.description)
+      end
+    end
   end
 end


### PR DESCRIPTION
Allow admins to page through the list of manual data load reports. 

- Add pagy support to the controller and template
- Change page size to 20 rather than 50

Also revises the recent amr import reports page to:

- Apply a 30 day window to the summary counts in the tabs
- Use 30 rather than 7 days as the window for totalling counts by identifier, but leaves summary of changes in last 48 hours
- Highlight disabled configs so we can see if we are still loading data using them