### PR TITLE
Make observations polymorphic and add transport survey observations

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -24,7 +24,6 @@ FactoryBot/CreateList:
     - 'spec/models/issue_spec.rb'
     - 'spec/models/procurement_route_spec.rb'
     - 'spec/models/school_group_spec.rb'
-    - 'spec/models/transport_survey_response_spec.rb'
     - 'spec/services/onboarding/reminder_mailer_spec.rb'
 
 # Offense count: 14
@@ -36,7 +35,6 @@ Lint/ConstantDefinitionInBlock:
     - 'spec/models/concerns/transifex_serialisable_spec.rb'
     - 'spec/models/concerns/translatable_attachment_spec.rb'
     - 'spec/services/alerts/adapters/analytics_adapter_spec.rb'
-    - 'spec/system/schools/transport_surveys_spec.rb'
 
 # Offense count: 2
 # Configuration parameters: MinSize.
@@ -63,7 +61,6 @@ RSpec/BeEql:
     - 'spec/models/school_spec.rb'
     - 'spec/models/school_target_spec.rb'
     - 'spec/models/school_time_spec.rb'
-    - 'spec/models/transport_survey_spec.rb'
     - 'spec/models/user_spec.rb'
     - 'spec/models/weather_station_spec.rb'
     - 'spec/services/activity_creator_spec.rb'
@@ -168,8 +165,6 @@ RSpec/ContextWording:
     - 'spec/models/school_time_spec.rb'
     - 'spec/models/scoreboard_spec.rb'
     - 'spec/models/scored_schools_list_spec.rb'
-    - 'spec/models/transport_survey_response_spec.rb'
-    - 'spec/models/transport_survey_spec.rb'
     - 'spec/models/user_spec.rb'
     - 'spec/routing/energy_tariffs_spec.rb'
     - 'spec/services/activation_email_sender_spec.rb'
@@ -281,7 +276,6 @@ RSpec/ContextWording:
     - 'spec/system/admin/school_removal_spec.rb'
     - 'spec/system/admin/settings/energy_tariffs_spec.rb'
     - 'spec/system/admin/settings_spec.rb'
-    - 'spec/system/admin/transport_types_spec.rb'
     - 'spec/system/admin_mode_spec.rb'
     - 'spec/system/calendar_spec.rb'
     - 'spec/system/case_studies_spec.rb'
@@ -343,8 +337,6 @@ RSpec/ContextWording:
     - 'spec/system/schools/progress_spec.rb'
     - 'spec/system/schools/recommendations_spec.rb'
     - 'spec/system/schools/school_targets_spec.rb'
-    - 'spec/system/schools/transport_surveys_app_spec.rb'
-    - 'spec/system/schools/transport_surveys_spec.rb'
     - 'spec/system/scoreboard_spec.rb'
     - 'spec/system/sign_in_spec.rb'
     - 'spec/system/solar_edge_installation_spec.rb'
@@ -384,7 +376,6 @@ RSpec/ExpectChange:
     - 'spec/models/tariff_price_spec.rb'
     - 'spec/models/tariff_standing_charge_spec.rb'
     - 'spec/models/temperature_recording_spec.rb'
-    - 'spec/models/transport_type_spec.rb'
     - 'spec/services/activity_creator_spec.rb'
     - 'spec/services/alerts/generate_analysis_pages_spec.rb'
     - 'spec/services/alerts/generate_and_save_alerts_and_benchmarks_spec.rb'
@@ -503,7 +494,6 @@ RSpec/LeakyConstantDeclaration:
     - 'spec/models/concerns/transifex_serialisable_spec.rb'
     - 'spec/models/concerns/translatable_attachment_spec.rb'
     - 'spec/services/alerts/adapters/analytics_adapter_spec.rb'
-    - 'spec/system/schools/transport_surveys_spec.rb'
 
 # Offense count: 177
 # Configuration parameters: .
@@ -539,9 +529,6 @@ RSpec/NamedSubject:
     - 'spec/models/school_group_spec.rb'
     - 'spec/models/school_spec.rb'
     - 'spec/models/scoreboard_spec.rb'
-    - 'spec/models/transport_survey_response_spec.rb'
-    - 'spec/models/transport_survey_spec.rb'
-    - 'spec/models/transport_type_spec.rb'
     - 'spec/services/activity_type_filter_spec.rb'
     - 'spec/services/database/vacuum_service_spec.rb'
     - 'spec/services/next_activity_suggester_with_filter_spec.rb'

--- a/app/controllers/schools/transport_surveys_controller.rb
+++ b/app/controllers/schools/transport_surveys_controller.rb
@@ -21,6 +21,10 @@ module Schools
       render :edit
     end
 
+    def edit
+      redirect_to school_transport_survey_responses_url(@school, @transport_survey)
+    end
+
     def update
       if @transport_survey.update(transport_survey_params)
         render json: @transport_survey, status: :ok

--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -88,6 +88,10 @@ class Observation < ApplicationRecord
 
   before_validation :set_observable, if: :observable
 
+  def self.default_timeline_icon
+    'square-check'
+  end
+
   private
 
   def add_bonus_points_for_included_images

--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -55,7 +55,6 @@ class Observation < ApplicationRecord
   # This is the first stage in moving this class over to being fully polymorphic
   # The idea is to eventually move all observation_types (above) to this way of doing things
   belongs_to :observable, polymorphic: true, optional: true
-  # delegated_type :observable, types: %w[TransportSurvey]
 
   validates_presence_of :at, :school
   validates_associated :temperature_recordings
@@ -79,7 +78,7 @@ class Observation < ApplicationRecord
   scope :recorded_in_last_week, -> { where('created_at >= ?', 1.week.ago)}
   scope :recorded_since, ->(date) { where('created_at >= ?', date)}
 
-  scope :engagement, -> { where(observation_type: [:temperature, :intervention, :activity, :audit, :school_target, :programme, :observable]) }
+  scope :engagement, -> { where(observation_type: [:temperature, :intervention, :activity, :audit, :school_target, :programme]) }
 
   has_rich_text :description
 

--- a/app/models/transport_survey.rb
+++ b/app/models/transport_survey.rb
@@ -20,6 +20,7 @@
 class TransportSurvey < ApplicationRecord
   belongs_to :school
   has_many :responses, inverse_of: :transport_survey
+  has_many :observations, as: :observable, dependent: :destroy
 
   validates :run_on, :school_id, presence: true
   validates :run_on, uniqueness: { scope: :school_id }
@@ -107,5 +108,13 @@ class TransportSurvey < ApplicationRecord
     responses_attributes.each do |response_attributes|
       responses.create_with(response_attributes).find_or_create_by(response_attributes.slice(:run_identifier, :surveyed_at))
     end
+    add_observation
+  end
+
+  def add_observation
+    return unless responses.any?
+    return if observations.any? # only one observation permitted per survey
+
+    observations.create!(at: run_on) # do we want to add any points?
   end
 end

--- a/app/models/transport_survey.rb
+++ b/app/models/transport_survey.rb
@@ -113,8 +113,16 @@ class TransportSurvey < ApplicationRecord
 
   def add_observation
     return unless responses.any?
-    return if observations.any? # only one observation permitted per survey
+    return if observations.any? # only one observation permitted per survey day
 
     observations.create!(at: run_on) # do we want to add any points?
+  end
+
+  def self.timeline_icon
+    'car'
+  end
+
+  def timeline_text
+    I18n.t('schools.observations.timeline.transport_survey.message', count: responses.count)
   end
 end

--- a/app/views/schools/observations/timeline/_observable.html.erb
+++ b/app/views/schools/observations/timeline/_observable.html.erb
@@ -1,0 +1,17 @@
+<% observable = observation.observable %>
+
+<td class="p-3 text-center">
+  <%= fa_icon("#{observable.class.try(:timeline_icon) || Observation.default_timeline_icon} fa-2x") %>
+</td>
+<td>
+  <h3 class="pt-1"><strong><%= link_to observable.timeline_text, polymorphic_path([observable.school, observable])%></strong></h3>
+  <span class="text-muted"><%= nice_dates(observation.at) %></span>
+</td>
+<% if show_actions && can?(:manage, observable) %>
+  <td class="text-right">
+    <div class="btn-group">
+      <%= link_to t('common.labels.edit'), edit_polymorphic_path([observable.school, observable]), class: 'btn btn-warning' %>
+      <%= link_to t('common.labels.delete'), polymorphic_path([observable.school, observable]), method: :delete, data: { confirm: t('common.confirm_delete', observable: observable.class.model_name.human) }, class: 'btn btn-danger' %>
+    </div>
+  </td>
+<% end %>

--- a/app/views/shared/_dashboard_timeline.html.erb
+++ b/app/views/shared/_dashboard_timeline.html.erb
@@ -12,7 +12,7 @@
 
   <div class="row justify-content-md-center">
     <div class="col col-md-10">
-      <%= render 'schools/observations/timeline', observations: observations, show_actions: true %>
+      <%= render 'schools/observations/timeline', observations: observations, show_actions: false %>
     </div>
   </div>
 <% end %>

--- a/app/views/shared/_dashboard_timeline.html.erb
+++ b/app/views/shared/_dashboard_timeline.html.erb
@@ -12,7 +12,7 @@
 
   <div class="row justify-content-md-center">
     <div class="col col-md-10">
-      <%= render 'schools/observations/timeline', observations: observations, show_actions: false%>
+      <%= render 'schools/observations/timeline', observations: observations, show_actions: true %>
     </div>
   </div>
 <% end %>

--- a/config/locales/common.yml
+++ b/config/locales/common.yml
@@ -6,6 +6,7 @@ en:
     back_to_top: Back to top
     bar_charts: Bar charts
     confirm: Are you sure?
+    confirm_delete: Are you sure you want to delete %{observable}?
     data: data
     electricity: Electricity
     electricity_and_solar_pv: Electricity and Solar PV

--- a/config/locales/views/schools/schools.yml
+++ b/config/locales/views/schools/schools.yml
@@ -332,6 +332,10 @@ en:
           completed_a_programme: Completed a programme
         temperatures:
           recorded_temperatures_in: Recorded temperatures in
+        transport_survey:
+          message:
+            one: Started a transport survey
+            other: Recorded %{count} transport survey responses
     private:
       access_disabled: This school has disabled public access to energy usage data and insights.
       login_links_html: Use the links below to log in as a member of staff or pupil from this school. Or <a href='%{schools_path}'>explore another school</a>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -266,7 +266,7 @@ Rails.application.routes.draw do
       resources :audits
 
       resources :temperature_observations, only: [:show, :new, :create, :index, :destroy]
-      resources :transport_surveys, only: [:show, :update, :index, :destroy], param: :run_on do
+      resources :transport_surveys, only: [:show, :update, :index, :destroy, :edit], param: :run_on do
         collection do
           get :start
         end

--- a/db/migrate/20231121141221_add_polymorphism_to_observation.rb
+++ b/db/migrate/20231121141221_add_polymorphism_to_observation.rb
@@ -1,0 +1,5 @@
+class AddPolymorphismToObservation < ActiveRecord::Migration[6.0]
+  def change
+    add_reference :observations, :observable, polymorphic: true, allow_nil: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -915,13 +915,13 @@ ActiveRecord::Schema.define(version: 2023_11_21_141221) do
     t.index ["replaced_by_id"], name: "index_global_meter_attributes_on_replaced_by_id"
   end
 
-  create_table "good_job_processes", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "good_job_processes", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.jsonb "state"
   end
 
-  create_table "good_job_settings", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "good_job_settings", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.text "key"
@@ -929,7 +929,7 @@ ActiveRecord::Schema.define(version: 2023_11_21_141221) do
     t.index ["key"], name: "index_good_job_settings_on_key", unique: true
   end
 
-  create_table "good_jobs", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "good_jobs", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.text "queue_name"
     t.integer "priority"
     t.jsonb "serialized_params"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_10_27_093450) do
+ActiveRecord::Schema.define(version: 2023_11_21_141221) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
@@ -915,13 +915,13 @@ ActiveRecord::Schema.define(version: 2023_10_27_093450) do
     t.index ["replaced_by_id"], name: "index_global_meter_attributes_on_replaced_by_id"
   end
 
-  create_table "good_job_processes", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "good_job_processes", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.jsonb "state"
   end
 
-  create_table "good_job_settings", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "good_job_settings", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.text "key"
@@ -929,7 +929,7 @@ ActiveRecord::Schema.define(version: 2023_10_27_093450) do
     t.index ["key"], name: "index_good_job_settings_on_key", unique: true
   end
 
-  create_table "good_jobs", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "good_jobs", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.text "queue_name"
     t.integer "priority"
     t.jsonb "serialized_params"
@@ -1227,9 +1227,12 @@ ActiveRecord::Schema.define(version: 2023_10_27_093450) do
     t.bigint "school_target_id"
     t.bigint "programme_id"
     t.integer "pupil_count"
+    t.string "observable_type"
+    t.bigint "observable_id"
     t.index ["activity_id"], name: "index_observations_on_activity_id"
     t.index ["audit_id"], name: "index_observations_on_audit_id"
     t.index ["intervention_type_id"], name: "index_observations_on_intervention_type_id"
+    t.index ["observable_type", "observable_id"], name: "index_observations_on_observable_type_and_observable_id"
     t.index ["programme_id"], name: "index_observations_on_programme_id"
     t.index ["school_id"], name: "index_observations_on_school_id"
     t.index ["school_target_id"], name: "index_observations_on_school_target_id"

--- a/lib/tasks/deployment/20231122132353_backfill_transport_observations.rake
+++ b/lib/tasks/deployment/20231122132353_backfill_transport_observations.rake
@@ -1,0 +1,13 @@
+namespace :after_party do
+  desc 'Deployment task: backfill_transport_observations'
+  task backfill_transport_observations: :environment do
+    puts "Running deploy task 'backfill_transport_observations'"
+
+    TransportSurvey.all.find_each(&:add_observation)
+
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord
+      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+  end
+end

--- a/spec/models/observation_spec.rb
+++ b/spec/models/observation_spec.rb
@@ -157,5 +157,19 @@ describe Observation do
         expect(observation.points).to eq(50)
       end
     end
+
+    context "when observable" do
+      let(:transport_survey) { create(:transport_survey, school: school) }
+
+      subject(:observation) { Observation.create(observable: transport_survey) }
+
+      it "sets observation_type" do
+        expect(observation.observation_type).to eq('observable')
+      end
+
+      it "sets school from related object" do
+        expect(observation.school).to eq(transport_survey.school)
+      end
+    end
   end
 end

--- a/spec/models/transport_survey_spec.rb
+++ b/spec/models/transport_survey_spec.rb
@@ -2,27 +2,27 @@ require 'rails_helper'
 
 describe 'TransportSurvey' do
   context "with valid attributes" do
-    subject { create :transport_survey }
+    subject(:transport_survey) { create :transport_survey }
 
     it { is_expected.to be_valid }
   end
 
   describe "#responses=" do
-    subject { create :transport_survey }
+    subject(:transport_survey) { create :transport_survey }
 
     describe "adding a response" do
       let(:attributes) { attributes_for(:transport_survey_response, surveyed_at: surveyed_at, run_identifier: run_identifier) }
       let(:surveyed_at) { DateTime.new(2021, 0o3, 18, 9, 0, 0) }
       let(:run_identifier) { 1234 }
 
-      before { subject.responses = [attributes] }
+      before { transport_survey.responses = [attributes] }
 
-      it { expect(subject.responses.length).to eql 1 }
+      it { expect(transport_survey.responses.length).to eql 1 }
 
       describe "adding another response" do
         let(:new_attributes) { attributes_for(:transport_survey_response, surveyed_at: new_surveyed_at, run_identifier: new_run_identifier) }
 
-        before { subject.responses = [new_attributes] }
+        before { transport_survey.responses = [new_attributes] }
 
         context "with the same run_identifier" do
           let(:new_run_identifier) { run_identifier }
@@ -30,13 +30,13 @@ describe 'TransportSurvey' do
           context "and the same surveyed_at time" do
             let(:new_surveyed_at) { surveyed_at }
 
-            it { expect(subject.responses.length).to eql 1 }
+            it { expect(transport_survey.responses.length).to eql 1 }
           end
 
           context "and different surveyed_at time" do
             let(:new_surveyed_at) { DateTime.new(2022, 0o3, 18, 9, 0, 0) }
 
-            it { expect(subject.responses.length).to eql 2 }
+            it { expect(transport_survey.responses.length).to eql 2 }
           end
         end
 
@@ -46,13 +46,13 @@ describe 'TransportSurvey' do
           context "and the same surveyed_at time" do
             let(:new_surveyed_at) { surveyed_at }
 
-            it { expect(subject.responses.length).to eql 2 }
+            it { expect(transport_survey.responses.length).to eql 2 }
           end
 
           context "and a different surveyed_at time" do
             let(:new_surveyed_at) { DateTime.new(2022, 0o3, 18, 9, 0, 0) }
 
-            it { expect(subject.responses.length).to eql 2 }
+            it { expect(transport_survey.responses.length).to eql 2 }
           end
         end
       end
@@ -60,64 +60,64 @@ describe 'TransportSurvey' do
   end
 
   describe "#total_responses" do
-    subject { create :transport_survey }
+    subject(:transport_survey) { create :transport_survey }
 
     context "with no responses" do
-      it { expect(subject.total_responses).to eql 0 }
+      it { expect(transport_survey.total_responses).to eql 0 }
     end
 
     context "with one response" do
       before do
-        create :transport_survey_response, transport_survey: subject, passengers: 2
+        create :transport_survey_response, transport_survey: transport_survey, passengers: 2
       end
 
-      it { expect(subject.total_responses).to eql 1 }
+      it { expect(transport_survey.total_responses).to eql 1 }
     end
 
     context "with more than one response" do
       before do
-        create :transport_survey_response, transport_survey: subject, passengers: 2
-        create :transport_survey_response, transport_survey: subject, passengers: 3
+        create :transport_survey_response, transport_survey: transport_survey, passengers: 2
+        create :transport_survey_response, transport_survey: transport_survey, passengers: 3
       end
 
-      it { expect(subject.total_responses).to eql 2 }
+      it { expect(transport_survey.total_responses).to eql 2 }
     end
   end
 
   describe "#total_carbon" do
-    subject { create :transport_survey }
+    subject(:transport_survey) { create :transport_survey }
 
     context "with no responses" do
-      it { expect(subject.total_carbon).to eql 0 }
+      it { expect(transport_survey.total_carbon).to eql 0 }
     end
 
     context "with one response" do
-      let!(:response) { create(:transport_survey_response, transport_survey: subject, passengers: 2) }
+      let!(:response) { create(:transport_survey_response, transport_survey: transport_survey, passengers: 2) }
 
-      it { expect(subject.total_carbon).to eql response.carbon }
+      it { expect(transport_survey.total_carbon).to eql response.carbon }
     end
 
     context "with more than one response" do
       let!(:responses) do
-        [create(:transport_survey_response, transport_survey: subject, passengers: 2),
-         create(:transport_survey_response, transport_survey: subject, passengers: 3)]
+        [create(:transport_survey_response, transport_survey: transport_survey, passengers: 2),
+         create(:transport_survey_response, transport_survey: transport_survey, passengers: 3)]
       end
 
       it "adds up the carbon for each response" do
-        expect(subject.total_carbon).to eql(responses[0].carbon + responses[1].carbon)
+        expect(transport_survey.total_carbon).to eql(responses[0].carbon + responses[1].carbon)
       end
     end
   end
 
   describe "Category based methods" do
-    subject { create :transport_survey }
+    subject(:transport_survey) { create :transport_survey }
 
     let(:categories) { TransportSurvey::TransportType.categories.keys << nil }
 
     def create_responses(cats)
       cats.each do |cat|
         transport_type = create(:transport_type, category: cat)
-        create(:transport_survey_response, transport_survey: subject, transport_type: transport_type, passengers: 3)
+        create(:transport_survey_response, transport_survey: transport_survey, transport_type: transport_type, passengers: 3)
       end
     end
 
@@ -126,7 +126,7 @@ describe 'TransportSurvey' do
         before { create_responses(categories) }
 
         it "returns a hash of responses per category" do
-          expect(subject.responses_per_category).to eql({ "car" => 1, "walking_and_cycling" => 1, "public_transport" => 1, "park_and_stride" => 1, "other" => 1 })
+          expect(transport_survey.responses_per_category).to eql({ "car" => 1, "walking_and_cycling" => 1, "public_transport" => 1, "park_and_stride" => 1, "other" => 1 })
         end
       end
 
@@ -134,21 +134,21 @@ describe 'TransportSurvey' do
         before { create_responses(categories.excluding('car', 'walking_and_cycling')) }
 
         it "returns a hash with zero values for missing categories" do
-          expect(subject.responses_per_category).to eql({ "car" => 0, "walking_and_cycling" => 0, "public_transport" => 1, "park_and_stride" => 1, "other" => 1 })
+          expect(transport_survey.responses_per_category).to eql({ "car" => 0, "walking_and_cycling" => 0, "public_transport" => 1, "park_and_stride" => 1, "other" => 1 })
         end
 
         context "and categories have multiple responses" do
           before { create_responses(categories) }
 
           it "adds them up" do
-            expect(subject.responses_per_category).to eql({ "car" => 1, "walking_and_cycling" => 1, "public_transport" => 2, "park_and_stride" => 2, "other" => 2 })
+            expect(transport_survey.responses_per_category).to eql({ "car" => 1, "walking_and_cycling" => 1, "public_transport" => 2, "park_and_stride" => 2, "other" => 2 })
           end
         end
       end
 
       context "when there are no responses" do
         it "returns a hash with zero values for missing categories" do
-          expect(subject.responses_per_category).to eql({ "car" => 0, "walking_and_cycling" => 0, "public_transport" => 0, "park_and_stride" => 0, "other" => 0 })
+          expect(transport_survey.responses_per_category).to eql({ "car" => 0, "walking_and_cycling" => 0, "public_transport" => 0, "park_and_stride" => 0, "other" => 0 })
         end
       end
     end
@@ -158,7 +158,7 @@ describe 'TransportSurvey' do
         before { create_responses(categories) }
 
         it "returns a hash of responses percentages per category" do
-          expect(subject.percentage_per_category).to eql({ "car" => 20.0, "walking_and_cycling" => 20.0, "public_transport" => 20.0, "park_and_stride" => 20.0, "other" => 20.0 })
+          expect(transport_survey.percentage_per_category).to eql({ "car" => 20.0, "walking_and_cycling" => 20.0, "public_transport" => 20.0, "park_and_stride" => 20.0, "other" => 20.0 })
         end
       end
 
@@ -166,21 +166,21 @@ describe 'TransportSurvey' do
         before { create_responses(categories.excluding('car', 'park_and_stride', nil)) }
 
         it "returns zero values for missing categories" do
-          expect(subject.percentage_per_category).to eql({ "car" => 0, "walking_and_cycling" => 50.0, "public_transport" => 50.0, "park_and_stride" => 0, "other" => 0 })
+          expect(transport_survey.percentage_per_category).to eql({ "car" => 0, "walking_and_cycling" => 50.0, "public_transport" => 50.0, "park_and_stride" => 0, "other" => 0 })
         end
 
         context "and categories have multiple responses" do
           before { create_responses(categories) }
 
           it "adds them up" do
-            expect(subject.percentage_per_category).to eql({ "car" => 14.285714285714285, "walking_and_cycling" => 28.57142857142857, "public_transport" => 28.57142857142857, "park_and_stride" => 14.285714285714285, "other" => 14.285714285714285 })
+            expect(transport_survey.percentage_per_category).to eql({ "car" => 14.285714285714285, "walking_and_cycling" => 28.57142857142857, "public_transport" => 28.57142857142857, "park_and_stride" => 14.285714285714285, "other" => 14.285714285714285 })
           end
         end
       end
 
       context "when there are no responses" do
         it "returns zero values for missing categories" do
-          expect(subject.percentage_per_category).to eql({ "car" => 0, "walking_and_cycling" => 0, "public_transport" => 0, "park_and_stride" => 0, "other" => 0 })
+          expect(transport_survey.percentage_per_category).to eql({ "car" => 0, "walking_and_cycling" => 0, "public_transport" => 0, "park_and_stride" => 0, "other" => 0 })
         end
       end
     end
@@ -190,7 +190,7 @@ describe 'TransportSurvey' do
         before { create_responses(categories) }
 
         it "returns passenger percentages per category" do
-          expect(subject.pie_chart_data).to eql([{ name: "Walking and cycling", y: 20.0 }, { name: "Car", y: 20.0 }, { name: "Public transport", y: 20.0 }, { name: "Park and stride", y: 20.0 }, { name: "Other", y: 20.0 }])
+          expect(transport_survey.pie_chart_data).to eql([{ name: "Walking and cycling", y: 20.0 }, { name: "Car", y: 20.0 }, { name: "Public transport", y: 20.0 }, { name: "Park and stride", y: 20.0 }, { name: "Other", y: 20.0 }])
         end
       end
 
@@ -198,25 +198,25 @@ describe 'TransportSurvey' do
         before { create_responses(categories.excluding('car', 'park_and_stride', nil)) }
 
         it "returns zero values for missing categories" do
-          expect(subject.pie_chart_data).to eql([{ name: "Walking and cycling", y: 50.0 }, { name: "Car", y: 0 }, { name: "Public transport", y: 50.0 }, { name: "Park and stride", y: 0 }, { name: "Other", y: 0 }])
+          expect(transport_survey.pie_chart_data).to eql([{ name: "Walking and cycling", y: 50.0 }, { name: "Car", y: 0 }, { name: "Public transport", y: 50.0 }, { name: "Park and stride", y: 0 }, { name: "Other", y: 0 }])
         end
       end
 
       context "when there are no responses" do
         it "returns zero values for missing categories" do
-          expect(subject.pie_chart_data).to eql([{ name: "Walking and cycling", y: 0 }, { name: "Car", y: 0 }, { name: "Public transport", y: 0 }, { name: "Park and stride", y: 0 }, { name: "Other", y: 0 }])
+          expect(transport_survey.pie_chart_data).to eql([{ name: "Walking and cycling", y: 0 }, { name: "Car", y: 0 }, { name: "Public transport", y: 0 }, { name: "Park and stride", y: 0 }, { name: "Other", y: 0 }])
         end
       end
     end
   end
 
   describe "time based methods" do
-    subject { create :transport_survey }
+    subject(:transport_survey) { create :transport_survey }
 
     def create_responses(times, cat)
       times.each do |time|
         transport_type = create(:transport_type, category: cat)
-        create(:transport_survey_response, transport_survey: subject, transport_type: transport_type, journey_minutes: time)
+        create(:transport_survey_response, transport_survey: transport_survey, transport_type: transport_type, journey_minutes: time)
       end
     end
 
@@ -227,7 +227,7 @@ describe 'TransportSurvey' do
         before { create_responses(TransportSurvey::Response.journey_minutes_options, category) }
 
         it "returns a hash of responses count per time" do
-          expect(subject.responses_per_time_for_category(category)).to eql({ 5 => 1, 10 => 1, 15 => 1, 20 => 1, 30 => 1, 45 => 1, 60 => 1 })
+          expect(transport_survey.responses_per_time_for_category(category)).to eql({ 5 => 1, 10 => 1, 15 => 1, 20 => 1, 30 => 1, 45 => 1, 60 => 1 })
         end
       end
 
@@ -238,7 +238,7 @@ describe 'TransportSurvey' do
         end
 
         it "adds up responses" do
-          expect(subject.responses_per_time_for_category(category)).to eql({ 5 => 1, 10 => 2, 15 => 2, 20 => 2, 30 => 2, 45 => 2, 60 => 2 })
+          expect(transport_survey.responses_per_time_for_category(category)).to eql({ 5 => 1, 10 => 2, 15 => 2, 20 => 2, 30 => 2, 45 => 2, 60 => 2 })
         end
       end
 
@@ -246,7 +246,7 @@ describe 'TransportSurvey' do
         before { create_responses(TransportSurvey::Response.journey_minutes_options[..0], category) }
 
         it "has zero values for those times" do
-          expect(subject.responses_per_time_for_category(category)).to eql({ 5 => 1, 10 => 0, 15 => 0, 20 => 0, 30 => 0, 45 => 0, 60 => 0 })
+          expect(transport_survey.responses_per_time_for_category(category)).to eql({ 5 => 1, 10 => 0, 15 => 0, 20 => 0, 30 => 0, 45 => 0, 60 => 0 })
         end
       end
 
@@ -257,7 +257,7 @@ describe 'TransportSurvey' do
         end
 
         it "only counts those in specified category" do
-          expect(subject.responses_per_time_for_category(category)).to eql({ 5 => 1, 10 => 0, 15 => 0, 20 => 0, 30 => 0, 45 => 0, 60 => 0 })
+          expect(transport_survey.responses_per_time_for_category(category)).to eql({ 5 => 1, 10 => 0, 15 => 0, 20 => 0, 30 => 0, 45 => 0, 60 => 0 })
         end
       end
     end
@@ -269,7 +269,7 @@ describe 'TransportSurvey' do
         before { create_responses(TransportSurvey::Response.journey_minutes_options, category) }
 
         it "sums 30+ minutes together" do
-          expect(subject.responses_per_time_for_category_car).to eql({ 5 => 1, 10 => 1, 15 => 1, 20 => 1, '30+' => 3 })
+          expect(transport_survey.responses_per_time_for_category_car).to eql({ 5 => 1, 10 => 1, 15 => 1, 20 => 1, '30+' => 3 })
         end
       end
 
@@ -280,7 +280,7 @@ describe 'TransportSurvey' do
         end
 
         it "sums 30+ minutes together" do
-          expect(subject.responses_per_time_for_category_car).to eql({ 5 => 1, 10 => 2, 15 => 2, 20 => 2, '30+' => 6 })
+          expect(transport_survey.responses_per_time_for_category_car).to eql({ 5 => 1, 10 => 2, 15 => 2, 20 => 2, '30+' => 6 })
         end
       end
     end
@@ -288,15 +288,60 @@ describe 'TransportSurvey' do
 
   describe "#today?" do
     context "when survey has a run_on date of today" do
-      subject { create :transport_survey, run_on: Time.zone.today }
+      subject(:transport_survey) { create :transport_survey, run_on: Time.zone.today }
 
-      it { expect(subject.today?).to be true }
+      it { expect(transport_survey.today?).to be true }
     end
 
     context "when survey has a run_on date other than today" do
-      subject { create :transport_survey, run_on: 3.days.ago }
+      subject(:transport_survey) { create :transport_survey, run_on: 3.days.ago }
 
-      it { expect(subject.today?).to be false }
+      it { expect(transport_survey.today?).to be false }
+    end
+  end
+
+  describe "#add_observation" do
+    context "when there are no responses" do
+      subject(:transport_survey) { create :transport_survey, run_on: Time.zone.today, responses: [] }
+
+      it 'does not add an observation' do
+        expect(transport_survey.observations).to be_empty
+      end
+    end
+
+    context "with responses" do
+      subject(:transport_survey) { create :transport_survey, run_on: Time.zone.today }
+
+      let(:attributes) { attributes_for(:transport_survey_response, surveyed_at: Time.zone.now, run_identifier: '2345') }
+
+      before { transport_survey.responses = [attributes] }
+
+      it 'adds an observation' do
+        expect(transport_survey.responses.length).to eql(1)
+        expect(Observation.find_by(observable: transport_survey)).not_to be_nil
+        expect(transport_survey.reload.observations.length).to eql(1)
+      end
+
+      context "when transport survey is removed" do
+        before do
+          transport_survey.destroy
+        end
+
+        it 'removes observation' do
+          expect(Observation.find_by(observable: transport_survey)).to be_nil
+        end
+      end
+
+      context "when more responses are added" do
+        let(:new_attributes) { attributes_for(:transport_survey_response, surveyed_at: Time.zone.now, run_identifier: '4567') }
+
+        before { transport_survey.responses = [new_attributes] }
+
+        it "doesn't add another observation" do
+          expect(transport_survey.responses.length).to eql(2)
+          expect(transport_survey.reload.observations.length).to eql(1)
+        end
+      end
     end
   end
 end

--- a/spec/models/transport_survey_spec.rb
+++ b/spec/models/transport_survey_spec.rb
@@ -17,7 +17,7 @@ describe 'TransportSurvey' do
 
       before { transport_survey.responses = [attributes] }
 
-      it { expect(transport_survey.responses.length).to eql 1 }
+      it { expect(transport_survey.responses.length).to be 1 }
 
       describe "adding another response" do
         let(:new_attributes) { attributes_for(:transport_survey_response, surveyed_at: new_surveyed_at, run_identifier: new_run_identifier) }
@@ -27,32 +27,32 @@ describe 'TransportSurvey' do
         context "with the same run_identifier" do
           let(:new_run_identifier) { run_identifier }
 
-          context "and the same surveyed_at time" do
+          context "with the same surveyed_at time" do
             let(:new_surveyed_at) { surveyed_at }
 
-            it { expect(transport_survey.responses.length).to eql 1 }
+            it { expect(transport_survey.responses.length).to be 1 }
           end
 
-          context "and different surveyed_at time" do
+          context "with a different surveyed_at time" do
             let(:new_surveyed_at) { DateTime.new(2022, 0o3, 18, 9, 0, 0) }
 
-            it { expect(transport_survey.responses.length).to eql 2 }
+            it { expect(transport_survey.responses.length).to be 2 }
           end
         end
 
         context "with a different run_identifier" do
           let(:new_run_identifier) { 9999 }
 
-          context "and the same surveyed_at time" do
+          context "with the same surveyed_at time" do
             let(:new_surveyed_at) { surveyed_at }
 
-            it { expect(transport_survey.responses.length).to eql 2 }
+            it { expect(transport_survey.responses.length).to be 2 }
           end
 
-          context "and a different surveyed_at time" do
+          context "with a different surveyed_at time" do
             let(:new_surveyed_at) { DateTime.new(2022, 0o3, 18, 9, 0, 0) }
 
-            it { expect(transport_survey.responses.length).to eql 2 }
+            it { expect(transport_survey.responses.length).to be 2 }
           end
         end
       end
@@ -63,7 +63,7 @@ describe 'TransportSurvey' do
     subject(:transport_survey) { create :transport_survey }
 
     context "with no responses" do
-      it { expect(transport_survey.total_responses).to eql 0 }
+      it { expect(transport_survey.total_responses).to be 0 }
     end
 
     context "with one response" do
@@ -71,7 +71,7 @@ describe 'TransportSurvey' do
         create :transport_survey_response, transport_survey: transport_survey, passengers: 2
       end
 
-      it { expect(transport_survey.total_responses).to eql 1 }
+      it { expect(transport_survey.total_responses).to be 1 }
     end
 
     context "with more than one response" do
@@ -80,7 +80,7 @@ describe 'TransportSurvey' do
         create :transport_survey_response, transport_survey: transport_survey, passengers: 3
       end
 
-      it { expect(transport_survey.total_responses).to eql 2 }
+      it { expect(transport_survey.total_responses).to be 2 }
     end
   end
 
@@ -88,13 +88,13 @@ describe 'TransportSurvey' do
     subject(:transport_survey) { create :transport_survey }
 
     context "with no responses" do
-      it { expect(transport_survey.total_carbon).to eql 0 }
+      it { expect(transport_survey.total_carbon).to be 0 }
     end
 
     context "with one response" do
       let!(:response) { create(:transport_survey_response, transport_survey: transport_survey, passengers: 2) }
 
-      it { expect(transport_survey.total_carbon).to eql response.carbon }
+      it { expect(transport_survey.total_carbon).to eq response.carbon }
     end
 
     context "with more than one response" do
@@ -137,7 +137,7 @@ describe 'TransportSurvey' do
           expect(transport_survey.responses_per_category).to eql({ "car" => 0, "walking_and_cycling" => 0, "public_transport" => 1, "park_and_stride" => 1, "other" => 1 })
         end
 
-        context "and categories have multiple responses" do
+        context "when categories have multiple responses" do
           before { create_responses(categories) }
 
           it "adds them up" do
@@ -169,7 +169,7 @@ describe 'TransportSurvey' do
           expect(transport_survey.percentage_per_category).to eql({ "car" => 0, "walking_and_cycling" => 50.0, "public_transport" => 50.0, "park_and_stride" => 0, "other" => 0 })
         end
 
-        context "and categories have multiple responses" do
+        context "when categories have multiple responses" do
           before { create_responses(categories) }
 
           it "adds them up" do
@@ -309,7 +309,7 @@ describe 'TransportSurvey' do
       end
     end
 
-    context "with responses" do
+    context "when there are responses" do
       subject(:transport_survey) { create :transport_survey, run_on: Time.zone.today }
 
       let(:attributes) { attributes_for(:transport_survey_response, surveyed_at: Time.zone.now, run_identifier: '2345') }
@@ -317,9 +317,9 @@ describe 'TransportSurvey' do
       before { transport_survey.responses = [attributes] }
 
       it 'adds an observation' do
-        expect(transport_survey.responses.length).to eql(1)
+        expect(transport_survey.responses.length).to be(1)
         expect(Observation.find_by(observable: transport_survey)).not_to be_nil
-        expect(transport_survey.reload.observations.length).to eql(1)
+        expect(transport_survey.reload.observations.length).to be(1)
       end
 
       context "when transport survey is removed" do
@@ -338,8 +338,8 @@ describe 'TransportSurvey' do
         before { transport_survey.responses = [new_attributes] }
 
         it "doesn't add another observation" do
-          expect(transport_survey.responses.length).to eql(2)
-          expect(transport_survey.reload.observations.length).to eql(1)
+          expect(transport_survey.responses.length).to be(2)
+          expect(transport_survey.reload.observations.length).to be(1)
         end
       end
     end

--- a/spec/system/admin/transport_types_spec.rb
+++ b/spec/system/admin/transport_types_spec.rb
@@ -5,7 +5,7 @@ describe "admin transport type", type: :system, include_application_helper: true
   let!(:transport_type) { create(:transport_type, can_share: false, park_and_stride: false) }
 
   describe 'when not logged in' do
-    context "and viewing the index" do
+    context "when viewing the index" do
       before do
         visit admin_transport_types_path
       end
@@ -15,7 +15,7 @@ describe "admin transport type", type: :system, include_application_helper: true
       end
     end
 
-    context "and viewing a transport type" do
+    context "when viewing a transport type" do
       before do
         visit admin_transport_type_path(transport_type)
       end
@@ -80,7 +80,7 @@ describe "admin transport type", type: :system, include_application_helper: true
         end
       end
 
-      context "and clicking the transport type link" do
+      context "when clicking the transport type link" do
         before do
           click_link(transport_type.name)
         end
@@ -95,7 +95,7 @@ describe "admin transport type", type: :system, include_application_helper: true
         it { expect(page).to have_link('Delete') }
         it { expect(page).to have_link('New Transport type') }
 
-        context "and clicking the edit button" do
+        context "when clicking the edit button" do
           before do
             click_link("Edit")
           end
@@ -105,7 +105,7 @@ describe "admin transport type", type: :system, include_application_helper: true
           end
         end
 
-        context "and clicking the new button" do
+        context "when clicking the new button" do
           before do
             click_link("New Transport type")
           end
@@ -115,7 +115,7 @@ describe "admin transport type", type: :system, include_application_helper: true
           end
         end
 
-        context "and clicking on the delete button" do
+        context "when clicking on the delete button" do
           before do
             click_link('Delete')
           end
@@ -142,12 +142,12 @@ describe "admin transport type", type: :system, include_application_helper: true
         end
       end
 
-      context "and some action buttons" do
+      context "with some action buttons" do
         it { expect(page).to have_link('Back') }
         it { expect(page).to have_link('Edit') }
         it { expect(page).to have_link('Delete') }
 
-        context "and clicking on the back button" do
+        context "when clicking on the back button" do
           before do
             click_link('Back')
           end
@@ -157,7 +157,7 @@ describe "admin transport type", type: :system, include_application_helper: true
           end
         end
 
-        context "and clicking on the edit button" do
+        context "when clicking on the edit button" do
           before do
             click_link('Edit')
           end
@@ -167,7 +167,7 @@ describe "admin transport type", type: :system, include_application_helper: true
           end
         end
 
-        context "and clicking on the delete button" do
+        context "when clicking on the delete button" do
           before do
             click_link('Delete')
           end
@@ -331,7 +331,7 @@ describe "admin transport type", type: :system, include_application_helper: true
     end
 
     describe "Deleting a transport type" do
-      context "from the index page" do
+      context "when on the index page" do
         context "when the transport type has associated responses" do
           before do
             create(:transport_survey_response, transport_type: transport_type)
@@ -352,7 +352,7 @@ describe "admin transport type", type: :system, include_application_helper: true
 
           it { expect(page).to have_selector(:table_row, display_attributes) }
 
-          context "and clicking delete and confirming" do
+          context "when clicking delete and confirming" do
             before do
               accept_confirm do
                 click_link("Delete")
@@ -374,7 +374,7 @@ describe "admin transport type", type: :system, include_application_helper: true
             end
           end
 
-          context "and clicking delete and dismissing" do
+          context "when clicking delete and dismissing" do
             before do
               dismiss_confirm do
                 click_link("Delete")

--- a/spec/system/schools/dashboard/timeline_spec.rb
+++ b/spec/system/schools/dashboard/timeline_spec.rb
@@ -7,12 +7,15 @@ RSpec.shared_examples "dashboard timeline" do
     create(:observation_with_temperature_recording_and_location, school: test_school)
     activity_type = create(:activity_type) # doesn't get saved if built with activity below
     create(:activity, school: test_school, activity_type: activity_type)
-    #will automatically add observation
+    # will automatically add observation
     create(:school_target, school: test_school, start_date: Time.zone.today)
+    transport_survey = create(:transport_survey, school: test_school, run_on: Time.zone.today)
+    transport_survey.responses = [attributes_for(:transport_survey_response)]
     visit school_path(test_school, switch: true)
   end
 
   it 'displays events in a timeline' do
+    expect(page).to have_content('Started a transport survey')
     expect(page).to have_content('Recorded temperatures in')
     expect(page).to have_content('Upgraded insulation')
     expect(page).to have_content('Completed an activity')

--- a/spec/system/schools/transport_surveys_app_spec.rb
+++ b/spec/system/schools/transport_surveys_app_spec.rb
@@ -13,7 +13,7 @@ describe 'TransportSurveys - App', type: :system do
         sign_in(user)
       end
 
-      context "viewing the start page" do
+      context "when viewing the start page" do
         before do
           visit start_school_transport_surveys_path(school)
         end
@@ -25,7 +25,7 @@ describe 'TransportSurveys - App', type: :system do
         context "when javascript is enabled", js: true do
           it { expect(page).to have_button('Launch survey app') }
 
-          context "launching the app" do
+          context "when launching the app" do
             before do
               click_button('Launch survey app')
             end
@@ -36,7 +36,7 @@ describe 'TransportSurveys - App', type: :system do
             it { expect(page).to have_link(weather) }
             it { expect(page).to have_button('Finish & save results 0', disabled: true) }
 
-            context "selecting the weather" do
+            context "when selecting the weather" do
               before do
                 click_link weather
               end
@@ -48,7 +48,7 @@ describe 'TransportSurveys - App', type: :system do
               it { expect(page).not_to have_button('Back') }
               it { expect(page).to have_button('Finish & save results 0', disabled: true) }
 
-              context "selecting a time" do
+              context "when selecting a time" do
                 before do
                   click_link time.to_s
                 end
@@ -59,7 +59,7 @@ describe 'TransportSurveys - App', type: :system do
                 it { expect(page).to have_button('Back') }
                 it { expect(page).to have_button('Finish & save results 0', disabled: true) }
 
-                context "clicking back button" do
+                context "when clicking back button" do
                   before do
                     click_button("Back")
                   end
@@ -68,7 +68,7 @@ describe 'TransportSurveys - App', type: :system do
                   it { expect(page).to have_content('Time: How many minutes did your journey take in total?') }
                 end
 
-                context "selecting a transport type where carbon cannot be shared" do
+                context "when selecting a transport type where carbon cannot be shared" do
                   let(:transport_type) { transport_type_not_shareable }
 
                   before do
@@ -81,7 +81,7 @@ describe 'TransportSurveys - App', type: :system do
                   it { expect(page).to have_button('Back') }
                   it { expect(page).to have_button('Finish & save results 0', disabled: true) }
 
-                  context "clicking back button" do
+                  context "when clicking back button" do
                     before do
                       click_button("Back")
                     end
@@ -90,7 +90,7 @@ describe 'TransportSurveys - App', type: :system do
                     it { expect(page).to have_content('Transport: What mode of transport did you use to get to school?') }
                   end
 
-                  context "confirming selection" do
+                  context "when confirming selection" do
                     before do
                       click_button("Confirm")
                     end
@@ -108,7 +108,7 @@ describe 'TransportSurveys - App', type: :system do
                   end
                 end
 
-                context "selecting a transport type where carbon can be shared" do
+                context "when selecting a transport type where carbon can be shared" do
                   let(:transport_type) { transport_type_shareable }
 
                   before do
@@ -122,7 +122,7 @@ describe 'TransportSurveys - App', type: :system do
                   it { expect(page).to have_button('Finish & save results 0', disabled: true) }
                   it { expect(page).to have_button('Back') }
 
-                  context "clicking back button" do
+                  context "when clicking back button" do
                     before do
                       click_button("Back")
                     end
@@ -131,7 +131,7 @@ describe 'TransportSurveys - App', type: :system do
                   end
 
 
-                  context "selecting passengers" do
+                  context "when selecting passengers" do
                     before do
                       click_link(passengers_link)
                     end
@@ -148,7 +148,7 @@ describe 'TransportSurveys - App', type: :system do
                     it { expect(page).to have_button('Back') }
                     it { expect(page).to have_button('Finish & save results 0', disabled: true) }
 
-                    context "clicking back button" do
+                    context "when clicking back button" do
                       before do
                         click_button("Back")
                       end
@@ -157,7 +157,7 @@ describe 'TransportSurveys - App', type: :system do
                       it { expect(page).to have_content('Sharing: How many pupils') }
                     end
 
-                    context "confirming selection" do
+                    context "when confirming selection" do
                       before do
                         click_button("Confirm")
                       end
@@ -173,7 +173,7 @@ describe 'TransportSurveys - App', type: :system do
                       it { expect(page).to have_button('Finish & save results 1', disabled: false) }
                       it { expect(page).not_to have_button('Back') }
 
-                      context "next survey run" do
+                      context "with next survey run" do
                         before do
                           click_button("Next pupil")
                         end
@@ -182,7 +182,7 @@ describe 'TransportSurveys - App', type: :system do
                         it { expect(page).to have_button('Finish & save results 1', disabled: false) }
                       end
 
-                      context "Saving results" do
+                      context "when saving results" do
                         before do
                           click_button("Finish & save results 1")
                         end

--- a/spec/system/schools/transport_surveys_spec.rb
+++ b/spec/system/schools/transport_surveys_spec.rb
@@ -157,10 +157,10 @@ describe 'TransportSurveys', type: :system, include_application_helper: true do
     # pupil - as above except deleting Surveys and Transport Survey Responses
     # public user - read access only for everything (but not the start page)
 
-    MANAGING_USER_TYPES = [:admin, :group_admin, :school_admin, :staff].freeze
-    SURVEYING_USER_TYPES = MANAGING_USER_TYPES + [:pupil]
+    managing_user_types = [:admin, :group_admin, :school_admin, :staff]
+    surveying_user_types = managing_user_types + [:pupil]
 
-    SURVEYING_USER_TYPES.each do |user_type|
+    surveying_user_types.each do |user_type|
       describe "as a #{user_type} user who can carry out surveys" do
         let(:user) { create(user_type, school: school) }
 
@@ -168,7 +168,7 @@ describe 'TransportSurveys', type: :system, include_application_helper: true do
           sign_in(user)
         end
 
-        context "viewing the start page" do
+        context "when viewing the start page" do
           before do
             visit start_school_transport_surveys_path(school)
           end
@@ -179,7 +179,7 @@ describe 'TransportSurveys', type: :system, include_application_helper: true do
           it { expect(page).to have_link('View all transport surveys') }
           it { expect(page).not_to have_css('#survey_nav') }
 
-          context "and clicking the 'View all transport surveys' button" do
+          context "when clicking the 'View all transport surveys' button" do
             before do
               click_link 'View all transport surveys'
             end
@@ -190,7 +190,7 @@ describe 'TransportSurveys', type: :system, include_application_helper: true do
       end
     end
 
-    MANAGING_USER_TYPES.each do |user_type|
+    managing_user_types.each do |user_type|
       describe "as a #{user_type} user who can delete surveys and manage & delete responses" do
         let!(:user) { create(user_type, school: school) }
 
@@ -203,7 +203,7 @@ describe 'TransportSurveys', type: :system, include_application_helper: true do
         let!(:transport_survey_response) { create(:transport_survey_response, transport_survey: transport_survey, transport_type: transport_type) }
 
 
-        context "viewing transport surveys index" do
+        context "when viewing transport surveys index" do
           before do
             visit school_transport_surveys_path(school)
           end
@@ -224,7 +224,7 @@ describe 'TransportSurveys', type: :system, include_application_helper: true do
             expect(page).to have_link('Delete')
           end
 
-          context "and managing responses" do
+          context "when managing responses" do
             before do
               within('table') do
                 click_link("Manage")
@@ -241,7 +241,7 @@ describe 'TransportSurveys', type: :system, include_application_helper: true do
               expect(page).to have_content(nice_date_times(transport_survey_response.surveyed_at, localtime: true))
             end
 
-            context "and deleting response" do
+            context "when deleting response" do
               before do
                 within('table') do
                   click_link('Delete')
@@ -259,7 +259,7 @@ describe 'TransportSurveys', type: :system, include_application_helper: true do
               expect(page).to have_link('Download responses')
             end
 
-            context "and downloading responses" do
+            context "when downloading responses" do
               before do
                 click_link('Download responses')
               end
@@ -278,7 +278,7 @@ describe 'TransportSurveys', type: :system, include_application_helper: true do
             end
           end
 
-          context "and deleting transport survey" do
+          context "when deleting transport survey" do
             before do
               within('table') do
                 click_link('Delete')
@@ -304,7 +304,7 @@ describe 'TransportSurveys', type: :system, include_application_helper: true do
         sign_in(pupil)
       end
 
-      context "viewing transport surveys index" do
+      context "when viewing transport surveys index" do
         before do
           visit school_transport_surveys_path(school)
         end
@@ -329,7 +329,7 @@ describe 'TransportSurveys', type: :system, include_application_helper: true do
           expect(page).not_to have_link('Delete')
         end
 
-        context "and viewing results" do
+        context "when viewing results" do
           before do
             click_link("View results")
           end
@@ -355,7 +355,7 @@ describe 'TransportSurveys', type: :system, include_application_helper: true do
     end
 
     describe 'as a public user with read only access' do
-      context "viewing the start page" do
+      context "when viewing the start page" do
         before do
           visit start_school_transport_surveys_path(school)
         end
@@ -363,7 +363,7 @@ describe 'TransportSurveys', type: :system, include_application_helper: true do
         it { expect(page).not_to have_content('Travel to School Surveys') }
       end
 
-      context "viewing transport surveys index" do
+      context "when viewing transport surveys index" do
         let!(:transport_survey) { create(:transport_survey, school: school) }
         let!(:transport_survey_response) { create(:transport_survey_response, transport_survey: transport_survey, transport_type: transport_type) }
 
@@ -392,7 +392,7 @@ describe 'TransportSurveys', type: :system, include_application_helper: true do
           expect(page).not_to have_link('Manage')
         end
 
-        context "and viewing results" do
+        context "when viewing results" do
           before do
             click_link("View results")
           end


### PR DESCRIPTION
* Makes observation polymorphic
* Adds transport observation using a generic template. Suspect when we move the others over, that they will mostly all need their own template still though
* Backfills old transport observations
* Also does a bit of a rubocop cleanup on the transport stuff (I removed all reference to transport from the rubocop todo and fixed it).