### PR TITLE
Tune vacuum analyse for reading tables

### DIFF
--- a/app/jobs/manual_data_load_run_job.rb
+++ b/app/jobs/manual_data_load_run_job.rb
@@ -24,7 +24,6 @@ class ManualDataLoadRunJob < ApplicationJob
       amr_uploaded_reading.update!(imported: true)
       manual_data_load_run.info("Inserted: #{amr_data_feed_import_log.records_imported}")
       manual_data_load_run.info("Updated: #{amr_data_feed_import_log.records_updated}")
-      vaccuum_for_large_imports(amr_data_feed_import_log.records_imported, amr_data_feed_import_log.records_updated)
       manual_data_load_run.info("SUCCESS")
       status = :done
     rescue => e
@@ -37,12 +36,6 @@ class ManualDataLoadRunJob < ApplicationJob
   end
 
   private
-
-  def vaccuum_for_large_imports(imported, updated)
-    if (imported.to_i + updated.to_i) > 10
-      Database::VacuumService.new([:amr_data_feed_readings]).perform
-    end
-  end
 
   def create_import_log(amr_data_feed_config, file_name)
     AmrDataFeedImportLog.create(

--- a/app/models/amr_data_feed_reading.rb
+++ b/app/models/amr_data_feed_reading.rb
@@ -36,6 +36,14 @@
 #  fk_rails_...  (meter_id => meters.id) ON DELETE => nullify
 #
 
+# Postgres autovacuum specific settings:
+# See: https://www.postgresql.org/docs/current/runtime-config-autovacuum.html
+# Applied using: ALTER TABLE amr_data_feed_readings SET (X = n)
+# autovacuum_vacuum_cost_delay = 0
+# autovacuum_analyze_scale_factor = 0
+# autovacuum_analyze_threshold = 10000
+# autovacuum_vacuum_scale_factor = 0
+# autovacuum_vacuum_threshold = 50000
 class AmrDataFeedReading < ApplicationRecord
   belongs_to :meter, optional: true
   belongs_to :amr_data_feed_import_log

--- a/app/models/amr_validated_reading.rb
+++ b/app/models/amr_validated_reading.rb
@@ -22,6 +22,14 @@
 #  fk_rails_...  (meter_id => meters.id) ON DELETE => cascade
 #
 
+# Postgres autovacuum specific settings:
+# See: https://www.postgresql.org/docs/current/runtime-config-autovacuum.html
+# Applied using: ALTER TABLE amr_validated_readings SET (X = n)
+# autovacuum_vacuum_cost_delay = 0
+# autovacuum_analyze_scale_factor = 0
+# autovacuum_analyze_threshold = 10000
+# autovacuum_vacuum_scale_factor = 0
+# autovacuum_vacuum_threshold = 50000
 class AmrValidatedReading < ApplicationRecord
   belongs_to :meter, inverse_of: :amr_validated_readings
 

--- a/app/services/database/vacuum_service.rb
+++ b/app/services/database/vacuum_service.rb
@@ -6,12 +6,13 @@ module Database
 
     ## NB: VACUUM does not work when run inside a transaction block
     ## For rspec, use ts: false as an argument to the block to prevent tests being wrapped in a transaction block
-    def perform
+    def perform(vacuum: false)
       @tables.each do |table|
         begin
-          ActiveRecord::Base.connection.execute("VACUUM ANALYSE #{table}")
+          sql = vacuum ? "VACUUM ANALYSE #{table}" : "ANALYSE #{table}"
+          ActiveRecord::Base.connection.execute(sql)
         rescue StandardError => exception
-          message = "VACUUM ANALYSE #{table} error: #{exception.message}"
+          message = "#{sql} error: #{exception.message}"
           Rails.logger.error(message)
           Rollbar.error(message)
         end

--- a/lib/tasks/amr_importer/import_all.rake
+++ b/lib/tasks/amr_importer/import_all.rake
@@ -14,7 +14,6 @@ namespace :amr do
         Rollbar.error(e, job: :import_all, config: config.identifier)
       end
     end
-    Database::VacuumService.new([:amr_data_feed_readings]).perform
     puts "#{DateTime.now.utc} amr import all end"
   end
 end

--- a/lib/tasks/amr_importer/import_n3rgy_readings.rake
+++ b/lib/tasks/amr_importer/import_n3rgy_readings.rake
@@ -12,7 +12,6 @@ namespace :amr do
     Meter.where(dcc_meter: true, consent_granted: true).each do |meter|
       Amr::N3rgyReadingsDownloadAndUpsert.new(meter: meter, config: config, start_date: start_date, end_date: end_date).perform
     end
-    Database::VacuumService.new([:amr_data_feed_readings]).perform
     puts "#{DateTime.now.utc} #{config.description} end"
   end
 end

--- a/lib/tasks/deployment/20231019160154_customise_vacuuming_of_reading_tables.rake
+++ b/lib/tasks/deployment/20231019160154_customise_vacuuming_of_reading_tables.rake
@@ -1,0 +1,42 @@
+namespace :after_party do
+  desc 'Deployment task: customise_vacuuming_of_reading_tables'
+  task customise_vacuuming_of_reading_tables: :environment do
+    puts "Running deploy task 'customise_vacuuming_of_reading_tables'"
+
+    #amr_data_feed_readings
+
+    #Reduce cost delay to complete autovacuum processes (vacuum, analyse) as quickly as possible
+    ActiveRecord::Base.connection.execute("ALTER TABLE amr_data_feed_readings SET (autovacuum_vacuum_cost_delay = 0)")
+
+    #Set scale factor to zero, rather than 0.05 so that we trigger the autovacuum process to run ANALYSE based on number of
+    #records changed, not a % of the table.
+    ActiveRecord::Base.connection.execute("ALTER TABLE amr_data_feed_readings SET (autovacuum_analyze_scale_factor = 0)")
+    #Increase analyse threshold from 50, so we will run analyse every 10000 rows
+    ActiveRecord::Base.connection.execute("ALTER TABLE amr_data_feed_readings SET (autovacuum_analyze_threshold = 10000)")
+
+    #Repeat the above settings but for controlling how often VACUUM is run. Use larger threshold for
+    #vacuum as its more expensive
+    ActiveRecord::Base.connection.execute("ALTER TABLE amr_data_feed_readings SET (autovacuum_vacuum_scale_factor = 0)")
+    ActiveRecord::Base.connection.execute("ALTER TABLE amr_data_feed_readings SET (autovacuum_vacuum_threshold = 50000)")
+
+    #amr_validated_readings
+    #This is already set, but reapplying here for documentation purposes
+    ActiveRecord::Base.connection.execute("ALTER TABLE amr_validated_readings SET (autovacuum_vacuum_cost_delay = 0)")
+
+    #Set scale factor to zero, rather than 0.05 so that we trigger the autovacuum process to run ANALYSE based on number of
+    #records changed, not a % of the table.
+    ActiveRecord::Base.connection.execute("ALTER TABLE amr_validated_readings SET (autovacuum_analyze_scale_factor = 0)")
+    #Increase analyse threshold from 50, so we will run analyse every 10000 rows
+    ActiveRecord::Base.connection.execute("ALTER TABLE amr_validated_readings SET (autovacuum_analyze_threshold = 10000)")
+
+    #Repeat the above settings but for controlling how often VACUUM is run. Use larger threshold for
+    #vacuum as its more expensive
+    ActiveRecord::Base.connection.execute("ALTER TABLE amr_validated_readings SET (autovacuum_vacuum_scale_factor = 0)")
+    ActiveRecord::Base.connection.execute("ALTER TABLE amr_validated_readings SET (autovacuum_vacuum_threshold = 50000)")
+
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord
+      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+  end
+end

--- a/lib/tasks/solar/import_low_carbon_hub_readings.rake
+++ b/lib/tasks/solar/import_low_carbon_hub_readings.rake
@@ -10,7 +10,6 @@ namespace :solar do
       puts "Running for #{installation.rbee_meter_id}"
       Solar::LowCarbonHubDownloadAndUpsert.new(installation: installation, start_date: start_date, end_date: end_date).perform
     end
-    Database::VacuumService.new([:amr_data_feed_readings]).perform
     puts "#{DateTime.now.utc} import_low_carbon_hub_readings end"
   end
 end

--- a/lib/tasks/solar/import_rtone_variant_readings.rake
+++ b/lib/tasks/solar/import_rtone_variant_readings.rake
@@ -10,7 +10,6 @@ namespace :solar do
       puts "Running for #{installation.rtone_meter_id}"
       Solar::RtoneVariantDownloadAndUpsert.new(installation: installation, start_date: start_date, end_date: end_date).perform
     end
-    Database::VacuumService.new([:amr_data_feed_readings]).perform
     puts "#{DateTime.now.utc} import_rtone_variant_readings end"
   end
 end

--- a/lib/tasks/solar/import_solar_edge_readings.rake
+++ b/lib/tasks/solar/import_solar_edge_readings.rake
@@ -10,7 +10,6 @@ namespace :solar do
       puts "Running for #{installation.school.name} #{installation.site_id}"
       Solar::SolarEdgeDownloadAndUpsert.new(installation: installation, start_date: start_date, end_date: end_date).perform
     end
-    Database::VacuumService.new([:amr_data_feed_readings]).perform
     puts "#{DateTime.now.utc} import_solar_edge_readings end"
   end
 end

--- a/spec/jobs/manual_data_load_run_job_spec.rb
+++ b/spec/jobs/manual_data_load_run_job_spec.rb
@@ -17,7 +17,6 @@ describe ManualDataLoadRunJob, ts: false do
 
   context 'with a valid file' do
     before do
-      expect_any_instance_of(Database::VacuumService).to receive(:perform)
       expect(run.status).to eq "pending"
       job.load(run.amr_uploaded_reading.amr_data_feed_config, run.amr_uploaded_reading, run)
     end
@@ -35,20 +34,6 @@ describe ManualDataLoadRunJob, ts: false do
     end
   end
 
-  context 'for small imports' do
-    let(:imported)            { 2 }
-    let(:updated)             { 0 }
-
-    before do
-      expect_any_instance_of(Database::VacuumService).not_to receive(:perform)
-      job.load(run.amr_uploaded_reading.amr_data_feed_config, run.amr_uploaded_reading, run)
-    end
-
-    it 'completed with no vacuum' do
-      expect(run.status).to eq "done"
-    end
-  end
-
   context 'when a problem occurs' do
     before do
       #stub the service
@@ -56,7 +41,6 @@ describe ManualDataLoadRunJob, ts: false do
       allow_any_instance_of(AmrDataFeedImportLog).to receive(:records_imported).and_return(0)
       allow_any_instance_of(AmrDataFeedImportLog).to receive(:records_updated).and_return(0)
       expect(run.status).to eq "pending"
-      expect_any_instance_of(Database::VacuumService).not_to receive(:perform)
       job.load(run.amr_uploaded_reading.amr_data_feed_config, run.amr_uploaded_reading, run)
     end
 


### PR DESCRIPTION
Some time ago we introduced the `VacuumService` to manually VACUUM and ANALYSE on the `amr_data_feed_readings` table as running `count` on the table was becoming very slow after updates. The analyse process recalculates the table statistics and avoids need to do a full scan to do the count.

Since then we've learned some more about how to tune the autovacuum process that should be running the VACUUM and ANALYSE process automatically. 

It turns out that due to the fact that the `amr_data_feed_readings` and `amr_validated_readings` are largely append-only, with lots of updates, the default postgres settings in RDS won't ensure that the autovacuum runs as frequently as needed.

This PR is an experiment in tuning [the autovacuum settings](https://www.postgresql.org/docs/current/runtime-config-autovacuum.html) for these two tables to avoid the need for manual vacuuming.

The changes are:

* Update the `VacuumService` so that it has the option of doing an ANALYSE separately to the VACUUM. For statistics we only need an ANALYSE which can be quicker. If we need to continue to run manual vacuums, then we'll want to do only ANALYSE
* Removes use of the service where its currently called after the daily data loads and via the manual data uploads run via admins
* Applies per-table settings to tune the vacuuming. The settings switch from triggering the processes based on a % of the table being changed to using a simple record count threshold. For tables that just grow over time a % approach isn't the best option. The initial values have been guessed based on looking at the current insert/update counts over a 24 hour period. They may need tweaking if the processes run too frequently.

The plan is to release this to test to try and assess impacts before pushing to live. If the settings make things worse we can roll back to manual vacuuming.