### PR TITLE
Make guard run rubocop with autocorrect

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -130,6 +130,7 @@ group :development, :test do
   gem 'webmock'
   gem 'foreman'
   gem 'guard-rspec', require: false
+  gem 'guard-rubocop', require: false
   gem 'terminal-notifier', require: false
   gem 'terminal-notifier-guard', require: false
   gem 'rb-readline', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -308,6 +308,9 @@ GEM
       guard (~> 2.1)
       guard-compat (~> 1.1)
       rspec (>= 2.99.0, < 4.0)
+    guard-rubocop (1.5.0)
+      guard (~> 2.0)
+      rubocop (< 2.0)
     handlebars_assets (0.23.9)
       execjs (~> 2.0)
       sprockets (>= 2.0.0)
@@ -764,6 +767,7 @@ DEPENDENCIES
   good_job (~> 3.4.6)
   groupdate (= 6.2.1)
   guard-rspec
+  guard-rubocop
   handlebars_assets
   i18n-tasks (~> 1.0.10)
   image_processing (~> 1.12)

--- a/Guardfile
+++ b/Guardfile
@@ -63,3 +63,7 @@ guard :rspec, cmd: "bundle exec rspec" do
 
   notification :terminal_notifier if `uname` =~ /Darwin/
 end
+
+guard :rubocop, all_on_start: false, cli: "--autocorrect --config=.rubocop.yml" do
+  watch(%r{.+\.rb$})
+end


### PR DESCRIPTION
Decided guard might be a better place to run rubocop with autocorrect (seeing as though I already run it). Will try it out anyway, hopefully won't get too annoying.