### PR TITLE
Remove :event Observation

### DIFF
--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -47,8 +47,10 @@ class Observation < ApplicationRecord
   belongs_to :programme, optional: true
   belongs_to :audit, optional: true
   belongs_to :school_target, optional: true
+
   # If adding a new observation type remember to also add a timelime template in app/views/schools/observations/timeline
-  enum observation_type: [:temperature, :intervention, :activity, :event, :audit, :school_target, :programme, :audit_activities_completed]
+  # event: 3 was removed as its no longer used
+  enum observation_type: { temperature: 0, intervention: 1, activity: 2, audit: 4, school_target: 5, programme: 6, audit_activities_completed: 7 }
 
   validates_presence_of :at, :school
   validates_associated :temperature_recordings

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -247,10 +247,6 @@ class School < ApplicationRecord
     end
   end
 
-  # Note that saved_change_to_activation_date? is a magic ActiveRecord method
-  # https://api.rubyonrails.org/classes/ActiveRecord/AttributeMethods/Dirty.html#method-i-will_save_change_to_attribute-3F
-  after_save :add_joining_observation, if: proc { saved_change_to_activation_date?(from: nil) }
-
   def deleted?
     not_active? and removal_date.present?
   end
@@ -685,13 +681,5 @@ class School < ApplicationRecord
     return unless latitude.blank? || longitude.blank? || country.blank?
 
     errors.add(:postcode, I18n.t('schools.school_details.geocode_not_found_message'))
-  end
-
-  def add_joining_observation
-    observations.create!(
-      observation_type: :event,
-      description: "#{name} became an active user of Energy Sparks!",
-      at: Time.zone.now
-    )
   end
 end

--- a/app/views/schools/observations/timeline/_event.html.erb
+++ b/app/views/schools/observations/timeline/_event.html.erb
@@ -1,7 +1,0 @@
-<td class="p-3 text-center">
-  <%= fa_icon("info fa-2x") %>
-</td>
-<td>
-  <h3 class="pt-1"><strong><%= observation.description %></strong></h3>
-  <span class="text-muted"><%= nice_dates(observation.at) %></span>
-</td>

--- a/lib/tasks/deployment/20231115133946_remove_event_observations.rake
+++ b/lib/tasks/deployment/20231115133946_remove_event_observations.rake
@@ -1,0 +1,16 @@
+namespace :after_party do
+  desc 'Deployment task: remove_event_observations'
+  task remove_event_observations: :environment do
+    puts "Running deploy task 'remove_event_observations'"
+
+    #remove instance of the :event Observation as its not longer needed/used
+    #use the enum id and call delete all to avoid instantiating the objects
+    #as :event has been removed as a valid enum value
+    Observation.where("observation_type = 3").delete_all
+
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord
+      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+  end
+end

--- a/spec/models/observation_spec.rb
+++ b/spec/models/observation_spec.rb
@@ -9,7 +9,6 @@ describe Observation do
   describe '#pupil_count' do
     it "is valid when present for interventions only" do
       expect(build(:observation, observation_type: :temperature, pupil_count: 12)).to be_invalid
-      expect(build(:observation, observation_type: :event, pupil_count: 12)).to be_invalid
       expect(build(:observation, observation_type: :activity, activity: create(:activity), pupil_count: 12)).to be_invalid
       expect(build(:observation, observation_type: :audit, audit: create(:audit), pupil_count: 12)).to be_invalid
       expect(build(:observation, observation_type: :school_target, school_target: create(:school_target), pupil_count: 12)).to be_invalid

--- a/spec/system/admin/school_configuration_spec.rb
+++ b/spec/system/admin/school_configuration_spec.rb
@@ -92,8 +92,6 @@ RSpec.describe "manage school configuration", type: :system do
     fill_in 'Activation date', with: activation_date.strftime("%d/%m/%Y")
     click_on('Update School')
 
-    expect(school.observations.first.description.to_s).to include("became an active user of Energy Sparks!")
-
     school.reload
     expect(school.activation_date).to eq activation_date
 


### PR DESCRIPTION
We were creating an `:event` observation type for schools when their activation date was set. This was originally used to add a message "X school has joined Energy Sparks" and later "X became an active user of Energy Sparks" to the school timeline.

But this hasn't been working properly as activation dates weren't being routinely set until this PR was completed: https://github.com/Energy-Sparks/energy-sparks/pull/3210.

This has lead to a number of schools having recent entries in their timeline, which is incorrect. The callback to add the Observation in the School class should have been using the activation date, not the current date.

As this feature of the timeline hasn't been working correctly for some time, and because its not adding much value, we've decided to just remove the events, rather than fix the data and the School model callback.

So this PR:

- alters the Observation class to use the Hash syntax for the enum, to remove `:event`
- adds an AfterParty task to remove the records with an observation_type of "3" (the events)
- removes the template to show the timeline entry
