### PR TITLE
Disable running rubocop autocorrect with guard. 

### DIFF
--- a/Guardfile
+++ b/Guardfile
@@ -64,6 +64,6 @@ guard :rspec, cmd: "bundle exec rspec" do
   notification :terminal_notifier if `uname` =~ /Darwin/
 end
 
-guard :rubocop, all_on_start: false, cli: "--autocorrect --config=.rubocop.yml" do
+guard :rubocop, all_on_start: false, cli: "--config=.rubocop.yml" do
   watch(%r{.+\.rb$})
 end


### PR DESCRIPTION
Still run the rubocop check though, this is useful. Having autocorrect run every time I saved a file was not ideal, as quite often I save a file without finishing what I'm doing and rubocop would autocorrect it mid-task...
Having the rubocop linter in my editor is proving to negate the need for autocorrecting. I also (hopefully) am more likely to learn the "right" way to be doing things.