### PR TITLE
Implement basic framework for producing a school comparison report

### DIFF
--- a/app/classes/comparison/report_definition.rb
+++ b/app/classes/comparison/report_definition.rb
@@ -1,8 +1,8 @@
 module Comparison
   class ReportDefinition
-    attr_reader :report_key, :advice_page, :schools, :metric_type_keys, :alert_types, :fuel_types, :order_key
+    attr_reader :report_key, :advice_page, :schools, :metric_type_keys, :alert_types, :fuel_types, :order_key, :order
 
-    def initialize(report_key:, advice_page:, schools:, metric_type_keys:, alert_types:, fuel_types:, order_key:)
+    def initialize(metric_type_keys:, order_key:, schools: [], report_key: nil, alert_types: nil, fuel_types: nil, advice_page: nil, order: :desc)
       @report_key = report_key
       @advice_page = advice_page
       @schools = schools
@@ -10,6 +10,7 @@ module Comparison
       @alert_types = alert_types
       @fuel_types = fuel_types
       @order_key = order_key
+      @order = order
     end
   end
 end

--- a/app/classes/comparison/report_definition.rb
+++ b/app/classes/comparison/report_definition.rb
@@ -1,0 +1,15 @@
+module Comparison
+  class ReportDefinition
+    attr_reader :report_key, :advice_page, :schools, :metric_type_keys, :alert_types, :fuel_types, :order_key
+
+    def initialize(report_key:, advice_page:, schools:, metric_type_keys:, alert_types:, fuel_types:, order_key:)
+      @report_key = report_key
+      @advice_page = advice_page
+      @schools = schools
+      @metric_type_keys = metric_type_keys
+      @alert_types = alert_types
+      @fuel_types = fuel_types
+      @order_key = order_key
+    end
+  end
+end

--- a/app/classes/comparison/report_result.rb
+++ b/app/classes/comparison/report_result.rb
@@ -1,0 +1,55 @@
+module Comparison
+  class ReportResult
+    attr_reader :definition, :metrics_by_school
+
+    def initialize(definition:, metrics_by_school:)
+      @definition = definition
+      @metrics_by_school = metrics_by_school
+    end
+
+    def schools
+      @metrics_by_school.keys
+    end
+
+    # Fetch a specific metric for a school based on its metric type key
+    def metric(school, metric_type_key)
+      return nil unless @metrics_by_school.key?(school)
+      metrics = @metrics_by_school[school]
+      metrics.detect {|m| m.metric_type.key.to_sym == metric_type_key}
+    end
+
+    # Find and use a metric. Avoids temporary assignments in templates
+    def with_metric(school, metric_type_key)
+      yield metric(school, metric_type_key)
+    end
+
+    # Find metric for a school and return its value formatted according to
+    # its units
+    def format_metric(school, metric_type_key)
+      metric = metric(school, metric_type_key)
+      return nil if metric.nil? || metric.value.nil?
+
+      # No need for formatting
+      # TODO: may need to consider formatting for some floats/integers
+      if [:boolean, :string, :integer, :float].include?(metric.units.to_sym)
+        metric.value
+      else
+        format(metric.value, metric.units.to_sym)
+      end
+    end
+
+    # Format a calculated value with provided units
+    def format(value, units)
+      FormatEnergyUnit.format(units, zero_out_small_values(value), :html, false, true, :benchmark).html_safe
+    end
+
+    private
+
+    # Ensure all tiny numbers are displayed as zero (e.g. -0.000000000000004736951571734001
+    # should be shown as 0 and not -4.7e-15)
+    def zero_out_small_values(value)
+      return value unless value.is_a?(Float)
+      value.between?(-0.001, 0.001) ? 0.0 : value
+    end
+  end
+end

--- a/app/controllers/comparisons/base_controller.rb
+++ b/app/controllers/comparisons/base_controller.rb
@@ -21,7 +21,7 @@ module Comparisons
     end
 
     # Implement in sub-class to return Chart Configuration Hash
-    def chart_configuration(result)
+    def chart_configuration(_result)
       nil
     end
 

--- a/app/controllers/comparisons/base_controller.rb
+++ b/app/controllers/comparisons/base_controller.rb
@@ -5,10 +5,19 @@ module Comparisons
 
     before_action :filter
 
-    before_action :set_included_schools
+    before_action :set_schools
     helper_method :index_params
 
+    def index
+      @result = Comparison::ReportService.new(definition: definition).perform
+    end
+
     private
+
+    # Implement in sub-class to return Comparison::ReportDefinition
+    def definition
+      nil
+    end
 
     def filter
       @filter ||=
@@ -21,8 +30,8 @@ module Comparisons
       filter.merge(anchor: filter[:search])
     end
 
-    def set_included_schools
-      @included_schools = included_schools
+    def set_schools
+      @schools = included_schools
     end
 
     def included_schools

--- a/app/controllers/comparisons/base_controller.rb
+++ b/app/controllers/comparisons/base_controller.rb
@@ -10,12 +10,18 @@ module Comparisons
 
     def index
       @result = Comparison::ReportService.new(definition: definition).perform
+      @chart = chart_configuration(result) unless result.schools.empty?
     end
 
     private
 
     # Implement in sub-class to return Comparison::ReportDefinition
     def definition
+      nil
+    end
+
+    # Implement in sub-class to return Chart Configuration Hash
+    def chart_configuration(result)
       nil
     end
 

--- a/app/controllers/comparisons/base_controller.rb
+++ b/app/controllers/comparisons/base_controller.rb
@@ -1,0 +1,38 @@
+module Comparisons
+  class BaseController < ApplicationController
+    include UserTypeSpecific
+    skip_before_action :authenticate_user!
+
+    before_action :filter
+
+    before_action :set_included_schools
+    helper_method :index_params
+
+    private
+
+    def filter
+      @filter ||=
+        params.permit(:search, :benchmark, :country, :school_type, :funder, school_group_ids: [], school_types: [])
+          .with_defaults(school_group_ids: [], school_types: School.school_types.keys)
+          .to_hash.symbolize_keys
+    end
+
+    def index_params
+      filter.merge(anchor: filter[:search])
+    end
+
+    def set_included_schools
+      @included_schools = included_schools
+    end
+
+    def included_schools
+      # wonder if this can be replaced by a use of the scope accessible_by(current_ability)
+      include_invisible = can? :show, :all_schools
+      school_params = filter.slice(:school_group_ids, :school_types, :school_type, :country, :funder).merge(include_invisible: include_invisible)
+
+      schools = SchoolFilter.new(**school_params).filter
+      schools.select {|s| can?(:show, s) } unless include_invisible
+      schools
+    end
+  end
+end

--- a/app/controllers/comparisons/baseload_per_pupil_controller.rb
+++ b/app/controllers/comparisons/baseload_per_pupil_controller.rb
@@ -1,5 +1,10 @@
 module Comparisons
   class BaseloadPerPupilController < BaseController
+    def index
+      @result = Comparison::ReportService.new(definition: definition).perform
+      @chart = chart_configuration(@result)
+    end
+
     private
 
     def definition
@@ -12,6 +17,39 @@ module Comparisons
         alert_types: AlertType.where(class_name: %w[AlertElectricityBaseloadVersusBenchmark AlertAdditionalPrioritisationData]),
         fuel_types: :electricity,
       )
+    end
+
+    def chart_configuration(result)
+      series_name = I18n.t('analytics.benchmarking.configuration.column_headings.baseload_per_pupil_w')
+      chart_data = {}
+
+      # Some charts also set x_max_value to 100 if there are metric values > 100
+      # Removes issues with schools with large % changes breaking the charts
+      #
+      # This could be done by clipping values to 100.0 if the metric has a
+      # unit of percentage/relative_percent
+      result.schools.each do |school|
+        metric = result.metric(school, :one_year_baseload_per_pupil_kw)
+        next if metric.nil? || metric.value.nil? || metric.value.nan? || metric.value.infinite?
+        # for a percentage metric we'd multiply * 100.0
+        # here we're converting from kW to W
+        chart_data[school] = metric.value * 1000.0
+      end
+
+      # TODO need to improve chart display so it has a proper title and subtitle like our other charts,
+      # that will be handled in a new chart component or view
+      #
+      # Other improvements: disable legend clicking, ensuring colour coding matches what we use elsewhere?
+      {
+        title: nil,
+        x_axis: chart_data.keys.map(&:name),
+        x_axis_ranges: nil,
+        x_data: { series_name => chart_data.values },
+        y_axis_label: I18n.t('chart_configuration.y_axis_label_name.kw'),
+        chart1_type: :bar,
+        chart1_subtype: :stacked,
+        config_name: :baseload_per_pupil
+      }
     end
   end
 end

--- a/app/controllers/comparisons/baseload_per_pupil_controller.rb
+++ b/app/controllers/comparisons/baseload_per_pupil_controller.rb
@@ -1,0 +1,7 @@
+module Comparisons
+  class BaseloadPerPupilController < BaseController
+    def index
+      puts @included_schools.count
+    end
+  end
+end

--- a/app/controllers/comparisons/baseload_per_pupil_controller.rb
+++ b/app/controllers/comparisons/baseload_per_pupil_controller.rb
@@ -1,7 +1,17 @@
 module Comparisons
   class BaseloadPerPupilController < BaseController
-    def index
-      puts @included_schools.count
+    private
+
+    def definition
+      Comparison::ReportDefinition.new(
+        report_key: :baseload_per_pupil,
+        advice_page: AdvicePage.find_by_key(:baseload),
+        schools: @schools,
+        metric_type_keys: [:one_year_baseload_per_pupil_kw, :average_baseload_last_year_gbp, :average_baseload_last_year_kw, :annual_baseload_percent, :one_year_saving_versus_exemplar_gbp, :electricity_economic_tariff_changed_this_year],
+        order_key: :one_year_baseload_per_pupil_kw,
+        alert_types: AlertType.where(class_name: %w[AlertElectricityBaseloadVersusBenchmark AlertAdditionalPrioritisationData]),
+        fuel_types: :electricity,
+      )
     end
   end
 end

--- a/app/models/comparison/metric.rb
+++ b/app/models/comparison/metric.rb
@@ -51,6 +51,7 @@ class Comparison::Metric < ApplicationRecord
 
   scope :with_metric_type, -> { includes(:metric_type) }
   scope :with_school, -> { includes(:school) }
+  scope :with_school_and_metric_type, -> { with_school.with_metric_type }
 
   scope :with_run, -> { joins(:benchmark_result_school_generation_run) }
 

--- a/app/models/comparison/metric.rb
+++ b/app/models/comparison/metric.rb
@@ -49,7 +49,9 @@ class Comparison::Metric < ApplicationRecord
   validates :school, :alert_type, :metric_type, presence: true
   validates :custom_period, presence: true, if: :custom?
 
-  scope :with_metric_type, -> { joins(:metric_type) }
+  scope :with_metric_type, -> { includes(:metric_type) }
+  scope :with_school, -> { includes(:school) }
+
   scope :with_run, -> { joins(:benchmark_result_school_generation_run) }
 
   scope :for_metric_type, ->(metric_type) { where(metric_type: metric_type) }
@@ -77,4 +79,6 @@ class Comparison::Metric < ApplicationRecord
     school_ids = Comparison::Metric.for_latest_benchmark_runs.for_metric_type(metric_type).has_value.order(value: order).pluck(:school_id)
     order(Arel.sql("array_position(array#{school_ids}, comparison_metrics.school_id)"))
   end
+
+  delegate :units, to: :metric_type
 end

--- a/app/services/comparison/report_service.rb
+++ b/app/services/comparison/report_service.rb
@@ -1,0 +1,24 @@
+module Comparison
+  class ReportService
+    def initialize(definition:)
+      @definition = definition
+    end
+
+    def perform
+      metrics = Comparison::Metric.for_latest_benchmark_runs.for_metric_type(
+        Comparison::MetricType.where(key: @definition.metric_type_keys, fuel_type: @definition.fuel_types)
+      ).with_metric_type.with_school.where(schools: @definition.schools).where(alert_type: @definition.alert_types).order_by_school_metric_value(
+        Comparison::MetricType.find_by(key: @definition.order_key)
+      )
+      metrics_by_school = metrics.inject({}) do |hash, metric|
+        if hash[metric.school]
+          hash[metric.school] << metric
+        else
+          hash[metric.school] = [metric]
+        end
+        hash
+      end
+      return ReportResult.new(definition: @definition, metrics_by_school: metrics_by_school)
+    end
+  end
+end

--- a/app/services/comparison/report_service.rb
+++ b/app/services/comparison/report_service.rb
@@ -5,19 +5,28 @@ module Comparison
     end
 
     def perform
-      metrics = Comparison::Metric.for_latest_benchmark_runs.for_metric_type(
-        Comparison::MetricType.where(key: @definition.metric_type_keys, fuel_type: @definition.fuel_types)
-      ).with_metric_type.with_school.where(schools: @definition.schools).where(alert_type: @definition.alert_types).order_by_school_metric_value(
-        Comparison::MetricType.find_by(key: @definition.order_key)
-      )
+      fuel_types = @definition.fuel_types || Comparison::MetricType.fuel_types.keys
+      alert_types = @definition.alert_types || AlertType.enabled
+
+      metric_types = Comparison::MetricType.where(key: @definition.metric_type_keys, fuel_type: fuel_types)
+      order_type = Comparison::MetricType.find_by(key: @definition.order_key)
+
+      metrics = Comparison::Metric
+                  .for_latest_benchmark_runs     # only load metrics for latest benchmark run per school
+                  .for_metric_type(metric_types) # fetch these metric types
+                  .where(schools: @definition.schools, alert_type: alert_types) # for schools and alerts
+                  .with_school_and_metric_type # include the school and metric type to avoid n+1 queries
+                  .order_by_school_metric_value(order_type, @definition.order) # apply custom order
+
+      # Ruby preserved order when iterating on a hash, so this allows us to
+      # iterate over this hash and access metrics for each school whilst preserving
+      # the order from the SQL query
       metrics_by_school = metrics.inject({}) do |hash, metric|
-        if hash[metric.school]
-          hash[metric.school] << metric
-        else
-          hash[metric.school] = [metric]
-        end
+        hash[metric.school] ||= []
+        hash[metric.school].push(metric)
         hash
       end
+
       return ReportResult.new(definition: @definition, metrics_by_school: metrics_by_school)
     end
   end

--- a/app/views/compare/_summary.html.erb
+++ b/app/views/compare/_summary.html.erb
@@ -13,7 +13,7 @@
         <%= t('compare.filter.schools_in_school_groups_html', school_groups: @filter[:school_group_ids].present? ? SchoolGroup.find(@filter[:school_group_ids]).map {|school_group| tag.span(school_group.name, class: 'badge badge-info')}.join(' ').html_safe : tag.span(t('compare.filter.all_groups'), class: 'badge badge-info')) %>
       <% end %>
     </p>
-    <%= render 'school_type_summary' %>
-    <%= render 'funder_summary' %>
+    <%= render 'compare/school_type_summary' %>
+    <%= render 'compare/funder_summary' %>
   <% end %>
 </div>

--- a/app/views/comparisons/baseload_per_pupil/index.html.erb
+++ b/app/views/comparisons/baseload_per_pupil/index.html.erb
@@ -23,7 +23,7 @@
   <div class="tab-pane fade show active" id="tables" role="tabpanel" aria-labelledby="tables-tab">
     <div class="row">
       <div class="col-sm-12">
-        <table class="table advice-table table-sorted">
+        <table id="comparison-table" class="table advice-table table-sorted">
           <thead>
             <tr>
               <th><%= t('analytics.benchmarking.configuration.column_headings.school') %></th>
@@ -49,7 +49,7 @@
               <tr>
                 <td>
                   <%= link_to school.name, advice_page_path(school, @result.definition.advice_page, :insights) %>
-                  <% if @result.metric(school, :electricity_economic_tariff_changed_this_year).value == true %>
+                  <% if @result.metric(school, :electricity_economic_tariff_changed_this_year)&.value == true %>
                     <a href="#electricity_economic_tariff_changed_this_year">[t]</a>
                   <% end %>
                 </td>
@@ -69,7 +69,7 @@
                 </td>
                 <td class="text-right">
                   <% @result.with_metric(school, :one_year_saving_versus_exemplar_gbp) do |metric| %>
-                    <%= @result.format([0.0, metric.value].max, metric.units.to_sym) %>
+                    <%= @result.format([0.0, metric.value].max, metric.units.to_sym) if metric.present? %>
                   <% end %>
                 </td>
               </tr>
@@ -92,5 +92,6 @@
     </div>
   </div>
   <div class="tab-pane fade show" id="charts" role="tabpanel" aria-labelledby="charts-tab">
+    <%= benchmark_chart_tag(@chart[:config_name], @chart) %>
   </div>
 </div>

--- a/app/views/comparisons/baseload_per_pupil/index.html.erb
+++ b/app/views/comparisons/baseload_per_pupil/index.html.erb
@@ -1,0 +1,5 @@
+<% content_for :page_title, 'Baseload Per Pupil' %>
+
+<h1>Report</h1>
+
+<%= render 'compare/summary' %>

--- a/app/views/comparisons/baseload_per_pupil/index.html.erb
+++ b/app/views/comparisons/baseload_per_pupil/index.html.erb
@@ -1,5 +1,96 @@
 <% content_for :page_title, 'Baseload Per Pupil' %>
 
-<h1>Report</h1>
+<h1><%= t('analytics.benchmarking.chart_table_config.baseload_per_pupil') %></h1>
 
 <%= render 'compare/summary' %>
+
+<%= t('analytics.benchmarking.content.baseload_per_pupil.introduction_text_html') %>
+
+<%= t('analytics.benchmarking.caveat_text.es_exclude_storage_heaters_and_solar_pv').html_safe %>
+
+<ul class="nav nav-tabs locales url-aware" id="compare-results-tabs" role="tablist">
+    <li class="nav-item">
+      <a class="nav-link active" id="tables-tab" data-toggle="tab" href="#tables"
+        role="tab" aria-controls="tables-content"><%= t('compare.show.tables') %></a>
+    </li>
+    <li class="nav-item">
+      <a class="nav-link" id="charts-tab" data-toggle="tab" href="#charts"
+        role="tab" aria-controls="charts-content"><%= t('compare.show.charts') %></a>
+    </li>
+</ul>
+
+<div class="tab-content" id="compare-results-content">
+  <div class="tab-pane fade show active" id="tables" role="tabpanel" aria-labelledby="tables-tab">
+    <div class="row">
+      <div class="col-sm-12">
+        <table class="table advice-table table-sorted">
+          <thead>
+            <tr>
+              <th><%= t('analytics.benchmarking.configuration.column_headings.school') %></th>
+              <th class="text-right">
+                <%= t('analytics.benchmarking.configuration.column_headings.baseload_per_pupil_w') %>
+              </th>
+              <th class="text-right">
+                <%= t('analytics.benchmarking.configuration.column_headings.last_year_cost_of_baseload') %>
+              </th>
+              <th class="text-right">
+                <%= t('analytics.benchmarking.configuration.column_headings.average_baseload_kw') %>
+              </th>
+              <th class="text-right">
+                <%= t('analytics.benchmarking.configuration.column_headings.baseload_percent') %>
+              </th>
+              <th class="text-right">
+                <%= t('analytics.benchmarking.configuration.column_headings.saving_if_matched_exemplar_school') %>
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            <% @result.schools.each do |school| %>
+              <tr>
+                <td>
+                  <%= link_to school.name, advice_page_path(school, @result.definition.advice_page, :insights) %>
+                  <% if @result.metric(school, :electricity_economic_tariff_changed_this_year).value == true %>
+                    <a href="#electricity_economic_tariff_changed_this_year">[t]</a>
+                  <% end %>
+                </td>
+                <td class="text-right">
+                  <% @result.with_metric(school, :one_year_baseload_per_pupil_kw) do |metric| %>
+                    <%= @result.format(metric.value * 1000.0, metric.units.to_sym) %>
+                  <% end %>
+                </td>
+                <td class="text-right">
+                  <%= @result.format_metric(school, :average_baseload_last_year_gbp) %>
+                </td>
+                <td class="text-right">
+                  <%= @result.format_metric(school, :average_baseload_last_year_kw) %>
+                </td>
+                <td class="text-right">
+                  <%= @result.format_metric(school, :annual_baseload_percent) %>
+                </td>
+                <td class="text-right">
+                  <% @result.with_metric(school, :one_year_saving_versus_exemplar_gbp) do |metric| %>
+                    <%= @result.format([0.0, metric.value].max, metric.units.to_sym) %>
+                  <% end %>
+                </td>
+              </tr>
+            <% end %>
+          </tbody>
+          <tfoot>
+            <tr>
+              <td colspan="6">
+                <p>
+                  <strong><%= t('analytics.benchmarking.content.footnotes.notes') %></strong>
+                </p>
+                <a name="electricity_economic_tariff_changed_this_year">[t]</a>
+                <%= t('analytics.benchmarking.configuration.the_tariff_has_changed_during_the_last_year_html') %>
+                <%= t('analytics.benchmarking.configuration.column_heading_explanation.last_year_definition_html') %>
+              </td>
+            </tr>
+          </tfoot>
+        </table>
+      </div>
+    </div>
+  </div>
+  <div class="tab-pane fade show" id="charts" role="tabpanel" aria-labelledby="charts-tab">
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -59,6 +59,10 @@ Rails.application.routes.draw do
     end
   end
 
+  namespace :comparisons do
+    resources :baseload_per_pupil, only: [:index]
+  end
+
   # redirect old benchmark URLs
   get '/benchmarks', to: redirect('/compare')
   get '/benchmark', to: redirect(BenchmarkRedirector.new)

--- a/spec/classes/comparison/report_result_spec.rb
+++ b/spec/classes/comparison/report_result_spec.rb
@@ -1,0 +1,60 @@
+require 'rails_helper'
+
+describe Comparison::ReportResult do
+  subject(:result) do
+    described_class.new(
+      definition: definition,
+      metrics_by_school: metrics_by_school
+    )
+  end
+
+  let(:definition) { build(:report_definition) }
+  let(:metrics_by_school) { {} }
+
+  let!(:metric_type) { create(:metric_type, units: :float) }
+  let!(:metric) { create(:metric, metric_type: metric_type) }
+
+  describe '#schools' do
+    context 'when there are no results' do
+      it { expect(result.schools).to be_empty }
+    end
+
+    context 'when there are results' do
+      let(:metrics_by_school) do
+        { metric.school => [metric] }.to_h
+      end
+
+      it { expect(result.schools).to eq([metric.school]) }
+    end
+  end
+
+  describe '#metric' do
+    context 'with results' do
+      let(:school) { metric.school }
+      let(:metrics_by_school) do
+        { school => [metric] }.to_h
+      end
+
+      it { expect(result.metric(school, metric_type.key.to_sym)).to eq metric }
+
+      context 'with unknown metric' do
+        it { expect(result.metric(school, :unknown)).to eq nil }
+      end
+    end
+  end
+
+  describe '#format_metric' do
+    let(:school) { metric.school }
+    let(:metrics_by_school) do
+      { school => [metric] }.to_h
+    end
+
+    it { expect(result.format_metric(school, metric_type.key.to_sym)).to eq metric.value }
+
+    context 'with a :kwh type' do
+      let!(:metric_type) { build(:metric_type, units: :kwh) }
+
+      it { expect(result.format_metric(school, metric_type.key.to_sym)).to eq metric.value.to_s }
+    end
+  end
+end

--- a/spec/factories/comparisons/report_definitions.rb
+++ b/spec/factories/comparisons/report_definitions.rb
@@ -1,0 +1,27 @@
+FactoryBot.define do
+  factory :report_definition, class: 'Comparison::ReportDefinition' do
+    transient do
+      metric_type_keys { [] }
+      order_key { [] }
+      schools { [] }
+      report_key { nil }
+      alert_types { nil }
+      fuel_types { nil }
+      advice_page { nil }
+      order { :desc }
+    end
+
+    initialize_with do
+      Comparison::ReportDefinition.new(
+        metric_type_keys: metric_type_keys,
+        order_key: order_key,
+        schools: schools,
+        report_key: report_key,
+        alert_types: alert_types,
+        fuel_types: fuel_types,
+        advice_page: advice_page,
+        order: order
+      )
+    end
+  end
+end

--- a/spec/factories/comparisons/report_results.rb
+++ b/spec/factories/comparisons/report_results.rb
@@ -1,0 +1,15 @@
+FactoryBot.define do
+  factory :report_result, class: 'Comparison::ReportResult' do
+    transient do
+      definition { build(:definition) }
+      metrics_by_school { {} }
+    end
+
+    initialize_with do
+      Comparison::ReportResult.new(
+        definition: definition,
+        metrics_by_school: metrics_by_school
+      )
+    end
+  end
+end

--- a/spec/models/comparison/metric_spec.rb
+++ b/spec/models/comparison/metric_spec.rb
@@ -154,23 +154,8 @@ RSpec.describe Comparison::Metric, type: :model do
   end
 
   describe '.order_by_school_metric_value' do
-    let!(:metric_type) { create(:metric_type) }
-
-    let!(:school_1) { create(:school) }
-    let!(:school_2) { create(:school) }
-
-    let!(:run_1) { create(:benchmark_result_school_generation_run, school: school_1)}
-    let!(:run_2) { create(:benchmark_result_school_generation_run, school: school_2)}
-
-    # Setup test data so that we have
-    # one run for each school, with one metric and metric type that we'll be sorting one
-    #
-    # school_1 has low value, school_2 has high_value
-    let!(:metric_1) { create(:metric, school: school_1, benchmark_result_school_generation_run: run_1, metric_type: metric_type, value: low_value) }
-    let!(:metric_2) { create(:metric, school: school_2, benchmark_result_school_generation_run: run_2, metric_type: metric_type, value: high_value) }
-
-    # ..plus one additional metric value that should be unused in sort
-    let!(:other_metric) { create(:metric, school: school_1, benchmark_result_school_generation_run: run_1, value: high_value) }
+    include_context 'with some schools and metrics' do
+    end
 
     shared_examples 'it sorts and returns results correctly' do
       subject(:results) { Comparison::Metric.order_by_school_metric_value(metric_type, order)}

--- a/spec/models/comparison/metric_spec.rb
+++ b/spec/models/comparison/metric_spec.rb
@@ -113,4 +113,128 @@ RSpec.describe Comparison::Metric, type: :model do
       end
     end
   end
+
+  describe '.for_latest_benchmark_runs' do
+    context 'with multiple runs for a school' do
+      let!(:school) { create(:school) }
+      let!(:metric_type) { create(:metric_type) }
+      let!(:runs) { create_list(:benchmark_result_school_generation_run, 2, school: school) }
+      let!(:metric_1) { create(:metric, school: school, benchmark_result_school_generation_run: runs[0], metric_type: metric_type) }
+      let!(:metric_2) { create(:metric, school: school, benchmark_result_school_generation_run: runs[1], metric_type: metric_type) }
+
+      it 'returns the latest metric' do
+        expect(Comparison::Metric.for_latest_benchmark_runs.count).to eq(1)
+        expect(Comparison::Metric.for_latest_benchmark_runs.first).to eq(metric_2)
+      end
+    end
+
+    context 'with multiple schools and runs' do
+      let!(:metric_type) { create :metric_type }
+
+      before do
+        # Setup test data so we have:
+        # 1 school with no runs or metrics
+        create(:school)
+        # 1 school with one run and 1 metric
+        create(:metric, metric_type: metric_type)
+        # 1 school with two runs, one with 2 metrics and most recent with 1 metric
+        school = create(:school)
+        runs = create_list(:benchmark_result_school_generation_run, 2, school: school)
+        create(:metric, school: school, benchmark_result_school_generation_run: runs[0], metric_type: metric_type)
+        create(:metric, school: school, benchmark_result_school_generation_run: runs[0])
+        create(:metric, school: school, benchmark_result_school_generation_run: runs[1], metric_type: metric_type)
+      end
+
+      it 'returns latest metrics for each school' do
+        # one for each school, and only metrics with latest run for each
+        expect(Comparison::Metric.for_latest_benchmark_runs.count).to eq(2)
+        expect(Comparison::Metric.for_latest_benchmark_runs.map(&:metric_type).uniq).to eq([metric_type])
+      end
+    end
+  end
+
+  describe '.order_by_school_metric_value' do
+    let!(:metric_type) { create(:metric_type) }
+
+    let!(:school_1) { create(:school) }
+    let!(:school_2) { create(:school) }
+
+    let!(:run_1) { create(:benchmark_result_school_generation_run, school: school_1)}
+    let!(:run_2) { create(:benchmark_result_school_generation_run, school: school_2)}
+
+    # Setup test data so that we have
+    # one run for each school, with one metric and metric type that we'll be sorting one
+    #
+    # school_1 has low value, school_2 has high_value
+    let!(:metric_1) { create(:metric, school: school_1, benchmark_result_school_generation_run: run_1, metric_type: metric_type, value: low_value) }
+    let!(:metric_2) { create(:metric, school: school_2, benchmark_result_school_generation_run: run_2, metric_type: metric_type, value: high_value) }
+
+    # ..plus one additional metric value that should be unused in sort
+    let!(:other_metric) { create(:metric, school: school_1, benchmark_result_school_generation_run: run_1, value: high_value) }
+
+    shared_examples 'it sorts and returns results correctly' do
+      subject(:results) { Comparison::Metric.order_by_school_metric_value(metric_type, order)}
+
+      context 'with :desc order' do
+        let(:order) { :desc }
+
+        it 'returns school with highest value first' do
+          expect(results[0].school).to eq(school_2)
+          expect(results[1].school).to eq(school_1)
+          expect(results[2].school).to eq(school_1)
+        end
+
+        it 'returns all the metrics' do
+          expect(results.count).to eq(3)
+        end
+      end
+
+      context 'with :asc order' do
+        let(:order) { :asc }
+
+        it 'returns school with highest value first' do
+          expect(results[0].school).to eq(school_1)
+          expect(results[1].school).to eq(school_1)
+          expect(results[2].school).to eq(school_2)
+        end
+
+        it 'returns all the metrics' do
+          expect(results.count).to eq(3)
+        end
+      end
+    end
+
+    context 'with integer values' do
+      let(:low_value) { 1 }
+      let(:high_value) { 10 }
+
+      it_behaves_like 'it sorts and returns results correctly'
+    end
+
+    context 'with Date values' do
+      let(:low_value) { Date.new(2024, 1, 1) }
+      let(:high_value) { Date.new(2024, 2, 1) }
+
+      it_behaves_like 'it sorts and returns results correctly'
+    end
+
+    context 'with float values' do
+      let(:low_value) { 0.1 }
+      let(:high_value) { 1.1 }
+
+      it_behaves_like 'it sorts and returns results correctly'
+
+      context 'with NAN value' do
+        let(:high_value) { Float::NAN }
+
+        it_behaves_like 'it sorts and returns results correctly'
+      end
+
+      context 'with Infinite value' do
+        let(:high_value) { Float::INFINITY }
+
+        it_behaves_like 'it sorts and returns results correctly'
+      end
+    end
+  end
 end

--- a/spec/services/comparison/report_service_spec.rb
+++ b/spec/services/comparison/report_service_spec.rb
@@ -1,0 +1,113 @@
+require 'rails_helper'
+
+describe Comparison::ReportService do
+  subject(:service) { described_class.new(definition: definition) }
+
+  let!(:metric_type) { create(:metric_type) }
+
+  let!(:school_1) { create(:school) }
+  let!(:school_2) { create(:school) }
+
+  let!(:run_1) { create(:benchmark_result_school_generation_run, school: school_1)}
+  let!(:run_2) { create(:benchmark_result_school_generation_run, school: school_2)}
+
+  # Setup test data so that we have
+  # one run for each school, with one metric each, using the metric type that we'll be sorting on
+  #
+  # school_1 has low value, school_2 has high_value
+  let!(:metric_1) { create(:metric, school: school_1, benchmark_result_school_generation_run: run_1, metric_type: metric_type, value: 10) }
+  let!(:metric_2) { create(:metric, school: school_2, benchmark_result_school_generation_run: run_2, metric_type: metric_type, value: 100) }
+
+  # ..plus one additional metric value to include in the results
+  let!(:other_metric) { create(:metric, school: school_1, benchmark_result_school_generation_run: run_1, value: 100) }
+
+  let(:definition) do
+    Comparison::ReportDefinition.new(
+      metric_type_keys: [metric_type.key.to_sym],
+      order_key: metric_type.key.to_sym,
+      schools: [school_1, school_2]
+    )
+  end
+
+  describe '#perform' do
+    subject(:result) { service.perform }
+
+    it { expect(result.definition).to eq(definition) }
+
+    context 'with a definition that includes no schools' do
+      let(:definition) do
+        Comparison::ReportDefinition.new(
+          metric_type_keys: [metric_type.key.to_sym],
+          order_key: metric_type.key.to_sym,
+          schools: []
+        )
+      end
+
+      it { expect(result.metrics_by_school.empty?).to be true}
+    end
+
+    context 'with a definition that includes a limited list of schools' do
+      let(:definition) do
+        Comparison::ReportDefinition.new(
+          metric_type_keys: [metric_type.key.to_sym],
+          order_key: metric_type.key.to_sym,
+          schools: [school_1]
+        )
+      end
+
+      it { expect(result.metrics_by_school.keys).to match_array([school_1]) }
+    end
+
+    context 'with a definition that includes several schools' do
+      let(:definition) do
+        Comparison::ReportDefinition.new(
+          metric_type_keys: [metric_type.key.to_sym],
+          order_key: metric_type.key.to_sym,
+          schools: [school_1, school_2]
+        )
+      end
+
+      it { expect(result.metrics_by_school.keys).to eq([school_2, school_1]) }
+
+      context 'when there are multiple metric types' do
+        let(:definition) do
+          Comparison::ReportDefinition.new(
+            metric_type_keys: [metric_type.key.to_sym, other_metric.metric_type.key.to_sym],
+            order_key: metric_type.key.to_sym,
+            schools: [school_1, school_2]
+          )
+        end
+
+        it { expect(result.metrics_by_school[school_1].size).to eq(2) }
+        it { expect(result.metrics_by_school[school_2].size).to eq(1) }
+      end
+
+      context 'when there is a restriction on alert types' do
+        let(:definition) do
+          Comparison::ReportDefinition.new(
+            metric_type_keys: [metric_type.key.to_sym, other_metric.metric_type.key.to_sym],
+            order_key: metric_type.key.to_sym,
+            alert_types: metric_1.alert_type,
+            schools: [school_1, school_2]
+          )
+        end
+
+        it { expect(result.metrics_by_school.keys).to eq([school_1]) }
+        it { expect(result.metrics_by_school[school_1].size).to eq(1) }
+      end
+
+      context 'when there is an alternate order' do
+        let(:definition) do
+          Comparison::ReportDefinition.new(
+            metric_type_keys: [metric_type.key.to_sym],
+            order_key: metric_type.key.to_sym,
+            schools: [school_1, school_2],
+            order: :asc
+          )
+        end
+
+        it { expect(result.metrics_by_school.keys).to eq([school_1, school_2]) }
+      end
+    end
+  end
+end

--- a/spec/services/comparison/report_service_spec.rb
+++ b/spec/services/comparison/report_service_spec.rb
@@ -3,23 +3,7 @@ require 'rails_helper'
 describe Comparison::ReportService do
   subject(:service) { described_class.new(definition: definition) }
 
-  let!(:metric_type) { create(:metric_type) }
-
-  let!(:school_1) { create(:school) }
-  let!(:school_2) { create(:school) }
-
-  let!(:run_1) { create(:benchmark_result_school_generation_run, school: school_1)}
-  let!(:run_2) { create(:benchmark_result_school_generation_run, school: school_2)}
-
-  # Setup test data so that we have
-  # one run for each school, with one metric each, using the metric type that we'll be sorting on
-  #
-  # school_1 has low value, school_2 has high_value
-  let!(:metric_1) { create(:metric, school: school_1, benchmark_result_school_generation_run: run_1, metric_type: metric_type, value: 10) }
-  let!(:metric_2) { create(:metric, school: school_2, benchmark_result_school_generation_run: run_2, metric_type: metric_type, value: 100) }
-
-  # ..plus one additional metric value to include in the results
-  let!(:other_metric) { create(:metric, school: school_1, benchmark_result_school_generation_run: run_1, value: 100) }
+  include_context 'with some schools and metrics'
 
   let(:definition) do
     Comparison::ReportDefinition.new(

--- a/spec/support/shared_contexts/metrics.rb
+++ b/spec/support/shared_contexts/metrics.rb
@@ -1,0 +1,22 @@
+RSpec.shared_context 'with some schools and metrics' do
+  let!(:metric_type) { create(:metric_type) }
+
+  let!(:school_1) { create(:school) }
+  let!(:school_2) { create(:school) }
+
+  let!(:run_1) { create(:benchmark_result_school_generation_run, school: school_1)}
+  let!(:run_2) { create(:benchmark_result_school_generation_run, school: school_2)}
+
+  let(:low_value) { 10 }
+  let(:high_value) { 100 }
+
+  # Setup test data so that we have
+  # one run for each school, with one metric each, using the metric type that we'll be sorting on
+  #
+  # school_1 has low value, school_2 has high_value
+  let!(:metric_1) { create(:metric, school: school_1, benchmark_result_school_generation_run: run_1, metric_type: metric_type, value: low_value) }
+  let!(:metric_2) { create(:metric, school: school_2, benchmark_result_school_generation_run: run_2, metric_type: metric_type, value: high_value) }
+
+  # ..plus one additional metric value to include in the results
+  let!(:other_metric) { create(:metric, school: school_1, benchmark_result_school_generation_run: run_1, value: high_value) }
+end

--- a/spec/system/comparisons/baseload_per_pupil_spec.rb
+++ b/spec/system/comparisons/baseload_per_pupil_spec.rb
@@ -1,0 +1,50 @@
+require 'rails_helper'
+
+describe 'baseload_per_pupil', type: :system do
+  let!(:advice_page) do
+    create(:advice_page, key: :baseload)
+  end
+
+  let!(:metric_type) do
+    create(:metric_type,
+      key: :one_year_baseload_per_pupil_kw,
+      units: :kw,
+      fuel_type: :electricity)
+  end
+
+  let!(:alert_type) do
+    create(:alert_type, class_name: 'AlertElectricityBaseloadVersusBenchmark')
+  end
+
+  let!(:school_1) { create(:school) }
+  let!(:run_1) { create(:benchmark_result_school_generation_run, school: school_1)}
+
+  let!(:one_year_baseload_per_pupil_kw) do
+    create(:metric,
+      school: school_1,
+      benchmark_result_school_generation_run: run_1,
+      metric_type: metric_type,
+      alert_type: alert_type,
+      value: 2.5)
+  end
+
+  before do
+    visit comparisons_baseload_per_pupil_index_path
+  end
+
+  it 'loads the report' do
+    expect(page).to have_content(I18n.t('analytics.benchmarking.chart_table_config.baseload_per_pupil'))
+  end
+
+  it 'links to the baseload page for the school' do
+    within('#comparison-table tbody') do
+      expect(page).to have_link(school_1.name, href: insights_school_advice_baseload_path(school_1))
+    end
+  end
+
+  it 'displays the metric' do
+    within('#comparison-table tbody tr:first') do
+      expect(page).to have_content('2,500')
+    end
+  end
+end


### PR DESCRIPTION
Based on https://github.com/Energy-Sparks/energy-sparks/pull/3421 which needs reviewing and merging first. Actual changes in this PR are smaller.

The key changes in this PR are:

* Adds scopes to `Metric` and `BenchmarkResultSchoolGenerationRun` to support querying for latest metrics for schools. 
* Adds some simple types `Comparison::ReportDefinition` and `Comparison::ReportResult` for the description of a report (as a list of metric types, etc) and results (as a hash of schools to metric values)
* A `Comparison::ReportService` that accepts a `ReportDefinition` and returns a `ReportResult`
* A initial base controller for running reports
* The implementation of the `baseload_per_pupil` report, using a definition which matches the existing comparison page. Has both a chart and a table

The PR currently uses the existing I18n translation keys for the report, although some of this will be moving into the database.

Expecting that specific implementation to be refactored as we extract/add components for tables and charts.

Some work is required to:

- adds some more tests for edge cases, e.g. missing metrics required for ordering
- finalising table layout, e.g. how do footnotes
- integration with the `Report` and `Footnote` model

...but I think all of that can probably be done in other PRs, as this is big enough already.

It'd be good to get some feedback on this so we can then move on to doing any necessary components for the tables/charts and start on porting over the rest of the reports.

It turned out to be quite easy to actually build the report page with all this in place.

I wasn't sure about the final URL structure, its currently using `/comparisons` but the existing code is at `/compare`. Should we move it?

