### PR TITLE
Reinstate webdrivers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -164,11 +164,11 @@ group :test do
   gem 'capybara'
   gem 'capybara-email'
   gem 'database_cleaner'
-  gem "webdrivers", '>= 5.3.0'
   gem 'selenium-webdriver'
   gem 'shoulda-matchers'
   gem 'show_me_the_cookies'
   gem 'simplecov', require: false, group: :test
   gem 'test-prof'
   gem 'timecop'
+  gem 'webdrivers', '>= 5.3.0' #may not be required in Ruby 3
 end

--- a/Gemfile
+++ b/Gemfile
@@ -164,6 +164,7 @@ group :test do
   gem 'capybara'
   gem 'capybara-email'
   gem 'database_cleaner'
+  gem "webdrivers", '>= 5.3.0'
   gem 'selenium-webdriver'
   gem 'shoulda-matchers'
   gem 'show_me_the_cookies'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -702,6 +702,10 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
+    webdrivers (5.3.1)
+      nokogiri (~> 1.6)
+      rubyzip (>= 1.3.0)
+      selenium-webdriver (~> 4.0, < 4.11)
     webmock (3.19.1)
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
@@ -827,6 +831,7 @@ DEPENDENCIES
   uglifier
   view_component
   web-console
+  webdrivers (>= 5.3.0)
   webmock
   webpacker
   wisper (= 2.0.0)


### PR DESCRIPTION
Add the webdriver gem back in to work around chromedriver install issues.

May need to be reverted in Ruby 3.0 branch.

Previous issues:

- having to pin driver: https://github.com/Energy-Sparks/energy-sparks/pull/2922
- them update to webdrivers, removing need to pin: https://github.com/Energy-Sparks/energy-sparks/pull/2992