### PR TITLE
Fix some additional text and chart issues with the advice pages

### DIFF
--- a/app/controllers/schools/advice/base_long_term_controller.rb
+++ b/app/controllers/schools/advice/base_long_term_controller.rb
@@ -27,6 +27,14 @@ module Schools
 
       private
 
+      def last_full_week_start_date(end_date)
+        if one_years_data?(analysis_start_date, analysis_end_date)
+          end_date.prev_year.end_of_week
+        else
+          analysis_start_date.end_of_week
+        end
+      end
+
       def multiple_meters?
         @school.meters.active.where(meter_type: fuel_type).count > 1
       end

--- a/app/views/schools/advice/electricity_out_of_hours/_analysis.html.erb
+++ b/app/views/schools/advice/electricity_out_of_hours/_analysis.html.erb
@@ -2,7 +2,11 @@
 <ul>
   <li>
     <a href='#last_twelve_months'>
-      <%= t('advice_pages.electricity_out_of_hours.analysis.last_twelve_months.title') %>
+      <% if @analysis_dates.one_years_data? %>
+        <%= t('advice_pages.electricity_out_of_hours.analysis.last_twelve_months.title') %>
+      <% else %>
+        <%= t('advice_pages.electricity_long_term.analysis.recent_trend.title') %>
+      <% end %>
     </a>
   </li>
   <li>

--- a/app/views/schools/advice/gas_out_of_hours/_analysis.html.erb
+++ b/app/views/schools/advice/gas_out_of_hours/_analysis.html.erb
@@ -2,7 +2,11 @@
 <ul>
   <li>
     <a href='#last_twelve_months'>
-      <%= t('advice_pages.gas_out_of_hours.analysis.last_twelve_months.title') %>
+      <% if @analysis_dates.one_years_data? %>
+        <%= t('advice_pages.gas_out_of_hours.analysis.last_twelve_months.title') %>
+      <% else %>
+        <%= t('advice_pages.gas_long_term.analysis.recent_trend.title') %>
+      <% end %>
     </a>
   </li>
   <li>

--- a/app/views/schools/advice/gas_out_of_hours/_by_day.html.erb
+++ b/app/views/schools/advice/gas_out_of_hours/_by_day.html.erb
@@ -29,29 +29,32 @@
   <% end %>
 <% end %>
 
-<%= render 'schools/advice/section_title',
-           section_id: 'usage_through_the_school_day',
-           section_title: t('advice_pages.gas_out_of_hours.analysis.usage_through_the_school_day.title') %>
+<% if analysis_dates.months_of_data >= 1 %>
 
-<%= t('advice_pages.gas_out_of_hours.analysis.usage_through_the_school_day.subtitle') %>
+  <%= render 'schools/advice/section_title',
+             section_id: 'usage_through_the_school_day',
+             section_title: t('advice_pages.gas_out_of_hours.analysis.usage_through_the_school_day.title') %>
 
-<%= component 'chart', chart_type: :gas_heating_season_intraday_up_to_1_year, school: school do |c| %>
-  <%# i18n-tasks-use t('advice_pages.gas_out_of_hours.analysis.usage_through_the_school_day.gas_heating_season_intraday_up_to_1_year.title') %>
-  <% c.with_title do %>
-    <%= t('advice_pages.gas_out_of_hours.'\
-          'analysis.usage_through_the_school_day.gas_heating_season_intraday_up_to_1_year.title') %>
-  <% end %>
-  <%# i18n-tasks-use t('advice_pages.gas_out_of_hours.analysis.usage_through_the_school_day.gas_heating_season_intraday_up_to_1_year.subtitle_html') %>
-  <% c.with_subtitle do
-       t('advice_pages.gas_out_of_hours.'\
-         'analysis.usage_through_the_school_day.gas_heating_season_intraday_up_to_1_year.subtitle_html',
-         start_month_year: short_dates(start_date),
-         end_month_year: short_dates(analysis_dates.end_date))
-     end %>
-  <%# i18n-tasks-use t('advice_pages.gas_out_of_hours.analysis.usage_through_the_school_day.gas_heating_season_intraday_up_to_1_year.footer_html') %>
-  <% c.with_footer do %>
-    <%= t('advice_pages.gas_out_of_hours.'\
-          'analysis.usage_through_the_school_day.gas_heating_season_intraday_up_to_1_year.footer_html',
-          insights_school_advice_heating_control_path: insights_school_advice_heating_control_path(school)) %>
+  <%= t('advice_pages.gas_out_of_hours.analysis.usage_through_the_school_day.subtitle') %>
+
+  <%= component 'chart', chart_type: :gas_heating_season_intraday_up_to_1_year, school: school do |c| %>
+    <%# i18n-tasks-use t('advice_pages.gas_out_of_hours.analysis.usage_through_the_school_day.gas_heating_season_intraday_up_to_1_year.title') %>
+    <% c.with_title do %>
+      <%= t('advice_pages.gas_out_of_hours.'\
+            'analysis.usage_through_the_school_day.gas_heating_season_intraday_up_to_1_year.title') %>
+    <% end %>
+    <%# i18n-tasks-use t('advice_pages.gas_out_of_hours.analysis.usage_through_the_school_day.gas_heating_season_intraday_up_to_1_year.subtitle_html') %>
+    <% c.with_subtitle do
+         t('advice_pages.gas_out_of_hours.'\
+           'analysis.usage_through_the_school_day.gas_heating_season_intraday_up_to_1_year.subtitle_html',
+           start_month_year: short_dates(start_date),
+           end_month_year: short_dates(analysis_dates.end_date))
+       end %>
+    <%# i18n-tasks-use t('advice_pages.gas_out_of_hours.analysis.usage_through_the_school_day.gas_heating_season_intraday_up_to_1_year.footer_html') %>
+    <% c.with_footer do %>
+      <%= t('advice_pages.gas_out_of_hours.'\
+            'analysis.usage_through_the_school_day.gas_heating_season_intraday_up_to_1_year.footer_html',
+            insights_school_advice_heating_control_path: insights_school_advice_heating_control_path(school)) %>
+    <% end %>
   <% end %>
 <% end %>

--- a/app/views/schools/advice/long_term/_recent_trend.html.erb
+++ b/app/views/schools/advice/long_term/_recent_trend.html.erb
@@ -34,7 +34,17 @@
 <% else %>
   <% chart_type = :"management_dashboard_group_by_week_#{fuel_type}" %>
   <%= component 'chart', chart_type: chart_type, school: school,
-                         chart_config: { y_axis_units: select_y_axis(school, chart_type, :£) } %>
+                         chart_config: { y_axis_units: select_y_axis(school, chart_type, :£) } do |c| %>
+      <% c.with_title { t("advice_pages.#{fuel_type}_out_of_hours.analysis.holiday_usage.#{chart_type}.title") } %>
+      <% c.with_subtitle do
+           t("advice_pages.#{fuel_type}_long_term.charts.group_by_week_#{fuel_type}.subtitle_html",
+             start_date: analysis_dates.last_full_week_start_date.to_s(:es_short),
+             end_date: analysis_dates.last_full_week_end_date.to_s(:es_short))
+         end %>
+      <% c.with_footer do %>
+        <p><%= t("advice_pages.#{fuel_type}_long_term.charts.group_by_week_#{fuel_type}.explanation_html") %></p>
+      <% end %>
+  <% end %>
 <% end %>
 
 <%= component 'chart', chart_type: :"#{fuel_type}_by_month_year_0_1", school: school do |c| %>

--- a/app/views/schools/advice/out_of_hours/_last_year.html.erb
+++ b/app/views/schools/advice/out_of_hours/_last_year.html.erb
@@ -1,7 +1,11 @@
+<% if analysis_dates.one_years_data? %>
+  <% section_title = t("advice_pages.#{fuel_type}_out_of_hours.analysis.last_twelve_months.title") %>
+<% else %>
+  <% section_title = t("advice_pages.#{fuel_type}_long_term.analysis.recent_trend.title") %>
+<% end %>
 <%= render 'schools/advice/section_title',
            section_id: 'last_twelve_months',
-           section_title:
-          t("advice_pages.#{fuel_type}_out_of_hours.analysis.last_twelve_months.title") %>
+           section_title: section_title %>
 
 <%= component 'chart', chart_type: chart, school: school do |c| %>
   <% c.with_title do %>

--- a/spec/system/schools/advice_pages/electricity_long_term_spec.rb
+++ b/spec/system/schools/advice_pages/electricity_long_term_spec.rb
@@ -105,12 +105,14 @@ RSpec.describe 'electricity long term advice page', :aggregate_failures do
           expect(page).to have_no_content(I18n.t('advice_pages.electricity_long_term.analysis.meter_breakdown.title'))
         end
 
-        it "doesn't notice saying usage is high" do
+        it "doesn't have a notice saying usage is high" do
           expect(page).to have_no_content(I18n.t('advice_pages.electricity_long_term.analysis.comparison.assessment.high.title'))
         end
 
         it 'includes expected charts' do
+          expect(page).to have_content(I18n.t('advice_pages.electricity_out_of_hours.analysis.holiday_usage.management_dashboard_group_by_week_electricity.title'))
           expect(page).to have_css('#chart_management_dashboard_group_by_week_electricity')
+
           expect(page).to have_css('#chart_wrapper_electricity_by_month_year_0_1')
           expect(page).to have_no_css('#chart_wrapper_group_by_week_electricity_versus_benchmark')
           expect(page).to have_no_css('#chart_wrapper_group_by_week_electricity_unlimited')

--- a/spec/system/schools/advice_pages/electricity_out_of_hours_spec.rb
+++ b/spec/system/schools/advice_pages/electricity_out_of_hours_spec.rb
@@ -114,7 +114,8 @@ RSpec.describe 'electricity out of hours advice page', type: :system do
         let(:reading_end_date)   { Date.new(2024, 1, 31) }
 
         it 'has last year section' do
-          expect(page).to have_content(I18n.t('advice_pages.electricity_out_of_hours.analysis.last_twelve_months.title'))
+          expect(page).to have_content(I18n.t('advice_pages.electricity_long_term.analysis.recent_trend.title'))
+          expect(page).not_to have_content(I18n.t('advice_pages.electricity_out_of_hours.analysis.last_twelve_months.title'))
           expect(page).to have_css('#chart_wrapper_daytype_breakdown_electricity_tolerant')
           expect(page).to have_css('#electricity-out-of-hours-table')
         end
@@ -172,6 +173,7 @@ RSpec.describe 'electricity out of hours advice page', type: :system do
         let(:reading_start_date) { 500.days.ago }
 
         it 'has last year section' do
+          expect(page).not_to have_content(I18n.t('advice_pages.electricity_long_term.analysis.recent_trend.title'))
           expect(page).to have_content(I18n.t('advice_pages.electricity_out_of_hours.analysis.last_twelve_months.title'))
           expect(page).to have_css('#chart_wrapper_daytype_breakdown_electricity_tolerant')
           expect(page).to have_css('#electricity-out-of-hours-table')

--- a/spec/system/schools/advice_pages/gas_long_term_spec.rb
+++ b/spec/system/schools/advice_pages/gas_long_term_spec.rb
@@ -99,11 +99,12 @@ RSpec.describe 'gas long term advice page', :aggregate_failures do
           expect(page).to have_no_content(I18n.t('advice_pages.gas_long_term.analysis.meter_breakdown.title'))
         end
 
-        it "doesn't says usage is high" do
+        it "doesn't say usage is high" do
           expect(page).to have_no_content(I18n.t('advice_pages.gas_long_term.analysis.comparison.assessment.high.title'))
         end
 
         it 'includes expected charts' do
+          expect(page).to have_content(I18n.t('advice_pages.gas_out_of_hours.analysis.holiday_usage.management_dashboard_group_by_week_gas.title'))
           expect(page).to have_css('#chart_management_dashboard_group_by_week_gas')
           expect(page).to have_css('#chart_wrapper_gas_by_month_year_0_1')
           expect(page).to have_no_css('#chart_wrapper_group_by_week_gas_unlimited')

--- a/spec/system/schools/advice_pages/gas_out_of_hours_spec.rb
+++ b/spec/system/schools/advice_pages/gas_out_of_hours_spec.rb
@@ -115,7 +115,8 @@ RSpec.describe 'gas out of hours advice page', type: :system do
         let(:reading_end_date)   { Date.new(2024, 1, 31) }
 
         it 'has last year section' do
-          expect(page).to have_content(I18n.t('advice_pages.gas_out_of_hours.analysis.last_twelve_months.title'))
+          expect(page).to have_content(I18n.t('advice_pages.gas_long_term.analysis.recent_trend.title'))
+          expect(page).not_to have_content(I18n.t('advice_pages.gas_out_of_hours.analysis.last_twelve_months.title'))
           expect(page).to have_css('#chart_wrapper_daytype_breakdown_gas_tolerant')
           expect(page).to have_css('#gas-out-of-hours-table')
         end
@@ -175,6 +176,7 @@ RSpec.describe 'gas out of hours advice page', type: :system do
         let(:reading_start_date) { 500.days.ago }
 
         it 'has last year section' do
+          expect(page).not_to have_content(I18n.t('advice_pages.gas_long_term.analysis.recent_trend.title'))
           expect(page).to have_content(I18n.t('advice_pages.gas_out_of_hours.analysis.last_twelve_months.title'))
           expect(page).to have_css('#chart_wrapper_daytype_breakdown_gas_tolerant')
           expect(page).to have_css('#gas-out-of-hours-table')

--- a/spec/system/schools/advice_pages/gas_out_of_hours_spec.rb
+++ b/spec/system/schools/advice_pages/gas_out_of_hours_spec.rb
@@ -110,6 +110,17 @@ RSpec.describe 'gas out of hours advice page', type: :system do
         end
       end
 
+      context 'with less than a month of data' do
+        let(:reading_start_date) { 20.days.ago }
+
+        it 'has by day section' do
+          expect(page).to have_content(I18n.t('advice_pages.gas_out_of_hours.analysis.usage_by_day_of_week.title'))
+          expect(page).to have_css('#chart_wrapper_gas_by_day_of_week_tolerant')
+          # not enough data for this
+          expect(page).not_to have_css('#chart_wrapper_gas_heating_season_intraday_up_to_1_year')
+        end
+      end
+
       context 'with less than a year of meter data' do
         let(:reading_start_date) { Date.new(2024, 1, 1) }
         let(:reading_end_date)   { Date.new(2024, 1, 31) }
@@ -124,6 +135,7 @@ RSpec.describe 'gas out of hours advice page', type: :system do
         it 'has by day section' do
           expect(page).to have_content(I18n.t('advice_pages.gas_out_of_hours.analysis.usage_by_day_of_week.title'))
           expect(page).to have_css('#chart_wrapper_gas_by_day_of_week_tolerant')
+          expect(page).to have_css('#chart_wrapper_gas_heating_season_intraday_up_to_1_year')
         end
 
         it 'does not have a holiday usage section' do


### PR DESCRIPTION
Fixes several issues with the advice pages:

- Revise section heading on out of hours page so its says "Recent trend" instead of "Last 12 months" if there's less than a year of data. Have reused translation key to keep consistent with long term trend page
- Restores the chart title and subtitle to the first chart on the long term usage page. We switch charts if there's <1 year but all charts should have a title and subtitle. As this chart is used on another page I've reused the translation key again
- Hide the heating use by day chart on the gas out of hours page if there's less than a month of data. Otherwise the chart fails to run. The analytics is not very clear on minimum data required for a fit, but 30 days seems to be a key threshold
