### PR TITLE
Add Scotland to national scoreboard

### DIFF
--- a/app/services/scoreboard_all.rb
+++ b/app/services/scoreboard_all.rb
@@ -13,7 +13,7 @@ class ScoreboardAll
   end
 
   def schools
-    School.where(country: %i[england wales])
+    School.where(country: %i[england wales scotland])
   end
 
   def scored_schools(**kwargs)


### PR DESCRIPTION
Assuming it's ok to use the England and Wales calendar still, have just added Scotland in to the list of schools.

Which I'm not sure it is this simple now I've thought about it. To quote Claudia:

"We want to include the points accrued during the Scottish school year 2023/2024 with the England and Wales school year 2023/2024 and have both in the national scoreboard."

English and Welsh scoreboards use the "England and Wales" calendar
Scottish scoreboards use the "Scotland" calendar
