### PR TITLE
Fix transport survey slugs for transifex

### DIFF
--- a/app/models/concerns/transifex_serialisable.rb
+++ b/app/models/concerns/transifex_serialisable.rb
@@ -117,7 +117,7 @@ module TransifexSerialisable
   end
 
   def resource_key
-    "#{self.class.model_name.i18n_key}_#{self.id}"
+    "#{self.class.model_name.param_key}_#{self.id}"
   end
 
   def yaml_template_to_mustache(value)

--- a/app/models/transport_survey/transport_type.rb
+++ b/app/models/transport_survey/transport_type.rb
@@ -54,4 +54,10 @@ class TransportSurvey::TransportType < ApplicationRecord
   def tx_name
     name
   end
+
+  # override default slug to use original name pre-moving to module
+  # keeps in sync with the data already in transifex
+  def tx_slug
+    "transport_type_#{self.id}"
+  end
 end

--- a/spec/models/transport_survey/transport_type_spec.rb
+++ b/spec/models/transport_survey/transport_type_spec.rb
@@ -65,7 +65,7 @@ describe TransportSurvey::TransportType do
     subject(:transport_type) { build(:transport_type) }
 
     it 'produces expected slug' do
-      expect(transport_type.tx_slug).to eq('transport_type_1')
+      expect(transport_type.tx_slug).to eq("transport_type_#{transport_type.id}")
     end
   end
 end

--- a/spec/models/transport_survey/transport_type_spec.rb
+++ b/spec/models/transport_survey/transport_type_spec.rb
@@ -60,4 +60,12 @@ describe TransportSurvey::TransportType do
       expect(TransportSurvey::TransportType.categories_with_other['other']).to be_nil
     end
   end
+
+  describe '#tx_slug' do
+    subject(:transport_type) { build(:transport_type) }
+
+    it 'produces expected slug' do
+      expect(transport_type.tx_slug).to eq('transport_type_1')
+    end
+  end
 end


### PR DESCRIPTION
Moving the `TransportSurvey::TransportType`s to a module has broken the serialisation to transifex for this content.

By default the `TransifexSerialisable` concern uses the `i18n_key` of the class name to produce the default slugs that are passed to transifex. For `TransportSurvey` this now returns this:

```
2.7.6 :007 > TransportSurvey::TransportType.model_name.i18n_key
 => :"transport_survey/transport_type" 
```

The forward slash is not valid in Transifex and causes an API error.

This PR:

* Changes the default serialisation to use `param_key`, which produces e.g. `transport_survey_transport_type` so that it better supports namespaced models in future
* Overrides `tx_slug` in `TransportSurvey` to use the old name so that we can keep the existing translations, otherwise these would be seen as new strings.
