### PR TITLE
Fix loading error when solar installations have no readings

### DIFF
--- a/app/models/low_carbon_hub_installation.rb
+++ b/app/models/low_carbon_hub_installation.rb
@@ -40,7 +40,7 @@ class LowCarbonHubInstallation < ApplicationRecord
   end
 
   def latest_electricity_reading
-    if electricity_meter && electricity_meter.amr_data_feed_readings
+    if electricity_meter && electricity_meter.amr_data_feed_readings.any?
       Date.parse(electricity_meter.amr_data_feed_readings.order(reading_date: :desc).first.reading_date)
     end
   end

--- a/app/models/rtone_variant_installation.rb
+++ b/app/models/rtone_variant_installation.rb
@@ -37,7 +37,7 @@ class RtoneVariantInstallation < ApplicationRecord
   validates_uniqueness_of :rtone_meter_id, scope: :school
 
   def latest_electricity_reading
-    if meter.amr_data_feed_readings.any?
+    if meter&.amr_data_feed_readings&.any?
       Date.parse(meter.amr_data_feed_readings.order(reading_date: :desc).first.reading_date)
     end
   end

--- a/app/models/solar_edge_installation.rb
+++ b/app/models/solar_edge_installation.rb
@@ -39,7 +39,7 @@ class SolarEdgeInstallation < ApplicationRecord
   end
 
   def latest_electricity_reading
-    if electricity_meter && electricity_meter.amr_data_feed_readings
+    if electricity_meter && electricity_meter.amr_data_feed_readings.any?
       Date.parse(electricity_meter.amr_data_feed_readings.order(reading_date: :desc).first.reading_date)
     end
   end

--- a/app/services/solar/base_download_and_upsert.rb
+++ b/app/services/solar/base_download_and_upsert.rb
@@ -9,10 +9,10 @@ module Solar
     def perform
       download_and_upsert
     rescue => e
+      Rollbar.error(e, job: job, school: school.name, start_date: start_date, end_date: end_date, installation_id: @installation.id)
       import_log.update!(error_messages: "Error downloading data from #{start_date} to #{end_date} for #{school.name} : #{e.class}  #{e.message}")
       Rails.logger.error "Exception: downloading solar data from #{start_date} to #{end_date} : #{e.class} #{e.message}"
       Rails.logger.error e.backtrace.join("\n")
-      Rollbar.error(e, job: job, school: school.name, start_date: start_date, end_date: end_date, installation_id: @installation.id)
     end
 
     protected

--- a/lib/tasks/solar/import_rtone_variant_readings.rake
+++ b/lib/tasks/solar/import_rtone_variant_readings.rake
@@ -6,9 +6,17 @@ namespace :solar do
     end_date = args[:end_date].present? ? Date.parse(args[:end_date]) : nil
 
     puts "#{DateTime.now.utc} import_rtone_variant_readings start"
-    RtoneVariantInstallation.all.each do |installation|
-      puts "Running for #{installation.rtone_meter_id}"
-      Solar::RtoneVariantDownloadAndUpsert.new(installation: installation, start_date: start_date, end_date: end_date).perform
+    begin
+      RtoneVariantInstallation.all.each do |installation|
+        puts "Running for #{installation.rtone_meter_id}"
+        Solar::RtoneVariantDownloadAndUpsert.new(installation: installation, start_date: start_date, end_date: end_date).perform
+      end
+    rescue => e
+      puts "Exception: importing readings #{e.class} #{e.message}"
+      puts e.backtrace.join("\n")
+      Rails.logger.error "Exception: importing readings: #{e.class} #{e.message}"
+      Rails.logger.error e.backtrace.join("\n")
+      Rollbar.error(e, job: :import_solar_edge_readings)
     end
     puts "#{DateTime.now.utc} import_rtone_variant_readings end"
   end

--- a/lib/tasks/solar/import_solar_edge_readings.rake
+++ b/lib/tasks/solar/import_solar_edge_readings.rake
@@ -6,9 +6,17 @@ namespace :solar do
     end_date = args[:end_date].present? ? Date.parse(args[:end_date]) : nil
 
     puts "#{DateTime.now.utc} import_solar_edge_readings start"
-    SolarEdgeInstallation.all.each do |installation|
-      puts "Running for #{installation.school.name} #{installation.site_id}"
-      Solar::SolarEdgeDownloadAndUpsert.new(installation: installation, start_date: start_date, end_date: end_date).perform
+    begin
+      SolarEdgeInstallation.all.each do |installation|
+        puts "Running for #{installation.school.name} #{installation.site_id}"
+        Solar::SolarEdgeDownloadAndUpsert.new(installation: installation, start_date: start_date, end_date: end_date).perform
+      end
+    rescue => e
+      puts "Exception: importing readings #{e.class} #{e.message}"
+      puts e.backtrace.join("\n")
+      Rails.logger.error "Exception: importing readings: #{e.class} #{e.message}"
+      Rails.logger.error e.backtrace.join("\n")
+      Rollbar.error(e, job: :import_solar_edge_readings)
     end
     puts "#{DateTime.now.utc} import_solar_edge_readings end"
   end

--- a/spec/factories/low_carbon_hub_installations_factory.rb
+++ b/spec/factories/low_carbon_hub_installations_factory.rb
@@ -7,6 +7,15 @@ FactoryBot.define do
     username { |n| "username_#{n}" }
     password { |n| "password_#{n}" }
 
+    trait :with_electricity_meter do
+      after(:create) do |low_carbon_hub_installation, _evaluator|
+        create(:electricity_meter,
+          mpan_mprn: 60000000000000 + low_carbon_hub_installation.rbee_meter_id.to_i,
+          pseudo: true,
+          low_carbon_hub_installation: low_carbon_hub_installation)
+      end
+    end
+
     factory :low_carbon_hub_installation_with_meters_and_validated_readings do
       transient do
         reading_count { 1 }

--- a/spec/factories/solar_edge_installations_factory.rb
+++ b/spec/factories/solar_edge_installations_factory.rb
@@ -6,6 +6,15 @@ FactoryBot.define do
     sequence(:mpan) { |n| n }
     sequence(:api_key) { |n| "api_key_#{n}" }
 
+    trait :with_electricity_meter do
+      after(:create) do |solar_edge_installation, _evaluator|
+        create(:electricity_meter,
+          mpan_mprn: 60000000000000 + solar_edge_installation.mpan.to_i,
+          pseudo: true,
+          solar_edge_installation: solar_edge_installation)
+      end
+    end
+
     factory :solar_edge_installation_with_meters_and_validated_readings do
       transient do
         reading_count { 1 }

--- a/spec/models/low_carbon_hub_installation_spec.rb
+++ b/spec/models/low_carbon_hub_installation_spec.rb
@@ -1,0 +1,59 @@
+require 'rails_helper'
+
+describe LowCarbonHubInstallation do
+  subject(:low_carbon_hub_installation) { create(:low_carbon_hub_installation) }
+
+  describe '#electricity_meter' do
+    let(:meter) { low_carbon_hub_installation.electricity_meter }
+
+    context 'when there is no meter' do
+      it 'returns nil' do
+        expect(meter).to be_nil
+      end
+    end
+
+    context 'when there is only an electricity meter' do
+      subject(:low_carbon_hub_installation) { create(:low_carbon_hub_installation, :with_electricity_meter) }
+
+      it 'returns the meter' do
+        expect(meter).to eq(low_carbon_hub_installation.meters.first)
+      end
+    end
+
+    context 'when all meters are present' do
+      subject(:low_carbon_hub_installation) { create(:low_carbon_hub_installation_with_meters_and_validated_readings) }
+
+      it 'returns the meter' do
+        expect(meter).to eq(Meter.electricity.first)
+      end
+    end
+  end
+
+  describe '#latest_electricity_reading' do
+    let(:latest_electricity_reading) { low_carbon_hub_installation.latest_electricity_reading }
+
+    context 'when there is no meter' do
+      it 'returns nil' do
+        expect(latest_electricity_reading).to be_nil
+      end
+    end
+
+    context 'when there is an electricity meter' do
+      context 'with no readings' do
+        let!(:electricity_meter) { create(:electricity_meter, mpan_mprn: 60000000000000 + low_carbon_hub_installation.rbee_meter_id.to_i, pseudo: true, low_carbon_hub_installation: low_carbon_hub_installation) }
+
+        it 'returns nil' do
+          expect(latest_electricity_reading).to be_nil
+        end
+      end
+
+      context 'with readings' do
+        let!(:electricity_meter) { create(:electricity_meter_with_reading, mpan_mprn: 60000000000000 + low_carbon_hub_installation.rbee_meter_id.to_i, pseudo: true, low_carbon_hub_installation: low_carbon_hub_installation) }
+
+        it 'returns the latest date' do
+          expect(latest_electricity_reading).to eq(Date.parse(AmrDataFeedReading.first.reading_date))
+        end
+      end
+    end
+  end
+end

--- a/spec/models/solar_edge_installation_spec.rb
+++ b/spec/models/solar_edge_installation_spec.rb
@@ -1,0 +1,60 @@
+require 'rails_helper'
+
+
+describe SolarEdgeInstallation do
+  subject(:solar_edge_installation) { create(:solar_edge_installation) }
+
+  describe '#electricity_meter' do
+    let(:meter) { solar_edge_installation.electricity_meter }
+
+    context 'when there is no meter' do
+      it 'returns nil' do
+        expect(meter).to be_nil
+      end
+    end
+
+    context 'when there is only an electricity meter' do
+      subject(:solar_edge_installation) { create(:solar_edge_installation, :with_electricity_meter) }
+
+      it 'returns the meter' do
+        expect(meter).to eq(solar_edge_installation.meters.first)
+      end
+    end
+
+    context 'when all meters are present' do
+      subject(:solar_edge_installation) { create(:solar_edge_installation_with_meters_and_validated_readings) }
+
+      it 'returns the meter' do
+        expect(meter).to eq(Meter.electricity.first)
+      end
+    end
+  end
+
+  describe '#latest_electricity_reading' do
+    let(:latest_electricity_reading) { solar_edge_installation.latest_electricity_reading }
+
+    context 'when there is no meter' do
+      it 'returns nil' do
+        expect(latest_electricity_reading).to be_nil
+      end
+    end
+
+    context 'when there is an electricity meter' do
+      context 'with no readings' do
+        let!(:electricity_meter) { create(:electricity_meter, mpan_mprn: 60000000000000 + solar_edge_installation.mpan.to_i, pseudo: true, solar_edge_installation: solar_edge_installation) }
+
+        it 'returns nil' do
+          expect(latest_electricity_reading).to be_nil
+        end
+      end
+
+      context 'with readings' do
+        let!(:electricity_meter) { create(:electricity_meter_with_reading, mpan_mprn: 60000000000000 + solar_edge_installation.mpan.to_i, pseudo: true, solar_edge_installation: solar_edge_installation) }
+
+        it 'returns the latest date' do
+          expect(latest_electricity_reading).to eq(Date.parse(AmrDataFeedReading.first.reading_date))
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
The check for existence of `amr_data_feed_readings` for the electricity meter associated with a solar installation is incorrect, it should be checking for `.any?`. 

Currently if the meter doesn't have readings, then we attempt to find the latest. This throws an exception during loading.

This should be throwing an exception which is caught and then logged in rollbar via `BaseDownloadAndUpsert#perform`. This hasn't been happening when this error occurs because the logging includes the `start_date` for the loading. This ends up calling the `latest_electricity_reading` method again which triggers the error.

The uncaught exception results in the whole loading run rake task to fail, but this only ends up in the logs not Rollbar.

This PR: 

- fixes the checks in the models
- adds specs for the models to demonstrate and test the behaviour
- updates the rake tasks to add a catch all exception handler

Note: I didn't add shared examples for the model specs, although the checks are largely identical, because there are slightly different ways to create the installations and associated meters. Trying to factor that out felt like it was add more overhead than I was saving.