### PR TITLE
Remove access to and use of annual estimates

### DIFF
--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -568,7 +568,7 @@ class School < ApplicationRecord
   end
 
   def all_pseudo_meter_attributes
-    all_attributes = [school_group_pseudo_meter_attributes, pseudo_meter_attributes, school_target_attributes, estimated_annual_consumption_meter_attributes].inject(global_pseudo_meter_attributes) do |collection, pseudo_attributes|
+    all_attributes = [school_group_pseudo_meter_attributes, pseudo_meter_attributes, school_target_attributes].inject(global_pseudo_meter_attributes) do |collection, pseudo_attributes|
       pseudo_attributes.each do |meter_type, attributes|
         collection[meter_type] ||= []
         collection[meter_type] = collection[meter_type] + attributes

--- a/app/views/schools/school_targets/current.html.erb
+++ b/app/views/schools/school_targets/current.html.erb
@@ -1,22 +1,20 @@
 <% content_for :page_title, t('schools.school_targets.current.page_title') %>
 
-<%= render "title", school_target: @school_target %>
+<%= render 'title', school_target: @school_target %>
 
 <% if @school_target.report_last_generated.nil? %>
   <%= render 'generating_report' %>
 <% else %>
   <%= render 'warn_recent_data' if @progress_summary.any_out_of_date_fuel_types? %>
-  <%= render "progress_notice", progress_summary: @progress_summary %>
-  <%= render "target_table", school_target: @school_target, progress_summary: @progress_summary, overview_data: @overview_data %>
+  <%= render 'progress_notice', progress_summary: @progress_summary %>
+  <%= render 'target_table', school_target: @school_target, progress_summary: @progress_summary,
+                             overview_data: @overview_data %>
   <div class="pt-2"></div>
 <% end %>
 
 <%= render 'prompt_to_review_target' if @prompt_to_review_target %>
 
-<% if @suggest_estimates_for_fuel_types.any? %>
-  <%= render 'prompt_to_add_estimate', school: @school, fuel_types: @suggest_estimates_for_fuel_types %>
-<% end %>
+<%= render 'previous_target', previous_target: @school.expired_target %>
 
-<%= render "previous_target", previous_target: @school.expired_target %>
-
-<%= render "schools/school_targets/achieving_your_targets", suggestions: @suggestions, actions: @actions, school: @school, daily_variation_url: nil %>
+<%= render 'schools/school_targets/achieving_your_targets', suggestions: @suggestions, actions: @actions,
+                                                            school: @school, daily_variation_url: nil %>

--- a/app/views/schools/school_targets/progress/current.html.erb
+++ b/app/views/schools/school_targets/progress/current.html.erb
@@ -5,30 +5,35 @@
 
   <div>
     <% if @school_target.school.has_expired_target_for_fuel_type?(@fuel_type) %>
-      <%= link_to t('schools.school_targets.progress.current.view_last_years_target_report'), {school_target_id: @school_target.school.expired_target }, class: "btn btn-outline-dark font-weight-bold" %>
+      <%= link_to t('schools.school_targets.progress.current.view_last_years_target_report'),
+                  { school_target_id: @school_target.school.expired_target },
+                  class: 'btn btn-outline-dark font-weight-bold' %>
     <% end %>
-    <%= link_to t('schools.school_targets.progress.current.review_targets'), school_school_target_path(@school, @school_target), class: "btn btn-outline-dark rounded-pill font-weight-bold" %>
-    <%= link_to_help_for_feature :school_targets, css: "btn btn-outline-dark rounded-pill font-weight-bold" %>
+    <%= link_to t('schools.school_targets.progress.current.review_targets'),
+                school_school_target_path(@school, @school_target),
+                class: 'btn btn-outline-dark rounded-pill font-weight-bold' %>
+    <%= link_to_help_for_feature :school_targets, css: 'btn btn-outline-dark rounded-pill font-weight-bold' %>
   </div>
 </div>
-
-<% if @suggest_estimate_important %>
-  <%= render 'schools/school_targets/prompt_to_add_estimate', school: @school, fuel_types: [@fuel_type.to_s] %>
-<% end %>
 
 <% if @recent_data %>
   <% if @latest_progress %>
     <% if @latest_progress == 0.0 %>
       <p>
-        <%= t('schools.school_targets.progress.current.unfortunately_as_much_as_last_year', fuel_type: human_fuel_type(@fuel_type)) %>
+        <%= t('schools.school_targets.progress.current.unfortunately_as_much_as_last_year',
+              fuel_type: human_fuel_type(@fuel_type)) %>
       </p>
     <% elsif @latest_progress > 0.0 %>
       <p>
-        <%= t('schools.school_targets.progress.current.unfortunately_more_than_last_year', fuel_type: human_fuel_type(@fuel_type), relative_percent: format_target(@latest_progress, :relative_percent)) %>.
+        <%= t('schools.school_targets.progress.current.unfortunately_more_than_last_year',
+              fuel_type: human_fuel_type(@fuel_type),
+              relative_percent: format_target(@latest_progress, :relative_percent)) %>.
       </p>
     <% else %>
       <p>
-        <%= t('schools.school_targets.progress.current.well_done_less_than_last_year', fuel_type: human_fuel_type(@fuel_type), relative_percent: format_target(@latest_progress, :relative_percent)) %>.
+        <%= t('schools.school_targets.progress.current.well_done_less_than_last_year',
+              fuel_type: human_fuel_type(@fuel_type),
+              relative_percent: format_target(@latest_progress, :relative_percent)) %>.
       </p>
     <% end %>
   <% end %>
@@ -36,17 +41,22 @@
   <div class="row alert info-bar text-light bg-negative">
     <div class="col">
       <span class="align-middle">
-        <%= t('schools.school_targets.progress.current.we_have_not_received_data', fuel_type: human_fuel_type(@fuel_type)) %>.
+        <%= t('schools.school_targets.progress.current.we_have_not_received_data',
+              fuel_type: human_fuel_type(@fuel_type)) %>.
       </span>
     </div>
   </div>
 <% end %>
 
 <p>
-  <%= t('schools.school_targets.progress.current.your_school_has_set_a_target_to_reduce_html', fuel_type: human_fuel_type(@fuel_type, include_storage_heaters: true), school_target_attributes: @school_target.attributes[@fuel_type.to_s], start_date: nice_dates(@school_target.start_date), target_date: nice_dates(@school_target.target_date)) %>.
+  <%= t('schools.school_targets.progress.current.your_school_has_set_a_target_to_reduce_html',
+        fuel_type: human_fuel_type(@fuel_type, include_storage_heaters: true),
+        school_target_attributes: @school_target.attributes[@fuel_type.to_s],
+        start_date: nice_dates(@school_target.start_date),
+        target_date: nice_dates(@school_target.target_date)) %>.
 </p>
 
-<% if @progress  %>
+<% if @progress %>
 
   <h3><%= t('schools.school_targets.progress.current.month_by_month_progress') %></h3>
 
@@ -64,9 +74,16 @@
     </tr>
     </thead>
     <tbody>
-    <%= render 'row', title: t('schools.school_targets.progress.current.target_consumption_kwh'), progress: @progress, data: @progress.monthly_targets_kwh, keys: @reporting_months, partial_months: {}, percentage_synthetic: @progress.percentage_synthetic, units: :kwh, final_row: false %>
-    <%= render 'row', title: t('schools.school_targets.progress.current.actual_consumption_kwh'), progress: @progress, data: @progress.monthly_usage_kwh, keys: @reporting_months, partial_months: @progress.partial_months, percentage_synthetic: {}, units: :kwh, final_row: false %>
-    <%= render 'row', title: t('schools.school_targets.progress.current.overall_change_since_last_year'), progress: @progress, data: @progress.monthly_performance_versus_synthetic_last_year, keys: @reporting_months, partial_months: @progress.partial_months, percentage_synthetic: {}, units: :relative_percent, final_row: true %>
+    <%= render 'row', title: t('schools.school_targets.progress.current.target_consumption_kwh'), progress: @progress,
+                      data: @progress.monthly_targets_kwh, keys: @reporting_months, partial_months: {},
+                      percentage_synthetic: @progress.percentage_synthetic, units: :kwh, final_row: false %>
+    <%= render 'row', title: t('schools.school_targets.progress.current.actual_consumption_kwh'), progress: @progress,
+                      data: @progress.monthly_usage_kwh, keys: @reporting_months,
+                      partial_months: @progress.partial_months, percentage_synthetic: {}, units: :kwh, final_row: false %>
+    <%= render 'row', title: t('schools.school_targets.progress.current.overall_change_since_last_year'),
+                      progress: @progress, data: @progress.monthly_performance_versus_synthetic_last_year,
+                      keys: @reporting_months, partial_months: @progress.partial_months,
+                      percentage_synthetic: {}, units: :relative_percent, final_row: true %>
     </tbody>
   </table>
 
@@ -86,17 +103,26 @@
     </tr>
     </thead>
     <tbody>
-    <%= render 'row', title: t('schools.school_targets.progress.current.target_consumption_kwh'), data: @progress.cumulative_targets_kwh, keys: @reporting_months, partial_months: {}, percentage_synthetic: @progress.percentage_synthetic, units: :kwh, final_row: false %>
-    <%= render 'row', title: t('schools.school_targets.progress.current.actual_consumption_kwh'), data: @progress.cumulative_usage_kwh, keys: @reporting_months, partial_months: @progress.partial_months, percentage_synthetic: {}, units: :kwh, final_row: false %>
-    <%= render 'row', title: t('schools.school_targets.progress.current.overall_performance_since_last_year'), data: @progress.cumulative_performance_versus_synthetic_last_year, keys: @reporting_months, partial_months: @progress.partial_months, percentage_synthetic: {}, units: :relative_percent, final_row: true %>
+    <%= render 'row', title: t('schools.school_targets.progress.current.target_consumption_kwh'),
+                      data: @progress.cumulative_targets_kwh, keys: @reporting_months, partial_months: {},
+                      percentage_synthetic: @progress.percentage_synthetic, units: :kwh, final_row: false %>
+    <%= render 'row', title: t('schools.school_targets.progress.current.actual_consumption_kwh'),
+                      data: @progress.cumulative_usage_kwh, keys: @reporting_months,
+                      partial_months: @progress.partial_months, percentage_synthetic: {}, units: :kwh, final_row: false %>
+    <%= render 'row', title: t('schools.school_targets.progress.current.overall_performance_since_last_year'),
+                      data: @progress.cumulative_performance_versus_synthetic_last_year, keys: @reporting_months,
+                      partial_months: @progress.partial_months, percentage_synthetic: {}, units: :relative_percent,
+                      final_row: true %>
     </tbody>
   </table>
 
-  <%= render 'footnotes', fuel_type: @fuel_type, school_target: @school_target, show_storage_heater_notes: @show_storage_heater_notes, progress: @progress %>
+  <%= render 'footnotes', fuel_type: @fuel_type, school_target: @school_target,
+                          show_storage_heater_notes: @show_storage_heater_notes, progress: @progress %>
 
   <h3><%= t('schools.school_targets.progress.current.progress_charts') %></h3>
 
-  <%= render 'charts', school: @school, fuel_type: @fuel_type == :storage_heaters ? :storage_heater : @fuel_type, progress: @progress %>
+  <%= render 'charts', school: @school, fuel_type: @fuel_type == :storage_heaters ? :storage_heater : @fuel_type,
+                       progress: @progress %>
 
   <% if current_user.present? && current_user.analytics? %>
     <h2><%= t('schools.school_targets.progress.current.debug') %></h2>
@@ -108,29 +134,15 @@
 
   <div class="alert alert-danger">
     <h4><%= t('schools.school_targets.progress.current.error_message') %></h4>
-
-    <% if @bad_estimate %>
-      <p>
-        <%= t('schools.school_targets.progress.current.error_bad_estimate_html', estimated_annual_consumptions_path: school_estimated_annual_consumptions_path(@school), fuel_type: @fuel_type) %>.
-      </p>
-      <p>
-        <%= t('schools.school_targets.progress.current.please_review_your_estimate_and_our_guidance_html', estimated_annual_consumptions_path: school_estimated_annual_consumptions_path(@school)) %>.
-      </p>
-      <p>
-        <%= t('schools.school_targets.progress.current.we_have_been_notified_about_this_error_1') %>.
-      </p>
-    <% else %>
-      <p><%= t('schools.school_targets.progress.current.we_have_been_notified_about_this_error_2') %>.</p>
-    <% end %>
+    <p><%= t('schools.school_targets.progress.current.we_have_been_notified_about_this_error_2') %>.</p>
   </div>
 
   <% if current_user.present? && current_user.analytics? %>
   <div class="alert alert-secondary">
     <h4><%= t('schools.school_targets.progress.current.debug') %></h4>
-    <p><strong><%= t('schools.school_targets.progress.current.error') %></strong>: <%= @debug_error if @debug_error.present? %></p>
-    <p><strong><%= t('schools.school_targets.progress.current.problem') %></strong>: <%= @debug_problem if @debug_problem.present? %></p>
+    <p><strong><%= t('schools.school_targets.progress.current.error') %></strong>: <%= @debug_error.presence %></p>
+    <p><strong><%= t('schools.school_targets.progress.current.problem') %></strong>: <%= @debug_problem.presence %></p>
   </div>
   <% end %>
-
 
 <% end %>

--- a/app/views/schools/show.html.erb
+++ b/app/views/schools/show.html.erb
@@ -1,7 +1,8 @@
 <%= content_for :page_title, t('schools.show.dashboard_title', school_name: @school.name) %>
 
 <%= render 'shared/dashboard_title', school: @school do %>
-  <%= render 'adult_dashboard_buttons', school: @school, co2_pages: @co2_pages, public: true, show_data_enabled_features: @show_data_enabled_features %>
+  <%= render 'adult_dashboard_buttons', school: @school, co2_pages: @co2_pages, public: true,
+                                        show_data_enabled_features: @show_data_enabled_features %>
 <% end %>
 
 <% if @overview_data %>
@@ -9,7 +10,8 @@
   <%= render 'management/schools/overview_data', overview_data: @overview_data %>
   <div class="text-right management-overview-caption">
     <%= @overview_data.date_ranges %>
-    <%= link_to_help_for_feature :management_summary_overview, title: "#{t('schools.show.more_information')} #{fa_icon('info-circle')}".html_safe %>
+    <%= link_to_help_for_feature :management_summary_overview,
+                                 title: "#{t('schools.show.more_information')} #{fa_icon('info-circle')}".html_safe %>
   </div>
 <% end %>
 
@@ -18,16 +20,13 @@
 <%= render 'management/schools/targets/progress_notice', school: @school, progress_summary: @progress_summary %>
 
 <% if @dashboard_alerts %>
-  <%= render 'shared/dashboard_alerts', dashboard_alerts: @dashboard_alerts, school: @school, content_field: :management_dashboard_title %>
+  <%= render 'shared/dashboard_alerts', dashboard_alerts: @dashboard_alerts, school: @school,
+                                        content_field: :management_dashboard_title %>
 <% end %>
 
 <% if @show_standard_prompts %>
   <%= render 'management/schools/dashboard_message', messageable: @school %>
   <%= render 'management/schools/dashboard_message', messageable: @school.try(:school_group) %>
-<% end %>
-
-<% if @suggest_estimates_for_fuel_types.present? && @suggest_estimates_for_fuel_types.any? %>
-  <%= render 'management/schools/prompt_for_estimate', school: @school, fuel_types: @suggest_estimates_for_fuel_types %>
 <% end %>
 
 <% if @prompt_for_bill %>
@@ -94,7 +93,8 @@
 
 <% if @management_priorities && @management_priorities.any? %>
   <h3><%= t('schools.show.energy_saving_opportunities') %></h3>
-  <%= render 'management/management_priorities/list', management_priorities: @management_priorities, school: @school, show_more: @show_more_management_priorities %>
+  <%= render 'management/management_priorities/list', management_priorities: @management_priorities,
+                                                      school: @school, show_more: @show_more_management_priorities %>
 <% end %>
 
 <%= render 'shared/dashboard_timeline', school: @school, observations: @observations %>
@@ -110,7 +110,10 @@
           <%= fa_icon('file-alt') %>
           <%= t('schools.show.print_view') %>
         <% end %>
-        <%= link_to t('schools.show.download_data'), school_downloads_path(@school), class: 'btn btn-outline-dark rounded-pill font-weight-bold' if can?(:download_school_data, @school) %>
+        <%= if can?(:download_school_data, @school)
+              link_to t('schools.show.download_data'), school_downloads_path(@school),
+                      class: 'btn btn-outline-dark rounded-pill font-weight-bold'
+            end %>
     </div>
   </div>
 <% end %>

--- a/app/views/shared/_manage_school.html.erb
+++ b/app/views/shared/_manage_school.html.erb
@@ -1,31 +1,77 @@
 <li class="nav-item dropdown">
-  <a class="nav-link dropdown-toggle" data-toggle="dropdown" id="manage_school" href="#" role="button" aria-haspopup="true" aria-expanded="false"><%= t('manage_school_menu.manage_school') %></a>
+  <a class="nav-link dropdown-toggle" data-toggle="dropdown" id="manage_school" href="#"
+     role="button" aria-haspopup="true" aria-expanded="false"><%= t('manage_school_menu.manage_school') %></a>
   <div class="dropdown-menu scrollable" aria-labelledby="manage_school" id="manage_school_menu">
     <%= link_to t('manage_school_menu.edit_school_details'), edit_school_path(school), class: 'dropdown-item' %>
-    <%= link_to t('manage_school_menu.edit_school_times'), edit_school_times_path(school), class: 'dropdown-item' if can? :manage_school_times, school %>
-    <%= link_to t('manage_school_menu.your_school_estate'), edit_school_your_school_estate_path(school), class: 'dropdown-item' if EnergySparks::FeatureFlags.active?(:your_school_estates) %>
-    <%= link_to t('manage_school_menu.school_calendar'), calendar_path(school.calendar), class: 'dropdown-item' if school.calendar && can?(:show, school.calendar) %>
-    <%= link_to t('manage_school_menu.manage_users'), school_users_path(school), class: 'dropdown-item' if can? :manage_users, school %>
-    <%= link_to t('manage_school_menu.manage_alert_contacts'), school_contacts_path(school), class: 'dropdown-item' if can? :manage, Contact %>
-    <%= link_to t('manage_school_menu.manage_meters'), school_meters_path(school), class: 'dropdown-item' if can? :index, Meter %>
-    <%= link_to t('manage_school_menu.manage_tariffs'), school_energy_tariffs_path(school), class: 'dropdown-item' if can? :manage, EnergyTariff %>
-    <%= link_to t('manage_school_menu.manage_usage_estimate'), school_estimated_annual_consumptions_path(school), class: 'dropdown-item' if school.latest_annual_estimate.present? || school.suggest_annual_estimate? %>
+    <%= if can? :manage_school_times, school
+          link_to t('manage_school_menu.edit_school_times'), edit_school_times_path(school), class: 'dropdown-item'
+        end %>
+    <%= if EnergySparks::FeatureFlags.active?(:your_school_estates)
+          link_to t('manage_school_menu.your_school_estate'), edit_school_your_school_estate_path(school),
+                  class: 'dropdown-item'
+        end %>
+    <%= if school.calendar && can?(:show, school.calendar)
+          link_to t('manage_school_menu.school_calendar'), calendar_path(school.calendar), class: 'dropdown-item'
+        end %>
+    <%= if can? :manage_users, school
+          link_to t('manage_school_menu.manage_users'), school_users_path(school), class: 'dropdown-item'
+        end %>
+    <%= if can? :manage, Contact
+          link_to t('manage_school_menu.manage_alert_contacts'), school_contacts_path(school), class: 'dropdown-item'
+        end %>
+    <%= if can? :index, Meter
+          link_to t('manage_school_menu.manage_meters'), school_meters_path(school), class: 'dropdown-item'
+        end %>
+    <%= if can? :manage, EnergyTariff
+          link_to t('manage_school_menu.manage_tariffs'), school_energy_tariffs_path(school), class: 'dropdown-item'
+        end %>
 
     <% if current_user.admin? %>
       <div class="dropdown-divider"></div>
     <% end %>
-    <%= link_to t('manage_school_menu.school_configuration'), edit_school_configuration_path(school), class: 'dropdown-item' if can? :configure, school %>
-    <%= link_to t('manage_school_menu.meter_attributes'), admin_school_meter_attributes_path(school), class: 'dropdown-item' if can? :manage, SchoolMeterAttribute %>
-    <%= link_to t('manage_school_menu.manage_audits'), school_audits_path(school), class: 'dropdown-item' if can? :manage, Audit %>
-    <%= link_to t('manage_school_menu.manage_partners'), admin_school_partners_path(school), class: 'dropdown-item' if can? :manage, SchoolPartner %>
-    <%= link_to t('manage_school_menu.manage_cads'), school_cads_path(school), class: 'dropdown-item' if can? :manage, Cad %>
-    <%= link_to t('manage_school_menu.manage_school_group'), admin_school_group_path(school.school_group), class: 'dropdown-item' if school.school_group && can?(:manage, school.school_group) %>
-    <%= link_to t('manage_school_menu.manage_issues'), admin_school_issues_path(school), class: 'dropdown-item' if can? :manage, Issue %>
-    <%= link_to t('manage_school_menu.batch_reports'), school_reports_path(school), class: 'dropdown-item' if can? :view_content_reports, school %>
-    <%= link_to t('schools.meters.index.view_target_data'), admin_school_target_data_path(school), class: 'dropdown-item' if current_user.admin? %>
-    <%= link_to t('manage_school_menu.review_targets'), school_school_targets_path(school), class: 'dropdown-item' if current_user.admin? && Targets::SchoolTargetService.targets_enabled?(school) && can?(:manage, SchoolTarget) && Targets::SchoolTargetService.new(school).enough_data? %>
-    <%= link_to t('manage_school_menu.expert_analysis'), admin_school_analysis_path(school), class: 'dropdown-item' if can? :expert_analyse, school %>
-    <%= link_to t('manage_school_menu.old_analysis_pages'), school_analysis_index_path(school), class: 'dropdown-item' if can? :view_advice_pages, school %>
-    <%= link_to t('manage_school_menu.remove_school'), removal_admin_school_path(school), class: 'dropdown-item' if can? :remove_school, school %>
+    <%= if can? :configure, school
+          link_to t('manage_school_menu.school_configuration'), edit_school_configuration_path(school),
+                  class: 'dropdown-item'
+        end %>
+    <%= if can? :manage, SchoolMeterAttribute
+          link_to t('manage_school_menu.meter_attributes'), admin_school_meter_attributes_path(school),
+                  class: 'dropdown-item'
+        end %>
+    <%= if can? :manage, Audit
+          link_to t('manage_school_menu.manage_audits'), school_audits_path(school), class: 'dropdown-item'
+        end %>
+    <%= if can? :manage, SchoolPartner
+          link_to t('manage_school_menu.manage_partners'), admin_school_partners_path(school), class: 'dropdown-item'
+        end %>
+    <%= if can? :manage, Cad
+          link_to t('manage_school_menu.manage_cads'), school_cads_path(school), class: 'dropdown-item'
+        end %>
+    <%= if school.school_group && can?(:manage, school.school_group)
+          link_to t('manage_school_menu.manage_school_group'), admin_school_group_path(school.school_group),
+                  class: 'dropdown-item'
+        end %>
+    <%= if can? :manage, Issue
+          link_to t('manage_school_menu.manage_issues'), admin_school_issues_path(school), class: 'dropdown-item'
+        end %>
+    <%= if can? :view_content_reports, school
+          link_to t('manage_school_menu.batch_reports'), school_reports_path(school), class: 'dropdown-item'
+        end %>
+    <%= if current_user.admin?
+          link_to t('schools.meters.index.view_target_data'), admin_school_target_data_path(school),
+                  class: 'dropdown-item'
+        end %>
+    <%= if current_user.admin? && Targets::SchoolTargetService.targets_enabled?(school) &&
+           can?(:manage, SchoolTarget) && Targets::SchoolTargetService.new(school).enough_data?
+          link_to t('manage_school_menu.review_targets'), school_school_targets_path(school), class: 'dropdown-item'
+        end %>
+    <%= if can? :expert_analyse, school
+          link_to t('manage_school_menu.expert_analysis'), admin_school_analysis_path(school), class: 'dropdown-item'
+        end %>
+    <%= if can? :view_advice_pages, school
+          link_to t('manage_school_menu.old_analysis_pages'), school_analysis_index_path(school), class: 'dropdown-item'
+        end %>
+    <%= if can? :remove_school, school
+          link_to t('manage_school_menu.remove_school'), removal_admin_school_path(school), class: 'dropdown-item'
+        end %>
   </div>
 </li>

--- a/config/locales/cy/views/schools/schools.yml
+++ b/config/locales/cy/views/schools/schools.yml
@@ -439,13 +439,11 @@ cy:
           cumulative_progress: Cynnydd cronnus
           debug: Dadfygio
           error: Gwall
-          error_bad_estimate_html: Mae'r <a href='%{estimated_annual_consumptions_path}'>amcangyfrif blynyddol</a> o'ch defnydd %{fuel_type} a ddarparwyd ar gyfer eich ysgol yn rhy isel
           error_message: Yn anffodus oherwydd gwall ni allwn arddangos eich adroddiad cynnydd manwl ar hyn o bryd
           month: Mis
           month_by_month_progress: Cynnydd o fis i fis
           overall_change_since_last_year: Newid cyffredinol ers y llynedd
           overall_performance_since_last_year: Perfformiad cyffredinol ers y llynedd
-          please_review_your_estimate_and_our_guidance_html: <a href='%{estimated_annual_consumptions_path}'>Adolygwch eich amcangyfrif ac ein arweiniad</a> i weld a yw'n gywir
           problem: Problem
           progress_charts: Siartiau cynnydd
           review_targets: Adolygu targedau
@@ -454,7 +452,6 @@ cy:
           unfortunately_as_much_as_last_year: Yn anffodus rydych chi'n defnyddio cymaint o %{fuel_type} ag y llynedd
           unfortunately_more_than_last_year: 'Yn anffodus rydych chi''n defnyddio %{relative_percent} yn fwy o %{fuel_type}na''r llynedd '
           view_last_years_target_report: Gweld adroddiad targed y llynedd
-          we_have_been_notified_about_this_error_1: Yn y cyfamser, rydym wedi cael gwybod am y gwall hwn ac byddwn yn ymchwilio iddo
           we_have_been_notified_about_this_error_2: Rydym wedi cael gwybod am y gwall hwn ac byddwn yn ymchwilio iddo
           we_have_not_received_data: Nid ydym wedi derbyn eich data am eich defnydd %{fuel_type} am dros dri deg diwrnod. O ganlyniad, bydd eich adroddiad cynnydd ar ei hôl hi
           well_done_less_than_last_year: Da iawn, rydych chi'n defnyddio %{relative_percent} yn llai o %{fuel_type} na'r llynedd

--- a/config/locales/views/schools/schools.yml
+++ b/config/locales/views/schools/schools.yml
@@ -488,13 +488,11 @@ en:
           cumulative_progress: Cumulative progress
           debug: Debug
           error: Error
-          error_bad_estimate_html: The <a href='%{estimated_annual_consumptions_path}'>annual estimate</a> of your %{fuel_type} usage that has been provided for your school is too low
           error_message: Unfortunately due to an error we are currently unable to display your detailed progress report
           month: Month
           month_by_month_progress: Month by month progress
           overall_change_since_last_year: Overall change since last year
           overall_performance_since_last_year: Overall performance since last year
-          please_review_your_estimate_and_our_guidance_html: Please <a href='%{estimated_annual_consumptions_path}'>review your estimate and our guidance</a> to see if it is correct
           problem: Problem
           progress_charts: Progress charts
           review_targets: Review targets
@@ -503,7 +501,6 @@ en:
           unfortunately_as_much_as_last_year: Unfortunately you are using as much %{fuel_type} as you did last year
           unfortunately_more_than_last_year: Unfortunately you are using %{relative_percent} more %{fuel_type} than last year
           view_last_years_target_report: View last year’s target report
-          we_have_been_notified_about_this_error_1: In the meantime, we have been notified about this error and will investigate
           we_have_been_notified_about_this_error_2: We have been notified about this error and will investigate
           we_have_not_received_data: We have not received data for your %{fuel_type} usage for over thirty days. As a result your progress report will be out of date
           well_done_less_than_last_year: Well done, you are using %{relative_percent} less %{fuel_type} than last year

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -577,8 +577,8 @@ describe School do
         subject.reload
       end
 
-      it 'the target should add meter attributes' do
-        expect(subject.all_pseudo_meter_attributes[:aggregated_electricity]).not_to be_empty
+      it 'they are not passed to the analytics' do
+        expect(subject.all_pseudo_meter_attributes).to eql({ :aggregated_electricity => [], :aggregated_gas => [], :solar_pv_consumed_sub_meter => [], :solar_pv_exported_sub_meter => [] })
       end
     end
   end
@@ -810,11 +810,10 @@ describe School do
       let!(:estimate)  { create(:estimated_annual_consumption, school: school, electricity: 1000.0, gas: 1500.0, storage_heaters: 500.0, year: 2021) }
 
       it 'maps them to the pseudo meters, targets, and estimates' do
-        expect(all_pseudo_meter_attributes[:aggregated_electricity].size).to eq 5
+        expect(all_pseudo_meter_attributes[:aggregated_electricity].size).to eq 4
         expect(all_pseudo_meter_attributes[:aggregated_electricity].map(&:attribute_type)).to match_array(
           %w[
             targeting_and_tracking
-            estimated_period_consumption
             accounting_tariff_generic
             accounting_tariff_generic
             accounting_tariff_generic

--- a/spec/system/schools/progress_spec.rb
+++ b/spec/system/schools/progress_spec.rb
@@ -230,8 +230,8 @@ describe 'target progress report', type: :system do
             expect(page).to have_content("We only have data on your electricity consumption from #{Date.parse(start_date).strftime('%b %Y')}")
           end
 
-          it 'shows prompt to add estimate' do
-            expect(page).to have_content('If you can supply an estimate of your annual consumption then we can generate a more detailed progress report')
+          it 'no longer shows prompt to add estimate' do
+            expect(page).not_to have_content('If you can supply an estimate of your annual consumption then we can generate a more detailed progress report')
           end
 
           it 'doesnt show prompt if different fuel type' do

--- a/spec/system/schools/school_targets_spec.rb
+++ b/spec/system/schools/school_targets_spec.rb
@@ -437,13 +437,13 @@ RSpec.shared_examples 'managing targets', include_application_helper: true do
           visit school_school_targets_path(test_school)
         end
 
-        it 'shows prompt to add estimate' do
-          expect(page).to have_content('If you can supply an estimate of your annual consumption then we can generate a more detailed progress report for your electricity')
+        it 'no longer prompts to add estimate' do
+          expect(page).not_to have_content('If you can supply an estimate of your annual consumption then we can generate a more detailed progress report for your electricity')
         end
 
-        it 'shows the prompt on school dashboard' do
+        it 'no longer shows the prompt on school dashboard' do
           visit school_path(test_school)
-          expect(page).to have_content('Add an estimate of your annual electricity consumption')
+          expect(page).not_to have_content('Add an estimate of your annual electricity consumption')
         end
       end
     end


### PR DESCRIPTION
The school targets feature allows users with limited data to provide an annual estimate. This is then used to try and produce estimates of their historical usage and to set targets. If not provided then schools can still set targets but get a very limited view of their progress.

There are some serious issues with the code that uses the estimates so we've decided to disable this part of the feature until we rebuilds the school targets feature in a few months.

So the functional changes in this PR are to:

- remove the prompt to set an estimate from school dashboard
- remove the prompt to set an estimate from school targets page
- remove the prompt to set an estimate from school target progress report
- remove links to set or manage a target from manage school menu
- remove code that passed any existing estimates to the analytics as meter attributes
- remove code in the school target progress report that displays custom error for "bad" estimates

These are a bit obscured as ERB lint required reformatting of several of the templates!

For now I've left all the rest of the code around annual estimates in place. This just removes ability to navigate to the forms, prompts to add estimates and their use.