### PR TITLE
bootstrap-email gem update

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,7 +59,7 @@ gem 'mailgun_rails' # Email service
 gem 'twilio-ruby' # For SMS notifications
 
 # Assets for Emails
-gem 'bootstrap-email', '~> 1.2.0' # TODO: higher versions break tests
+gem 'bootstrap-email'
 
 # Frontend
 gem 'bootstrap', '~> 4' # Use bootstrap for responsive layout

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -166,7 +166,7 @@ GEM
       autoprefixer-rails (>= 9.1.0)
       popper_js (>= 1.16.1, < 2)
       sassc-rails (>= 2.0.0)
-    bootstrap-email (1.2.0)
+    bootstrap-email (1.4.1)
       htmlbeautifier (~> 1.3)
       nokogiri (~> 1.6)
       premailer (~> 1.7)
@@ -717,7 +717,7 @@ DEPENDENCIES
   binding_of_caller
   bootsnap
   bootstrap (~> 4)
-  bootstrap-email (~> 1.2.0)
+  bootstrap-email
   bootstrap4-datetime-picker-rails
   brakeman
   bullet

--- a/spec/mailers/bill_request_mailer_spec.rb
+++ b/spec/mailers/bill_request_mailer_spec.rb
@@ -25,8 +25,8 @@ RSpec.describe BillRequestMailer do
 
       it 'sends an email with en strings' do
         expect(@email.subject).to eql("Please upload a recent energy bill to Energy Sparks")
-        expect(@email.body.to_s).to include("Please upload an energy bill for Test School")
-        expect(@email.body.to_s).to include("http://localhost/schools/test-school/consent_documents")
+        expect(@email.html_part.decoded).to include("Please upload an energy bill for Test School")
+        expect(@email.html_part.decoded).to include("http://localhost/schools/test-school/consent_documents")
       end
     end
 
@@ -35,8 +35,8 @@ RSpec.describe BillRequestMailer do
 
       it 'sends an email with cy strings' do
         expect(@email.subject).to eql("Uwchlwythwch fil ynni diweddar i Sbarcynni")
-        expect(@email.body.to_s).to include("Uwchlwythwch fil ynni ar gyfer Test School")
-        expect(@email.body.to_s).to include("http://cy.localhost/schools/test-school/consent_documents")
+        expect(@email.html_part.decoded).to include("Uwchlwythwch fil ynni ar gyfer Test School")
+        expect(@email.html_part.decoded).to include("http://cy.localhost/schools/test-school/consent_documents")
       end
     end
   end

--- a/spec/mailers/consent_grant_mailer_spec.rb
+++ b/spec/mailers/consent_grant_mailer_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe ConsentGrantMailer do
 
       it 'sends an email with en strings' do
         expect(@email.subject).to eql("Your grant of consent to Energy Sparks")
-        expect(@email.body.to_s).to include("Thank you for granting permission for Energy Sparks to access data for Test School")
+        expect(@email.html_part.decoded).to include("Thank you for granting permission for Energy Sparks to access data for Test School")
       end
     end
 
@@ -31,7 +31,7 @@ RSpec.describe ConsentGrantMailer do
 
       it 'sends an email with cy strings' do
         expect(@email.subject).to eql("Eich caniatâd i Sbarcynni")
-        expect(ActionController::Base.helpers.sanitize(@email.body.to_s)).to include("Diolch am roi caniatâd i Sbarcynni gael mynediad at ddata ar gyfer Test School")
+        expect(ActionController::Base.helpers.sanitize(@email.html_part.decoded)).to include("Diolch am roi caniatâd i Sbarcynni gael mynediad at ddata ar gyfer Test School")
       end
     end
   end

--- a/spec/mailers/consent_request_mailer_spec.rb
+++ b/spec/mailers/consent_request_mailer_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe ConsentRequestMailer do
 
       it 'sends an email with en strings' do
         expect(email.subject).to eql("We need permission to access your school's energy data")
-        expect(email.body.to_s).to include("Please provide permission for Energy Sparks to access data for Test School")
+        expect(email.html_part.decoded).to include("Please provide permission for Energy Sparks to access data for Test School")
       end
     end
 
@@ -30,7 +30,7 @@ RSpec.describe ConsentRequestMailer do
 
       it 'sends an email with cy strings' do
         expect(email.subject).to eql I18n.t('consent_request_mailer.request_consent.subject', locale: :cy)
-        expect(ActionController::Base.helpers.sanitize(email.body.to_s)).to include(I18n.t('consent_request_mailer.request_consent.description', school_name: 'Test School', locale: :cy))
+        expect(ActionController::Base.helpers.sanitize(email.html_part.decoded)).to include(I18n.t('consent_request_mailer.request_consent.description', school_name: 'Test School', locale: :cy))
       end
     end
   end

--- a/spec/mailers/dcc_mailer_spec.rb
+++ b/spec/mailers/dcc_mailer_spec.rb
@@ -13,10 +13,10 @@ RSpec.describe DccMailer do
       expect(ActionMailer::Base.deliveries.count).to be 1
       email = ActionMailer::Base.deliveries.last
       expect(email.subject).to eql "New smart meters found"
-      expect(email.body.to_s).to include(meter_1.mpan_mprn.to_s)
-      expect(email.body.to_s).to include('Big School')
-      expect(email.body.to_s).to include(meter_2.mpan_mprn.to_s)
-      expect(email.body.to_s).to include('Little School')
+      expect(email.html_part.decoded).to include(meter_1.mpan_mprn.to_s)
+      expect(email.html_part.decoded).to include('Big School')
+      expect(email.html_part.decoded).to include(meter_2.mpan_mprn.to_s)
+      expect(email.html_part.decoded).to include('Little School')
     end
   end
 end

--- a/spec/mailers/energy_sparks_devise_mailer_spec.rb
+++ b/spec/mailers/energy_sparks_devise_mailer_spec.rb
@@ -25,8 +25,8 @@ RSpec.describe EnergySparksDeviseMailer do
       end
 
       it 'contains links to default site but not cy site' do
-        expect(@email.body.to_s).to include("http://localhost/users/confirmation?confirmation_token=")
-        expect(@email.body.to_s).not_to include("http://cy.localhost/users/confirmation?confirmation_token=")
+        expect(@email.html_part.decoded).to include("http://localhost/users/confirmation?confirmation_token=")
+        expect(@email.html_part.decoded).not_to include("http://cy.localhost/users/confirmation?confirmation_token=")
       end
     end
 
@@ -38,8 +38,8 @@ RSpec.describe EnergySparksDeviseMailer do
       end
 
       it 'contains links to default site and cy site' do
-        expect(@email.body.to_s).to include("http://localhost/users/confirmation?confirmation_token=")
-        expect(@email.body.to_s).to include("http://cy.localhost/users/confirmation?confirmation_token=")
+        expect(@email.html_part.decoded).to include("http://localhost/users/confirmation?confirmation_token=")
+        expect(@email.html_part.decoded).to include("http://cy.localhost/users/confirmation?confirmation_token=")
       end
     end
 

--- a/spec/mailers/energy_tariffs_mailer_spec.rb
+++ b/spec/mailers/energy_tariffs_mailer_spec.rb
@@ -22,11 +22,11 @@ RSpec.describe EnergyTariffsMailer, include_application_helper: true do
         expect(email.to).to eq([school_group_admin.email])
         #encountered some character encoding issues â and ŵ being escape to &#xxxx; and unclear how to force that encoding when checking against YAML
         #So instead check for text explicitly
-        expect(email.body.to_s).to include('Ymddiriedolaeth Aml-Academi')
-        expect(email.body.to_s).to include("http://cy.localhost/school_groups/#{school_group.slug}/energy_tariffs")
-        expect(email.body.to_s).to include(I18n.t('energy_tariffs_mailer.group_admin_review_group_tariffs_reminder.mail_body.you_can_set', locale: :cy))
-        expect(email.body.to_s).to include(I18n.t('energy_tariffs_mailer.group_admin_review_group_tariffs_reminder.mail_body.to_review', locale: :cy))
-        expect(email.body.to_s).to include(I18n.t('energy_tariffs_mailer.group_admin_review_group_tariffs_reminder.mail_body.in_future', locale: :cy))
+        expect(email.html_part.decoded).to include('Ymddiriedolaeth Aml-Academi')
+        expect(email.html_part.decoded).to include("http://cy.localhost/school_groups/#{school_group.slug}/energy_tariffs")
+        expect(email.html_part.decoded).to include(I18n.t('energy_tariffs_mailer.group_admin_review_group_tariffs_reminder.mail_body.you_can_set', locale: :cy))
+        expect(email.html_part.decoded).to include(I18n.t('energy_tariffs_mailer.group_admin_review_group_tariffs_reminder.mail_body.to_review', locale: :cy))
+        expect(email.html_part.decoded).to include(I18n.t('energy_tariffs_mailer.group_admin_review_group_tariffs_reminder.mail_body.in_future', locale: :cy))
       end
     end
 
@@ -39,11 +39,11 @@ RSpec.describe EnergyTariffsMailer, include_application_helper: true do
         email = ActionMailer::Base.deliveries.last
         expect(email.subject).to eq(I18n.t('energy_tariffs_mailer.group_admin_review_group_tariffs_reminder.subject', school_group_name: school_group.name, locale: :en))
         expect(email.to).to eq([school_group_admin.email])
-        expect(email.body.to_s).to include('Multi-Academy Trust')
-        expect(email.body.to_s).to include("http://localhost/school_groups/#{school_group.slug}/energy_tariffs")
-        expect(email.body.to_s).to include(I18n.t('energy_tariffs_mailer.group_admin_review_group_tariffs_reminder.mail_body.you_can_set', locale: :en))
-        expect(email.body.to_s).to include(I18n.t('energy_tariffs_mailer.group_admin_review_group_tariffs_reminder.mail_body.to_review', locale: :en))
-        expect(email.body.to_s).to include(I18n.t('energy_tariffs_mailer.group_admin_review_group_tariffs_reminder.mail_body.in_future', locale: :en))
+        expect(email.html_part.decoded).to include('Multi-Academy Trust')
+        expect(email.html_part.decoded).to include("http://localhost/school_groups/#{school_group.slug}/energy_tariffs")
+        expect(email.html_part.decoded).to include(I18n.t('energy_tariffs_mailer.group_admin_review_group_tariffs_reminder.mail_body.you_can_set', locale: :en))
+        expect(email.html_part.decoded).to include(I18n.t('energy_tariffs_mailer.group_admin_review_group_tariffs_reminder.mail_body.to_review', locale: :en))
+        expect(email.html_part.decoded).to include(I18n.t('energy_tariffs_mailer.group_admin_review_group_tariffs_reminder.mail_body.in_future', locale: :en))
       end
     end
   end
@@ -63,10 +63,10 @@ RSpec.describe EnergyTariffsMailer, include_application_helper: true do
         email = ActionMailer::Base.deliveries.last
         expect(email.subject).to eq(I18n.t('energy_tariffs_mailer.school_admin_review_school_tariffs_reminder.subject', school_name: school.name, locale: :en))
         expect(email.to).to eq([school_admin.email])
-        expect(email.body.to_s).to include(I18n.t('energy_tariffs_mailer.school_admin_review_school_tariffs_reminder.mail_body.to_help', school_name: school.name, locale: :en))
-        expect(email.body.to_s).to include("http://localhost/schools/#{school.slug}/energy_tariffs")
-        expect(email.body.to_s).to include(I18n.t('energy_tariffs_mailer.school_admin_review_school_tariffs_reminder.mail_body.to_review', locale: :en))
-        expect(email.body.to_s).to include(I18n.t('energy_tariffs_mailer.school_admin_review_school_tariffs_reminder.mail_body.in_future', locale: :en))
+        expect(email.html_part.decoded).to include(I18n.t('energy_tariffs_mailer.school_admin_review_school_tariffs_reminder.mail_body.to_help', school_name: school.name, locale: :en))
+        expect(email.html_part.decoded).to include("http://localhost/schools/#{school.slug}/energy_tariffs")
+        expect(email.html_part.decoded).to include(I18n.t('energy_tariffs_mailer.school_admin_review_school_tariffs_reminder.mail_body.to_review', locale: :en))
+        expect(email.html_part.decoded).to include(I18n.t('energy_tariffs_mailer.school_admin_review_school_tariffs_reminder.mail_body.in_future', locale: :en))
       end
     end
 
@@ -79,10 +79,10 @@ RSpec.describe EnergyTariffsMailer, include_application_helper: true do
         email = ActionMailer::Base.deliveries.last
         expect(email.subject).to eq(I18n.t('energy_tariffs_mailer.school_admin_review_school_tariffs_reminder.subject', school_name: school.name, locale: :cy))
         expect(email.to).to eq([school_admin.email])
-        expect(email.body.to_s).to include("tariffau ynni ar gyfer #{school.name}")
-        expect(email.body.to_s).to include("http://cy.localhost/schools/#{school.slug}/energy_tariffs")
-        expect(email.body.to_s).to include(I18n.t('energy_tariffs_mailer.school_admin_review_school_tariffs_reminder.mail_body.to_review', locale: :cy))
-        expect(email.body.to_s).to include(I18n.t('energy_tariffs_mailer.school_admin_review_school_tariffs_reminder.mail_body.in_future', locale: :cy))
+        expect(email.html_part.decoded).to include("tariffau ynni ar gyfer #{school.name}")
+        expect(email.html_part.decoded).to include("http://cy.localhost/schools/#{school.slug}/energy_tariffs")
+        expect(email.html_part.decoded).to include(I18n.t('energy_tariffs_mailer.school_admin_review_school_tariffs_reminder.mail_body.to_review', locale: :cy))
+        expect(email.html_part.decoded).to include(I18n.t('energy_tariffs_mailer.school_admin_review_school_tariffs_reminder.mail_body.in_future', locale: :cy))
       end
     end
   end

--- a/spec/mailers/onboarding_mailer_spec.rb
+++ b/spec/mailers/onboarding_mailer_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe OnboardingMailer do
   let(:country)           { 'wales' }
   let(:school_onboarding) { create(:school_onboarding, school_name: 'Test School', created_by: user, school: school, country: country) }
   let(:email)             { ActionMailer::Base.deliveries.last }
-  let(:body) { ActionController::Base.helpers.sanitize(email.body.to_s) }
+  let(:body) { ActionController::Base.helpers.sanitize(email.html_part.decoded) }
 
   around do |example|
     ClimateControl.modify WELSH_APPLICATION_HOST: 'cy.localhost' do

--- a/spec/mailers/recent_activities_mailer_spec.rb
+++ b/spec/mailers/recent_activities_mailer_spec.rb
@@ -17,10 +17,10 @@ RSpec.describe RecentActivitiesMailer do
       expect(ActionMailer::Base.deliveries.count).to be 1
       email = ActionMailer::Base.deliveries.last
       expect(email.subject).to eql "Recently recorded activities"
-      expect(email.body.to_s).to include('first activity')
-      expect(email.body.to_s).to include('second activity')
-      expect(email.body.to_s).to include('first action')
-      expect(email.body.to_s).to include('second action')
+      expect(email.html_part.decoded).to include('first activity')
+      expect(email.html_part.decoded).to include('second activity')
+      expect(email.html_part.decoded).to include('first action')
+      expect(email.html_part.decoded).to include('second action')
     end
   end
 end

--- a/spec/services/activation_email_sender_spec.rb
+++ b/spec/services/activation_email_sender_spec.rb
@@ -78,7 +78,7 @@ describe ActivationEmailSender, :schools, type: :service do
         context 'the email contains' do
           let(:email) { ActionMailer::Base.deliveries.last }
 
-          let(:email_body) { email.body.to_s }
+          let(:email_body) { email.html_part.decoded }
           let(:matcher) { Capybara::Node::Simple.new(email_body) }
 
           before do

--- a/spec/services/alerts/generate_email_notifications_spec.rb
+++ b/spec/services/alerts/generate_email_notifications_spec.rb
@@ -64,7 +64,7 @@ describe Alerts::GenerateEmailNotifications do
 
     context 'when generating email body' do
         let(:email)       { ActionMailer::Base.deliveries.last }
-        let(:email_body)  { email.body.to_s }
+        let(:email_body)  { email.html_part.decoded }
         let(:matcher)     { Capybara::Node::Simple.new(email_body.to_s) }
 
         let(:params) do
@@ -102,7 +102,7 @@ describe Alerts::GenerateEmailNotifications do
 
   context 'when adding targets section' do
     let(:email) { ActionMailer::Base.deliveries.last }
-    let(:email_body) { email.body.to_s }
+    let(:email_body) { email.html_part.decoded }
     let(:matcher) { Capybara::Node::Simple.new(email_body.to_s) }
 
     context 'and theres enough data' do
@@ -189,7 +189,7 @@ describe Alerts::GenerateEmailNotifications do
 
     it 'links to a find out more if there is one associated with the content' do
       email = ActionMailer::Base.deliveries.last
-      expect(email.body.to_s).to include('Find out more')
+      expect(email.html_part.decoded).to include('Find out more')
     end
   end
 end

--- a/spec/services/rollbar_notifier_service_spec.rb
+++ b/spec/services/rollbar_notifier_service_spec.rb
@@ -72,7 +72,7 @@ describe RollbarNotifierService do
 
       email = ActionMailer::Base.deliveries.last
       expect(email.subject).to include('Custom Error Reports')
-      email_body = email.body.to_s
+      email_body = email.html_part.decoded
       expect(email_body).to include("Custom Error Reports")
     end
 
@@ -81,7 +81,7 @@ describe RollbarNotifierService do
 
       RollbarNotifierService.new(rql_jobs).perform
       email = ActionMailer::Base.deliveries.last
-      email_body = email.body.to_s
+      email_body = email.html_part.decoded
       RollbarNotifierService::REPORTS.each_value do |report|
         expect(email_body).to include(report[:title])
       end
@@ -91,7 +91,7 @@ describe RollbarNotifierService do
       allow(rql_jobs).to receive(:run_query).and_return(job_result)
       RollbarNotifierService.new(rql_jobs).perform
       email = ActionMailer::Base.deliveries.last
-      email_body = email.body.to_s
+      email_body = email.html_part.decoded
       expect(email_body).to include("Thu 10th Dec 2020")
     end
 
@@ -100,7 +100,7 @@ describe RollbarNotifierService do
         allow(rql_jobs).to receive(:run_query).and_return(job_result)
         RollbarNotifierService.new(rql_jobs).perform
         email = ActionMailer::Base.deliveries.last
-        email_body = email.body.to_s
+        email_body = email.html_part.decoded
         expect(email_body).to match(%r{href="https://rollbar.com/energysparks/EnergySparksTestEnvironment/items/564/occurrences/145051707090"})
       end
     end

--- a/spec/services/schools/bill_request_service_spec.rb
+++ b/spec/services/schools/bill_request_service_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Schools::BillRequestService do
   let!(:school)           { create(:school) }
   let!(:service)          { Schools::BillRequestService.new(school) }
   let(:email)             { ActionMailer::Base.deliveries.last }
-  let(:email_body)        { email.body.to_s }
+  let(:email_body)        { email.html_part.decoded }
 
   context 'listing users' do
     context 'with no users' do

--- a/spec/services/schools/consent_request_service_spec.rb
+++ b/spec/services/schools/consent_request_service_spec.rb
@@ -47,12 +47,12 @@ RSpec.describe Schools::ConsentRequestService do
       end
 
       it 'includes the school name' do
-        email_body = @email.body.to_s
+        email_body = @email.html_part.decoded
         expect(email_body).to include(school.name)
       end
 
       it 'includes a link to the give consent page' do
-        email_body = @email.body.to_s
+        email_body = @email.html_part.decoded
         node = Capybara::Node::Simple.new(email_body.to_s)
         expect(node).to have_link('Give consent')
       end

--- a/spec/services/targets/target_mailer_service_spec.rb
+++ b/spec/services/targets/target_mailer_service_spec.rb
@@ -162,9 +162,9 @@ RSpec.describe Targets::TargetMailerService do
     let(:enough_data) { true }
 
     let(:email)         { ActionMailer::Base.deliveries.last }
-    let(:email_body)    { email.body.to_s }
+    let(:email_body)    { email.html_part.decoded }
     let(:email_subject) { email.subject }
-    let(:matcher)       { Capybara::Node::Simple.new(email_body.to_s) }
+    let(:matcher)       { Capybara::Node::Simple.new(email_body) }
 
     it 'sends an email' do
       service.invite_schools_to_set_first_target
@@ -230,8 +230,8 @@ RSpec.describe Targets::TargetMailerService do
     let(:enough_data) { true }
 
     let(:email)       { ActionMailer::Base.deliveries.last }
-    let(:email_body)  { email.body.to_s }
-    let(:matcher)     { Capybara::Node::Simple.new(email_body.to_s) }
+    let(:email_body)  { email.html_part.decoded }
+    let(:matcher)     { Capybara::Node::Simple.new(email_body) }
 
     it 'sends an email' do
       service.invite_schools_to_review_target
@@ -281,7 +281,7 @@ RSpec.describe Targets::TargetMailerService do
     let(:enough_data) { true }
 
     let(:email)       { ActionMailer::Base.deliveries.last }
-    let(:email_body)  { email.body.to_s }
+    let(:email_body)  { email.html_part.decoded }
     let(:matcher)     { Capybara::Node::Simple.new(email_body.to_s) }
 
     it 'sends an email' do

--- a/spec/support/shared_examples/admin_school_group_onboardings.rb
+++ b/spec/support/shared_examples/admin_school_group_onboardings.rb
@@ -76,7 +76,7 @@ RSpec.shared_examples "admin school group onboardings" do
           it "sends email" do
             email = ActionMailer::Base.deliveries.last
             expect(email.subject).to include("Don't forget to set up your school on Energy Sparks")
-            expect(email.body.to_s).to include(onboarding_path(onboarding))
+            expect(email.html_part.decoded).to include(onboarding_path(onboarding))
           end
         end
       end

--- a/spec/system/admin/meter_reviews/consent_requests_spec.rb
+++ b/spec/system/admin/meter_reviews/consent_requests_spec.rb
@@ -125,7 +125,7 @@ RSpec.describe 'consent_requests', type: :system do
           @email = ActionMailer::Base.deliveries.last
           expect(@email.to).to match_array([school_admin.email])
           expect(@email.subject).to eql("Your grant of consent to Energy Sparks")
-          email_body = @email.body.to_s
+          email_body = @email.html_part.decoded
           body = Capybara::Node::Simple.new(email_body)
           expect(body).to have_link('terms and conditions')
         end

--- a/spec/system/admin/school_onboarding_spec.rb
+++ b/spec/system/admin/school_onboarding_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe "onboarding", :schools, type: :system do
 
       email = ActionMailer::Base.deliveries.last
       expect(email.subject).to include('Set up your school on Energy Sparks')
-      expect(email.body.to_s).to include(onboarding_path(onboarding))
+      expect(email.html_part.decoded).to include(onboarding_path(onboarding))
     end
 
     it 'sends reminder emails when requested' do
@@ -85,7 +85,7 @@ RSpec.describe "onboarding", :schools, type: :system do
       click_on 'Send reminder email'
 
       expect(last_email.subject).to include("Don't forget to set up your school on Energy Sparks")
-      expect(last_email.body.to_s).to include(onboarding_path(onboarding))
+      expect(last_email.html_part.decoded).to include(onboarding_path(onboarding))
     end
 
     it 'allows editing of an onboarding setup' do

--- a/spec/system/password_reset_spec.rb
+++ b/spec/system/password_reset_spec.rb
@@ -25,7 +25,7 @@ describe 'password reset' do
       let(:preferred_locale) { :en }
 
       it 'links to non-locale specific site' do
-        expect(email.body).to include("http://localhost/users/password/edit?reset_password_token=")
+        expect(email.html_part.decoded).to include("http://localhost/users/password/edit?reset_password_token=")
       end
     end
 
@@ -33,7 +33,7 @@ describe 'password reset' do
       let(:preferred_locale) { :cy }
 
       it 'links to locale specific site' do
-        expect(email.body).to include("http://cy.localhost/users/password/edit?reset_password_token=")
+        expect(email.html_part.decoded).to include("http://cy.localhost/users/password/edit?reset_password_token=")
       end
     end
 
@@ -42,7 +42,7 @@ describe 'password reset' do
 
       it 'shows locale selector' do
         expect(user.reload.preferred_locale).to eq("cy")
-        urls = URI.extract(email.body.to_s, ['http'])
+        urls = URI.extract(email.html_part.decoded, ['http'])
         visit urls.last
         expect(page).to have_content('Preferred language')
         fill_in "New password", with: "password"

--- a/spec/system/schools/consent_documents_spec.rb
+++ b/spec/system/schools/consent_documents_spec.rb
@@ -105,7 +105,7 @@ describe 'consent documents', type: :system do
       context 'an energysparks admin is emailed' do
         let(:deliveries)  { ActionMailer::Base.deliveries.count }
         let(:email)       { ActionMailer::Base.deliveries.last }
-        let(:email_body)  { email.body.to_s }
+        let(:email_body)  { email.html_part.decoded }
         let(:matcher)     { Capybara::Node::Simple.new(email_body.to_s) }
 
         before do


### PR DESCRIPTION
looks to relate to https://github.com/bootstrap-email/bootstrap-email/releases/tag/1.3.0 where plain text email support was added so need to change how the email body is accessed