### PR TITLE
Temporarily require 2 years data for monthly comparison chart

### DIFF
--- a/app/views/schools/advice/long_term/_recent_trend.html.erb
+++ b/app/views/schools/advice/long_term/_recent_trend.html.erb
@@ -37,20 +37,22 @@
                          chart_config: { y_axis_units: select_y_axis(school, chart_type, :£) } %>
 <% end %>
 
-<%= component 'chart', chart_type: :"#{fuel_type}_by_month_year_0_1", school: school do |c| %>
-  <% key_prefix = 'advice_pages.electricity_long_term.charts.electricity_by_month_year' %>
-  <% key_suffix = analysis_dates.one_years_data? ? '_two_years' : '' %>
-  <%# i18n-tasks-use t('advice_pages.electricity_long_term.charts.electricity_by_month_year.title_two_years') %>
-  <%# i18n-tasks-use t('advice_pages.electricity_long_term.charts.electricity_by_month_year.title') %>
-  <% c.with_title { t("#{key_prefix}.title#{key_suffix}", fuel_type: fuel_type) } %>
-  <%# i18n-tasks-use t('advice_pages.electricity_long_term.charts.electricity_by_month_year.subtitle_two_years_html') %>
-  <%# i18n-tasks-use t('advice_pages.electricity_long_term.charts.electricity_by_month_year.subtitle_html') %>
-  <% c.with_subtitle do
-       t("#{key_prefix}.subtitle#{key_suffix}_html", end_date: analysis_dates.end_date.to_s(:es_short),
-                                                     start_date: analysis_dates.start_date.to_s(:es_short),
-                                                     fuel_type: fuel_type )
-     end %>
-  <% c.with_footer do %>
-    <p><%= t("advice_pages.#{fuel_type}_long_term.charts.#{fuel_type}_by_month_year.explanation") %></p>
+<% if analysis_dates.months_of_data > 23 %>
+  <%= component 'chart', chart_type: :"#{fuel_type}_by_month_year_0_1", school: school do |c| %>
+    <% key_prefix = 'advice_pages.electricity_long_term.charts.electricity_by_month_year' %>
+    <% key_suffix = analysis_dates.one_years_data? ? '_two_years' : '' %>
+    <%# i18n-tasks-use t('advice_pages.electricity_long_term.charts.electricity_by_month_year.title_two_years') %>
+    <%# i18n-tasks-use t('advice_pages.electricity_long_term.charts.electricity_by_month_year.title') %>
+    <% c.with_title { t("#{key_prefix}.title#{key_suffix}", fuel_type: fuel_type) } %>
+    <%# i18n-tasks-use t('advice_pages.electricity_long_term.charts.electricity_by_month_year.subtitle_two_years_html') %>
+    <%# i18n-tasks-use t('advice_pages.electricity_long_term.charts.electricity_by_month_year.subtitle_html') %>
+    <% c.with_subtitle do
+         t("#{key_prefix}.subtitle#{key_suffix}_html", end_date: analysis_dates.end_date.to_s(:es_short),
+                                                       start_date: analysis_dates.start_date.to_s(:es_short),
+                                                       fuel_type: fuel_type)
+       end %>
+    <% c.with_footer do %>
+      <p><%= t("advice_pages.#{fuel_type}_long_term.charts.#{fuel_type}_by_month_year.explanation") %></p>
+    <% end %>
   <% end %>
 <% end %>

--- a/spec/system/schools/advice_pages/electricity_long_term_spec.rb
+++ b/spec/system/schools/advice_pages/electricity_long_term_spec.rb
@@ -111,7 +111,8 @@ RSpec.describe 'electricity long term advice page', :aggregate_failures do
 
         it 'includes expected charts' do
           expect(page).to have_css('#chart_management_dashboard_group_by_week_electricity')
-          expect(page).to have_css('#chart_wrapper_electricity_by_month_year_0_1')
+          # TEMPORARY
+          expect(page).not_to have_css('#chart_wrapper_electricity_by_month_year_0_1')
           expect(page).to have_no_css('#chart_wrapper_group_by_week_electricity_versus_benchmark')
           expect(page).to have_no_css('#chart_wrapper_group_by_week_electricity_unlimited')
           expect(page).to have_no_css('#chart_wrapper_electricity_longterm_trend')
@@ -135,9 +136,34 @@ RSpec.describe 'electricity long term advice page', :aggregate_failures do
           expect(page).to have_css('#chart_wrapper_group_by_week_electricity')
           expect(page).to have_css('#chart_wrapper_group_by_week_electricity_versus_benchmark')
           expect(page).to have_css('#chart_wrapper_group_by_week_electricity_unlimited')
-          expect(page).to have_css('#chart_wrapper_electricity_by_month_year_0_1')
+          # TEMPORARY
+          expect(page).not_to have_css('#chart_wrapper_electricity_by_month_year_0_1')
           # not enough data for this
           expect(page).to have_no_css('#chart_wrapper_electricity_longterm_trend')
+        end
+      end
+
+      context 'with more than 800 days of meter data' do
+        let(:reading_start_date) { 800.days.ago }
+
+        it_behaves_like 'an electricity long term advice page tab', tab: 'Analysis'
+
+        it 'includes expected sections' do
+          expect(page).to have_content(I18n.t('advice_pages.electricity_long_term.analysis.recent_trend.title'))
+          expect(page).to have_content(I18n.t('advice_pages.electricity_long_term.analysis.comparison.title'))
+          expect(page).to have_no_content(I18n.t('advice_pages.electricity_long_term.analysis.meter_breakdown.title'))
+        end
+
+        it 'says usage is high' do
+          expect(page).to have_content(I18n.t('advice_pages.electricity_long_term.analysis.comparison.assessment.high.title'))
+        end
+
+        it 'includes expected charts' do
+          expect(page).to have_css('#chart_wrapper_group_by_week_electricity')
+          expect(page).to have_css('#chart_wrapper_group_by_week_electricity_versus_benchmark')
+          expect(page).to have_css('#chart_wrapper_group_by_week_electricity_unlimited')
+          expect(page).to have_css('#chart_wrapper_electricity_by_month_year_0_1')
+          expect(page).to have_css('#chart_wrapper_electricity_longterm_trend')
         end
       end
     end

--- a/spec/system/schools/advice_pages/gas_long_term_spec.rb
+++ b/spec/system/schools/advice_pages/gas_long_term_spec.rb
@@ -105,7 +105,8 @@ RSpec.describe 'gas long term advice page', :aggregate_failures do
 
         it 'includes expected charts' do
           expect(page).to have_css('#chart_management_dashboard_group_by_week_gas')
-          expect(page).to have_css('#chart_wrapper_gas_by_month_year_0_1')
+          # TEMPORARY
+          expect(page).not_to have_css('#chart_wrapper_gas_by_month_year_0_1')
           expect(page).to have_no_css('#chart_wrapper_group_by_week_gas_unlimited')
           expect(page).to have_no_css('#chart_wrapper_gas_longterm_trend')
         end
@@ -127,9 +128,33 @@ RSpec.describe 'gas long term advice page', :aggregate_failures do
         it 'includes expected charts' do
           expect(page).to have_css('#chart_wrapper_group_by_week_gas')
           expect(page).to have_css('#chart_wrapper_group_by_week_gas_unlimited')
-          expect(page).to have_css('#chart_wrapper_gas_by_month_year_0_1')
+          # TEMPORARY
+          expect(page).not_to have_css('#chart_wrapper_gas_by_month_year_0_1')
           # not enough data for these
           expect(page).to have_no_css('#chart_wrapper_gas_longterm_trend')
+        end
+      end
+
+      context 'with more than 800 days of meter data' do
+        let(:reading_start_date) { 800.days.ago }
+
+        it_behaves_like 'a gas long term advice page tab', tab: 'Analysis'
+
+        it 'includes expected sections' do
+          expect(page).to have_content(I18n.t('advice_pages.gas_long_term.analysis.recent_trend.title'))
+          expect(page).to have_content(I18n.t('advice_pages.gas_long_term.analysis.comparison.title'))
+          expect(page).to have_no_content(I18n.t('advice_pages.gas_long_term.analysis.meter_breakdown.title'))
+        end
+
+        it 'says usage is high' do
+          expect(page).to have_content(I18n.t('advice_pages.gas_long_term.analysis.comparison.assessment.high.title'))
+        end
+
+        it 'includes expected charts' do
+          expect(page).to have_css('#chart_wrapper_group_by_week_gas')
+          expect(page).to have_css('#chart_wrapper_group_by_week_gas_unlimited')
+          expect(page).to have_css('#chart_wrapper_gas_by_month_year_0_1')
+          expect(page).to have_css('#chart_wrapper_gas_longterm_trend')
         end
       end
     end


### PR DESCRIPTION
Temporarily change the long term usage page so that a broken chart only displays when there is 2 years data.

This avoids a bug in the chart whilst working on a proper fix in the analytics.