### PR TITLE
Remove validation on fields removed from alert type rating forms

### DIFF
--- a/app/models/alert_type_rating_content_version.rb
+++ b/app/models/alert_type_rating_content_version.rb
@@ -91,12 +91,9 @@ class AlertTypeRatingContentVersion < ApplicationRecord
     [
       :pupil_dashboard_title,
       :management_dashboard_title,
-      :find_out_more_title, :find_out_more_content,
       :email_title, :email_content, :sms_content,
-      :find_out_more_chart_variable, :find_out_more_chart_title,
       :management_priorities_title,
-      :analysis_title, :analysis_subtitle,
-      :find_out_more_table_variable
+      :analysis_title, :analysis_subtitle
     ]
   end
 
@@ -146,10 +143,6 @@ class AlertTypeRatingContentVersion < ApplicationRecord
   validates :pupil_dashboard_title,
     presence: true,
     if: ->(content) { content.alert_type_rating && content.alert_type_rating.pupil_dashboard_alert_active?},
-    on: :create
-  validates :find_out_more_title, :find_out_more_content,
-    presence: true,
-    if: ->(content) { content.alert_type_rating && content.alert_type_rating.find_out_more_active?},
     on: :create
   validates :sms_content,
     presence: true,

--- a/spec/models/alert_type_rating_content_version_spec.rb
+++ b/spec/models/alert_type_rating_content_version_spec.rb
@@ -21,6 +21,37 @@ describe AlertTypeRatingContentVersion do
     end
   end
 
+  describe 'validations' do
+    context 'with sms active' do
+      let(:alert_type_rating) { create(:alert_type_rating, sms_active: true) }
+      let(:alert_type_rating_content_version) { build(:alert_type_rating_content_version, alert_type_rating: alert_type_rating, sms_content: sms_content) }
+
+      context 'with no sms content' do
+        let(:sms_content) { nil }
+
+        it 'is not valid' do
+          expect(alert_type_rating_content_version).not_to be_valid
+        end
+      end
+
+      context 'with no sms content' do
+        let(:sms_content) { 'text message' }
+
+        it 'is valid' do
+          expect(alert_type_rating_content_version).to be_valid
+        end
+
+        context 'with find_out_more_active' do
+          let(:alert_type_rating) { create(:alert_type_rating, sms_active: true, find_out_more_active: true) }
+
+          it 'is valid' do
+            expect(alert_type_rating_content_version).to be_valid
+          end
+        end
+      end
+    end
+  end
+
   describe 'meets_timings?' do
     let(:start_date) { nil }
     let(:end_date) { nil }


### PR DESCRIPTION
A while ago we removed the "find out more" fields from the editable fields on the alert type rating forms. But the validation associated with those fields was accidentally left in place. This means it's not possible to edit the content of some ratings as the update fails validation for fields not shown to the user.

This PR removes those validation rules. 

I will separately do another, larger PR to properly retire the old "find out more" feature which is otherwise inactive.
