### PR TITLE
Ensure activation date is set

### DIFF
--- a/app/services/school_creator.rb
+++ b/app/services/school_creator.rb
@@ -46,6 +46,7 @@ class SchoolCreator
   def make_data_enabled!
     raise Error.new('School must be visible before enabling data') unless @school.visible
     @school.update!(data_enabled: true)
+    @school.update!(activation_date: Time.zone.today) unless @school.activation_date.present?
     onboarding_service.record_event(@school.school_onboarding, :onboarding_data_enabled)
     broadcast(:school_made_data_enabled, @school)
   end

--- a/lib/tasks/deployment/20231108184512_set_activation_dates.rake
+++ b/lib/tasks/deployment/20231108184512_set_activation_dates.rake
@@ -1,0 +1,17 @@
+namespace :after_party do
+  desc 'Deployment task: set_activation_dates'
+  task set_activation_dates: :environment do
+    puts "Running deploy task 'set_activation_dates'"
+
+    SchoolOnboarding.complete.each do |school_onboarding|
+      unless school_onboarding.school.activation_date.present?
+        school_onboarding.school.update!(activation_date: school_onboarding.first_made_data_enabled)
+      end
+    end
+
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord
+      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+  end
+end

--- a/spec/services/school_creator_spec.rb
+++ b/spec/services/school_creator_spec.rb
@@ -128,6 +128,22 @@ describe SchoolCreator, :schools, type: :service do
       expect(school.has_school_onboarding_event?(:onboarding_data_enabled)).to be_truthy
     end
 
+    it 'records activation date' do
+      service.make_data_enabled!
+      school.reload
+      expect(school.activation_date).to eq(Time.zone.today)
+    end
+
+    context 'when there is an activation date' do
+      let(:school) { create :school, data_enabled: false, visible: visible, activation_date: Time.zone.today - 1 }
+
+      it 'does not change the activation date' do
+        service.make_data_enabled!
+        school.reload
+        expect(school.activation_date).to eq(Time.zone.today - 1)
+      end
+    end
+
     context 'where the school is not visible' do
       let(:visible) { false }
 


### PR DESCRIPTION
Schools have an "activation date" attribute which can be edited by admins to set the date the school became active on energy sparks. This date is used by the analytics as the start date for some of the school comparison reports (specifically, the report looking at change in energy use since activation).

If the activation date is nil then the analytics defaults to the school record creation date.

In some cases this can be quite different. A few schools have taken a number of months before they've become data enabled.

This PR does 2 things:

- set the activation date when a school first becomes data enabled
- retrospectively sets the activation dates for existing schools to the date they first became data enabled, where we have that information

This will improve some of the historical reporting.