### PR TITLE
Improve solar edge forms and allow testing of API access

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -63,3 +63,4 @@
 //= require live_data
 //= require gtag
 //= require cocoon
+//= require loading

--- a/app/assets/javascripts/loading.js
+++ b/app/assets/javascripts/loading.js
@@ -1,26 +1,21 @@
 $(function() {
 
   // Change the link's icon while the request is performing
-  $(document).on('click', 'a[data-remote]', function(event, b, c) {
+  $(document).on('click', 'a.check-button[data-remote]', function(event, b, c) {
     var icon = $(this).find('i');
     icon.data('old-class', icon.attr('class'));
     icon.attr('class', 'fas fa-spinner fa-spin');
   });
 
-  // Change the link's icon back after it's finished.
-  $(document).on('ajax:complete', function(e) {
-    var icon = $(e.target).find('i');
-    if (icon.data('old-class')) {
-      icon.attr('class', icon.data('old-class'));
-      icon.data('old-class', null);
-    }
-  })
-
-  // Don't fail silently
-  $(document).ajaxError(function( event, jqxhr, settings, exception ) {
-    if (jqxhr.status) {
-      alert("Something went wrong (" + jqxhr.status + ')');
-    }
-  });
+  if ($("a.check-button[data-remote]").length) {
+    // Change the link's icon back after it's finished.
+    $(document).on('ajax:complete', function(e) {
+      var icon = $(e.target).find('i');
+      if (icon.data('old-class')) {
+        icon.attr('class', icon.data('old-class'));
+        icon.data('old-class', null);
+      }
+    })
+  }
 
 })

--- a/app/assets/javascripts/loading.js
+++ b/app/assets/javascripts/loading.js
@@ -1,0 +1,26 @@
+$(function() {
+
+  // Change the link's icon while the request is performing
+  $(document).on('click', 'a[data-remote]', function(event, b, c) {
+    var icon = $(this).find('i');
+    icon.data('old-class', icon.attr('class'));
+    icon.attr('class', 'fas fa-spinner fa-spin');
+  });
+
+  // Change the link's icon back after it's finished.
+  $(document).on('ajax:complete', function(e) {
+    var icon = $(e.target).find('i');
+    if (icon.data('old-class')) {
+      icon.attr('class', icon.data('old-class'));
+      icon.data('old-class', null);
+    }
+  })
+
+  // Don't fail silently
+  $(document).ajaxError(function( event, jqxhr, settings, exception ) {
+    if (jqxhr.status) {
+      alert("Something went wrong (" + jqxhr.status + ')');
+    }
+  });
+
+})

--- a/app/controllers/schools/solar_edge_installations_controller.rb
+++ b/app/controllers/schools/solar_edge_installations_controller.rb
@@ -47,6 +47,11 @@ module Schools
       redirect_to school_solar_feeds_configuration_index_path(@school), notice: "Solar Edge API feed deleted"
     end
 
+    def check
+      @api_ok = Solar::SolarEdgeInstallationFactory.check(@solar_edge_installation)
+      respond_to(&:js)
+    end
+
     private
 
     def solar_edge_installation_params

--- a/app/controllers/schools/solar_edge_installations_controller.rb
+++ b/app/controllers/schools/solar_edge_installations_controller.rb
@@ -2,6 +2,17 @@ module Schools
   class SolarEdgeInstallationsController < ApplicationController
     load_and_authorize_resource :school
     load_and_authorize_resource through: :school
+    before_action :set_breadcrumbs
+
+    def show
+      @api_params = { api_key: @solar_edge_installation.api_key, format: :json }
+
+      if @solar_edge_installation.cached_api_information?
+        start_time = @solar_edge_installation.api_latest_data_date.strftime('%Y-%m-%d 00:00:00')
+        end_time = @solar_edge_installation.api_latest_data_date.strftime('%Y-%m-%d 00:00:00')
+        @reading_params = @api_params.merge({ timeUnit: "QUARTER_OF_AN_HOUR", startTime: start_time, endTime: end_time })
+      end
+    end
 
     def new
     end
@@ -58,6 +69,12 @@ module Schools
       params.require(:solar_edge_installation).permit(
         :site_id, :amr_data_feed_config_id, :mpan, :api_key
       )
+    end
+
+    def set_breadcrumbs
+      @breadcrumbs = [
+        { name: "Solar API Feeds" },
+      ]
     end
   end
 end

--- a/app/models/solar_edge_installation.rb
+++ b/app/models/solar_edge_installation.rb
@@ -43,4 +43,13 @@ class SolarEdgeInstallation < ApplicationRecord
       Date.parse(electricity_meter.amr_data_feed_readings.order(reading_date: :desc).first.reading_date)
     end
   end
+
+  def cached_api_information?
+    information.present?
+  end
+
+  def api_latest_data_date
+    return nil unless information['dates'].present?
+    return Date.parse(information['dates'].last)
+  end
 end

--- a/app/services/solar/solar_edge_installation_factory.rb
+++ b/app/services/solar/solar_edge_installation_factory.rb
@@ -29,6 +29,16 @@ module Solar
       end
     end
 
+    def self.check(installation)
+      begin
+        solar_edge_api = SolarEdgeAPI.new(installation.api_key)
+        solar_edge_api.site_details
+        true
+      rescue
+        false
+      end
+    end
+
     def perform
       installation = SolarEdgeInstallation.where(school_id: @school.id, mpan: @mpan, site_id: @site_id, api_key: @api_key, amr_data_feed_config: @amr_data_feed_config).first_or_create!
 

--- a/app/views/schools/solar_edge_installations/_form.html.erb
+++ b/app/views/schools/solar_edge_installations/_form.html.erb
@@ -1,10 +1,13 @@
 <%= simple_form_for [school, solar_edge_installation] do |form| %>
   <%= render 'shared/errors', subject: solar_edge_installation, subject_name: 'solar edge api feed' %>
 
-  <%= form.input :amr_data_feed_config_id, collection: AmrDataFeedConfig.solar_edge_api.pluck(:description, :id), label_method: :first, value_method: :second, include_blank: false %>
-  <%= form.input :mpan, as: :string, disabled: solar_edge_installation.persisted? %>
-  <%= form.input :site_id, as: :string, label: "Site id" %>
-  <%= form.input :api_key, as: :string, label: "API key" %>
+  <%= form.hidden_field :amr_data_feed_config_id, value: AmrDataFeedConfig.solar_edge_api.first.id %>
+
+  <%= form.input :site_id, as: :string, disabled: solar_edge_installation.persisted?, label: "Site id", hint: "The unique site id in the Solar Edge system. This cannot be changed once the installation has been created." %>
+
+  <%= form.input :mpan, as: :string, disabled: solar_edge_installation.persisted?, label: 'MPAN or unique id', hint: 'When a school has a single array, use the MPAN of the mains meter. Otherwise use the site id. This will ensure the solar meters are correctly generated. This cannot be changed once the installation has been created.' %>
+
+  <%= form.input :api_key, as: :string, label: "API key", hint: 'The code that authorises us to access data for this site.' %>
 
   <div class="actions">
     <%= form.submit "Submit", class: 'btn btn-primary'%>

--- a/app/views/schools/solar_edge_installations/check.js.erb
+++ b/app/views/schools/solar_edge_installations/check.js.erb
@@ -1,1 +1,1 @@
-$('#solar-edge-<%= @solar_edge_installation.id %>-test').html('<i class="fas <%= @api_ok ? 'text-success fa-circle-check' : 'text-danger fa-circle-xmark' %>"></i> Test');
+$('#solar-edge-<%= @solar_edge_installation.id %>-test').html('<i class="fas <%= @api_ok ? 'text-success fa-circle-check' : 'text-danger fa-circle-xmark' %>"></i> Check');

--- a/app/views/schools/solar_edge_installations/check.js.erb
+++ b/app/views/schools/solar_edge_installations/check.js.erb
@@ -1,1 +1,1 @@
-$('#solar-edge-<%= @solar_edge_installation.id %>-test').html('<i class="fas <%= @api_ok ? 'text-success fa-circle-check' : 'text-danger fa-circle-xmark' %>"></i> Check');
+$('#solar-edge-<%= @solar_edge_installation.id %>-test').html('<i class="fas <%= @api_ok ? 'text-success fa-circle-check' : 'text-danger fa-circle-xmark' %>"></i> Check API');

--- a/app/views/schools/solar_edge_installations/check.js.erb
+++ b/app/views/schools/solar_edge_installations/check.js.erb
@@ -1,0 +1,1 @@
+$('#solar-edge-<%= @solar_edge_installation.id %>-test').html('<i class="fas <%= @api_ok ? 'text-success fa-circle-check' : 'text-danger fa-circle-xmark' %>"></i> Test');

--- a/app/views/schools/solar_edge_installations/edit.html.erb
+++ b/app/views/schools/solar_edge_installations/edit.html.erb
@@ -1,5 +1,4 @@
-<h1>Update Solar Edge API feed</h1>
-<h2><%= @school.name %></h2>
+<h1>Update SolarEdge Site <%= @solar_edge_installation.site_id %></h1>
 
 <%= render 'form', school: @school, solar_edge_installation: @solar_edge_installation %>
 

--- a/app/views/schools/solar_edge_installations/new.html.erb
+++ b/app/views/schools/solar_edge_installations/new.html.erb
@@ -1,5 +1,4 @@
-<h1>Create a new Solar Edge API feed</h1>
-<h2><%= @school.name %></h2>
+<h1>Add a new Solar Edge Site for <%= @school.name %></h1>
 
 <%= render 'form', school: @school, solar_edge_installation: @solar_edge_installation %>
 

--- a/app/views/schools/solar_edge_installations/show.html.erb
+++ b/app/views/schools/solar_edge_installations/show.html.erb
@@ -5,28 +5,32 @@
   </div>
 </div>
 
-<h2>Cached site information</h2>
+<% if @solar_edge_installation.cached_api_information? %>
+  <h2>Cached site information</h2>
 
-<p>
-The following is a summary of the site description. It was last refreshed on <%= nice_date_times(@solar_edge_installation.updated_at) %>. Edit and then save the site to update this cached copy. Or click the links below to view live (raw) data.
-</p>
+  <p>
+  The following is a summary of the site description. It was last refreshed on <%= nice_date_times(@solar_edge_installation.updated_at) %>. Edit and then save the site to update this cached copy. Or click the links below to view live (raw) data.
+  </p>
 
-<table class="table">
-  <thead>
-    <tr>
-      <th>Field</th>
-      <th>Value</th>
-    </tr>
-  </thead>
-  <tbody>
-    <% @solar_edge_installation.information.each do |key, value| %>
+  <table class="table">
+    <thead>
       <tr>
-        <th><%= key %></th>
-        <td><%= value %></td>
+        <th>Field</th>
+        <th>Value</th>
       </tr>
-    <% end %>
-  </tbody>
-</table>
+    </thead>
+    <tbody>
+      <% @solar_edge_installation.information.each do |key, value| %>
+        <tr>
+          <th><%= key %></th>
+          <td><%= value %></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+<% else %>
+  <p>There is no cached copy of the site metadata</p>
+<% end %>
 
 <h2>Developer Debug links</h2>
 
@@ -34,25 +38,21 @@ The following is a summary of the site description. It was last refreshed on <%=
   The following URLs provide direct access to some of the data from the Solar Edge API. We only currently load the metered data. The other links are useful for debugging and helping with setup.
 </p>
 
-<% params = {api_key: @solar_edge_installation.api_key, format: :json} %>
 <ul>
- <li><%= link_to 'Site Details', "#{SolarEdgeAPI::BASE_URL}/sites/list?#{params.to_query}" %> - live version of the above <code>site_details</code> data. Summarises all sites for which this API key has access</li>
- <li><%= link_to 'Data Period', "#{SolarEdgeAPI::BASE_URL}/site/#{@solar_edge_installation.site_id}/dataPeriod?#{params.to_query}" %> - live version of the above <code>dates</code>. Returns the dates of earliest and latest readings</li>
- <li><%= link_to 'Site Overview', "#{SolarEdgeAPI::BASE_URL}/site/#{@solar_edge_installation.site_id}/overview?#{params.to_query}" %> - The current power and daily, monthly, yearly and life time energy production for this specific site id</li>
- <li><%= link_to 'Components List', "#{SolarEdgeAPI::BASE_URL}/equipment/#{@solar_edge_installation.site_id}/list?#{params.to_query}" %> - return a list of the inverters/SMIs for this site</li>
+ <li><%= link_to 'Site Details', "#{SolarEdgeAPI::BASE_URL}/sites/list?#{@api_params.to_query}" %> - live version of the above <code>site_details</code> data. Summarises all sites for which this API key has access</li>
+ <li><%= link_to 'Data Period', "#{SolarEdgeAPI::BASE_URL}/site/#{@solar_edge_installation.site_id}/dataPeriod?#{@api_params.to_query}" %> - live version of the above <code>dates</code>. Returns the dates of earliest and latest readings</li>
+ <li><%= link_to 'Site Overview', "#{SolarEdgeAPI::BASE_URL}/site/#{@solar_edge_installation.site_id}/overview?#{@api_params.to_query}" %> - The current power and daily, monthly, yearly and life time energy production for this specific site id</li>
+ <li><%= link_to 'Components List', "#{SolarEdgeAPI::BASE_URL}/equipment/#{@solar_edge_installation.site_id}/list?#{@api_params.to_query}" %> - return a list of the inverters/SMIs for this site</li>
 
- <li><%= link_to 'Inventory', "#{SolarEdgeAPI::BASE_URL}/site/#{@solar_edge_installation.site_id}/inventory?#{params.to_query}" %> - return the inventory of SolarEdge equipment for this site id, including inverters/SMIs, batteries, meters, gateways and sensors. Indicates whether meters are real or virtual (calculated from other meters)</li>
+ <li><%= link_to 'Inventory', "#{SolarEdgeAPI::BASE_URL}/site/#{@solar_edge_installation.site_id}/inventory?#{@api_params.to_query}" %> - return the inventory of SolarEdge equipment for this site id, including inverters/SMIs, batteries, meters, gateways and sensors. Indicates whether meters are real or virtual (calculated from other meters)</li>
 
- <%
- start_time = (Date.parse(@solar_edge_installation.information['dates'].last) - 1).strftime('%Y-%m-%d 00:00:00')
- end_time = Date.parse(@solar_edge_installation.information['dates'].last).strftime('%Y-%m-%d 00:00:00')
- reading_params = params.merge({timeUnit: "QUARTER_OF_AN_HOUR", startTime: start_time, endTime: end_time})
- %>
+ <% if @reading_params.present? %>
+   <li><%= link_to 'Readings', "#{SolarEdgeAPI::BASE_URL}/site/#{@solar_edge_installation.site_id}/energyDetails?#{@reading_params.to_query}" %> - return the readings for the latest date (based on cached date)</li>
+   <li><%= link_to 'Meter data', "#{SolarEdgeAPI::BASE_URL}/site/#{@solar_edge_installation.site_id}/meters?#{@reading_params.merge({timeUnit: 'DAY'}).to_query}" %> - lifetime energy reading for each meter and the device its connected to</li>
+ <% end %>
 
- <li><%= link_to 'Readings', "#{SolarEdgeAPI::BASE_URL}/site/#{@solar_edge_installation.site_id}/energyDetails?#{reading_params.to_query}" %> - return the readings for the latest date (based on cached date)</li>
- <li><%= link_to 'Meter data', "#{SolarEdgeAPI::BASE_URL}/site/#{@solar_edge_installation.site_id}/meters?#{reading_params.merge({timeUnit: 'DAY'}).to_query}" %> - lifetime energy reading for each meter and the device its connected to</li>
- <li><%= link_to 'Environmental Benefits', "#{SolarEdgeAPI::BASE_URL}/site/#{@solar_edge_installation.site_id}/envBenefits?#{params.to_query}" %> - returns all environmental benefits for this site id, e.g. CO2 emissions saved, equivalent trees planted, and light bulbs powered for a day.</li>
- <li><%= link_to 'Current Power Flow', "#{SolarEdgeAPI::BASE_URL}/site/#{@solar_edge_installation.site_id}/currentPowerFlow?#{params.to_query}" %> - retrieves the current power flow between all elements of the site including PV array, storage (battery), loads (consumption) and grid.</li>
+ <li><%= link_to 'Environmental Benefits', "#{SolarEdgeAPI::BASE_URL}/site/#{@solar_edge_installation.site_id}/envBenefits?#{@api_params.to_query}" %> - returns all environmental benefits for this site id, e.g. CO2 emissions saved, equivalent trees planted, and light bulbs powered for a day.</li>
+ <li><%= link_to 'Current Power Flow', "#{SolarEdgeAPI::BASE_URL}/site/#{@solar_edge_installation.site_id}/currentPowerFlow?#{@api_params.to_query}" %> - retrieves the current power flow between all elements of the site including PV array, storage (battery), loads (consumption) and grid.</li>
 </ul>
 
 <p><%= link_to 'Delete', school_solar_edge_installation_path(@school, @solar_edge_installation), method: :delete, data: { confirm: 'Are you sure? This will delete the meters' }, class: 'btn' %>

--- a/app/views/schools/solar_edge_installations/show.html.erb
+++ b/app/views/schools/solar_edge_installations/show.html.erb
@@ -1,6 +1,15 @@
-<h1><%= @school.name %> Site id <%= @solar_edge_installation.site_id %></h1>
+<div class="d-flex justify-content-between align-items-center">
+  <h1>SolarEdge Site <%= @solar_edge_installation.site_id %></h1>
+  <div class="h5">
+    <%= link_to "All Solar API feeds",  school_solar_feeds_configuration_index_path(@school), class: 'btn btn-outline-dark round-pill' %>
+  </div>
+</div>
 
-<p><%= link_to "All Solar API feeds for #{@school.name}",  school_solar_feeds_configuration_index_path(@school) %>
+<h2>Cached site information</h2>
+
+<p>
+The following is a summary of the site description. It was last refreshed on <%= nice_date_times(@solar_edge_installation.updated_at) %>. Edit and then save the site to update this cached copy. Or click the links below to view live (raw) data.
+</p>
 
 <table class="table">
   <thead>
@@ -19,4 +28,31 @@
   </tbody>
 </table>
 
-<p><%= link_to 'Delete', school_solar_edge_installation_path(@school, @solar_edge_installation), method: :delete, data: { confirm: 'Are you sure?' }, class: 'btn' %>
+<h2>Developer Debug links</h2>
+
+<p>
+  The following URLs provide direct access to some of the data from the Solar Edge API. We only currently load the metered data. The other links are useful for debugging and helping with setup.
+</p>
+
+<% params = {api_key: @solar_edge_installation.api_key, format: :json} %>
+<ul>
+ <li><%= link_to 'Site Details', "#{SolarEdgeAPI::BASE_URL}/sites/list?#{params.to_query}" %> - live version of the above <code>site_details</code> data. Summarises all sites for which this API key has access</li>
+ <li><%= link_to 'Data Period', "#{SolarEdgeAPI::BASE_URL}/site/#{@solar_edge_installation.site_id}/dataPeriod?#{params.to_query}" %> - live version of the above <code>dates</code>. Returns the dates of earliest and latest readings</li>
+ <li><%= link_to 'Site Overview', "#{SolarEdgeAPI::BASE_URL}/site/#{@solar_edge_installation.site_id}/overview?#{params.to_query}" %> - The current power and daily, monthly, yearly and life time energy production for this specific site id</li>
+ <li><%= link_to 'Components List', "#{SolarEdgeAPI::BASE_URL}/equipment/#{@solar_edge_installation.site_id}/list?#{params.to_query}" %> - return a list of the inverters/SMIs for this site</li>
+
+ <li><%= link_to 'Inventory', "#{SolarEdgeAPI::BASE_URL}/site/#{@solar_edge_installation.site_id}/inventory?#{params.to_query}" %> - return the inventory of SolarEdge equipment for this site id, including inverters/SMIs, batteries, meters, gateways and sensors. Indicates whether meters are real or virtual (calculated from other meters)</li>
+
+ <%
+ start_time = (Date.parse(@solar_edge_installation.information['dates'].last) - 1).strftime('%Y-%m-%d 00:00:00')
+ end_time = Date.parse(@solar_edge_installation.information['dates'].last).strftime('%Y-%m-%d 00:00:00')
+ reading_params = params.merge({timeUnit: "QUARTER_OF_AN_HOUR", startTime: start_time, endTime: end_time})
+ %>
+
+ <li><%= link_to 'Readings', "#{SolarEdgeAPI::BASE_URL}/site/#{@solar_edge_installation.site_id}/energyDetails?#{reading_params.to_query}" %> - return the readings for the latest date (based on cached date)</li>
+ <li><%= link_to 'Meter data', "#{SolarEdgeAPI::BASE_URL}/site/#{@solar_edge_installation.site_id}/meters?#{reading_params.merge({timeUnit: 'DAY'}).to_query}" %> - lifetime energy reading for each meter and the device its connected to</li>
+ <li><%= link_to 'Environmental Benefits', "#{SolarEdgeAPI::BASE_URL}/site/#{@solar_edge_installation.site_id}/envBenefits?#{params.to_query}" %> - returns all environmental benefits for this site id, e.g. CO2 emissions saved, equivalent trees planted, and light bulbs powered for a day.</li>
+ <li><%= link_to 'Current Power Flow', "#{SolarEdgeAPI::BASE_URL}/site/#{@solar_edge_installation.site_id}/currentPowerFlow?#{params.to_query}" %> - retrieves the current power flow between all elements of the site including PV array, storage (battery), loads (consumption) and grid.</li>
+</ul>
+
+<p><%= link_to 'Delete', school_solar_edge_installation_path(@school, @solar_edge_installation), method: :delete, data: { confirm: 'Are you sure? This will delete the meters' }, class: 'btn' %>

--- a/app/views/schools/solar_feeds_configuration/_solar_edge_feeds.html.erb
+++ b/app/views/schools/solar_feeds_configuration/_solar_edge_feeds.html.erb
@@ -15,8 +15,8 @@
           <td>
             <p>
               <%= link_to 'Edit', edit_school_solar_edge_installation_path(school, installation), class: 'btn' %>
-              <%= link_to 'Delete', school_solar_edge_installation_path(school, installation), method: :delete, data: { confirm: 'Are you sure? This will delete the meters' }, class: 'btn btn-danger' %>
               <%= link_to "#{fa_icon('circle-question')} Check".html_safe, check_school_solar_edge_installation_path(school, installation), id: "solar-edge-#{installation.id}-test", method: :post, remote: true, class: 'btn' %>
+              <%= link_to 'Delete', school_solar_edge_installation_path(school, installation), method: :delete, data: { confirm: 'Are you sure? This will delete the meters' }, class: 'btn btn-danger' %>
             </p>
           </td>
         </tr>

--- a/app/views/schools/solar_feeds_configuration/_solar_edge_feeds.html.erb
+++ b/app/views/schools/solar_feeds_configuration/_solar_edge_feeds.html.erb
@@ -2,20 +2,22 @@
   <table class="table table-sm">
     <tbody>
       <tr>
-        <th class="w-25">Mpan</th>
-        <th class="w-25">Site Id</th>
+        <th>Mpan (or Id)</th>
+        <th>Site Id</th>
         <th>API Key</th>
-        <th class="w-25">Actions</th>
+        <th>Last updated</th>
+        <th>Actions</th>
       </tr>
       <% solar_edge_installations.each do |installation| %>
         <tr>
           <td><%= link_to installation.mpan, school_solar_edge_installation_path(school, installation) %></td>
           <td><%= installation.site_id %></td>
           <td><%= installation.api_key %></td>
+          <td><%= nice_date_times(installation.updated_at) %></td>
           <td>
             <p>
               <%= link_to 'Edit', edit_school_solar_edge_installation_path(school, installation), class: 'btn' %>
-              <%= link_to "#{fa_icon('circle-question')} Check".html_safe, check_school_solar_edge_installation_path(school, installation), id: "solar-edge-#{installation.id}-test", method: :post, remote: true, class: 'btn' %>
+              <%= link_to "#{fa_icon('circle-question')} Check API".html_safe, check_school_solar_edge_installation_path(school, installation), id: "solar-edge-#{installation.id}-test", method: :post, remote: true, class: 'btn' %>
               <%= link_to 'Delete', school_solar_edge_installation_path(school, installation), method: :delete, data: { confirm: 'Are you sure? This will delete the meters' }, class: 'btn btn-danger' %>
             </p>
           </td>
@@ -24,7 +26,7 @@
     </tbody>
   </table>
 <% else %>
-  <p>This school has no Solar Edge API feeds</p>
+  <p>This school has no Solar Edge sites</p>
 <% end %>
 
 <p><%= link_to 'New Solar Edge API feed', new_school_solar_edge_installation_path, class: 'btn' %></p>

--- a/app/views/schools/solar_feeds_configuration/_solar_edge_feeds.html.erb
+++ b/app/views/schools/solar_feeds_configuration/_solar_edge_feeds.html.erb
@@ -15,7 +15,7 @@
           <td>
             <p>
               <%= link_to 'Edit', edit_school_solar_edge_installation_path(school, installation), class: 'btn' %>
-              <%= link_to 'Delete', school_solar_edge_installation_path(school, installation), method: :delete, data: { confirm: 'Are you sure?' }, class: 'btn btn-danger' %>
+              <%= link_to 'Delete', school_solar_edge_installation_path(school, installation), method: :delete, data: { confirm: 'Are you sure? This will delete the meters' }, class: 'btn btn-danger' %>
             </p>
 
           </td>

--- a/app/views/schools/solar_feeds_configuration/_solar_edge_feeds.html.erb
+++ b/app/views/schools/solar_feeds_configuration/_solar_edge_feeds.html.erb
@@ -17,7 +17,7 @@
           <td>
             <p>
               <%= link_to 'Edit', edit_school_solar_edge_installation_path(school, installation), class: 'btn' %>
-              <%= link_to "#{fa_icon('circle-question')} Check API".html_safe, check_school_solar_edge_installation_path(school, installation), id: "solar-edge-#{installation.id}-test", method: :post, remote: true, class: 'btn' %>
+              <%= link_to "#{fa_icon('circle-question')} Check API".html_safe, check_school_solar_edge_installation_path(school, installation), id: "solar-edge-#{installation.id}-test", method: :post, remote: true, class: 'btn check-button' %>
               <%= link_to 'Delete', school_solar_edge_installation_path(school, installation), method: :delete, data: { confirm: 'Are you sure? This will delete the meters' }, class: 'btn btn-danger' %>
             </p>
           </td>

--- a/app/views/schools/solar_feeds_configuration/_solar_edge_feeds.html.erb
+++ b/app/views/schools/solar_feeds_configuration/_solar_edge_feeds.html.erb
@@ -16,8 +16,8 @@
             <p>
               <%= link_to 'Edit', edit_school_solar_edge_installation_path(school, installation), class: 'btn' %>
               <%= link_to 'Delete', school_solar_edge_installation_path(school, installation), method: :delete, data: { confirm: 'Are you sure? This will delete the meters' }, class: 'btn btn-danger' %>
+              <%= link_to "#{fa_icon('circle-question')} Check".html_safe, check_school_solar_edge_installation_path(school, installation), id: "solar-edge-#{installation.id}-test", method: :post, remote: true, class: 'btn' %>
             </p>
-
           </td>
         </tr>
       <% end %>

--- a/app/views/schools/solar_feeds_configuration/index.html.erb
+++ b/app/views/schools/solar_feeds_configuration/index.html.erb
@@ -1,11 +1,13 @@
-<h1>Solar API feeds for <%= @school.name %></h1>
-
-<p><%= link_to 'View all school meters',  school_meters_path(@school) %></p>
+<div class="d-flex justify-content-between align-items-center">
+  <h1>Solar API feeds for <%= @school.name %></h1>
+  <div class="h5">
+    <%= link_to "School meter management", school_meters_path(@school), class: 'btn btn-outline-dark round-pill' %>
+  </div>
+</div>
 
 <h3>Solar Edge</h3>
 
 <%= render 'solar_edge_feeds', school: @school, solar_edge_installations: @solar_edge_installations %>
-
 
 <h3>Rtone</h3>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -296,7 +296,11 @@ Rails.application.routes.draw do
 
       resources :solar_feeds_configuration, only: [:index]
 
-      resources :solar_edge_installations, only: [:new, :show, :create, :edit, :update, :destroy]
+      resources :solar_edge_installations, only: [:new, :show, :create, :edit, :update, :destroy] do
+        member do
+          post :check
+        end
+      end
       resources :low_carbon_hub_installations, only: [:new, :show, :create, :edit, :update, :destroy]
       resources :rtone_variant_installations, only: [:new, :create, :edit, :update, :destroy]
 

--- a/spec/factories/solar_edge_installations_factory.rb
+++ b/spec/factories/solar_edge_installations_factory.rb
@@ -5,6 +5,9 @@ FactoryBot.define do
     amr_data_feed_config
     sequence(:mpan) { |n| n }
     sequence(:api_key) { |n| "api_key_#{n}" }
+    information do
+      { site_detail: "", dates: %w(2023-01-01 2023-10-01) }
+    end
 
     trait :with_electricity_meter do
       after(:create) do |solar_edge_installation, _evaluator|

--- a/spec/system/solar_edge_installation_spec.rb
+++ b/spec/system/solar_edge_installation_spec.rb
@@ -98,6 +98,18 @@ RSpec.describe "Solar edge installation management", :solar_edge_installations, 
         end
       end
 
+      context 'when installation has no cached data' do
+        let!(:installation) { create(:solar_edge_installation, school: school, information: nil) }
+
+        it 'can still be viewed' do
+          click_on(installation.mpan)
+          expect(page).not_to have_content("Cached site information")
+          expect(page).to have_content("There is no cached copy of the site metadata")
+          expect(page).to have_link("Data Period")
+          expect(page).not_to have_link("Readings")
+        end
+      end
+
       context 'when checking an installation', js: true do
         before do
           allow(Solar::SolarEdgeInstallationFactory).to receive(:check).and_return(ok)

--- a/spec/system/solar_edge_installation_spec.rb
+++ b/spec/system/solar_edge_installation_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe "Solar edge installation management", :solar_edge_installations, 
     end
 
     context 'with existing installation' do
-      let!(:api_feed) { create(:solar_edge_installation, school: school) }
+      let!(:installation) { create(:solar_edge_installation, school: school) }
 
       before do
         click_on 'Manage Solar API feeds'
@@ -56,7 +56,7 @@ RSpec.describe "Solar edge installation management", :solar_edge_installations, 
 
       it 'displays the feed config' do
         expect(page).not_to have_content("This school has no Solar Edge API feeds")
-        expect(page).to have_content(api_feed.site_id)
+        expect(page).to have_content(installation.site_id)
       end
 
       it 'allows editing' do
@@ -68,7 +68,7 @@ RSpec.describe "Solar edge installation management", :solar_edge_installations, 
 
         expect(page).to have_content("Solar Edge API feed was updated")
 
-        expect(SolarEdgeInstallation.first.mpan).to eql api_feed.mpan
+        expect(SolarEdgeInstallation.first.mpan).to eql installation.mpan
         expect(SolarEdgeInstallation.first.site_id).to eql site_id
         expect(SolarEdgeInstallation.first.api_key).to eql api_key
       end
@@ -76,10 +76,17 @@ RSpec.describe "Solar edge installation management", :solar_edge_installations, 
       it 'allows deletion' do
         expect { click_on 'Delete'}.to change { SolarEdgeInstallation.count }.by(-1)
       end
+
+      it 'allows viewing' do
+        click_on(installation.mpan)
+        expect(page).to have_content("site_details")
+        expect(page).to have_content("dates")
+        expect(page).to have_link("Data Period")
+      end
     end
 
     context 'with an installation with meters' do
-      let!(:api_feed) { create(:solar_edge_installation_with_meters_and_validated_readings, school: school) }
+      let!(:installation) { create(:solar_edge_installation_with_meters_and_validated_readings, school: school) }
 
       before do
         click_on 'Manage Solar API feeds'

--- a/spec/system/solar_edge_installation_spec.rb
+++ b/spec/system/solar_edge_installation_spec.rb
@@ -27,12 +27,12 @@ RSpec.describe "Solar edge installation management", :solar_edge_installations, 
       end
 
       it 'has no installation by default' do
-        expect(page).to have_content("This school has no Solar Edge API feeds")
+        expect(page).to have_content("This school has no Solar Edge sites")
       end
 
       it 'allows an installation to be added' do
         click_on 'New Solar Edge API feed'
-        expect(page).to have_content("Create a new Solar Edge API feed")
+        expect(page).to have_content("Add a new Solar Edge Site")
 
         fill_in(:solar_edge_installation_mpan, with: mpan)
         fill_in(:solar_edge_installation_site_id, with: site_id)
@@ -40,6 +40,10 @@ RSpec.describe "Solar edge installation management", :solar_edge_installations, 
 
         expect { click_on 'Submit'}.to change { SolarEdgeInstallation.count }.by(1)
         expect(page).to have_content("Solar Edge installation was successfully created")
+
+        expect(page).to have_content(mpan)
+        expect(page).to have_content(site_id)
+        expect(page).to have_content(api_key)
 
         expect(SolarEdgeInstallation.first.mpan).to eql mpan
         expect(SolarEdgeInstallation.first.site_id).to eql site_id
@@ -50,27 +54,30 @@ RSpec.describe "Solar edge installation management", :solar_edge_installations, 
     context 'with existing installation' do
       let!(:installation) { create(:solar_edge_installation, school: school) }
 
+      let(:new_api_key)   { '99999' }
+
       before do
         click_on 'Manage Solar API feeds'
       end
 
       it 'displays the feed config' do
-        expect(page).not_to have_content("This school has no Solar Edge API feeds")
+        expect(page).not_to have_content("This school has no Solar Edge sites")
         expect(page).to have_content(installation.site_id)
       end
 
       it 'allows editing' do
         click_on 'Edit'
-        expect(page).to have_content("Update Solar Edge API feed")
-        fill_in(:solar_edge_installation_site_id, with: site_id)
-        fill_in(:solar_edge_installation_api_key, with: api_key)
+        expect(page).to have_content("Update SolarEdge Site")
+
+        expect(find('#solar_edge_installation_mpan').disabled?).to be true
+        expect(find('#solar_edge_installation_site_id').disabled?).to be true
+
+        fill_in(:solar_edge_installation_api_key, with: new_api_key)
         click_on 'Submit'
 
         expect(page).to have_content("Solar Edge API feed was updated")
-
-        expect(SolarEdgeInstallation.first.mpan).to eql installation.mpan
-        expect(SolarEdgeInstallation.first.site_id).to eql site_id
-        expect(SolarEdgeInstallation.first.api_key).to eql api_key
+        expect(page).to have_content(new_api_key)
+        expect(SolarEdgeInstallation.first.api_key).to eql new_api_key
       end
 
       it 'allows deletion' do

--- a/spec/system/solar_edge_installation_spec.rb
+++ b/spec/system/solar_edge_installation_spec.rb
@@ -83,6 +83,41 @@ RSpec.describe "Solar edge installation management", :solar_edge_installations, 
         expect(page).to have_content("dates")
         expect(page).to have_link("Data Period")
       end
+
+      it 'displays the check button with a question mark by default' do
+        within "#solar-edge-#{installation.id}-test" do
+          expect(page).to have_content('Check')
+          expect(page).to have_css("i[class*='fa-circle-question']")
+        end
+      end
+
+      context 'when checking an installation', js: true do
+        before do
+          allow(Solar::SolarEdgeInstallationFactory).to receive(:check).and_return(ok)
+        end
+
+        context 'when check returns true' do
+          let(:ok) { true }
+
+          it 'updates the button correctly' do
+            find("#solar-edge-#{installation.id}-test").click
+            within "#solar-edge-#{installation.id}-test" do
+              expect(page).to have_css("i[class*='fa-circle-check']")
+            end
+          end
+        end
+
+        context 'when check returns false' do
+          let(:ok) { false }
+
+          it 'updates the button correctly' do
+            find("#solar-edge-#{installation.id}-test").click
+            within "#solar-edge-#{installation.id}-test" do
+              expect(page).to have_css("i[class*='fa-circle-xmark']")
+            end
+          end
+        end
+      end
     end
 
     context 'with an installation with meters' do


### PR DESCRIPTION
First of several PRs aimed at improving the setup and management of API feeds from the SolarEdge platform.

This initial PR:

* Tidies up the Solar API feed page and forms, to add hints, disable fields that shouldn't be edited and display date when a site was last edited
* Improve the page for viewing the configuration of a feed to include a bit of context and some direct links to API endpoints to facilitate debugging of issues
* Adds a "Check API" button for admins to allow them to confirm that the saved credentials are working without having to wait for an overnight run of the solar data loader

Follow on PRs will refactor and improve the services supporting management of the feeds and adding option for admin to trigger a manual data load from the API.