### PR TITLE
Fix PROB data report

### DIFF
--- a/app/controllers/admin/prob_data_reports_controller.rb
+++ b/app/controllers/admin/prob_data_reports_controller.rb
@@ -12,7 +12,7 @@ module Admin
                          .joins('LEFT JOIN school_groups on schools.school_group_id = school_groups.id')
                          .where(status: 'PROB')
                          .group('school_groups.name', 'schools.name', 'schools.slug', 'meters.meter_type', 'meters.name', :mpan_mprn, 'meters.id')
-                         .order('count(*) DESC')
+                         .order('count(mpan_mprn) DESC')
                          .count
                          .map { |row| row.to_a.flatten }
     end

--- a/app/views/admin/prob_data_reports/index.html.erb
+++ b/app/views/admin/prob_data_reports/index.html.erb
@@ -1,8 +1,8 @@
-<%= render 'header', title: "PROB data report" do %>
+<%= render 'header', title: 'PROB data report' do %>
   <%= header_nav_link 'Admin', admin_url %>
 <% end %>
 
-<table class="table table-striped">
+<table class="table table-sorted">
   <thead>
     <tr>
       <th>School group</th>
@@ -20,7 +20,8 @@
           <%= link_to row[1], school_meters_path(school_id: row[2]) %>
         </td>
         <td>
-          <%= link_to [row[4], row[5]].reject(&:blank?).join(': '), admin_reports_amr_validated_reading_url(meter_id: row[6]) %>
+          <%= link_to [row[4], row[5]].reject(&:blank?).join(': '),
+                      admin_reports_amr_validated_reading_url(meter_id: row[6]) %>
         </td>
         <td><%= Meter.meter_types.key(row[3]).humanize %></td>
         <td>


### PR DESCRIPTION
Fixed issue in query for PROB data report and makes table sortable.

I'm sure this used to work, so maybe broke with Rails upgrade. Error from query was:

`ActiveRecord::UnknownAttributeReference: Query method called with non-attribute argument(s): "count(*) DESC"`

