### PR TITLE
Fix metering agent charges

### DIFF
--- a/app/models/energy_tariff_charge.rb
+++ b/app/models/energy_tariff_charge.rb
@@ -82,11 +82,11 @@ class EnergyTariffCharge < ApplicationRecord
         name: I18n.t('user_tariff_charge.fixed_charge')
       },
       nhh_metering_agent_charge: {
-        units: [:kwh, :day, :month, :quarter],
+        units: [:day, :month, :quarter],
         name: I18n.t('user_tariff_charge.nhh_metering_agent_charge')
       },
       nhh_automatic_meter_reading_charge: {
-        units: [:kwh, :day, :month, :quarter],
+        units: [:day, :month, :quarter],
         name: I18n.t('user_tariff_charge.nhh_automatic_meter_reading_charge')
       },
       meter_asset_provider_charge: {

--- a/lib/tasks/deployment/20240206121518_metering_agent_charge.rake
+++ b/lib/tasks/deployment/20240206121518_metering_agent_charge.rake
@@ -4,6 +4,7 @@ namespace :after_party do
     puts "Running deploy task 'metering_agent_charge'"
 
     EnergyTariffCharge.where(charge_type: :nhh_metering_agent_charge, units: :kwh).update_all(units: :day)
+    EnergyTariffCharge.where(charge_type: :nhh_automatic_meter_reading_charge, units: :kwh).update_all(units: :day)
 
     # Update task as completed.  If you remove the line below, the task will
     # run with every deploy (or every time you call after_party:run).

--- a/lib/tasks/deployment/20240206121518_metering_agent_charge.rake
+++ b/lib/tasks/deployment/20240206121518_metering_agent_charge.rake
@@ -1,0 +1,13 @@
+namespace :after_party do
+  desc 'Deployment task: metering_agent_charge'
+  task metering_agent_charge: :environment do
+    puts "Running deploy task 'metering_agent_charge'"
+
+    EnergyTariffCharge.where(charge_type: :nhh_metering_agent_charge, units: :kwh).update_all(units: :day)
+
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord
+      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+  end
+end


### PR DESCRIPTION
There is some incorrect configuration in the tariff editor. The metering agent charge and automatic meter reading charges should be configurable for day/month/year and not kwh.

This PR fixes the issue and migrates any existing charges with invalid configuration. I've already manually fixed the only example I've found as it was breaking school regeneration.