### PR TITLE
Move programme observation

### DIFF
--- a/app/components/timeline_component.rb
+++ b/app/components/timeline_component.rb
@@ -167,10 +167,6 @@ class TimelineComponent < ViewComponent::Base
   end
 
   class Programme < ObservationBase
-    def observable
-      observation.programme
-    end
-
     def show_path
       programme_type_path(observable.programme_type)
     end

--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -43,7 +43,7 @@ class Observation < ApplicationRecord
   has_many   :temperature_recordings
   has_many   :locations, through: :temperature_recordings
 
-  belongs_to :programme, optional: true # will remove this later
+  belongs_to :programme, optional: true # to be removed when column is removed
   belongs_to :intervention_type, optional: true
   belongs_to :activity, optional: true
   belongs_to :audit, optional: true
@@ -51,7 +51,7 @@ class Observation < ApplicationRecord
 
   # If adding a new observation type remember to also modify the timeline component
   # events: 3 has been removed
-  # events: 6 is to be removed when relationship is
+  # events: 6 is to be removed when programme relationship is removed
   enum observation_type: { temperature: 0, intervention: 1, activity: 2, audit: 4, school_target: 5, programme: 6, audit_activities_completed: 7, observable: 8 }
 
   # This is the first stage in moving this class over to being fully polymorphic

--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -44,7 +44,6 @@ class Observation < ApplicationRecord
   has_many   :locations, through: :temperature_recordings
   belongs_to :intervention_type, optional: true
   belongs_to :activity, optional: true
-  belongs_to :programme, optional: true
   belongs_to :audit, optional: true
   belongs_to :school_target, optional: true
 
@@ -61,7 +60,6 @@ class Observation < ApplicationRecord
 
   validates :intervention_type_id, presence: { message: 'please select an option' }, if: :intervention?
   validates :activity_id, presence: true, if: :activity?
-  validates :programme_id, presence: true, if: :programme?
   validates :audit_id, presence: true, if: :audit?
   validates :school_target_id, presence: true, if: :school_target?
   validates :audit_id, presence: true, if: :audit_activities_completed?

--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -80,7 +80,7 @@ class Observation < ApplicationRecord
   scope :recorded_in_last_week, -> { where('created_at >= ?', 1.week.ago)}
   scope :recorded_since, ->(date) { where('created_at >= ?', date)}
 
-  scope :engagement, -> { where(observation_type: [:temperature, :intervention, :activity, :audit, :school_target, :programme]) }
+  scope :engagement, -> { where(observation_type: [:temperature, :intervention, :activity, :audit, :school_target, :observable]) }
 
   has_rich_text :description
 

--- a/app/models/programme.rb
+++ b/app/models/programme.rb
@@ -27,6 +27,7 @@ class Programme < ApplicationRecord
   belongs_to :school
   has_many :programme_activities
   has_many :activities, through: :programme_activities
+  has_many :observations, as: :observable
 
   enum status: { started: 0, completed: 1, abandoned: 2 } do
     event :complete do

--- a/app/models/programme.rb
+++ b/app/models/programme.rb
@@ -64,8 +64,8 @@ class Programme < ApplicationRecord
   end
 
   def add_observation
-    Observation.where(school: school,
-      observation_type: :programme, programme_id: id
-    ).first_or_create(at: self.ended_on, points: points_for_completion)
+    return unless completed?
+
+    self.observations.first_or_create(at: self.ended_on, points: points_for_completion)
   end
 end

--- a/db/migrate/20231207104401_move_programme_observation.rb
+++ b/db/migrate/20231207104401_move_programme_observation.rb
@@ -5,13 +5,9 @@ class MoveProgrammeObservation < ActiveRecord::Migration[6.0]
       observation.observation_type = :observable
       observation.save!
     end
-
-    remove_column :observations, :programme_id
   end
 
   def down
-    add_reference :observations, :programme, index: true
-
     Observation.where(observable_type: 'Programme').find_each do |observation|
       observation.programme = observation.observable
       observation.observable = nil

--- a/db/migrate/20231207104401_move_programme_observation.rb
+++ b/db/migrate/20231207104401_move_programme_observation.rb
@@ -1,14 +1,21 @@
 class MoveProgrammeObservation < ActiveRecord::Migration[6.0]
   def up
     Observation.where(observation_type: :programme).find_each do |observation|
-      observation.observable = observation.programme
+      observation.obserable = observation.programme
+      observation.observation_type = :observable
       observation.save!
     end
+
+    remove_column :observations, :programme_id
   end
 
   def down
-    Observation.where(observation_type: :programme).find_each do |observation|
+    add_reference :observations, :programme, index: true
+
+    Observation.where(observable_type: 'Programme').find_each do |observation|
+      observation.programme = observation.observable
       observation.observable = nil
+      observation.observation_type = :programme
       observation.save!
     end
   end

--- a/db/migrate/20231207104401_move_programme_observation.rb
+++ b/db/migrate/20231207104401_move_programme_observation.rb
@@ -1,7 +1,7 @@
 class MoveProgrammeObservation < ActiveRecord::Migration[6.0]
   def up
     Observation.where(observation_type: :programme).find_each do |observation|
-      observation.obserable = observation.programme
+      observation.observable = observation.programme
       observation.observation_type = :observable
       observation.save!
     end

--- a/db/migrate/20231207104401_move_programme_observation.rb
+++ b/db/migrate/20231207104401_move_programme_observation.rb
@@ -1,0 +1,15 @@
+class MoveProgrammeObservation < ActiveRecord::Migration[6.0]
+  def up
+    Observation.where(observation_type: :programme).find_each do |observation|
+      observation.observable = observation.programme
+      observation.save!
+    end
+  end
+
+  def down
+    Observation.where(observation_type: :programme).find_each do |observation|
+      observation.observable = nil
+      observation.save!
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_11_21_141221) do
+ActiveRecord::Schema.define(version: 2023_12_07_104401) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_11_21_141221) do
+ActiveRecord::Schema.define(version: 2023_12_07_104401) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
@@ -1225,10 +1225,10 @@ ActiveRecord::Schema.define(version: 2023_11_21_141221) do
     t.bigint "audit_id"
     t.boolean "involved_pupils", default: false, null: false
     t.bigint "school_target_id"
+    t.bigint "programme_id"
     t.integer "pupil_count"
     t.string "observable_type"
     t.bigint "observable_id"
-    t.bigint "programme_id"
     t.index ["activity_id"], name: "index_observations_on_activity_id"
     t.index ["audit_id"], name: "index_observations_on_audit_id"
     t.index ["intervention_type_id"], name: "index_observations_on_intervention_type_id"
@@ -1978,6 +1978,7 @@ ActiveRecord::Schema.define(version: 2023_11_21_141221) do
   add_foreign_key "observations", "activities", on_delete: :nullify
   add_foreign_key "observations", "audits"
   add_foreign_key "observations", "intervention_types", on_delete: :restrict
+  add_foreign_key "observations", "programmes", on_delete: :cascade
   add_foreign_key "observations", "school_targets"
   add_foreign_key "observations", "schools", on_delete: :cascade
   add_foreign_key "programmes", "programme_types", on_delete: :cascade

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -915,13 +915,13 @@ ActiveRecord::Schema.define(version: 2023_12_07_104401) do
     t.index ["replaced_by_id"], name: "index_global_meter_attributes_on_replaced_by_id"
   end
 
-  create_table "good_job_processes", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "good_job_processes", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.jsonb "state"
   end
 
-  create_table "good_job_settings", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "good_job_settings", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.text "key"
@@ -929,7 +929,7 @@ ActiveRecord::Schema.define(version: 2023_12_07_104401) do
     t.index ["key"], name: "index_good_job_settings_on_key", unique: true
   end
 
-  create_table "good_jobs", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
+  create_table "good_jobs", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.text "queue_name"
     t.integer "priority"
     t.jsonb "serialized_params"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_12_07_104401) do
+ActiveRecord::Schema.define(version: 2023_11_21_141221) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
@@ -915,13 +915,13 @@ ActiveRecord::Schema.define(version: 2023_12_07_104401) do
     t.index ["replaced_by_id"], name: "index_global_meter_attributes_on_replaced_by_id"
   end
 
-  create_table "good_job_processes", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "good_job_processes", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.jsonb "state"
   end
 
-  create_table "good_job_settings", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "good_job_settings", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.text "key"
@@ -929,7 +929,7 @@ ActiveRecord::Schema.define(version: 2023_12_07_104401) do
     t.index ["key"], name: "index_good_job_settings_on_key", unique: true
   end
 
-  create_table "good_jobs", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "good_jobs", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.text "queue_name"
     t.integer "priority"
     t.jsonb "serialized_params"
@@ -1225,10 +1225,10 @@ ActiveRecord::Schema.define(version: 2023_12_07_104401) do
     t.bigint "audit_id"
     t.boolean "involved_pupils", default: false, null: false
     t.bigint "school_target_id"
-    t.bigint "programme_id"
     t.integer "pupil_count"
     t.string "observable_type"
     t.bigint "observable_id"
+    t.bigint "programme_id"
     t.index ["activity_id"], name: "index_observations_on_activity_id"
     t.index ["audit_id"], name: "index_observations_on_audit_id"
     t.index ["intervention_type_id"], name: "index_observations_on_intervention_type_id"
@@ -1978,7 +1978,6 @@ ActiveRecord::Schema.define(version: 2023_12_07_104401) do
   add_foreign_key "observations", "activities", on_delete: :nullify
   add_foreign_key "observations", "audits"
   add_foreign_key "observations", "intervention_types", on_delete: :restrict
-  add_foreign_key "observations", "programmes", on_delete: :cascade
   add_foreign_key "observations", "school_targets"
   add_foreign_key "observations", "schools", on_delete: :cascade
   add_foreign_key "programmes", "programme_types", on_delete: :cascade

--- a/spec/components/previews/compact_timeline_component_preview.rb
+++ b/spec/components/previews/compact_timeline_component_preview.rb
@@ -1,6 +1,5 @@
 class CompactTimelineComponentPreview < ViewComponent::Preview
   def with_observations
-    programme = Programme.last
     audit = Audit.last
 
     observations = [
@@ -9,7 +8,7 @@ class CompactTimelineComponentPreview < ViewComponent::Preview
       Observation.new(school: audit.school, observation_type: 'audit_activities_completed', audit: audit, at: Time.zone.yesterday, points: SiteSettings.current.audit_activities_bonus_points),
       Observation.find_by(observation_type: 'intervention'),
       Observation.find_by(observable_type: 'TransportSurvey'),
-      Observation.new(school: programme.school, observation_type: 'observable', observable: programme, at: Time.zone.yesterday, points: programme.programme_type.bonus_score),
+      Observation.find_by(observable_type: 'Programme'),
       Observation.find_by(observation_type: 'school_target'),
       Observation.find_by(observation_type: 'temperature')
     ].compact.sort_by(&:at).reverse

--- a/spec/components/previews/compact_timeline_component_preview.rb
+++ b/spec/components/previews/compact_timeline_component_preview.rb
@@ -8,7 +8,7 @@ class CompactTimelineComponentPreview < ViewComponent::Preview
       Observation.new(school: audit.school, observation_type: 'audit', audit: audit, at: Time.zone.yesterday),
       Observation.new(school: audit.school, observation_type: 'audit_activities_completed', audit: audit, at: Time.zone.yesterday, points: SiteSettings.current.audit_activities_bonus_points),
       Observation.find_by(observation_type: 'intervention'),
-      Observation.find_by(observation_type: 'observable'),
+      Observation.find_by(observable_type: 'TransportSurvey'),
       Observation.new(school: programme.school, observation_type: 'observable', observable: programme, at: Time.zone.yesterday, points: programme.programme_type.bonus_score),
       Observation.find_by(observation_type: 'school_target'),
       Observation.find_by(observation_type: 'temperature')

--- a/spec/components/previews/compact_timeline_component_preview.rb
+++ b/spec/components/previews/compact_timeline_component_preview.rb
@@ -9,7 +9,7 @@ class CompactTimelineComponentPreview < ViewComponent::Preview
       Observation.new(school: audit.school, observation_type: 'audit_activities_completed', audit: audit, at: Time.zone.yesterday, points: SiteSettings.current.audit_activities_bonus_points),
       Observation.find_by(observation_type: 'intervention'),
       Observation.find_by(observation_type: 'observable'),
-      Observation.new(school: programme.school, observation_type: 'programme', programme: programme, at: Time.zone.yesterday, points: programme.programme_type.bonus_score),
+      Observation.new(school: programme.school, observation_type: 'observable', observable: programme, at: Time.zone.yesterday, points: programme.programme_type.bonus_score),
       Observation.find_by(observation_type: 'school_target'),
       Observation.find_by(observation_type: 'temperature')
     ].compact.sort_by(&:at).reverse

--- a/spec/components/previews/timeline_component_preview.rb
+++ b/spec/components/previews/timeline_component_preview.rb
@@ -1,6 +1,5 @@
 class TimelineComponentPreview < ViewComponent::Preview
   def with_observations
-    programme = Programme.last
     audit = Audit.last
 
     observations = [
@@ -9,7 +8,7 @@ class TimelineComponentPreview < ViewComponent::Preview
       Observation.new(school: audit.school, observation_type: 'audit_activities_completed', audit: audit, at: Time.zone.yesterday, points: SiteSettings.current.audit_activities_bonus_points),
       Observation.find_by(observation_type: 'intervention'),
       Observation.find_by(observable_type: 'TransportSurvey'),
-      Observation.new(school: programme.school, observation_type: 'observable', observable: programme, at: Time.zone.yesterday, points: programme.programme_type.bonus_score),
+      Observation.find_by(observable_type: 'Programme'),
       Observation.find_by(observation_type: 'school_target'),
       Observation.find_by(observation_type: 'temperature'),
     ].compact.sort_by(&:at).reverse

--- a/spec/components/previews/timeline_component_preview.rb
+++ b/spec/components/previews/timeline_component_preview.rb
@@ -8,7 +8,7 @@ class TimelineComponentPreview < ViewComponent::Preview
       Observation.new(school: audit.school, observation_type: 'audit', audit: audit, at: Time.zone.yesterday),
       Observation.new(school: audit.school, observation_type: 'audit_activities_completed', audit: audit, at: Time.zone.yesterday, points: SiteSettings.current.audit_activities_bonus_points),
       Observation.find_by(observation_type: 'intervention'),
-      Observation.find_by(observation_type: 'observable'),
+      Observation.find_by(observable_type: 'TransportSurvey'),
       Observation.new(school: programme.school, observation_type: 'observable', observable: programme, at: Time.zone.yesterday, points: programme.programme_type.bonus_score),
       Observation.find_by(observation_type: 'school_target'),
       Observation.find_by(observation_type: 'temperature'),

--- a/spec/components/previews/timeline_component_preview.rb
+++ b/spec/components/previews/timeline_component_preview.rb
@@ -9,7 +9,7 @@ class TimelineComponentPreview < ViewComponent::Preview
       Observation.new(school: audit.school, observation_type: 'audit_activities_completed', audit: audit, at: Time.zone.yesterday, points: SiteSettings.current.audit_activities_bonus_points),
       Observation.find_by(observation_type: 'intervention'),
       Observation.find_by(observation_type: 'observable'),
-      Observation.new(school: programme.school, observation_type: 'programme', programme: programme, at: Time.zone.yesterday, points: programme.programme_type.bonus_score),
+      Observation.new(school: programme.school, observation_type: 'observable', observable: programme, at: Time.zone.yesterday, points: programme.programme_type.bonus_score),
       Observation.find_by(observation_type: 'school_target'),
       Observation.find_by(observation_type: 'temperature'),
     ].compact.sort_by(&:at).reverse

--- a/spec/components/timeline_component_spec.rb
+++ b/spec/components/timeline_component_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe TimelineComponent, type: :component, include_url_helpers: true do
 
     it { expect(html).to have_css("i.fa-clipboard-check") }
     it { expect(html).to have_content("Completed a programme: ") }
-    it { expect(html).to have_link(observation.programme.programme_type.title, href: programme_type_path(observation.programme.programme_type)) }
+    it { expect(html).to have_link(observation.observable.programme_type.title, href: programme_type_path(observation.observable.programme_type)) }
 
     context "when show_actions is true" do
       let(:show_actions) { true }

--- a/spec/factories/observations_factory.rb
+++ b/spec/factories/observations_factory.rb
@@ -24,8 +24,8 @@ FactoryBot.define do
     end
 
     trait :programme do
-      observation_type { :programme }
-      programme
+      observation_type { :observable }
+      association :observable, factory: :programme
     end
 
     trait :temperature do
@@ -35,7 +35,7 @@ FactoryBot.define do
 
     trait :transport_survey do
       observation_type { :observable }
-      observable { create(:transport_survey) }
+      association :observable, factory: :transport_survey
     end
 
     trait :school_target do

--- a/spec/models/programme_spec.rb
+++ b/spec/models/programme_spec.rb
@@ -4,7 +4,8 @@ describe 'Programme' do
   let(:school) { create :school }
   let(:programme_type) { create(:programme_type, bonus_score: 12) }
 
-  let(:programme) { create(:programme, programme_type: programme_type, started_on: '2020-01-01', school: school) }
+  let(:status) { :started }
+  let(:programme) { create(:programme, programme_type: programme_type, started_on: '2020-01-01', school: school, status: status) }
   let(:last_observation) { programme.observations.last }
 
   it { expect(programme.observations.count).to eq(0) }
@@ -33,7 +34,7 @@ describe 'Programme' do
 
       context "with observation" do
         it { expect(programme.observations.count).to eq(1) }
-        it { expect(last_observation.at).not_to be_nil }
+        it { expect(last_observation.at).to eq(programme.ended_on) }
         it { expect(last_observation.school).to eq(school) }
         it { expect(last_observation.observation_type).to eq('observable') }
 
@@ -56,7 +57,7 @@ describe 'Programme' do
 
       context "with observation" do
         it { expect(programme.observations.count).to eq(1) }
-        it { expect(last_observation.at).not_to be_nil }
+        it { expect(last_observation.at).to eq(programme.ended_on) }
         it { expect(last_observation.school).to eq(school) }
         it { expect(last_observation.observation_type).to eq('observable') }
 
@@ -78,6 +79,33 @@ describe 'Programme' do
 
     it "doesn't set ended_on" do
       expect(programme.ended_on).to be_nil
+    end
+  end
+
+  describe "#add_observation" do
+    before do
+      programme.add_observation
+    end
+
+    context "when programme is not complete" do
+      let(:status) { :started }
+
+      it "doesn't add obervation" do
+        expect(programme.observations.count).to eq(0)
+      end
+    end
+
+    context "when programme is complete" do
+      let(:status) { :completed }
+
+      it "adds obervation" do
+        expect(programme.observations.count).to eq(1)
+      end
+
+      it "only adds one observation" do
+        programme.add_observation
+        expect(programme.observations.count).to eq(1)
+      end
     end
   end
 end

--- a/spec/system/schools/dashboard/timeline_spec.rb
+++ b/spec/system/schools/dashboard/timeline_spec.rb
@@ -11,10 +11,12 @@ RSpec.shared_examples "dashboard timeline" do
     create(:school_target, school: test_school, start_date: Time.zone.today)
     transport_survey = create(:transport_survey, school: test_school, run_on: Time.zone.today)
     transport_survey.responses = [attributes_for(:transport_survey_response)]
+    create(:observation, :programme, school: test_school)
     visit school_path(test_school, switch: true)
   end
 
   it 'displays events in a timeline' do
+    expect(page).to have_content('Completed a programme')
     expect(page).to have_content('Recorded a transport survey response')
     expect(page).to have_content('Recorded temperatures in')
     expect(page).to have_content('Upgraded insulation')


### PR DESCRIPTION
Move observations for programmes to use the new polymorphic relationship.
Keeps the old programme_id column in the table for now, will remove all these when they are all moved.

Worth noting that I don't think there are any observations of these types in the database - has nobody ever completed a programme? Or maybe it's not working (there are tests which indicate the code should be working)?