### PR TITLE
Fix out of date alert

### DIFF
--- a/app/services/alerts/system/missing_data.rb
+++ b/app/services/alerts/system/missing_data.rb
@@ -41,12 +41,8 @@ module Alerts
           rating: [0.0, rating].max,
           enough_data: :enough,
           relevance: :relevant,
-          template_data: {
-            mpan_mprns: mpan_mprns
-          },
-          template_data_cy: {
-            mpan_mprns: mpan_mprns(locale: :cy)
-          },
+          template_data: {},
+          template_data_cy: {},
           priority_data: {
             time_of_year_relevance: 5.0
           }
@@ -68,10 +64,6 @@ module Alerts
 
       def cutoff
         @cutoff ||= @today - MISSING_CUTOFF_DAYS.days
-      end
-
-      def mpan_mprns(locale: :en)
-        I18n.with_locale(locale) { @aggregated_meters.meter_list.to_sentence }
       end
     end
   end

--- a/app/services/alerts/system/missing_electricity_data.rb
+++ b/app/services/alerts/system/missing_electricity_data.rb
@@ -1,18 +1,8 @@
 module Alerts
   module System
     class MissingElectricityData
-      # Temporary constant to match analytics
-      TEMPLATE_VARIABLES = {
-        mpan_mprns: {
-          description: 'A list of the MPAN/MPRNs for the late running meters',
-          units: :string
-        }
-      }.freeze
-
       def self.front_end_template_variables
-        {
-          'General' => TEMPLATE_VARIABLES
-        }
+        {}
       end
 
       def self.front_end_template_charts

--- a/app/services/alerts/system/missing_gas_data.rb
+++ b/app/services/alerts/system/missing_gas_data.rb
@@ -1,18 +1,8 @@
 module Alerts
   module System
     class MissingGasData
-      # Temporary constant to match analytics
-      TEMPLATE_VARIABLES = {
-        mpan_mprns: {
-          description: 'A list of the MPAN/MPRNs for the late running meters',
-          units: :string
-        }
-      }.freeze
-
       def self.front_end_template_variables
-        {
-          'General' => TEMPLATE_VARIABLES
-        }
+        {}
       end
 
       def self.front_end_template_charts

--- a/spec/services/alerts/system/missing_electricity_data_spec.rb
+++ b/spec/services/alerts/system/missing_electricity_data_spec.rb
@@ -20,7 +20,6 @@ describe Alerts::System::MissingElectricityData do
     let(:electricity_end_date) { today - 21.days }
 
     before do
-      allow(electricity_aggregate_meter).to receive(:meter_list).and_return(%w[11234567890 21234567890 31234567890])
       allow(meter_collection).to receive(:aggregated_electricity_meters).and_return(electricity_aggregate_meter)
     end
 
@@ -40,9 +39,8 @@ describe Alerts::System::MissingElectricityData do
       expect(report.relevance).to eq(:relevant)
     end
 
-    it 'has the mpan_mprns as a variable' do
-      expect(report.template_data[:mpan_mprns]).to eq('11234567890, 21234567890, and 31234567890')
-      expect(report.template_data_cy[:mpan_mprns]).to eq('11234567890, 21234567890, a 31234567890')
+    it 'has no template variables' do
+      expect(report.template_data).to be_empty
     end
 
     it 'has a priority relevance of 5' do

--- a/spec/services/alerts/system/missing_gas_data_spec.rb
+++ b/spec/services/alerts/system/missing_gas_data_spec.rb
@@ -20,7 +20,6 @@ describe Alerts::System::MissingGasData do
     let(:gas_end_date) { today - 21.days }
 
     before do
-      allow(gas_aggregate_meter).to receive(:meter_list).and_return(%w[11234567890 21234567890 31234567890])
       allow(meter_collection).to receive(:aggregated_heat_meters).and_return(gas_aggregate_meter)
     end
 
@@ -40,9 +39,8 @@ describe Alerts::System::MissingGasData do
       expect(report.relevance).to eq(:relevant)
     end
 
-    it 'has the mpan_mprns as a variable' do
-      expect(report.template_data[:mpan_mprns]).to eq('11234567890, 21234567890, and 31234567890')
-      expect(report.template_data_cy[:mpan_mprns]).to eq('11234567890, 21234567890, a 31234567890')
+    it 'has no template variables' do
+      expect(report.template_data).to be_empty
     end
 
     it 'has a priority relevance of 5' do


### PR DESCRIPTION
This recent change introduced a bug in the alert that warns about missing data: https://github.com/Energy-Sparks/energy-sparks/pull/3181

The code calls `#meter_list` on the aggregate meter, but this isn't a method that is implemented by that class. The failure wasn't seen earlier because the specs mocked out that method so the tests pass.

As we're no longer checking individual meters it doesnt make sense to add a list of mpans to the alert report anyway, so I've just removed support for that, as well as calls to the method.