### PR TITLE
Halt regeneration if aggregation fails

### DIFF
--- a/app/jobs/school_batch_run_job.rb
+++ b/app/jobs/school_batch_run_job.rb
@@ -8,8 +8,8 @@ class SchoolBatchRunJob < ApplicationJob
   def perform(school_batch_run)
     school_batch_run.info('STARTED')
     school_batch_run.update(status: :running)
-    Schools::SchoolRegenerationService.new(school: school_batch_run.school, logger: school_batch_run).perform
-    school_batch_run.info('FINISHED')
+    success = Schools::SchoolRegenerationService.new(school: school_batch_run.school, logger: school_batch_run).perform
+    school_batch_run.info(success ? 'FINISHED' : 'FAILED')
     school_batch_run.update(status: :done)
   rescue => e
     school_batch_run.error(e.message)


### PR DESCRIPTION
Some further improvements to the service responsible for regenerating schools each day, and on demand by admins.

Reviewing Rollbar we are getting some errors from the analysis which are due to the aggregation process failing. This leaves the meter collection in an inconsistent state and we end up trying to calculate, e.g. equivalences, without the necessary data. We log each of these errors which just adds noise: the actual problem is the failure to aggregate properly.

This PR updates the service so that if the aggregation step throws an exception then we don't continue with the final steps. The school is just removed from the rails cache.

So the new process is:

- validate the school's meter data and update the database if sucessful
- if the validation step fails and we cant update their data, then continue using any previously saved data, so the school can at least see any existing analysis
- if the aggregation step fails then we can't continue any further, so just end the process
- if both validation and aggregation steps complete, then update equivalences, saved metrics, etc
