### PR TITLE
Fix link in my school menu

### DIFF
--- a/app/views/shared/_my_school_menu.html.erb
+++ b/app/views/shared/_my_school_menu.html.erb
@@ -38,7 +38,7 @@
     <%= link_to t('my_school_menu.complete_pupil_activities'), activity_categories_path, class: 'dropdown-item' %>
 
     <!-- Energy saving actions -->
-    <%= link_to t('my_school_menu.energy_saving_actions'), school_interventions_path(current_user.school), class: 'dropdown-item' if can? :index, Observation %>
+    <%= link_to t('my_school_menu.energy_saving_actions'), intervention_type_groups_path, class: 'dropdown-item' %>
 
     <!-- School programmes -->
     <%= link_to t('my_school_menu.school_programmes'), programme_types_path, class: 'dropdown-item' %>

--- a/spec/system/schools/dashboard/navigation_spec.rb
+++ b/spec/system/schools/dashboard/navigation_spec.rb
@@ -182,9 +182,9 @@ RSpec.describe "adult dashboard navigation", type: :system do
       expect(page).to have_link("Storage heater usage")
       expect(page).to have_link("Energy analysis")
       expect(page).to have_link("My alerts")
-      expect(page).to have_link("School programmes")
-      expect(page).to have_link("Complete pupil activities")
-      expect(page).to have_link("Energy saving actions")
+      expect(page).to have_link("School programmes", href: programme_types_path)
+      expect(page).to have_link("Complete pupil activities", href: activity_categories_path)
+      expect(page).to have_link("Energy saving actions", href: intervention_type_groups_path)
       expect(page).to have_link("Download our data")
     end
 


### PR DESCRIPTION
Testing out the school admin pages I noticed that one of the links in the "My school" menu is linking to the school's list of interventions, rather than the energy saving action index page.

I've fixed that and updated the tests so they're doing something a bit more useful.

I've left off revising other parts of the menu, e.g. to add link to recommendations page, as we can review that in 2024.