### PR TITLE
Long term benchmarks require a year

### DIFF
--- a/app/services/schools/advice_page_benchmarks/long_term_usage_benchmark_generator.rb
+++ b/app/services/schools/advice_page_benchmarks/long_term_usage_benchmark_generator.rb
@@ -2,11 +2,15 @@ module Schools
   module AdvicePageBenchmarks
     class LongTermUsageBenchmarkGenerator < SchoolBenchmarkGenerator
       def benchmark_school
-        return unless usage_service.enough_data?
+        return unless enough_data?
         usage_service.benchmark_usage.category
       end
 
       private
+
+      def enough_data?
+        Util::MeterDateRangeChecker.new(@aggregate_school.aggregate_meter(advice_page_fuel_type)).one_years_data?
+      end
 
       def usage_service
         @usage_service ||= Schools::Advice::LongTermUsageService.new(@school, @aggregate_school, advice_page_fuel_type)


### PR DESCRIPTION
The long term usage service now only requires 90 days of data, but for benchmarking we need a year.

This PR updates the benchmark generator that generates the grading shown on the advice page index to use a year of data.

Also reworks the spec to actually run the benchmark end to end rather than using mocks.