### PR TITLE
Include national scoreboard position on the podium

### DIFF
--- a/app/components/podium_component.rb
+++ b/app/components/podium_component.rb
@@ -19,6 +19,10 @@ class PodiumComponent < ViewComponent::Base
     podium.school
   end
 
+  def national_podium
+    podium.national_podium
+  end
+
   def render?
     podium
   end

--- a/app/components/podium_component/podium_component.html.erb
+++ b/app/components/podium_component/podium_component.html.erb
@@ -1,7 +1,11 @@
 <div<%= " id=#{id}" if id %> class="podium-component<%= classes %>">
   <% if podium.includes_school? && podium.school_has_points? %>
     <% if EnergySparks::FeatureFlags.active?(:activities_2023) %>
-      <h4 class="text-center"><%= t('components.podium.full_position_html', position_ordinal: podium.school_position.ordinal, scoreboard: podium.scoreboard.name, scoreboard_path: scoreboard_path(podium.scoreboard)) %>.</h4>
+      <h4 class="text-center"><%= t('components.podium.full_position_html', position_ordinal: podium.school_position.ordinal,
+        scoreboard: podium.scoreboard.name,
+        scoreboard_path: scoreboard_path(podium.scoreboard),
+        national_position_ordinal: national_podium.school_position.ordinal,
+        national_scoreboard_path: scoreboard_path(national_podium.scoreboard)) %>.</h4>
     <% else %>
       <h4 class="text-center"><%= t('components.podium.position_html', position_ordinal: podium.school_position.ordinal) %>.</h4>
     <% end %>

--- a/app/components/podium_component/podium_component.html.erb
+++ b/app/components/podium_component/podium_component.html.erb
@@ -1,7 +1,8 @@
 <div<%= " id=#{id}" if id %> class="podium-component<%= classes %>">
   <% if podium.includes_school? && podium.school_has_points? %>
     <% if EnergySparks::FeatureFlags.active?(:activities_2023) %>
-      <h4 class="text-center"><%= t('components.podium.full_position_html', position_ordinal: podium.school_position.ordinal,
+      <h4 class="text-center"><%= t('components.podium.full_position_html',
+        position_ordinal: podium.school_position.ordinal,
         scoreboard: podium.scoreboard.name,
         scoreboard_path: scoreboard_path(podium.scoreboard),
         national_position_ordinal: national_podium.school_position.ordinal,

--- a/app/models/podium.rb
+++ b/app/models/podium.rb
@@ -66,6 +66,10 @@ class Podium
     @school = school
   end
 
+  def national_podium
+    @national_podium ||= Podium.create(school: school, scoreboard: ScoreboardAll.new)
+  end
+
   def high_to_low
     @positions
   end

--- a/config/locales/views/components/podium.yml
+++ b/config/locales/views/components/podium.yml
@@ -3,7 +3,7 @@ en:
   components:
     podium:
       complete_an_activity_html: <a href="%{recommendations_path}">Complete an activity</a> to score points on Energy Sparks
-      full_position_html: You are in <strong>%{position_ordinal} place</strong> on the <a href='%{scoreboard_path}'>%{scoreboard} scoreboard</a>
+      full_position_html: You are in <strong>%{position_ordinal} place</strong> on the <a href='%{scoreboard_path}'>%{scoreboard} scoreboard</a> and <strong>%{national_position_ordinal} place</strong> <a href='%{national_scoreboard_path}'>nationally</a>
       no_points_this_year: Your school hasn't scored any points yet this school year
       points: points
       points_needed_to_overtake: You only need to score %{points} points to overtake the next school!

--- a/spec/components/podium_component_spec.rb
+++ b/spec/components/podium_component_spec.rb
@@ -10,8 +10,7 @@ RSpec.describe PodiumComponent, type: :component, include_url_helpers: true do
   let(:params) { all_params }
 
   before do
-    # required for national scoreboard
-    create(:calendar, title: 'England and Wales', calendar_type: 'national')
+    create(:national_calendar, title: 'England and Wales') # required for podium to show national placing
   end
 
   let(:html) do

--- a/spec/system/activities_spec.rb
+++ b/spec/system/activities_spec.rb
@@ -5,6 +5,7 @@ describe 'viewing and recording activities', type: :system do
 
   let!(:subject)  { Subject.create(name: "Science and Technology") }
   let!(:ks1)      { KeyStage.create(name: 'KS1') }
+
   let(:activity_data_driven)    { true }
   let(:school_data_enabled)     { true }
 
@@ -16,7 +17,10 @@ describe 'viewing and recording activities', type: :system do
   let!(:scoreboard) { create :scoreboard }
   let(:school) { create_active_school(data_enabled: school_data_enabled, scoreboard: scoreboard) }
 
-  before { SiteSettings.create!(audit_activities_bonus_points: 50) }
+  before do
+    SiteSettings.create!(audit_activities_bonus_points: 50)
+    create(:national_calendar, title: 'England and Wales') # required for podium to show national placing
+  end
 
   let!(:audit) { create(:audit, :with_activity_and_intervention_types, school: school) }
 

--- a/spec/system/interventions_spec.rb
+++ b/spec/system/interventions_spec.rb
@@ -21,6 +21,7 @@ describe 'viewing and recording action', type: :system do
 
   before do
     SiteSettings.current.update(photo_bonus_points: photo_bonus_points)
+    create(:national_calendar, title: 'England and Wales') # required for podium to show national placing
   end
 
   context 'as a public user' do

--- a/spec/system/pupils/prompts_spec.rb
+++ b/spec/system/pupils/prompts_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe "pupil dashboard prompts", type: :system do
 
   before do
     SiteSettings.create!(temperature_recording_months: (1..12).map(&:to_s), electricity_price: 1, solar_export_price: 1, gas_price: 1)
+    create(:national_calendar, title: 'England and Wales') # required for podium to show national placing
     sign_in(user) if user.present?
     visit pupils_school_path(school)
   end


### PR DESCRIPTION
The podium text now includes national position:

![image](https://github.com/Energy-Sparks/energy-sparks/assets/6051/471b0f4f-089b-44d5-a50e-1f46bcbccf62)
