### PR TITLE
Fix solar charts

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,7 @@ gem 'pg'
 gem 'pg_search'
 
 # Dashboard analytics
-gem 'energy-sparks_analytics', github: 'Energy-Sparks/energy-sparks_analytics', tag: '5.0.1'
+gem 'energy-sparks_analytics', github: 'Energy-Sparks/energy-sparks_analytics', tag: '5.0.2'
 # gem 'energy-sparks_analytics', github: 'Energy-Sparks/energy-sparks_analytics', branch: '5.0.0'
 # gem 'energy-sparks_analytics', path: '../energy-sparks_analytics'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/Energy-Sparks/energy-sparks_analytics.git
-  revision: eb38c54f69308fe5e49e66b7dcbbeefe432d945c
-  tag: 5.0.1
+  revision: 48327c951306133b229c23cf2a2f577a85989c84
+  tag: 5.0.2
   specs:
     energy-sparks_analytics (1.2.1)
       activesupport (>= 6.0, < 7.1)

--- a/app/services/charts/annotate.rb
+++ b/app/services/charts/annotate.rb
@@ -6,7 +6,7 @@ module Charts
     end
 
     def annotate_weekly(x_axis_categories)
-      return if x_axis_categories.empty?
+      return if x_axis_categories.nil? || x_axis_categories.empty?
 
       date_categories = date_categories_for(x_axis_categories)
 

--- a/spec/services/charts/annotate_spec.rb
+++ b/spec/services/charts/annotate_spec.rb
@@ -45,6 +45,11 @@ describe Charts::Annotate do
       ]
     end
 
+    context 'with missing series' do
+      it { expect(subject_electricity.annotate_weekly([])).to be_nil}
+      it { expect(subject_electricity.annotate_weekly(nil)).to be_nil}
+    end
+
     context 'with no intervention or activity observations' do
       it 'returns no annotations' do
         expect(subject_multi_fuel.annotate_weekly(x_axis_categories)).to be_empty


### PR DESCRIPTION
* Update analytics to include fix for solar charts: https://github.com/Energy-Sparks/energy-sparks_analytics/pull/661
* Small change to the Annotate service so that it doesn't throw an error if the series are missing. This can happen if the chart being annotated fails to load. Reduces some noise in Rollbar.