### PR TITLE
Write migration to populate `Comparison::MetricType` with existing benchmark variable definitions

### DIFF
--- a/app/models/advice_page.rb
+++ b/app/models/advice_page.rb
@@ -34,6 +34,12 @@ class AdvicePage < ApplicationRecord
 
   scope :by_key, -> { order(key: :asc) }
 
+  # Required as multiple is not yet supported in advice page list
+  # Could be used for the total energy use page.
+  def self.display_fuel_types
+    fuel_types.reject {|k, _v| k.to_sym == :multiple}
+  end
+
   def label
     key.humanize
   end

--- a/app/models/alert_type.rb
+++ b/app/models/alert_type.rb
@@ -45,6 +45,7 @@ class AlertType < ApplicationRecord
   scope :electricity,   -> { where(fuel_type: :electricity) }
   scope :gas,           -> { where(fuel_type: :gas) }
   scope :no_fuel,       -> { where(fuel_type: nil) }
+  scope :with_benchmarks, -> { where(benchmark: true) }
 
   scope :editable, -> { where.not(background: true) }
 
@@ -68,19 +69,27 @@ class AlertType < ApplicationRecord
     end
   end
 
+  def class_from_name
+    class_name.constantize
+  end
+
   def cleaned_template_variables
     # TODO: make the analytics code remove the £ sign
-    class_name.constantize.front_end_template_variables.deep_transform_keys do |key|
+    class_from_name.front_end_template_variables.deep_transform_keys do |key|
       :"#{key.to_s.gsub('£', 'gbp')}"
     end
   end
 
   def available_charts
-    class_name.constantize.front_end_template_charts.map { |variable_name, values| [values[:description], variable_name] }
+    class_from_name.front_end_template_charts.map { |variable_name, values| [values[:description], variable_name] }
   end
 
   def available_tables
-    class_name.constantize.front_end_template_tables.map { |variable_name, values| [values[:description], variable_name] }
+    class_from_name.front_end_template_tables.map { |variable_name, values| [values[:description], variable_name] }
+  end
+
+  def benchmark_variables
+    class_from_name.benchmark_template_variables
   end
 
   def worst_management_priority_rating

--- a/app/models/comparison/metric_type.rb
+++ b/app/models/comparison/metric_type.rb
@@ -19,8 +19,24 @@ class Comparison::MetricType < ApplicationRecord
   extend Mobility
   include EnumFuelType
 
-  enum units: [:float, :date, :percent, :relative_percent]
-  # are there more? [:£, :co2, :kwh, :time, :string, :kw]
+  UNIT_TYPES = {
+    float: 0,
+    integer: 1,
+    boolean: 2,
+    string: 3,
+    date: 4,
+    kwh: 5,
+    £: 6,
+    £current: 7,
+    co2: 8,
+    kw: 9,
+    percent: 10,
+    relative_percent: 11,
+    £_per_kw: 12,
+    £_per_kwh: 13
+  }.freeze
+
+  enum units: UNIT_TYPES
 
   translates :label, type: :string, fallbacks: { cy: :en }
   translates :description, type: :string, fallbacks: { cy: :en }

--- a/app/models/concerns/enum_fuel_type.rb
+++ b/app/models/concerns/enum_fuel_type.rb
@@ -5,7 +5,8 @@ module EnumFuelType
     electricity: 0,
     gas: 1,
     storage_heater: 2,
-    solar_pv: 3
+    solar_pv: 3,
+    multiple: 4 # e.g. for metrics that are for total usage
   }.freeze
 
   included do

--- a/app/services/comparison/metric_migration_service.rb
+++ b/app/services/comparison/metric_migration_service.rb
@@ -1,0 +1,79 @@
+module Comparison
+  # Populate the MetricType model based on the definitions in the analytics
+  class MetricMigrationService
+    def migrate
+      AlertType.enabled.each do |alert_type|
+        create_metrics(alert_type) if alert_type.benchmark_variables.present?
+      end
+      true
+    rescue => e
+      puts e
+      puts e.backtrace
+      false
+    end
+
+    # Maps the units defined by the alert classes to what we will be storing
+    # in the database
+    def units_for_metric_type(unit)
+      # fallback if not declared by analytics
+      return :float if unit.nil?
+      return :boolean if unit == TrueClass
+      # String => :string, Integer => :integer
+      return unit.to_s.downcase.to_sym if unit.is_a?(Class)
+      # { kw: :electricity}
+      return unit.keys.first if unit.is_a?(Hash)
+      # 00:30
+      return :string if unit == :timeofday
+      return :string if unit == :school_type
+      return :integer if [:days, :years].include?(unit)
+      return :float if [:morning_start_time, :optimum_start_sensitivity, :r2, :opt_start_standard_deviation, :m2, :pupils, :co2t, :kwp].include?(unit)
+      # Let everything else pass through
+      unit.to_sym
+    end
+
+    def fuel_type_for_metric_type(key, definition, alert_type)
+      return alert_type.fuel_type.to_sym if alert_type.fuel_type.present?
+
+      if definition[:units].is_a?(Hash)
+        # { kwh: :electricity }
+        return definition[:units].values[0]
+      end
+
+      # other keys, e.g. from AlertEnergyAnnualVersusBenchmark include
+      # the fuel type in the name
+      case key.to_s
+      when /electricity/
+        return :electricity
+      when /gas/
+        return :gas
+      when /storage_heater/
+        return :storage_heater
+      when /solar/
+        return :solar_pv
+      end
+
+      return :multiple
+    end
+
+    private
+
+    def create_metrics(alert_type)
+      alert_type.class_from_name.benchmark_template_variables.each do |key, definition|
+        next if ignore?(key)
+        MetricType.find_or_create_by!(
+          key: key.to_sym,
+          fuel_type: fuel_type_for_metric_type(key, definition, alert_type)
+        ) do |new_record|
+          new_record.units = units_for_metric_type(definition[:units])
+          # these will later need to be reviewed and replaced
+          new_record.label = definition[:description]
+          new_record.description = "Migrated from #{alert_type.class_name} (#{definition[:benchmark_code]})"
+        end
+      end
+    end
+
+    def ignore?(key)
+      [:activation_date, :floor_area, :pupils, :school_name, :school_area, :school_type, :school_type_name, :urn, :degree_days_15_5C_domestic].include?(key)
+    end
+  end
+end

--- a/app/services/comparison/metric_migration_service.rb
+++ b/app/services/comparison/metric_migration_service.rb
@@ -43,16 +43,16 @@ module Comparison
       # the fuel type in the name
       case key.to_s
       when /electricity/
-        return :electricity
+        :electricity
       when /gas/
-        return :gas
+        :gas
       when /storage_heater/
-        return :storage_heater
+        :storage_heater
       when /solar/
-        return :solar_pv
+        :solar_pv
+      else
+        :multiple
       end
-
-      return :multiple
     end
 
     private

--- a/app/views/schools/advice/index/_page_list.html.erb
+++ b/app/views/schools/advice/index/_page_list.html.erb
@@ -1,20 +1,20 @@
-<% AdvicePage.fuel_types.keys.each_with_index do |fuel_type, idx| %>
+<% AdvicePage.display_fuel_types.keys.each_with_index do |fuel_type, idx| %>
   <div class="col">
     <% if display_advice_page?(school, fuel_type) %>
       <div class="row mt-4">
         <div class="col-3">
           <h4>
             <span class="<%= fuel_type_class(fuel_type) %>">
-              <%= fa_icon( fuel_type_icon(fuel_type) ) %>
+              <%= fa_icon(fuel_type_icon(fuel_type)) %>
             </span>
             <%= t("advice_pages.nav.sections.#{fuel_type}") %>
           </h4>
         </div>
         <div class="col-7"></div>
-        <div class="col-2 <%= idx == 0 ? 'bg-light' : ''%>">
+        <div class="col-2 <%= idx.zero? ? 'bg-light' : '' %>">
           <% if idx == 0 %>
             <div class="advice-page-benchmark-label">
-              <strong><%= t("advice_pages.index.show.how_do_you_compare") %></strong>
+              <strong><%= t('advice_pages.index.show.how_do_you_compare') %></strong>
             </div>
           <% end %>
         </div>
@@ -38,13 +38,18 @@
               <% if school_benchmark.present? %>
                 <div class="col-2 bg-<%= school_benchmark.benchmarked_as %>">
                   <div class="advice-page-benchmark-colored-label">
-                    <%= link_to t("advice_pages.benchmarks.#{school_benchmark.benchmarked_as}"), advice_page_path(school, ap) %>
+                    <%= link_to t("advice_pages.benchmarks.#{school_benchmark.benchmarked_as}"),
+                                advice_page_path(school, ap) %>
                   </div>
                 </div>
               <% else %>
                 <div class="col-2 bg-light">
                   <div class="advice-page-benchmark-muted-label">
-                    <%= can_benchmark?(advice_page: ap) ? t("advice_pages.index.show.not_available") : t("advice_pages.index.show.not_applicable") %>
+                    <% if can_benchmark?(advice_page: ap) %>
+                      <%= t('advice_pages.index.show.not_available') %>
+                    <% else %>
+                      <%= t('advice_pages.index.show.not_applicable') %>
+                    <% end %>
                   </div>
                 </div>
               <% end %>

--- a/spec/services/comparison/metric_migration_service_spec.rb
+++ b/spec/services/comparison/metric_migration_service_spec.rb
@@ -75,8 +75,7 @@ describe Comparison::MetricMigrationService do
     end
 
     context 'with an test alert' do
-      # rubocop:disable RSpec/LeakyConstantDeclaration
-      # rubocop:disable Lint/ConstantDefinitionInBlock
+      # rubocop:disable RSpec/LeakyConstantDeclaration, Lint/ConstantDefinitionInBlock
       class TestAlert < AlertAnalysisBase
         VARIABLES = {
           benchmark_per_pupil: {
@@ -95,8 +94,7 @@ describe Comparison::MetricMigrationService do
           { 'Test Vars' => VARIABLES }.merge(self.superclass.template_variables)
         end
       end
-      # rubocop:enable RSpec/LeakyConstantDeclaration
-      # rubocop:enable Lint/ConstantDefinitionInBlock
+      # rubocop:enable RSpec/LeakyConstantDeclaration, Lint/ConstantDefinitionInBlock
 
       let!(:alert_type) do
         create(:alert_type, enabled: true,

--- a/spec/services/comparison/metric_migration_service_spec.rb
+++ b/spec/services/comparison/metric_migration_service_spec.rb
@@ -25,7 +25,38 @@ describe Comparison::MetricMigrationService do
   end
 
   describe '#fuel_type_for_metric_type' do
-    it 'does something'
+    context 'when the alert type has a fuel type' do
+      let!(:alert_type) do
+        create(:alert_type, enabled: true,
+          fuel_type: :electricity, class_name: 'AlertElectricityBaseloadVersusBenchmark')
+      end
+
+      it { expect(service.fuel_type_for_metric_type(:unknown, {}, alert_type)).to eq :electricity }
+      it { expect(service.fuel_type_for_metric_type(:gas_annual_kwh, { units: :unknown }, alert_type)).to eq :electricity }
+      it { expect(service.fuel_type_for_metric_type(:annual_kw, { units: { kw: :gas } }, alert_type)).to eq :electricity }
+    end
+
+    context 'when the alert type has no fuel type' do
+      let!(:alert_type) do
+        create(:alert_type, enabled: true,
+          fuel_type: nil, class_name: 'AlertEnergyAnnualVersusBenchmark')
+      end
+
+      context 'with a fuel type in the analytics metric definition' do
+        it { expect(service.fuel_type_for_metric_type(:annual_kw, { units: { kw: :gas } }, alert_type)).to eq :gas }
+      end
+
+      context 'when the metric name includes a fuel type' do
+        it { expect(service.fuel_type_for_metric_type(:annual_electricity_kwh, { units: :kwh }, alert_type)).to eq :electricity }
+        it { expect(service.fuel_type_for_metric_type(:annual_solar_kwh, { units: :kwh }, alert_type)).to eq :solar_pv }
+        it { expect(service.fuel_type_for_metric_type(:annual_gas_kwh, { units: :kwh }, alert_type)).to eq :gas }
+        it { expect(service.fuel_type_for_metric_type(:annual_storage_heaters_kwh, { units: :kwh }, alert_type)).to eq :storage_heater }
+      end
+
+      context 'when there is no other fuel type' do
+        it { expect(service.fuel_type_for_metric_type(:annual_kwh, { units: :kwh }, alert_type)).to eq :multiple }
+      end
+    end
   end
 
   describe '#migrate' do
@@ -52,6 +83,11 @@ describe Comparison::MetricMigrationService do
             description: 'benchmark_per_pupil description',
             units: :kwh,
             benchmark_code: 'abc'
+          },
+          school_name: {
+            description: 'should be ignored',
+            units: String,
+            benchmark_code: 'xyz'
           }
         }.freeze
 
@@ -62,16 +98,13 @@ describe Comparison::MetricMigrationService do
       # rubocop:enable RSpec/LeakyConstantDeclaration
       # rubocop:enable Lint/ConstantDefinitionInBlock
 
-
       let!(:alert_type) do
         create(:alert_type, enabled: true,
           fuel_type: :electricity, class_name: 'TestAlert')
       end
 
-      it 'creates the expected metric types' do
+      it 'correctly creates the metric types' do
         service.migrate
-        expect(Comparison::MetricType.count).to eq(2)
-
         metric = Comparison::MetricType.order(:key).first
         expect(metric.key.to_sym).to eq(:benchmark_per_pupil)
         expect(metric.label).to eq('benchmark_per_pupil description')
@@ -84,7 +117,10 @@ describe Comparison::MetricMigrationService do
         expect(metric.units.to_sym).to eq :float
       end
 
-      it 'does not create ignored metrics'
+      it 'does not create ignored metrics' do
+        service.migrate
+        expect(Comparison::MetricType.count).to eq(2)
+      end
     end
 
     context 'with a real alert type that produces benchmarks' do

--- a/spec/services/comparison/metric_migration_service_spec.rb
+++ b/spec/services/comparison/metric_migration_service_spec.rb
@@ -1,0 +1,116 @@
+require 'rails_helper'
+
+describe Comparison::MetricMigrationService do
+  subject(:service) do
+    described_class.new
+  end
+
+  describe '#units_for_metric_type' do
+    it { expect(service.units_for_metric_type(nil)).to eq :float }
+    it { expect(service.units_for_metric_type(:£)).to eq :£ }
+    it { expect(service.units_for_metric_type(:£current)).to eq :£current }
+    it { expect(service.units_for_metric_type(:co2)).to eq :co2 }
+    it { expect(service.units_for_metric_type(:kwh)).to eq :kwh }
+    it { expect(service.units_for_metric_type(:£_per_kw)).to eq :£_per_kw }
+    it { expect(service.units_for_metric_type(:percent)).to eq :percent }
+    it { expect(service.units_for_metric_type(:relative_percent)).to eq :relative_percent }
+    it { expect(service.units_for_metric_type(Float)).to eq :float }
+    it { expect(service.units_for_metric_type(Integer)).to eq :integer }
+    it { expect(service.units_for_metric_type(TrueClass)).to eq :boolean }
+    it { expect(service.units_for_metric_type(String)).to eq :string }
+    it { expect(service.units_for_metric_type(Date)).to eq :date }
+    it { expect(service.units_for_metric_type(:kw)).to eq :kw }
+    it { expect(service.units_for_metric_type({ kw: :electricity })).to eq :kw }
+    it { expect(service.units_for_metric_type(:timeofday)).to eq :string }
+  end
+
+  describe '#fuel_type_for_metric_type' do
+    it 'does something'
+  end
+
+  describe '#migrate' do
+    context 'with an alert type without benchmark variables' do
+      let!(:alert_type) do
+        create(:alert_type, enabled: true, class_name: 'AdviceElectricityMeterBreakdownBase')
+      end
+
+      before do
+        service.migrate
+      end
+
+      it 'does not create anything' do
+        expect(Comparison::MetricType.count).to be(0)
+      end
+    end
+
+    context 'with an test alert' do
+      # rubocop:disable RSpec/LeakyConstantDeclaration
+      # rubocop:disable Lint/ConstantDefinitionInBlock
+      class TestAlert < AlertAnalysisBase
+        VARIABLES = {
+          benchmark_per_pupil: {
+            description: 'benchmark_per_pupil description',
+            units: :kwh,
+            benchmark_code: 'abc'
+          }
+        }.freeze
+
+        def self.template_variables
+          { 'Test Vars' => VARIABLES }.merge(self.superclass.template_variables)
+        end
+      end
+      # rubocop:enable RSpec/LeakyConstantDeclaration
+      # rubocop:enable Lint/ConstantDefinitionInBlock
+
+
+      let!(:alert_type) do
+        create(:alert_type, enabled: true,
+          fuel_type: :electricity, class_name: 'TestAlert')
+      end
+
+      it 'creates the expected metric types' do
+        service.migrate
+        expect(Comparison::MetricType.count).to eq(2)
+
+        metric = Comparison::MetricType.order(:key).first
+        expect(metric.key.to_sym).to eq(:benchmark_per_pupil)
+        expect(metric.label).to eq('benchmark_per_pupil description')
+        expect(metric.units.to_sym).to eq :kwh
+
+        # from base class
+        metric = Comparison::MetricType.order(:key).last
+        expect(metric.key.to_sym).to eq(:rating)
+        expect(metric.label).to eq('Rating out of 10')
+        expect(metric.units.to_sym).to eq :float
+      end
+
+      it 'does not create ignored metrics'
+    end
+
+    context 'with a real alert type that produces benchmarks' do
+      let!(:alert_type) do
+        create(:alert_type, enabled: true,
+          fuel_type: :electricity, class_name: 'AlertElectricityBaseloadVersusBenchmark')
+      end
+
+      it 'creates the expected metric types' do
+        service.migrate
+        expect(Comparison::MetricType.count).to eq(7)
+        metric = Comparison::MetricType.where(key: :average_baseload_last_year_kw, fuel_type: :electricity).first
+        expect(metric.label).to eq 'Average baseload last year kW'
+        expect(metric.units.to_sym).to eq :kw
+      end
+
+      context 'when metric type already exists' do
+        let!(:metric_type) do
+          create(:metric_type, fuel_type: :electricity, key: :average_baseload_last_year_kw)
+        end
+
+        it 'creates the rest' do
+          service.migrate
+          expect(Comparison::MetricType.count).to eq(7)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds a service that reads the existing benchmark metrics defined in the analytics alert classes and then creates new `MetricType` records for the new school comparison tool.

The mapping:

- handles the variety of different units supported by the analytics, mapping them into a new simpler range.
- ignores some existing metrics that are just copies of attributes from other models, e.g. the school name, that can be easily added to templates
- identifies the fuel type from the metric based on the alert type configuration or, failing that, the name or configuration of the metric. Some values are for multiple fuel types, e.g. annual total energy consumption. A new `:multiple` fuel type is added to support that, but this required some tweaks (and erblint tidying) to the advice pages

In addition to the spec, the code has been run on all configured alerts. Currently outputs 458 MetricType records.

Some further work is required to finalise some of the unit types, and possibly the metric definitions used in the mapping (e.g. if we want to rename some metrics) but this can come in further PRs. 

Current expectation is that this may be run as required during development, but prior to release of the newer code we'll run this via an afterparty task to populate the database.