### PR TITLE
Re-enable overcommit forbidden branch hook

### DIFF
--- a/.overcommit.yml
+++ b/.overcommit.yml
@@ -204,9 +204,8 @@ PreCommit:
     install_command: 'gem install foodcritic'
 
   ForbiddenBranches:
-    enabled: false
-    description: 'Check for commit to forbidden branch'
-    quiet: true
+    enabled: true
+    description: 'Check for commit to forbidden branch (master)'
     branch_patterns: ['master']
 
   GoLint:

--- a/.overcommit.yml
+++ b/.overcommit.yml
@@ -798,6 +798,11 @@ PrePush:
     required_executable: 'rake'
     install_command: 'gem install rake'
 
+  ForbiddenBranches:
+    enabled: true
+    description: 'Check for commit to forbidden branch (master)'
+    branch_patterns: ['master']
+
 # Hooks that run during `git rebase`, before any commits are rebased.
 # If a hook fails, the rebase is aborted.
 PreRebase:


### PR DESCRIPTION
This PR enables the forbidden branche(s) pre-commit hook to prevent committing to master.
It can be overidden by `SKIP=ForbiddenBranches git commit -m "my commit message" `
