### PR TITLE
Correct truncation of schedule data and only produce estimates when required

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,7 @@ gem 'closed_struct'
 gem 'pg_search'
 
 # Dashboard analytics
-gem 'energy-sparks_analytics', git: 'https://github.com/Energy-Sparks/energy-sparks_analytics.git', tag: '4.0.5'
+gem 'energy-sparks_analytics', git: 'https://github.com/Energy-Sparks/energy-sparks_analytics.git', tag: '4.0.6'
 #gem 'energy-sparks_analytics', git: 'https://github.com/Energy-Sparks/energy-sparks_analytics.git', branch: 'post-aggregation-clean-up'
 #gem 'energy-sparks_analytics', path: '../energy-sparks_analytics'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/Energy-Sparks/energy-sparks_analytics.git
-  revision: a116e2a424e391b54c230ea96376c71f51c99487
-  tag: 4.0.5
+  revision: e007c6f9acc8c103a5948b8e96019b62c24da168
+  tag: 4.0.6
   specs:
     energy-sparks_analytics (1.2.1)
       activesupport (>= 6.0, < 7.1)

--- a/app/services/targets/generate_estimated_usage.rb
+++ b/app/services/targets/generate_estimated_usage.rb
@@ -7,13 +7,17 @@ module Targets
 
     def generate
       estimates = {}
-      add_estimate_for_fuel_type(estimates, :electricity) if @school.has_electricity?
-      add_estimate_for_fuel_type(estimates, :gas) if @school.has_gas?
-      add_estimate_for_fuel_type(estimates, :storage_heater) if @school.has_storage_heaters?
+      add_estimate_for_fuel_type(estimates, :electricity) if @school.has_electricity? && suggested?(:electricity)
+      add_estimate_for_fuel_type(estimates, :gas) if @school.has_gas? && suggested?(:gas)
+      add_estimate_for_fuel_type(estimates, :storage_heater) if @school.has_storage_heaters? && suggested?(:storage_heater)
       estimates
     end
 
     private
+
+    def suggested?(fuel_type)
+      @school.configuration.suggest_annual_estimate_for_fuel_type?(fuel_type)
+    end
 
     def add_estimate_for_fuel_type(estimates, fuel_type)
       begin

--- a/spec/services/targets/generate_estimated_usage_spec.rb
+++ b/spec/services/targets/generate_estimated_usage_spec.rb
@@ -11,21 +11,46 @@ describe Targets::GenerateEstimatedUsage, type: :service do
   end
 
   describe '#generate' do
-    context 'with all fuel types' do
+    let(:data) { service.generate }
+
+    before do
+      allow_any_instance_of(TargetsService).to receive(:annual_kwh_estimate_kwh).and_return(99)
+    end
+
+    context 'with school that has all fuel types' do
       let(:fuel_configuration) do
         Schools::FuelConfiguration.new(
           has_storage_heaters: true, has_gas: true, has_electricity: true)
       end
 
-      before do
-        allow_any_instance_of(TargetsService).to receive(:annual_kwh_estimate_kwh).and_return(99)
+      context 'and estimates are required for all' do
+        before do
+          school.configuration.update!(suggest_estimates_fuel_types: %w(electricity gas storage_heater))
+        end
+
+        it 'produces all estimates' do
+          expect(data[:electricity]).to eq 99
+          expect(data[:gas]).to eq 99
+          expect(data[:storage_heater]).to eq 99
+        end
       end
 
-      it 'lists all estimates' do
-        data = service.generate
-        expect(data[:electricity]).to eq 99
-        expect(data[:gas]).to eq 99
-        expect(data[:storage_heater]).to eq 99
+      context 'and estimates suggested for gas only' do
+        before do
+          school.configuration.update!(suggest_estimates_fuel_types: ["gas"])
+        end
+
+        it 'produces an estimate for gas only' do
+          expect(data[:electricity]).to be_nil
+          expect(data[:gas]).to eq 99
+          expect(data[:storage_heater]).to be_nil
+        end
+      end
+
+      it 'does not produce estimates unless needed' do
+        expect(data[:electricity]).to be_nil
+        expect(data[:gas]).to be_nil
+        expect(data[:storage_heater]).to be_nil
       end
     end
 
@@ -35,13 +60,21 @@ describe Targets::GenerateEstimatedUsage, type: :service do
           has_electricity: true)
       end
 
-      before do
-        allow_any_instance_of(TargetsService).to receive(:annual_kwh_estimate_kwh).and_return(99)
+      context 'and estimates are required' do
+        before do
+          school.configuration.update!(suggest_estimates_fuel_types: ["electricity"])
+        end
+
+        it 'produces estimate for electricity' do
+          expect(data[:electricity]).to eq 99
+          expect(data[:gas]).to be_nil
+          expect(data[:storage_heater]).to be_nil
+        end
       end
 
-      it 'lists all estimates' do
+      it 'does not produce estimates by default' do
         data = service.generate
-        expect(data[:electricity]).to eq 99
+        expect(data[:electricity]).to be_nil
         expect(data[:gas]).to be_nil
         expect(data[:storage_heater]).to be_nil
       end


### PR DESCRIPTION
For schools with less than a year of data, we offer the option of them providing an estimate of their annual usage so that they can still set a target even if we have limited historical data.

If we have some data for the school (e.g. a few months) we try and help them produce a decent estimate by providing a calculation of our own. The school `Configuration` class stores whether an estimate is necessary for a fuel type and our best guess.

Debugging a problem regenerating some schools I found to issues with this code.

- there was a bug in the truncation of the schedule data, which meant that calculating some estimates was failing. This is fixed in the analytics (https://github.com/Energy-Sparks/energy-sparks_analytics/pull/613)
- we are currently producing estimates for all fuel types, regardless of whether they're actually needed. e.g. we are still estimating electricity usage even if the school has >1 year of data

This PR bumps the analytics tag to include the bug fix and updates the `GenerateEstimatedUsage` service to check whether an estimate is actually needed before attempting to generate one.