### PR TITLE
Make all dropdown menus scrollable so they can be seen on smaller screens

### DIFF
--- a/app/views/shared/_about_menu.html.erb
+++ b/app/views/shared/_about_menu.html.erb
@@ -1,6 +1,6 @@
 <li class="nav-item dropdown" id="about-menu">
   <a class="nav-link dropdown-toggle" href="#" id="aboutDropDown" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"><%= t('about_menu.about_us') %></a>
-  <div class="dropdown-menu" aria-labelledby="aboutDropDown">
+  <div class="dropdown-menu scrollable" aria-labelledby="aboutDropDown">
     <%= link_to t('about_menu.contact'), contact_path, class: 'dropdown-item' %>
     <%= link_to t('about_menu.team'), team_path, class: 'dropdown-item' %>
     <%= link_to t('about_menu.blog'), "http://blog.energysparks.uk", target:"_blank", class: 'dropdown-item' %>

--- a/app/views/shared/_my_school_menu.html.erb
+++ b/app/views/shared/_my_school_menu.html.erb
@@ -1,6 +1,6 @@
 <li class="nav-item dropdown" id="my_school_menu">
   <a class="nav-link dropdown-toggle" href="#" id="my_school" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"><%= t('my_school_menu.my_school') %></a>
-  <div class="dropdown-menu" aria-labelledby="my_school">
+  <div class="dropdown-menu scrollable" aria-labelledby="my_school">
     <!--School -->
     <%= link_to current_user.school.name, school_path(current_user.school), class: 'dropdown-item' %>
 

--- a/app/views/shared/_our_services_menu.html.erb
+++ b/app/views/shared/_our_services_menu.html.erb
@@ -1,6 +1,6 @@
 <li class="nav-item dropdown" id="our-services">
   <a class="nav-link dropdown-toggle" href="#" id="ourServicesDropDown" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"><%= t('our_services_menu.our_services') %></a>
-  <div class="dropdown-menu" aria-labelledby="ourServicesDropDown">
+  <div class="dropdown-menu scrollable" aria-labelledby="ourServicesDropDown">
     <%= link_to t('our_services_menu.for_schools'), for_schools_path, class: 'dropdown-item' %>
     <%= link_to t('our_services_menu.for_multi_academy_trusts'), for_multi_academy_trusts_path, class: 'dropdown-item' %>
     <%= link_to t('our_services_menu.for_local_authorities'), for_local_authorities_path, class: 'dropdown-item' %>


### PR DESCRIPTION
The main point of this PR was to make all elements of the "My school" menu accessible on smaller screens.

I’ve fixed this by making the menu scrollable. The Manage School menu was already scrollable, as we were having the same issue because it had so many items, even for bigger screens.

I’ve also added this to the Our services and About us menus, as whilst they are not quite as long, the same issue could occur on smaller screens such as a phone.