### PR TITLE
Initial version of report for identifying engaged schools

### DIFF
--- a/app/controllers/admin/reports/engaged_schools_controller.rb
+++ b/app/controllers/admin/reports/engaged_schools_controller.rb
@@ -2,7 +2,7 @@ module Admin
   module Reports
     class EngagedSchoolsController < AdminController
       def index
-        @engaged_schools = School.engaged.by_name
+        @engaged_schools = School.engaged.joins(:school_group).order('school_groups.name asc, name asc')
       end
     end
   end

--- a/app/controllers/admin/reports/engaged_schools_controller.rb
+++ b/app/controllers/admin/reports/engaged_schools_controller.rb
@@ -1,0 +1,9 @@
+module Admin
+  module Reports
+    class EngagedSchoolsController < AdminController
+      def index
+        @engaged_schools = School.engaged.by_name
+      end
+    end
+  end
+end

--- a/app/controllers/admin/reports/engaged_schools_controller.rb
+++ b/app/controllers/admin/reports/engaged_schools_controller.rb
@@ -2,14 +2,14 @@ module Admin
   module Reports
     class EngagedSchoolsController < AdminController
       def index
+        @engaged_schools = ::Schools::EngagedSchoolService.list_engaged_schools
+
         respond_to do |format|
           format.html do
-            @engaged_schools = ::Schools::EngagedSchoolService.list_engaged_schools
             @visible_schools = School.visible.count
             @percentage = percentage_engaged
           end
           format.csv do
-            @engaged_schools = ::Schools::EngagedSchoolService.list_engaged_schools
             send_data csv_report(@engaged_schools), filename: "engaged-schools-report-#{Time.zone.now.iso8601}".parameterize + '.csv'
           end
         end

--- a/app/controllers/admin/reports/engaged_schools_controller.rb
+++ b/app/controllers/admin/reports/engaged_schools_controller.rb
@@ -23,9 +23,24 @@ module Admin
 
       def csv_report(engaged_schools)
         CSV.generate(headers: true) do |csv|
-          csv << []
+          csv << ['School Group', 'School', 'Funder', 'Country', 'Activities', 'Actions',
+                  'Programmes', 'Target?', 'Transport survey?', 'Temperatures?',
+                  'Active users', 'Last visit']
           engaged_schools.each do |service|
-            csv << [service.school.name]
+            csv << [
+              service.school_group.name,
+              service.school.name,
+              service.school.funder.present? ? service.school.funder.name : nil,
+              service.school.country.humanize,
+              service.recent_activity_count,
+              service.recent_action_count,
+              service.recently_enrolled_programme_count,
+              service.active_target? ? 'Y' : 'N',
+              service.transport_surveys? ? 'Y' : 'N',
+              service.temperature_recordings? ? 'Y' : 'N',
+              service.recently_logged_in_user_count,
+              service.most_recent_login.present? ? service.most_recent_login.iso8601 : nil
+            ]
           end
         end
       end

--- a/app/controllers/admin/reports/engaged_schools_controller.rb
+++ b/app/controllers/admin/reports/engaged_schools_controller.rb
@@ -2,7 +2,32 @@ module Admin
   module Reports
     class EngagedSchoolsController < AdminController
       def index
-        @engaged_schools = School.engaged.joins(:school_group).order('school_groups.name asc, name asc')
+        respond_to do |format|
+          format.html do
+            @engaged_schools = ::Schools::EngagedSchoolService.list_engaged_schools
+            @visible_schools = School.visible.count
+            @percentage = percentage_engaged
+          end
+          format.csv do
+            @engaged_schools = ::Schools::EngagedSchoolService.list_engaged_schools
+            send_data csv_report(@engaged_schools), filename: "engaged-schools-report-#{Time.zone.now.iso8601}".parameterize + '.csv'
+          end
+        end
+      end
+
+      private
+
+      def percentage_engaged
+        sprintf('%.2f', @engaged_schools.size / @visible_schools.to_f * 100)
+      end
+
+      def csv_report(engaged_schools)
+        CSV.generate(headers: true) do |csv|
+          csv << []
+          engaged_schools.each do |service|
+            csv << [service.school.name]
+          end
+        end
       end
     end
   end

--- a/app/models/academic_year.rb
+++ b/app/models/academic_year.rb
@@ -18,6 +18,10 @@ class AcademicYear < ApplicationRecord
 
   scope :for_date, ->(date) { where('start_date <= ? AND end_date >= ?', date, date) }
 
+  def self.current
+    for_date(Time.zone.today).first
+  end
+
   def current?(today = Time.zone.today)
     (start_date <= today) && (end_date >= today)
   end

--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -70,6 +70,7 @@ class Observation < ApplicationRecord
   scope :between, ->(first_date, last_date) { where('at BETWEEN ? AND ?', first_date, last_date) }
   scope :recorded_in_last_year, -> { where('created_at >= ?', 1.year.ago)}
   scope :recorded_in_last_week, -> { where('created_at >= ?', 1.week.ago)}
+  scope :recorded_since, ->(date) { where('created_at >= ?', date)}
 
   scope :engagement, -> { where(observation_type: [:temperature, :intervention, :activity, :audit, :school_target, :programme]) }
 

--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -71,6 +71,8 @@ class Observation < ApplicationRecord
   scope :recorded_in_last_year, -> { where('created_at >= ?', 1.year.ago)}
   scope :recorded_in_last_week, -> { where('created_at >= ?', 1.week.ago)}
 
+  scope :engagement, -> { where(observation_type: [:temperature, :intervention, :activity, :audit, :school_target, :programme]) }
+
   has_rich_text :description
 
   before_save :add_points_for_interventions, if: :intervention?

--- a/app/models/programme.rb
+++ b/app/models/programme.rb
@@ -49,7 +49,9 @@ class Programme < ApplicationRecord
     end
   end
 
-  scope :recently_started_non_default, ->(date) { Programme.where.not(programme_type: ProgrammeType.default).where('created_at > ?', date) }
+  scope :recently_started, ->(date) { where('created_at > ?', date) }
+  scope :recently_started_non_default, ->(date) { recently_started(date).where.not(programme_type: ProgrammeType.default) }
+
   scope :active, -> { joins(:programme_type).merge(ProgrammeType.active) }
 
   delegate :title, :description, :short_description, :document_link, :image, to: :programme_type

--- a/app/models/programme.rb
+++ b/app/models/programme.rb
@@ -49,6 +49,7 @@ class Programme < ApplicationRecord
     end
   end
 
+  scope :recently_started_non_default, ->(date) { Programme.where.not(programme_type: ProgrammeType.default).where('created_at > ?', date) }
   scope :active, -> { joins(:programme_type).merge(ProgrammeType.active) }
 
   delegate :title, :description, :short_description, :document_link, :image, to: :programme_type

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -205,10 +205,12 @@ class School < ApplicationRecord
   #TODO: exclude default programme
   scope :with_recent_engagement, -> { where(id: Observation.engagement.recorded_since(AcademicYear.current.start_date).select(:school_id)) }
 
+  scope :with_transport_survey, -> { where(id: TransportSurvey.recently_added(AcademicYear.current.start_date).select(:school_id))}
+
   #TODO: cluster users, not just those directly linked
   scope :with_recently_logged_in_users, -> { where(id: User.recently_logged_in(AcademicYear.current.start_date).select(:school_id))}
 
-  scope :engaged, -> { with_recent_engagement.or(with_recently_logged_in_users) }
+  scope :engaged, -> { with_recent_engagement.or(with_recently_logged_in_users).or(with_transport_survey) }
 
   validates_presence_of :urn, :name, :address, :postcode, :website, :school_type
   validates_uniqueness_of :urn

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -203,10 +203,10 @@ class School < ApplicationRecord
 
   #includes creating a target, recording activities and actions, having an audit, starting a programme, recording temperatures
   #TODO: exclude default programme
-  scope :with_recent_engagement, -> { where(id: Observation.engagement.recorded_since(30.days.ago).select(:school_id)) }
+  scope :with_recent_engagement, -> { where(id: Observation.engagement.recorded_since(AcademicYear.current.start_date).select(:school_id)) }
 
   #TODO: cluster users, not just those directly linked
-  scope :with_recently_logged_in_users, -> { where(id: User.recently_logged_in(30.days.ago).select(:school_id))}
+  scope :with_recently_logged_in_users, -> { where(id: User.recently_logged_in(AcademicYear.current.start_date).select(:school_id))}
 
   scope :engaged, -> { with_recent_engagement.or(with_recently_logged_in_users) }
 

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -201,6 +201,14 @@ class School < ApplicationRecord
   scope :with_energy_tariffs, -> { joins("INNER JOIN energy_tariffs ON energy_tariffs.tariff_holder_id = schools.id AND tariff_holder_type = 'School'").group('schools.id').order('schools.name') }
   scope :with_community_use, -> { where(id: SchoolTime.community_use.select(:school_id))}
 
+  #includes creating a target, recording activities and actions, having an audit, starting a programme, recording temperatures
+  #TODO: exclude default programme
+  scope :with_recent_engagement, -> { where(id: Observation.engagement.recorded_in_last_year.select(:school_id)) }
+  #TODO: cluster users, not just those directly linked
+  scope :with_recently_logged_in_users, -> { where(id: User.recently_logged_in.select(:school_id))}
+
+  scope :engaged, -> { with_recent_engagement.or(with_recently_logged_in_users) }
+
   validates_presence_of :urn, :name, :address, :postcode, :website, :school_type
   validates_uniqueness_of :urn
   validates :floor_area, :number_of_pupils, :cooks_dinners_for_other_schools_count, numericality: { greater_than: 0, allow_blank: true }

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -203,9 +203,10 @@ class School < ApplicationRecord
 
   #includes creating a target, recording activities and actions, having an audit, starting a programme, recording temperatures
   #TODO: exclude default programme
-  scope :with_recent_engagement, -> { where(id: Observation.engagement.recorded_in_last_year.select(:school_id)) }
+  scope :with_recent_engagement, -> { where(id: Observation.engagement.recorded_since(30.days.ago).select(:school_id)) }
+
   #TODO: cluster users, not just those directly linked
-  scope :with_recently_logged_in_users, -> { where(id: User.recently_logged_in.select(:school_id))}
+  scope :with_recently_logged_in_users, -> { where(id: User.recently_logged_in(30.days.ago).select(:school_id))}
 
   scope :engaged, -> { with_recent_engagement.or(with_recently_logged_in_users) }
 

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -206,11 +206,12 @@ class School < ApplicationRecord
   scope :with_recent_engagement, -> { where(id: Observation.engagement.recorded_since(AcademicYear.current.start_date).select(:school_id)) }
 
   scope :with_transport_survey, -> { where(id: TransportSurvey.recently_added(AcademicYear.current.start_date).select(:school_id))}
+  scope :joined_programme, -> { where(id: Programme.recently_started_non_default(AcademicYear.current.start_date).select(:school_id))}
 
   #TODO: cluster users, not just those directly linked
   scope :with_recently_logged_in_users, -> { where(id: User.recently_logged_in(AcademicYear.current.start_date).select(:school_id))}
 
-  scope :engaged, -> { with_recent_engagement.or(with_recently_logged_in_users).or(with_transport_survey) }
+  scope :engaged, -> { with_recent_engagement.or(with_recently_logged_in_users).or(with_transport_survey).or(joined_programme) }
 
   validates_presence_of :urn, :name, :address, :postcode, :website, :school_type
   validates_uniqueness_of :urn

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -202,16 +202,19 @@ class School < ApplicationRecord
   scope :with_community_use, -> { where(id: SchoolTime.community_use.select(:school_id))}
 
   #includes creating a target, recording activities and actions, having an audit, starting a programme, recording temperatures
-  #TODO: exclude default programme
   scope :with_recent_engagement, -> { where(id: Observation.engagement.recorded_since(AcademicYear.current.start_date).select(:school_id)) }
 
+  #have recently run a transport survey
   scope :with_transport_survey, -> { where(id: TransportSurvey.recently_added(AcademicYear.current.start_date).select(:school_id))}
+
+  #have recently started a programme that isn't the default programme
   scope :joined_programme, -> { where(id: Programme.recently_started_non_default(AcademicYear.current.start_date).select(:school_id))}
 
   #TODO: cluster users, not just those directly linked
   scope :with_recently_logged_in_users, -> { where(id: User.recently_logged_in(AcademicYear.current.start_date).select(:school_id))}
 
-  scope :engaged, -> { with_recent_engagement.or(with_recently_logged_in_users).or(with_transport_survey).or(joined_programme) }
+  #combination of other scopes to define an engaged school
+  scope :engaged, -> { active.with_recent_engagement.or(with_recently_logged_in_users).or(with_transport_survey).or(joined_programme) }
 
   validates_presence_of :urn, :name, :address, :postcode, :website, :school_type
   validates_uniqueness_of :urn

--- a/app/models/school_target.rb
+++ b/app/models/school_target.rb
@@ -42,7 +42,7 @@ class SchoolTarget < ApplicationRecord
   scope :by_date, -> { order(created_at: :desc) }
   scope :by_start_date, -> { order(start_date: :desc) }
   scope :expired, -> { where(":now >= start_date and :now >= target_date", now: Time.zone.today) }
-  scope :currently_active, -> { where('start_date <= ? and target_date <= ?', Time.zone.today, Time.zone.today.next_year) }
+  scope :currently_active, -> { where('start_date <= :now and :now <= target_date', now: Time.zone.today) }
 
   before_save :adjust_target_date
   after_save :add_observation

--- a/app/models/transport_survey.rb
+++ b/app/models/transport_survey.rb
@@ -24,6 +24,9 @@ class TransportSurvey < ApplicationRecord
   validates :run_on, :school_id, presence: true
   validates :run_on, uniqueness: { scope: :school_id }
 
+  scope :recently_run, ->(date) { where('run_on >= ?', date)}
+  scope :recently_added, ->(date) { where('created_at >= ?', date)}
+
   def to_param
     run_on.to_s
   end

--- a/app/models/transport_survey.rb
+++ b/app/models/transport_survey.rb
@@ -24,7 +24,6 @@ class TransportSurvey < ApplicationRecord
   validates :run_on, :school_id, presence: true
   validates :run_on, uniqueness: { scope: :school_id }
 
-  scope :recently_run, ->(date) { where('run_on >= ?', date)}
   scope :recently_added, ->(date) { where('created_at >= ?', date)}
 
   def to_param

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -69,6 +69,7 @@ class User < ApplicationRecord
 
   scope :alertable, -> { where(role: [User.roles[:staff], User.roles[:school_admin], User.roles[:volunteer]]) }
 
+  scope :recently_logged_in, -> { where('last_sign_in_at >= ?', 1.year.ago) }
   validates :email, presence: true
 
   validates :pupil_password, presence: true, if: :pupil?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -69,7 +69,7 @@ class User < ApplicationRecord
 
   scope :alertable, -> { where(role: [User.roles[:staff], User.roles[:school_admin], User.roles[:volunteer]]) }
 
-  scope :recently_logged_in, -> { where('last_sign_in_at >= ?', 1.year.ago) }
+  scope :recently_logged_in, ->(date) { where('last_sign_in_at >= ?', date) }
   validates :email, presence: true
 
   validates :pupil_password, presence: true, if: :pupil?

--- a/app/services/schools/engaged_school_service.rb
+++ b/app/services/schools/engaged_school_service.rb
@@ -1,0 +1,59 @@
+module Schools
+  class EngagedSchoolService
+    attr_reader :school
+
+    def initialize(school)
+      @school = school
+    end
+
+    def self.list_engaged_schools
+      School.engaged.joins(:school_group).order('school_groups.name asc, name asc').map {|s| EngagedSchoolService.new(s) }
+    end
+
+    def school_group
+      @school.school_group
+    end
+
+    def recent_activity_count
+      @school.activities.where('created_at >= ?', since).count
+    end
+
+    def recent_action_count
+      @school.observations.intervention.where('created_at >= ?', since).count
+    end
+
+    def recently_enrolled_programme_count
+      @school.programmes.recently_started_non_default(since).count
+    end
+
+    def active_target?
+      @active_target ||= @school.school_targets.currently_active.any?
+    end
+
+    def transport_surveys?
+      @transport_surveys ||= @school.transport_surveys.recently_added(since).any?
+    end
+
+    def temperature_recordings?
+      @temperature_recordings ||= @school.observations.temperature.where('created_at >= ?', since).any?
+    end
+
+    def recently_logged_in_user_count
+      recently_logged_in.count
+    end
+
+    def most_recent_login
+      @most_recent_login ||= recently_logged_in.pluck(:last_sign_in_at).max
+    end
+
+    private
+
+    def recently_logged_in
+      @recently_logged_in ||= @school.users.recently_logged_in(since)
+    end
+
+    def since
+      @since ||= AcademicYear.current.start_date
+    end
+  end
+end

--- a/app/views/admin/reports/engaged_schools/index.html.erb
+++ b/app/views/admin/reports/engaged_schools/index.html.erb
@@ -1,0 +1,17 @@
+<h1>Engaged Schools</h1>
+
+
+<table class="table">
+  <thead>
+    <tr>
+      <th>School</th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @engaged_schools.each do |school| %>
+      <tr>
+        <td><%= link_to school.name, school_path(school) %></td>
+      </tr>
+    <% end %>
+  </tbody>
+<table>

--- a/app/views/admin/reports/engaged_schools/index.html.erb
+++ b/app/views/admin/reports/engaged_schools/index.html.erb
@@ -22,9 +22,9 @@
   <li>We're looking at engagement since early September of the current English school year</li>
 </ul>
 
-<p>Using the above measures, EnergySparks currently has <strong><%= @engaged_schools.count %></strong> engaged schools</p>
+<p>Using the above measures, EnergySparks currently has <strong><%= @engaged_schools.count %></strong> engaged schools out of <strong><%= @visible_schools %></strong> schools (<strong><%= @percentage %>%</strong>)</p>
 
-<table class="table table-sorted">
+<table class="table table-sorted table-sm">
   <thead>
     <tr>
       <th>School Group</th>
@@ -38,33 +38,24 @@
       <th>Transport survey?</th>
       <th>Temperatures?</th>
       <th>Active users</th>
-      <th>Most recent visit</th>
+      <th>Last visit</th>
     </tr>
   </thead>
   <tbody>
-    <% @engaged_schools.each do |school| %>
+    <% @engaged_schools.each do |service| %>
       <tr>
-        <td><%= link_to school.school_group.name, school_group_path(school.school_group) %></td>
-        <td><%= link_to school.name, school_path(school) %></td>
-        <td><%= school.funder.name if school.funder %></td>
-        <td><%= school.country.humanize %></td>
-        <td><%= link_to school.activities.where('created_at >= ?', AcademicYear.current.start_date).count, school_timeline_path(school) %></td>
-        <td><%= link_to school.observations.intervention.where('created_at >= ?', AcademicYear.current.start_date).count, school_timeline_path(school) %></td>
-        <td><%= school.programmes.recently_started_non_default(AcademicYear.current.start_date).count %></td>
-
-        <% active_targets = school.school_targets.currently_active.any? %>
-        <td data-order="<%= active_targets ? '1' : '0' %>"><%= checkmark(active_targets, off_class: 'text-muted') %></td>
-
-        <% surveys = school.transport_surveys.recently_run(AcademicYear.current.start_date).any? %>
-        <td data-order="<%= surveys ? '1' : '0' %>"><%= checkmark(surveys, off_class: 'text-muted') %></td>
-
-        <% temperatures = school.observations.temperature.where('created_at >= ?', AcademicYear.current.start_date).any? %>
-        <td data-order="<%= temperatures ? '1' : '0' %>"><%= checkmark(temperatures, off_class: 'text-muted') %></td>
-
-        <td><%= link_to school.users.recently_logged_in(AcademicYear.current.start_date).count, admin_school_group_users_path(school.school_group) %></td>
-
-        <% most_recent = school.users.recently_logged_in(AcademicYear.current.start_date).pluck(:last_sign_in_at).max %>
-        <td data-order="<%= most_recent.present? ? most_recent.iso8601 : '' %>"><%= nice_date_times(most_recent) %></td>
+        <td><%= link_to service.school_group.name, school_group_path(service.school_group) %></td>
+        <td><%= link_to service.school.name, school_path(service.school) %></td>
+        <td><%= service.school.funder.name if service.school.funder %></td>
+        <td><%= service.school.country.humanize %></td>
+        <td><%= link_to service.recent_activity_count, school_timeline_path(service.school) %></td>
+        <td><%= link_to service.recent_action_count, school_timeline_path(service.school) %></td>
+        <td><%= service.recently_enrolled_programme_count %></td>
+        <td data-order="<%= service.active_target? ? '1' : '0' %>"><%= checkmark(service.active_target?, off_class: 'text-muted') %></td>
+        <td data-order="<%= service.transport_surveys? ? '1' : '0' %>"><%= checkmark(service.transport_surveys?, off_class: 'text-muted') %></td>
+        <td data-order="<%= service.temperature_recordings? ? '1' : '0' %>"><%= checkmark(service.temperature_recordings?, off_class: 'text-muted') %></td>
+        <td><%= link_to service.recently_logged_in_user_count, admin_school_group_users_path(service.school_group) %></td>
+        <td data-order="<%= service.most_recent_login.present? ? service.most_recent_login.iso8601 : '' %>"><%= nice_date_times(service.most_recent_login) %></td>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/admin/reports/engaged_schools/index.html.erb
+++ b/app/views/admin/reports/engaged_schools/index.html.erb
@@ -1,27 +1,53 @@
 <h1>Engaged Schools</h1>
 
+<p>
+  The following report lists "engaged schools". An engaged school has done one of the following since the start of the current academic year (<%= nice_dates(AcademicYear.current.start_date) %>):
+</p>
+
+<ul>
+  <li>Recorded a pupil activity or adult action, set a target, started a programme, received an audit, recorded some temperatures or run a transport survey</li>
+  <li><b>OR</b> had at least one school or pupil user login to the application. Users need to log in to use the above features, but some users may log in but not otherwise engage with that functionality, by including logged in visits in our list of engaged schools we can more better track 'silent' users and schools.</li>
+</ul>
+
+<p>
+  <strong>Notes</strong>:
+</p>
+
+<ul>
+  <li>We only started comprehensively logging all visits by logged in users in October 2023. So this may explain why there are no logged in users, but schools have, e.g. recorded an activity.</li>
+  <li>Users can record they've attended training by recording an action, but otherwise attendance at our training events isn't included as a measure of engagement</li>
+  <li>When we check the dates for activity and actions being recorded, we check the date it was added to the system. So recording historical activities and actions count as engagement for the current academic year, because the user is engaging with the site</li>
+  <li>For audits the date checked is when the auditor starts adding the report to the website, which may be after the actual audit date</li>
+  <li>We're looking at engagement since early September of the current English school year</li>
+</ul>
 
 <table class="table table-sorted">
   <thead>
     <tr>
       <th>School Group</th>
       <th>School</th>
-      <th>Recent activities</th>
-      <th>Recent actions</th>
-      <th>Current target?</th>
-      <th>Recent logged in users</th>
-      <th>Most recent sign-in</th>
+      <th>Funder</th>
+      <th>Activities</th>
+      <th>Actions</th>
+      <th>Target?</th>
+      <th>Transport survey?</th>
+      <th>Logged temperatures?</th>
+      <th>Active users</th>
+      <th>Most recent visit</th>
     </tr>
   </thead>
   <tbody>
     <% @engaged_schools.each do |school| %>
       <tr>
-        <td><%= school.school_group.name %></td>
+        <td><%= link_to school.school_group.name, school_group_path(school.school_group) %></td>
         <td><%= link_to school.name, school_path(school) %></td>
-        <td><%= school.activities.where('created_at >= ?', AcademicYear.current.start_date).count %></td>
-        <td><%= school.observations.intervention.where('created_at >= ?', AcademicYear.current.start_date).count %></td>
+        <td><%= school.funder.name if school.funder %></td>
+        <td><%= link_to school.activities.where('created_at >= ?', AcademicYear.current.start_date).count, school_timeline_path(school) %></td>
+        <td><%= link_to school.observations.intervention.where('created_at >= ?', AcademicYear.current.start_date).count, school_timeline_path(school) %></td>
         <td data-order="<%= school.school_targets.currently_active.any? ? '1' : '0' %>"><%= checkmark(school.school_targets.currently_active.any?, off_class: 'text-muted') %></td>
-        <td><%= school.users.recently_logged_in(AcademicYear.current.start_date).count %></td>
+        <td data-order="<%= school.transport_surveys.recently_run(AcademicYear.current.start_date).any? ? '1' : '0' %>"><%= checkmark(school.transport_surveys.recently_run(AcademicYear.current.start_date).any?, off_class: 'text-muted') %></td>
+        <td data-order="<%= school.observations.temperature.where('created_at >= ?', AcademicYear.current.start_date).any? ? '1' : '0' %>"><%= checkmark(school.observations.temperature.where('created_at >= ?', AcademicYear.current.start_date).any?, off_class: 'text-muted') %></td>
+        <td><%= link_to school.users.recently_logged_in(AcademicYear.current.start_date).count, admin_school_group_users_path(school.school_group) %></td>
         <% most_recent = school.users.recently_logged_in(AcademicYear.current.start_date).pluck(:last_sign_in_at).max %>
         <td data-order="<%= most_recent.present? ? most_recent.iso8601 : '' %>"><%= nice_date_times(most_recent) %></td>
       </tr>

--- a/app/views/admin/reports/engaged_schools/index.html.erb
+++ b/app/views/admin/reports/engaged_schools/index.html.erb
@@ -16,10 +16,13 @@
 <ul>
   <li>We only started comprehensively logging all visits by logged in users in October 2023. So this may explain why there are no logged in users, but schools have, e.g. recorded an activity.</li>
   <li>Users can record they've attended training by recording an action, but otherwise attendance at our training events isn't included as a measure of engagement</li>
+  <li>All schools are enrolled in the default programme when they finish onboarding. This isn't included in the below figures, which only include programmes where the school have opted to start it themselves</li>
   <li>When we check the dates for activity and actions being recorded, we check the date it was added to the system. So recording historical activities and actions count as engagement for the current academic year, because the user is engaging with the site</li>
   <li>For audits the date checked is when the auditor starts adding the report to the website, which may be after the actual audit date</li>
   <li>We're looking at engagement since early September of the current English school year</li>
 </ul>
+
+<p>Using the above measures, EnergySparks currently has <strong><%= @engaged_schools.count %></strong> engaged schools</p>
 
 <table class="table table-sorted">
   <thead>
@@ -27,11 +30,13 @@
       <th>School Group</th>
       <th>School</th>
       <th>Funder</th>
+      <th>Country</th>
       <th>Activities</th>
       <th>Actions</th>
+      <th>Programmes</th>
       <th>Target?</th>
       <th>Transport survey?</th>
-      <th>Logged temperatures?</th>
+      <th>Temperatures?</th>
       <th>Active users</th>
       <th>Most recent visit</th>
     </tr>
@@ -42,12 +47,22 @@
         <td><%= link_to school.school_group.name, school_group_path(school.school_group) %></td>
         <td><%= link_to school.name, school_path(school) %></td>
         <td><%= school.funder.name if school.funder %></td>
+        <td><%= school.country.humanize %></td>
         <td><%= link_to school.activities.where('created_at >= ?', AcademicYear.current.start_date).count, school_timeline_path(school) %></td>
         <td><%= link_to school.observations.intervention.where('created_at >= ?', AcademicYear.current.start_date).count, school_timeline_path(school) %></td>
-        <td data-order="<%= school.school_targets.currently_active.any? ? '1' : '0' %>"><%= checkmark(school.school_targets.currently_active.any?, off_class: 'text-muted') %></td>
-        <td data-order="<%= school.transport_surveys.recently_run(AcademicYear.current.start_date).any? ? '1' : '0' %>"><%= checkmark(school.transport_surveys.recently_run(AcademicYear.current.start_date).any?, off_class: 'text-muted') %></td>
-        <td data-order="<%= school.observations.temperature.where('created_at >= ?', AcademicYear.current.start_date).any? ? '1' : '0' %>"><%= checkmark(school.observations.temperature.where('created_at >= ?', AcademicYear.current.start_date).any?, off_class: 'text-muted') %></td>
+        <td><%= school.programmes.recently_started_non_default(AcademicYear.current.start_date).count %></td>
+
+        <% active_targets = school.school_targets.currently_active.any? %>
+        <td data-order="<%= active_targets ? '1' : '0' %>"><%= checkmark(active_targets, off_class: 'text-muted') %></td>
+
+        <% surveys = school.transport_surveys.recently_run(AcademicYear.current.start_date).any? %>
+        <td data-order="<%= surveys ? '1' : '0' %>"><%= checkmark(surveys, off_class: 'text-muted') %></td>
+
+        <% temperatures = school.observations.temperature.where('created_at >= ?', AcademicYear.current.start_date).any? %>
+        <td data-order="<%= temperatures ? '1' : '0' %>"><%= checkmark(temperatures, off_class: 'text-muted') %></td>
+
         <td><%= link_to school.users.recently_logged_in(AcademicYear.current.start_date).count, admin_school_group_users_path(school.school_group) %></td>
+
         <% most_recent = school.users.recently_logged_in(AcademicYear.current.start_date).pluck(:last_sign_in_at).max %>
         <td data-order="<%= most_recent.present? ? most_recent.iso8601 : '' %>"><%= nice_date_times(most_recent) %></td>
       </tr>

--- a/app/views/admin/reports/engaged_schools/index.html.erb
+++ b/app/views/admin/reports/engaged_schools/index.html.erb
@@ -24,6 +24,10 @@
 
 <p>Using the above measures, EnergySparks currently has <strong><%= @engaged_schools.count %></strong> engaged schools out of <strong><%= @visible_schools %></strong> schools (<strong><%= @percentage %>%</strong>)</p>
 
+<div class="d-flex justify-content-end">
+  <%= link_to 'Download as CSV', admin_reports_engaged_schools_path(format: :csv), class: 'btn btn-outline-dark font-weight-bold' %>
+</div>
+
 <table class="table table-sorted table-sm">
   <thead>
     <tr>

--- a/app/views/admin/reports/engaged_schools/index.html.erb
+++ b/app/views/admin/reports/engaged_schools/index.html.erb
@@ -10,6 +10,7 @@
       <th>Recent actions</th>
       <th>Current target?</th>
       <th>Recent logged in users</th>
+      <th>Most recent sign-in</th>
     </tr>
   </thead>
   <tbody>
@@ -17,10 +18,12 @@
       <tr>
         <td><%= school.school_group.name %></td>
         <td><%= link_to school.name, school_path(school) %></td>
-        <td><%= school.activities.where('created_at >= ?', 30.days.ago).count %></td>
-        <td><%= school.observations.intervention.where('created_at >= ?', 30.days.ago).count %></td>
+        <td><%= school.activities.where('created_at >= ?', AcademicYear.current.start_date).count %></td>
+        <td><%= school.observations.intervention.where('created_at >= ?', AcademicYear.current.start_date).count %></td>
         <td data-order="<%= school.school_targets.currently_active.any? ? '1' : '0' %>"><%= checkmark(school.school_targets.currently_active.any?, off_class: 'text-muted') %></td>
-        <td><%= school.users.recently_logged_in(30.days.ago).count %></td>
+        <td><%= school.users.recently_logged_in(AcademicYear.current.start_date).count %></td>
+        <% most_recent = school.users.recently_logged_in(AcademicYear.current.start_date).pluck(:last_sign_in_at).max %>
+        <td data-order="<%= most_recent.present? ? most_recent.iso8601 : '' %>"><%= nice_date_times(most_recent) %></td>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/admin/reports/engaged_schools/index.html.erb
+++ b/app/views/admin/reports/engaged_schools/index.html.erb
@@ -1,16 +1,26 @@
 <h1>Engaged Schools</h1>
 
 
-<table class="table">
+<table class="table table-sorted">
   <thead>
     <tr>
+      <th>School Group</th>
       <th>School</th>
+      <th>Recent activities</th>
+      <th>Recent actions</th>
+      <th>Current target?</th>
+      <th>Recent logged in users</th>
     </tr>
   </thead>
   <tbody>
     <% @engaged_schools.each do |school| %>
       <tr>
+        <td><%= school.school_group.name %></td>
         <td><%= link_to school.name, school_path(school) %></td>
+        <td><%= school.activities.where('created_at >= ?', 30.days.ago).count %></td>
+        <td><%= school.observations.intervention.where('created_at >= ?', 30.days.ago).count %></td>
+        <td data-order="<%= school.school_targets.currently_active.any? ? '1' : '0' %>"><%= checkmark(school.school_targets.currently_active.any?, off_class: 'text-muted') %></td>
+        <td><%= school.users.recently_logged_in(30.days.ago).count %></td>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/admin/reports/index.html.erb
+++ b/app/views/admin/reports/index.html.erb
@@ -15,6 +15,7 @@
       <li><%= link_to "Schools removed", admin_schools_removals_path %></li>
       <li><%= link_to "Issues & Notes", admin_issues_path %></li>
       <li><%= link_to "Funder allocation report", admin_reports_funder_allocations_path %></li>
+      <li><%= link_to "Engaged Schools", admin_reports_engaged_schools_path %></li>
     </ul>
 
     <h3>Activities</h3>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -561,6 +561,7 @@ Rails.application.routes.draw do
       resources :activity_types, only: [:index, :show]
       resources :dcc_status, only: [:index]
       resources :solar_panels, only: [:index]
+      resources :engaged_schools, only: [:index]
       resources :community_use, only: [:index]
       resource :unvalidated_readings, only: [:show]
       resource :funder_allocations, only: [:show] do

--- a/spec/factories/programme_factory.rb
+++ b/spec/factories/programme_factory.rb
@@ -1,6 +1,8 @@
 FactoryBot.define do
   factory :programme do
     school
+    programme_type
+    started_on { Time.zone.today }
 
     factory :programme_with_activities do
       programme_type_with_activity_types

--- a/spec/services/schools/engaged_school_service_spec.rb
+++ b/spec/services/schools/engaged_school_service_spec.rb
@@ -1,0 +1,119 @@
+require 'rails_helper'
+
+describe Schools::EngagedSchoolService, type: :service do
+  let!(:academic_year) { create(:academic_year) }
+
+  subject(:service) { Schools::EngagedSchoolService.new(school) }
+
+  describe '.list_engaged_schools' do
+    let!(:inactive)  { create(:school, :with_school_group, :with_points, active: false) }
+    let!(:school)    { create(:school, :with_school_group, :with_points, active: true) }
+
+    let(:engaged_schools) { Schools::EngagedSchoolService.list_engaged_schools }
+
+    it 'returns active schools with recent activities' do
+      expect(engaged_schools.count).to eq 1
+    end
+
+    it 'wraps schools in the service' do
+      expect(engaged_schools.first.school).to eq school
+    end
+  end
+
+  describe '#recent_activity_count' do
+    let!(:school)               { create(:school, :with_school_group, :with_points) }
+    let(:recent_activity_count) { service.recent_activity_count }
+
+    it 'returns the expected count' do
+      expect(recent_activity_count).to eq 1
+    end
+  end
+
+  describe '#recent_action_count' do
+    let!(:school)               { create(:school, :with_school_group) }
+    let!(:action)               { create(:observation, :intervention, school: school) }
+    let(:recent_action_count)   { service.recent_action_count }
+
+    it 'returns the expected count' do
+      expect(recent_action_count).to eq 1
+    end
+  end
+
+  describe '#recently_enrolled_programme_count' do
+    let!(:school)               { create(:school, :with_school_group) }
+    let!(:programme)            { create(:programme, school: school) }
+    let(:recently_enrolled_programme_count) { service.recently_enrolled_programme_count }
+
+    it 'returns the expected count' do
+      expect(recently_enrolled_programme_count).to eq 1
+    end
+  end
+
+  describe '#active_target?' do
+    let!(:school)               { create(:school, :with_school_group) }
+    let(:target)                { service.active_target? }
+
+    it 'returns the false' do
+      expect(target).to be false
+    end
+
+    context 'with a target' do
+      let!(:school_target) { create(:school_target, school: school) }
+
+      it 'returns the true' do
+        expect(target).to be true
+      end
+    end
+  end
+
+  describe '#transport_survey?' do
+    let!(:school)               { create(:school, :with_school_group) }
+    let(:survey)                { service.transport_surveys? }
+
+    it 'returns false' do
+      expect(survey).to be false
+    end
+
+    context 'with a target' do
+      let!(:transport_survey) { create(:transport_survey, school: school) }
+
+      it 'returns true' do
+        expect(survey).to be true
+      end
+    end
+  end
+
+  describe '#temperature_recordings?' do
+    let!(:school)               { create(:school, :with_school_group) }
+    let(:temperatures)          { service.temperature_recordings? }
+
+    it 'returns false' do
+      expect(temperatures).to be false
+    end
+
+    context 'with a target' do
+      let!(:temperature_recordings) { create(:observation, :temperature, school: school) }
+
+      it 'returns true' do
+        expect(temperatures).to be true
+      end
+    end
+  end
+
+  describe '#recently_logged_in_user_count' do
+    let!(:school)   { create(:school, :with_school_group) }
+    let(:count)     { service.recently_logged_in_user_count }
+
+    it 'returns zero when no recent users' do
+      expect(count).to eq 0
+    end
+
+    context 'with recent users' do
+      let!(:user) { create(:school_admin, school: school, last_sign_in_at: Time.zone.today)}
+
+      it 'returns count of recent users' do
+        expect(count).to eq 1
+      end
+    end
+  end
+end

--- a/spec/system/admin/reports/engaged_services_spec.rb
+++ b/spec/system/admin/reports/engaged_services_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+describe 'Engaged Schools Report', type: :system do
+  let(:admin)         { create(:admin) }
+  let!(:school)       { create(:school, :with_school_group, :with_points, active: true) }
+  let(:last_sign_in)  { Time.zone.now }
+  let!(:user)         { create(:school_admin, school: school, last_sign_in_at: last_sign_in)}
+
+  before do
+    sign_in(admin)
+    visit root_path
+    click_on 'Manage'
+    click_on 'Reports'
+  end
+
+  it 'displays a report' do
+    click_on 'Engaged Schools'
+    expect(page).to have_content(school.school_group.name)
+    expect(page).to have_link(school.name, href: school_path(school))
+    expect(page).to have_link('1', href: school_timeline_path(school))
+  end
+
+  describe 'when downloading the CSV' do
+    let(:lines) { page.body.lines.collect(&:chomp) }
+
+    it 'provides a CSV download' do
+      click_on 'Engaged Schools'
+      click_on 'Download as CSV'
+      expect(lines.first.split(',')).to eq ['School Group', 'School', 'Funder', 'Country', 'Activities', 'Actions', 'Programmes', 'Target?', 'Transport survey?', 'Temperatures?', 'Active users', 'Last visit']
+      expect(lines.second.split(',')).to eq [school.school_group.name, school.name, '', school.country.humanize, '1', '0', '0', 'N', 'N', 'N', '1', last_sign_in.iso8601]
+
+      expect(lines.count).to eq 2
+    end
+  end
+end


### PR DESCRIPTION
An initial attempt at producing an admin report that lists "engaged schools".

The definition of an engaged school is one that has recently logged in users, or has used features of the site to record activities, actions, etc. The `:engaged` scope on the School model encompasses this. A number of other scopes have been added to other models to make it easier to build the required queries.

A new admin report page with a CSV download has been added, but depending on performance this might need to be turned into an emailed report. This prototype will be deployed to test for further review before merging.

Still to do:

- [x] Get internal feedback
- [x] Test performance as a page vs emailed report
- [x] Include cluster school users to recently active users? - no