### PR TITLE
Remove axis choices for thermostatic analysis charts

### DIFF
--- a/app/views/schools/advice/storage_heaters/_analysis.html.erb
+++ b/app/views/schools/advice/storage_heaters/_analysis.html.erb
@@ -131,7 +131,7 @@
 
 <%= render 'your_thermostatic_control_notice' %>
 
-<%= component 'chart', chart_type: :storage_heater_thermostatic, school: @school do |c| %>
+<%= component 'chart', chart_type: :storage_heater_thermostatic, axis_controls: false, school: @school do |c| %>
   <% c.with_title do %>
     <%= t('advice_pages.storage_heaters.analysis.thermostatic_control.storage_heater_thermostatic.title') %>
   <% end %>

--- a/app/views/schools/advice/thermostatic_control/_analysis.html.erb
+++ b/app/views/schools/advice/thermostatic_control/_analysis.html.erb
@@ -39,7 +39,7 @@
        ) %>
 </p>
 
-<%= component 'chart', chart_type: :thermostatic_up_to_1_year, school: @school do |c| %>
+<%= component 'chart', chart_type: :thermostatic_up_to_1_year, axis_controls: false, school: @school do |c| %>
   <% c.with_title do %>
     <%= t('advice_pages.thermostatic_control.analysis.thermostatic_up_to_1_year.title') %>
   <% end %>
@@ -68,7 +68,7 @@
 
 <%= t('advice_pages.thermostatic_control.analysis.an_alternative_way_of_looking_html') %>
 
-<%= component 'chart', chart_type: :thermostatic_control_large_diurnal_range, school: @school do |c| %>
+<%= component 'chart', chart_type: :thermostatic_control_large_diurnal_range, axis_controls: false, school: @school do |c| %>
   <% c.with_title do %>
     <%= t('advice_pages.thermostatic_control.analysis.thermostatic_control_large_diurnal_range.title') %>
   <% end %>

--- a/spec/system/schools/advice_pages/storage_heaters_spec.rb
+++ b/spec/system/schools/advice_pages/storage_heaters_spec.rb
@@ -95,6 +95,9 @@ RSpec.describe "storage heaters advice page", type: :system do
         expect(page).to have_css('#chart_wrapper_storage_heater_group_by_week_long_term')
         expect(page).to have_css('#chart_wrapper_heating_on_off_by_week_storage_heater')
         expect(page).to have_css('#chart_wrapper_storage_heater_thermostatic')
+        within '#chart_wrapper_storage_heater_thermostatic' do
+          expect(page).not_to have_css(".axis-choice")
+        end
         expect(page).to have_content("Storage heater use during holidays")
         expect(page).to have_content(Date.new(2021, 12, 18).to_s(:es_short))
       end

--- a/spec/system/schools/advice_pages/thermostatic_control_spec.rb
+++ b/spec/system/schools/advice_pages/thermostatic_control_spec.rb
@@ -59,6 +59,12 @@ RSpec.describe "thermostatic control advice page", type: :system do
         expect(page).to have_content("Your school's R² value is 0.67 which is about average")
         expect(page).to have_css('#chart_wrapper_thermostatic_up_to_1_year')
         expect(page).to have_css('#chart_wrapper_thermostatic_control_large_diurnal_range')
+
+        ['#chart_wrapper_thermostatic_up_to_1_year', '#chart_wrapper_thermostatic_control_large_diurnal_range'].each do |chart_type|
+          within chart_type do
+            expect(page).not_to have_css(".axis-choice")
+          end
+        end
       end
     end
 


### PR DESCRIPTION
The thermostatic analysis charts plot consumption (kWh) against temperature. This is to show how the linear regression has associated usage across different temperatures with periods when the heating is on or off.

The charts don't support viewing the data as cost or co2 emissions vs temperature.

This PR ensures that the chart axis controls are disabled for these charts on the gas and storage heater analysis pages.