### PR TITLE
Change loading period for sheffield solar

### DIFF
--- a/lib/tasks/data_feeds/solar_pv_tuos_loader.rake
+++ b/lib/tasks/data_feeds/solar_pv_tuos_loader.rake
@@ -3,8 +3,8 @@ namespace :data_feeds do
   task :solar_pv_tuos_loader, [:start_date, :end_date] => :environment do |_t, args|
     puts "#{DateTime.now.utc} solar_pv_tuos_loader start"
 
-    start_date = args[:start_date].present? ? Date.parse(args[:start_date]) : Date.yesterday - 11
-    end_date = args[:end_date].present? ? Date.parse(args[:end_date]) : Date.yesterday - 1
+    start_date = args[:start_date].present? ? Date.parse(args[:start_date]) : Date.yesterday - 7
+    end_date = args[:end_date].present? ? Date.parse(args[:end_date]) : Date.yesterday
 
     DataFeeds::SolarPvTuosLoader.new(start_date, end_date).import
     puts "#{DateTime.now.utc} solar_pv_tuos_loader end"


### PR DESCRIPTION
Every day we load data from the PV Live API. Currently we (re)load a 10 day period that starts 2 days before the job runs (`Date.yesterday - 1`). This gives us a 1 day lag in our data, but the API has data up until yesterday.

This PR changes the loading window to be the previous 7 days.