### PR TITLE
Change style of disabled button on record activity / action pages

### DIFF
--- a/app/assets/javascripts/select.js
+++ b/app/assets/javascripts/select.js
@@ -26,4 +26,13 @@ $(document).ready(function() {
   if ($("form .must-select").length > 0) {
     $("form .must-select").closest('form').find(':submit').prop('disabled', true);
   }
+
+  $(document).on('change','.must-select.disable-tooltip', function() {
+    if ($(this).val()) {
+      $(this).closest('form').find(':submit').tooltip('dispose');
+    } else {
+      $(this).closest('form').find(':submit').tooltip('enable');
+    }
+  });
+
 });

--- a/app/views/activity_types/_prompt_score.html.erb
+++ b/app/views/activity_types/_prompt_score.html.erb
@@ -6,8 +6,9 @@
     <div class="col-lg-7 col-sm-12 align-self-center">
       <%= t('activity_types.show.complete_this_activity_html', count: activity_type.score) %>
     </div>
-    <div class="col-lg-4 col-sm-12">
-      <%= link_to t('activity_types.show.record_this_activity'), new_school_activity_path(school, activity_type_id: activity_type.id), class: 'btn btn-primary' %>
+    <div class="col-lg-4 col-sm-12 align-self-center">
+      <div class="d-none d-sm-block d-md-block d-lg-none pt-2"></div>
+      <%= link_to t('activity_types.show.record_this_activity'), new_school_activity_path(school, activity_type_id: activity_type.id), class: 'btn btn-primary float-lg-right' %>
     </div>
   </div>
 <% end %>

--- a/app/views/activity_types/_prompt_score_for_group.html.erb
+++ b/app/views/activity_types/_prompt_score_for_group.html.erb
@@ -1,17 +1,18 @@
 <%= simple_form_for :activity_type, url: for_school_activity_type_path(activity_type), method: :get do |f| %>
   <%= component 'notice', status: :neutral, classes: 'mb-4' do %>
     <div class="row" role="alert">
-      <div class="col-lg-1 d-none d-lg-block align-self-center">
+      <div class="col-lg-1 d-none d-lg-block">
         <i class="fas fa-tasks fa-3x"></i>
       </div>
-      <div class="col-lg-7 col-sm-12 align-self-center">
+      <div class="col-lg-8 col-sm-12 align-self-center">
         <%= t('activity_types.show.complete_this_activity_for_group_html', count: activity_type.score) %>
-        <div class="w-75 pt-3">
-          <%= select_tag :school_id, options_from_collection_for_select(schools, :id, :name), include_blank: t('activity_types.show.select_school'), class: 'form-control select2 must-select' %>
+        <div class="pt-2 w-75">
+          <%= select_tag :school_id, options_from_collection_for_select(schools, :id, :name), include_blank: t('activity_types.show.select_school'), class: 'form-control select2 must-select disable-tooltip' %>
         </div>
       </div>
-      <div class="col-lg-4 col-sm-12">
-        <%= f.submit t('activity_types.show.record_this_activity'), class: 'btn btn-primary' %>
+      <div class="col-lg-3 col-sm-12">
+        <div class="d-none d-sm-block d-md-block d-lg-none pt-2"></div>
+        <%= f.submit t('activity_types.show.record_this_activity'), class: 'btn btn-light float-lg-right', 'data-toggle': 'tooltip', 'data-placement': 'bottom', title: t('activity_types.show.select_school') %>
       </div>
     </div>
   <% end %>

--- a/app/views/intervention_types/_prompt_score.html.erb
+++ b/app/views/intervention_types/_prompt_score.html.erb
@@ -1,17 +1,14 @@
-<div class="row">
-  <div class="col-md-9">
-    <%= component 'notice', status: :neutral, classes: 'mb-4' do %>
-      <div class="row" role="alert">
-        <div class="col-lg-1 d-none d-lg-block align-self-center">
-          <i class="fas fa-tasks fa-3x"></i>
-        </div>
-        <div class="col-lg-7 col-sm-12 align-self-center">
-          <%= t('intervention_types.prompt_score.complete_this_action_html', count: intervention_type.score) %><br />
-        </div>
-        <div class="col-lg-4 col-sm-12">
-          <%= link_to t('intervention_types.prompt_score.record_this_action'), new_school_intervention_path(school, intervention_type_id: intervention_type.id), class: 'btn btn-primary' %>
-        </div>
-      </div>
-    <% end %>
+<%= component 'notice', status: :neutral, classes: 'mb-4' do %>
+  <div class="row" role="alert">
+    <div class="col-lg-1 d-none d-lg-block align-self-center">
+      <i class="fas fa-tasks fa-3x"></i>
+    </div>
+    <div class="col-lg-7 col-sm-12 align-self-center">
+      <%= t('intervention_types.prompt_score.complete_this_action_html', count: intervention_type.score) %><br />
+    </div>
+    <div class="col-lg-4 col-sm-12 align-self-center">
+      <div class="d-none d-sm-block d-md-block d-lg-none pt-2"></div>
+      <%= link_to t('intervention_types.prompt_score.record_this_action'), new_school_intervention_path(school, intervention_type_id: intervention_type.id), class: 'btn btn-primary float-lg-right' %>
+    </div>
   </div>
-</div>
+<% end %>

--- a/app/views/intervention_types/_prompt_score_for_group.html.erb
+++ b/app/views/intervention_types/_prompt_score_for_group.html.erb
@@ -1,22 +1,19 @@
 <%= simple_form_for :intervention_type, url: for_school_intervention_type_path(intervention_type), method: :get do |f| %>
-  <div class="row">
-    <div class="col-md-9">
-      <%= component 'notice', status: :neutral, classes: 'mb-4' do %>
-        <div class="row" role="alert">
-          <div class="col-lg-1 d-none d-lg-block align-self-center">
-            <i class="fas fa-tasks fa-3x"></i>
-          </div>
-          <div class="col-lg-7 col-sm-12 align-self-center">
-            <%= t('intervention_types.prompt_score.complete_this_action_for_group_html', count: intervention_type.score) %><br />
-            <div class="w-75 pt-3">
-              <%= select_tag :school_id, options_from_collection_for_select(schools, :id, :name), include_blank: t('activity_types.show.select_school'), class: 'form-control select2 must-select' %>
-            </div>
-          </div>
-          <div class="col-lg-4 col-sm-12">
-            <%= f.submit t('intervention_types.prompt_score.record_this_action'), class: 'btn btn-primary' %>
-          </div>
+  <%= component 'notice', status: :neutral, classes: 'mb-4' do %>
+    <div class="row" role="alert">
+      <div class="col-lg-1 d-none d-lg-block">
+        <i class="fas fa-tasks fa-3x"></i>
+      </div>
+      <div class="col-lg-8 col-sm-12 align-self-center">
+        <%= t('intervention_types.prompt_score.complete_this_action_for_group_html', count: intervention_type.score) %><br />
+        <div class="pt-3 w-75">
+          <%= select_tag :school_id, options_from_collection_for_select(schools, :id, :name), include_blank: t('activity_types.show.select_school'), class: 'form-control select2 must-select disable-tooltip' %>
         </div>
-      <% end %>
+      </div>
+      <div class="col-lg-3 col-sm-12">
+        <div class="d-none d-sm-block d-md-block d-lg-none pt-2"></div>
+        <%= f.submit t('intervention_types.prompt_score.record_this_action'), class: 'btn btn-light float-lg-right', 'data-toggle': 'tooltip', 'data-placement': 'bottom', title: t('activity_types.show.select_school') %>
+      </div>
     </div>
-  </div>
+  <% end %>
 <% end %>


### PR DESCRIPTION
This does a few things.

- Changes the style of the disabled button on record activity and action pages.
- Makes the notice that contains this form full width on the activity pages to match the style of the action pages
- Adds a tooltip to the disabled button when disabled (and removes when not)
- Changes the alignment a bit of this form

All of which is up for discussion... see what you think!