### PR TITLE
Add trait for creating previous and next academic years to calendars factory

### DIFF
--- a/spec/factories/calendars_factory.rb
+++ b/spec/factories/calendars_factory.rb
@@ -45,15 +45,11 @@ FactoryBot.define do
     #Ensures there is a previous, current and upcoming AcademicYear
     trait :with_previous_and_next_academic_years do
       after(:create) do |calendar, _evaluator|
-        current_year = Time.zone.today.year
+        today = Time.zone.today
         #At the end of the year, school academic year started in previous year
         #But otherwise, the previous academic year started 2 years ago
-        if Time.zone.today >= Date.new(current_year, 9, 1)
-          start_year = current_year - 1
-        else
-          start_year = current_year - 2
-        end
-        end_year = current_year + 1
+        start_year = today.year - (today.month < 9 ? 2 : 1)
+        end_year = today.year + 1
         (start_year..end_year).each do |year|
           create(:academic_year, calendar: calendar, start_date: Date.new(year, 9, 1), end_date: Date.new(year + 1, 8, 31))
         end

--- a/spec/factories/calendars_factory.rb
+++ b/spec/factories/calendars_factory.rb
@@ -42,6 +42,24 @@ FactoryBot.define do
       end
     end
 
+    #Ensures there is a previous, current and upcoming AcademicYear
+    trait :with_previous_and_next_academic_years do
+      after(:create) do |calendar, _evaluator|
+        current_year = Time.zone.today.year
+        #At the end of the year, school academic year started in previous year
+        #But otherwise, the previous academic year started 2 years ago
+        if Time.zone.today >= Date.new(current_year, 9, 1)
+          start_year = current_year - 1
+        else
+          start_year = current_year - 2
+        end
+        end_year = current_year + 1
+        (start_year..end_year).each do |year|
+          create(:academic_year, calendar: calendar, start_date: Date.new(year, 9, 1), end_date: Date.new(year + 1, 8, 31))
+        end
+      end
+    end
+
     trait :with_terms do
       transient do
         term_count { 5 }

--- a/spec/models/school_group_spec.rb
+++ b/spec/models/school_group_spec.rb
@@ -233,7 +233,7 @@ describe SchoolGroup, :school_groups, type: :model do
 
   context 'as a Scorable' do
     let!(:school_group)      { create :school_group, default_template_calendar: template_calendar }
-    let!(:template_calendar) { create :template_calendar }
+    let!(:template_calendar) { create :template_calendar, :with_previous_and_next_academic_years }
     let(:scoreboard)   { nil }
 
     it_behaves_like 'a scorable'

--- a/spec/models/scoreboard_spec.rb
+++ b/spec/models/scoreboard_spec.rb
@@ -69,7 +69,7 @@ describe Scoreboard, :scoreboards, type: :model do
 
   context 'as a Scorable' do
     let!(:scoreboard) { create :scoreboard, academic_year_calendar: template_calendar }
-    let!(:template_calendar) { create :template_calendar }
+    let!(:template_calendar) { create :template_calendar, :with_previous_and_next_academic_years }
     let(:school_group) { nil }
 
     it_behaves_like 'a scorable'

--- a/spec/support/shared_examples/scorable.rb
+++ b/spec/support/shared_examples/scorable.rb
@@ -3,7 +3,6 @@ RSpec.shared_examples "a scorable" do
     let!(:schools) { (1..5).collect { |n| create :school, :with_points, score_points: 6 - n, scoreboard: scoreboard, school_group: school_group, activities_happened_on: 6.months.ago, template_calendar: subject.scorable_calendar}}
 
     it 'returns schools in points order' do
-      #pry
       travel_to subject.previous_academic_year.start_date do
         expect(subject.scored_schools.map(&:sum_points)).to eq([5, 4, 3, 2, 1])
         expect(subject.scored_schools.map(&:id)).to eq(schools.map(&:id))

--- a/spec/support/shared_examples/scorable.rb
+++ b/spec/support/shared_examples/scorable.rb
@@ -3,6 +3,7 @@ RSpec.shared_examples "a scorable" do
     let!(:schools) { (1..5).collect { |n| create :school, :with_points, score_points: 6 - n, scoreboard: scoreboard, school_group: school_group, activities_happened_on: 6.months.ago, template_calendar: subject.scorable_calendar}}
 
     it 'returns schools in points order' do
+      #pry
       travel_to subject.previous_academic_year.start_date do
         expect(subject.scored_schools.map(&:sum_points)).to eq([5, 4, 3, 2, 1])
         expect(subject.scored_schools.map(&:id)).to eq(schools.map(&:id))

--- a/spec/system/school_groups_spec.rb
+++ b/spec/system/school_groups_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe 'school groups', :school_groups, type: :system do
   let(:public) { true }
-  let!(:template_calendar) { create :template_calendar }
+  let!(:template_calendar) { create :template_calendar, :with_previous_and_next_academic_years }
   let!(:school_group)          { create(:school_group, public: public, default_template_calendar: template_calendar) }
 
   let!(:user)                  { create(:user) }


### PR DESCRIPTION
Some recently added tests around the scorable concern rely on creating a calendar for the `Scorable`. The calendar needs to have some terms and a correct set of calendar years.

Currently the academic years were being created as a side effect of adding the terms. And the logic for that was just creating academic years for the previous and next _calendar_ year.

This works fine between 1st September and 31st December because the previous school year is in the previous calendar year.

But the test data is incorrect from 1st January as the previous school year begins two calendar years before that. E.g. on 1st January 2023 the school year is the Sept 2023-August 2024 period and the previous school year is Sept 2022-August 2023.

The incorrectly setup data causes three sets of specs to fail.

I've added a trait that correctly creates previous, current and latest academic years regardless of the time of year and updated the specs to use it. This should resolve the problems