### PR TITLE
Add task to load funders

### DIFF
--- a/lib/tasks/deployment/20231115140506_load_funders.rake
+++ b/lib/tasks/deployment/20231115140506_load_funders.rake
@@ -1,0 +1,36 @@
+namespace :after_party do
+  desc 'Deployment task: load_funders'
+  task load_funders: :environment do
+    puts "Running deploy task 'load_funders'"
+
+    file_name = File.join( File.expand_path(File.dirname(__FILE__)) , "funders.csv" )
+    CSV.foreach( file_name, headers: true ) do |row|
+      _school_group = row[0]
+      school_name = row[1]
+      funder_name = row[2]
+
+      school = School.find_by_name(school_name)
+      puts "No school called: #{school_name}" unless school
+      next unless school
+
+      if funder_name.present?
+        funder = Funder.find_by_name(funder_name.rstrip)
+        if funder
+          school.update!(funder: funder)
+        else
+          puts "No funder called: #{funder_name}"
+        end
+      else
+        #no funder in spreadsheet, as school is now archived/removed,
+        #so set to nil
+        school.update!(funder: nil)
+      end
+
+    end
+
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord
+      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+  end
+end

--- a/lib/tasks/deployment/funders.csv
+++ b/lib/tasks/deployment/funders.csv
@@ -1,0 +1,1128 @@
+"School group","School name","Funder"
+"ACES Academies Trust","Godmanchester Community Academy","Drax"
+"All Saints Catholic Academy Trust","Divine Saviour Catholic Primary School",
+"All Saints Catholic Academy Trust","Holy Rood Catholic Primary School",
+"All Saints Catholic Academy Trust","St Joan of Arc Catholic Secondary School",
+"All Saints Catholic Academy Trust","St John Fisher Catholic Primary School",
+"All Saints Catholic Academy Trust","St John's Catholic Primary School, Rickmansworth",
+"Anglian Learning","Bassingbourn Village College","Waiting list for funding"
+"Anglian Learning","Bottisham Community Primary School","Waiting list for funding"
+"Anglian Learning","Bottisham Village College",
+"Anglian Learning","Fen Ditton Community Primary School","Waiting list for funding"
+"Anglian Learning","Howard Community Primary School","Drax"
+"Anglian Learning","Joyce Frankland Academy, Newport","Waiting list for funding"
+"Anglian Learning","Linton Heights Junior School","Waiting list for funding"
+"Anglian Learning","Linton Village College","Waiting list for funding"
+"Anglian Learning","Marleigh Primary Academy","Waiting list for funding"
+"Anglian Learning","Sawston Village College","Waiting list for funding"
+"Anglian Learning","Stapleford Community Primary School","Waiting list for funding"
+"Anglian Learning","The Icknield Primary School","Waiting list for funding"
+"Anglian Learning","The Meadow Primary School","Waiting list for funding"
+"Anglian Learning","The Netherhall School and Sixth Form Centre","Waiting list for funding"
+"Anglian Learning","The Pines","Waiting list for funding"
+"Arden Forest Multi-Academy Trust","St Nicholas C of E Primary School","Elbow Beach"
+"Arden Forest Multi-Academy Trust","Coughton C of E Primary School","Elbow Beach"
+"Arden Forest Multi-Academy Trust","Harbury C of E Primary School","Elbow Beach"
+"Arden Forest Multi-Academy Trust","Henley in Arden Primary School","Elbow Beach"
+"Arden Forest Multi-Academy Trust","Studley Infants' School","Elbow Beach"
+"Arden Forest Multi-Academy Trust","Tanworth-in-Arden Primary School and Nursery","Elbow Beach"
+"Arden Forest Multi-Academy Trust","Temple Grafton Primary School","Elbow Beach"
+"Arden Forest Multi-Academy Trust","The Ferncumbe C of E Primary School","Elbow Beach"
+"Arden Forest Multi-Academy Trust","Wootton Wawen C of E Primary School","Pending data"
+"Aurora Academies Trust","City Academy Whitehawk",
+"Aurora Academies Trust","Glenleigh Park Primary Academy",
+"Aurora Academies Trust","Heron Park Primary Academy",
+"Aurora Academies Trust","King Offa Primary Academy",
+"Aurora Academies Trust","Oakwood Primary Academy",
+"Aurora Academies Trust","The Gatwick School",
+"Aurora Academies Trust","Westvale Park Primary Academy",
+"Bath and NE Somerset","Paulton Junior School",
+"Bath and NE Somerset","Twerton Infant School","Postcode Local Trust"
+"Bath and Wells Multi Academy Trust","Batheaston Church School",
+"Bath and Wells Multi Academy Trust","Freshford Church School","OVO Foundation"
+"Bath and Wells Multi Academy Trust","St Andrew's Church School",
+"Bath and Wells Multi Academy Trust","St Michael's Junior Church School","Postcode Local Trust"
+"Bath and Wells Multi Academy Trust","St Saviours Infant Church School",
+"Bath and Wells Multi Academy Trust","St Saviours Junior Church School",
+"Bath and Wells Multi Academy Trust","St Stephen's Church School",
+"Bath and Wells Multi Academy Trust","Swainswick Church School","OVO Foundation"
+"Birmingham","Arden Primary School","Postcode Local Trust"
+"Bradgate Education Partnership","Broomfield Primary School","Waiting list for funding"
+"Bradgate Education Partnership","Church Hill Infant School","Drax"
+"Bradgate Education Partnership","Eastfield Primary School","Waiting list for funding"
+"Bradgate Education Partnership","Gaddesby Primary School","Waiting list for funding"
+"Bradgate Education Partnership","Great Dalby Primary School","Waiting list for funding"
+"Bradgate Education Partnership","Highgate Primary School","Drax"
+"Bradgate Education Partnership","Mercenfeld Primary School","Waiting list for funding"
+"Bradgate Education Partnership","Newtown Linford Primary School","Waiting list for funding"
+"Bradgate Education Partnership","Ratby Primary School","Drax"
+"Bradgate Education Partnership","Seagrave Village Primary School","Waiting list for funding"
+"Bradgate Education Partnership","Stafford Leys Primary School","Waiting list for funding"
+"Bradgate Education Partnership","Swallowdale Primary School","Drax"
+"Bradgate Education Partnership","The Merton Primary School","Waiting list for funding"
+"Bradgate Education Partnership","The Pochin School","Waiting list for funding"
+"Bradgate Education Partnership","The Roundhill Academy","MAT funding"
+"Bradgate Education Partnership","Wreake Valley Academy","MAT funding"
+"Brighton and Hove","Balfour Primary School","Brighton Energy Co-op"
+"Brighton and Hove","Carden Nursery & Primary School",
+"Brighton and Hove","Coldean Primary School","Brighton Energy Co-op"
+"Brighton and Hove","Cottesmore St Mary Primary School",
+"Brighton and Hove","Dorothy Stringer School","Waiting list for funding"
+"Brighton and Hove","Goldstone Primary School",
+"Brighton and Hove","Hertford Junior School","Brighton Energy Co-op"
+"Brighton and Hove","Hove Junior School (Portland Road site)",
+"Brighton and Hove","Middle Street Primary School",
+"Brighton and Hove","Moulsecoomb Primary school",
+"Brighton and Hove","St Bernadette's R C Primary School",
+"Brighton and Hove","St John the Baptist Catholic Primary School, Brighton","Waiting list for funding"
+"Brighton and Hove","St Luke's Primary School",
+"Brighton and Hove","St Margaret's Primary School",
+"Brighton and Hove","St Mary's Catholic Primary School, Hove",
+"Brighton and Hove","St Nicolas Primary School",
+"Brighton and Hove","Stanford Junior School",
+"Brighton and Hove","West Hove Infant School (School Road Site)","Waiting list for funding"
+"Brighton and Hove","West Hove Infants and Hove Juniors (Holland Road site)","Waiting list for funding"
+"Brighton and Hove","Woodingdean Primary School","Brighton Energy Co-op"
+"Bristol","Redfield Educate Together Primary Academy",
+"Camden","Gospel Oak Primary and Nursery School",
+"Carmarthenshire/Sir GÃ¢r","Bryngwyn School","Carmarthenshire Council"
+"Carmarthenshire/Sir GÃ¢r","Halfway CP School",
+"Carmarthenshire/Sir GÃ¢r","Model Church In Wales School","Carmarthenshire Council"
+"Carmarthenshire/Sir GÃ¢r","Penygaer Primary School and Ysgol Dewi Sant",
+"Carmarthenshire/Sir GÃ¢r","Ysgol Bro Brynach","Carmarthenshire Council"
+"Carmarthenshire/Sir GÃ¢r","Ysgol Bro Dinefwr",
+"Carmarthenshire/Sir GÃ¢r","Ysgol Coedcae School","School self funding"
+"Carmarthenshire/Sir GÃ¢r","Ysgol Gwynfryn",
+"Carmarthenshire/Sir GÃ¢r","Ysgol Gymraeg Brynsierfel",
+"Carmarthenshire/Sir GÃ¢r","Ysgol Gymraeg Rhydaman",
+"Carmarthenshire/Sir GÃ¢r","Ysgol Gymraeg Teilo Sant",
+"Carmarthenshire/Sir GÃ¢r","Ysgol Gymunedol Peniel",
+"Carmarthenshire/Sir GÃ¢r","Ysgol Hafodwenog","Carmarthenshire Council"
+"Carmarthenshire/Sir GÃ¢r","Ysgol Llangadog",
+"Carmarthenshire/Sir GÃ¢r","Ysgol Maes Y Gwendraeth",
+"Carmarthenshire/Sir GÃ¢r","Ysgol Pen Rhos",
+"Carmarthenshire/Sir GÃ¢r","Ysgol Pontyberem","Carmarthenshire Council"
+"Carmarthenshire/Sir GÃ¢r","Ysgol Rhys Prichard",
+"Carmarthenshire/Sir GÃ¢r","Ysgol Trimsaran",
+"Central Region Schools Trust","Abbeywood First & Church Hill Middle School","MAT funding"
+"Central Region Schools Trust","Arrow Vale High School","MAT funding"
+"Central Region Schools Trust","Arrow Valley First School","MAT funding"
+"Central Region Schools Trust","Gospel Oak School, Tipton","MAT funding"
+"Central Region Schools Trust","Holyhead School","MAT funding"
+"Central Region Schools Trust","Ipsley CE Middle School","MAT funding"
+"Central Region Schools Trust","Lickhill Primary School","MAT funding"
+"Central Region Schools Trust","Oldbury Park Primary School","MAT funding"
+"Central Region Schools Trust","St Stephen's CE First School","MAT funding"
+"Central Region Schools Trust","Sutton Park Primary School","MAT funding"
+"Central Region Schools Trust","Waseley Hills High School","MAT funding"
+"Coastal Academies Trust","Cliftonville Primary School & Pre-School","MAT funding"
+"Coastal Academies Trust","Dane Court Grammar School",
+"Coastal Academies Trust","Hartsdown Academy","MAT funding"
+"Coastal Academies Trust","King Ethelbert School",
+"Concordia MAT","Childer Thornton Primary School",
+"Concordia MAT","Highfields Academy, Nantwich",
+"Concordia MAT","Parklands Primary School",
+"Concordia MAT","Town Lane Infant School",
+"Concordia MAT","Wolverham Primary School",
+"De Ferrers Trust","Granville Academy","Elbow Beach"
+"De Ferrers Trust","Lansdowne Infant School","Elbow Beach"
+"De Ferrers Trust","Richard Wakefield C.E. Primary Academy","Elbow Beach"
+"De Ferrers Trust","The Pingle Academy","Elbow Beach"
+"De Ferrers Trust","Eton Park Junior","Elbow Beach"
+"De Ferrers Trust","Horninglow Primary School","Elbow Beach"
+"De Ferrers Trust","The De Ferrers Academy- Dove Campus","Elbow Beach"
+"Derby College","Derby College Broomfield Hall","Drax"
+"Derby College","Derby College Ilkeston Campus","Drax"
+"Derby College","Derby College Joseph Wright Centre","Drax"
+"Derby College","Derby College The Roundhouse","Drax"
+"Derbyshire","Stanton Vale School","Drax"
+"Devon","Braunton Academy","OVO Foundation"
+"Devon","South Molton Community Primary School","Pending data"
+"Doncaster","Scawthorpe Sunnyfields Primary School","Drax"
+"Durham","Durham Sixth Form Centre","Waiting list for funding"
+"Durham","Green Lane CE Primary",
+"Durham","King James 1 Community Academy","School self funding"
+"Durham","Red Rose Primary",
+"East Sussex","All Saints Primary School",
+"East Sussex","All Saints' & St Richard's C of E Primary School",
+"East Sussex","Barcombe Primary School",
+"East Sussex","Catsfield Primary School",
+"East Sussex","Chantry Community Primary School",
+"East Sussex","Dallington Primary School",
+"East Sussex","Ditchling (St. Margaret's) CE Primary and Nursery School",
+"East Sussex","Forest Row Primary School",
+"East Sussex","Hamsey Primary School",
+"East Sussex","Heathfield Community College",
+"East Sussex","Herstmonceux Church of England Primary School",
+"East Sussex","Little Horsted Primary School",
+"East Sussex","Newick Primary School",
+"East Sussex","Peasmarsh Primary School",
+"East Sussex","Pevensey & Westham CE Primary School",
+"East Sussex","Plumpton Primary School",
+"East Sussex","Ringmer Primary School",
+"East Sussex","Robsack Wood Primary Academy",
+"East Sussex","Sacred Heart Catholic Primary School",
+"East Sussex","Sandown Primary School",
+"East Sussex","Seaford Primary School",
+"East Sussex","South Malling Primary and Nursery School",
+"East Sussex","St Mary's Catholic Primary School, Chapel Green",
+"East Sussex","St Richard's Catholic College",
+"East Sussex","The Haven Primary School",
+"East Sussex","Willingdon Community School","School self funding"
+"East Sussex","Wivelsfield Primary School",
+"Eastern Multi-Academy Trust","Admirals Academy","MAT funding"
+"Eastern Multi-Academy Trust","Eastgate Academy","Drax"
+"Eastern Multi-Academy Trust","Emneth Academy","Drax"
+"Eastern Multi-Academy Trust","Glade Academy","Drax"
+"Eastern Multi-Academy Trust","King's Lynn Academy","Drax"
+"Eastern Multi-Academy Trust","Nelson Academy","Drax"
+"Eastern Multi-Academy Trust","North Wootton Academy","MAT funding"
+"Eastern Multi-Academy Trust","Norwich Road Academy","Drax"
+"Eastern Multi-Academy Trust","Raleigh Infant Academy","MAT funding"
+"Eastern Multi-Academy Trust","Southery Academy","Drax"
+"Eastern Multi-Academy Trust","Upwell Academy","Drax"
+"Edinburgh","Craigentinny Primary School",
+"Edinburgh","Cramond Primary School",
+"Edinburgh","Currie Primary School",
+"Edinburgh","James Gillespie's High School","Centrica"
+"Edinburgh","St Thomas Of Aquin's High School","Centrica"
+"Edinburgh","Wardie Primary School","Centrica"
+"Essex","Chase Lane Primary and Nursery School","Drax"
+"Futura Learning Partnership","Aspire Academy","Postcode Local Trust"
+"Futura Learning Partnership","Chandag Infant School","OVO Foundation"
+"Futura Learning Partnership","Chandag Junior School","OVO Foundation"
+"Futura Learning Partnership","Cheddar Grove Primary School","OVO Foundation"
+"Futura Learning Partnership","IKB Academy","MAT funding"
+"Futura Learning Partnership","Saltford C of E Primary School","MAT funding"
+"Futura Learning Partnership","Sir Bernard Lovell Academy","OVO Foundation"
+"Futura Learning Partnership","St John's Primary School, Keynsham",
+"Futura Learning Partnership","The Meadows Primary School","MAT funding"
+"Futura Learning Partnership","Two Rivers Church of England Primary School","OVO Foundation"
+"Futura Learning Partnership","Wansdyke Primary School","OVO Foundation"
+"Futura Learning Partnership","Wellsway School","MAT funding"
+"Girls Day School Trust","Belvedere Academy","MAT funding"
+"Girls Day School Trust","Birkenhead High School Academy","MAT funding"
+"Girls Day School Trust","Blackheath High Junior School","MAT funding"
+"Girls Day School Trust","Blackheath High Senior School","MAT funding"
+"Girls Day School Trust","Brighton Girls","MAT funding"
+"Girls Day School Trust","Bromley High School","MAT funding"
+"Girls Day School Trust","Croydon High School","MAT funding"
+"Girls Day School Trust","Howell's Prep and Nursery School","MAT funding"
+"Girls Day School Trust","Howell's Senior School","MAT funding"
+"Girls Day School Trust","Kensington Prep School","MAT funding"
+"Girls Day School Trust","Newcastle High School for Girls Junior School","MAT funding"
+"Girls Day School Trust","Newcastle High School for Girls Senior School","MAT funding"
+"Girls Day School Trust","Northampton High School","MAT funding"
+"Girls Day School Trust","Northwood College","MAT funding"
+"Girls Day School Trust","Norwich High School for Girls","MAT funding"
+"Girls Day School Trust","Notting Hill & Ealing High Junior School","MAT funding"
+"Girls Day School Trust","Notting Hill & Ealing High Senior School","MAT funding"
+"Girls Day School Trust","Nottingham Girls' High School","MAT funding"
+"Girls Day School Trust","Oxford High for Girls Pre-Prep","MAT funding"
+"Girls Day School Trust","Oxford High for Girls Prep","MAT funding"
+"Girls Day School Trust","Oxford High Senior School","MAT funding"
+"Girls Day School Trust","Portsmouth High Prep School","MAT funding"
+"Girls Day School Trust","Portsmouth High Senior School","MAT funding"
+"Girls Day School Trust","Putney High School","MAT funding"
+"Girls Day School Trust","Royal High Prep School Bath","MAT funding"
+"Girls Day School Trust","Royal High Senior School Bath","MAT funding"
+"Girls Day School Trust","Sheffield Girls' Senior School","MAT funding"
+"Girls Day School Trust","Shrewsbury High Junior School","MAT funding"
+"Girls Day School Trust","Shrewsbury High Senior School","MAT funding"
+"Girls Day School Trust","South Hampstead High Junior School","MAT funding"
+"Girls Day School Trust","South Hampstead High Senior School","MAT funding"
+"Girls Day School Trust","Streatham & Clapham High Prep School","MAT funding"
+"Girls Day School Trust","Streatham & Clapham High School","MAT funding"
+"Girls Day School Trust","Sutton High School","MAT funding"
+"Girls Day School Trust","Sydenham High School","MAT funding"
+"Girls Day School Trust","Wimbledon High School","MAT funding"
+"Hampshire","Castle Hill Primary School - Rooksdown Campus",
+"Hampshire","Hounsdown School",
+"Hampshire","Swaythling Primary School",
+"Harris Federation","Harris Academy and Primary Academy Chafford Hundred","Drax"
+"Harris Federation","Harris Academy Battersea","OVO Foundation"
+"Harris Federation","Harris Academy Beckenham","OVO Foundation"
+"Harris Federation","Harris Academy Bermondsey","OVO Foundation"
+"Harris Federation","Harris Academy Chobham","OVO Foundation"
+"Harris Federation","Harris Academy Clapham","OVO Foundation"
+"Harris Federation","Harris Academy Falconwood","OVO Foundation"
+"Harris Federation","Harris Academy Greenwich","OVO Foundation"
+"Harris Federation","Harris Academy Merton","OVO Foundation"
+"Harris Federation","Harris Academy Ockendon","Drax"
+"Harris Federation","Harris Academy Orpington","OVO Foundation"
+"Harris Federation","Harris Academy Peckham","OVO Foundation"
+"Harris Federation","Harris Academy Purley","OVO Foundation"
+"Harris Federation","Harris Academy Rainham","OVO Foundation"
+"Harris Federation","Harris Academy Riverside","Drax"
+"Harris Federation","Harris Academy South Norwood - Clocktower Campus","OVO Foundation"
+"Harris Federation","Harris Academy South Norwood - Beulah Hill Campus","OVO Foundation"
+"Harris Federation","Harris Academy South Norwood - Upper Site","OVO Foundation"
+"Harris Federation","Harris Academy St John's Wood","OVO Foundation"
+"Harris Federation","Harris Academy Sutton","OVO Foundation"
+"Harris Federation","Harris Academy Tottenham","OVO Foundation"
+"Harris Federation","Harris Academy Wimbledon","OVO Foundation"
+"Harris Federation","Harris Boys Academy East Dulwich","OVO Foundation"
+"Harris Federation","Harris City Academy Crystal Palace","OVO Foundation"
+"Harris Federation","Harris Clapham Sixth Form","OVO Foundation"
+"Harris Federation","Harris Garrard Academy","OVO Foundation"
+"Harris Federation","Harris Girls Academy Bromley","OVO Foundation"
+"Harris Federation","Harris Girls Academy East Dulwich","OVO Foundation"
+"Harris Federation","Harris Invictus Academy Croydon","OVO Foundation"
+"Harris Federation","Harris Junior Academy Carshalton","OVO Foundation"
+"Harris Federation","Harris Primary Academy Beckenham","OVO Foundation"
+"Harris Federation","Harris Primary Academy Beckenham Green","OVO Foundation"
+"Harris Federation","Harris Primary Academy Benson","OVO Foundation"
+"Harris Federation","Harris Primary Academy Coleraine Park","OVO Foundation"
+"Harris Federation","Harris Primary Academy Croydon","OVO Foundation"
+"Harris Federation","Harris Primary Academy Crystal Palace","OVO Foundation"
+"Harris Federation","Harris Primary Academy East Dulwich","OVO Foundation"
+"Harris Federation","Harris Primary Academy Haling Park","OVO Foundation"
+"Harris Federation","Harris Primary Academy Kenley","OVO Foundation"
+"Harris Federation","Harris Primary Academy Mayflower","Drax"
+"Harris Federation","Harris Primary Academy Merton","OVO Foundation"
+"Harris Federation","Harris Primary Academy Peckham Park","OVO Foundation"
+"Harris Federation","Harris Primary Academy Philip Lane","OVO Foundation"
+"Harris Federation","Harris Primary Academy Purley Way","OVO Foundation"
+"Harris Federation","Harris Primary Academy Shortlands","OVO Foundation"
+"Harris Federation","Harris Professional Skills Sixth Form","OVO Foundation"
+"Harris Federation","Harris Westminster Sixth Form","OVO Foundation"
+"HEART Academies Trust, Bedford","Bedford Academy","Drax"
+"HEART Academies Trust, Bedford","Cauldwell School","Drax"
+"HEART Academies Trust, Bedford","Shackleton Primary","Drax"
+"HEART Academies Trust, Bedford","Shortstown Primary","Drax"
+"Heart Education Trust, Norfolk","Heartsease Primary Academy","Drax"
+"Heart Education Trust, Norfolk","Henderson Green Primary Academy","Drax"
+"Heart Education Trust, Norfolk","Lingwood Primary Academy","Drax"
+"Heart Education Trust, Norfolk","Valley Primary Academy","Drax"
+"Hertfordshire","Beaumont School","School self funding"
+"Hertfordshire","Birchwood High School","Drax"
+"Highland","Alness Academy",
+"Highland","Aviemore Primary School",
+"Highland","Ben Wyvis Primary School",
+"Highland","Bualnaluib Primary School",
+"Highland","Dalneigh Primary School","Centrica"
+"Highland","Farr Primary School",
+"Highland","Grantown Grammar School",
+"Highland","Inver Primary School",
+"Highland","Inverness High School",
+"Highland","Mallaig High School","Centrica"
+"Highland","Miller Academy Primary School",
+"Highland","Milton of Leys Primary School",
+"Highland","Mulbuie Primary School",
+"Highland","Pennyland Primary School",
+"Highland","Poolewe Primary school",
+"Highland","Smithton Primary School",
+"Highland","Tain Royal Academy",
+"Highland","Tomnacross Primary School",
+"Highland","Ullapool High school",
+"Highland","Ullapool Primary School",
+"Hollingworth Learning Trust","Newhouse Academy",
+"Inspiring Futures Through Learning","Ashbrook School","Waiting list for funding"
+"Inspiring Futures Through Learning","Chestnuts Primary School","Waiting list for funding"
+"Inspiring Futures Through Learning","Exeter School","Drax"
+"Inspiring Futures Through Learning","Fairfields Primary School","Waiting list for funding"
+"Inspiring Futures Through Learning","Glebe Farm School","Waiting list for funding"
+"Inspiring Futures Through Learning","Heronshaw School","Waiting list for funding"
+"Inspiring Futures Through Learning","Holmwood School","Waiting list for funding"
+"Inspiring Futures Through Learning","Olney Infant Academy","Waiting list for funding"
+"Inspiring Futures Through Learning","Olney Middle School","Waiting list for funding"
+"Inspiring Futures Through Learning","Priors Hall","Drax"
+"Inspiring Futures Through Learning","Rickley Park Primary School","Waiting list for funding"
+"Inspiring Futures Through Learning","St Mary and St Giles Church of England School - North Site","Waiting list for funding"
+"Inspiring Futures Through Learning","St Mary and St Giles Church of England School - South Site","Waiting list for funding"
+"Inspiring Futures Through Learning","Two Mile Ash School","Waiting list for funding"
+"Inspiring Futures Through Learning","Whitehouse Primary School","Waiting list for funding"
+"Inspiring Futures Through Learning","Woodnewton School","Drax"
+"Kent","St Peter-in-Thanet C of E Junior School",
+"Kent","The Judd School",
+"King Edward VI Academy Trust","King Edward VI Aston School","MAT funding"
+"King Edward VI Academy Trust","King Edward VI Balaam Wood Academy","Postcode Local Trust"
+"King Edward VI Academy Trust","King Edward VI Camp Hill School","MAT funding"
+"King Edward VI Academy Trust","King Edward VI Five Ways School","MAT funding"
+"King Edward VI Academy Trust","King Edward VI Handsworth Grammar School for Boys","MAT funding"
+"King Edward VI Academy Trust","King Edward VI Handsworth School for Girls","MAT funding"
+"King Edward VI Academy Trust","King Edward VI Handsworth Wood Girls' Academy","Postcode Local Trust"
+"King Edward VI Academy Trust","King Edward VI Lordswood School for Girls","MAT funding"
+"King Edward VI Academy Trust","King Edward VI Northfield School for Girls","Postcode Local Trust"
+"King Edward VI Academy Trust","King Edward VI Sheldon Heath Academy","Postcode Local Trust"
+"Kings Group Academies","King's Academy Binfield","MAT funding"
+"Kings Group Academies","King's Academy Prospect","MAT funding"
+"Leger Education Trust","Askern Littlemoor Infant Academy","Drax"
+"Leger Education Trust","Askern Moss Road Infant Academy","Drax"
+"Leger Education Trust","Campsmount Academy","Drax"
+"Leger Education Trust","Castle Hills Primary Academy","Drax"
+"Leger Education Trust","Spa Academy Askern","Drax"
+"Leicester and Leicestershire","Charnwood Primary School","Leicester City Council"
+"Leicester and Leicestershire","Beaumont Lodge Primary School","Leicester City Council"
+"Leicester and Leicestershire","Beaumont Leys School","Leicester City Council"
+"Leicester and Leicestershire","Ellesmere College - Aylestone Meadows Campus","Leicester City Council"
+"Leicester and Leicestershire","Medway Community Primary School","Leicester City Council"
+"Leicester and Leicestershire","Moat Community College","Leicester City Council"
+"Leicester and Leicestershire","Montrose School","Leicester City Council"
+"Leicester and Leicestershire","Whitehall Primary School","Leicester City Council"
+"Leicester and Leicestershire","Avenue Primary School","Drax"
+"Leicester and Leicestershire","Barley Croft Primary School","Drax"
+"Leicester and Leicestershire","Caldecote Community Primary School","Drax"
+"Leicester and Leicestershire","Evington Valley Primary School",
+"Leicester and Leicestershire","Green Lane Infant School","Leicester City Council"
+"Leicester and Leicestershire","Hastings High School",
+"Leicester and Leicestershire","Highfields Primary School","Drax"
+"Leicester and Leicestershire","King Richard III Infant and Nursery School","Drax"
+"Leicester and Leicestershire","Mellor Community Primary School","Pending data"
+"Leicester and Leicestershire","New College Leicester","Drax"
+"Leicester and Leicestershire","Overdale Junior & Infant Schools","Leicester City Council"
+"Leicester and Leicestershire","Parks Primary School","Drax"
+"Leicester and Leicestershire","Sandfield Close Primary School","Leicester City Council"
+"Leicester and Leicestershire","Sparkenhoe Community Primary School","Leicester City Council"
+"Leicester and Leicestershire","Spinney Hill Primary School","Drax"
+"Leicester and Leicestershire","St Mary's Fields Primary School","Drax"
+"Leicester and Leicestershire","Stokes Wood Primary School","Drax"
+"Leicester and Leicestershire","Taylor Road Primary School","Drax"
+"Leicester and Leicestershire","Uplands Infant School & Junior L.E.A.D. Academy","Drax"
+"Leicester and Leicestershire","Wyvern Primary School","Drax"
+"Leigh Academies Trust","Bearsted Primary Academy and Snowfields Academy","Waiting list for funding"
+"Leigh Academies Trust","Cherry Orchard Primary Academy","Waiting list for funding"
+"Leigh Academies Trust","Dartford Primary Academy - Infant site","Waiting list for funding"
+"Leigh Academies Trust","Dartford Primary Academy - Junior site","Waiting list for funding"
+"Leigh Academies Trust","Eastcote Primary Academy","Waiting list for funding"
+"Leigh Academies Trust","Ebbsfleet Academy","Waiting list for funding"
+"Leigh Academies Trust","Hartley Primary Academy","Waiting list for funding"
+"Leigh Academies Trust","High Halstow Primary Academy","Waiting list for funding"
+"Leigh Academies Trust","Horsmonden Primary Academy","Waiting list for funding"
+"Leigh Academies Trust","Inspiration Academy","Waiting list for funding"
+"Leigh Academies Trust","Langley Park Primary Academy","Waiting list for funding"
+"Leigh Academies Trust","Leigh Academy Blackheath","Waiting list for funding"
+"Leigh Academies Trust","Leigh Academy Rainham","Waiting list for funding"
+"Leigh Academies Trust","Leigh Academy Tonbridge","Waiting list for funding"
+"Leigh Academies Trust","Longfield Academy","Waiting list for funding"
+"Leigh Academies Trust","Marden Primary Academy","Waiting list for funding"
+"Leigh Academies Trust","Mascalls Academy","Waiting list for funding"
+"Leigh Academies Trust","Milestone Academy","Waiting list for funding"
+"Leigh Academies Trust","Molehill Primary Academy","Waiting list for funding"
+"Leigh Academies Trust","Oaks Primary Academy","Waiting list for funding"
+"Leigh Academies Trust","Paddock Wood Primary Academy","Waiting list for funding"
+"Leigh Academies Trust","Peninsula East Primary Academy","Waiting list for funding"
+"Leigh Academies Trust","Sir Joseph Williamson's Mathematical School","Waiting list for funding"
+"Leigh Academies Trust","Snowfields Academy - Cranbrook Campus","Waiting list for funding"
+"Leigh Academies Trust","Stationers' Crown Woods Academy","Waiting list for funding"
+"Leigh Academies Trust","Strood Academy","Waiting list for funding"
+"Leigh Academies Trust","The Halley Academy","Waiting list for funding"
+"Leigh Academies Trust","The Hundred of Hoo Academy Primary","Waiting list for funding"
+"Leigh Academies Trust","The Hundred of Hoo Academy Secondary","Waiting list for funding"
+"Leigh Academies Trust","The Hundred of Hoo Nursery","Waiting list for funding"
+"Leigh Academies Trust","The Leigh Academy","Waiting list for funding"
+"Leigh Academies Trust","The Leigh UTC","Waiting list for funding"
+"Leigh Academies Trust","Tree Tops Primary Academy","Waiting list for funding"
+"Leigh Academies Trust","Wilmington Academy","Waiting list for funding"
+"Lighthouse Schools Partnership","Backwell Junior School","OVO Foundation"
+"Lighthouse Schools Partnership","Backwell School","OVO Foundation"
+"Lighthouse Schools Partnership","Bishop Sutton Primary School",
+"Lighthouse Schools Partnership","Chew Valley School","OVO Foundation"
+"Lighthouse Schools Partnership","Churchill Academy & Sixth Form","OVO Foundation"
+"Lighthouse Schools Partnership","Churchill C of E Primary School","Pending data"
+"Lighthouse Schools Partnership","East Harptree Primary School","OVO Foundation"
+"Lighthouse Schools Partnership","Flax Bourton Primary School","OVO Foundation"
+"Lighthouse Schools Partnership","Gordano School","OVO Foundation"
+"Lighthouse Schools Partnership","Grove Junior School","OVO Foundation"
+"Lighthouse Schools Partnership","Hannah More Infants","OVO Foundation"
+"Lighthouse Schools Partnership","High Down Schools","OVO Foundation"
+"Lighthouse Schools Partnership","Northleaze Primary School","OVO Foundation"
+"Lighthouse Schools Partnership","Portishead Primary School","OVO Foundation"
+"Lighthouse Schools Partnership","St Peter's Primary School","OVO Foundation"
+"Lighthouse Schools Partnership","Stanton Drew Primary School",
+"Lighthouse Schools Partnership","West Leigh Infant School","OVO Foundation"
+"Lighthouse Schools Partnership","Whitchurch Primary School","OVO Foundation"
+"Lighthouse Schools Partnership","Winford Primary School","OVO Foundation"
+"Lighthouse Schools Partnership","Yatton Infant School","OVO Foundation"
+"Lighthouse Schools Partnership","Yatton Junior School","OVO Foundation"
+"Lionheart Multi-Academy Trust","Beauchamp City Sixth Form","MAT funding"
+"Lionheart Multi-Academy Trust","Beauchamp College","Drax"
+"Lionheart Multi-Academy Trust","Brocks Hill Primary School","Drax"
+"Lionheart Multi-Academy Trust","Broom Leys Primary School","Drax"
+"Lionheart Multi-Academy Trust","Castle Rock School","Drax"
+"Lionheart Multi-Academy Trust","Hallam Fields Primary School","Drax"
+"Lionheart Multi-Academy Trust","Highcliffe Primary Academy","MAT funding"
+"Lionheart Multi-Academy Trust","Humphrey Perkins School","Drax"
+"Lionheart Multi-Academy Trust","Judgemeadow Community College","Pending data"
+"Lionheart Multi-Academy Trust","Martin High School","Drax"
+"Lionheart Multi-Academy Trust","Riverside Primary Academy","Drax"
+"Lionheart Multi-Academy Trust","Sir Jonathan North College","Drax"
+"Lionheart Multi-Academy Trust","The Cedars Academy","Drax"
+"Lionheart Multi-Academy Trust","The Newbridge School","Drax"
+"Manchester","Ashbury Meadow Primary School","School self funding"
+"Manchester","Camberwell Park School","School self funding"
+"Manchester","Castlefield Campus","School self funding"
+"Manchester","Cheetham CE Community Academy","School self funding"
+"Manchester","Heald Place Primary School","School self funding"
+"Manchester","Lancasterian School","School self funding"
+"Manchester","Meade Hill School","School self funding"
+"Manchester","Our Lady's R.C. High School","School self funding"
+"Manchester","Park View Community School","School self funding"
+"Manchester","Southern Cross School","School self funding"
+"Merthyr Tydfil","Coed-Y-Dderwen",
+"Merthyr Tydfil","Gellifaelog Primary",
+"Merthyr Tydfil","Goetre Primary School",
+"Merthyr Tydfil","Heolgerrig Community School",
+"Merthyr Tydfil","Twynyrodyn Community School",
+"Merthyr Tydfil","Ynysowen Primary School",
+"Merthyr Tydfil","Ysgol Rhyd-Y-Grug",
+"Midsomer Norton Schools Partnership","Beechen Cliff School","OVO Foundation"
+"Midsomer Norton Schools Partnership","Buckler's Mead School","OVO Foundation"
+"Midsomer Norton Schools Partnership","Clutton Primary School","OVO Foundation"
+"Midsomer Norton Schools Partnership","Critchill School","Postcode Local Trust"
+"Midsomer Norton Schools Partnership","Dundry Primary School","OVO Foundation"
+"Midsomer Norton Schools Partnership","Farrington Gurney Primary School","OVO Foundation"
+"Midsomer Norton Schools Partnership","Hayesfield Girls' School and Mixed Sixth Form","OVO Foundation"
+"Midsomer Norton Schools Partnership","Hemington Primary School","Pending data"
+"Midsomer Norton Schools Partnership","High Littleton Primary School","OVO Foundation"
+"Midsomer Norton Schools Partnership","Knowle DGE Academy","OVO Foundation"
+"Midsomer Norton Schools Partnership","Leigh on Mendip School","OVO Foundation"
+"Midsomer Norton Schools Partnership","Longvernal Primary School","OVO Foundation"
+"Midsomer Norton Schools Partnership","Midsomer Norton Primary School","OVO Foundation"
+"Midsomer Norton Schools Partnership","Norton Hill Primary School","OVO Foundation"
+"Midsomer Norton Schools Partnership","Norton Hill School","OVO Foundation"
+"Midsomer Norton Schools Partnership","Notton House School","OVO Foundation"
+"Midsomer Norton Schools Partnership","Park Road Support Centre",
+"Midsomer Norton Schools Partnership","Peasedown St John Primary","OVO Foundation"
+"Midsomer Norton Schools Partnership","Preston School Academy","OVO Foundation"
+"Midsomer Norton Schools Partnership","Shoscombe Church Primary School","OVO Foundation"
+"Midsomer Norton Schools Partnership","Somervale School","OVO Foundation"
+"Midsomer Norton Schools Partnership","Soundwell Academy","OVO Foundation"
+"Midsomer Norton Schools Partnership","St Dunstan's School","OVO Foundation"
+"Midsomer Norton Schools Partnership","St John's Primary School, Radstock","OVO Foundation"
+"Midsomer Norton Schools Partnership","St Julian's Church School","School self funding"
+"Midsomer Norton Schools Partnership","St Marks C of E School","Postcode Local Trust"
+"Midsomer Norton Schools Partnership","St Mary's Primary School Timsbury","OVO Foundation"
+"Midsomer Norton Schools Partnership","St Matthias Academy","Postcode Local Trust"
+"Midsomer Norton Schools Partnership","Trinity Church School","Postcode Local Trust"
+"Midsomer Norton Schools Partnership","Welton Primary School","OVO Foundation"
+"Midsomer Norton Schools Partnership","Westfield Primary School","OVO Foundation"
+"Midsomer Norton Schools Partnership","Writhlington School","OVO Foundation"
+"Moray","Anderson's Primary School",
+"Moray","Forres Academy",
+"Moray","New Elgin Primary School",
+"Moray","Pilmuir Primary School",
+"Moray","Speyside High School",
+"Moray","St Gerardine Primary School",
+"Newport/Casnewydd","Alway Primary School","Egni"
+"Newport/Casnewydd","Caerleon Comprehensive School","Egni"
+"Newport/Casnewydd","Eveswell Primary School","Egni"
+"Newport/Casnewydd","Jubilee Park Primary School","Egni"
+"Newport/Casnewydd","Llanmartin Primary School","Egni"
+"Newport/Casnewydd","Lliswerry High School","Egni"
+"Newport/Casnewydd","Lliswerry Primary School","Egni"
+"Newport/Casnewydd","Maesglas Primary School","Egni"
+"Newport/Casnewydd","Maindee Primary School","Egni"
+"Newport/Casnewydd","Malpas Court School","Egni"
+"Newport/Casnewydd","Marshfield Primary School","Egni"
+"Newport/Casnewydd","Pentrepoeth Primary School","Egni"
+"Newport/Casnewydd","Rogerstone Primary School","Egni"
+"Newport/Casnewydd","St Julian's High School","Egni"
+"Newport/Casnewydd","St Julian's Primary School","Egni"
+"Newport/Casnewydd","Ysgol Gyfun Gwent is Coed","Egni"
+"Newport/Casnewydd","Ysgol Gymraeg Casnewydd","Egni"
+"Norfolk","John Grant School","Drax"
+"Norfolk","Sheringham Woodfields School","Drax"
+"North Lincolnshire","Baysgarth School","Drax"
+"North Lincolnshire","Belton All Saints C of E Primary School",
+"North Lincolnshire","Bottesford Junior School",
+"North Lincolnshire","Brigg Primary School",
+"North Lincolnshire","Burton upon Stather Primary School",
+"North Lincolnshire","Castledyke Primary School","Pending data"
+"North Lincolnshire","Gunness and Burringham C of E Primary School","Drax"
+"North Lincolnshire","Holme Valley Primary School","Pending data"
+"North Lincolnshire","Killingholme Primary School","Drax"
+"North Lincolnshire","Kirmington St Helena's C of E Primary School","Pending data"
+"North Lincolnshire","Kirton Lindsey Primary School",
+"North Lincolnshire","Leys Farm Junior School","Drax"
+"North Lincolnshire","Oakfield Primary School","Drax"
+"North Lincolnshire","Priory Lane Community School","Pending data"
+"North Lincolnshire","Sir John Nelthorpe School","Drax"
+"North Lincolnshire","South Ferriby Primary School",
+"North Lincolnshire","St Barnabas C of E Primary, Barnetby","Pending data"
+"North Lincolnshire","St Peter & St Paul CE Primary School","Drax"
+"North Lincolnshire","The Grange Primary School, Scunthorpe","Drax"
+"North Lincolnshire","Westcliffe Primary School","Drax"
+"North Lincolnshire","Wroot Travis Charity C of E Primary School","Pending data"
+"North Star Community Trust","Enfield Heights Academy","OVO Foundation"
+"North Star Community Trust","Heron Hall Academy","OVO Foundation"
+"North Star Community Trust","Kingfisher Hall Primary Academy","OVO Foundation"
+"North Star Community Trust","Woodpecker Hall Academy","OVO Foundation"
+"Nottingham","Claremont Primary and Nursery School","Pending data"
+"Oasis Multi-Academy Trust","Oasis Academy - Arena","OVO Foundation"
+"Oasis Multi-Academy Trust","Oasis Academy - Aspinal","MAT funding"
+"Oasis Multi-Academy Trust","Oasis Academy - Bank Leaze","Postcode Local Trust"
+"Oasis Multi-Academy Trust","Oasis Academy - Blakenhale Infants and Junior School","Postcode Local Trust"
+"Oasis Multi-Academy Trust","Oasis Academy - Boulton","Pending data"
+"Oasis Multi-Academy Trust","Oasis Academy - Brightstowe","Pending data"
+"Oasis Multi-Academy Trust","Oasis Academy - Brislington","Pending data"
+"Oasis Multi-Academy Trust","Oasis Academy - Broadoak","MAT funding"
+"Oasis Multi-Academy Trust","Oasis Academy - Byron","OVO Foundation"
+"Oasis Multi-Academy Trust","Oasis Academy - Clarksfield","Pending data"
+"Oasis Multi-Academy Trust","Oasis Academy - Connaught","Postcode Local Trust"
+"Oasis Multi-Academy Trust","Oasis Academy - Coulsdon","OVO Foundation"
+"Oasis Multi-Academy Trust","Oasis Academy - Don Valley","Drax"
+"Oasis Multi-Academy Trust","Oasis Academy - Enfield","OVO Foundation"
+"Oasis Multi-Academy Trust","Oasis Academy - Fir Vale","Drax"
+"Oasis Multi-Academy Trust","Oasis Academy - Foundry","Postcode Local Trust"
+"Oasis Multi-Academy Trust","Oasis Academy - Hadley","OVO Foundation"
+"Oasis Multi-Academy Trust","Oasis Academy - Harpur Mount","Pending data"
+"Oasis Multi-Academy Trust","Oasis Academy - Henderson Avenue","Drax"
+"Oasis Multi-Academy Trust","Oasis Academy - Hobmoor","Postcode Local Trust"
+"Oasis Multi-Academy Trust","Oasis Academy - Immingham","Drax"
+"Oasis Multi-Academy Trust","Oasis Academy - Isle of Sheppey, East Campus","MAT funding"
+"Oasis Multi-Academy Trust","Oasis Academy - Isle of Sheppey, West Campus","MAT funding"
+"Oasis Multi-Academy Trust","Oasis Academy - Johanna","OVO Foundation"
+"Oasis Multi-Academy Trust","Oasis Academy - John Williams","Postcode Local Trust"
+"Oasis Multi-Academy Trust","Oasis Academy - Leesbrook","MAT funding"
+"Oasis Multi-Academy Trust","Oasis Academy - Limeside","MAT funding"
+"Oasis Multi-Academy Trust","Oasis Academy - Lister Park","Drax"
+"Oasis Multi-Academy Trust","Oasis Academy - Long Cross","Postcode Local Trust"
+"Oasis Multi-Academy Trust","Oasis Academy - Longmeadow","Postcode Local Trust"
+"Oasis Multi-Academy Trust","Oasis Academy - Lords Hill","MAT funding"
+"Oasis Multi-Academy Trust","Oasis Academy - Marksbury Road","Postcode Local Trust"
+"Oasis Multi-Academy Trust","Oasis Academy - Mayfield","MAT funding"
+"Oasis Multi-Academy Trust","Oasis Academy - Media City UK","MAT funding"
+"Oasis Multi-Academy Trust","Oasis Academy - New Oak","Postcode Local Trust"
+"Oasis Multi-Academy Trust","Oasis Academy - Nunsthorpe","Drax"
+"Oasis Multi-Academy Trust","Oasis Academy - Oldham","MAT funding"
+"Oasis Multi-Academy Trust","Oasis Academy - Parkwood","Pending data"
+"Oasis Multi-Academy Trust","Oasis Academy - Pinewood","Pending data"
+"Oasis Multi-Academy Trust","Oasis Academy - Putney","OVO Foundation"
+"Oasis Multi-Academy Trust","Oasis Academy - Ryelands","OVO Foundation"
+"Oasis Multi-Academy Trust","Oasis Academy - Shirley Park - Long Lane campus","OVO Foundation"
+"Oasis Multi-Academy Trust","Oasis Academy - Shirley Park - Stroud Green campus","OVO Foundation"
+"Oasis Multi-Academy Trust","Oasis Academy - Short Heath Primary","Postcode Local Trust"
+"Oasis Multi-Academy Trust","Oasis Academy - Silvertown","OVO Foundation"
+"Oasis Multi-Academy Trust","Oasis Academy - Skinner Street","Pending data"
+"Oasis Multi-Academy Trust","Oasis Academy - South Bank","OVO Foundation"
+"Oasis Multi-Academy Trust","Oasis Academy - Temple","Pending data"
+"Oasis Multi-Academy Trust","Oasis Academy - Warndon","Postcode Local Trust"
+"Oasis Multi-Academy Trust","Oasis Academy - Watermead","Drax"
+"Oasis Multi-Academy Trust","Oasis Academy - Wintringham","Drax"
+"Oasis Multi-Academy Trust","Oasis Academy - Woodview","Postcode Local Trust"
+"Other Independent Schools","Ewell Castle School","School self funding"
+"Other Independent Schools","Forest School","School self funding"
+"Other Independent Schools","Francis Holland School - Regents Park","School self funding"
+"Other Independent Schools","Francis Holland School - Sloane Square","School self funding"
+"Other Independent Schools","Sherborne Girls","School self funding"
+"Oxfordshire","Caldecott Primary School",
+"Oxfordshire","Long Furlong Primary School",
+"Oxfordshire","St. Nicolas Primary School",
+"Oxfordshire","West Witney Primary School","Waiting list for funding"
+"Oxfordshire","Windmill Primary School","School self funding"
+"Oxfordshire","Wootton St Peter's Primary School","Waiting list for funding"
+"Palladian Academy Trust","Combe Down Primary School",
+"Palladian Academy Trust","Oldfield Park Junior School",
+"Palladian Academy Trust","Ralph Allen School",
+"Palladian Academy Trust","St Martin's Garden Primary School","Postcode Local Trust"
+"Palladian Academy Trust","St Philip’s Primary School","OVO Foundation"
+"Palladian Academy Trust","Widcombe Infant School","OVO Foundation"
+"Palladian Academy Trust","Widcombe Junior School",
+"Palladian Academy Trust","Winsley CE Primary School",
+"Pathfinder Multi Academy Trust","Acomb Primary School",
+"Pathfinder Multi Academy Trust","Archbishop Holgateâ€™s School",
+"Pathfinder Multi Academy Trust","Badger Hill Primary School",
+"Pathfinder Multi Academy Trust","Clifton with Rawcliffe Primary School",
+"Pathfinder Multi Academy Trust","Hempland Primary School",
+"Pathfinder Multi Academy Trust","New Earswick Primary School",
+"Pathfinder Multi Academy Trust","Tang Hall Primary School",
+"Peterborough Diocese Education Trust","Barby C of E Primary School","Laser 50%"
+"Peterborough Diocese Education Trust","Blakesley C of E Primary School","Laser 50%"
+"Peterborough Diocese Education Trust","Braunston C of E Primary School","Laser 50%"
+"Peterborough Diocese Education Trust","Collingtree C of E Primary School","Laser 50%"
+"Peterborough Diocese Education Trust","Cottingham C of E Primary School","Laser 50%"
+"Peterborough Diocese Education Trust","Cranford C of E Primary School","Laser 50%"
+"Peterborough Diocese Education Trust","Freeman's Endowed C of E Junior Academy","Laser 50%"
+"Peterborough Diocese Education Trust","Great Addington C of E Primary School","Laser 50%"
+"Peterborough Diocese Education Trust","Greens Norton C of E Primary School","Laser 50%"
+"Peterborough Diocese Education Trust","Guilsborough C of E Primary School","Laser 50%"
+"Peterborough Diocese Education Trust","Isham C of E Primary School","Laser 50%"
+"Peterborough Diocese Education Trust","Kislingbury C of E Primary School","Laser 50%"
+"Peterborough Diocese Education Trust","Loddington C of E Primary School","Laser 50%"
+"Peterborough Diocese Education Trust","Mears Ashby C of E Primary School","Laser 50%"
+"Peterborough Diocese Education Trust","Milton Parochial Primary School","Laser 50%"
+"Peterborough Diocese Education Trust","Oundle C of E Primary School","Laser 50%"
+"Peterborough Diocese Education Trust","Pytchley C of E Primary School","Laser 50%"
+"Peterborough Diocese Education Trust","Ringstead C of E Primary School","Laser 50%"
+"Peterborough Diocese Education Trust","Ryhall C of E Academy","Laser 50%"
+"Peterborough Diocese Education Trust","Silverstone C of E Primary","Laser 50%"
+"Peterborough Diocese Education Trust","Spratton C of E Primary School","Laser 50%"
+"Peterborough Diocese Education Trust","St Andrew's C of E Primary School & Nursery","Laser 50%"
+"Peterborough Diocese Education Trust","Staverton C of E Primary School","Laser 50%"
+"Peterborough Diocese Education Trust","St Barnabas C of E School","Laser 50%"
+"Peterborough Diocese Education Trust","St James C of E Primary School","Laser 50%"
+"Peterborough Diocese Education Trust","St Luke's C of E Primary School","Laser 50%"
+"Peterborough Diocese Education Trust","St Mary's C of E Primary School","Laser 50%"
+"Peterborough Diocese Education Trust","Sywell C of E Primary School","Laser 50%"
+"Peterborough Diocese Education Trust","Towcester C of E Primary School","Laser 50%"
+"Peterborough Diocese Education Trust","Trinity C of E Primary School","Laser 50%"
+"Peterborough Diocese Education Trust","Weldon C of E Primary School","Laser 50%"
+"Peterborough Diocese Education Trust","Welford, Sibbertoft & Sulby Endowed School","Laser 50%"
+"Peterborough Diocese Education Trust","William Law C of E Primary School","Laser 50%"
+"Pembrokeshire/Sir Penfro","Broad Haven CP School","Egni"
+"Pembrokeshire/Sir Penfro","Coastlands CP School","Egni"
+"Pembrokeshire/Sir Penfro","Fenton Community Primary School","Egni"
+"Pembrokeshire/Sir Penfro","Gelliswick School","Egni"
+"Pembrokeshire/Sir Penfro","Golden Grove School","Egni"
+"Pembrokeshire/Sir Penfro","Johnston School","Egni"
+"Pembrokeshire/Sir Penfro","Lamphey Primary School","Egni"
+"Pembrokeshire/Sir Penfro","Mary Immaculate Catholic Primary School","Egni"
+"Pembrokeshire/Sir Penfro","Pembroke Dock Community School","Egni"
+"Pembrokeshire/Sir Penfro","Pennar Community School","Egni"
+"Pembrokeshire/Sir Penfro","Portfield Special School","Egni"
+"Pembrokeshire/Sir Penfro","Prendergast Primary School","Egni"
+"Pembrokeshire/Sir Penfro","Puncheston Community Primary School","Egni"
+"Pembrokeshire/Sir Penfro","Saundersfoot Community Primary School","Egni"
+"Pembrokeshire/Sir Penfro","St Aidan's School","Egni"
+"Pembrokeshire/Sir Penfro","St Florence VC Church in Wales School","Pending data"
+"Pembrokeshire/Sir Penfro","St Francis Catholic Primary School","Egni"
+"Pembrokeshire/Sir Penfro","Stepaside Primary School","Egni"
+"Pembrokeshire/Sir Penfro","Tenby CIW Primary School","Egni"
+"Pembrokeshire/Sir Penfro","Ysgol Bro Ingli","Egni"
+"Pembrokeshire/Sir Penfro","Ysgol Brynconin","Pending data"
+"Pembrokeshire/Sir Penfro","Ysgol Casblaidd","Pending data"
+"Pembrokeshire/Sir Penfro","Ysgol Gymunedol Croesgoch","Egni"
+"Pembrokeshire/Sir Penfro","Ysgol Penrhyn Dewi - Campws Aidan","Egni"
+"Pembrokeshire/Sir Penfro","Ysgol Penrhyn Dewi - Campws Non","Egni"
+"Pembrokeshire/Sir Penfro","Ysgol Penrhyn Dewi VA - Campws Dewi","Egni"
+"Pembrokeshire/Sir Penfro","Ysgol Wirfoddol Cilgerran","Egni"
+"Pembrokeshire/Sir Penfro","Ysgol y Frenni","Egni"
+"Perth and Kinross","Alyth Primary School",
+"Perth and Kinross","Crieff High School",
+"Perth and Kinross","Crieff Primary School",
+"Perth and Kinross","Errol Primary School",
+"Perth and Kinross","Fairview School","Centrica"
+"Perth and Kinross","Invergowrie Primary School","Centrica"
+"Perth and Kinross","Kenmore Primary School",
+"Perth and Kinross","Kinross High School",
+"Perth and Kinross","Moncreiffe Primary School","Centrica"
+"Perth and Kinross","Oakbank Primary School",
+"Perth and Kinross","Perth Grammar School",
+"Perth and Kinross","Stanley Primary School",
+"Peterborough","Leighton Primary School","Drax"
+"Prince Albert Community Trust","Birchfield Primary School","Postcode Local Trust"
+"Prince Albert Community Trust","Heathfield Primary School","Postcode Local Trust"
+"Prince Albert Community Trust","Highfield J&I School","Postcode Local Trust"
+"Prince Albert Community Trust","Prince Albert High School","Postcode Local Trust"
+"Prince Albert Community Trust","Prince Albert Primary School","Postcode Local Trust"
+"Prince Albert Community Trust","Sutton Park Primary School","Postcode Local Trust"
+"Reading","Thameside Primary School",
+"Red Kite Learning Trust","Austhorpe Primary School","MAT funding"
+"Red Kite Learning Trust","Colton Primary School","MAT funding"
+"Red Kite Learning Trust","Coppice Valley Primary School","Drax"
+"Red Kite Learning Trust","Crawshaw Academy","Drax"
+"Red Kite Learning Trust","Harrogate Grammar School","MAT funding"
+"Red Kite Learning Trust","Meadowfield Primary School","Drax"
+"Red Kite Learning Trust","Oatlands Junior School","MAT funding"
+"Red Kite Learning Trust","Rossett Acre Primary School","MAT funding"
+"Red Kite Learning Trust","Rossett School","Drax"
+"Red Kite Learning Trust","Temple Learning Academy","Drax"
+"Red Kite Learning Trust","Temple Moor High School","Drax"
+"Red Kite Learning Trust","Templenewsam Halton Primary School","Drax"
+"Red Kite Learning Trust","Western Primary School","MAT funding"
+"Red Kite Learning Trust","Whitkirk Primary School","Drax"
+"River Learning Trust","Barton Park Primary School",
+"River Learning Trust","Bayards Hill Primary School",
+"River Learning Trust","Beckley Church of England Primary School",
+"River Learning Trust","Charlbury Primary School",
+"River Learning Trust","Cheney School",
+"River Learning Trust","Chipping Norton School",
+"River Learning Trust","Cutteslowe Primary School",
+"River Learning Trust","Edith Moorhouse Primary School",
+"River Learning Trust","Garsington Church of England Primary School",
+"River Learning Trust","Gosford Hill School",
+"River Learning Trust","Horspath Church of England Primary School",
+"River Learning Trust","Kingsdown School",
+"River Learning Trust","Larkrise Primary School",
+"River Learning Trust","Madley Brook Primary School",
+"River Learning Trust","Middle Barton Primary School",
+"River Learning Trust","New Marston Primary School and Nursery",
+"River Learning Trust","Rose Hill Primary School",
+"River Learning Trust","Sandhills Community Primary School",
+"River Learning Trust","Seven Fields Primary School",
+"River Learning Trust","The Cherwell School",
+"River Learning Trust","The Marlborough School",
+"River Learning Trust","The Oxford Academy",
+"River Learning Trust","The Swan School",
+"River Learning Trust","Tower Hill Community Primary School",
+"River Learning Trust","Wheatley Park School",
+"River Learning Trust","Windrush Church of England Primary School",
+"River Learning Trust","Witney Community Primary School",
+"River Learning Trust","Wolvercote Primary School",
+"Roseland Multi-Academy Trust","Falmouth School","MAT funding"
+"Roseland Multi-Academy Trust","The Roseland Academy","MAT funding"
+"Roseland Multi-Academy Trust","Treviglas Academy","MAT funding"
+"Rotherham","Aughton Early Years Centre","Drax"
+"Rotherham","Bramley Sunnyside Junior School","Drax"
+"Rotherham","Broom Valley Community School","Drax"
+"Rotherham","Newman School - Additional Resource Site","Drax"
+"Rotherham","Newman School - Whiston Main Site","Drax"
+"Rotherham","St Joseph's Catholic Primary School, Dinnington","Drax"
+"SENDAT","Chalk Hill","Drax"
+"SENDAT","Duke of Lancaster Academy","Drax"
+"SENDAT","Priory School - Mount Road","Drax"
+"SENDAT","Sunrise Academy","Drax"
+"Sheffield","Abbey Lane Primary School",
+"Sheffield","Brunswick Community Primary School","Drax"
+"Sheffield","Coit Primary School","Drax"
+"Sheffield","Ecclesall Primary School",
+"Sheffield","Ecclesfield Primary School","Drax"
+"Sheffield","King Edward VII Upper School","Drax"
+"Sheffield","Mossbrook School","Drax"
+"Sheffield","Mundella Primary School","Drax"
+"Sheffield","Porter Croft Church of England Primary Academy","Drax"
+"Sheffield","St Thomas of Canterbury School",
+"Sheffield","Watercliffe Meadow Community Primary School","Drax"
+"Somerset","Frome College","OVO Foundation"
+"Somerset","Hugh Sexey C of E Middle School",
+"Somerset","Oakfield Academy","OVO Foundation"
+"Somerset","St Louis Catholic Primary School",
+"Somerset","St Benedict's C of E Junior School","Postcode Local Trust"
+"Somerset","Trinity C of E First School","OVO Foundation"
+"South West Essex Community Education Trust","Chadwell St Mary Primary School","Drax"
+"South West Essex Community Education Trust","Deneholm Primary School","Drax"
+"South West Essex Community Education Trust","Marshalls Park Academy","OVO Foundation"
+"South West Essex Community Education Trust","Orsett Heath Academy","Drax"
+"South West Essex Community Education Trust","Stifford Clays Primary School","Drax"
+"South West Essex Community Education Trust","William Edwards School","Drax"
+"Spencer Academies Trust","Arnold Hill Spencer Academy","Pending data"
+"Spencer Academies Trust","Ashwood Spencer Academy","Drax"
+"Spencer Academies Trust","Brackensdale Spencer Academy","Drax"
+"Spencer Academies Trust","Castleward Spencer Academy","Pending data"
+"Spencer Academies Trust","Millside Spencer Academy","Pending data"
+"Spencer Academies Trust","Chellaston Fields Spencer Academy","Drax"
+"Spencer Academies Trust","Chetwynd Spencer Academy","Drax"
+"Spencer Academies Trust","Clover Leys Spencer Academy","Pending data"
+"Spencer Academies Trust","Derby Moor Spencer Academy","Drax"
+"Spencer Academies Trust","Fairfield Spencer Academy","Drax"
+"Spencer Academies Trust","Farnborough Spencer Academy","Drax"
+"Spencer Academies Trust","George Spencer Academy","MAT funding"
+"Spencer Academies Trust","Glenbrook Spencer Academy","Drax"
+"Spencer Academies Trust","Heanor Gate Spencer Academy","Drax"
+"Spencer Academies Trust","Highfields Spencer Academy","MAT funding"
+"Spencer Academies Trust","Hilton Spencer Academy","Drax"
+"Spencer Academies Trust","Inkersall Spencer Academy","Drax"
+"Spencer Academies Trust","John Port Spencer Academy","MAT funding"
+"Spencer Academies Trust","Long Field Spencer Academy","MAT funding"
+"Spencer Academies Trust","Portland Spencer Academy","Drax"
+"Spencer Academies Trust","Rosecliffe Spencer Academy","MAT funding"
+"Spencer Academies Trust","Rushcliffe Spencer Academy","Drax"
+"Spencer Academies Trust","St Giles Spencer Academy","Drax"
+"Spencer Academies Trust","Sunnyside Spencer Academy","Drax"
+"Spencer Academies Trust","The Mease Spencer Academy","MAT funding"
+"Spencer Academies Trust","Wyndham Spencer Academy","Drax"
+"St Ralph Sherwin CMAT","All Saints Catholic Voluntary Academy",
+"St Ralph Sherwin CMAT","Blessed Robert Sutton Catholic Voluntary Academy",
+"St Ralph Sherwin CMAT","Christ the King Catholic Voluntary Academy",
+"St Ralph Sherwin CMAT","English Martyrs' Catholic Voluntary Academy","Drax"
+"St Ralph Sherwin CMAT","Saint John Houghton Catholic Voluntary Academy",
+"St Ralph Sherwin CMAT","St Alban's Catholic Primary School",
+"St Ralph Sherwin CMAT","St Anne's Catholic Voluntary Academy",
+"St Ralph Sherwin CMAT","St Charles Catholic Voluntary Academy",
+"St Ralph Sherwin CMAT","St Edward's Catholic Voluntary Academy",
+"St Ralph Sherwin CMAT","St Elizabeth's Catholic Voluntary Academy",
+"St Ralph Sherwin CMAT","St George's Catholic Voluntary Academy",
+"St Ralph Sherwin CMAT","St John Fisher Catholic Voluntary Academy",
+"St Ralph Sherwin CMAT","St Joseph's Catholic Primary School, Derby",
+"St Ralph Sherwin CMAT","St Margaret's Catholic Voluntary Academy",
+"St Ralph Sherwin CMAT","St Philip Howard Catholic Voluntary Academy","Drax"
+"St Ralph Sherwin CMAT","St Thomas Catholic Voluntary Academy","Drax"
+"St Ralph Sherwin CMAT","St Thomas More Catholic Voluntary Academy",
+"St Ralph Sherwin CMAT","St. Mary's Catholic Primary School, Glossop",
+"St Thomas Aquinas CMAT","Bishop Ellis Catholic Voluntary Academy","Elbow Beach"
+"St Thomas Aquinas CMAT","Christ the King Catholic Primary School (Infant site)","Elbow Beach"
+"St Thomas Aquinas CMAT","Christ the King Catholic Voluntary Academy (Junior Site)","Elbow Beach"
+"St Thomas Aquinas CMAT","De Lisle College","Elbow Beach"
+"St Thomas Aquinas CMAT","English Martyrs' Catholic School (Leicester)","Elbow Beach"
+"St Thomas Aquinas CMAT","English Martyrs Catholic Voluntary Academy (Oakham)","Elbow Beach"
+"St Thomas Aquinas CMAT","Holy Cross Catholic Primary School (Leicester)","Elbow Beach"
+"St Thomas Aquinas CMAT","Sacred Heart Catholic Voluntary Academy (Loughborough)","Pending data"
+"St Thomas Aquinas CMAT","Saint Martin's Catholic Academy","Elbow Beach"
+"St Thomas Aquinas CMAT","St Charles Primary School","Elbow Beach"
+"St Thomas Aquinas CMAT","St. Joseph's Catholic Voluntary Academy (Market Harborough)","Elbow Beach"
+"St Thomas Aquinas CMAT","St. Patrick's Catholic Voluntary Academy","Pending data"
+"St Thomas Aquinas CMAT","St Paul's Catholic School","Elbow Beach"
+"St Thomas Aquinas CMAT","St Peter’s Catholic Primary School (Hinckley)","Elbow Beach"
+"St Thomas Aquinas CMAT","St Winefride’s Catholic Voluntary Academy","Elbow Beach"
+"Stour Vale Multi-Academy Trust","Earls High School","Postcode Local Trust"
+"Stour Vale Multi-Academy Trust","Northfield Road Primary","Postcode Local Trust"
+"Stour Vale Multi-Academy Trust","Redhill High School",
+"Stour Vale Multi-Academy Trust","Ridgewood High School",
+"Suffolk","St Mary's Church of England Academy","Drax"
+"Sutton","Robin Hood Junior School","OVO Foundation"
+"Swansea/Abertawe","Birchgrove Comprehensive School","School self funding"
+"Swansea/Abertawe","Birchgrove Primary School","Swansea Council"
+"Swansea/Abertawe","Bishop Gore School","Swansea Council"
+"Swansea/Abertawe","Bishop Vaughan Catholic School",
+"Swansea/Abertawe","Bishopston Comprehensive School",
+"Swansea/Abertawe","Bishopston Comprehensive School Sports Hall",
+"Swansea/Abertawe","Bishopston Primary School","Swansea Council"
+"Swansea/Abertawe","Blaenymaes Primary School",
+"Swansea/Abertawe","Brynhyfryd Primary School","Swansea Council"
+"Swansea/Abertawe","Brynmill Primary School",
+"Swansea/Abertawe","Burlais Primary School","Swansea Council"
+"Swansea/Abertawe","Cadle Primary School","Swansea Council"
+"Swansea/Abertawe","Casllwchwr Primary School",
+"Swansea/Abertawe","Cefn Hengoed Community School",
+"Swansea/Abertawe","Christchurch Primary School","Swansea Council"
+"Swansea/Abertawe","Cila Primary School","Swansea Council"
+"Swansea/Abertawe","Clase Primary School","Swansea Council"
+"Swansea/Abertawe","Clwyd Community Primary",
+"Swansea/Abertawe","Clydach Primary School","Swansea Council"
+"Swansea/Abertawe","Craigfelen Primary School","Swansea Council"
+"Swansea/Abertawe","Crwys Primary School",
+"Swansea/Abertawe","Cwm Glas Primary","Swansea Council"
+"Swansea/Abertawe","Cwmrhydyceirw Primary School","Swansea Council"
+"Swansea/Abertawe","Danygraig Primary School","Swansea Council"
+"Swansea/Abertawe","Dunvant Primary School",
+"Swansea/Abertawe","Dylan Thomas Community School","Swansea Council"
+"Swansea/Abertawe","Gendros Primary School",
+"Swansea/Abertawe","Glais Primary School",
+"Swansea/Abertawe","Glyncollen Primary School",
+"Swansea/Abertawe","Gors Community Primary School","Swansea Council"
+"Swansea/Abertawe","Gorseinon Primary School","Swansea Council"
+"Swansea/Abertawe","Gowerton Primary School","Swansea Council"
+"Swansea/Abertawe","Gowerton Secondary School",
+"Swansea/Abertawe","Gwyrosydd Primary School","Swansea Council"
+"Swansea/Abertawe","Hafod Primary School",
+"Swansea/Abertawe","Hendrefoilan Primary school",
+"Swansea/Abertawe","Knelston Primary School","Swansea Council"
+"Swansea/Abertawe","Llangyfelach Primary School","Swansea Council"
+"Swansea/Abertawe","Llanrhidian Primary School","Swansea Council"
+"Swansea/Abertawe","Maes Derw","Swansea Council"
+"Swansea/Abertawe","Mayals Primary School","Swansea Council"
+"Swansea/Abertawe","Morriston Comprehensive School",
+"Swansea/Abertawe","Morriston Primary School","Swansea Council"
+"Swansea/Abertawe","Newton Primary School","Swansea Council"
+"Swansea/Abertawe","Olchfa School",
+"Swansea/Abertawe","Oystermouth Primary School","Swansea Council"
+"Swansea/Abertawe","Parkland Primary School","Swansea Council"
+"Swansea/Abertawe","Pen y fro Primary School","Swansea Council"
+"Swansea/Abertawe","Penclawdd Primary School",
+"Swansea/Abertawe","Pengelli Primary School",
+"Swansea/Abertawe","Penllergaer Primary School",
+"Swansea/Abertawe","Pennard Primary School",
+"Swansea/Abertawe","Pentre'r Graig Primary School","Swansea Council"
+"Swansea/Abertawe","Pentrechwyth Primary School",
+"Swansea/Abertawe","Pentrehafod Comprehensive",
+"Swansea/Abertawe","Penyrheol Comprehensive","Self funding and Egni Co-op (50:50)"
+"Swansea/Abertawe","Penyrheol Primary School","Swansea Council"
+"Swansea/Abertawe","Plasmarl Primary School",
+"Swansea/Abertawe","Pontarddulais Comprehensive School",
+"Swansea/Abertawe","Pontarddulais Primary School","School self funding"
+"Swansea/Abertawe","Pontlliw Primary School","Swansea Council"
+"Swansea/Abertawe","Portmead Primary School",
+"Swansea/Abertawe","Sea View Community Primary School",
+"Swansea/Abertawe","Sketty Primary School","Swansea Council"
+"Swansea/Abertawe","St David's Catholic Primary School and Grange Primary School","Swansea Council"
+"Swansea/Abertawe","St Helen's Primary School","Swansea Council"
+"Swansea/Abertawe","St Illtyd's Primary School","Swansea Council"
+"Swansea/Abertawe","St Joseph's Cathedral School",
+"Swansea/Abertawe","St Joseph's Catholic Primary School, Swansea","Swansea Council"
+"Swansea/Abertawe","St Thomas Community Primary School",
+"Swansea/Abertawe","Talycopa Primary School","Swansea Council"
+"Swansea/Abertawe","Terrace Road Primary School",
+"Swansea/Abertawe","Townhill Community Primary School","Swansea Council"
+"Swansea/Abertawe","Trallwn Primary School",
+"Swansea/Abertawe","Tre Uchaf Primary School",
+"Swansea/Abertawe","Waun Wen Primary School","Swansea Council"
+"Swansea/Abertawe","Waunarlwydd Primary School","Swansea Council"
+"Swansea/Abertawe","Whitestone Primary School","Swansea Council"
+"Swansea/Abertawe","YGG Llwynderw",
+"Swansea/Abertawe","YGG Y Login Fach","Swansea Council"
+"Swansea/Abertawe","Ynystawe Primary School","Swansea Council"
+"Swansea/Abertawe","Ysgol Crug Glas","Swansea Council"
+"Swansea/Abertawe","Ysgol Gyfun Gŵyr","Swansea Council"
+"Swansea/Abertawe","Ysgol Gyfun Gymraeg Bryn Tawe","Swansea Council"
+"Swansea/Abertawe","Ysgol Gymraeg Bryn y Mor","Swansea Council"
+"Swansea/Abertawe","Ysgol Gymraeg Lon Las","Swansea Council"
+"Swansea/Abertawe","Ysgol Gymraeg Pontybrenin","School self funding"
+"Swansea/Abertawe","Ysgol Gymraeg Y Cwm","Swansea Council"
+"Swansea/Abertawe","Ysgol Gynradd Gymraeg Bryniago",
+"Swansea/Abertawe","Ysgol Gynradd Gymraeg Gellionnen","Swansea Council"
+"Swansea/Abertawe","Ysgol Gynradd Gymraeg Tan-y-lan","Swansea Council"
+"Swansea/Abertawe","Ysgol Gynradd Gymraeg Tirdeunaw","Swansea Council"
+"Swansea/Abertawe","Ysgol Pen y Bryn","Swansea Council"
+"TEAM Education Trust","Model Village Primary School","Pending data"
+"TEAM Education Trust","Stubbin Wood and Woodhoots Nursery","Drax"
+"TEAM Education Trust","Stubbin Wood School and Shirebrook Academy","Drax"
+"TEAM Education Trust","Whaley Thorns Primary School and Nursery","Pending data"
+"Tees Valley Collaborative Trust","Bishopton Centre",
+"Tees Valley Collaborative Trust","Errington Primary",
+"Tees Valley Collaborative Trust","Prior Pursglove College",
+"Tees Valley Collaborative Trust","Stockton Sixth Form College",
+"Telford and Wrekin","Hollinswood Primary School and Nursery","Postcode Local Trust"
+"The Cam Academy Trust","Comberton Village College","Drax"
+"The GORSE Academies Trust","Bardsey Primary School","MAT funding"
+"The GORSE Academies Trust","Boston Spa Academy","Drax"
+"The GORSE Academies Trust","Bruntcliffe Academy","Drax"
+"The GORSE Academies Trust","Hillcrest Academy","Drax"
+"The GORSE Academies Trust","Morley Newlands Academy","Drax"
+"The GORSE Academies Trust","Richmond Hill Academy","Drax"
+"The GORSE Academies Trust","Ryecroft Academy","Drax"
+"The GORSE Academies Trust","The Farnley Academy","Drax"
+"The GORSE Academies Trust","The Morley Academy","Drax"
+"The GORSE Academies Trust","The Ruth Gorse Academy","Drax"
+"The GORSE Academies Trust","The Stephen Longfellow Academy","Drax"
+"The Partnership Trust","Abbot Alphege Academy","Postcode Local Trust"
+"The Partnership Trust","Cameley C of E Primary School","OVO Foundation"
+"The Partnership Trust","Castle Primary School","Postcode Local Trust"
+"The Partnership Trust","Fosse Way School","Postcode Local Trust"
+"The Partnership Trust","Hayesdown First School","OVO Foundation"
+"The Partnership Trust","Marksbury C of E Primary School","OVO Foundation"
+"The Partnership Trust","Pensford Primary School","OVO Foundation"
+"The Partnership Trust","Roundhill Primary School","Postcode Local Trust"
+"The Partnership Trust","The Mendip School","Postcode Local Trust"
+"The Partnership Trust","Weston All Saints Primary School","OVO Foundation"
+"The Priory Learning Trust","Berrow Primary Church Academy","Pending data"
+"The Priory Learning Trust","East Huntspill Primary Academy","Postcode Local Trust"
+"The Priory Learning Trust","Pawlett Primary School Academy","Postcode Local Trust"
+"The Priory Learning Trust","Priory Community School Academy","MAT funding"
+"The Priory Learning Trust","St Anne's Church Academy - West Wick Site","MAT funding"
+"The Priory Learning Trust","The King Alfred School","MAT funding"
+"The Priory Learning Trust","West Huntspill Primary Academy","Postcode Local Trust"
+"The Priory Learning Trust","Worle Community School","MAT funding"
+"Tower Hamlets","Harry Gosling Primary School","OVO Foundation"
+"Trafford","Saint Ambrose College",
+"United Learning","Abbey Hey Primary Academy",
+"United Learning","Accrington Academy","School self funding"
+"United Learning","Avonbourne Boys' Academy","OVO Foundation"
+"United Learning","Avonbourne Girls' Academy","OVO Foundation"
+"United Learning","Avonwood Primary School","OVO Foundation"
+"United Learning","Barnsley Academy","Drax"
+"United Learning","Cravenwood Primary Academy",
+"United Learning","Glenmoor Academy","OVO Foundation"
+"United Learning","Hill View Primary School",
+"United Learning","Longshaw Primary Academy","OVO Foundation"
+"United Learning","Newstead Wood School","OVO Foundation"
+"United Learning","Northampton Academy","Drax"
+"United Learning","Richard Rose Central Academy",
+"United Learning","Richard Rose Morton Academy",
+"United Learning","Salford City Academy",
+"United Learning","Salisbury Manor Primary School","OVO Foundation"
+"United Learning","Sheffield Park Academy","Drax"
+"United Learning","Sheffield Springs Academy","Drax"
+"United Learning","Southway Primary School",
+"United Learning","Stockport Academy",
+"United Learning","Surbiton High School","School self funding"
+"United Learning","Swindon Academy - Alton Close","Postcode Local Trust"
+"United Learning","Swindon Academy - Beech Avenue","Postcode Local Trust"
+"United Learning","The Albion Academy",
+"United Learning","The Cornerstone Academy","Postcode Local Trust"
+"United Learning","The Hurlingham Academy","OVO Foundation"
+"United Learning","The Hyndburn Academy",
+"United Learning","The Regis School","School self funding"
+"United Learning","The Regis School - Arena Sports Centre & Swimming Pool","School self funding"
+"United Learning","Walthamstow Primary Academy","OVO Foundation"
+"United Learning","Whittingham Primary Academy","OVO Foundation"
+"United Learning","Winston Way Academy","OVO Foundation"
+"United Learning","Winton Academy","OVO Foundation"
+"United Learning","Wye School",
+"Unity Schools Partnership","Abbots Green Academy","Drax"
+"Unity Schools Partnership","Breckland School","Drax"
+"Unity Schools Partnership","Burton End Primary Academy","Drax"
+"Unity Schools Partnership","Castle Manor Academy","Drax"
+"Unity Schools Partnership","Churchill Special School","Drax"
+"Unity Schools Partnership","Clements Primary School","Drax"
+"Unity Schools Partnership","County Upper School","MAT funding"
+"Unity Schools Partnership","Coupals Primary Academy","Drax"
+"Unity Schools Partnership","Ditton Lodge Primary School","Pending data"
+"Unity Schools Partnership","Felixstowe School","Drax"
+"Unity Schools Partnership","Glemsford Primary Academy","Drax"
+"Unity Schools Partnership","Horringer Court Middle School",
+"Unity Schools Partnership","Houldsworth Valley Primary Academy","Drax"
+"Unity Schools Partnership","Kedington Primary Academy","Pending data"
+"Unity Schools Partnership","Langer Primary Academy","Drax"
+"Unity Schools Partnership","Laureate Community Academy","Drax"
+"Unity Schools Partnership","Newmarket Academy","Drax"
+"Unity Schools Partnership","Place Farm Academy","Drax"
+"Unity Schools Partnership","Samuel Ward Academy","MAT funding"
+"Unity Schools Partnership","Sir Bobby Robson School","Drax"
+"Unity Schools Partnership","Sir Peter Hall Special School","Drax"
+"Unity Schools Partnership","St. Edward’s Church of England Academy","MAT funding"
+"Unity Schools Partnership","Steeple Bumpstead Primary School","Drax"
+"Unity Schools Partnership","Sybil Andrews Academy","MAT funding"
+"Unity Schools Partnership","The Bridge School","Drax"
+"Unity Schools Partnership","Thomas Gainsborough School","Drax"
+"Unity Schools Partnership","Tollgate Primary School","Drax"
+"Unity Schools Partnership","Wells Hall Primary School","Drax"
+"Unity Schools Partnership","West Row Academy","MAT funding"
+"Unity Schools Partnership","Westfield Primary Academy","Drax"
+"Unity Schools Partnership","Westley Middle School","Drax"
+"Unity Schools Partnership","Wickhambrook Primary Academy","Drax"
+"Unity Schools Partnership","Woodhall Primary School","Drax"
+"Warwickshire","Whitestone Infant School","Waiting list for funding"
+"Wensum Trust","Acle Academy","Drax"
+"Wensum Trust","Alderman Peel High School","Drax"
+"Wensum Trust","Arden Grove Infant and Nursery School","Drax"
+"Wensum Trust","Burnham Market Primary School","Drax"
+"Wensum Trust","Firside Junior School",
+"Wensum Trust","Garrick Green Infant School","Drax"
+"Wensum Trust","Heather Avenue Infant School","Drax"
+"Wensum Trust","Hellesdon High School","Drax"
+"Wensum Trust","Kinsale Junior School",
+"Wensum Trust","Lodge Lane Infant School","Drax"
+"Wensum Trust","Wells-next-the-Sea Primary and Nursery School","Drax"
+"Wessex Multi-Academy Trust","Manor Park First School","Laser 50%"
+"Wessex Multi-Academy Trust","Milborne St Andrew First School","Laser 50%"
+"Wessex Multi-Academy Trust","Piddle Valley First School","Laser 50%"
+"Wessex Multi-Academy Trust","Puddletown First School","Laser 50%"
+"Wessex Multi-Academy Trust","St Mary's Middle School","Laser 50%"
+"Wessex Multi-Academy Trust","Frome Valley First School","Laser 50%"
+"Wessex Multi-Academy Trust","Bere Regis School","Laser 50%"
+"Wessex Multi-Academy Trust","Damers First School","Laser 50%"
+"Wessex Multi-Academy Trust","Dorchester Middle School","Laser 50%"
+"Wessex Multi-Academy Trust","St Osmunds Middle School","Laser 50%"
+"Wessex Multi-Academy Trust","The Purbeck School","Laser 50%"
+"Wessex Multi-Academy Trust","The Thomas Hardye School","Laser 50%"
+"Wickersley Partnership Trust","Aston Hall Primary School","Drax"
+"Wickersley Partnership Trust","Aston Lodge Primary School","Drax"
+"Wickersley Partnership Trust","Brinsworth Whitehill Primary School","MAT funding"
+"Wickersley Partnership Trust","Clifton Community School","Drax"
+"Wickersley Partnership Trust","Foljambe Primary School","Drax"
+"Wickersley Partnership Trust","Monkwood Primary Academy","Drax"
+"Wickersley Partnership Trust","Rawmarsh Ashwood Primary School","Drax"
+"Wickersley Partnership Trust","Rawmarsh Community School","Drax"
+"Wickersley Partnership Trust","Rawmarsh Sandhill Primary Academy","Drax"
+"Wickersley Partnership Trust","The Gainsborough Academy","Pending data"
+"Wickersley Partnership Trust","Thrybergh Academy","Drax"
+"Wickersley Partnership Trust","Thrybergh Primary School","Drax"
+"Wickersley Partnership Trust","Wickersley School and Sports College","MAT funding"
+"Wiltshire","Alderbury & West Grimstead Primary School","OVO Foundation"
+"Wiltshire","Bellefield Primary School","OVO Foundation"
+"Wiltshire","Bratton Primary School","OVO Foundation"
+"Wiltshire","Brinkworth Earl Danby's Primary School",
+"Wiltshire","Broad Town Primary school",
+"Wiltshire","Chapmanslade CE VA Primary School",
+"Wiltshire","Colerne Primary School",
+"Wiltshire","Collingbourne Primary School",
+"Wiltshire","Crudwell Primary School","OVO Foundation"
+"Wiltshire","Frogwell Primary School","Postcode Local Trust"
+"Wiltshire","Hilperton Primary School","OVO Foundation"
+"Wiltshire","Kington St Michael Primary School","OVO Foundation"
+"Wiltshire","Lacock Primary School","OVO Foundation"
+"Wiltshire","Langley Fitzurse Primary School","OVO Foundation"
+"Wiltshire","Luckington Community School","OVO Foundation"
+"Wiltshire","Lyneham Primary School","OVO Foundation"
+"Wiltshire","Matravers School","OVO Foundation"
+"Wiltshire","Mere Primary School","OVO Foundation"
+"Wiltshire","Neston Primary School",
+"Wiltshire","Sambourne Primary School","OVO Foundation"
+"Wiltshire","St George's Catholic Primary School","OVO Foundation"
+"Wiltshire","St John's Catholic Primary School, Trowbridge","OVO Foundation"
+"Wiltshire","St Joseph's Catholic Primary School, Devizes","Postcode Local Trust"
+"Wiltshire","St Joseph's Catholic Primary School, Malmesbury","OVO Foundation"
+"Wiltshire","St Mary's Primary School, Purton","OVO Foundation"
+"Wiltshire","St Michael's Primary School, Aldbourne","OVO Foundation"
+"Wiltshire","Stanton St Quintin Primary & Nursery School","OVO Foundation"
+"Wiltshire","Staverton Primary School","OVO Foundation"
+"Wiltshire","Urchfont Primary School","OVO Foundation"
+"Wiltshire","Walwayne Court Primary School","OVO Foundation"
+"Wiltshire","Wardour Catholic Primary School",
+"Wiltshire","Westbury Leigh Primary School","OVO Foundation"
+"Windsor and Maidenhead","Cox Green School","Elbow Beach"
+"Windsor and Maidenhead","Furze Platt Senior School",
+"Windsor and Maidenhead","Kings Court First School",
+"Windsor and Maidenhead","Queen Anne Royal Free C of E First School",
+"Wirral","South Wirral High School",


### PR DESCRIPTION
Adds an after party task to load contents of a CSV file to populate list of funders.

This is a one-off, if we do this again we'll provide a better starting point for matching to avoid looking for schools/funders by name.