### PR TITLE
Revise admin reports to support reviewing analysis

### DIFF
--- a/app/controllers/admin/reports/community_use_controller.rb
+++ b/app/controllers/admin/reports/community_use_controller.rb
@@ -1,0 +1,9 @@
+module Admin
+  module Reports
+    class CommunityUseController < AdminController
+      def index
+        @schools = School.process_data.with_community_use.by_name
+      end
+    end
+  end
+end

--- a/app/controllers/admin/reports/solar_panels_controller.rb
+++ b/app/controllers/admin/reports/solar_panels_controller.rb
@@ -3,6 +3,7 @@ module Admin
     class SolarPanelsController < AdminController
       def index
         @solar_panels = MeterAttribute.solar_panels
+        @number_of_schools = @solar_panels.uniq(&:school_id).count
       end
     end
   end

--- a/app/models/meter_attribute.rb
+++ b/app/models/meter_attribute.rb
@@ -48,27 +48,28 @@ class MeterAttribute < ApplicationRecord
 
   def self.solar_panels
     query = <<-SQL.squish
-      SELECT ma.id, m.school_id, ma.meter_id, solar.*
+      SELECT ma.id, m.school_id, s.name, ma.meter_id, solar.*
       FROM meter_attributes ma
-      INNER JOIN meters m ON ma.meter_id = m.id,
-      JSON_TO_RECORD(ma.input_data) AS solar(start_date TEXT, end_date TEXT, kwp TEXT, orientation TEXT, tilt TEXT, shading TEXT, fit_£_per_kwh TEXT, maximum_export_level_kw TEXT)
+      INNER JOIN meters m ON ma.meter_id = m.id
+      INNER JOIN schools s ON m.school_id = s.id,
+      JSON_TO_RECORD(ma.input_data) AS solar(start_date TEXT, end_date TEXT, kwp TEXT, orientation TEXT, tilt TEXT, shading TEXT, fit_£_per_kwh TEXT)
       WHERE ma.attribute_type='solar_pv' AND ma.deleted_by_id IS NULL AND ma.replaced_by_id IS NULL
-      ORDER BY meter_id;
+      ORDER BY s.name;
     SQL
     sanitized_query = ActiveRecord::Base.sanitize_sql_array(query)
     MeterAttribute.connection.select_all(sanitized_query).rows.map do |row|
       OpenStruct.new(
         meter_attribute_id: row[0],
         school_id: row[1],
-        meter: Meter.find(row[2]),
-        start_date: row[3],
-        end_date: row[4],
-        kwp: row[5],
-        orientation: row[6],
-        tilt: row[7],
-        shading: row[8],
-        fit_£_per_kwh: row[9],
-        maximum_export_level_kw: row[10]
+        school_name: row[2],
+        meter: Meter.find(row[3]),
+        start_date: row[4],
+        end_date: row[5],
+        kwp: row[6],
+        orientation: row[7],
+        tilt: row[8],
+        shading: row[9],
+        fit_£_per_kwh: row[10]
       )
     end
   end

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -199,6 +199,7 @@ class School < ApplicationRecord
   scope :not_in_cluster, -> { where(school_group_cluster_id: nil) }
 
   scope :with_energy_tariffs, -> { joins("INNER JOIN energy_tariffs ON energy_tariffs.tariff_holder_id = schools.id AND tariff_holder_type = 'School'").group('schools.id').order('schools.name') }
+  scope :with_community_use, -> { where(id: SchoolTime.community_use.select(:school_id))}
 
   validates_presence_of :urn, :name, :address, :postcode, :website, :school_type
   validates_uniqueness_of :urn

--- a/app/models/school_time.rb
+++ b/app/models/school_time.rb
@@ -22,6 +22,9 @@
 class SchoolTime < ApplicationRecord
   belongs_to :school, inverse_of: :school_times
 
+  scope :unique_days, -> { distinct(:days).pluck(:day) }
+  scope :unique_calendar_periods, -> { distinct(:calendar_periods).pluck(:calendar_period) }
+
   enum day: [:monday, :tuesday, :wednesday, :thursday, :friday, :saturday, :sunday, :weekdays, :weekends, :everyday]
   enum usage_type: [:school_day, :community_use]
   enum calendar_period: [:term_times, :only_holidays, :all_year]

--- a/app/views/admin/reports/community_use/index.html.erb
+++ b/app/views/admin/reports/community_use/index.html.erb
@@ -1,0 +1,35 @@
+<% content_for :page_title, 'Community Use Report' %>
+
+<h1>Community Use Report</h1>
+
+<p>
+  This report list the <strong><%= @schools.length %></strong> schools that has at least one "community use" period configured, along with
+  a brief summary of their configuration. Click through to view the detailed configuration of times.
+</p>
+
+<div class="row">
+  <table class="table table-sorted">
+    <thead>
+    <tr>
+      <th>School</th>
+      <th>Days</th>
+      <th>Time Of Year</th>
+      <th></th>
+    </tr>
+    </thead>
+    <tbody>
+    <% @schools.each do |school| %>
+      <tr>
+        <td><%= link_to(school.name, school_path(school)) %></td>
+        <td><%= school.school_times.community_use.unique_days.map{|d| t_day(d) }.to_sentence %></td>
+        <td><%= school.school_times.community_use.unique_calendar_periods.map{|t| t_period(t) }.sort.to_sentence %></td>
+        <td>
+          <div class="btn-group">
+            <%= link_to 'View', edit_school_times_path(school, id: 'community-use-section'), class: 'btn btn-sm' %>
+          </div>
+        </td>
+      </tr>
+    <% end %>
+    </tbody>
+  </table>
+</div>

--- a/app/views/admin/reports/index.html.erb
+++ b/app/views/admin/reports/index.html.erb
@@ -42,6 +42,7 @@
       <li><%= link_to "DCC Meter Status", admin_reports_dcc_status_index_path %></li>
       <li><%= link_to "PROB data report", admin_prob_data_reports_path %></li>
       <li><%= link_to "Solar Panels", admin_reports_solar_panels_path %></li>
+      <li><%= link_to "Community Use", admin_reports_community_use_index_path %></li>
     </ul>
 
     <h3>Tariffs</h3>

--- a/app/views/admin/reports/solar_panels/index.html.erb
+++ b/app/views/admin/reports/solar_panels/index.html.erb
@@ -3,12 +3,19 @@
 <h1>Solar Panel Summary</h1>
 
 <p>
-  This report summarises the solar panels configured on Energy Sparks to allow us
-  to generate synthetic solar data.
+  This report list all schools with a "solar_pv" meter attribute. We use this
+  configuration to estimate the school's solar power generation using data from
+  Sheffield University.
 </p>
 
 <p>
-  Solar panel overrides are not included.
+  The table lists a number of optional attributes. Only the dates and kwp values are
+  required.
+</p>
+
+<p>
+  Solar panel overrides, which are used to substitute data where we have actual
+  meter solar data are not included here.
 </p>
 
 <div class="row">
@@ -24,14 +31,13 @@
       <th>tilt</th>
       <th>shading</th>
       <th>fit_£_per_kwh</th>
-      <th>maximum_export_level_kw</th>
       <th></th>
     </tr>
     </thead>
     <tbody>
     <% @solar_panels.each do |solar_panel_config| %>
       <tr>
-        <td><%= link_to(solar_panel_config.meter.school_name, school_path(solar_panel_config.meter.school)) %></td>
+        <td><%= link_to(solar_panel_config.school_name, school_path(solar_panel_config.meter.school)) %></td>
         <td><%= link_to(solar_panel_config.meter.display_name, school_meter_path(solar_panel_config.meter.school, solar_panel_config.meter)) %></td>
         <td><%= solar_panel_config.start_date %></td>
         <td><%= solar_panel_config.end_date %></td>
@@ -40,7 +46,6 @@
         <td><%= solar_panel_config.tilt %></td>
         <td><%= solar_panel_config.shading %></td>
         <td><%= solar_panel_config.fit_£_per_kwh %></td>
-        <td><%= solar_panel_config.maximum_export_level_kw %></td>
         <td>
           <div class="btn-group">
             <%= link_to 'Edit', edit_admin_school_meter_attribute_path(solar_panel_config.meter.school, id: solar_panel_config.meter_attribute_id), class: 'btn btn-sm' %>

--- a/app/views/admin/reports/solar_panels/index.html.erb
+++ b/app/views/admin/reports/solar_panels/index.html.erb
@@ -3,7 +3,7 @@
 <h1>Solar Panel Summary</h1>
 
 <p>
-  This report list all schools with a "solar_pv" meter attribute. We use this
+  This report lists all <strong><%= @number_of_schools %></strong> schools with a "solar_pv" meter attribute. We use this
   configuration to estimate the school's solar power generation using data from
   Sheffield University.
 </p>

--- a/app/views/schools/times/edit.html.erb
+++ b/app/views/schools/times/edit.html.erb
@@ -13,7 +13,7 @@
 
 <div class="row pt-3">
   <div class="col">
-    <h1><%= t('schools.times.edit.community_use.title') %></h1>
+    <h1 id="community-use-section"><%= t('schools.times.edit.community_use.title') %></h1>
   </div>
 </div>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -561,6 +561,7 @@ Rails.application.routes.draw do
       resources :activity_types, only: [:index, :show]
       resources :dcc_status, only: [:index]
       resources :solar_panels, only: [:index]
+      resources :community_use, only: [:index]
       resource :unvalidated_readings, only: [:show]
       resource :funder_allocations, only: [:show] do
         post :deliver

--- a/spec/factories/meter_attribute.rb
+++ b/spec/factories/meter_attribute.rb
@@ -10,4 +10,21 @@ FactoryBot.define do
     input_data { { "start_date" => "01/01/2010", "end_date" => "01/01/2025", "power_kw" => "70", "charge_start_time" => { "hour" => "0", "minutes" => "0" }, "charge_end_time" => { "hour" => "24", "minutes" => "0" } } }
     association :meter, factory: :electricity_meter
   end
+
+  factory :solar_pv_attribute, class: 'MeterAttribute' do
+    transient do
+      start_date    { '01/01/2023' }
+      end_date      { '01/01/2024' }
+      kwp           { 15.0 }
+    end
+    attribute_type { :solar_pv }
+    association :meter, factory: :electricity_meter
+    input_data do
+      {
+        start_date: start_date,
+        end_date: end_date,
+        kwp: kwp
+      }
+    end
+  end
 end

--- a/spec/factories/school_time_factory.rb
+++ b/spec/factories/school_time_factory.rb
@@ -1,5 +1,25 @@
 FactoryBot.define do
-  factory :school_time do
+  trait :community_use_time do
+    usage_type      { :community_use }
+    calendar_period { :term_times }
+  end
+
+  trait :school_opening_time do
+    usage_type        { :school_day }
+    calendar_period   { :term_times }
+  end
+
+  factory :school_time, traits: [:school_open_time] do
     school
+    day             { :monday }
+    opening_time    { 800 }
+    closing_time    { 1600 }
+  end
+
+  factory :community_use, class: 'SchoolTime', traits: [:community_use_time] do
+    school
+    day             { :monday }
+    opening_time    { 1800 }
+    closing_time    { 2000 }
   end
 end

--- a/spec/factories/school_time_factory.rb
+++ b/spec/factories/school_time_factory.rb
@@ -9,7 +9,7 @@ FactoryBot.define do
     calendar_period   { :term_times }
   end
 
-  factory :school_time, traits: [:school_open_time] do
+  factory :school_time, traits: [:school_opening_time] do
     school
     day             { :monday }
     opening_time    { 800 }

--- a/spec/models/meter_attribute_spec.rb
+++ b/spec/models/meter_attribute_spec.rb
@@ -47,7 +47,7 @@ describe MeterAttribute do
   end
 
   describe '.solar_panels' do
-    let(:config) { { start_date: "2022-01-01", kwp: "10", end_date: "2023-01-01", orientation: '0', tilt: '30', shading: '6', fit_£_per_kwh: '0.3', maximum_export_level_kw: '5' } }
+    let(:config) { { start_date: "2022-01-01", kwp: "10", end_date: "2023-01-01", orientation: '0', tilt: '30', shading: '6', fit_£_per_kwh: '0.3' } }
     let!(:solar_attribute) { create(:meter_attribute, attribute_type: :solar_pv, input_data: config)}
     let!(:other_attribute) { create(:meter_attribute, attribute_type: :tariff, input_data: { type: 'economy_7' })}
     let(:solar_panels)  { MeterAttribute.solar_panels }
@@ -58,13 +58,13 @@ describe MeterAttribute do
       expect(panel.meter_attribute_id).to eq solar_attribute.id
       expect(panel.meter).to eq solar_attribute.meter
       expect(panel.school_id).to eq solar_attribute.meter.school.id
+      expect(panel.school_name).to eq solar_attribute.meter.school_name
       expect(panel.start_date).to eq '2022-01-01'
       expect(panel.end_date).to eq '2023-01-01'
       expect(panel.orientation).to eq '0'
       expect(panel.tilt).to eq '30'
       expect(panel.shading).to eq '6'
       expect(panel.fit_£_per_kwh).to eq '0.3'
-      expect(panel.maximum_export_level_kw).to eq '5'
     end
   end
 end

--- a/spec/system/admin/reports/community_use_spec.rb
+++ b/spec/system/admin/reports/community_use_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+describe 'Community Use Report', type: :system do
+  let(:admin)                       { create(:admin) }
+  let!(:community_use)              { create(:community_use) }
+
+  before do
+    sign_in(admin)
+    visit root_path
+    click_on 'Manage'
+    click_on 'Reports'
+  end
+
+  it 'displays a report' do
+    click_on 'Community Use'
+    expect(page).to have_link(community_use.school.name, href: school_path(community_use.school))
+    expect(page).to have_content('Monday')
+    expect(page).to have_content('Term Times')
+    expect(page).to have_link('View', href: edit_school_times_path(community_use.school, id: 'community-use-section'))
+  end
+end

--- a/spec/system/admin/reports/solar_panels_spec.rb
+++ b/spec/system/admin/reports/solar_panels_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+describe 'Solar Panels Report', type: :system do
+  let(:admin) { create(:admin) }
+  let!(:solar_panels) { create(:solar_pv_attribute) }
+
+  before do
+    sign_in(admin)
+    visit root_path
+    click_on 'Manage'
+    click_on 'Reports'
+  end
+
+  it 'displays a report' do
+    click_on 'Solar Panels'
+    expect(page).to have_link(solar_panels.meter.school.name, href: school_path(solar_panels.meter.school))
+    expect(page).to have_link(solar_panels.meter.name, href: school_meter_path(solar_panels.meter.school, solar_panels.meter))
+    expect(page).to have_content(solar_panels.input_data['start_date'])
+    expect(page).to have_content(solar_panels.input_data['end_date'])
+    expect(page).to have_content(solar_panels.input_data['kwp'])
+    expect(page).to have_link('Edit', href: edit_admin_school_meter_attribute_path(solar_panels.meter.school, id: solar_panels.id))
+  end
+end


### PR DESCRIPTION
To properly review and test some of the recent changes to the baseload analysis we need better reports on:

- which schools have synthetic solar data
- which schools have community use periods

The first list help us identify schools affected by the change in algorithm, the second so that we can review impacts on community use reporting in charts.

This PR

- revises the existing solar report to add a school count, remove an unneeded column and some small optimisations
- adds a report that summarises which schools have community use periods configured with a summary of which days and calendar periods those periods cover