### PR TITLE
Ensure climate change levy displays on cost table

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,8 +22,8 @@ gem 'closed_struct'
 gem 'pg_search'
 
 # Dashboard analytics
-gem 'energy-sparks_analytics', git: 'https://github.com/Energy-Sparks/energy-sparks_analytics.git', tag: '4.1.7'
-#gem 'energy-sparks_analytics', git: 'https://github.com/Energy-Sparks/energy-sparks_analytics.git', branch: '3896-new-school-comparison-benchmark-for-ovo-analysis'
+#gem 'energy-sparks_analytics', git: 'https://github.com/Energy-Sparks/energy-sparks_analytics.git', tag: '4.1.7'
+gem 'energy-sparks_analytics', git: 'https://github.com/Energy-Sparks/energy-sparks_analytics.git', branch: '3924-climate-charge-levy-not-appearing-on-the-current-costs-table'
 #gem 'energy-sparks_analytics', path: '../energy-sparks_analytics'
 
 # Using master due to it having a patch which doesn't override Enumerable#sum if it's already defined

--- a/Gemfile
+++ b/Gemfile
@@ -22,8 +22,8 @@ gem 'closed_struct'
 gem 'pg_search'
 
 # Dashboard analytics
-#gem 'energy-sparks_analytics', git: 'https://github.com/Energy-Sparks/energy-sparks_analytics.git', tag: '4.1.7'
-gem 'energy-sparks_analytics', git: 'https://github.com/Energy-Sparks/energy-sparks_analytics.git', branch: '3924-climate-charge-levy-not-appearing-on-the-current-costs-table'
+gem 'energy-sparks_analytics', git: 'https://github.com/Energy-Sparks/energy-sparks_analytics.git', tag: '4.1.8'
+#gem 'energy-sparks_analytics', git: 'https://github.com/Energy-Sparks/energy-sparks_analytics.git', branch: '3924-climate-charge-levy-not-appearing-on-the-current-costs-table'
 #gem 'energy-sparks_analytics', path: '../energy-sparks_analytics'
 
 # Using master due to it having a patch which doesn't override Enumerable#sum if it's already defined

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/Energy-Sparks/energy-sparks_analytics.git
-  revision: 513c9174bc3fca9e52aa96e8bb0db84879a841c1
-  branch: 3924-climate-charge-levy-not-appearing-on-the-current-costs-table
+  revision: 22ff5450543cd7bf3da15b5c5cbd8f9a4bdd7ba7
+  tag: 4.1.8
   specs:
     energy-sparks_analytics (1.2.1)
       activesupport (>= 6.0, < 7.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/Energy-Sparks/energy-sparks_analytics.git
-  revision: b5a9279dbf7662bc01b2ab305bddc02b5add36bd
-  tag: 4.1.7
+  revision: 513c9174bc3fca9e52aa96e8bb0db84879a841c1
+  branch: 3924-climate-charge-levy-not-appearing-on-the-current-costs-table
   specs:
     energy-sparks_analytics (1.2.1)
       activesupport (>= 6.0, < 7.1)

--- a/app/components/meter_costs_table_component.rb
+++ b/app/components/meter_costs_table_component.rb
@@ -99,7 +99,7 @@ class MeterCostsTableComponent < ViewComponent::Base
   end
 
   def other
-    [:feed_in_tariff_levy, :climate_change_levy__2021_22, :renewable_energy_obligation]
+    [:feed_in_tariff_levy, :climate_change_levy, :renewable_energy_obligation]
   end
 
   def vat_charges

--- a/config/locales/cy/views/advice_pages/advice_pages.yml
+++ b/config/locales/cy/views/advice_pages/advice_pages.yml
@@ -106,8 +106,7 @@ cy:
       labels:
         bill_components:
           agreed_availability_charge: Tâl argaeledd y cytunwyd arno
-          climate_change_levy__2020_21: Ardoll newid hinsawdd (2020/21)
-          climate_change_levy__2021_22: Ardoll newid hinsawdd (2021/22)
+          climate_change_levy: Ardoll newid hinsawdd
           commodity_rate: Cyfradd nwyddau
           data_collection_dcda_agent_charge: Tâl asiant DC/DA
           day_night: "%{time_from} i %{time_to}"

--- a/config/locales/views/advice_pages/advice_pages.yml
+++ b/config/locales/views/advice_pages/advice_pages.yml
@@ -107,8 +107,7 @@ en:
       labels:
         bill_components:
           agreed_availability_charge: Agreed availability charge
-          climate_change_levy__2020_21: Climate change levy (2020/21)
-          climate_change_levy__2021_22: Climate change levy (2021/22)
+          climate_change_levy: Climate change levy
           commodity_rate: Commodity rate
           data_collection_dcda_agent_charge: DC/DA agent charge
           day_night: "%{time_from} to %{time_to}"


### PR DESCRIPTION
Pulls in the changes from: https://github.com/Energy-Sparks/energy-sparks_analytics/pull/636.

Also updated the meter table component and translation keys so that the Climate Change Levy costs display correctly.