### PR TITLE
Fix flickering TransifexSerialisable test

### DIFF
--- a/spec/models/concerns/transifex_serialisable_spec.rb
+++ b/spec/models/concerns/transifex_serialisable_spec.rb
@@ -73,12 +73,12 @@ describe TransifexSerialisable do
     end
 
     it 'model shows no content present if no attributes set' do
-      serialisable = @tx_serialisables.first.new
+      serialisable = ActivityCategory.new #use this as an example of implementing class
       expect(serialisable).not_to have_content
     end
 
     it 'model shows content present if some attribute set' do
-      clazz = @tx_serialisables.first
+      clazz = ActivityCategory #use this as an example of implementing class
       attr = clazz.mobility_attributes.first
       serialisable = clazz.new(attr => 'something')
       expect(serialisable).to have_content

--- a/spec/models/concerns/transifex_serialisable_spec.rb
+++ b/spec/models/concerns/transifex_serialisable_spec.rb
@@ -73,13 +73,13 @@ describe TransifexSerialisable do
     end
 
     it 'model shows no content present if no attributes set' do
-      serialisable = ActivityCategory.new #use this as an example of implementing class
-      expect(serialisable).not_to have_content
+      #use this as an example of implementing class
+      expect(ActivityCategory.new).not_to have_content
     end
 
     it 'model shows content present if some attribute set' do
       clazz = ActivityCategory #use this as an example of implementing class
-      attr = clazz.mobility_attributes.first
+      attr = ActivityCategory.mobility_attributes.first
       serialisable = clazz.new(attr => 'something')
       expect(serialisable).to have_content
     end


### PR DESCRIPTION
This spec selects a class that implements TransifexSerialisable and then confirms that the `has_content` method works correctly with and without attributes set.

It currently builds a list of all the classes that implements the model than selects the first one. The `AlertTypeRatingContentVersion` model relies on having an associated `AlertTypeRating` instance to guide how it is serialised. If this class ends up being the first in the list, then the spec fails as the dependent object hasn't been created.

Have updated the test to use a specific implementing class (`ActivityCategory`) to test the generic behaviour.