### PR TITLE
Make intervention message the same as production

### DIFF
--- a/app/components/timeline_component.rb
+++ b/app/components/timeline_component.rb
@@ -145,6 +145,10 @@ class TimelineComponent < ViewComponent::Base
       observation.intervention_type
     end
 
+    def message
+      observable.name
+    end
+
     def show_path
       school_intervention_path(school, observation)
     end
@@ -155,10 +159,6 @@ class TimelineComponent < ViewComponent::Base
 
     def delete_path
       school_intervention_path(school, observation)
-    end
-
-    def target
-      observable.name
     end
 
     def show_buttons?

--- a/config/locales/views/components/timeline.yml
+++ b/config/locales/views/components/timeline.yml
@@ -16,7 +16,6 @@ en:
         message: Completed all audit activities
       intervention:
         compact_message_html: <a href="%{school_path}">%{school}</a> scored <strong>%{count} points</strong> after they recorded "<a href="%{compact_path}">%{target}</a>"
-        message: Completed an action
       programme:
         compact_message_html: <a href="%{school_path}">%{school}</a> scored <strong>%{count} points</strong> after they <a href="%{compact_path}">completed a programme</a>
         message: Completed a programme

--- a/spec/components/timeline_component_spec.rb
+++ b/spec/components/timeline_component_spec.rb
@@ -95,7 +95,6 @@ RSpec.describe TimelineComponent, type: :component, include_url_helpers: true do
     let(:observation) { create(:observation, :intervention) }
 
     it { expect(html).to have_css("i.fa-#{observation.intervention_type.intervention_type_group.icon}") }
-    it { expect(html).to have_content("Completed an action: ") } # I did change this to add this prefix!
     it { expect(html).to have_link(observation.intervention_type.name, href: school_intervention_path(observation.school, observation)) }
 
     context "when show_actions is true" do


### PR DESCRIPTION
Just remembered that I changed the intervention timeline message to be "Completed an action: %{name of intervention}"
Where it should just be "%{name of intervention}"

This fixes that