### PR TITLE
Change how chart errors are logged

### DIFF
--- a/app/controllers/schools/charts_controller.rb
+++ b/app/controllers/schools/charts_controller.rb
@@ -37,7 +37,7 @@ class Schools::ChartsController < ApplicationController
       chart_config,
       transformations: get_transformations,
       provide_advice: provide_advice,
-      reraise_exception: true
+      report_exception: report_exception?
     ).data
 
     if output
@@ -61,5 +61,13 @@ class Schools::ChartsController < ApplicationController
     params.fetch(:date_ranges) { {} }.values.map do |range|
       Date.parse(range['start'])..Date.parse(range['end'])
     end
+  end
+
+  #Always report exceptions in development and on the test server
+  #Otherwise supress exceptions from charts requested by admins
+  def report_exception?
+    return true unless Rails.env.production?
+    return true if ENV['ENVIRONMENT_IDENTIFIER'] != 'production'
+    !current_user_admin?
   end
 end

--- a/app/models/chart_data.rb
+++ b/app/models/chart_data.rb
@@ -3,14 +3,14 @@ require 'dashboard'
 class ChartData
   OPERATIONS = %i[move extend contract compare].freeze
 
-  def initialize(school, aggregated_school, original_chart_type, chart_config, transformations: [], provide_advice: false, reraise_exception: false)
+  def initialize(school, aggregated_school, original_chart_type, chart_config, transformations: [], provide_advice: false, report_exception: false)
     @school = school
     @aggregated_school = aggregated_school
     @original_chart_type = original_chart_type
     @chart_config_overrides = chart_config
     @transformations = transformations
     @provide_advice = provide_advice
-    @reraise_exception = reraise_exception
+    @report_exception = report_exception
   end
 
   def data
@@ -47,11 +47,11 @@ class ChartData
       transformed_chart_type,         # chart_param
       true,                           # resolve_inheritance
       nil,                            # override_config
-      @reraise_exception,             # reraise_exception
+      @report_exception,              # reraise_exception, in analytics
       provide_advice: @provide_advice # provide_advice
     )
   rescue => e
-    if @reraise_exception
+    if @report_exception
       Rollbar.error(
         e,
         school_name: @school.name,

--- a/app/services/schools/generate_analysis_chart_configuration.rb
+++ b/app/services/schools/generate_analysis_chart_configuration.rb
@@ -55,7 +55,7 @@ module Schools
         @aggregated_meter_collection,
         chart_type,
         chart_config,
-        reraise_exception: false
+        report_exception: false
       ).has_chart_data?
     end
 

--- a/app/services/schools/generate_dashboard_chart_configuration.rb
+++ b/app/services/schools/generate_dashboard_chart_configuration.rb
@@ -43,7 +43,7 @@ module Schools
       # We therefore mark reraise exception false here (used by ChartManager#run_chart) as we don't want to log
       # errors unnecessarily.
       chart_config = { y_axis_units: :kwh }
-      ChartData.new(@school, @aggregated_meter_collection, chart_type, chart_config, reraise_exception: false)
+      ChartData.new(@school, @aggregated_meter_collection, chart_type, chart_config, report_exception: false)
     end
 
     def can_run_chart?(chart_type)


### PR DESCRIPTION
We recently changed the application to log all errors from the charting framework. Previously errors were swallowed up in the analytics code making it hard to identify when broken charts were displayed to users.

So we now request that the analytics re-raises exceptions, and then log them to Rollbar in some circumstances. A user only ever sees an error message.

However the admin pages for reviewing and fixing gas modelling errors are too noisy: they have a lot of charts and lots can break. this triggers our alarm threshold for frequent errors.

To avoid this I've revised how we log chart errors:

- they should be logged outside of production
- they should be logged on the test server (which is technically 'production' in Rails terms)
- they should be logged on production, but only for non admin users

This means Rollbar will still contain meaningful reports of users seeing errors, but will no longer include errors from admins.

I felt this was better than:

- revising our alarm threshold to work around issues with admins using one page
- disabling error reporting completely

Fixing the gas modelling errors is a whole other task: in some cases the modelling just wont work with limited data, but its useful to have this page to explore the options.

I wouldn't normally write controller specs, but felt this was right option here as its the controller driving the behaviour, so just added to that existing spec.