### PR TITLE
Allow group admins to edit tariffs for schools in their group

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -53,7 +53,8 @@ class Ability
         can :update_settings, SchoolGroup, id: user.school_group_id
         can :manage, SchoolGroupCluster, school_group_id: user.school_group_id
         can :manage, EnergyTariff, tariff_holder: user.school_group
-        can :manage, EnergyTariff, school: { school_group_id: user.school_group_id, visible: true }
+
+        can :manage, EnergyTariff, related_school_scope
 
         can [:show, :update], Calendar do |calendar|
           user.school_group.calendars.include?(calendar)

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -53,6 +53,7 @@ class Ability
         can :update_settings, SchoolGroup, id: user.school_group_id
         can :manage, SchoolGroupCluster, school_group_id: user.school_group_id
         can :manage, EnergyTariff, tariff_holder: user.school_group
+        can :manage, EnergyTariff, school: { school_group_id: user.school_group_id, visible: true }
 
         can [:show, :update], Calendar do |calendar|
           user.school_group.calendars.include?(calendar)

--- a/app/views/shared/_manage_school.html.erb
+++ b/app/views/shared/_manage_school.html.erb
@@ -8,10 +8,7 @@
     <%= link_to t('manage_school_menu.manage_users'), school_users_path(school), class: 'dropdown-item' if can? :manage_users, school %>
     <%= link_to t('manage_school_menu.manage_alert_contacts'), school_contacts_path(school), class: 'dropdown-item' if can? :manage, Contact %>
     <%= link_to t('manage_school_menu.manage_meters'), school_meters_path(school), class: 'dropdown-item' if can? :index, Meter %>
-
-    <% if can?(:manage, EnergyTariff) %>
-      <%= link_to t('manage_school_menu.manage_tariffs'), school_energy_tariffs_path(school), class: 'dropdown-item' %>
-    <% end %>
+    <%= link_to t('manage_school_menu.manage_tariffs'), school_energy_tariffs_path(school), class: 'dropdown-item' if can? :manage, EnergyTariff %>
 
     <%= link_to t('manage_school_menu.manage_usage_estimate'), school_estimated_annual_consumptions_path(school), class: 'dropdown-item' if school.latest_annual_estimate.present? || school.suggest_annual_estimate? %>
 

--- a/app/views/shared/_manage_school.html.erb
+++ b/app/views/shared/_manage_school.html.erb
@@ -8,7 +8,11 @@
     <%= link_to t('manage_school_menu.manage_users'), school_users_path(school), class: 'dropdown-item' if can? :manage_users, school %>
     <%= link_to t('manage_school_menu.manage_alert_contacts'), school_contacts_path(school), class: 'dropdown-item' if can? :manage, Contact %>
     <%= link_to t('manage_school_menu.manage_meters'), school_meters_path(school), class: 'dropdown-item' if can? :index, Meter %>
-    <%= link_to t('manage_school_menu.manage_tariffs'), school_energy_tariffs_path(school), class: 'dropdown-item' if can? :manage, EnergyTariff %>
+
+    <% if can?(:manage, EnergyTariff) %>
+      <%= link_to t('manage_school_menu.manage_tariffs'), school_energy_tariffs_path(school), class: 'dropdown-item' %>
+    <% end %>
+
     <%= link_to t('manage_school_menu.manage_usage_estimate'), school_estimated_annual_consumptions_path(school), class: 'dropdown-item' if school.latest_annual_estimate.present? || school.suggest_annual_estimate? %>
 
     <% if current_user.admin? %>

--- a/app/views/shared/_manage_school.html.erb
+++ b/app/views/shared/_manage_school.html.erb
@@ -9,7 +9,6 @@
     <%= link_to t('manage_school_menu.manage_alert_contacts'), school_contacts_path(school), class: 'dropdown-item' if can? :manage, Contact %>
     <%= link_to t('manage_school_menu.manage_meters'), school_meters_path(school), class: 'dropdown-item' if can? :index, Meter %>
     <%= link_to t('manage_school_menu.manage_tariffs'), school_energy_tariffs_path(school), class: 'dropdown-item' if can? :manage, EnergyTariff %>
-
     <%= link_to t('manage_school_menu.manage_usage_estimate'), school_estimated_annual_consumptions_path(school), class: 'dropdown-item' if school.latest_annual_estimate.present? || school.suggest_annual_estimate? %>
 
     <% if current_user.admin? %>

--- a/spec/models/abilities_spec.rb
+++ b/spec/models/abilities_spec.rb
@@ -173,8 +173,8 @@ describe Ability do
       it { is_expected.not_to be_able_to(:show_management_dash, create(:school_group))}
       it { is_expected.to be_able_to(:update_settings, school_group)}
 
-      it { is_expected.not_to be_able_to(:manage, school.energy_tariffs.build)}
       it { is_expected.to be_able_to(:manage, school_group.energy_tariffs.build)}
+      it { is_expected.to be_able_to(:manage, school.energy_tariffs.build)}
       it { is_expected.not_to be_able_to(:manage, SiteSettings.current.energy_tariffs.build)}
 
       context 'is onboarding' do

--- a/spec/models/abilities_spec.rb
+++ b/spec/models/abilities_spec.rb
@@ -175,6 +175,7 @@ describe Ability do
 
       it { is_expected.to be_able_to(:manage, school_group.energy_tariffs.build)}
       it { is_expected.to be_able_to(:manage, school.energy_tariffs.build)}
+
       it { is_expected.not_to be_able_to(:manage, SiteSettings.current.energy_tariffs.build)}
 
       context 'is onboarding' do

--- a/spec/system/schools/energy_tariffs_spec.rb
+++ b/spec/system/schools/energy_tariffs_spec.rb
@@ -22,6 +22,14 @@ describe 'school energy tariffs', type: :system do
       it_behaves_like "a school tariff editor"
     end
 
+    context 'as a group_admin user for this schools group' do
+      let!(:school_group) { create(:school_group) }
+      let!(:school)       { create_active_school(school_group: school_group)}
+      let!(:current_user) { create(:group_admin, school_group: school_group) }
+
+      it_behaves_like "a school tariff editor"
+    end
+
     context 'as a group_admin user' do
       let!(:current_user) { create(:group_admin) }
 


### PR DESCRIPTION
Revises the ability and adds specs to confirm that a group admin can edit tariffs for any school in their group.

There's a test for the ability, and new system specs for the tariff editor.