### PR TITLE
Don't add a margin for sub nav when not logged in

### DIFF
--- a/app/assets/stylesheets/base.scss
+++ b/app/assets/stylesheets/base.scss
@@ -35,7 +35,7 @@ div.application.container {
   padding-bottom: 30px;
 }
 
-body.with-sub-nav div.application.container {
+div.application.container.sub-nav {
   margin-top: 100px;
 }
 

--- a/app/helpers/nav_helper.rb
+++ b/app/helpers/nav_helper.rb
@@ -36,8 +36,13 @@ module NavHelper
     @header_fix_enabled == true
   end
 
+  def sub_nav?
+    @sub_nav == true
+  end
+
   def conditional_application_container_classes
     classes = ''
+    classes += ' sub-nav' if sub_nav?
     classes += ' header-fix' if header_fix_enabled?
     classes
   end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -3,7 +3,7 @@
   <head>
     <%= render 'shared/head' %>
   </head>
-  <body vocab="http://schema.org/" class="<%= 'with-sub-nav' if show_sub_nav?(@school || @tariff_holder, @hide_subnav) || request.path.starts_with?('/school_groups') %>">
+  <body vocab="http://schema.org/" class="<%= 'with-sub-nav' if show_sub_nav?(@school || @tariff_holder, @hide_subnav) || (request.path.starts_with?('/school_groups') && can?(:update_settings, @school_group || @tariff_holder)) %>">
     <%= render 'shared/navigation' %>
     <div class="application container<%= conditional_application_container_classes %>">
       <%= render 'shared/breadcrumbs' %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -3,7 +3,7 @@
   <head>
     <%= render 'shared/head' %>
   </head>
-  <body vocab="http://schema.org/" class="<%= 'with-sub-nav' if show_sub_nav?(@school || @tariff_holder, @hide_subnav) || (request.path.starts_with?('/school_groups') && can?(:update_settings, @school_group || @tariff_holder)) %>">
+  <body vocab="http://schema.org/">
     <%= render 'shared/navigation' %>
     <div class="application container<%= conditional_application_container_classes %>">
       <%= render 'shared/breadcrumbs' %>

--- a/app/views/school_groups/_sub_nav.html.erb
+++ b/app/views/school_groups/_sub_nav.html.erb
@@ -1,3 +1,4 @@
+<% @sub_nav = true %>
 <nav class="navbar navbar-expand-lg navbar-custom sub-navbar" id='school-group-subnav'>
   <div class="container">
     <div>

--- a/app/views/shared/_nav.html.erb
+++ b/app/views/shared/_nav.html.erb
@@ -1,4 +1,4 @@
-<nav class="navbar <%= navbar_expand_class %> navbar-custom<%= " navbar-mini" if local_assigns[:with_sub_nav] %>">
+<nav class="navbar <%= navbar_expand_class %> navbar-custom<%= " navbar-mini" if local_assigns[:mini_nav] %>">
   <div class="container">
     <%= navbar_image_link %>
     <%= on_test_link %>
@@ -14,7 +14,7 @@
             <%= link_to t('nav.sign_out'), destroy_user_session_path, method: :delete, class: 'nav-link' %>
           </li>
         <% else %>
-          <% if local_assigns[:with_sub_nav] %>
+          <% if local_assigns[:mini_nav] %>
             <li class="nav-item">
               <%= link_to t('nav.sign_in'), new_user_session_path, class: 'nav-link' %>
             </li>

--- a/app/views/shared/_navigation.html.erb
+++ b/app/views/shared/_navigation.html.erb
@@ -1,15 +1,15 @@
 <div class='fixed-top'>
   <% if show_sub_nav?(@school, @hide_subnav) %>
-    <%= render 'shared/nav', with_sub_nav: true %>
+    <%= render 'shared/nav', mini_nav: true %>
     <%= render 'shared/sub_nav', podium: current_school_podium, school: @school || @tariff_holder %>
   <% elsif @tariff_holder&.school? && show_sub_nav?(@tariff_holder, @hide_subnav) %>
-    <%= render 'shared/nav', with_sub_nav: true %>
+    <%= render 'shared/nav', mini_nav: true %>
     <%= render 'shared/sub_nav', podium: current_school_podium, school: @tariff_holder %>
   <% elsif @school_group && EnergySparks::FeatureFlags.active?(:enhanced_school_group_dashboard) && request.path.starts_with?('/school_groups') && can?(:update_settings, @school_group) %>
-    <%= render 'shared/nav', with_sub_nav: true %>
+    <%= render 'shared/nav', mini_nav: true %>
     <%= render('school_groups/sub_nav', school_group: @school_group) if can?(:update_settings, @school_group || @tariff_holder) %>
   <% elsif @tariff_holder&.school_group? && EnergySparks::FeatureFlags.active?(:enhanced_school_group_dashboard) && request.path.starts_with?('/school_groups') && can?(:update_settings, @tariff_holder) %>
-    <%= render 'shared/nav', with_sub_nav: true %>
+    <%= render 'shared/nav', mini_nav: true %>
     <%= render('school_groups/sub_nav', school_group: @tariff_holder) if can?(:update_settings, @tariff_holder) %>
   <% else %>
     <%= render 'shared/nav' %>

--- a/app/views/shared/_sub_nav.html.erb
+++ b/app/views/shared/_sub_nav.html.erb
@@ -1,3 +1,4 @@
+<% @sub_nav = true %>
 <nav class="navbar navbar-expand-lg navbar-custom sub-navbar">
   <div class="container">
     <% if school.active %>

--- a/spec/models/procurement_route_spec.rb
+++ b/spec/models/procurement_route_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe ProcurementRoute, type: :model do
   describe ".to_csv" do
     let(:procurement_route) { create(:procurement_route) }
     let(:data_source) { create(:data_source) }
-    subject { procurement_route.to_csv }
+    subject(:csv) { procurement_route.to_csv }
 
     let(:header) { "School group,School,MPAN/MPRN,Meter type,Active,Half-Hourly,First validated meter reading,Last validated meter reading,Admin Meter Status,Data Source,Open issues count,Open issues" }
 
@@ -41,12 +41,12 @@ RSpec.describe ProcurementRoute, type: :model do
         end
       end
 
-      it { expect(subject.lines.count).to eq(3) }
-      it { expect(subject.lines.first.chomp).to eq(header) }
+      it { expect(csv.lines.count).to eq(3) }
+      it { expect(csv.lines.first.chomp).to eq(header) }
 
       2.times do |i|
         it 'returns rows for all meters for active schools with this procurement route' do
-          expect(subject.lines[i + 1].chomp).to eq(
+          expect(csv).to include(
             (
               [
                 meters[i].school.school_group.try(:name),
@@ -72,12 +72,12 @@ RSpec.describe ProcurementRoute, type: :model do
         create_list(:gas_meter, 2)
       end
 
-      it { expect(subject.lines.count).to eq(1) }
+      it { expect(csv.lines.count).to eq(1) }
     end
 
     context "with no meters" do
-      it { expect(subject.lines.count).to eq(1) }
-      it { expect(subject.lines.first.chomp).to eq(header) }
+      it { expect(csv.lines.count).to eq(1) }
+      it { expect(csv.lines.first.chomp).to eq(header) }
     end
   end
 end


### PR DESCRIPTION
When not logged in and viewing this page, there is a margin for the sub nav but there is no sub nav present:
https://energysparks.uk/school_groups/prince-albert-community-trust

I've taken the complexity out of deciding to show a bigger margin or not and just created a switch that is set when the sub-nav is rendered. The logic for showing a sub-nav is rather complex (see shared/_navigation.html.erb) and not something that can be easily summed up in a one-liner.

This also (hopefully) fixes a flickering test