### PR TITLE
Add default format

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -337,7 +337,7 @@ Rails.application.routes.draw do
       resources :content_reports, only: [:index, :show]
       resources :equivalence_reports, only: [:index, :show]
       get :chart, to: 'charts#show'
-      get :annotations, to: 'annotations#show'
+      get :annotations, to: 'annotations#show', defaults: {format: :json}
 
       get :timeline, to: 'timeline#show'
 


### PR DESCRIPTION
The annotations controller doesn't have a default format set, but always returns JSON. So we get a bit of noise in Rollbar when crawlers do a GET request without an Accept header. Add a default format to the route to stop this.