### PR TITLE
Fix link in alert emails

### DIFF
--- a/app/views/alert_mailer/alert_email.html.erb
+++ b/app/views/alert_mailer/alert_email.html.erb
@@ -28,7 +28,7 @@
 <% end %>
 
 <p>
-  <%= t('alert_mailer.alert_email.dashboard_and_analysis_message_html', school_url: school_url(@school, params: weekly_alert_utm_parameters), school_analysis_index_url: school_analysis_index_url(@school, params: weekly_alert_utm_parameters)) %>.
+  <%= t('alert_mailer.alert_email.dashboard_and_analysis_message_html', school_url: school_url(@school, params: weekly_alert_utm_parameters), school_analysis_index_url: school_advice_url(@school, params: weekly_alert_utm_parameters)) %>.
 </p>
 
 <%= link_to t('alert_mailer.alert_email.view_your_school_dashboard'), school_url(@school, params: weekly_alert_utm_parameters), class: 'btn btn-primary mt-3 mb-3 ax-right'%>

--- a/spec/services/alerts/generate_email_notifications_spec.rb
+++ b/spec/services/alerts/generate_email_notifications_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 describe Alerts::GenerateEmailNotifications do
+  include Rails.application.routes.url_helpers
+
   let(:school)               { create(:school) }
   let(:alert_generation_run) { create(:alert_generation_run, school: school) }
   let(:alert_type)           { create(:alert_type, advice_page: create(:advice_page, key: :baseload))}
@@ -61,9 +63,17 @@ describe Alerts::GenerateEmailNotifications do
     end
 
     context 'when generating email body' do
-        let(:email) { ActionMailer::Base.deliveries.last }
-        let(:email_body) { email.body.to_s }
-        let(:matcher) { Capybara::Node::Simple.new(email_body.to_s) }
+        let(:email)       { ActionMailer::Base.deliveries.last }
+        let(:email_body)  { email.body.to_s }
+        let(:matcher)     { Capybara::Node::Simple.new(email_body.to_s) }
+
+        let(:params) do
+          {
+            "utm_source": "weekly-alert",
+            "utm_medium": "email",
+            "utm_campaign": "alerts"
+          }
+        end
 
         it 'includes all alert content' do
           expect(email_body).to include('You need to do something')
@@ -83,9 +93,9 @@ describe Alerts::GenerateEmailNotifications do
 
         it 'includes links to dashboard and analysis pages' do
           expect(email_body).to include("Stay up to date")
-          expect(matcher).to have_link("school dashboard")
-          expect(matcher).to have_link("detailed analysis")
-          expect(matcher).to have_link("View your school dashboard")
+          expect(matcher).to have_link("school dashboard", href: school_url(school, params: params, host: 'localhost'))
+          expect(matcher).to have_link("detailed analysis", href: school_advice_url(school, params: params, host: 'localhost'))
+          expect(matcher).to have_link("View your school dashboard", href: school_url(school, params: params, host: 'localhost'))
         end
     end
   end


### PR DESCRIPTION
The email alerts still have a link to the old advice page. This PR updates the alert template to fix the link and add explicit assertions for the expected urls to the spec, not just checks for the link text.