### PR TITLE
Fix tariff editor page calendar language

### DIFF
--- a/app/components/date_picker_form_component/date_picker_form_component.js
+++ b/app/components/date_picker_form_component/date_picker_form_component.js
@@ -1,6 +1,6 @@
 "use strict"
 
-window.onload = function() {
+window.addEventListener("load", (event) => {
   document.querySelectorAll(`[id^="datepickerformcomponent"]`).forEach(element => {
     $('#' + element.id).datetimepicker({
       format: 'DD/MM/YYYY',
@@ -8,4 +8,4 @@ window.onload = function() {
       locale: moment.locale()
     });
   });
-};
+});

--- a/app/components/panel_switcher_component/panel_switcher_component.js
+++ b/app/components/panel_switcher_component/panel_switcher_component.js
@@ -14,6 +14,6 @@ const panel_switcher = (function () {
   }
 })();
 
-window.onload = function() {
+window.addEventListener("load", (event) => {
   $('.panel-switcher-component').on('change', 'input', panel_switcher.updatePanel);
-};
+});


### PR DESCRIPTION
Looks like window.onload overwrites any previous settings of itself - this meant that when the new panel switcher component was added, which also used window.onload, it was overwriting the window.onload for the date picker form component - which is also where it's locale was set.

Fortunately we can use window.addEventListeners instead which appends rather than overwrites
(Jquery is not available at the point this is called, so we use full fat JS)