### PR TITLE
fix test flake

### DIFF
--- a/app/services/template_interpolation.rb
+++ b/app/services/template_interpolation.rb
@@ -1,5 +1,6 @@
-require 'mustache'
 require 'closed_struct'
+require 'mobility/action_text'
+require 'mustache'
 
 class TemplateInterpolation
   def initialize(object, with_objects: {}, proxy: [], render_with: Mustache.new)
@@ -17,9 +18,8 @@ class TemplateInterpolation
     end
     templated = fields.inject(with_proxied_objects) do |collection, field|
       template = @object.send(field) || ""
-      collection[field] = if template.is_a?(ActionText::RichText)
-                            process_rich_text_template(template, with)
-                          elsif template.is_a?(Mobility::Backends::ActionText::RichTextTranslation)
+      collection[field] = case template
+                          when ActionText::RichText, Mobility::Backends::ActionText::RichTextTranslation
                             process_rich_text_template(template, with)
                           else
                             process_string_template(template, with)


### PR DESCRIPTION
seen on https://github.com/Energy-Sparks/energy-sparks/actions/runs/7143231490/job/19454241740
```
1) TemplateInterpolation interpolation handles nil templates
     Failure/Error: elsif template.is_a?(Mobility::Backends::ActionText::RichTextTranslation)

     NameError:
       uninitialized constant Mobility::Backends::ActionText
     # ./app/services/template_interpolation.rb:22:in `block in interpolate'
     # ./app/services/template_interpolation.rb:18:in `each'
     # ./app/services/template_interpolation.rb:18:in `inject'
     # ./app/services/template_interpolation.rb:18:in `interpolate'
     # ./spec/services/template_interpolation_spec.rb:101:in `block (3 levels) in <top (required)>'
```