### PR TITLE
Make the word "Activity" only appear once

### DIFF
--- a/app/views/shared/activities/_previous_records.html.erb
+++ b/app/views/shared/activities/_previous_records.html.erb
@@ -5,7 +5,7 @@
         <%= far_icon("check-circle text-success fa-3x") %>
       </div>
       <div class="col-lg-11 col-sm-12 align-self-center">
-        <%= label %> <%= t('activities.previous_records.previously_completed', label: label) %>
+        <%= t('activities.previous_records.previously_completed', label: label) %>
         <strong>
           <%= link_to "#{human_counts(list)}", school_timeline_path(school) %>
         </strong>


### PR DESCRIPTION
This fixes the word activity appearing twice in this notice:
![image](https://github.com/Energy-Sparks/energy-sparks/assets/6051/2b171b32-8d42-4ecf-8e8d-2243152a3630)
