### PR TITLE
Fix error in recent changes service

### DIFF
--- a/app/services/schools/advice/recent_changes_service.rb
+++ b/app/services/schools/advice/recent_changes_service.rb
@@ -33,6 +33,7 @@ module Schools
 
       def full_previous_week?
         return false unless full_last_week?
+        return false unless previous_week_date_range.any?
         return false unless aggregate_meter.amr_data.start_date <= previous_week_date_range.first
 
         (previous_week_date_range.first..previous_week_date_range.last).count == 7
@@ -104,16 +105,8 @@ module Schools
         )
       end
 
-      def asof_date
-        @asof_date ||= AggregateSchoolService.analysis_date(@meter_collection, @fuel_type)
-      end
-
       def aggregate_meter
         @meter_collection.aggregate_meter(@fuel_type)
-      end
-
-      def meter_data_checker
-        @meter_data_checker ||= Util::MeterDateRangeChecker.new(aggregate_meter, asof_date)
       end
     end
   end

--- a/spec/services/schools/advice/recent_changes_service_spec.rb
+++ b/spec/services/schools/advice/recent_changes_service_spec.rb
@@ -1,52 +1,59 @@
 require 'rails_helper'
 
 RSpec.describe Schools::Advice::RecentChangesService, type: :service do
-  let(:school) { create(:school) }
-  let(:gas_aggregate_meter) { double('gas-aggregated-meter', aggregate_meter?: true)}
+  let(:school)                      { create(:school) }
+
+  let(:gas_aggregate_meter)         { double('gas-aggregated-meter', aggregate_meter?: true)}
   let(:electricity_aggregate_meter) { double('electricity-aggregated-meter', aggregate_meter?: true)}
-  let(:meter_collection) { double(:meter_collection, aggregated_heat_meters: gas_aggregate_meter, aggregated_electricity_meters: electricity_aggregate_meter) }
-  let(:meter_data_checker) { double(:meter_data_checker) }
-  let(:earliest_date) { Date.parse('20220101') }
+  let(:meter_collection)            do
+    double(:meter_collection, aggregated_heat_meters: gas_aggregate_meter, aggregated_electricity_meters: electricity_aggregate_meter)
+  end
   let(:amr_data) { double('amr-data') }
 
-  context 'with a gas fuel type' do
-    let(:service) do
-      Schools::Advice::RecentChangesService.new(school: school, meter_collection: meter_collection, fuel_type: :gas)
-    end
+  subject(:service) do
+    Schools::Advice::RecentChangesService.new(school: school, meter_collection: meter_collection, fuel_type: :gas)
+  end
 
+  before do
+    allow(meter_collection).to receive(:aggregate_meter) { gas_aggregate_meter }
+    allow(gas_aggregate_meter).to receive(:amr_data).and_return(amr_data)
+  end
+
+  describe '#enough_data?' do
     before do
-      allow(meter_collection).to receive(:aggregate_meter) { gas_aggregate_meter }
-      allow(gas_aggregate_meter).to receive(:amr_data).and_return(amr_data)
-      allow(amr_data).to receive(:end_date).and_return(Time.zone.today)
-      allow(amr_data).to receive(:start_date).and_return(Time.zone.today - 1.year)
+      allow(amr_data).to receive(:start_date).and_return(start_date)
+      allow(amr_data).to receive(:end_date).and_return(end_date)
     end
 
-    context 'date handling for data returned by the service' do
-      it 'returns true if there is at least a full weeks worth of data' do
-        start_date = Date.new(2023, 3, 26)
-        end_date = Date.new(2023, 4, 1)
+    context 'when there is one full week of data' do
+      let(:start_date) { Date.new(2023, 3, 26) }
+      let(:end_date)   { Date.new(2023, 4, 1) }
+
+      it 'returns true' do
         expect((start_date..end_date).count).to eq(7)
         expect(start_date.sunday?).to eq(true)
         expect(end_date.saturday?).to eq(true)
-        allow(amr_data).to receive(:start_date).and_return(start_date)
-        allow(amr_data).to receive(:end_date).and_return(end_date)
-
-        last_week_date_range = service.send(:last_week_date_range)
-        previous_week_date_range = service.send(:previous_week_date_range)
-        expect(last_week_date_range).to eq([Date.new(2023, 3, 26), Date.new(2023, 4, 1)])
-        expect(previous_week_date_range).to eq([])
-        expect([last_week_date_range.first.sunday?, last_week_date_range.last.saturday?]).to eq([true, true])
 
         expect(service.enough_data?).to eq(true)
         expect(service.data_available_from).to eq(nil)
-      end
 
-      it 'returns true if there is at least a full weeks worth of data' do
-        start_date = Date.new(2023, 3, 19)
-        end_date = Date.new(2023, 4, 1)
+        last_week_date_range = service.send(:last_week_date_range)
+        previous_week_date_range = service.send(:previous_week_date_range)
+        expect(last_week_date_range).to eq([start_date, end_date])
+        expect(previous_week_date_range).to eq([])
+        expect([last_week_date_range.first.sunday?, last_week_date_range.last.saturday?]).to eq([true, true])
+      end
+    end
+
+    context 'when there if two full weeks of data' do
+      let(:start_date) { Date.new(2023, 3, 19) }
+      let(:end_date)   { Date.new(2023, 4, 1) }
+
+      it 'returns true' do
         expect((start_date..end_date).count).to eq(14)
-        allow(amr_data).to receive(:start_date).and_return(start_date)
-        allow(amr_data).to receive(:end_date).and_return(end_date)
+
+        expect(service.enough_data?).to eq(true)
+        expect(service.data_available_from).to eq(nil)
 
         last_week_date_range = service.send(:last_week_date_range)
         previous_week_date_range = service.send(:previous_week_date_range)
@@ -54,28 +61,67 @@ RSpec.describe Schools::Advice::RecentChangesService, type: :service do
         expect(previous_week_date_range).to eq([Date.new(2023, 3, 19), Date.new(2023, 3, 25)])
         expect([last_week_date_range.first.sunday?, last_week_date_range.last.saturday?]).to eq([true, true])
         expect([previous_week_date_range.first.sunday?, previous_week_date_range.last.saturday?]).to eq([true, true])
-
-        expect(service.enough_data?).to eq(true)
-        expect(service.data_available_from).to eq(nil)
       end
+    end
 
-      it 'returns false if there is no full weeks worth of data' do
-        start_date = Date.new(2023, 3, 27)
-        end_date = Date.new(2023, 4, 2)
+    context 'when there is not a full calendar week of data' do
+      let(:start_date) { Date.new(2023, 3, 27) }
+      let(:end_date)   { Date.new(2023, 4, 2) }
+
+      it 'returns false' do
         expect((start_date..end_date).count).to eq(7)
         expect(start_date.monday?).to eq(true)
         expect(end_date.sunday?).to eq(true)
-        allow(amr_data).to receive(:start_date).and_return(start_date)
-        allow(amr_data).to receive(:end_date).and_return(end_date)
+
+        expect(service.enough_data?).to eq(false)
+        # This is the next occuring sunday from the last week end date plus 1 week
+        expect(service.data_available_from).to eq(Date.new(2023, 4, 9))
 
         last_week_date_range = service.send(:last_week_date_range)
         previous_week_date_range = service.send(:previous_week_date_range)
         expect(last_week_date_range).to eq([Date.new(2023, 3, 27), Date.new(2023, 4, 1)])
         expect(previous_week_date_range).to eq([])
         expect([last_week_date_range.first.monday?, last_week_date_range.last.saturday?]).to eq([true, true])
+      end
+    end
+  end
 
-        expect(service.enough_data?).to eq(false)
-        expect(service.data_available_from).to eq(Date.new(2023, 4, 9)) # This is the next occuring sunday from the last week end date plus 1 week
+  describe '#recent_usage' do
+    before do
+      allow(amr_data).to receive(:start_date).and_return(start_date)
+      allow(amr_data).to receive(:end_date).and_return(end_date)
+    end
+
+    let(:recent_usage) { service.recent_usage }
+
+    context 'when there is two full weeks of data' do
+      let(:start_date) { Date.new(2023, 3, 19) }
+      let(:end_date)   { Date.new(2023, 4, 1) }
+
+      before do
+        allow(amr_data).to receive(:kwh_date_range).and_return(1.0)
+      end
+
+      it 'returns expected usage' do
+        expect(recent_usage.last_week).not_to eq(0.0)
+        expect(recent_usage.previous_week).not_to be_nil
+        expect(recent_usage.previous_week.date_range).to eq([start_date, start_date + 6])
+        expect(recent_usage.change).not_to be_nil
+      end
+    end
+
+    context 'there is less than 2 weeks of data' do
+      let(:end_date)     { Date.new(2023, 12, 11) }
+      let(:start_date)   { Date.new(2023, 12, 3) }
+
+      before do
+        allow(amr_data).to receive(:kwh_date_range).and_return(1.0)
+      end
+
+      it 'returns expected usage' do
+        expect(recent_usage.last_week).not_to eq(0.0)
+        expect(recent_usage.previous_week).to be_nil
+        expect(recent_usage.change).to be_nil
       end
     end
   end


### PR DESCRIPTION
The recent changes service calculates the usage for and aggregate meter:

- the usage for the last week of data
- the usage for the previous week 
- change

To align with other parts of EnergySparks it doesn't look at last 7 days, but last calendar weeks.

There's a bug in the code where if there's >7 days but <14 days the previous week check fails with an error. This is currently affecting 1 school.

The PR fixes that with a small change to the `full_previous_week?` method. I've also removed some unused methods from the class and refactored the spec to push it more in line with our preferred approach.