### PR TITLE
Add another special case for unvalidated reading report

### DIFF
--- a/app/models/amr_data_feed_reading.rb
+++ b/app/models/amr_data_feed_reading.rb
@@ -100,6 +100,7 @@ class AmrDataFeedReading < ApplicationRecord
         SELECT mpan_mprn, meter_id, identifier, amr_data_feed_configs.description, reading_date,
         CASE
           WHEN reading_date ~ '\\d{1,2}-(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)-\\d{2}' THEN to_date(reading_date, 'DD-MON-YY')
+          WHEN date_format='%d-%b-%y' AND reading_date~'\\d{4}-\\d{2}-\\d{2}' THEN to_date(reading_date, 'YYYY-MM-DD')
           WHEN date_format='%d-%m-%Y' AND reading_date~'\\d{4}-\\d{2}-\\d{2}' THEN to_date(reading_date, 'YYYY-MM-DD')
           WHEN date_format='%d-%m-%Y' THEN to_date(reading_date, 'DD-MM-YYYY')
           WHEN date_format='%d/%m/%Y' AND reading_date~'\\d{4}-\\d{2}-\\d{2}' THEN to_date(reading_date, 'YYYY-MM-DD')

--- a/spec/models/amr_data_feed_reading_spec.rb
+++ b/spec/models/amr_data_feed_reading_spec.rb
@@ -40,6 +40,7 @@ describe AmrDataFeedReading do
 
     context 'with incorrectly loaded data' do
       FORMATS = {
+        '%d-%b-%y' => '2023-06-28',
         '%Y-%m-%d' => '28-Jun-23',
         '%d-%m-%Y' => '2023-06-28',
         '%e %b %Y %H:%M:%S' => '2023-06-28'


### PR DESCRIPTION
Add another format specific check to the unvalidated readings report.

I'm not sure if the cause here is the date format being updated and so historical data is now problematic. Or recent data was loaded with an unexpected date format.

Need to tackle the longer term fix of actually storing the parsed dates on the unvalidated readings table, not reparsing later. That warrants a separate discussion and PR.