### PR TITLE
Fix column alignment on meters table

### DIFF
--- a/app/views/schools/meters/index.html.erb
+++ b/app/views/schools/meters/index.html.erb
@@ -41,8 +41,8 @@
   </div>
 <% end %>
 
-<% colspan = current_user.admin? ? 14 : 11 %>
-<% first_colspan = current_user.admin? ? 3 : 2 %>
+<% colspan = current_user.admin? ? 16 : 11 %>
+<% first_colspan = current_user.admin? ? 6 : 2 %>
 
 <div class="table-responsive">
 <table class="table table-sm">


### PR DESCRIPTION
Fix the colspan for admins, otherwise headings are misaligned.