### PR TITLE
Update analytics to include bug fix for tariff service

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,8 +25,8 @@ gem 'closed_struct'
 gem 'pg'
 
 # Dashboard analytics
-gem 'energy-sparks_analytics', github: 'Energy-Sparks/energy-sparks_analytics', tag: '5.0.7'
-# gem 'energy-sparks_analytics', github: 'Energy-Sparks/energy-sparks_analytics', branch: 'monthly-charts-with-up-to-a-year'
+# gem 'energy-sparks_analytics', github: 'Energy-Sparks/energy-sparks_analytics', tag: '5.0.7'
+gem 'energy-sparks_analytics', github: 'Energy-Sparks/energy-sparks_analytics', branch: '4001-baseload-page-error-with-lagging-data'
 # gem 'energy-sparks_analytics', path: '../energy-sparks_analytics'
 
 # Using master due to it having a patch which doesn't override Enumerable#sum if it's already defined

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/Energy-Sparks/energy-sparks_analytics.git
-  revision: a41628c53e418395a15300deb1d19273fc7e5aa8
-  tag: 5.0.7
+  revision: 6e78c5b6144bfe2a0867d8d4cb58be978c669159
+  branch: 4001-baseload-page-error-with-lagging-data
   specs:
     energy-sparks_analytics (1.2.1)
       activesupport (>= 6.0, < 7.1)


### PR DESCRIPTION
Avoid an issue with baseload page failing to load with lagging data and newer tariffs