### PR TITLE
Remove ability to manage dark sky areas

### DIFF
--- a/app/controllers/admin/dark_sky_areas_controller.rb
+++ b/app/controllers/admin/dark_sky_areas_controller.rb
@@ -4,39 +4,5 @@ module Admin
 
     def index
     end
-
-    def new
-    end
-
-    def create
-      if @dark_sky_area.save
-        redirect_to admin_dark_sky_areas_path, notice: 'New Dark Sky Area created. Data will be back filled overnight.'
-      else
-        render :new
-      end
-    end
-
-    def edit
-    end
-
-    def update
-      if @dark_sky_area.update(dark_sky_area_params)
-        @dark_sky_area.dark_sky_temperature_readings.delete_all if lat_long_changed?
-        redirect_to admin_dark_sky_areas_path, notice: 'Dark Sky Area was updated.'
-      else
-        render :edit
-      end
-    end
-
-    private
-
-    def lat_long_changed?
-      changes = @dark_sky_area.previous_changes
-      changes.key?(:latitude) || changes.key?(:longitude)
-    end
-
-    def dark_sky_area_params
-      params.require(:dark_sky_area).permit(:title, :latitude, :longitude, :back_fill_years)
-    end
   end
 end

--- a/app/views/admin/dark_sky_areas/_form.html.erb
+++ b/app/views/admin/dark_sky_areas/_form.html.erb
@@ -1,7 +1,0 @@
-<%= simple_form_for([:admin, dark_sky_area]) do |f| %>
-  <%= f.input :title, as: :string %>
-  <%= f.input :latitude %>
-  <%= f.input :longitude %>
-  <%= f.input :back_fill_years %>
-  <%= f.submit class: 'btn btn-primary', data: {confirm: 'Modifying latitude or longitude will reset data for this area - are you sure?'} %>
-<% end %>

--- a/app/views/admin/dark_sky_areas/edit.html.erb
+++ b/app/views/admin/dark_sky_areas/edit.html.erb
@@ -1,7 +1,0 @@
-<h1>Edit Dark Sky Area</h1>
-
-<%= render 'form', dark_sky_area: @dark_sky_area %>
-
-<div class="other-actions">
-  <%= link_to 'Back', admin_dark_sky_areas_path, class: 'btn' %>
-</div>

--- a/app/views/admin/dark_sky_areas/index.html.erb
+++ b/app/views/admin/dark_sky_areas/index.html.erb
@@ -1,5 +1,11 @@
 <h1>Dark Sky Areas</h1>
 
+<p>
+This is historical data from the Dark Sky weather service which was used in
+EnergySparks until March 2023. This page provides a summary of the archive
+we still hold and use for some schools.
+</p>
+
 <% if @dark_sky_areas.any? %>
 <table class="table table-sorted">
   <thead>
@@ -25,8 +31,9 @@
         <td><%= dark_sky_area.last_reading_date %></td>
         <td><%= dark_sky_area.back_fill_years %></td>
         <td>
-          <div class='btn-group'>
-            <%= link_to 'Edit', edit_admin_dark_sky_area_path(dark_sky_area), class: 'btn' %>
+          <div class="btn-group">
+            <%= link_to "Report", data_feeds_dark_sky_temperature_readings_path(dark_sky_area.id), class: 'btn btn-sm' %>
+            <%= link_to "CSV", data_feeds_dark_sky_temperature_readings_path(dark_sky_area.id, format: "csv"), class: 'btn btn-sm' %>
           </div>
         </td>
       </tr>
@@ -36,5 +43,3 @@
 <% else %>
   <p>There are no Dark Sky Areas</p>
 <% end %>
-
-<%= link_to 'New Dark Sky Area', new_admin_dark_sky_area_path, class: 'btn' %>

--- a/app/views/admin/dark_sky_areas/new.html.erb
+++ b/app/views/admin/dark_sky_areas/new.html.erb
@@ -1,7 +1,0 @@
-<h1>New Dark Sky Area</h1>
-
-<%= render 'form', dark_sky_area: @dark_sky_area %>
-
-<div class="other-actions">
-  <%= link_to 'Back', admin_dark_sky_areas_path, class: 'btn' %>
-</div>

--- a/app/views/admin/index.html.erb
+++ b/app/views/admin/index.html.erb
@@ -43,7 +43,6 @@
     <ul>
       <li><%= link_to "AMR Data feed configuration", admin_amr_data_feed_configs_path %></li>
       <li><%= link_to "Energy Tariffs", admin_settings_energy_tariffs_path %></li>
-      <li><%= link_to "Dark Sky Areas", admin_dark_sky_areas_path %></li>
       <li><%= link_to "Solar PV Areas", admin_solar_pv_tuos_areas_path %></li>
       <li><%= link_to "Weather Stations", admin_weather_stations_path %></li>
       <li><%= link_to "Data Sources", admin_data_sources_path %></li>

--- a/app/views/admin/reports/index.html.erb
+++ b/app/views/admin/reports/index.html.erb
@@ -64,83 +64,21 @@
 
 <hr>
 
-<h2>External Data Feed Reports</h2>
+<h2>Other Reports</h2>
 
 <div class="row">
   <div class="col">
     <h3>Carbon Intensity</h3>
     <ul>
       <li><%= link_to 'Carbon intensity data', data_feeds_carbon_intensity_readings_path %></li>
-    </ul>
-  </div>
-  <div class="col">
-    <h3>Dark Sky Feed</h3>
-    <ul>
-      <% DarkSkyArea.all.order(:title).each do |area| %>
-        <li><%= link_to "#{area.title}", data_feeds_dark_sky_temperature_readings_path(area.id) %></li>
-      <% end %>
-    </ul>
-  </div>
-  <div class="col">
-    <h3>Solar PV Feed</h3>
-    <ul>
-      <% SolarPvTuosArea.all.order(:title).each do |area| %>
-        <li><%= link_to "#{area.title}", data_feeds_solar_pv_tuos_readings_path(area.id) %></li>
-      <% end %>
-    </ul>
-  </div>
-  <div class="col">
-    <h3>Weather Stations</h3>
-    <ul>
-      <% WeatherStation.by_title.each do |area| %>
-        <li><%= link_to "#{area.title}", data_feeds_weather_observations_path(area.id) %></li>
-      <% end %>
-    </ul>
-  </div>
-</div>
-
-<hr>
-
-<h2>Downloads</h2>
-
-<div class="row">
-  <div class="col">
-    <ul>
-      <li><%= link_to "Download meter collections", admin_schools_meter_collections_path %></li>
-      <li><%= link_to "Download meter attributes", admin_meter_attributes_path(format: :yaml) %></li>
-    </ul>
-  </div>
-</div>
-
-<div class="row">
-  <div class="col">
-    <h3>Carbon Intensity</h3>
-    <ul>
       <li><%= link_to 'Carbon intensity data CSV', data_feeds_carbon_intensity_readings_path(format: "csv") %></li>
     </ul>
   </div>
   <div class="col">
-    <h3>Dark Sky Feed</h3>
+    <h3>Misc Downloads</h3>
     <ul>
-      <% DarkSkyArea.all.order(:title).each do |area| %>
-        <li><%= link_to "CSV for #{area.title}", data_feeds_dark_sky_temperature_readings_path(area.id, format: "csv") %></li>
-      <% end %>
-    </ul>
-  </div>
-  <div class="col">
-    <h3>Solar PV Feed</h3>
-    <ul>
-      <% SolarPvTuosArea.all.order(:title).each do |area| %>
-        <li><%= link_to "CSV for #{area.title}", data_feeds_solar_pv_tuos_readings_path(area.id, format: "csv") %></li>
-      <% end %>
-    </ul>
-  </div>
-  <div class="col">
-    <h3>Weather Stations</h3>
-    <ul>
-      <% WeatherStation.by_title.each do |area| %>
-        <li><%= link_to "CSV for #{area.title}", data_feeds_weather_observations_path(area.id, format: "csv") %></li>
-      <% end %>
+      <li><%= link_to "Download meter collections", admin_schools_meter_collections_path %></li>
+      <li><%= link_to "Download meter attributes", admin_meter_attributes_path(format: :yaml) %></li>
     </ul>
   </div>
 </div>

--- a/app/views/admin/solar_pv_tuos_areas/index.html.erb
+++ b/app/views/admin/solar_pv_tuos_areas/index.html.erb
@@ -43,7 +43,9 @@
         <td><%= area.schools.count %></td>
         <td>
           <div class='btn-group'>
-            <%= link_to 'Edit', edit_admin_solar_pv_tuos_area_path(area), class: 'btn' %>
+            <%= link_to 'Edit', edit_admin_solar_pv_tuos_area_path(area), class: 'btn btn-sm' %>
+            <%= link_to "Report", data_feeds_solar_pv_tuos_readings_path(area.id), class: 'btn btn-sm' %>
+            <%= link_to "CSV", data_feeds_solar_pv_tuos_readings_path(area.id, format: "csv"), class: 'btn btn-sm' %>
           </div>
         </td>
       </tr>

--- a/app/views/admin/weather_stations/index.html.erb
+++ b/app/views/admin/weather_stations/index.html.erb
@@ -1,5 +1,9 @@
 <h1>Weather Stations</h1>
 
+<p>
+The following table lists all of the locations for which we are loading temperature data. For more historical data see <%= link_to "Dark Sky Areas", admin_dark_sky_areas_path %>.
+</p>
+
 <% if @weather_stations.any? %>
 <table class="table table-sorted">
   <thead>
@@ -29,13 +33,16 @@
         <td><%= station.active? %></td>
         <td>
           <div class='btn-group'>
-            <%= link_to 'Edit', edit_admin_weather_station_path(station), class: 'btn' %>
+            <%= link_to 'Edit', edit_admin_weather_station_path(station), class: 'btn btn-sm' %>
+            <%= link_to "Report", data_feeds_weather_observations_path(station.id), class: 'btn btn-sm' %>
+            <%= link_to "CSV", data_feeds_weather_observations_path(station.id, format: "csv"), class: 'btn btn-sm' %>
           </div>
         </td>
       </tr>
     <% end %>
   </tbody>
 </table>
+
 <% else %>
   <p>There are no Weather Stations</p>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -452,7 +452,7 @@ Rails.application.routes.draw do
     resources :intervention_type_groups, except: [:destroy]
     resources :intervention_types, except: [:show]
 
-    resources :dark_sky_areas, except: [:destroy, :show]
+    resources :dark_sky_areas, only: :index
     resources :weather_stations, except: [:destroy, :show]
     resources :solar_pv_tuos_areas, except: [:destroy, :show]
 

--- a/spec/system/admin/dark_sky_areas_spec.rb
+++ b/spec/system/admin/dark_sky_areas_spec.rb
@@ -13,46 +13,8 @@ RSpec.describe 'Dark sky areas', type: :system do
       visit root_path
       click_on 'Manage'
       click_on 'Admin'
+      click_on 'Weather Stations'
       click_on 'Dark Sky Areas'
-    end
-
-    it 'can create a new dark sky area' do
-      expect(page).to have_content("There are no Dark Sky Areas")
-
-      click_on 'New Dark Sky Area'
-
-      fill_in 'Title', with: title
-      fill_in 'Latitude', with: latitude
-      fill_in 'Longitude', with: longitude
-      fill_in 'Back fill years', with: back_fill_years
-
-      expect { click_on 'Create' }.to change { DarkSkyArea.count }.by(1)
-
-      expect(page).to have_content("New Dark Sky Area created")
-      expect(page).to have_content('Dark Sky Areas')
-      expect(page).to have_content title
-      expect(page).to have_content latitude
-      expect(page).to have_content longitude
-      expect(page).to have_content back_fill_years
-    end
-
-    it 'checks for valid fields' do
-      click_on 'New Dark Sky Area'
-
-      fill_in 'Title', with: title
-      fill_in 'Latitude', with: latitude
-
-      expect { click_on 'Create' }.to change { DarkSkyArea.count }.by(0)
-
-      expect(page).to have_content("can't be blank")
-
-      fill_in 'Longitude', with: longitude
-      expect { click_on 'Create' }.to change { DarkSkyArea.count }.by(1)
-
-      expect(page).to have_content('Dark Sky Areas')
-      expect(page).to have_content title
-      expect(page).to have_content latitude
-      expect(page).to have_content longitude
     end
 
     context 'with an existing dark sky area' do
@@ -61,95 +23,17 @@ RSpec.describe 'Dark sky areas', type: :system do
       before do
         click_on 'Manage'
         click_on 'Admin'
+        click_on 'Weather Stations'
         click_on 'Dark Sky Areas'
+      end
 
-        expect(DarkSkyArea.count).to be 1
+      it 'can be viewed' do
         expect(page).to have_content('Dark Sky Areas')
         expect(page).to have_content title
         expect(page).to have_content latitude
         expect(page).to have_content longitude
-      end
-
-      it 'can be edited' do
-        expect(DarkSkyArea.count).to be 1
-        click_on 'Edit'
-
-        new_latitude = 111.111
-        new_longitude = 999.999
-        new_back_fill_years = 5
-        fill_in 'Latitude', with: new_latitude
-        fill_in 'Longitude', with: new_longitude
-        fill_in 'Back fill years', with: new_back_fill_years
-
-        click_on 'Update'
-
-        expect(page).to have_content("Dark Sky Area was updated")
-
-        expect(page).to have_content('Dark Sky Areas')
-        expect(page).to have_content title
-        expect(page).to have_content new_latitude
-        expect(page).to have_content new_longitude
-        expect(page).to have_content new_back_fill_years
-      end
-
-      it 'checks for valid fields on update' do
-        click_on 'Edit'
-
-        new_latitude = 111.111
-        new_longitude = 999.999
-
-        fill_in 'Latitude', with: ''
-        fill_in 'Longitude', with: new_longitude
-
-        click_on 'Update'
-
-        expect(page).to have_content("can't be blank")
-
-        fill_in 'Latitude', with: new_latitude
-
-        click_on 'Update'
-        expect(page).to have_content("Dark Sky Area was updated")
-
-        expect(page).to have_content('Dark Sky Areas')
-        expect(page).to have_content title
-        expect(page).to have_content new_latitude
-        expect(page).to have_content new_longitude
-      end
-
-      it 'deletes old temperature readings if lat/long changed' do
-        DataFeeds::DarkSkyTemperatureReading.create!(
-          reading_date: '2020-03-25',
-          temperature_celsius_x48: 48.times.map {rand(40.0)},
-          area_id: area.id
-        )
-
-        expect(area.dark_sky_temperature_readings.count).to eq(1)
-
-        click_on 'Edit'
-
-        new_title = 'New title for this area'
-        new_latitude = 111.111
-        new_longitude = 999.999
-
-        fill_in 'Title', with: new_title
-
-        click_on 'Update'
-
-        expect(page).to have_content("Dark Sky Area was updated")
-        expect(page).to have_content new_title
-        expect(area.dark_sky_temperature_readings.count).to eq(1)
-
-        click_on 'Edit'
-
-        fill_in 'Latitude', with: new_latitude
-        fill_in 'Longitude', with: new_longitude
-
-        click_on 'Update'
-
-        expect(page).to have_content("Dark Sky Area was updated")
-        expect(page).to have_content new_latitude
-        expect(page).to have_content new_longitude
-        expect(area.dark_sky_temperature_readings.count).to eq(0)
+        expect(page).to have_content('Report')
+        expect(page).to have_content('CSV')
       end
     end
   end

--- a/spec/system/admin/solar_pv_areas_spec.rb
+++ b/spec/system/admin/solar_pv_areas_spec.rb
@@ -69,17 +69,19 @@ RSpec.describe 'Solar pv areas', type: :system do
         click_on 'Manage'
         click_on 'Admin'
         click_on 'Solar PV Areas'
+      end
 
-        expect(SolarPvTuosArea.count).to be 1
+      it 'shows the area' do
         expect(page).to have_content('Solar PV Areas')
         expect(page).to have_content title
         expect(page).to have_content latitude
         expect(page).to have_content longitude
         expect(page).to have_content 'ABC'
+        expect(page).to have_content('Report')
+        expect(page).to have_content('CSV')
       end
 
       it 'can be edited' do
-        expect(SolarPvTuosArea.count).to be 1
         click_on 'Edit'
 
         new_latitude = 111.111

--- a/spec/system/admin/weather_stations_spec.rb
+++ b/spec/system/admin/weather_stations_spec.rb
@@ -67,16 +67,18 @@ RSpec.describe 'Weather stations', type: :system do
         click_on 'Manage'
         click_on 'Admin'
         click_on 'Weather Stations'
+      end
 
-        expect(WeatherStation.count).to be 1
+      it 'displays the station' do
         expect(page).to have_content('Weather Stations')
         expect(page).to have_content title
         expect(page).to have_content latitude
         expect(page).to have_content longitude
+        expect(page).to have_content('Report')
+        expect(page).to have_content('CSV')
       end
 
       it 'can be edited' do
-        expect(WeatherStation.count).to be 1
         click_on 'Edit'
 
         new_latitude = 111.111


### PR DESCRIPTION
Tidying up a bit of technical debt.

The Dark Sky weather service shut down earlier this year. We've kept the data as it is still used by some schools.

This PR:

- removes the ability to create, edit and add new areas
- adds a note that this is old data to the admin page and move it off the main admin homepage
- move around some of the links to reports and CSV downloads for solar areas, weather stations to standardise on where these can be found and reduce the size of the admin/reports page