### PR TITLE
Init date pickers in reverse order

### DIFF
--- a/app/assets/javascripts/usage_charts.js
+++ b/app/assets/javascripts/usage_charts.js
@@ -123,13 +123,13 @@ $(document).ready(function() {
     var firstDataPicker = $(chartDiv).find("input[name='first-date-picker']");
     var firstDataPickerWrapper = $(firstDataPicker).closest('.date');
     if (firstDataPickerWrapper.length) {
-      setUpDatePicker(firstDataPickerWrapper, firstDataPicker, minMaxReadings, defaultDate, period);
+      setUpDatePicker(firstDataPickerWrapper, firstDataPicker, minMaxReadings, defaultComparisonDate, period);
     }
 
     var secondDataPicker = $(chartDiv).find("input[name='second-date-picker']");
     var secondDataPickerWrapper = $(secondDataPicker).closest('.date');
     if (secondDataPickerWrapper.length) {
-      setUpDatePicker(secondDataPickerWrapper, secondDataPicker, minMaxReadings, defaultComparisonDate, period);
+      setUpDatePicker(secondDataPickerWrapper, secondDataPicker, minMaxReadings, defaultDate, period);
     }
 
     var chartContainer = $(chartDiv).find('.usage-chart').first();


### PR DESCRIPTION
We have some charts that provide date picker components, e.g.

/schools/st-mary-s-fields-primary-school/advice/electricity_recent_changes/analysis
/schools/st-mary-s-fields-primary-school/usage?period=weekly&supply=electricity
/schools/st-mary-s-fields-primary-school/usage?period=daily&supply=electricity

The default dates for each picker is initialised in the javascript. Currently the way these are setup the most recent date ends up in the first picker and the older date in the second. This is a bit counter-intuitive as you'd expect the older date to be first.

There's a suggestion to reverse this to make it clearer. A user can end up choosing whatever series they want in whatever order, but this introduces a better default on page load.