### PR TITLE
Remove mpans reformatted by Excel

### DIFF
--- a/lib/tasks/deployment/20231018135908_remove_invalid_mpans_from_readings.rake
+++ b/lib/tasks/deployment/20231018135908_remove_invalid_mpans_from_readings.rake
@@ -1,0 +1,15 @@
+namespace :after_party do
+  desc 'Deployment task: remove_invalid_mpans_from_readings'
+  task remove_invalid_mpans_from_readings: :environment do
+    puts "Running deploy task 'remove_invalid_mpans_from_readings'"
+
+    #Remove readings that have been manually uploads with mpans that have been
+    #reformatted by Excel, e.g. to "22E+13"
+    AmrDataFeedReading.where("mpan_mprn like ?", "%+%").delete_all
+
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord
+      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+  end
+end


### PR DESCRIPTION
When the admins export from Excel to CSV, its possible for the MPANs to be accidentally reformatted based on how they are shown on screen rather than as the full string. This has lead to data in the database with data like "7.22E+13".

Delete all these records from the AmrDataFeedReading table.