### PR TITLE
Check if all schools have been filtered before running comparison

### DIFF
--- a/app/controllers/compare_controller.rb
+++ b/app/controllers/compare_controller.rb
@@ -5,7 +5,7 @@ class CompareController < ApplicationController
   before_action :filter
   before_action :benchmark_groups, only: [:benchmarks]
 
-  before_action :set_included_schools
+  before_action :set_included_schools, only: [:benchmarks, :show]
   helper_method :index_params
 
   # filters

--- a/app/controllers/compare_controller.rb
+++ b/app/controllers/compare_controller.rb
@@ -80,8 +80,6 @@ class CompareController < ApplicationController
     content_manager.content(fetch_benchmark_data, benchmark, user_type: user_type_hash, online: true)
     # rubocop:disable Lint/RescueException
   rescue Exception => e
-    puts e
-    puts e.backtrace
     # rubocop:enable Lint/RescueException
     Rollbar.error(e, benchmark: benchmark)
     []

--- a/app/views/compare/no_schools.html.erb
+++ b/app/views/compare/no_schools.html.erb
@@ -1,0 +1,9 @@
+<% content_for :page_title, t('compare.benchmarks.title') %>
+
+<h1><%= t('compare.benchmarks.title') %></h1>
+
+<%= render 'summary' %>
+
+<p>
+  <%= t('compare.filter.no_schools') %>
+</p>

--- a/config/locales/cy/views/compare/compare.yml
+++ b/config/locales/cy/views/compare/compare.yml
@@ -18,6 +18,7 @@ cy:
       schools_with_country_html: Cymharu ysgolion yn %{country}
       schools_with_type_html: 'Cymharu ysgolion o fath: %{school_type}'
       select_one: Dewiswch o leiaf un
+      no_schools: Nid oes unrhyw ysgolion i adrodd eu bod yn defnyddio'r hidlydd hwn
     index:
       country:
         tab: Dewiswch wlad

--- a/config/locales/views/compare/compare.yml
+++ b/config/locales/views/compare/compare.yml
@@ -11,6 +11,7 @@ en:
       change_benchmark: Change benchmark
       change_options: Change options
       country: 'Select country:'
+      no_schools: There are no schools to report using this filter
       school_groups: 'Select school groups:'
       school_type: 'Select school type:'
       school_types_html: 'Including: %{school_types}'

--- a/spec/system/compare_spec.rb
+++ b/spec/system/compare_spec.rb
@@ -192,14 +192,14 @@ describe 'compare pages', :compare, type: :system do
   end
 
   ## tests ##
-
   let(:user) {}
   let(:all_school_types) { School.school_types.keys }
   let!(:funder)          { create(:funder, name: "Grant Funder") }
   let!(:school_group)    { create(:school_group, name: "Group 1") }
-  let!(:school)          { create(:school, school_group: school_group, funder: funder)}
+  #the stubbed out geocoder stamps on the country if the postcode is defaulted
+  let!(:school)          { create(:school, country: :scotland, postcode: 'EH99 1SP', school_group: school_group, funder: funder)}
   let!(:school_group_2)  { create(:school_group, name: "Group 2") }
-  let!(:school_2)        { create(:school, school_group: school_group_2)}
+  let!(:school_2)        { create(:school, country: :scotland, postcode: 'EH99 1SP', school_group: school_group_2)}
 
   let(:benchmark_groups) { [{ name: 'Benchmark group name', description: 'Benchmark description', benchmarks: { a_benchmark_key: 'Benchmark name' } }] }
 

--- a/spec/system/compare_spec.rb
+++ b/spec/system/compare_spec.rb
@@ -145,6 +145,10 @@ describe 'compare pages', :compare, type: :system do
     it { expect(page).to have_link('Change options')}
   end
 
+  shared_examples "an empty filter notice" do
+    it { expect(page).to have_content('There are no schools to report using this filter') }
+  end
+
   ## contexts ##
 
   shared_context 'index page context' do
@@ -369,6 +373,19 @@ describe 'compare pages', :compare, type: :system do
 
           it_behaves_like "an index page", tab: 'Choose groups'
           it_behaves_like "a form filter", id: '#groups', school_groups: ["Group 1", "Group 2"], school_types_excluding: ['infant']
+        end
+
+        context "Filtering all schools" do
+          before do
+            click_on "Change options"
+            within '#groups' do
+              uncheck 'Primary'
+              click_on 'Compare schools'
+            end
+          end
+
+          it_behaves_like "a filter summary", school_types_excluding: ['infant'], school_groups: ["Group 1", "Group 2"]
+          it_behaves_like "an empty filter notice"
         end
 
         context "results page" do


### PR DESCRIPTION
Currently if a user filters the list of schools to an empty list we still try and run the school benchmark. This causes an error in the analytics which is logged to Rollbar. This seems to be happening quite often, sometimes from crawlers/bots.

I've amended the controller so:

- it loads the list of schools as a before action
- checks whether there are any schools before displaying list of benchmarks, using some existing translations for the text
- also checks whether the list is empty after running, a user shouldn't be able to get to that screen but crawlers/bots rechecking existing URLs may do