### PR TITLE
Add further exception for incorrectly formatted dates

### DIFF
--- a/app/models/amr_data_feed_reading.rb
+++ b/app/models/amr_data_feed_reading.rb
@@ -107,6 +107,7 @@ class AmrDataFeedReading < ApplicationRecord
           WHEN date_format='%d/%m/%Y' THEN to_date(reading_date, 'DD/MM/YYYY')
           WHEN date_format='%d/%m/%y' AND reading_date~'\\d{4}-\\d{2}-\\d{2}' THEN to_date(reading_date, 'YYYY-MM-DD')
           WHEN date_format='%d/%m/%y' THEN to_date(reading_date, 'DD/MM/YY')
+          WHEN date_format='%Y-%m-%d' AND reading_date~'\\d{2}/\\d{2}/\\d{4}' THEN to_date(reading_date, 'DD/MM/YYYY')
           WHEN date_format='%Y-%m-%d' THEN to_date(reading_date, 'YYYY-MM-DD')
           WHEN date_format='%Y-%m-%d' THEN to_date(reading_date, 'YYYY-MM-DD ')
           WHEN date_format='%y-%m-%d' THEN to_date(reading_date, 'YY-MM-DD ')

--- a/spec/models/amr_data_feed_reading_spec.rb
+++ b/spec/models/amr_data_feed_reading_spec.rb
@@ -39,17 +39,18 @@ describe AmrDataFeedReading do
     end
 
     context 'with incorrectly loaded data' do
-      FORMATS = {
-        '%d-%b-%y' => '2023-06-28',
-        '%Y-%m-%d' => '28-Jun-23',
-        '%d-%m-%Y' => '2023-06-28',
-        '%e %b %Y %H:%M:%S' => '2023-06-28'
-      }.freeze
+      FORMATS = [
+        ['%d-%b-%y', '2023-06-28'],
+        ['%Y-%m-%d', '28-Jun-23'],
+        ['%Y-%m-%d', '28/06/2023'],
+        ['%d-%m-%Y', '2023-06-28'],
+        ['%e %b %Y %H:%M:%S', '2023-06-28'],
+      ].freeze
 
-      FORMATS.each do |format, read_date|
-        context "it parses #{read_date} despite format being #{format}" do
-          let(:date_format)   { format }
-          let(:reading_date)  { read_date }
+      FORMATS.each do |format|
+        context "it parses #{format[1]} despite format being #{format[0]}" do
+          let(:date_format)   { format[0] }
+          let(:reading_date)  { format[1] }
 
           it { expect(results[0]['latest_reading']).to eq Date.new(2023, 6, 28).iso8601 }
         end


### PR DESCRIPTION
Add another exception to the admin report to handle incorrectly loaded reading dates. These cause the report to fail, but not the loader.

I'll get the broader fix for this issue (storing parsed dates at loading time rather than reparsing prior to validation) moved up the priority list.