### PR TITLE
Revise when out gas use through the school day chart is displayed

### DIFF
--- a/app/controllers/schools/advice/gas_out_of_hours_controller.rb
+++ b/app/controllers/schools/advice/gas_out_of_hours_controller.rb
@@ -2,6 +2,7 @@ module Schools
   module Advice
     class GasOutOfHoursController < BaseOutOfHoursController
       before_action :load_dashboard_alerts, only: [:insights, :analysis]
+      before_action :set_heating_model_available, only: [:analysis]
 
       private
 
@@ -11,6 +12,10 @@ module Schools
 
       def advice_page_key
         :gas_out_of_hours
+      end
+
+      def set_heating_model_available
+        @heating_model_available = HeatingControlService.new(@school, aggregate_school).enough_data?
       end
     end
   end

--- a/app/views/schools/advice/gas_out_of_hours/_by_day.html.erb
+++ b/app/views/schools/advice/gas_out_of_hours/_by_day.html.erb
@@ -29,7 +29,7 @@
   <% end %>
 <% end %>
 
-<% if analysis_dates.months_of_data >= 1 %>
+<% if analysis_dates.months_of_data >= 1 && @heating_model_available %>
 
   <%= render 'schools/advice/section_title',
              section_id: 'usage_through_the_school_day',


### PR DESCRIPTION
There is a chart on the out of hours usage page that requires a heating model to work correctly.

At the moment the page is just checking for >1 month of data as the analytics by default requires at least 30 days. But it still might not generate a valid heating model from the available data, there needs to be sufficient data to calculate usage for heating on/off. These don't quite align with "summer" and "winter" date periods, so it's difficult to check without actually calculating the regression models.

To handle this I've I've revised the gas out of hours page so that it applies the same check to see if there's enough data as the heating control page. If there isn't then the chart isn't shown.
