### PR TITLE
Prepare recommendations page for feedback

### DIFF
--- a/app/components/info_bar_component.rb
+++ b/app/components/info_bar_component.rb
@@ -4,15 +4,18 @@ class InfoBarComponent < ViewComponent::Base
   include ApplicationHelper
   attr_accessor :status, :title, :icon, :buttons
 
-  def initialize(status: :neutral, title:, icon:, buttons:, classes: nil)
+  def initialize(status: :neutral, title:, icon:, buttons:, classes: nil, style: :normal)
     @status = status
     @title = title
     @icon = icon
     @buttons = buttons
     @classes = classes
+    @style = style
   end
 
   def classes
-    @classes || ' p-4 mb-2'
+    classes = " #{@classes}"
+    classes += @style == :compact ? ' p-3 mb-2' : ' p-4 mb-4'
+    classes
   end
 end

--- a/app/components/info_bar_component.rb
+++ b/app/components/info_bar_component.rb
@@ -4,10 +4,15 @@ class InfoBarComponent < ViewComponent::Base
   include ApplicationHelper
   attr_accessor :status, :title, :icon, :buttons
 
-  def initialize(status: :neutral, title:, icon:, buttons:)
+  def initialize(status: :neutral, title:, icon:, buttons:, classes: nil)
     @status = status
     @title = title
     @icon = icon
     @buttons = buttons
+    @classes = classes
+  end
+
+  def classes
+    @classes || ' p-4 mb-2'
   end
 end

--- a/app/components/info_bar_component.rb
+++ b/app/components/info_bar_component.rb
@@ -2,7 +2,7 @@
 
 class InfoBarComponent < ViewComponent::Base
   include ApplicationHelper
-  attr_accessor :status, :title, :icon, :buttons
+  attr_accessor :status, :title, :icon, :buttons, :style
 
   def initialize(status: :neutral, title:, icon:, buttons:, classes: nil, style: :normal)
     @status = status
@@ -15,7 +15,7 @@ class InfoBarComponent < ViewComponent::Base
 
   def classes
     classes = " #{@classes}"
-    classes += @style == :compact ? ' p-3 mb-2' : ' p-4 mb-4'
+    classes += @style == :compact ? ' mb-3' : ' mb-4'
     classes
   end
 end

--- a/app/components/info_bar_component/info_bar_component.html.erb
+++ b/app/components/info_bar_component/info_bar_component.html.erb
@@ -6,11 +6,11 @@
       </div>
     </div>
     <% if buttons.present? %>
-      <div class='<%= "col-md-#{11 - buttons.size * 3}" %>'>
+      <div class='<%= "col-md-#{11 - buttons.size * 2}" %>'>
         <%= title %>
       </div>
       <% buttons.each do |title, path| %>
-        <div class="col-md-3 d-flex justify-content-end">
+        <div class="col-md-2 d-flex justify-content-end">
           <%= link_to sanitize(title), path, class: "btn btn-light btn rounded-pill font-weight-bold", style: 'height: fit-content;' %>
         </div>
       <% end %>

--- a/app/components/info_bar_component/info_bar_component.html.erb
+++ b/app/components/info_bar_component/info_bar_component.html.erb
@@ -1,4 +1,4 @@
-<%= component 'notice', status: status, classes: classes do %>
+<%= component 'notice', status: status, classes: classes, style: style do %>
   <div class="row align-items-center">
     <div class="col-md-1 d-flex justify-content-center align-content-center">
       <div class="d-flex align-content-center flex-wrap">

--- a/app/components/info_bar_component/info_bar_component.html.erb
+++ b/app/components/info_bar_component/info_bar_component.html.erb
@@ -1,4 +1,4 @@
-<%= component 'notice', status: status, classes: 'mb-4' do %>
+<%= component 'notice', status: status, classes: classes do %>
   <div class="row align-items-center">
     <div class="col-md-1 d-flex justify-content-center align-content-center">
       <div class="d-flex align-content-center flex-wrap">

--- a/app/components/notice_component.rb
+++ b/app/components/notice_component.rb
@@ -15,7 +15,7 @@ class NoticeComponent < ViewComponent::Base
 
   def classes
     classes = " #{@status}"
-    classes += @classes ? " #{@classes}" : " p-4"
+    classes += @classes ? " #{@classes}" : " p-4 mb-4"
     classes
   end
 

--- a/app/components/notice_component.rb
+++ b/app/components/notice_component.rb
@@ -3,9 +3,10 @@
 class NoticeComponent < ViewComponent::Base
   renders_one :link
 
-  def initialize(status:, classes: nil)
+  def initialize(status:, classes: nil, style: :normal)
     @status = status
     @classes = classes
+    @style = style
     validate
   end
 
@@ -15,7 +16,8 @@ class NoticeComponent < ViewComponent::Base
 
   def classes
     classes = " #{@status}"
-    classes += @classes ? " #{@classes}" : " p-4 mb-4"
+    classes += @style == :compact ? ' p-3' : ' p-4'
+    classes += " #{@classes}" if @classes
     classes
   end
 

--- a/app/components/notice_component.rb
+++ b/app/components/notice_component.rb
@@ -4,8 +4,8 @@ class NoticeComponent < ViewComponent::Base
   renders_one :link
 
   def initialize(status:, classes: nil)
-    @classes = classes
     @status = status
+    @classes = classes
     validate
   end
 
@@ -15,7 +15,7 @@ class NoticeComponent < ViewComponent::Base
 
   def classes
     classes = " #{@status}"
-    classes += " #{@classes}" if @classes
+    classes += @classes ? " #{@classes}" : " p-4"
     classes
   end
 

--- a/app/components/notice_component/notice_component.html.erb
+++ b/app/components/notice_component/notice_component.html.erb
@@ -1,4 +1,4 @@
-<div class="p-4 notice-component<%= classes %>">
+<div class="notice-component<%= classes %>">
   <%= content %>
   <% if link %>
     <div class="text-right">

--- a/app/components/panel_switcher_component/panel_switcher_component.html.erb
+++ b/app/components/panel_switcher_component/panel_switcher_component.html.erb
@@ -6,12 +6,14 @@
     <p><%= description %></p>
   <% end %>
 
-  <% panels.each do |panel| %>
-    <div class="form-check form-check-inline">
-      <%= radio_button_tag name, panel.name, panel.name == selected, class: 'form-check-input' %>
-      <%= label_tag  "#{name}_#{panel.name}", panel.label, title: t('components.panel_switcher.change_to', name: panel.label), 'data-toggle': 'tooltip', class: "form-check-label" %>
-    </div>
-  <% end %>
+  <div class="pb-1">
+    <% panels.each do |panel| %>
+      <div class="form-check form-check-inline">
+        <%= radio_button_tag name, panel.name, panel.name == selected, class: 'form-check-input' %>
+        <%= label_tag  "#{name}_#{panel.name}", panel.label, title: t('components.panel_switcher.change_to', name: panel.label), 'data-toggle': 'tooltip', class: "form-check-label" %>
+      </div>
+    <% end %>
+  </div>
 
   <% panels.each do |panel| %>
     <div class="panel <%= panel.name %>" <%= 'hidden' unless panel.name == selected %>>

--- a/app/services/audits/progress.rb
+++ b/app/services/audits/progress.rb
@@ -6,15 +6,24 @@ module Audits
       @audit = audit
     end
 
-    def notification_text
+    def message
       I18n.t('schools.prompts.audit.message_html',
         completed_activities_count: completed_activities_count,
         total_activities_count: total_activities_count,
         completed_actions_count: completed_actions_count,
-        total_actions_count: total_actions_count,
+        total_actions_count: total_actions_count
+      )
+    end
+
+    def summary
+      I18n.t('schools.prompts.audit.summary_html',
         remaining_points: remaining_points,
         bonus_points: bonus_points
-      ).html_safe
+      )
+    end
+
+    def notification
+      (message + "<br />" + summary).html_safe
     end
 
     def completed_activities_count

--- a/app/services/programmes/progress.rb
+++ b/app/services/programmes/progress.rb
@@ -12,16 +12,23 @@ module Programmes
     # The number of different activity types associated with the programme that have been completed.
     delegate :count, to: :activity_types_completed, prefix: :activity_types_completed
 
-    def notification_text
+    def message
       I18n.t('schools.prompts.programme.message_html',
         programme_type_title: programme_type_title,
         programme_activities_count: programme_activities_count,
         activity_types_count: activity_types_count,
+        activity_types_total_scores: activity_types_total_scores)
+    end
+
+    def summary
+      I18n.t('schools.prompts.programme.summary_html',
         count: activity_types_uncompleted_count,
-        activity_types_total_scores: activity_types_total_scores,
         activity_types_uncompleted_scores: activity_types_uncompleted_scores,
-        programme_points_for_completion: programme_points_for_completion
-      ).html_safe
+        programme_points_for_completion: programme_points_for_completion)
+    end
+
+    def notification
+      (message + "<br />" + summary).html_safe
     end
 
     def activity_types_total_scores

--- a/app/views/schools/_prompt_audit.html.erb
+++ b/app/views/schools/_prompt_audit.html.erb
@@ -1,6 +1,7 @@
 <% if local_assigns[:audit] %>
   <%= component 'info_bar',
     status: :neutral,
+    style: :compact,
     title: Audits::Progress.new(audit).notification,
     icon: fa_icon('fas fa-laptop fa-3x'),
     buttons:  { t('common.labels.view_now') => school_audit_path(audit.school, audit) }

--- a/app/views/schools/_prompt_audit.html.erb
+++ b/app/views/schools/_prompt_audit.html.erb
@@ -1,7 +1,7 @@
 <% if local_assigns[:audit] %>
   <%= component 'info_bar',
     status: :neutral,
-    title: Audits::Progress.new(audit).notification_text,
+    title: Audits::Progress.new(audit).notification,
     icon: fa_icon('fas fa-tasks fa-3x'),
     buttons:  { t('common.labels.view_now') => school_audit_path(audit.school, audit) }
   %>

--- a/app/views/schools/_prompt_audit.html.erb
+++ b/app/views/schools/_prompt_audit.html.erb
@@ -2,7 +2,7 @@
   <%= component 'info_bar',
     status: :neutral,
     title: Audits::Progress.new(audit).notification,
-    icon: fa_icon('fas fa-tasks fa-3x'),
+    icon: fa_icon('fas fa-laptop fa-3x'),
     buttons:  { t('common.labels.view_now') => school_audit_path(audit.school, audit) }
   %>
 <% end %>

--- a/app/views/schools/_prompt_to_complete_programme.html.erb
+++ b/app/views/schools/_prompt_to_complete_programme.html.erb
@@ -2,7 +2,7 @@
   <% programmes.each do |programme| %>
     <%= component 'info_bar',
         status: :neutral,
-        title: Programmes::Progress.new(programme).notification_text,
+        title: Programmes::Progress.new(programme).notification,
         icon: fa_icon('fas fa-tasks fa-3x'),
         buttons: { I18n.t('common.labels.view_now') => programme_type_path(programme.programme_type) }
     %>

--- a/app/views/schools/_prompt_to_complete_programme.html.erb
+++ b/app/views/schools/_prompt_to_complete_programme.html.erb
@@ -2,6 +2,7 @@
   <% programmes.each do |programme| %>
     <%= component 'info_bar',
         status: :neutral,
+        style: :compact,
         title: Programmes::Progress.new(programme).notification,
         icon: fa_icon('fas fa-tasks fa-3x'),
         buttons: { I18n.t('common.labels.view_now') => programme_type_path(programme.programme_type) }
@@ -10,6 +11,7 @@
 <% else %>
   <%= component 'info_bar',
       status: :positive,
+      style: :compact,
       title: I18n.t('schools.prompts.programme.choose_a_new_programme_message'),
       icon: fa_icon('fas fa-tasks fa-3x'),
       buttons: { I18n.t('schools.prompts.programme.start_a_new_programme') => programme_types_path }

--- a/app/views/schools/recommendations/index.html.erb
+++ b/app/views/schools/recommendations/index.html.erb
@@ -2,8 +2,6 @@
 
 <p><%= t('schools.recommendations.intro') %></p>
 
-<p>Scope: <%= @scope %></p>
-
 <!-- we may move fetching the params for these into the controller later on -->
 <%= render('schools/prompt_to_complete_programme', programmes: @school.programmes.started.order(started_on: :desc)) %>
 <%= render('schools/prompt_audit', audit: Audits::AuditService.new(@school).last_audit) %>

--- a/config/locales/views/schools/schools.yml
+++ b/config/locales/views/schools/schools.yml
@@ -338,13 +338,15 @@ en:
       page_title: "%{school} has no public data"
     prompts:
       audit:
-        message_html: You have completed <strong>%{completed_activities_count}/%{total_activities_count}</strong> of the activities and <strong>%{completed_actions_count}/%{total_actions_count}</strong> of the actions from your recent energy audit. Complete the others to score <span class="badge badge-success">%{remaining_points}</span> points and <span class="badge badge-success">%{bonus_points}</span> bonus points for completing all audit tasks
+        message_html: You have completed <strong>%{completed_activities_count}/%{total_activities_count}</strong> of the activities and <strong>%{completed_actions_count}/%{total_actions_count}</strong> of the actions from your recent energy audit
+        summary_html: Complete the others to score <span class="badge badge-success">%{remaining_points}</span> points and <span class="badge badge-success">%{bonus_points}</span> bonus points for completing all audit tasks
       programme:
         choose_a_new_programme_message: It's time to choose a new programme of activities. What challenge will you take on next?
-        message_html:
-          one: You have completed <strong>%{programme_activities_count}/%{activity_types_count}</strong> of the activities in the <strong>%{programme_type_title}</strong> programme. Complete the final activity now to score <span class="badge badge-success">%{activity_types_uncompleted_scores}</span> points and <span class="badge badge-success">%{programme_points_for_completion}</span> bonus points for completing the programme
-          other: You have completed <strong>%{programme_activities_count}/%{activity_types_count}</strong> of the activities in the <strong>%{programme_type_title}</strong> programme. Complete the final <strong>%{count}</strong> activities now to score <span class="badge badge-success">%{activity_types_uncompleted_scores}</span> points and <span class="badge badge-success">%{programme_points_for_completion}</span> bonus points for completing the programme
+        message_html: You have completed <strong>%{programme_activities_count}/%{activity_types_count}</strong> of the activities in the <strong>%{programme_type_title}</strong> programme
         start_a_new_programme: Start a new programme
+        summary_html:
+          one: Complete the final activity now to score <span class="badge badge-success">%{activity_types_uncompleted_scores}</span> points and <span class="badge badge-success">%{programme_points_for_completion}</span> bonus points for completing the programme
+          other: Complete the final <strong>%{count}</strong> activities now to score <span class="badge badge-success">%{activity_types_uncompleted_scores}</span> points and <span class="badge badge-success">%{programme_points_for_completion}</span> bonus points for completing the programme
     pupils:
       edit:
         title: Edit pupil account

--- a/spec/components/info_bar_component_spec.rb
+++ b/spec/components/info_bar_component_spec.rb
@@ -13,7 +13,8 @@ RSpec.describe InfoBarComponent, type: :component do
       icon: icon.html_safe,
       title: title,
       buttons: { button_title => button_link },
-      classes: "extra-classes"
+      classes: "extra-classes",
+      style: :compact
     }
   end
 
@@ -42,7 +43,7 @@ RSpec.describe InfoBarComponent, type: :component do
   end
 
   it 'right aligns the button link' do
-    expect(html).to have_css('.col-md-3.justify-content-end')
+    expect(html).to have_css('.col-md-2.justify-content-end')
   end
 
   it 'includes icon' do
@@ -58,7 +59,7 @@ RSpec.describe InfoBarComponent, type: :component do
   end
 
   it 'includes the link' do
-    within('.row .col-md-3') do
+    within('.row .col-md-2') do
       expect(html).to have_link(button_title, href: button_link)
     end
   end
@@ -67,12 +68,29 @@ RSpec.describe InfoBarComponent, type: :component do
     expect(html).to have_css('div.notice-component.extra-classes')
   end
 
-  context "with no classes" do
-    let(:params) { all_params.except(:classes) }
+  context "with :style" do
+    context "when :style is :normal" do
+      let(:params) { all_params.merge({ style: :normal })}
 
-    it "adds default classes" do
-      expect(html).to have_css('div.notice-component.p-4')
-      expect(html).to have_css('div.notice-component.mb-2')
+      it "adds normal classes" do
+        expect(html).to have_css('div.notice-component.p-4.mb-4')
+      end
+    end
+
+    context "when :style is :compact" do
+      let(:params) { all_params.merge({ style: :compact })}
+
+      it "adds compact classes" do
+        expect(html).to have_css('div.notice-component.p-3.mb-2')
+      end
+    end
+
+    context "when :style is not provided" do
+      let(:params) { all_params.except(:style) }
+
+      it "adds normal classes" do
+        expect(html).to have_css('div.notice-component.p-4.mb-4')
+      end
     end
   end
 end

--- a/spec/components/info_bar_component_spec.rb
+++ b/spec/components/info_bar_component_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe InfoBarComponent, type: :component do
       let(:params) { all_params.merge({ style: :compact })}
 
       it "adds compact classes" do
-        expect(html).to have_css('div.notice-component.p-3.mb-2')
+        expect(html).to have_css('div.notice-component.p-3.mb-3')
       end
     end
 

--- a/spec/components/info_bar_component_spec.rb
+++ b/spec/components/info_bar_component_spec.rb
@@ -8,13 +8,16 @@ RSpec.describe InfoBarComponent, type: :component do
   let(:button_link)   { 'http://www.example.com' }
   let(:icon)          { '<i class="fas fa-school fa-3x"></i>' }
   let(:status)        { :neutral }
-  let(:params)        do
+  let(:all_params) do
     {
       icon: icon.html_safe,
       title: title,
-      buttons: { button_title => button_link }
+      buttons: { button_title => button_link },
+      classes: "extra-classes"
     }
   end
+
+  let(:params) { all_params }
 
   let(:component) { InfoBarComponent.new(**params) }
 
@@ -57,6 +60,19 @@ RSpec.describe InfoBarComponent, type: :component do
   it 'includes the link' do
     within('.row .col-md-3') do
       expect(html).to have_link(button_title, href: button_link)
+    end
+  end
+
+  it "has additional classes" do
+    expect(html).to have_css('div.notice-component.extra-classes')
+  end
+
+  context "with no classes" do
+    let(:params) { all_params.except(:classes) }
+
+    it "adds default classes" do
+      expect(html).to have_css('div.notice-component.p-4')
+      expect(html).to have_css('div.notice-component.mb-2')
     end
   end
 end

--- a/spec/components/notice_component_spec.rb
+++ b/spec/components/notice_component_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe NoticeComponent, type: :component, include_application_helper: tr
       let(:params) { all_params.except(:classes) }
 
       it "adds default classes" do
-        expect(html).to have_css('div.notice-component.p-4')
+        expect(html).to have_css('div.notice-component.p-4.mb-4')
       end
     end
   end

--- a/spec/components/notice_component_spec.rb
+++ b/spec/components/notice_component_spec.rb
@@ -41,6 +41,14 @@ RSpec.describe NoticeComponent, type: :component, include_application_helper: tr
         end
       end
     end
+
+    context "with no classes" do
+      let(:params) { all_params.except(:classes) }
+
+      it "adds default classes" do
+        expect(html).to have_css('div.notice-component.p-4')
+      end
+    end
   end
 
   context "with no link" do

--- a/spec/components/notice_component_spec.rb
+++ b/spec/components/notice_component_spec.rb
@@ -42,11 +42,29 @@ RSpec.describe NoticeComponent, type: :component, include_application_helper: tr
       end
     end
 
-    context "with no classes" do
-      let(:params) { all_params.except(:classes) }
+    context "with :style" do
+      context "when :style is :normal" do
+        let(:params) { all_params.merge({ style: :normal })}
 
-      it "adds default classes" do
-        expect(html).to have_css('div.notice-component.p-4.mb-4')
+        it "adds normal classes" do
+          expect(html).to have_css('div.notice-component.p-4')
+        end
+      end
+
+      context "when :style is :compact" do
+        let(:params) { all_params.merge({ style: :compact })}
+
+        it "adds compact classes" do
+          expect(html).to have_css('div.notice-component.p-3')
+        end
+      end
+
+      context "when :style is not provided" do
+        let(:params) { all_params.except(:style) }
+
+        it "adds normal classes" do
+          expect(html).to have_css('div.notice-component.p-4')
+        end
       end
     end
   end

--- a/spec/services/audits/progress_spec.rb
+++ b/spec/services/audits/progress_spec.rb
@@ -10,8 +10,8 @@ describe Audits::Progress, type: :service do
   subject(:service) { Audits::Progress.new(audit) }
 
   context "with no actions or activities completed" do
-    describe "#notification_text" do
-      it { expect(service.notification_text).to eq("You have completed <strong>0/3</strong> of the activities and <strong>0/3</strong> of the actions from your recent energy audit. Complete the others to score <span class=\"badge badge-success\">165</span> points and <span class=\"badge badge-success\">50</span> bonus points for completing all audit tasks") }
+    describe "#notification" do
+      it { expect(service.notification).to eq("You have completed <strong>0/3</strong> of the activities and <strong>0/3</strong> of the actions from your recent energy audit<br />Complete the others to score <span class=\"badge badge-success\">165</span> points and <span class=\"badge badge-success\">50</span> bonus points for completing all audit tasks") }
     end
 
     describe "#completed_activities_count" do
@@ -53,8 +53,8 @@ describe Audits::Progress, type: :service do
 
     before { ActivityCreator.new(activity).process }
 
-    describe "#notification_text" do
-      it { expect(service.notification_text).to eq("You have completed <strong>1/3</strong> of the activities and <strong>1/3</strong> of the actions from your recent energy audit. Complete the others to score <span class=\"badge badge-success\">110</span> points and <span class=\"badge badge-success\">50</span> bonus points for completing all audit tasks") }
+    describe "#notification" do
+      it { expect(service.notification).to eq("You have completed <strong>1/3</strong> of the activities and <strong>1/3</strong> of the actions from your recent energy audit<br />Complete the others to score <span class=\"badge badge-success\">110</span> points and <span class=\"badge badge-success\">50</span> bonus points for completing all audit tasks") }
     end
   end
 
@@ -64,8 +64,8 @@ describe Audits::Progress, type: :service do
 
     before { ActivityCreator.new(activity).process }
 
-    describe "#notification_text" do
-      it { expect(service.notification_text).to eq("You have completed <strong>0/3</strong> of the activities and <strong>0/3</strong> of the actions from your recent energy audit. Complete the others to score <span class=\"badge badge-success\">165</span> points and <span class=\"badge badge-success\">50</span> bonus points for completing all audit tasks") }
+    describe "#notification" do
+      it { expect(service.notification).to eq("You have completed <strong>0/3</strong> of the activities and <strong>0/3</strong> of the actions from your recent energy audit<br />Complete the others to score <span class=\"badge badge-success\">165</span> points and <span class=\"badge badge-success\">50</span> bonus points for completing all audit tasks") }
     end
   end
 
@@ -77,8 +77,8 @@ describe Audits::Progress, type: :service do
       end
     end
 
-    describe "#notification_text" do
-      it { expect(service.notification_text).to eq("You have completed <strong>3/3</strong> of the activities and <strong>0/3</strong> of the actions from your recent energy audit. Complete the others to score <span class=\"badge badge-success\">90</span> points and <span class=\"badge badge-success\">0</span> bonus points for completing all audit tasks") }
+    describe "#notification" do
+      it { expect(service.notification).to eq("You have completed <strong>3/3</strong> of the activities and <strong>0/3</strong> of the actions from your recent energy audit<br />Complete the others to score <span class=\"badge badge-success\">90</span> points and <span class=\"badge badge-success\">0</span> bonus points for completing all audit tasks") }
     end
   end
 end

--- a/spec/services/programmes/progress_spec.rb
+++ b/spec/services/programmes/progress_spec.rb
@@ -15,18 +15,18 @@ describe Programmes::Progress, type: :service do
       ActivityCreator.new(activity).process
     end
 
-    describe '#notification_text' do
+    describe '#notification' do
       context 'when the programme is completed within the same academic year as started' do
         it 'returns the full notification text used on the school dashboard' do
           allow_any_instance_of(School).to receive(:academic_year_for) { OpenStruct.new(current?: true) }
-          expect(service.notification_text).to eq("You have completed <strong>1/3</strong> of the activities in the <strong>#{programme_type.title}</strong> programme. Complete the final <strong>2</strong> activities now to score <span class=\"badge badge-success\">50</span> points and <span class=\"badge badge-success\">12</span> bonus points for completing the programme")
+          expect(service.notification).to eq("You have completed <strong>1/3</strong> of the activities in the <strong>#{programme_type.title}</strong> programme<br />Complete the final <strong>2</strong> activities now to score <span class=\"badge badge-success\">50</span> points and <span class=\"badge badge-success\">12</span> bonus points for completing the programme")
         end
       end
 
       context 'when the programme is completed outside of the academic year as started' do
         it 'returns the full notification text used on the school dashboard' do
           allow_any_instance_of(School).to receive(:academic_year_for) { OpenStruct.new(current?: false) }
-          expect(service.notification_text).to eq("You have completed <strong>1/3</strong> of the activities in the <strong>#{programme_type.title}</strong> programme. Complete the final <strong>2</strong> activities now to score <span class=\"badge badge-success\">50</span> points and <span class=\"badge badge-success\">0</span> bonus points for completing the programme")
+          expect(service.notification).to eq("You have completed <strong>1/3</strong> of the activities in the <strong>#{programme_type.title}</strong> programme<br />Complete the final <strong>2</strong> activities now to score <span class=\"badge badge-success\">50</span> points and <span class=\"badge badge-success\">0</span> bonus points for completing the programme")
         end
       end
     end
@@ -94,10 +94,10 @@ describe Programmes::Progress, type: :service do
   end
 
   context "no activities completed yet" do
-    describe '#notification_text' do
+    describe '#notification' do
       it 'returns the full notification text' do
         allow_any_instance_of(School).to receive(:academic_year_for) { OpenStruct.new(current?: true) }
-        expect(service.notification_text).to eq("You have completed <strong>0/3</strong> of the activities in the <strong>#{programme_type.title}</strong> programme. Complete the final <strong>3</strong> activities now to score <span class=\"badge badge-success\">75</span> points and <span class=\"badge badge-success\">12</span> bonus points for completing the programme")
+        expect(service.notification).to eq("You have completed <strong>0/3</strong> of the activities in the <strong>#{programme_type.title}</strong> programme<br />Complete the final <strong>3</strong> activities now to score <span class=\"badge badge-success\">75</span> points and <span class=\"badge badge-success\">12</span> bonus points for completing the programme")
       end
     end
   end
@@ -112,10 +112,10 @@ describe Programmes::Progress, type: :service do
       end
     end
 
-    describe '#notification_text' do
-      it 'returns the singular notification text' do
+    describe '#notification' do
+      it 'returns the singular notification' do
         allow_any_instance_of(School).to receive(:academic_year_for) { OpenStruct.new(current?: true) }
-        expect(service.notification_text).to eq("You have completed <strong>2/3</strong> of the activities in the <strong>#{programme_type.title}</strong> programme. Complete the final activity now to score <span class=\"badge badge-success\">25</span> points and <span class=\"badge badge-success\">12</span> bonus points for completing the programme")
+        expect(service.notification).to eq("You have completed <strong>2/3</strong> of the activities in the <strong>#{programme_type.title}</strong> programme<br />Complete the final activity now to score <span class=\"badge badge-success\">25</span> points and <span class=\"badge badge-success\">12</span> bonus points for completing the programme")
       end
     end
   end

--- a/spec/system/schools/recommendations_spec.rb
+++ b/spec/system/schools/recommendations_spec.rb
@@ -63,7 +63,7 @@ describe 'Recommendations Page', type: :system, include_application_helper: true
       let(:setup_data) { create(:programme, programme_type: programme_type, started_on: Time.zone.today, school: school) }
 
       it "has prompts to complete programmes" do
-        expect(page).to have_content("You have completed 0/3 of the activities in the #{programme_type.title} programme. Complete the final 3 activities now to score 75 points and 12 bonus points for completing the programme")
+        expect(page).to have_content("You have completed 0/3 of the activities in the #{programme_type.title} programmeComplete the final 3 activities now to score 75 points and 12 bonus points for completing the programme")
       end
     end
 
@@ -74,7 +74,7 @@ describe 'Recommendations Page', type: :system, include_application_helper: true
       end
 
       it "has prompt to complete audit actions and activities" do
-        expect(page).to have_content("You have completed 0/3 of the activities and 0/3 of the actions from your recent energy audit. Complete the others to score 165 points and 50 bonus points for completing all audit tasks")
+        expect(page).to have_content("You have completed 0/3 of the activities and 0/3 of the actions from your recent energy auditComplete the others to score 165 points and 50 bonus points for completing all audit tasks")
       end
     end
   end

--- a/spec/system/schools/recommendations_spec.rb
+++ b/spec/system/schools/recommendations_spec.rb
@@ -79,7 +79,6 @@ describe 'Recommendations Page', type: :system, include_application_helper: true
     end
   end
 
-
   context "based on your energy usage section" do
     let(:section) { find(:css, '#energy-usage') }
 


### PR DESCRIPTION
- [x] Put each prompt sentence on separate lines on this card
- [x] Change prompt icon for different types of notice on this card
- [x] Try making the vertical space around the prompts smaller on this card
- [x] Remove “scope” debug text on this card

* This also makes notice and info_bar classes more configurable. 
* Also makes info_bar buttons use two columns rather than 3. This makes more space for the text.
* Also now adds a "style" option to info_bar so we can choose :compact or :normal. 