### PR TITLE
Spread out compact observations slightly

### DIFF
--- a/app/components/observation_component/observation_base.html.erb
+++ b/app/components/observation_component/observation_base.html.erb
@@ -1,5 +1,5 @@
 <% if compact %>
-  <div class="row">
+  <div class="row pb-1">
     <div class="col-1"><%= icon %></div>
     <div class="col-11"><%= I18n.t("components.observation.#{self.class.name.demodulize.underscore}.compact_message_html", school: school.name, school_path: school_path(school), target: target, message: message, count: observation.points || 0, compact_path: compact_path).html_safe %></div>
   </div>

--- a/app/components/scoreboard_summary_component.rb
+++ b/app/components/scoreboard_summary_component.rb
@@ -22,7 +22,7 @@ class ScoreboardSummaryComponent < ViewComponent::Base
   end
 
   def limit
-    5
+    4
   end
 
   def observations

--- a/spec/components/scoreboard_summary_component_spec.rb
+++ b/spec/components/scoreboard_summary_component_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe ScoreboardSummaryComponent, type: :component, include_url_helpers
   end
 
   describe "#limit" do
-    it { expect(component.limit).to be(5) }
+    it { expect(component.limit).to be(4) }
   end
 
   describe "#school" do


### PR DESCRIPTION
Also reduces the amount observations shown from 5 to 4, which looks slightly better given the extra padding on each row.