### PR TITLE
Override resource key not tx_slug

### DIFF
--- a/app/models/transport_survey/transport_type.rb
+++ b/app/models/transport_survey/transport_type.rb
@@ -55,9 +55,9 @@ class TransportSurvey::TransportType < ApplicationRecord
     name
   end
 
-  # override default slug to use original name pre-moving to module
+  # override default key and slug to use original name pre-moving to module
   # keeps in sync with the data already in transifex
-  def tx_slug
+  def resource_key
     "transport_type_#{self.id}"
   end
 end


### PR DESCRIPTION
I recently did a PR to fix synchronisation of the transport type model to Transifex: https://github.com/Energy-Sparks/energy-sparks/pull/3249

In that PR I override the `tx_slug` method to change the URL path for the resource created in the Transifex API, to a legal value.

But I should have overridden `resource_key` as that is used to create the slugs AND to index into the returned JSON to extract the data for the translated object.

Because I only overrode `tx_slug` we were doing the push correctly, but the pull was failing. This fixes that issue.