### PR TITLE
Check for nil result in admin target report

### DIFF
--- a/app/services/targets/admin_report_service.rb
+++ b/app/services/targets/admin_report_service.rb
@@ -39,7 +39,7 @@ module Targets
         data = service.report
         data.each do |school, school_result|
           FUEL_TYPES.each do |fuel_type|
-            if school_result[fuel_type].present?
+            if school_result && school_result[fuel_type].present?
               csv << [
                 school_group.name,
                 school.name,


### PR DESCRIPTION
Minor issue. There's a weekly admin report that runs on a Friday that sends a summary of state of the targets feature to admins.

The service used to generate the summary for each school may return nil if there's an unexpected error in running the school target, this isn't being checked for in the calling service. So I've fixed that.

The underlying errors are already being logged, so this will fix the report but we've already got visibility of the other issues.