### PR TITLE
Add matching for single digits in 'DD-MON-YY' format

### DIFF
--- a/app/models/amr_data_feed_reading.rb
+++ b/app/models/amr_data_feed_reading.rb
@@ -99,7 +99,7 @@ class AmrDataFeedReading < ApplicationRecord
       SELECT mpan_mprn, meter_id, identifier, description, MIN(parsed_date) as earliest_reading, MAX(parsed_date) as latest_reading FROM (
         SELECT mpan_mprn, meter_id, identifier, amr_data_feed_configs.description, reading_date,
         CASE
-          WHEN reading_date ~ '\\d{2}-(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)-\\d{2}' THEN to_date(reading_date, 'DD-MON-YY')
+          WHEN reading_date ~ '\\d{1,2}-(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)-\\d{2}' THEN to_date(reading_date, 'DD-MON-YY')
           WHEN date_format='%d-%m-%Y' AND reading_date~'\\d{4}-\\d{2}-\\d{2}' THEN to_date(reading_date, 'YYYY-MM-DD')
           WHEN date_format='%d-%m-%Y' THEN to_date(reading_date, 'DD-MM-YYYY')
           WHEN date_format='%d/%m/%Y' AND reading_date~'\\d{4}-\\d{2}-\\d{2}' THEN to_date(reading_date, 'YYYY-MM-DD')

--- a/spec/models/amr_data_feed_reading_spec.rb
+++ b/spec/models/amr_data_feed_reading_spec.rb
@@ -53,6 +53,15 @@ describe AmrDataFeedReading do
           it { expect(results[0]['latest_reading']).to eq Date.new(2023, 6, 28).iso8601 }
         end
       end
+
+      context 'with single digit date' do
+        let(:date_format)   { '%d/%m/%Y' }
+        let(:reading_date)  { '2-Jun-23' }
+
+        context "it parses correctly" do
+          it { expect(results[0]['latest_reading']).to eq Date.new(2023, 6, 2).iso8601 }
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Some of the incorrectly loaded data uses a single digit format. Revise the regex that matches these to capture them properly.