### PR TITLE
Change data check to use BaseloadAnalysis class

### DIFF
--- a/app/services/schools/advice/baseload_service.rb
+++ b/app/services/schools/advice/baseload_service.rb
@@ -199,7 +199,7 @@ module Schools
         meter = load_meter ? meter_for_mpan(analytics_meter.mpan_mprn) : nil
         seasonal_baseload_service = Baseload::SeasonalBaseloadService.new(analytics_meter, date)
         #return if there's not enough data, then return limited object
-        return OpenStruct.new(meter: meter, enough_data?: false, data_available_from: seasonal_baseload_service.data_available_from) unless seasonal_baseload_service.enough_data?
+        return OpenStruct.new(meter: meter, enough_data?: false, data_available_from: seasonal_baseload_service.data_available_from) unless enough_data_for_meter?(analytics_meter)
         variation = seasonal_baseload_service.seasonal_variation
         #we may have >1 year of data, but not enough to actually calculate a seasonal analysis
         #e.g. a meter for a swimming pool only used in the summer
@@ -227,8 +227,9 @@ module Schools
 
       def calculate_intraweek_variation(analytics_meter = aggregate_meter, date = asof_date, load_meter = false)
         intraweek_baseload_service = Baseload::IntraweekBaseloadService.new(analytics_meter, date)
+        baseload_analysis = Baseload::BaseloadAnalysis.new(analytics_meter)
         meter = load_meter ? meter_for_mpan(analytics_meter.mpan_mprn) : nil
-        return OpenStruct.new(meter: meter, enough_data?: false, data_available_from: intraweek_baseload_service.data_available_from) unless intraweek_baseload_service.enough_data?
+        return OpenStruct.new(meter: meter, enough_data?: false, data_available_from: intraweek_baseload_service.data_available_from) unless enough_data_for_meter?(analytics_meter)
         variation = intraweek_baseload_service.intraweek_variation
         saving = intraweek_baseload_service.estimated_costs
         build_intraweek_variation(meter, variation, saving)
@@ -251,6 +252,10 @@ module Schools
 
       def intraweek_variation_rating(percentage)
         calculate_rating_from_range(0.1, 0.3, percentage)
+      end
+
+      def enough_data_for_meter?(analytics_meter)
+        Baseload::BaseloadAnalysis.new(analytics_meter).one_years_data?
       end
     end
   end

--- a/app/services/schools/advice/baseload_service.rb
+++ b/app/services/schools/advice/baseload_service.rb
@@ -227,7 +227,6 @@ module Schools
 
       def calculate_intraweek_variation(analytics_meter = aggregate_meter, date = asof_date, load_meter = false)
         intraweek_baseload_service = Baseload::IntraweekBaseloadService.new(analytics_meter, date)
-        baseload_analysis = Baseload::BaseloadAnalysis.new(analytics_meter)
         meter = load_meter ? meter_for_mpan(analytics_meter.mpan_mprn) : nil
         return OpenStruct.new(meter: meter, enough_data?: false, data_available_from: intraweek_baseload_service.data_available_from) unless enough_data_for_meter?(analytics_meter)
         variation = intraweek_baseload_service.intraweek_variation

--- a/spec/services/schools/advice/baseload_service_spec.rb
+++ b/spec/services/schools/advice/baseload_service_spec.rb
@@ -198,7 +198,7 @@ RSpec.describe Schools::Advice::BaseloadService, type: :service do
 
     before do
       allow_any_instance_of(Baseload::SeasonalBaseloadService).to receive(:seasonal_variation).and_return(seasonal_variation)
-      allow_any_instance_of(Baseload::SeasonalBaseloadService).to receive(:enough_data?).and_return(enough_data)
+      allow_any_instance_of(Baseload::BaseloadAnalysis).to receive(:one_years_data?).and_return(enough_data)
       allow_any_instance_of(Baseload::SeasonalBaseloadService).to receive(:data_available_from).and_return(data_available_from)
       allow_any_instance_of(Baseload::SeasonalBaseloadService).to receive(:estimated_costs).and_return(savings)
     end
@@ -245,7 +245,7 @@ RSpec.describe Schools::Advice::BaseloadService, type: :service do
 
     before do
       allow_any_instance_of(Baseload::IntraweekBaseloadService).to receive(:intraweek_variation).and_return(intraweek_variation)
-      allow_any_instance_of(Baseload::IntraweekBaseloadService).to receive(:enough_data?).and_return(enough_data)
+      allow_any_instance_of(Baseload::BaseloadAnalysis).to receive(:one_years_data?).and_return(enough_data)
       allow_any_instance_of(Baseload::IntraweekBaseloadService).to receive(:data_available_from).and_return(data_available_from)
       allow_any_instance_of(Baseload::IntraweekBaseloadService).to receive(:estimated_costs).and_return(savings)
     end


### PR DESCRIPTION
If a school has just short of a years data for some meters, then the seasonal and intraweek variation analysis for those meters breaks. There's a discrepancy between the date checking between the services.

To fix this now, I've changed the BaseloadService to call the analysis Baseload::BaseloadAnalysis class directly for the individual meter breakdown. This fixes a broken page for one school so they can properly access their baseload analysis.

