### PR TITLE
Reduce Rollbar noise from expected exceptions in the school targets feature

### DIFF
--- a/app/services/targets/generate_fuel_types.rb
+++ b/app/services/targets/generate_fuel_types.rb
@@ -11,6 +11,8 @@ module Targets
         fuel_types << "electricity" if enough_data_for_electricity?
         fuel_types << "gas" if enough_data_for_gas?
         fuel_types << "storage_heater" if enough_data_for_storage_heater?
+      rescue TargetDates::TargetDateBeforeFirstMeterStartDate
+        #noop
       rescue => e
         Rollbar.error(e, scope: :fuel_types_with_enough_data, school_id: @school.id, school: @school.name)
       end

--- a/app/services/targets/generate_progress_service.rb
+++ b/app/services/targets/generate_progress_service.rb
@@ -117,6 +117,8 @@ module Targets
     def target_progress(fuel_type)
       begin
         @progress_by_fuel_type[fuel_type] ||= target_service(fuel_type).progress
+      rescue TargetDates::TargetDateBeforeFirstMeterStartDate
+        return nil
       rescue => e
         report_to_rollbar_once(e, fuel_type)
         return nil


### PR DESCRIPTION
The analytics throws some exceptions when it cannot properly generate a progress report and other data associated with a school target.

Currently we log all these in Rollbar, but some of them can be ignored as they are data issues rather than bugs. For example it throws an exception if the gas data doesn't start before the target period. This can happen because schools can set targets regardless of how much data they have. We just give them a more limited report.

So while its valid to throw an exception because the analytics can't do anything for that fuel type, we don't need to report this to Rollbar as an error or warning.

This PR catches this expected exception and does not log to Rollbar. This will reduce a small number of persistent reports.