### PR TITLE
Change monthly comparison charts to use 12 months

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,8 +25,8 @@ gem 'closed_struct'
 gem 'pg'
 
 # Dashboard analytics
-gem 'energy-sparks_analytics', github: 'Energy-Sparks/energy-sparks_analytics', tag: '5.0.6'
-# gem 'energy-sparks_analytics', github: 'Energy-Sparks/energy-sparks_analytics', branch: '3996-allow-peak-usage-calculations-and-benchmarks-to-work-with-limited-data'
+# gem 'energy-sparks_analytics', github: 'Energy-Sparks/energy-sparks_analytics', tag: '5.0.6'
+gem 'energy-sparks_analytics', github: 'Energy-Sparks/energy-sparks_analytics', branch: 'monthly-charts-with-up-to-a-year'
 # gem 'energy-sparks_analytics', path: '../energy-sparks_analytics'
 
 # Using master due to it having a patch which doesn't override Enumerable#sum if it's already defined

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/Energy-Sparks/energy-sparks_analytics.git
-  revision: 7e7b3bf3b23f2e8329bc4673af0d2ad1fbd31f8e
-  tag: 5.0.6
+  revision: 395e4de877e5620772e3ab4ce8b96730443def2c
+  branch: monthly-charts-with-up-to-a-year
   specs:
     energy-sparks_analytics (1.2.1)
       activesupport (>= 6.0, < 7.1)
@@ -821,4 +821,4 @@ DEPENDENCIES
   wisper-rspec
 
 BUNDLED WITH
-   2.5.5
+   2.5.4

--- a/app/views/schools/advice/long_term/_recent_trend.html.erb
+++ b/app/views/schools/advice/long_term/_recent_trend.html.erb
@@ -37,22 +37,20 @@
                          chart_config: { y_axis_units: select_y_axis(school, chart_type, :£) } %>
 <% end %>
 
-<% if analysis_dates.months_of_data > 23 %>
-  <%= component 'chart', chart_type: :"#{fuel_type}_by_month_year_0_1", school: school do |c| %>
-    <% key_prefix = 'advice_pages.electricity_long_term.charts.electricity_by_month_year' %>
-    <% key_suffix = analysis_dates.one_years_data? ? '_two_years' : '' %>
-    <%# i18n-tasks-use t('advice_pages.electricity_long_term.charts.electricity_by_month_year.title_two_years') %>
-    <%# i18n-tasks-use t('advice_pages.electricity_long_term.charts.electricity_by_month_year.title') %>
-    <% c.with_title { t("#{key_prefix}.title#{key_suffix}", fuel_type: fuel_type) } %>
-    <%# i18n-tasks-use t('advice_pages.electricity_long_term.charts.electricity_by_month_year.subtitle_two_years_html') %>
-    <%# i18n-tasks-use t('advice_pages.electricity_long_term.charts.electricity_by_month_year.subtitle_html') %>
-    <% c.with_subtitle do
-         t("#{key_prefix}.subtitle#{key_suffix}_html", end_date: analysis_dates.end_date.to_s(:es_short),
-                                                       start_date: analysis_dates.start_date.to_s(:es_short),
-                                                       fuel_type: fuel_type)
-       end %>
-    <% c.with_footer do %>
-      <p><%= t("advice_pages.#{fuel_type}_long_term.charts.#{fuel_type}_by_month_year.explanation") %></p>
-    <% end %>
+<%= component 'chart', chart_type: :"#{fuel_type}_by_month_year_0_1", school: school do |c| %>
+  <% key_prefix = 'advice_pages.electricity_long_term.charts.electricity_by_month_year' %>
+  <% key_suffix = analysis_dates.one_years_data? ? '_two_years' : '' %>
+  <%# i18n-tasks-use t('advice_pages.electricity_long_term.charts.electricity_by_month_year.title_two_years') %>
+  <%# i18n-tasks-use t('advice_pages.electricity_long_term.charts.electricity_by_month_year.title') %>
+  <% c.with_title { t("#{key_prefix}.title#{key_suffix}", fuel_type: fuel_type) } %>
+  <%# i18n-tasks-use t('advice_pages.electricity_long_term.charts.electricity_by_month_year.subtitle_two_years_html') %>
+  <%# i18n-tasks-use t('advice_pages.electricity_long_term.charts.electricity_by_month_year.subtitle_html') %>
+  <% c.with_subtitle do
+       t("#{key_prefix}.subtitle#{key_suffix}_html", end_date: analysis_dates.end_date.to_s(:es_short),
+                                                     start_date: analysis_dates.start_date.to_s(:es_short),
+                                                     fuel_type: fuel_type)
+     end %>
+  <% c.with_footer do %>
+    <p><%= t("advice_pages.#{fuel_type}_long_term.charts.#{fuel_type}_by_month_year.explanation") %></p>
   <% end %>
 <% end %>

--- a/spec/system/schools/advice_pages/electricity_long_term_spec.rb
+++ b/spec/system/schools/advice_pages/electricity_long_term_spec.rb
@@ -111,8 +111,7 @@ RSpec.describe 'electricity long term advice page', :aggregate_failures do
 
         it 'includes expected charts' do
           expect(page).to have_css('#chart_management_dashboard_group_by_week_electricity')
-          # TEMPORARY
-          expect(page).not_to have_css('#chart_wrapper_electricity_by_month_year_0_1')
+          expect(page).to have_css('#chart_wrapper_electricity_by_month_year_0_1')
           expect(page).to have_no_css('#chart_wrapper_group_by_week_electricity_versus_benchmark')
           expect(page).to have_no_css('#chart_wrapper_group_by_week_electricity_unlimited')
           expect(page).to have_no_css('#chart_wrapper_electricity_longterm_trend')
@@ -136,15 +135,14 @@ RSpec.describe 'electricity long term advice page', :aggregate_failures do
           expect(page).to have_css('#chart_wrapper_group_by_week_electricity')
           expect(page).to have_css('#chart_wrapper_group_by_week_electricity_versus_benchmark')
           expect(page).to have_css('#chart_wrapper_group_by_week_electricity_unlimited')
-          # TEMPORARY
-          expect(page).not_to have_css('#chart_wrapper_electricity_by_month_year_0_1')
+          expect(page).to have_css('#chart_wrapper_electricity_by_month_year_0_1')
           # not enough data for this
           expect(page).to have_no_css('#chart_wrapper_electricity_longterm_trend')
         end
       end
 
-      context 'with more than 800 days of meter data' do
-        let(:reading_start_date) { 800.days.ago }
+      context 'with more than two years of meter data' do
+        let(:reading_start_date) { 730.days.ago }
 
         it_behaves_like 'an electricity long term advice page tab', tab: 'Analysis'
 

--- a/spec/system/schools/advice_pages/gas_long_term_spec.rb
+++ b/spec/system/schools/advice_pages/gas_long_term_spec.rb
@@ -105,8 +105,7 @@ RSpec.describe 'gas long term advice page', :aggregate_failures do
 
         it 'includes expected charts' do
           expect(page).to have_css('#chart_management_dashboard_group_by_week_gas')
-          # TEMPORARY
-          expect(page).not_to have_css('#chart_wrapper_gas_by_month_year_0_1')
+          expect(page).to have_css('#chart_wrapper_gas_by_month_year_0_1')
           expect(page).to have_no_css('#chart_wrapper_group_by_week_gas_unlimited')
           expect(page).to have_no_css('#chart_wrapper_gas_longterm_trend')
         end
@@ -128,15 +127,14 @@ RSpec.describe 'gas long term advice page', :aggregate_failures do
         it 'includes expected charts' do
           expect(page).to have_css('#chart_wrapper_group_by_week_gas')
           expect(page).to have_css('#chart_wrapper_group_by_week_gas_unlimited')
-          # TEMPORARY
-          expect(page).not_to have_css('#chart_wrapper_gas_by_month_year_0_1')
+          expect(page).to have_css('#chart_wrapper_gas_by_month_year_0_1')
           # not enough data for these
           expect(page).to have_no_css('#chart_wrapper_gas_longterm_trend')
         end
       end
 
-      context 'with more than 800 days of meter data' do
-        let(:reading_start_date) { 800.days.ago }
+      context 'with more than two years of meter data' do
+        let(:reading_start_date) { 730.days.ago }
 
         it_behaves_like 'a gas long term advice page tab', tab: 'Analysis'
 


### PR DESCRIPTION
Updates the analytics so that the application is using the revised configuration for the monthly comparison charges on the long term usage pages. [See this PR](https://github.com/Energy-Sparks/energy-sparks_analytics/pull/670).

Reverses the temporary change to hide those charts if a school has less than 2 years of data and tweaks specs.