### PR TITLE
Remove scheduled upload of unvalidated meter collections to S3

### DIFF
--- a/.ebextensions/cronjob.config
+++ b/.ebextensions/cronjob.config
@@ -122,16 +122,6 @@ files:
             00 6 * * * root /bin/bash -l -c 'cd /var/app/current && RAILS_ENV=production bin/run_as_webapp bundle exec rake school:daily_regeneration >> log/jobs.log 2>&1'
 
     #
-    # Upload unvalidated schools to S3.
-    #
-    "/etc/cron.d/daily-s3-unvalidated-upload":
-        mode: "000644"
-        owner: root
-        group: root
-        content: |
-            00 21 * * 0 root /bin/bash -l -c 'cd /var/app/current && RAILS_ENV=production bin/run_as_webapp bundle exec rake utility:save_unvalidated_schools_to_s3 >> log/jobs.log 2>&1'
-
-    #
     # Generate subscriptions
     #
     "/etc/cron.d/generate-subscriptions":
@@ -306,5 +296,7 @@ commands:
         command: "rm -f /etc/cron.d/send-delayed-job-memory-usage-metrics-to-cloudwatch"
     remove_delayed_job_process_metrics_cron:
         command: "rm -f /etc/cron.d/send-delayed-job-process-metrics-to-cloudwatch"
+    remove_daily-s3-unvalidated-upload:
+        command: "rm -f /etc/cron.d/daily-s3-unvalidated-upload"
     remove_old_cron:
         command: "rm -f /etc/cron.d/*.bak"


### PR DESCRIPTION
We have a rake tasks that pushes a subset of school data to S3. The meter collections have been used for doing bulk testing of the analytics. We are no longer doing this on a regular basis, as we're moving towards more rspec based testing. 

As the job involves a big spike in CPU and memory usage to generate and then upload the data to S3 I'm disabling the job.

I've retained the rake task so we can re-run on demand if we do find we need access to meter collection files in bulk. It's still possible to manually download data for specific schools from the test and production servers.