### PR TITLE
Adult and pupil dashboards: add a prompt to complete recommended pupil or adult led activities

### DIFF
--- a/app/controllers/pupils/schools_controller.rb
+++ b/app/controllers/pupils/schools_controller.rb
@@ -35,6 +35,7 @@ module Pupils
       @show_temperature_observations = show_temperature_observations?
       @observations = setup_timeline(@school.observations)
       @default_equivalences = default_equivalences
+      @programmes_to_prompt = @school.programmes.last_started
     end
 
     def setup_data_enabled_features

--- a/app/controllers/schools_controller.rb
+++ b/app/controllers/schools_controller.rb
@@ -150,6 +150,7 @@ private
 
   def setup_default_features
     @observations = setup_timeline(@school.observations)
+
     #Setup management dashboard features if users has permission
     #to do that
     @show_standard_prompts = show_standard_prompts?(@school)
@@ -158,14 +159,8 @@ private
       @add_pupils = site_settings.message_for_no_pupil_accounts && @school.users.pupil.empty? && can?(:manage_users, @school)
       @prompt_training = @show_data_enabled_features && current_user.confirmed_at > 30.days.ago
       @prompt_for_bill = @school.bill_requested && can?(:index, ConsentDocument)
-      @programmes_to_prompt = select_programmes_to_prompt
+      @programmes_to_prompt = @school.programmes.last_started
     end
-  end
-
-  def select_programmes_to_prompt
-    # Initially just a single prompt for the programme that the school most recently started.
-    # We might revise this to show multiple programmes, or choose a random programme.
-    @school.programmes.started.order(started_on: :desc).limit(1)
   end
 
   def setup_data_enabled_features

--- a/app/models/programme.rb
+++ b/app/models/programme.rb
@@ -51,9 +51,9 @@ class Programme < ApplicationRecord
 
   scope :recently_started, ->(date) { where('created_at > ?', date) }
   scope :recently_started_non_default, ->(date) { recently_started(date).where.not(programme_type: ProgrammeType.default) }
-
+  scope :in_reverse_start_order, -> { started.order(started_on: :desc) }
   scope :active, -> { joins(:programme_type).merge(ProgrammeType.active) }
-
+  scope :last_started, -> { in_reverse_start_order.limit(1) }
   delegate :title, :description, :short_description, :document_link, :image, to: :programme_type
 
   def points_for_completion

--- a/app/views/pupils/schools/show.html.erb
+++ b/app/views/pupils/schools/show.html.erb
@@ -49,6 +49,8 @@
   <% end %>
 <% end %>
 
+<%= render 'schools/prompt_recommendations', school: @school %>
+
 <%= render 'schools/dashboard/transport_surveys', school: @school %>
 
 <div class="row">

--- a/app/views/pupils/schools/show.html.erb
+++ b/app/views/pupils/schools/show.html.erb
@@ -53,7 +53,6 @@
   <%= render 'schools/prompt_to_complete_programme', programmes: @programmes_to_prompt %>
   <%= render 'schools/prompt_recommendations_scoreboard', school: @school %>
 <% end %>
-
 <%= render 'schools/dashboard/transport_surveys', school: @school %>
 
 <div class="row">

--- a/app/views/pupils/schools/show.html.erb
+++ b/app/views/pupils/schools/show.html.erb
@@ -49,7 +49,10 @@
   <% end %>
 <% end %>
 
-<%= render 'schools/prompt_recommendations', school: @school %>
+<% if EnergySparks::FeatureFlags.active?(:activities_2023) %>
+  <%= render 'schools/prompt_to_complete_programme', programmes: @programmes_to_prompt %>
+  <%= render 'schools/prompt_recommendations_scoreboard', school: @school %>
+<% end %>
 
 <%= render 'schools/dashboard/transport_surveys', school: @school %>
 

--- a/app/views/schools/_engagement_prompts.html.erb
+++ b/app/views/schools/_engagement_prompts.html.erb
@@ -1,13 +1,23 @@
-<%= component 'info_bar',
+<% if EnergySparks::FeatureFlags.active?(:activities_2023) %>
+  <!-- assume this should only be shown if -->
+  <%= component 'info_bar',
     status: :neutral,
-    title: t('schools.show.complete_activities'),
-    icon: fa_icon('chalkboard-teacher fa-3x'),
-    buttons: { t('schools.show.record_pupil_activity') => activity_categories_path }
+    title: I18n.t('schools.prompts.recommendations.message_html'),
+    icon: fa_icon('tasks fa-3x'),
+    buttons: { I18n.t('schools.prompts.recommendations.button') => school_recommendations_path(@school) }
+  %>
+<% end %>
+
+<%= component 'info_bar',
+  status: :neutral,
+  title: t('schools.show.complete_activities'),
+  icon: fa_icon('chalkboard-teacher fa-3x'),
+  buttons: { t('schools.show.record_pupil_activity') => activity_categories_path }
 %>
 
 <%= component 'info_bar',
-    status: :neutral,
-    title: t('schools.show.complete_interventions'),
-    icon: fa_icon('school fa-3x'),
-    buttons: { t('schools.show.record_action') => intervention_type_groups_path }
+  status: :neutral,
+  title: t('schools.show.complete_interventions'),
+  icon: fa_icon('school fa-3x'),
+  buttons: { t('schools.show.record_action') => intervention_type_groups_path }
 %>

--- a/app/views/schools/_engagement_prompts.html.erb
+++ b/app/views/schools/_engagement_prompts.html.erb
@@ -1,13 +1,3 @@
-<% if EnergySparks::FeatureFlags.active?(:activities_2023) %>
-  <!-- assume this should only be shown if -->
-  <%= component 'info_bar',
-    status: :neutral,
-    title: I18n.t('schools.prompts.recommendations.message_html'),
-    icon: fa_icon('tasks fa-3x'),
-    buttons: { I18n.t('schools.prompts.recommendations.button') => school_recommendations_path(@school) }
-  %>
-<% end %>
-
 <%= component 'info_bar',
   status: :neutral,
   title: t('schools.show.complete_activities'),

--- a/app/views/schools/_prompt_recommendations.html.erb
+++ b/app/views/schools/_prompt_recommendations.html.erb
@@ -2,5 +2,5 @@
   status: :neutral,
   title: I18n.t('schools.prompts.recommendations.message'),
   icon: fa_icon('clipboard-list fa-3x'),
-  buttons: { I18n.t('common.labels.choose_activity') => school_recommendations_path(@school) }
+  buttons: { I18n.t('common.labels.choose_activity') => school_recommendations_path(@school, scope: :adult) }
 %>

--- a/app/views/schools/_prompt_recommendations.html.erb
+++ b/app/views/schools/_prompt_recommendations.html.erb
@@ -1,30 +1,6 @@
-<% if EnergySparks::FeatureFlags.active?(:activities_2023) %>
-
-  <% position = current_school_podium.try(:school_position) %>
-
-  <% unless position.try(:points) %>
-    <%= component 'info_bar',
-        status: :neutral,
-        title: I18n.t('schools.prompts.recommendations.no_points_message'),
-        icon: fa_icon('crown fa-3x'),
-        buttons: { I18n.t('schools.prompts.recommendations.button') => school_recommendations_path(@school) }
-    %>
-  <% else %>
-    <% if position.position == 1 %>
-      <%= component 'info_bar',
-        status: :positive,
-        title: I18n.t('schools.prompts.recommendations.top_message_html', points: position.points, position: position.ordinal).html_safe,
-        icon: fa_icon('crown fa-3x'),
-        buttons: { I18n.t('schools.prompts.recommendations.button') => school_recommendations_path(@school) }
-    %>
-    <% else %>
-      <%= component 'info_bar',
-        status: :positive,
-        title: I18n.t('schools.prompts.recommendations.not_top_message_html',
-          points: position.points, position: position.ordinal).html_safe,
-        icon: fa_icon('crown fa-3x'),
-        buttons: { I18n.t('schools.prompts.recommendations.button') => school_recommendations_path(@school) }
-      %>
-    <% end %>
-  <% end %>
-<% end %>
+<%= component 'info_bar',
+  status: :neutral,
+  title: I18n.t('schools.prompts.recommendations.message'),
+  icon: fa_icon('clipboard-list fa-3x'),
+  buttons: { I18n.t('common.labels.choose_activity') => school_recommendations_path(@school) }
+%>

--- a/app/views/schools/_prompt_recommendations.html.erb
+++ b/app/views/schools/_prompt_recommendations.html.erb
@@ -1,0 +1,30 @@
+<% if EnergySparks::FeatureFlags.active?(:activities_2023) %>
+
+  <% position = current_school_podium.try(:school_position) %>
+
+  <% unless position.try(:points) %>
+    <%= component 'info_bar',
+        status: :neutral,
+        title: I18n.t('schools.prompts.recommendations.no_points_message'),
+        icon: fa_icon('crown fa-3x'),
+        buttons: { I18n.t('schools.prompts.recommendations.button') => school_recommendations_path(@school) }
+    %>
+  <% else %>
+    <% if position.position == 1 %>
+      <%= component 'info_bar',
+        status: :positive,
+        title: I18n.t('schools.prompts.recommendations.top_message_html', points: position.points, position: position.ordinal).html_safe,
+        icon: fa_icon('crown fa-3x'),
+        buttons: { I18n.t('schools.prompts.recommendations.button') => school_recommendations_path(@school) }
+    %>
+    <% else %>
+      <%= component 'info_bar',
+        status: :positive,
+        title: I18n.t('schools.prompts.recommendations.not_top_message_html',
+          points: position.points, position: position.ordinal).html_safe,
+        icon: fa_icon('crown fa-3x'),
+        buttons: { I18n.t('schools.prompts.recommendations.button') => school_recommendations_path(@school) }
+      %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/schools/_prompt_recommendations_scoreboard.html.erb
+++ b/app/views/schools/_prompt_recommendations_scoreboard.html.erb
@@ -1,0 +1,15 @@
+<% position = current_school_podium.try(:school_position) %>
+<% unless position.try(:points) %>
+  <%= component 'info_bar',
+      status: :neutral,
+      title: I18n.t('schools.prompts.recommendations_scoreboard.no_points_message'),
+      icon: fa_icon('trophy fa-3x'),
+      buttons: { I18n.t('common.labels.choose_activity') => school_recommendations_path(@school) }
+  %>
+<% else %>
+  <%= component 'info_bar',
+    status: :positive,
+    title: I18n.t('schools.prompts.recommendations_scoreboard.message_html', points: position.points, count: position.ordinal).html_safe,
+    icon: fa_icon('trophy fa-3x'),
+    buttons: { I18n.t('common.labels.choose_activity') => school_recommendations_path(@school) } %>
+<% end %>

--- a/app/views/schools/_prompt_recommendations_scoreboard.html.erb
+++ b/app/views/schools/_prompt_recommendations_scoreboard.html.erb
@@ -4,12 +4,12 @@
       status: :neutral,
       title: I18n.t('schools.prompts.recommendations_scoreboard.no_points_message'),
       icon: fa_icon('trophy fa-3x'),
-      buttons: { I18n.t('common.labels.choose_activity') => school_recommendations_path(@school) }
+      buttons: { I18n.t('common.labels.choose_activity') => school_recommendations_path(@school, scope: :pupil) }
   %>
 <% else %>
   <%= component 'info_bar',
     status: :positive,
-    title: I18n.t('schools.prompts.recommendations_scoreboard.message_html', points: position.points, count: position.ordinal).html_safe,
+    title: I18n.t('schools.prompts.recommendations_scoreboard.message_html', points: position.points, position: position.ordinal, count: position.position).html_safe,
     icon: fa_icon('trophy fa-3x'),
-    buttons: { I18n.t('common.labels.choose_activity') => school_recommendations_path(@school) } %>
+    buttons: { I18n.t('common.labels.choose_activity') => school_recommendations_path(@school, scope: :pupil) } %>
 <% end %>

--- a/app/views/schools/_prompt_to_complete_programme.html.erb
+++ b/app/views/schools/_prompt_to_complete_programme.html.erb
@@ -2,18 +2,18 @@
   <% programmes.each do |programme| %>
     <%= component 'info_bar',
         status: :neutral,
-        style: :compact,
+        style: local_assigns[:style],
         title: Programmes::Progress.new(programme).notification,
-        icon: fa_icon('fas fa-tasks fa-3x'),
+        icon: fa_icon('tasks fa-3x'),
         buttons: { I18n.t('common.labels.view_now') => programme_type_path(programme.programme_type) }
     %>
   <% end %>
 <% else %>
   <%= component 'info_bar',
       status: :positive,
-      style: :compact,
+      style: local_assigns[:style],
       title: I18n.t('schools.prompts.programme.choose_a_new_programme_message'),
-      icon: fa_icon('fas fa-tasks fa-3x'),
+      icon: fa_icon('tasks fa-3x'),
       buttons: { I18n.t('schools.prompts.programme.start_a_new_programme') => programme_types_path }
   %>
 <% end %>

--- a/app/views/schools/recommendations/index.html.erb
+++ b/app/views/schools/recommendations/index.html.erb
@@ -4,7 +4,7 @@
 
 <!-- we may move fetching the params for these into the controller later on -->
 <%= render('schools/prompt_to_complete_programme', programmes: @school.programmes.started.order(started_on: :desc), style: :compact) %>
-<%= render('schools/prompt_audit', audit: Audits::AuditService.new(@school).last_audit) %>
+<%= render('schools/prompt_audit', audit: Audits::AuditService.new(@school).last_audit, style: :compact) %>
 
 <% display_options = { classes: 'pb-4', limit: 5, limit_lg: 3 } %>
 

--- a/app/views/schools/recommendations/index.html.erb
+++ b/app/views/schools/recommendations/index.html.erb
@@ -3,7 +3,7 @@
 <p><%= t('schools.recommendations.intro') %></p>
 
 <!-- we may move fetching the params for these into the controller later on -->
-<%= render('schools/prompt_to_complete_programme', programmes: @school.programmes.started.order(started_on: :desc)) %>
+<%= render('schools/prompt_to_complete_programme', programmes: @school.programmes.started.order(started_on: :desc), style: :compact) %>
 <%= render('schools/prompt_audit', audit: Audits::AuditService.new(@school).last_audit) %>
 
 <% display_options = { classes: 'pb-4', limit: 5, limit_lg: 3 } %>

--- a/app/views/schools/show.html.erb
+++ b/app/views/schools/show.html.erb
@@ -13,10 +13,6 @@
   </div>
 <% end %>
 
-<% if EnergySparks::FeatureFlags.active?(:activities_2023) %>
-  <%= render('schools/prompt_to_complete_programme', programmes: @programmes_to_prompt) %>
-<% end %>
-
 <h3><%= t('schools.show.act_on_energy_usage') %></h3>
 
 <%= render 'management/schools/targets/progress_notice', school: @school, progress_summary: @progress_summary %>
@@ -28,6 +24,10 @@
 <% if @show_standard_prompts %>
   <%= render 'management/schools/dashboard_message', messageable: @school %>
   <%= render 'management/schools/dashboard_message', messageable: @school.try(:school_group) %>
+<% end %>
+
+<% if EnergySparks::FeatureFlags.active?(:activities_2023) %>
+  <%= render('schools/prompt_to_complete_programme', programmes: @programmes_to_prompt) %>
 <% end %>
 
 <% if @suggest_estimates_for_fuel_types.present? && @suggest_estimates_for_fuel_types.any? %>

--- a/app/views/schools/show.html.erb
+++ b/app/views/schools/show.html.erb
@@ -26,10 +26,6 @@
   <%= render 'management/schools/dashboard_message', messageable: @school.try(:school_group) %>
 <% end %>
 
-<% if EnergySparks::FeatureFlags.active?(:activities_2023) %>
-  <%= render('schools/prompt_to_complete_programme', programmes: @programmes_to_prompt) %>
-<% end %>
-
 <% if @suggest_estimates_for_fuel_types.present? && @suggest_estimates_for_fuel_types.any? %>
   <%= render 'management/schools/prompt_for_estimate', school: @school, fuel_types: @suggest_estimates_for_fuel_types %>
 <% end %>
@@ -59,7 +55,12 @@
 <% end %>
 
 <% if @show_standard_prompts %>
-  <%= render 'schools/engagement_prompts', school: @school %>
+  <% if EnergySparks::FeatureFlags.active?(:activities_2023) %>
+    <%= render 'schools/prompt_to_complete_programme', programmes: @programmes_to_prompt %>
+    <%= render 'schools/prompt_recommendations', school: @school %>
+  <% else %>
+    <%= render 'schools/engagement_prompts', school: @school %>
+  <% end %>
 <% end %>
 
 <% if @add_pupils %>

--- a/config/locales/common.yml
+++ b/config/locales/common.yml
@@ -21,6 +21,7 @@ en:
       attributes: Attributes
       back: Back
       cancel: Cancel
+      choose_activity: Choose activity
       close: Close
       continue: Continue
       create: Create

--- a/config/locales/views/schools/schools.yml
+++ b/config/locales/views/schools/schools.yml
@@ -350,6 +350,9 @@ en:
       recommendations:
         button: Choose activity
         message_html: Complete one of our recommended pupil or adult lead activities to start reducing your energy usage
+        no_points_message: You haven't scored any points this year. Complete your next activity to get on the scoreboard!
+        not_top_message_html: Well done, you have scored <span class="badge badge-success">%{points}</span> points so far and you're in <strong>%{position}</strong> position on the scoreboard. Complete your next activity to climb higher up the scoreboard!
+        top_message_html: Well done, you have scored <span class="badge badge-success">%{points}</span> points and you're in <strong>%{position}</strong> position on the scoreboard! Keep up the momentum to help you stay top!
     pupils:
       edit:
         title: Edit pupil account

--- a/config/locales/views/schools/schools.yml
+++ b/config/locales/views/schools/schools.yml
@@ -348,11 +348,13 @@ en:
           one: Complete the final activity now to score <span class="badge badge-success">%{activity_types_uncompleted_scores}</span> points and <span class="badge badge-success">%{programme_points_for_completion}</span> bonus points for completing the programme
           other: Complete the final <strong>%{count}</strong> activities now to score <span class="badge badge-success">%{activity_types_uncompleted_scores}</span> points and <span class="badge badge-success">%{programme_points_for_completion}</span> bonus points for completing the programme
       recommendations:
-        button: Choose activity
-        message_html: Complete one of our recommended pupil or adult lead activities to start reducing your energy usage
+        message: Complete one of our recommended pupil or adult led activities to start reducing your energy usage
+      recommendations_scoreboard:
+        message_html:
+          one: Well done, you have scored <span class="badge badge-success">%{points}</span> points and you're in <strong>%{count}</strong> position on the scoreboard! Keep up the good work to help you stay top!
+          other: Well done, you have scored <span class="badge badge-success">%{points}</span> points so far and you're in <strong>%{count}</strong> position on the scoreboard. Complete your next activity to climb higher up the scoreboard!
+          zero: You haven't scored any points this year. Complete your next activity to get on the scoreboard!
         no_points_message: You haven't scored any points this year. Complete your next activity to get on the scoreboard!
-        not_top_message_html: Well done, you have scored <span class="badge badge-success">%{points}</span> points so far and you're in <strong>%{position}</strong> position on the scoreboard. Complete your next activity to climb higher up the scoreboard!
-        top_message_html: Well done, you have scored <span class="badge badge-success">%{points}</span> points and you're in <strong>%{position}</strong> position on the scoreboard! Keep up the momentum to help you stay top!
     pupils:
       edit:
         title: Edit pupil account

--- a/config/locales/views/schools/schools.yml
+++ b/config/locales/views/schools/schools.yml
@@ -351,9 +351,8 @@ en:
         message: Complete one of our recommended pupil or adult led activities to start reducing your energy usage
       recommendations_scoreboard:
         message_html:
-          one: Well done, you have scored <span class="badge badge-success">%{points}</span> points and you're in <strong>%{count}</strong> position on the scoreboard! Keep up the good work to help you stay top!
-          other: Well done, you have scored <span class="badge badge-success">%{points}</span> points so far and you're in <strong>%{count}</strong> position on the scoreboard. Complete your next activity to climb higher up the scoreboard!
-          zero: You haven't scored any points this year. Complete your next activity to get on the scoreboard!
+          one: Well done, you have scored <span class="badge badge-success">%{points}</span> points and you're in <strong>%{position}</strong> position on the scoreboard! Keep up the good work to help you stay top!
+          other: Well done, you have scored <span class="badge badge-success">%{points}</span> points so far and you're in <strong>%{position}</strong> position on the scoreboard. Complete your next activity to climb higher up the scoreboard!
         no_points_message: You haven't scored any points this year. Complete your next activity to get on the scoreboard!
     pupils:
       edit:

--- a/config/locales/views/schools/schools.yml
+++ b/config/locales/views/schools/schools.yml
@@ -347,6 +347,9 @@ en:
         summary_html:
           one: Complete the final activity now to score <span class="badge badge-success">%{activity_types_uncompleted_scores}</span> points and <span class="badge badge-success">%{programme_points_for_completion}</span> bonus points for completing the programme
           other: Complete the final <strong>%{count}</strong> activities now to score <span class="badge badge-success">%{activity_types_uncompleted_scores}</span> points and <span class="badge badge-success">%{programme_points_for_completion}</span> bonus points for completing the programme
+      recommendations:
+        button: Choose activity
+        message_html: Complete one of our recommended pupil or adult lead activities to start reducing your energy usage
     pupils:
       edit:
         title: Edit pupil account

--- a/spec/support/shared_examples/prompts.rb
+++ b/spec/support/shared_examples/prompts.rb
@@ -24,47 +24,16 @@ RSpec.shared_examples "a training prompt" do |displayed:|
 end
 
 RSpec.shared_examples "a complete programme prompt" do |displayed:|
-  let(:message) { "You have completed 0/3 of the activities" }
+  let(:message) { "Start a new programme" }
   include_examples "a standard prompt", displayed: displayed
 end
 
 RSpec.shared_examples "a recommendations prompt" do |displayed:|
   let(:message) { "Complete one of our recommended pupil or adult led activities to start reducing your energy usage" }
-  it_behaves_like "a standard prompt", displayed: displayed
+  include_examples "a standard prompt", displayed: displayed
 end
 
-RSpec.shared_examples "a functional training prompt" do
-  context "when school is data enabled" do
-    let(:data_enabled) { true }
-
-    context "when user confirmed in the last 30 days" do
-      let(:confirmed_at) { 2.days.ago }
-
-      it_behaves_like "a training prompt", displayed: true
-    end
-
-    context "when user confirmed more than 30 days ago" do
-      let(:confirmed_at) { 31.days.ago }
-
-      it_behaves_like "a training prompt", displayed: false
-    end
-  end
-
-  context "when school is not data enabled" do
-    let(:data_enabled) { false }
-
-    it_behaves_like "a training prompt", displayed: false
-
-    context "when user confirmed more than 30 days ago" do
-      let(:confirmed_at) { 31.days.ago }
-
-      it_behaves_like "a training prompt", displayed: false
-    end
-
-    context "when user confirmed in the last 30 days" do
-      let(:confirmed_at) { 2.days.ago }
-
-      it_behaves_like "a training prompt", displayed: false
-    end
-  end
+RSpec.shared_examples "a recommendations scoreboard prompt" do |displayed:|
+  let(:message) { "You haven't scored any points this year. Complete your next activity to get on the scoreboard!" }
+  include_examples "a standard prompt", displayed: displayed
 end

--- a/spec/support/shared_examples/prompts.rb
+++ b/spec/support/shared_examples/prompts.rb
@@ -1,0 +1,70 @@
+RSpec.shared_examples "a standard prompt" do |displayed:|
+  context "when displayed", if: displayed do
+    it { expect(page).to have_content(message) }
+  end
+
+  context "when hidden", unless: displayed do
+    it { expect(page).not_to have_content(message) }
+  end
+end
+
+RSpec.shared_examples "dashboard message prompts" do |displayed:|
+  include_examples "a standard prompt", displayed: displayed do
+    let(:message) { "School group message" }
+  end
+
+  include_examples "a standard prompt", displayed: displayed do
+    let(:message) { "School message" }
+  end
+end
+
+RSpec.shared_examples "a training prompt" do |displayed:|
+  let(:message) { "New to Energy Sparks? Sign up to one of our upcoming free online training courses to help you get the most from the service." }
+  include_examples "a standard prompt", displayed: displayed
+end
+
+RSpec.shared_examples "a complete programme prompt" do |displayed:|
+  let(:message) { "You have completed 0/3 of the activities" }
+  include_examples "a standard prompt", displayed: displayed
+end
+
+RSpec.shared_examples "a recommendations prompt" do |displayed:|
+  let(:message) { "Complete one of our recommended pupil or adult led activities to start reducing your energy usage" }
+  it_behaves_like "a standard prompt", displayed: displayed
+end
+
+RSpec.shared_examples "a functional training prompt" do
+  context "when school is data enabled" do
+    let(:data_enabled) { true }
+
+    context "when user confirmed in the last 30 days" do
+      let(:confirmed_at) { 2.days.ago }
+
+      it_behaves_like "a training prompt", displayed: true
+    end
+
+    context "when user confirmed more than 30 days ago" do
+      let(:confirmed_at) { 31.days.ago }
+
+      it_behaves_like "a training prompt", displayed: false
+    end
+  end
+
+  context "when school is not data enabled" do
+    let(:data_enabled) { false }
+
+    it_behaves_like "a training prompt", displayed: false
+
+    context "when user confirmed more than 30 days ago" do
+      let(:confirmed_at) { 31.days.ago }
+
+      it_behaves_like "a training prompt", displayed: false
+    end
+
+    context "when user confirmed in the last 30 days" do
+      let(:confirmed_at) { 2.days.ago }
+
+      it_behaves_like "a training prompt", displayed: false
+    end
+  end
+end

--- a/spec/support/shared_examples/prompts.rb
+++ b/spec/support/shared_examples/prompts.rb
@@ -33,8 +33,19 @@ RSpec.shared_examples "a recommendations prompt" do |displayed:|
   include_examples "a standard prompt", displayed: displayed
 end
 
-RSpec.shared_examples "a recommendations scoreboard prompt" do |displayed:|
-  let(:message) { "You haven't scored any points this year. Complete your next activity to get on the scoreboard!" }
+RSpec.shared_examples "a recommendations scoreboard prompt" do |displayed: true, position: 0, points: 0|
+  let(:no_position) { "You haven't scored any points this year. Complete your next activity to get on the scoreboard!" }
+  let(:not_top) { "Well done, you have scored #{points} points so far and you're in #{position.ordinalize} position on the scoreboard. Complete your next activity to climb higher up the scoreboard!" }
+  let(:top) { "Well done, you have scored #{points} points and you're in #{position.ordinalize} position on the scoreboard! Keep up the good work to help you stay top!" }
+
+  let(:message) do
+    case position
+    when 0 then no_position
+    when 1 then top
+    else not_top
+    end
+  end
+
   include_examples "a standard prompt", displayed: displayed
 end
 

--- a/spec/support/shared_examples/prompts.rb
+++ b/spec/support/shared_examples/prompts.rb
@@ -37,3 +37,8 @@ RSpec.shared_examples "a recommendations scoreboard prompt" do |displayed:|
   let(:message) { "You haven't scored any points this year. Complete your next activity to get on the scoreboard!" }
   include_examples "a standard prompt", displayed: displayed
 end
+
+RSpec.shared_examples "a transport survey prompt" do |displayed:|
+  let(:message) { "Start a transport survey so that you can find out how much carbon your school community generates by travelling to school" }
+  include_examples "a standard prompt", displayed: displayed
+end

--- a/spec/support/shared_examples/prompts.rb
+++ b/spec/support/shared_examples/prompts.rb
@@ -42,3 +42,9 @@ RSpec.shared_examples "a transport survey prompt" do |displayed:|
   let(:message) { "Start a transport survey so that you can find out how much carbon your school community generates by travelling to school" }
   include_examples "a standard prompt", displayed: displayed
 end
+
+RSpec.shared_examples "a temperature measuring prompt" do |displayed:|
+  let(:message) { "Measure classroom temperatures to find out whether you should turn down the heating to save energy" }
+
+  include_examples "a standard prompt", displayed: displayed
+end

--- a/spec/system/pupils/prompts_spec.rb
+++ b/spec/system/pupils/prompts_spec.rb
@@ -1,0 +1,78 @@
+require 'rails_helper'
+
+RSpec.describe "pupil dashboard prompts", type: :system do
+  let(:confirmed_at)                    { 1.day.ago }
+  let(:school)                          { create(:school, :with_school_group, data_enabled: true) }
+  let(:activities_2023_feature)         { false }
+
+  around do |example|
+    ClimateControl.modify FEATURE_FLAG_ACTIVITIES_2023: activities_2023_feature.to_s do
+      example.run
+    end
+  end
+
+  before do
+    sign_in(user) if user.present?
+    visit pupils_school_path(school)
+  end
+
+  context "with activities_2023 feature flag switched on" do
+    let(:activities_2023_feature) { true }
+
+    context 'when user is a guest' do
+      let(:user) { nil }
+
+      pending do
+        it_behaves_like "a complete programme prompt", displayed: false
+        it_behaves_like "a recommendations scoreboard prompt", displayed: false
+      end
+    end
+
+    context 'when user is from another school' do
+      let(:school2) { create(:school) }
+      let(:user)    { create(:staff, school: school2) }
+
+      pending do
+        it_behaves_like "a complete programme prompt", displayed: false
+        it_behaves_like "a recommendations scoreboard prompt", displayed: false
+      end
+    end
+
+    context 'when user is a pupil' do
+      let(:user) { create(:pupil, school: school, confirmed_at: confirmed_at) }
+
+      it_behaves_like "a complete programme prompt", displayed: true
+      it_behaves_like "a recommendations scoreboard prompt", displayed: true
+    end
+
+    context 'when user is staff' do
+      let(:user) { create(:staff, school: school, confirmed_at: confirmed_at) }
+
+      it_behaves_like "a complete programme prompt", displayed: true
+      it_behaves_like "a recommendations scoreboard prompt", displayed: true
+    end
+
+    context 'when user is a school admin' do
+      let(:user) { create(:school_admin, school: school, confirmed_at: confirmed_at) }
+
+      it_behaves_like "a complete programme prompt", displayed: true
+      it_behaves_like "a recommendations scoreboard prompt", displayed: true
+    end
+
+    context 'when user is a group admin' do
+      let(:school_group)  { create(:school_group) }
+      let(:school)        { create(:school, school_group: school_group, data_enabled: true) }
+      let(:user)          { create(:group_admin, school_group: school_group, school: school, confirmed_at: confirmed_at) }
+
+      it_behaves_like "a complete programme prompt", displayed: true
+      it_behaves_like "a recommendations scoreboard prompt", displayed: true
+    end
+
+    context 'when user is an admin' do
+      let(:user) { create(:admin, confirmed_at: confirmed_at) }
+
+      it_behaves_like "a complete programme prompt", displayed: true
+      it_behaves_like "a recommendations scoreboard prompt", displayed: true
+    end
+  end
+end

--- a/spec/system/pupils/prompts_spec.rb
+++ b/spec/system/pupils/prompts_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe "pupil dashboard prompts", type: :system do
       pending do
         it_behaves_like "a complete programme prompt", displayed: false
         it_behaves_like "a recommendations scoreboard prompt", displayed: false
+        it_behaves_like "a transport survey prompt", displayed: false
       end
     end
 
@@ -35,6 +36,7 @@ RSpec.describe "pupil dashboard prompts", type: :system do
       pending do
         it_behaves_like "a complete programme prompt", displayed: false
         it_behaves_like "a recommendations scoreboard prompt", displayed: false
+        it_behaves_like "a transport survey prompt", displayed: false
       end
     end
 
@@ -43,6 +45,7 @@ RSpec.describe "pupil dashboard prompts", type: :system do
 
       it_behaves_like "a complete programme prompt", displayed: true
       it_behaves_like "a recommendations scoreboard prompt", displayed: true
+      it_behaves_like "a transport survey prompt", displayed: true
     end
 
     context 'when user is staff' do
@@ -50,6 +53,7 @@ RSpec.describe "pupil dashboard prompts", type: :system do
 
       it_behaves_like "a complete programme prompt", displayed: true
       it_behaves_like "a recommendations scoreboard prompt", displayed: true
+      it_behaves_like "a transport survey prompt", displayed: true
     end
 
     context 'when user is a school admin' do
@@ -57,6 +61,7 @@ RSpec.describe "pupil dashboard prompts", type: :system do
 
       it_behaves_like "a complete programme prompt", displayed: true
       it_behaves_like "a recommendations scoreboard prompt", displayed: true
+      it_behaves_like "a transport survey prompt", displayed: true
     end
 
     context 'when user is a group admin' do
@@ -66,6 +71,7 @@ RSpec.describe "pupil dashboard prompts", type: :system do
 
       it_behaves_like "a complete programme prompt", displayed: true
       it_behaves_like "a recommendations scoreboard prompt", displayed: true
+      it_behaves_like "a transport survey prompt", displayed: true
     end
 
     context 'when user is an admin' do
@@ -73,6 +79,7 @@ RSpec.describe "pupil dashboard prompts", type: :system do
 
       it_behaves_like "a complete programme prompt", displayed: true
       it_behaves_like "a recommendations scoreboard prompt", displayed: true
+      it_behaves_like "a transport survey prompt", displayed: true
     end
   end
 end

--- a/spec/system/pupils/prompts_spec.rb
+++ b/spec/system/pupils/prompts_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe "pupil dashboard prompts", type: :system do
   let(:school)                          { create(:school, :with_school_group, data_enabled: true) }
   let(:activities_2023_feature)         { false }
 
+
   around do |example|
     ClimateControl.modify FEATURE_FLAG_ACTIVITIES_2023: activities_2023_feature.to_s do
       example.run
@@ -12,6 +13,7 @@ RSpec.describe "pupil dashboard prompts", type: :system do
   end
 
   before do
+    SiteSettings.create!(temperature_recording_months: (1..12).map(&:to_s), electricity_price: 1, solar_export_price: 1, gas_price: 1)
     sign_in(user) if user.present?
     visit pupils_school_path(school)
   end
@@ -22,10 +24,11 @@ RSpec.describe "pupil dashboard prompts", type: :system do
     context 'when user is a guest' do
       let(:user) { nil }
 
-      pending do
+      pending "a discussion on current behaviour" do
         it_behaves_like "a complete programme prompt", displayed: false
         it_behaves_like "a recommendations scoreboard prompt", displayed: false
         it_behaves_like "a transport survey prompt", displayed: false
+        it_behaves_like "a temperature measuring prompt", displayed: false
       end
     end
 
@@ -33,10 +36,11 @@ RSpec.describe "pupil dashboard prompts", type: :system do
       let(:school2) { create(:school) }
       let(:user)    { create(:staff, school: school2) }
 
-      pending do
+      pending "a discussion on current behaviour" do
         it_behaves_like "a complete programme prompt", displayed: false
         it_behaves_like "a recommendations scoreboard prompt", displayed: false
         it_behaves_like "a transport survey prompt", displayed: false
+        it_behaves_like "a temperature measuring prompt", displayed: false
       end
     end
 
@@ -46,6 +50,7 @@ RSpec.describe "pupil dashboard prompts", type: :system do
       it_behaves_like "a complete programme prompt", displayed: true
       it_behaves_like "a recommendations scoreboard prompt", displayed: true
       it_behaves_like "a transport survey prompt", displayed: true
+      it_behaves_like "a temperature measuring prompt", displayed: true
     end
 
     context 'when user is staff' do
@@ -54,6 +59,7 @@ RSpec.describe "pupil dashboard prompts", type: :system do
       it_behaves_like "a complete programme prompt", displayed: true
       it_behaves_like "a recommendations scoreboard prompt", displayed: true
       it_behaves_like "a transport survey prompt", displayed: true
+      it_behaves_like "a temperature measuring prompt", displayed: true
     end
 
     context 'when user is a school admin' do
@@ -62,6 +68,7 @@ RSpec.describe "pupil dashboard prompts", type: :system do
       it_behaves_like "a complete programme prompt", displayed: true
       it_behaves_like "a recommendations scoreboard prompt", displayed: true
       it_behaves_like "a transport survey prompt", displayed: true
+      it_behaves_like "a temperature measuring prompt", displayed: true
     end
 
     context 'when user is a group admin' do
@@ -72,6 +79,7 @@ RSpec.describe "pupil dashboard prompts", type: :system do
       it_behaves_like "a complete programme prompt", displayed: true
       it_behaves_like "a recommendations scoreboard prompt", displayed: true
       it_behaves_like "a transport survey prompt", displayed: true
+      it_behaves_like "a temperature measuring prompt", displayed: true
     end
 
     context 'when user is an admin' do
@@ -80,6 +88,49 @@ RSpec.describe "pupil dashboard prompts", type: :system do
       it_behaves_like "a complete programme prompt", displayed: true
       it_behaves_like "a recommendations scoreboard prompt", displayed: true
       it_behaves_like "a transport survey prompt", displayed: true
+      it_behaves_like "a temperature measuring prompt", displayed: true
+    end
+  end
+
+  ### context to be removed when activities_2023 feature tidied up ###
+  context "with activities_2023 feature flag switched off" do
+    let(:activities_2023_feature) { false }
+
+    context 'when user is a pupil' do
+      let(:user) { create(:pupil, school: school, confirmed_at: confirmed_at) }
+
+      it_behaves_like "a complete programme prompt", displayed: false
+      it_behaves_like "a recommendations scoreboard prompt", displayed: false
+    end
+
+    context 'when user is staff' do
+      let(:user) { create(:staff, school: school, confirmed_at: confirmed_at) }
+
+      it_behaves_like "a complete programme prompt", displayed: false
+      it_behaves_like "a recommendations scoreboard prompt", displayed: false
+    end
+
+    context 'when user is a school admin' do
+      let(:user) { create(:school_admin, school: school, confirmed_at: confirmed_at) }
+
+      it_behaves_like "a complete programme prompt", displayed: false
+      it_behaves_like "a recommendations scoreboard prompt", displayed: false
+    end
+
+    context 'when user is a group admin' do
+      let(:school_group)  { create(:school_group) }
+      let(:school)        { create(:school, school_group: school_group, data_enabled: true) }
+      let(:user)          { create(:group_admin, school_group: school_group, school: school, confirmed_at: confirmed_at) }
+
+      it_behaves_like "a complete programme prompt", displayed: false
+      it_behaves_like "a recommendations scoreboard prompt", displayed: false
+    end
+
+    context 'when user is an admin' do
+      let(:user) { create(:admin, confirmed_at: confirmed_at) }
+
+      it_behaves_like "a complete programme prompt", displayed: false
+      it_behaves_like "a recommendations scoreboard prompt", displayed: false
     end
   end
 end

--- a/spec/system/schools/dashboard/prompts_spec.rb
+++ b/spec/system/schools/dashboard/prompts_spec.rb
@@ -26,6 +26,14 @@ shared_examples "a dashboard not showing complete programme prompt" do
   it { expect(page).not_to have_content("You have completed 0/3 of the activities") }
 end
 
+shared_examples "a dashboard showing recommendations prompt" do
+  it { expect(page).to have_content("Complete one of our recommended pupil or adult lead activities to start reducing your energy usage") }
+end
+
+shared_examples "a dashboard not showing recommendations prompt" do
+  it { expect(page).not_to have_content("Complete one of our recommended pupil or adult lead activities to start reducing your energy usage") }
+end
+
 shared_examples "a dashboard training prompt" do
   context "school is data enabled" do
     let(:data_enabled) { true }
@@ -95,6 +103,7 @@ RSpec.describe "adult dashboard prompts", type: :system do
       it_behaves_like "a dashboard not showing dashboard messages"
       it_behaves_like "a dashboard not showing training prompt"
       it_behaves_like "a dashboard not showing complete programme prompt"
+      it_behaves_like "a dashboard not showing recommendations prompt"
     end
 
     context 'as user from another school' do
@@ -104,6 +113,7 @@ RSpec.describe "adult dashboard prompts", type: :system do
       it_behaves_like "a dashboard not showing dashboard messages"
       it_behaves_like "a dashboard not showing training prompt"
       it_behaves_like "a dashboard not showing complete programme prompt"
+      it_behaves_like "a dashboard not showing recommendations prompt"
     end
 
     context 'as pupil' do
@@ -112,6 +122,7 @@ RSpec.describe "adult dashboard prompts", type: :system do
       it_behaves_like "a dashboard showing dashboard messages"
       it_behaves_like "a dashboard showing training prompt"
       it_behaves_like "a dashboard showing complete programme prompt"
+      it_behaves_like "a dashboard showing recommendations prompt"
     end
 
     context 'as staff' do
@@ -120,6 +131,7 @@ RSpec.describe "adult dashboard prompts", type: :system do
       it_behaves_like "a dashboard showing dashboard messages"
       it_behaves_like "a dashboard showing training prompt"
       it_behaves_like "a dashboard showing complete programme prompt"
+      it_behaves_like "a dashboard showing recommendations prompt"
     end
 
     context 'as school admin' do
@@ -128,6 +140,7 @@ RSpec.describe "adult dashboard prompts", type: :system do
       it_behaves_like "a dashboard showing dashboard messages"
       it_behaves_like "a dashboard showing training prompt"
       it_behaves_like "a dashboard showing complete programme prompt"
+      it_behaves_like "a dashboard showing recommendations prompt"
     end
 
     context 'as group admin' do
@@ -138,6 +151,7 @@ RSpec.describe "adult dashboard prompts", type: :system do
       it_behaves_like "a dashboard showing dashboard messages"
       it_behaves_like "a dashboard showing training prompt"
       it_behaves_like "a dashboard showing complete programme prompt"
+      it_behaves_like "a dashboard showing recommendations prompt"
     end
 
     context 'as admin' do
@@ -146,6 +160,7 @@ RSpec.describe "adult dashboard prompts", type: :system do
       it_behaves_like "a dashboard showing dashboard messages"
       it_behaves_like "a dashboard showing training prompt"
       it_behaves_like "a dashboard showing complete programme prompt"
+      it_behaves_like "a dashboard showing recommendations prompt"
     end
   end
 
@@ -157,18 +172,21 @@ RSpec.describe "adult dashboard prompts", type: :system do
       let(:user) { create(:pupil, school: school, confirmed_at: confirmed_at) }
 
       it_behaves_like "a dashboard not showing complete programme prompt"
+      it_behaves_like "a dashboard not showing recommendations prompt"
     end
 
     context 'as staff' do
       let(:user) { create(:staff, school: school, confirmed_at: confirmed_at) }
 
       it_behaves_like "a dashboard not showing complete programme prompt"
+      it_behaves_like "a dashboard not showing recommendations prompt"
     end
 
     context 'as school admin' do
       let(:user) { create(:school_admin, school: school, confirmed_at: confirmed_at) }
 
       it_behaves_like "a dashboard not showing complete programme prompt"
+      it_behaves_like "a dashboard not showing recommendations prompt"
     end
 
     context 'as group admin' do
@@ -177,12 +195,14 @@ RSpec.describe "adult dashboard prompts", type: :system do
       let(:user)          { create(:group_admin, school_group: school_group, school: school, confirmed_at: confirmed_at) }
 
       it_behaves_like "a dashboard not showing complete programme prompt"
+      it_behaves_like "a dashboard not showing recommendations prompt"
     end
 
     context 'as admin' do
       let(:user) { create(:admin, confirmed_at: confirmed_at) }
 
       it_behaves_like "a dashboard not showing complete programme prompt"
+      it_behaves_like "a dashboard not showing recommendations prompt"
     end
   end
 end

--- a/spec/system/schools/dashboard/prompts_spec.rb
+++ b/spec/system/schools/dashboard/prompts_spec.rb
@@ -1,76 +1,5 @@
 require 'rails_helper'
 
-shared_examples "a dashboard showing dashboard messages" do
-  it { expect(page).to have_content("School group message") }
-  it { expect(page).to have_content("School message") }
-end
-
-shared_examples "a dashboard not showing dashboard messages" do
-  it { expect(page).not_to have_content("School group message") }
-  it { expect(page).not_to have_content("School message") }
-end
-
-shared_examples "a dashboard showing training prompt" do
-  it { expect(page).to have_content("New to Energy Sparks? Sign up to one of our upcoming free online training courses to help you get the most from the service.") }
-end
-
-shared_examples "a dashboard not showing training prompt" do
-  it { expect(page).not_to have_content("New to Energy Sparks? Sign up to one of our upcoming free online training courses to help you get the most from the service.") }
-end
-
-shared_examples "a dashboard showing complete programme prompt" do
-  it { expect(page).to have_content("You have completed 0/3 of the activities") }
-end
-
-shared_examples "a dashboard not showing complete programme prompt" do
-  it { expect(page).not_to have_content("You have completed 0/3 of the activities") }
-end
-
-shared_examples "a dashboard showing recommendations prompt" do
-  it { expect(page).to have_content("Complete one of our recommended pupil or adult lead activities to start reducing your energy usage") }
-end
-
-shared_examples "a dashboard not showing recommendations prompt" do
-  it { expect(page).not_to have_content("Complete one of our recommended pupil or adult lead activities to start reducing your energy usage") }
-end
-
-shared_examples "a dashboard training prompt" do
-  context "school is data enabled" do
-    let(:data_enabled) { true }
-
-    context "and user confirmed in the last 30 days" do
-      let(:confirmed_at) { 2.days.ago }
-
-      it_behaves_like "a dashboard showing training prompt"
-    end
-
-    context "and user confirmed more than 30 days ago" do
-      let(:confirmed_at) { 31.days.ago }
-
-      it_behaves_like "a dashboard not showing training prompt"
-    end
-  end
-
-  context "school is not data enabled" do
-    let(:data_enabled) { false }
-
-    it_behaves_like "a dashboard not showing training prompt"
-    context "and user confirmed more than 30 days ago" do
-      let(:confirmed_at) { 31.days.ago }
-
-      it_behaves_like "a dashboard not showing training prompt"
-    end
-
-    context "and user confirmed in the last 30 days" do
-      let(:confirmed_at) { 2.days.ago }
-
-      it_behaves_like "a dashboard not showing training prompt"
-    end
-  end
-end
-
-########### TESTS START HERE ###########
-
 RSpec.describe "adult dashboard prompts", type: :system do
   let(:data_enabled)                    { true }
   let(:confirmed_at)                    { 1.day.ago }
@@ -100,47 +29,47 @@ RSpec.describe "adult dashboard prompts", type: :system do
     context 'as guest' do
       let(:user) { nil }
 
-      it_behaves_like "a dashboard not showing dashboard messages"
-      it_behaves_like "a dashboard not showing training prompt"
-      it_behaves_like "a dashboard not showing complete programme prompt"
-      it_behaves_like "a dashboard not showing recommendations prompt"
+      it_behaves_like "dashboard message prompts", displayed: false
+      it_behaves_like "a training prompt", displayed: false
+      it_behaves_like "a complete programme prompt", displayed: false
+      it_behaves_like "a recommendations prompt", displayed: false
     end
 
     context 'as user from another school' do
       let(:school2) { create(:school) }
       let(:user)    { create(:staff, school: school2) }
 
-      it_behaves_like "a dashboard not showing dashboard messages"
-      it_behaves_like "a dashboard not showing training prompt"
-      it_behaves_like "a dashboard not showing complete programme prompt"
-      it_behaves_like "a dashboard not showing recommendations prompt"
+      it_behaves_like "dashboard message prompts", displayed: false
+      it_behaves_like "a training prompt", displayed: false
+      it_behaves_like "a complete programme prompt", displayed: false
+      it_behaves_like "a recommendations prompt", displayed: false
     end
 
     context 'as pupil' do
       let(:user) { create(:pupil, school: school, confirmed_at: confirmed_at) }
 
-      it_behaves_like "a dashboard showing dashboard messages"
-      it_behaves_like "a dashboard showing training prompt"
-      it_behaves_like "a dashboard showing complete programme prompt"
-      it_behaves_like "a dashboard showing recommendations prompt"
+      it_behaves_like "dashboard message prompts", displayed: true
+      it_behaves_like "a training prompt", displayed: true
+      it_behaves_like "a complete programme prompt", displayed: true
+      it_behaves_like "a recommendations prompt", displayed: true
     end
 
     context 'as staff' do
       let(:user) { create(:staff, school: school, confirmed_at: confirmed_at) }
 
-      it_behaves_like "a dashboard showing dashboard messages"
-      it_behaves_like "a dashboard showing training prompt"
-      it_behaves_like "a dashboard showing complete programme prompt"
-      it_behaves_like "a dashboard showing recommendations prompt"
+      it_behaves_like "dashboard message prompts", displayed: true
+      it_behaves_like "a training prompt", displayed: true
+      it_behaves_like "a complete programme prompt", displayed: true
+      it_behaves_like "a recommendations prompt", displayed: true
     end
 
     context 'as school admin' do
       let(:user) { create(:school_admin, school: school, confirmed_at: confirmed_at) }
 
-      it_behaves_like "a dashboard showing dashboard messages"
-      it_behaves_like "a dashboard showing training prompt"
-      it_behaves_like "a dashboard showing complete programme prompt"
-      it_behaves_like "a dashboard showing recommendations prompt"
+      it_behaves_like "dashboard message prompts", displayed: true
+      it_behaves_like "a training prompt", displayed: true
+      it_behaves_like "a complete programme prompt", displayed: true
+      it_behaves_like "a recommendations prompt", displayed: true
     end
 
     context 'as group admin' do
@@ -148,19 +77,19 @@ RSpec.describe "adult dashboard prompts", type: :system do
       let(:school)        { create(:school, school_group: school_group, data_enabled: data_enabled) }
       let(:user)          { create(:group_admin, school_group: school_group, school: school, confirmed_at: confirmed_at) }
 
-      it_behaves_like "a dashboard showing dashboard messages"
-      it_behaves_like "a dashboard showing training prompt"
-      it_behaves_like "a dashboard showing complete programme prompt"
-      it_behaves_like "a dashboard showing recommendations prompt"
+      it_behaves_like "dashboard message prompts", displayed: true
+      it_behaves_like "a training prompt", displayed: true
+      it_behaves_like "a complete programme prompt", displayed: true
+      it_behaves_like "a recommendations prompt", displayed: true
     end
 
     context 'as admin' do
       let(:user) { create(:admin, confirmed_at: confirmed_at) }
 
-      it_behaves_like "a dashboard showing dashboard messages"
-      it_behaves_like "a dashboard showing training prompt"
-      it_behaves_like "a dashboard showing complete programme prompt"
-      it_behaves_like "a dashboard showing recommendations prompt"
+      it_behaves_like "dashboard message prompts", displayed: true
+      it_behaves_like "a training prompt", displayed: true
+      it_behaves_like "a complete programme prompt", displayed: true
+      it_behaves_like "a recommendations prompt", displayed: true
     end
   end
 
@@ -171,22 +100,22 @@ RSpec.describe "adult dashboard prompts", type: :system do
     context 'as pupil' do
       let(:user) { create(:pupil, school: school, confirmed_at: confirmed_at) }
 
-      it_behaves_like "a dashboard not showing complete programme prompt"
-      it_behaves_like "a dashboard not showing recommendations prompt"
+      it_behaves_like "a complete programme prompt", displayed: false
+      it_behaves_like "a recommendations prompt", displayed: false
     end
 
     context 'as staff' do
       let(:user) { create(:staff, school: school, confirmed_at: confirmed_at) }
 
-      it_behaves_like "a dashboard not showing complete programme prompt"
-      it_behaves_like "a dashboard not showing recommendations prompt"
+      it_behaves_like "a complete programme prompt", displayed: false
+      it_behaves_like "a recommendations prompt", displayed: false
     end
 
     context 'as school admin' do
       let(:user) { create(:school_admin, school: school, confirmed_at: confirmed_at) }
 
-      it_behaves_like "a dashboard not showing complete programme prompt"
-      it_behaves_like "a dashboard not showing recommendations prompt"
+      it_behaves_like "a complete programme prompt", displayed: false
+      it_behaves_like "a recommendations prompt", displayed: false
     end
 
     context 'as group admin' do
@@ -194,15 +123,23 @@ RSpec.describe "adult dashboard prompts", type: :system do
       let(:school)        { create(:school, school_group: school_group, data_enabled: data_enabled) }
       let(:user)          { create(:group_admin, school_group: school_group, school: school, confirmed_at: confirmed_at) }
 
-      it_behaves_like "a dashboard not showing complete programme prompt"
-      it_behaves_like "a dashboard not showing recommendations prompt"
+      it_behaves_like "a complete programme prompt", displayed: false
+      it_behaves_like "a recommendations prompt", displayed: false
     end
 
     context 'as admin' do
       let(:user) { create(:admin, confirmed_at: confirmed_at) }
 
-      it_behaves_like "a dashboard not showing complete programme prompt"
-      it_behaves_like "a dashboard not showing recommendations prompt"
+      it_behaves_like "a complete programme prompt", displayed: false
+      it_behaves_like "a recommendations prompt", displayed: false
     end
+  end
+
+  ## Testing functionality rather than just if they appear or not
+  context "with working prompts" do
+    let(:activities_2023_feature) { true }
+    let(:user) { create(:staff, school: school, confirmed_at: confirmed_at) }
+
+    it_behaves_like "a functional training prompt"
   end
 end


### PR DESCRIPTION
The main point of this PR is to a link to the recommendations page from both adult and pupil dashboards. It does more though...

**Adult Dashboard**

* Adds a single prompt to the recommendations page
* Reworks the prompt spec to make it usable for the pupil dashboard prompts spec

**Pupil Dashboard:**

* Adds a single prompt to the recommendations page with 3 variations
* Also adds the prompt to complete a programme as discussed
* Have added a bunch of spec to check the prompt behaviour. Worth noting that current behaviour on this page is that all the prompts are visible regardless of if a user is logged in or not. Some of the prompts redirect to a login page when clicked, so is not ideal. For now, I have added these two prompts in the same way but we ought to revisit this when we discuss the adult dashboard (or sooner).

Also note I used include_examples rather than it_behaves_like as the test descriptions didn't make sense / were too long otherwise. 