### PR TITLE
Rework funded schools report

### DIFF
--- a/app/controllers/admin/reports/funder_allocations_controller.rb
+++ b/app/controllers/admin/reports/funder_allocations_controller.rb
@@ -4,8 +4,7 @@ module Admin
   module Reports
     class FunderAllocationsController < AdminController
       def show
-        @funders = School.visible.left_joins(:funder).group('funders.id')
-                         .select('funders.*, COUNT(schools.id) as school_count').order('funders.name')
+        @funders = Funder.school_counts
       end
 
       def deliver

--- a/app/controllers/admin/reports/funder_allocations_controller.rb
+++ b/app/controllers/admin/reports/funder_allocations_controller.rb
@@ -4,7 +4,10 @@ module Admin
   module Reports
     class FunderAllocationsController < AdminController
       def show
-        @funders = Funder.school_counts
+        @funders_visible = Funder.funded_school_counts(visible: true, data_enabled: false)
+        @funders_visible_and_enabled = Funder.funded_school_counts(visible: true, data_enabled: true)
+        @unfunded_visible = School.visible.unfunded.count
+        @unfunded_visible_and_enabled = School.visible.data_enabled.unfunded.count
       end
 
       def deliver

--- a/app/models/funder.rb
+++ b/app/models/funder.rb
@@ -9,8 +9,26 @@ class Funder < ApplicationRecord
   has_many :schools
   has_many :school_groups
 
-  scope :with_schools,  -> { where('id IN (SELECT DISTINCT(funder_id) FROM schools)') }
+  scope :with_schools,  -> { where('id IN (SELECT DISTINCT(funder_id) FROM schools UNION SELECT DISTINCT(funder_id) FROM school_groups)') }
   scope :by_name,       -> { order(name: :asc) }
 
   validates :name, presence: true, uniqueness: true
+
+  def self.school_counts
+    query = <<-SQL.squish
+      select funders.name, count(x.id) from funders LEFT JOIN (
+       select funders.id as funder_id, schools.id as id from schools, school_groups, funders
+       where school_groups.funder_id = funders.id and schools.school_group_id = school_groups.id
+       union all
+       select funders.id as funder_id, schools.id as id from schools, funders
+       where schools.funder_id = funders.id
+       ) as x ON funders.id = x.funder_id
+      group by funders.name
+      order by funders.name;
+    SQL
+    sanitized_query = ActiveRecord::Base.sanitize_sql_array(query)
+    Funder.connection.select_all(sanitized_query).rows.map do |row|
+      OpenStruct.new(name: row[0], school_count: row[1])
+    end
+  end
 end

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -218,6 +218,9 @@ class School < ApplicationRecord
   # combination of other scopes to define an engaged school
   scope :engaged, -> { active.with_recent_engagement.or(with_recently_logged_in_users).or(with_transport_survey).or(joined_programme) }
 
+  # schools that are not linked to a funder either directly or via their school group
+  scope :unfunded, -> { joins(:school_group).where('schools.funder_id is null AND school_groups.funder_id is null')}
+
   validates_presence_of :urn, :name, :address, :postcode, :website, :school_type
   validates_uniqueness_of :urn
   validates :floor_area, :number_of_pupils, :cooks_dinners_for_other_schools_count, numericality: { greater_than: 0, allow_blank: true }

--- a/app/views/admin/reports/funder_allocations/show.html.erb
+++ b/app/views/admin/reports/funder_allocations/show.html.erb
@@ -2,27 +2,50 @@
 
 <h1>Funder school count</h1>
 
+<h2>Funded schools</h2>
+
+<p>
+  This table summarises the number of visible and data enabled schools for each funder, along with a count of
+  schools which have no funder assigned.
+</p>
+<p>
+  Visible schools have finished onboarding, but do not yet have their data enabled. Funders are either directly linked
+  to schools or via their school group.
+</p>
 <table class="table">
   <thead>
     <tr>
       <th scope="col">Funder</th>
-      <th scope="col">Count</th>
+      <th scope="col">Visible not data enabled</th>
+      <th scope="col">Visible and data enabled</th>
     </tr>
   </thead>
   <tbody>
-    <% for funder in @funders %>
+    <% @funders_visible.each do |funder, school_count| %>
       <tr>
-        <td><%= funder.name.nil? ? 'No funder' : funder.name %></td>
-        <td><%= funder.school_count %></td>
+        <td><%= funder %></td>
+        <td><%= school_count %></td>
+        <td><%= @funders_visible_and_enabled[funder] %></td>
       </tr>
     <% end %>
+    <tr>
+      <td>No funder</td>
+      <td><%= @unfunded_visible %></td>
+      <td><%= @unfunded_visible_and_enabled %></td>
+    </tr>
   </tbody>
 <table>
 
 <h1>Funder allocation report</h1>
 
 <p>
-Generates a report designed to support allocating schools across potential funders.
+  Generates a report designed to support allocating schools across potential funders. The report includes all
+  active schools as well as those that have been archived.
+</p>
+
+<p>
+  Active schools includes all schools that are either still in the process of onboarding, or have completed onboarding.
+  So this report will include more schools than are shown in the above table.
 </p>
 
 <%= form_tag deliver_admin_reports_funder_allocations_path, method: :post do %>
@@ -30,10 +53,6 @@ Generates a report designed to support allocating schools across potential funde
     <%= fa_icon('envelope') %> Email funder report
   <% end %>
 <% end %>
-
-<p>
-  The report includes all visible schools.
-</p>
 
 <p>
   Summary of column headings:
@@ -46,7 +65,7 @@ Generates a report designed to support allocating schools across potential funde
   <li>Data visible? - true or false depending on whether school is data visible</li>
   <li>Onboarding date - date school onboarding was completed. Will be empty for some older schools, or any created manually</li>
   <li>Date enabled date - date school was first made data enabled. Consistent with the "recently onboarded" report. Will be empty if school not yet visible</li>
-  <li>Funder</li>
+  <li>Funder - the funder either directly linked to the school or to its school group</li>
   <li>Funding status</li>
   <li>Postcode</li>
   <li>Country</li>

--- a/spec/models/funder_spec.rb
+++ b/spec/models/funder_spec.rb
@@ -1,0 +1,67 @@
+require 'rails_helper'
+
+describe Funder do
+  let!(:funder) { create(:funder) }
+
+  describe '#with_schools' do
+    context 'when funder has no schools or groups' do
+      it 'is empty' do
+        expect(Funder.with_schools).to be_empty
+      end
+    end
+
+    context 'when funder has a school' do
+      let!(:school) { create(:school, funder: funder)}
+
+      it 'returns the funder' do
+        expect(Funder.with_schools).to eq([funder])
+      end
+    end
+
+    context 'when funder has a school group' do
+      let!(:school_group) { create(:school_group, funder: funder)}
+      let!(:school) { create(:school, school_group: school_group)}
+
+      it 'returns the funder' do
+        expect(Funder.with_schools).to eq([funder])
+      end
+    end
+  end
+
+  describe '#school_counts' do
+    subject(:school_counts) { Funder.school_counts }
+
+    context 'when funder has no schools or groups' do
+      it 'returns zero count' do
+        expect(school_counts.first).to have_attributes(name: funder.name, school_count: 0)
+      end
+    end
+
+    context 'when funder has a school' do
+      let!(:school) { create(:school, visible: true, funder: funder)}
+
+      it 'returns the funder' do
+        expect(school_counts.first).to have_attributes(name: funder.name, school_count: 1)
+      end
+    end
+
+    context 'when funder has a school group' do
+      let!(:school_group) { create(:school_group, funder: funder)}
+      let!(:schools) { create_list(:school, 3, visible: true, school_group: school_group)}
+
+      it 'returns the funder' do
+        expect(school_counts.first).to have_attributes(name: funder.name, school_count: 3)
+      end
+    end
+
+    context 'when funder has a school group and a school' do
+      let!(:school_group) { create(:school_group, funder: funder)}
+      let!(:school) { create(:school, visible: true, funder: funder)}
+      let!(:schools) { create_list(:school, 3, visible: true, school_group: school_group)}
+
+      it 'returns the funder' do
+        expect(school_counts.first).to have_attributes(name: funder.name, school_count: 4)
+      end
+    end
+  end
+end

--- a/spec/models/funder_spec.rb
+++ b/spec/models/funder_spec.rb
@@ -29,11 +29,11 @@ describe Funder do
   end
 
   describe '#school_counts' do
-    subject(:school_counts) { Funder.school_counts }
+    subject(:school_counts) { Funder.funded_school_counts }
 
     context 'when funder has no schools or groups' do
       it 'returns zero count' do
-        expect(school_counts.first).to have_attributes(name: funder.name, school_count: 0)
+        expect(school_counts[funder.name]).to eq(0)
       end
     end
 
@@ -41,7 +41,7 @@ describe Funder do
       let!(:school) { create(:school, visible: true, funder: funder)}
 
       it 'returns the funder' do
-        expect(school_counts.first).to have_attributes(name: funder.name, school_count: 1)
+        expect(school_counts[funder.name]).to eq(1)
       end
     end
 
@@ -50,7 +50,7 @@ describe Funder do
       let!(:schools) { create_list(:school, 3, visible: true, school_group: school_group)}
 
       it 'returns the funder' do
-        expect(school_counts.first).to have_attributes(name: funder.name, school_count: 3)
+        expect(school_counts[funder.name]).to eq(3)
       end
     end
 
@@ -60,7 +60,28 @@ describe Funder do
       let!(:schools) { create_list(:school, 3, visible: true, school_group: school_group)}
 
       it 'returns the funder' do
-        expect(school_counts.first).to have_attributes(name: funder.name, school_count: 4)
+        expect(school_counts[funder.name]).to eq(4)
+      end
+    end
+
+    context 'when schools is linked directly and indirectly' do
+      let!(:school_group) { create(:school_group, funder: funder)}
+      let!(:school) { create(:school, school_group: school_group, visible: true, funder: funder)}
+
+      it 'returns the funder' do
+        expect(school_counts[funder.name]).to eq(1)
+      end
+    end
+
+    context 'when school has their own funder' do
+      let(:other_funder)  { create(:funder) }
+      let!(:school_group) { create(:school_group, funder: funder)}
+      let!(:schools) { create_list(:school, 3, visible: true, school_group: school_group)}
+      let!(:school) { create(:school, school_group: school_group, funder: other_funder)}
+
+      it 'returns the funder' do
+        expect(school_counts[funder.name]).to eq(3)
+        expect(school_counts[other_funder.name]).to eq(1)
       end
     end
   end


### PR DESCRIPTION
There's a problem with the funded school count on the funder allocation report.

Schools can be associated with a funder either

- by a direct association
- indirectly, via their school group

Currently the numbers only include schools that are directly linked to schools, so undercounts the total for each funder. The unfunded school count is also incorrect as its not allowing for schools linked via their school group.

I've written a SQL query that correctly selects, groups and counts the data and added a method to the Funder model. I've also added a scope to School to count unfunded schools which aren't returned by that query.

The report table has been updated to include numbers of visible and data enabled schools as separate columns.

There might be a more elegant way to write the query, but this correctly counts in all situations. I've added tests for those to confirm the query is returning as expected.