### PR TITLE
Allow filtering by funder on school comparison pages

### DIFF
--- a/app/controllers/compare_controller.rb
+++ b/app/controllers/compare_controller.rb
@@ -27,7 +27,7 @@ class CompareController < ApplicationController
 
   def filter
     @filter ||=
-      params.permit(:search, :benchmark, :country, :school_type, school_group_ids: [], school_types: [])
+      params.permit(:search, :benchmark, :country, :school_type, :funder, school_group_ids: [], school_types: [])
         .with_defaults(school_group_ids: [], school_types: School.school_types.keys)
         .to_hash.symbolize_keys
   end
@@ -51,7 +51,7 @@ class CompareController < ApplicationController
   def included_schools
     # wonder if this can be replaced by a use of the scope accessible_by(current_ability)
     include_invisible = can? :show, :all_schools
-    school_params = filter.slice(:school_group_ids, :school_types, :school_type, :country).merge(include_invisible: include_invisible)
+    school_params = filter.slice(:school_group_ids, :school_types, :school_type, :country, :funder).merge(include_invisible: include_invisible)
 
     schools = SchoolFilter.new(**school_params).filter
     schools.select {|s| can?(:show, s) } unless include_invisible

--- a/app/models/funder.rb
+++ b/app/models/funder.rb
@@ -9,5 +9,8 @@ class Funder < ApplicationRecord
   has_many :schools
   has_many :school_groups
 
+  scope :with_schools,  -> { where('id IN (SELECT DISTINCT(funder_id) FROM schools)') }
+  scope :by_name,       -> { order(name: :asc) }
+
   validates :name, presence: true, uniqueness: true
 end

--- a/app/services/school_filter.rb
+++ b/app/services/school_filter.rb
@@ -1,8 +1,9 @@
 class SchoolFilter
-  def initialize(school_group_ids: [], scoreboard_ids: [], school_types: [], school_type: nil, country: nil, include_invisible: false)
+  def initialize(school_group_ids: [], scoreboard_ids: [], school_types: [], school_type: nil, country: nil, funder: nil, include_invisible: false)
     @school_group_ids = school_group_ids.reject(&:blank?)
     @scoreboard_ids = scoreboard_ids.reject(&:blank?)
     @school_types = school_type.present? ? [school_type] : school_types
+    @funders = funder.present? ? [funder] : []
     @country = country
     @default_scope = include_invisible ? School.process_data.data_enabled : School.process_data.data_enabled.visible
   end
@@ -13,6 +14,7 @@ class SchoolFilter
     schools = schools_from_scoreboards(schools) if @scoreboard_ids.any?
     schools = schools_with_school_type(schools) if @school_types.any?
     schools = schools_with_country(schools) if @country.present?
+    schools = schools_with_funder(schools) if @funders.present?
     schools.to_a
   end
 
@@ -32,5 +34,9 @@ class SchoolFilter
 
   def schools_with_country(schools)
     schools.where(country: @country)
+  end
+
+  def schools_with_funder(schools)
+    schools.where(funder_id: @funders)
   end
 end

--- a/app/views/compare/_funder_filter.html.erb
+++ b/app/views/compare/_funder_filter.html.erb
@@ -1,0 +1,6 @@
+<div class="form-group mt-3">
+  <label>Limit to funder (admin only option)</label>
+  <div>
+    <%= select_tag :funder, options_for_select(Funder.with_schools.by_name.map {|funder| ["Funded by #{funder.name}", funder.id]}, @filter[:funder]), include_blank: 'All schools', class: 'form-control' %>
+  </div>
+</div>

--- a/app/views/compare/_funder_summary.html.erb
+++ b/app/views/compare/_funder_summary.html.erb
@@ -1,0 +1,5 @@
+<p>
+  <% if @filter[:funder].present? %>
+    Funder: <span class='badge badge-info'><%= Funder.find(@filter[:funder]).name %></span>
+  <% end %>
+</p>

--- a/app/views/compare/_summary.html.erb
+++ b/app/views/compare/_summary.html.erb
@@ -14,5 +14,6 @@
       <% end %>
     </p>
     <%= render 'school_type_summary' %>
+    <%= render 'funder_summary' %>
   <% end %>
 </div>

--- a/app/views/compare/tab_content/_country.html.erb
+++ b/app/views/compare/tab_content/_country.html.erb
@@ -15,6 +15,7 @@
         <%= label_tag 'country_', t('compare.filter.all_countries'), class: 'form-check-label' %>
       </div>
       <%= render 'school_type_filter', type: 'categories' %>
+      <%= render 'funder_filter' if can?(:compare, :funders) %>
       <div class="pt-2">
         <%= submit_tag 'Compare schools', class: 'btn' %>
       </div>

--- a/spec/factories/funders.rb
+++ b/spec/factories/funders.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :funder do
+    sequence(:name) {|n| "Funder name #{n}"}
+  end
+end

--- a/spec/services/school_filter_spec.rb
+++ b/spec/services/school_filter_spec.rb
@@ -5,7 +5,9 @@ describe SchoolFilter do
   let(:school_group_b)      { create(:school_group) }
   let(:scoreboard_a)        { create(:scoreboard) }
   let(:scoreboard_b)        { create(:scoreboard) }
-  let!(:school_1)                 { create(:school, school_group: school_group_a, scoreboard: scoreboard_a) }
+  let(:funder_1)            { create(:funder) }
+  let(:funder_2)            { create(:funder) }
+  let!(:school_1)                 { create(:school, school_group: school_group_a, scoreboard: scoreboard_a, funder: funder_1) }
   let!(:school_2)                 { create(:school, school_group: school_group_b, scoreboard: scoreboard_b, school_type: :secondary) }
   let!(:school_3_invisible)       { create(:school, school_group: school_group_b, scoreboard: scoreboard_a, visible: false) }
   let!(:school_no_data)           { create(:school, school_group: school_group_a, process_data: false) }
@@ -50,5 +52,10 @@ describe SchoolFilter do
 
   it 'filters by scoreboard and group' do
     expect(SchoolFilter.new(include_invisible: true, scoreboard_ids: [scoreboard_a], school_group_ids: [school_group_b.id]).filter).to eq [school_3_invisible]
+  end
+
+  it 'filters by funder' do
+    expect(SchoolFilter.new(funder: funder_1.id).filter).to eq [school_1]
+    expect(SchoolFilter.new(funder: funder_2.id).filter).to eq []
   end
 end

--- a/spec/system/compare_spec.rb
+++ b/spec/system/compare_spec.rb
@@ -407,12 +407,12 @@ describe 'compare pages', :compare, type: :system do
     context "'Country' filter tab" do
       before { click_on 'Choose country' }
 
-      it_behaves_like "an index page", tab: 'Choose country'
+      it_behaves_like "an index page", tab: 'Choose country', show_your_group_tab: false
       it { expect(page).to have_content "Compare schools by country" }
       it { expect(page).to have_content "Limit to funder (admin only option)"}
 
       it_behaves_like "a form filter", id: '#country', country: "All countries"
-      it_behaves_like "a form filter", id: '#funder', country: "All schools"
+      it_behaves_like "a form filter", id: '#funder', funder: "All schools"
 
       context "Benchmark page" do
         include_context 'benchmarks page context'
@@ -420,21 +420,25 @@ describe 'compare pages', :compare, type: :system do
           within '#country' do
             choose 'Scotland'
             uncheck 'Middle'
-            choose 'Funded by Grant Funder'
+          end
+          within '#funder' do
+            select 'Funded by Grant Funder'
+          end
+          within '#country' do
             click_on 'Compare schools'
           end
         end
 
         it_behaves_like "a benchmark list page"
         it_behaves_like "a filter summary", country: "Scotland", school_types_excluding: ['middle']
-        it_behaves_like "a filter summary", funder: "Funded By Grant Funder"
+        it_behaves_like "a filter summary", funder: "Grant Funder"
 
         context "Changing options" do
           before { click_on "Change options" }
 
-          it_behaves_like "an index page", tab: 'Choose country'
+          it_behaves_like "an index page", tab: 'Choose country', show_your_group_tab: false
           it_behaves_like "a form filter", id: '#country', country: 'scotland', school_types_excluding: ['middle']
-          it_behaves_like "a form filter", id: '#funder', funder: "Funded by Grant Funder"
+          it_behaves_like "a form filter", id: '#country', funder: "Funded by Grant Funder"
         end
 
         context "results page" do
@@ -443,12 +447,12 @@ describe 'compare pages', :compare, type: :system do
 
           it_behaves_like "a results page"
           it_behaves_like "a filter summary", country: "Scotland", school_types_excluding: ['middle']
-          it_behaves_like "a filter summary", funder: "Funded by Grant Funder"
+          it_behaves_like "a filter summary", funder: "Grant Funder"
 
           context "Changing options" do
             before { click_on "Change options" }
 
-            it_behaves_like "an index page", tab: 'Choose country'
+            it_behaves_like "an index page", tab: 'Choose country', show_your_group_tab: false
             it_behaves_like "a form filter", id: '#country', country: 'scotland', school_types_excluding: ['middle']
           end
         end

--- a/spec/system/compare_spec.rb
+++ b/spec/system/compare_spec.rb
@@ -412,7 +412,6 @@ describe 'compare pages', :compare, type: :system do
       it { expect(page).to have_content "Limit to funder (admin only option)"}
 
       it_behaves_like "a form filter", id: '#country', country: "All countries"
-      it_behaves_like "a form filter", id: '#funder', funder: "All schools"
 
       context "Benchmark page" do
         include_context 'benchmarks page context'


### PR DESCRIPTION
Adds a new admin-only option on the "Choose country" tab of the school comparison page.

The new select box and filter allows an admin to further refine the list of schools to just those associated with a specific funder.

As the admins need to also narrow by country and school type it seemed better to add this as a new option rather than a new tab.
