### PR TITLE
Remove reference to MeterAttributes helper

### DIFF
--- a/app/controllers/admin/schools/single_meter_attributes_controller.rb
+++ b/app/controllers/admin/schools/single_meter_attributes_controller.rb
@@ -4,8 +4,6 @@ module Admin
       before_action :set_view_paths
       load_and_authorize_resource :school
 
-      include MeterAttributesHelper
-
       def show
         @available_meter_attributes = MeterAttributes.all
         @meter = @school.meters.find(params[:id])


### PR DESCRIPTION
Helper as removed in earlier PR. Reference didn't cause any issues, except when released to test. The missing class caused the rails app to fail to start.