### PR TITLE
Add adhoc report for summarising school data availability

### DIFF
--- a/lib/tasks/schools/fuel_data_analysis_report.rake
+++ b/lib/tasks/schools/fuel_data_analysis_report.rake
@@ -1,0 +1,41 @@
+namespace :schools do
+  desc 'Run report to check data availability for targets feature'
+  task fuel_data_analysis_report: [:environment] do
+    puts "#{Time.zone.now} Generating fuel data analysis report"
+    filename = "/tmp/school-fuel-data-analysis.csv"
+    CSV.open(filename, "w") do |csv|
+     csv << ["ID","School","School Group","School Type","Country","Funder","Activation Date","Electricity?",
+       "Electricity Start","Electricity End","Gas?", "Gas Start","Gas End",
+       "Storage heaters?","Storage heater Start","Storage heater End",
+       "Solar?","Swimming Pool","Biomass?","District heating?","LPG?","Oil?"]
+     School.process_data.order(:name).each do |s|
+      csv << [
+        s.id,
+        s.name,
+        s.area_name,
+        s.school_type,
+        s.country,
+        s.funder&.name,
+        (s.activation_date || s.created_at.to_date).iso8601,
+        s.has_electricity?,
+        s.configuration.aggregate_meter_dates.dig("electricity", "start_date"),
+        s.configuration.aggregate_meter_dates.dig("electricity", "end_date"),
+        s.has_gas?,
+        s.configuration.aggregate_meter_dates.dig("gas", "start_date"),
+        s.configuration.aggregate_meter_dates.dig("gas", "end_date"),
+        s.has_storage_heaters?,
+        s.configuration.aggregate_meter_dates.dig("storage_heater", "start_date"),
+        s.configuration.aggregate_meter_dates.dig("storage_heater", "end_date"),
+        s.has_solar_pv?,
+        s.has_swimming_pool,
+        s.alternative_heating_biomass,
+        s.alternative_heating_district_heating,
+        s.alternative_heating_lpg,
+        s.alternative_heating_oil
+      ]
+     end
+    end
+    puts "#{Time.zone.now} Data written to #{filename}"
+    puts "#{Time.zone.now} Generating fuel data analysis report"
+  end
+end


### PR DESCRIPTION
Adds a rake task to generate an ad hoc report for extracting summary of school information along with what fuel types and data they have. Will be run manually for the moment whilst I'd doing some analysis of data availability. Will automate later.