### PR TITLE
Fix TransportSurvey::TransportType names

### DIFF
--- a/lib/tasks/deployment/20231120150555_fix_transport_type_names.rake
+++ b/lib/tasks/deployment/20231120150555_fix_transport_type_names.rake
@@ -1,0 +1,13 @@
+namespace :after_party do
+  desc 'Deployment task: fix_transport_type_names'
+  task fix_transport_type_names: :environment do
+    puts "Running deploy task 'fix_transport_type_names'"
+
+    ActiveRecord::Base.connection.execute("update mobility_string_translations set translatable_type='TransportSurvey::TransportType' where translatable_type='TransportType'")
+
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord
+      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+  end
+end


### PR DESCRIPTION
Just noticed that transport type names were showing as “null” in the transport survey app. Dug around and realised that when we did the class reorg, that we needed to also consider fields translated with mobility.

In the mobility_string_translations table, the translatable_type was still being referred to as TransportType rather than the new name: TransportSurvey::TransportType. This fixes this.

This is something we need to be aware of in the future when renaming classes... Also goes for anything that is polymorphic with a type column in.