### PR TITLE
Alternate comparison framework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,7 +30,6 @@ coverage
 profiles
 .env
 *.txt
-*.sql
 *.DS_Store
 *csv
 !etc/**/*csv

--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,7 @@ gem 'after_party' # load data after deploy
 gem 'auto_strip_attributes', '~> 2.5'
 gem 'closed_struct'
 gem 'pg'
+gem 'scenic'
 
 # Dashboard analytics
 gem 'energy-sparks_analytics', github: 'Energy-Sparks/energy-sparks_analytics', tag: '5.0.9'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -618,6 +618,9 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
+    scenic (1.7.0)
+      activerecord (>= 4.0.0)
+      railties (>= 4.0.0)
     scout_apm (5.3.5)
       parser
     selenium-webdriver (4.17.0)
@@ -798,6 +801,7 @@ DEPENDENCIES
   rubocop-rails
   rubocop-rspec
   sass-rails
+  scenic
   scout_apm
   selenium-webdriver
   shoulda-matchers

--- a/app/controllers/comparisons/base_controller.rb
+++ b/app/controllers/comparisons/base_controller.rb
@@ -1,0 +1,47 @@
+module Comparisons
+  class BaseController < ApplicationController
+    include UserTypeSpecific
+    skip_before_action :authenticate_user!
+
+    before_action :filter
+
+    before_action :set_schools
+    helper_method :index_params
+    before_action :set_advice_page
+
+    private
+
+    def set_advice_page
+      @advice_page = load_advice_page
+    end
+
+    def load_advice_page
+      nil
+    end
+
+    def filter
+      @filter ||=
+        params.permit(:search, :benchmark, :country, :school_type, :funder, school_group_ids: [], school_types: [])
+          .with_defaults(school_group_ids: [], school_types: School.school_types.keys)
+          .to_hash.symbolize_keys
+    end
+
+    def index_params
+      filter.merge(anchor: filter[:search])
+    end
+
+    def set_schools
+      @schools = included_schools
+    end
+
+    def included_schools
+      # wonder if this can be replaced by a use of the scope accessible_by(current_ability)
+      include_invisible = can? :show, :all_schools
+      school_params = filter.slice(:school_group_ids, :school_types, :school_type, :country, :funder).merge(include_invisible: include_invisible)
+
+      schools = SchoolFilter.new(**school_params).filter
+      schools.select {|s| can?(:show, s) } unless include_invisible
+      schools
+    end
+  end
+end

--- a/app/controllers/comparisons/baseload_per_pupil_controller.rb
+++ b/app/controllers/comparisons/baseload_per_pupil_controller.rb
@@ -1,0 +1,48 @@
+module Comparisons
+  class BaseloadPerPupilController < BaseController
+    def index
+      @results = Comparison::BaseloadPerPupil.where(school: @schools).where.not(one_year_baseload_per_pupil_kw: nil).order(one_year_baseload_per_pupil_kw: :desc)
+      puts @results.count.inspect
+      @chart = chart_configuration(@results)
+    end
+
+    private
+
+    def load_advice_page
+      AdvicePage.find_by_key(:baseload)
+    end
+
+    def chart_configuration(results)
+      series_name = I18n.t('analytics.benchmarking.configuration.column_headings.baseload_per_pupil_w')
+      chart_data = {}
+
+      # Some charts also set x_max_value to 100 if there are metric values > 100
+      # Removes issues with schools with large % changes breaking the charts
+      #
+      # This could be done by clipping values to 100.0 if the metric has a
+      # unit of percentage/relative_percent
+      results.each do |baseload_per_pupil|
+        metric = baseload_per_pupil.one_year_baseload_per_pupil_kw
+        next if metric.nil? || metric.nan? || metric.infinite?
+        # for a percentage metric we'd multiply * 100.0
+        # here we're converting from kW to W
+        chart_data[baseload_per_pupil.school] = metric * 1000.0
+      end
+
+      # TODO need to improve chart display so it has a proper title and subtitle like our other charts,
+      # that will be handled in a new chart component or view
+      #
+      # Other improvements: disable legend clicking, ensuring colour coding matches what we use elsewhere?
+      {
+        title: nil,
+        x_axis: chart_data.keys.map(&:name),
+        x_axis_ranges: nil,
+        x_data: { series_name => chart_data.values },
+        y_axis_label: I18n.t('chart_configuration.y_axis_label_name.kw'),
+        chart1_type: :bar,
+        chart1_subtype: :stacked,
+        config_name: :baseload_per_pupil
+      }
+    end
+  end
+end

--- a/app/models/alert.rb
+++ b/app/models/alert.rb
@@ -19,6 +19,8 @@
 #  template_data           :json
 #  template_data_cy        :json
 #  updated_at              :datetime         not null
+#  variables               :json
+#  variables_cy            :json
 #
 # Indexes
 #
@@ -89,6 +91,14 @@ class Alert < ApplicationRecord
   def template_variables(locale = I18n.locale)
     template_data_for_locale(locale).deep_transform_keys do |key|
       :"#{key.to_s.gsub('£', 'gbp')}"
+    end
+  end
+
+  def raw_variables(locale = I18n.locale)
+    if locale == :cy
+      variables_cy&.any? ? variables_cy : variables
+    else
+      variables
     end
   end
 

--- a/app/models/comparison/baseload_per_pupil.rb
+++ b/app/models/comparison/baseload_per_pupil.rb
@@ -1,0 +1,8 @@
+class Comparison::BaseloadPerPupil < ApplicationRecord
+  belongs_to :school
+  self.primary_key = :id
+
+  def readonly?
+    true
+  end
+end

--- a/app/models/comparison/metric.rb
+++ b/app/models/comparison/metric.rb
@@ -2,22 +2,24 @@
 #
 # Table name: comparison_metrics
 #
-#  alert_type_id    :bigint(8)        not null
-#  asof_date        :date
-#  created_at       :datetime         not null
-#  custom_period_id :bigint(8)
-#  enough_data      :boolean          default(FALSE)
-#  id               :bigint(8)        not null, primary key
-#  metric_type_id   :bigint(8)        not null
-#  recent_data      :boolean          default(FALSE)
-#  reporting_period :integer
-#  school_id        :bigint(8)        not null
-#  updated_at       :datetime         not null
-#  value            :string
-#  whole_period     :boolean          default(FALSE)
+#  alert_type_id                             :bigint(8)        not null
+#  asof_date                                 :date
+#  benchmark_result_school_generation_run_id :bigint(8)
+#  created_at                                :datetime         not null
+#  custom_period_id                          :bigint(8)
+#  enough_data                               :boolean          default(FALSE)
+#  id                                        :bigint(8)        not null, primary key
+#  metric_type_id                            :bigint(8)        not null
+#  recent_data                               :boolean          default(FALSE)
+#  reporting_period                          :integer
+#  school_id                                 :bigint(8)        not null
+#  updated_at                                :datetime         not null
+#  value                                     :string
+#  whole_period                              :boolean          default(FALSE)
 #
 # Indexes
 #
+#  idx_benchmark_school_run_metrics              (benchmark_result_school_generation_run_id)
 #  index_comparison_metrics_on_alert_type_id     (alert_type_id)
 #  index_comparison_metrics_on_custom_period_id  (custom_period_id)
 #  index_comparison_metrics_on_metric_type_id    (metric_type_id)
@@ -26,7 +28,7 @@
 # Foreign Keys
 #
 #  fk_rails_...  (custom_period_id => comparison_periods.id) ON DELETE => cascade
-#  fk_rails_...  (metric_type_id => comparison_metrics.id) ON DELETE => cascade
+#  fk_rails_...  (metric_type_id => comparison_metric_types.id) ON DELETE => cascade
 #  fk_rails_...  (school_id => schools.id) ON DELETE => cascade
 #
 class Comparison::Metric < ApplicationRecord

--- a/app/services/alerts/adapters/report.rb
+++ b/app/services/alerts/adapters/report.rb
@@ -1,8 +1,9 @@
 module Alerts
   module Adapters
     class Report
-      attr_reader :valid, :rating, :enough_data, :relevance, :template_data, :template_data_cy, :chart_data, :table_data, :priority_data, :benchmark_data, :benchmark_data_cy, :asof_date
-      def initialize(valid:, rating:, enough_data:, relevance:, template_data: {}, template_data_cy: {}, chart_data: {}, table_data: {}, priority_data: {}, benchmark_data: {}, benchmark_data_cy: {})
+      attr_reader :valid, :rating, :enough_data, :relevance, :template_data, :template_data_cy, :chart_data, :table_data, :priority_data, :benchmark_data, :benchmark_data_cy, :asof_date, :variables, :variables_cy
+
+      def initialize(valid:, rating:, enough_data:, relevance:, template_data: {}, template_data_cy: {}, chart_data: {}, table_data: {}, priority_data: {}, benchmark_data: {}, benchmark_data_cy: {}, variables: {}, variables_cy: {})
         @valid = valid
         @rating = rating
         @enough_data = enough_data
@@ -14,6 +15,8 @@ module Alerts
         @priority_data = priority_data
         @benchmark_data = benchmark_data
         @benchmark_data_cy = benchmark_data_cy
+        @variables = variables
+        @variables_cy = variables_cy
       end
 
       def displayable?

--- a/app/services/alerts/alert_attributes_factory.rb
+++ b/app/services/alerts/alert_attributes_factory.rb
@@ -24,6 +24,8 @@ module Alerts
         chart_data:               @alert_report.chart_data,
         table_data:               @alert_report.table_data,
         priority_data:            @alert_report.priority_data,
+        variables:                @alert_report.variables,
+        variables_cy:             @alert_report.variables_cy
       }
     end
   end

--- a/app/views/compare/_summary.html.erb
+++ b/app/views/compare/_summary.html.erb
@@ -13,7 +13,7 @@
         <%= t('compare.filter.schools_in_school_groups_html', school_groups: @filter[:school_group_ids].present? ? SchoolGroup.find(@filter[:school_group_ids]).map {|school_group| tag.span(school_group.name, class: 'badge badge-info')}.join(' ').html_safe : tag.span(t('compare.filter.all_groups'), class: 'badge badge-info')) %>
       <% end %>
     </p>
-    <%= render 'school_type_summary' %>
-    <%= render 'funder_summary' %>
+    <%= render 'compare/school_type_summary' %>
+    <%= render 'compare/funder_summary' %>
   <% end %>
 </div>

--- a/app/views/comparisons/baseload_per_pupil/index.html.erb
+++ b/app/views/comparisons/baseload_per_pupil/index.html.erb
@@ -1,0 +1,95 @@
+<% content_for :page_title, 'Baseload Per Pupil' %>
+
+<h1><%= t('analytics.benchmarking.chart_table_config.baseload_per_pupil') %></h1>
+
+<%= render 'compare/summary' %>
+
+<%= t('analytics.benchmarking.content.baseload_per_pupil.introduction_text_html') %>
+
+<%= t('analytics.benchmarking.caveat_text.es_exclude_storage_heaters_and_solar_pv').html_safe %>
+
+<ul class="nav nav-tabs locales url-aware" id="compare-results-tabs" role="tablist">
+    <li class="nav-item">
+      <a class="nav-link active" id="tables-tab" data-toggle="tab" href="#tables"
+        role="tab" aria-controls="tables-content"><%= t('compare.show.tables') %></a>
+    </li>
+    <li class="nav-item">
+      <a class="nav-link" id="charts-tab" data-toggle="tab" href="#charts"
+        role="tab" aria-controls="charts-content"><%= t('compare.show.charts') %></a>
+    </li>
+</ul>
+
+<div class="tab-content" id="compare-results-content">
+  <div class="tab-pane fade show active" id="tables" role="tabpanel" aria-labelledby="tables-tab">
+    <div class="row">
+      <div class="col-sm-12">
+        <table id="comparison-table" class="table advice-table table-sorted">
+          <thead>
+            <tr>
+              <th><%= t('analytics.benchmarking.configuration.column_headings.school') %></th>
+              <th class="text-right">
+                <%= t('analytics.benchmarking.configuration.column_headings.baseload_per_pupil_w') %>
+              </th>
+              <th class="text-right">
+                <%= t('analytics.benchmarking.configuration.column_headings.last_year_cost_of_baseload') %>
+              </th>
+              <th class="text-right">
+                <%= t('analytics.benchmarking.configuration.column_headings.average_baseload_kw') %>
+              </th>
+              <th class="text-right">
+                <%= t('analytics.benchmarking.configuration.column_headings.baseload_percent') %>
+              </th>
+              <th class="text-right">
+                <%= t('analytics.benchmarking.configuration.column_headings.saving_if_matched_exemplar_school') %>
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            <% @results.each do |baseload_per_pupil| %>
+              <tr>
+                <td>
+                  <%= link_to baseload_per_pupil.school.name,
+                              advice_page_path(baseload_per_pupil.school, @advice_page, :insights) %>
+                  <% if baseload_per_pupil.electricity_economic_tariff_changed_this_year == true %>
+                    <a href="#electricity_economic_tariff_changed_this_year">[t]</a>
+                  <% end %>
+                </td>
+                <td class="text-right">
+                  <%= format_unit(baseload_per_pupil.one_year_baseload_per_pupil_kw * 1000.0, :kw, true, :benchmark) %>
+                </td>
+                <td class="text-right">
+                  <%= format_unit(baseload_per_pupil.average_baseload_last_year_gbp, :£, true, :benchmark) %>
+                </td>
+                <td class="text-right">
+                  <%= format_unit(baseload_per_pupil.average_baseload_last_year_kw, :kw, true, :benchmark) %>
+                </td>
+                <td class="text-right">
+                  <%= format_unit(baseload_per_pupil.annual_baseload_percent, :percent, true, :benchmark) %>
+                </td>
+                <td class="text-right">
+                  <%= format_unit([0.0, baseload_per_pupil.one_year_saving_versus_exemplar_gbp].max, :£, true,
+                                  :benchmark) %>
+                </td>
+              </tr>
+            <% end %>
+          </tbody>
+          <tfoot>
+            <tr>
+              <td colspan="6">
+                <p>
+                  <strong><%= t('analytics.benchmarking.content.footnotes.notes') %></strong>
+                </p>
+                <a name="electricity_economic_tariff_changed_this_year">[t]</a>
+                <%= t('analytics.benchmarking.configuration.the_tariff_has_changed_during_the_last_year_html') %>
+                <%= t('analytics.benchmarking.configuration.column_heading_explanation.last_year_definition_html') %>
+              </td>
+            </tr>
+          </tfoot>
+        </table>
+      </div>
+    </div>
+  </div>
+  <div class="tab-pane fade show" id="charts" role="tabpanel" aria-labelledby="charts-tab">
+    <%= benchmark_chart_tag(@chart[:config_name], @chart) %>
+  </div>
+</div>

--- a/app/views/schools/alerts/show.html.erb
+++ b/app/views/schools/alerts/show.html.erb
@@ -15,6 +15,11 @@
         <h5>Template variables (Welsh)</h5>
         <%= sanitize ap(@alert.template_variables(:cy), index: false, plain: true)%>
 
+        <h5>Raw variables (English)</h5>
+        <%= sanitize ap(@alert.raw_variables(:en), index: false, plain: true)%>
+        <h5>Raw variables (Welsh)</h5>
+        <%= sanitize ap(@alert.raw_variables(:cy), index: false, plain: true)%>
+
         <h5>Chart data</h5>
         <%= sanitize ap(@alert.chart_data, index: false, plain: true)%>
         <h5>Table data</h5>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -59,6 +59,11 @@ Rails.application.routes.draw do
     end
   end
 
+
+  namespace :comparisons do
+    resources :baseload_per_pupil, only: [:index]
+  end
+
   # redirect old benchmark URLs
   get '/benchmarks', to: redirect('/compare')
   get '/benchmark', to: redirect(BenchmarkRedirector.new)

--- a/db/migrate/20240218141409_add_alert_columns.rb
+++ b/db/migrate/20240218141409_add_alert_columns.rb
@@ -1,0 +1,6 @@
+class AddAlertColumns < ActiveRecord::Migration[6.1]
+  def change
+    add_column :alerts, :variables, :json
+    add_column :alerts, :variables_cy, :json
+  end
+end

--- a/db/migrate/20240218144324_create_baseload_per_pupils.rb
+++ b/db/migrate/20240218144324_create_baseload_per_pupils.rb
@@ -1,0 +1,5 @@
+class CreateBaseloadPerPupils < ActiveRecord::Migration[6.1]
+  def change
+    create_view :baseload_per_pupils
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_02_09_094457) do
+ActiveRecord::Schema.define(version: 2024_02_18_141409) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
@@ -366,6 +366,8 @@ ActiveRecord::Schema.define(version: 2024_02_09_094457) do
     t.json "priority_data", default: {}
     t.bigint "alert_generation_run_id"
     t.json "template_data_cy", default: {}
+    t.json "variables"
+    t.json "variables_cy"
     t.index ["alert_generation_run_id"], name: "index_alerts_on_alert_generation_run_id"
     t.index ["alert_type_id", "created_at"], name: "index_alerts_on_alert_type_id_and_created_at"
     t.index ["alert_type_id"], name: "index_alerts_on_alert_type_id"
@@ -681,7 +683,9 @@ ActiveRecord::Schema.define(version: 2024_02_09_094457) do
     t.date "asof_date"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.bigint "benchmark_result_school_generation_run_id"
     t.index ["alert_type_id"], name: "index_comparison_metrics_on_alert_type_id"
+    t.index ["benchmark_result_school_generation_run_id"], name: "idx_benchmark_school_run_metrics"
     t.index ["custom_period_id"], name: "index_comparison_metrics_on_custom_period_id"
     t.index ["metric_type_id"], name: "index_comparison_metrics_on_metric_type_id"
     t.index ["school_id"], name: "index_comparison_metrics_on_school_id"
@@ -2022,7 +2026,7 @@ ActiveRecord::Schema.define(version: 2024_02_09_094457) do
   add_foreign_key "calendars", "calendars", column: "based_on_id", on_delete: :restrict
   add_foreign_key "cluster_schools_users", "schools", on_delete: :cascade
   add_foreign_key "cluster_schools_users", "users", on_delete: :cascade
-  add_foreign_key "comparison_metrics", "comparison_metrics", column: "metric_type_id", on_delete: :cascade
+  add_foreign_key "comparison_metrics", "comparison_metric_types", column: "metric_type_id", on_delete: :cascade
   add_foreign_key "comparison_metrics", "comparison_periods", column: "custom_period_id", on_delete: :cascade
   add_foreign_key "comparison_metrics", "schools", on_delete: :cascade
   add_foreign_key "comparison_reports", "comparison_periods", column: "custom_period_id", on_delete: :cascade

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_02_18_141409) do
+ActiveRecord::Schema.define(version: 2024_02_18_144324) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
@@ -2149,4 +2149,35 @@ ActiveRecord::Schema.define(version: 2024_02_18_141409) do
   add_foreign_key "users", "schools", on_delete: :cascade
   add_foreign_key "users", "staff_roles", on_delete: :restrict
   add_foreign_key "weather_observations", "weather_stations", on_delete: :cascade
+
+  create_view "baseload_per_pupils", sql_definition: <<-SQL
+      SELECT latest_runs.id,
+      additional.school_id,
+      baseload.alert_generation_run_id,
+      baseload.average_baseload_last_year_kw,
+      baseload.average_baseload_last_year_gbp,
+      baseload.one_year_baseload_per_pupil_kw,
+      baseload.annual_baseload_percent,
+      baseload.one_year_saving_versus_exemplar_gbp,
+      additional.electricity_economic_tariff_changed_this_year
+     FROM ( SELECT alerts.alert_generation_run_id,
+              data.average_baseload_last_year_kw,
+              data.average_baseload_last_year_gbp,
+              data.one_year_baseload_per_pupil_kw,
+              data.annual_baseload_percent,
+              data.one_year_saving_versus_exemplar_gbp
+             FROM alerts,
+              LATERAL json_to_record(alerts.variables) data(average_baseload_last_year_kw double precision, average_baseload_last_year_gbp double precision, one_year_baseload_per_pupil_kw double precision, annual_baseload_percent double precision, one_year_saving_versus_exemplar_gbp double precision)
+            WHERE (alerts.alert_type_id = 1)) baseload,
+      ( SELECT alerts.alert_generation_run_id,
+              alerts.school_id,
+              data.electricity_economic_tariff_changed_this_year
+             FROM alerts,
+              LATERAL json_to_record(alerts.variables) data(electricity_economic_tariff_changed_this_year boolean)
+            WHERE (alerts.alert_type_id = 59)) additional,
+      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
+             FROM alert_generation_runs
+            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
+    WHERE ((baseload.alert_generation_run_id = latest_runs.id) AND (additional.alert_generation_run_id = latest_runs.id));
+  SQL
 end

--- a/db/views/baseload_per_pupils_v01.sql
+++ b/db/views/baseload_per_pupils_v01.sql
@@ -1,0 +1,29 @@
+SELECT latest_runs.id,
+       additional.school_id,
+       baseload.*,
+       additional.electricity_economic_tariff_changed_this_year
+FROM
+  (
+    SELECT alert_generation_run_id, data.*
+    FROM alerts, json_to_record(variables) AS data(
+      average_baseload_last_year_kw float,
+      average_baseload_last_year_gbp float,
+      one_year_baseload_per_pupil_kw float,
+      annual_baseload_percent float,
+      one_year_saving_versus_exemplar_gbp float
+    )
+    WHERE alert_type_id=1
+  ) AS baseload,
+  (
+    SELECT alert_generation_run_id, school_id, data.*
+    FROM alerts, json_to_record(variables) AS data(electricity_economic_tariff_changed_this_year boolean)
+    WHERE alert_type_id=59
+  ) AS additional,
+  (
+    SELECT DISTINCT ON (school_id) id
+    FROM alert_generation_runs
+    ORDER BY school_id, created_at DESC
+  ) latest_runs
+WHERE
+  baseload.alert_generation_run_id = latest_runs.id AND
+  additional.alert_generation_run_id = latest_runs.id;


### PR DESCRIPTION
This PR implements an alternative approach for storing and querying metrics for the new school comparison pages.

Rather than use a new `Comparison::Metric` table this approach does the following:

- stores the raw variable data in the Alert table, keeping all the generated metrics in a single location
- uses the [Scenic](https://github.com/scenic-views/scenic) gem to create a database view which has the necessary data for the report
- uses basic model-view-controller setup to implement the report, making the query code much simpler

The view relies on using the Postgres [json_t_record](https://www.postgresql.org/docs/9.5/functions-json.html) function to extract specific keys from the variables stored in the `Alert` table. The function has to cast these to a type known by the database. This means that we can rely on ActiveRecord to handle the type conversions. 

The Postgres [floating point types](https://www.postgresql.org/docs/14/datatype-numeric.html#DATATYPE-FLOAT) support handling of Nan/Infinitity/-Infinity values so that removes the need to add extra round-tripping over those values.

Overall I think this approach is actually better than what I had originally designed and implemented, so am proposing we use this approach instead although still need to work through a few things.

Advantages:

- there's less code involved
- much of the work of migrating the existing reports will be writing the SQL for the views which will follow a fairly predictable pattern.
- for those reports that have more complex sorting or selection criteria these will be easier to implement as we'll just be using standard SELECT/ORDER by clauses in the queries over the views
- we can more easily calculate, e.g. sum/min/max/average values in the queries over the views, doing more work in the database
- we can increase performance by using Scenic support for materialised views (ensuring they are refreshed after each daily benchmark run) and then adding indexes

Disadvantages:

- Requires database migrations every time we change the report? But this seems very minor
- Involves some custom Postgres functions, so we're more closely tied to that as a database. But we have dependencies on it elsewhere
- No others...?
- 
Still to be worked through:

- ensuring that the stored JSON can be correctly cast to the native postgres type. Postgres already handles casting of iso 8601 formatted data, and I've added support for Float values. But need to ensure that booleans (which are stored at `t`/`f` are mapped to [a supported text value](https://www.postgresql.org/docs/14/datatype-boolean.html)

This PR still needs tidying up of some of the code and additional of test cases.



 