### PR TITLE
Add correct variables to solar pv page

### DIFF
--- a/app/views/schools/advice/solar_pv/_analysis_has_solar_pv.html.erb
+++ b/app/views/schools/advice/solar_pv/_analysis_has_solar_pv.html.erb
@@ -81,7 +81,7 @@
 
 <p><%= t('advice_pages.solar_pv.has_solar_pv.analysis.there_may_be_extra_returns') %>.</p>
 
-<table class="table table-sm">
+<table class="table table-sm" id="investment-returns">
   <thead class="thead-dark">
     <tr>
       <th class="text-center" style="width: 50%">
@@ -94,8 +94,8 @@
   </thead>
   <tbody>
     <tr>
-      <td><%= t('advice_pages.solar_pv.has_solar_pv.analysis.before_april_2019_content_html') %></td>
-      <td><%= t('advice_pages.solar_pv.has_solar_pv.analysis.after_april_2019_content_html') %></td>
+      <td><%= t('advice_pages.solar_pv.has_solar_pv.analysis.before_april_2019_content_html', solar_generation: format_unit(@existing_benefits.annual_solar_pv_kwh, :kwh)) %></td>
+      <td><%= t('advice_pages.solar_pv.has_solar_pv.analysis.after_april_2019_content_html', export_price: BenchmarkMetrics.pricing.solar_export_price * 100, export_value: format_unit(@existing_benefits.export_£, :£)) %></td>
     </tr>
   </tbody>
 </table>

--- a/config/locales/cy/views/advice_pages/solar_pv.yml
+++ b/config/locales/cy/views/advice_pages/solar_pv.yml
@@ -4,11 +4,11 @@ cy:
       has_solar_pv:
         analysis:
           after_april_2019: Ar ôl Ebrill 2019
-          after_april_2019_content_html: Bydd arbediad ychwanegol o tua £79 o drydan wedi'i allforio o dan y <a href="https://www.ofgem.gov.uk/environmental-and-social-schemes/smart-export-guarantee-seg">SEG (Gwarant Allforio Clyfar)</a>
+          after_april_2019_content_html: Bydd arbediad ychwanegol o tua %{export_value} o drydan wedi'i allforio o dan y <a href="https://www.ofgem.gov.uk/environmental-and-social-schemes/smart-export-guarantee-seg">SEG (Gwarant Allforio Clyfar)</a>
           before_april_2019: Cyn Ebrill 2019
           before_april_2019_content_html: |-
             <p>Gallai'r ysgol hefyd elwa o gymhorthdal y llywodraeth o'r enw <a href="https://www.ofgem.gov.uk/environmental-and-social-schemes/feed-tariffs-fit">'tariff cyflenwi trydan'</a>.</p>
-            <p>Bydd swm y tariff cyflenwi trydan yn dibynnu ar bryd y gosodwyd y paneli ac fel arfer mae o fewn yr ystod 5p/kWh i 40 p/kWh x cyfanswm y 'Cynhyrchiad Ffotofoltäig' o 5,693 kWh, bob blwyddyn</p>
+            <p>Bydd swm y tariff cyflenwi trydan yn dibynnu ar bryd y gosodwyd y paneli ac fel arfer mae o fewn yr ystod 5p/kWh i 40 p/kWh x cyfanswm y 'Cynhyrchiad Ffotofoltäig' o %{solar_generation} kWh, bob blwyddyn</p>
           benefits_of_having_installed_solar_panels: Manteision gosod paneli solar
           if_the_panels_are_owned_by_a_third_party: Os yw'r paneli yn eiddo i drydydd parti
           if_the_panels_are_owned_by_the_school: Os yw'r paneli yn eiddo i'r ysgol

--- a/config/locales/views/advice_pages/solar_pv.yml
+++ b/config/locales/views/advice_pages/solar_pv.yml
@@ -5,11 +5,13 @@ en:
       has_solar_pv:
         analysis:
           after_april_2019: After April 2019
-          after_april_2019_content_html: There will be an extra saving of about £79 from exported electricity under the <a href="https://www.ofgem.gov.uk/environmental-and-social-schemes/smart-export-guarantee-seg">SEG (Smart Export Guarantee)</a>
+          after_april_2019_content_html: |-
+            <p>The school might also gain between 1p and 15p per kWh of exported electricity under the <a href="https://www.ofgem.gov.uk/environmental-and-social-schemes/smart-export-guarantee-seg">SEG (Smart Export Guarantee)</a>. This rate will be agreed with your energy provider.</p>
+            <p>Using Energy Spark’s average SEG rate of %{export_price}p per kWh, we estimate that your school will have received  %{export_value} under the SEG in the last year.</p>
           before_april_2019: Before April 2019
           before_april_2019_content_html: |-
             <p>The school might also gain from the government subsidy called <a href="https://www.ofgem.gov.uk/environmental-and-social-schemes/feed-tariffs-fit">'feed-in-tariff'</a>.</p>
-            <p>The amount of the feed in tariff will depend on when the panels were installed and is typically in the range 5p/kWh to 40 p/kWh x the total 'Photovoltaic production' of 5,694 kWh, each year</p>
+            <p>The amount of the feed in tariff will depend on when the panels were installed and is typically in the range 5p/kWh to 40 p/kWh x the total 'Photovoltaic production' of %{solar_generation} kWh, each year</p>
           benefits_of_having_installed_solar_panels: Benefits of having installed solar panels
           if_the_panels_are_owned_by_a_third_party: If the panels are owned by a third-party
           if_the_panels_are_owned_by_the_school: If the panels are owned by the school

--- a/spec/system/schools/advice_pages/solar_pv_spec.rb
+++ b/spec/system/schools/advice_pages/solar_pv_spec.rb
@@ -126,8 +126,13 @@ RSpec.describe "solar pv advice page", type: :system do
         expect(page).to have_content('Long term trends')
         expect(page).to have_content('Recent electricity consumption and solar production')
         expect(page).to have_content('Benefits of having installed solar panels')
-        expect(page).to have_content('Before April 2019')
-        expect(page).to have_content('After April 2019')
+        within('#investment-returns') do
+          expect(page).to have_content('Before April 2019')
+          expect(page).to have_content('14,000 kWh')
+          expect(page).to have_content('After April 2019')
+          expect(page).to have_content("#{BenchmarkMetrics.pricing.solar_export_price * 100}p per kWh")
+          expect(page).to have_content('£65')
+        end
         expect(page).to have_css('#chart_wrapper_solar_pv_group_by_month')
         expect(page).to have_css('#chart_wrapper_solar_pv_last_7_days_by_submeter')
       end


### PR DESCRIPTION
When a school has solar pv we show the benefits of having the solar panels.

There's currently a bug in this version of the page. The table summarising the benefits if the school owns the panels should include how much energy the panels produced, as well as an estimate of the export value of that energy they've exported.

Currently the page just has hard-coded figures: a mistake from when the pages were rebuilt.

This PR replaces the hard-coded text with the actual values and updates the description of the Solar Export Guarantee with new text. We don't know the actual price that a school may be getting, so we now just show our estimate along with an indication of the likely range.

I've updated the system specs to check for these values.