### PR TITLE
Create component for displaying comparison charts

### DIFF
--- a/app/components/comparison_chart_component.rb
+++ b/app/components/comparison_chart_component.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+# For displaying stacked bar charts on the school comparison reports
+class ComparisonChartComponent < ViewComponent::Base
+  renders_one :title
+  renders_one :subtitle
+
+  attr_reader :id
+
+  def initialize(id:, x_axis:, x_data:, y_axis_label:)
+    @id = id
+    @x_axis = x_axis
+    @x_data = x_data
+    @y_axis_label = y_axis_label
+  end
+
+  def height
+    number_of_records = @x_axis.size
+    [30 * number_of_records, 700].max
+  end
+
+  def chart_json
+    output = ChartDataValues.new(chart_config, @id).process
+    formatted_json_data = ChartDataValues.as_chart_json(output)
+
+    {
+      type: @id,
+      no_advice: true,
+      no_zoom: true,
+      transformations: [],
+      jsonData: formatted_json_data
+    }.to_json
+  end
+
+  private
+
+  def chart_config
+    {
+      x_axis: @x_axis,
+      x_data: @x_data,
+      y_axis_label: @y_axis_label,
+      chart1_type: :bar,
+      chart1_subtype: :stacked
+    }
+  end
+end

--- a/app/components/comparison_chart_component/comparison_chart_component.html.erb
+++ b/app/components/comparison_chart_component/comparison_chart_component.html.erb
@@ -1,0 +1,18 @@
+<div id="chart_wrapper_<%= id %>" class="chart-wrapper">
+
+  <% if title %>
+    <h4 id="chart-section-<%= id %>" class="chart-title"><%= title %></h4>
+  <% end %>
+
+  <% if subtitle %>
+    <h5 class="chart-subtitle"><%= subtitle %></h5>
+  <% end %>
+
+  <div id='chart_<%= id %>'
+       class='analysis-chart tabbed'
+       style='height:<%= height %>px;'
+       data-autoload-chart="true"
+       data-chart-config='<%= chart_json %>'>
+  </div>
+
+</div>

--- a/app/controllers/comparisons/base_controller.rb
+++ b/app/controllers/comparisons/base_controller.rb
@@ -11,7 +11,7 @@ module Comparisons
 
     def index
       @results = load_data
-      @chart = create_chart(@results)
+      @charts = create_charts(@results)
     end
 
     private
@@ -39,7 +39,7 @@ module Comparisons
     end
 
     # Create the chart configuration used to display chart
-    def create_chart(_results)
+    def create_charts(_results)
       nil
     end
 
@@ -66,23 +66,6 @@ module Comparisons
       schools = SchoolFilter.new(**school_params).filter
       schools.select {|s| can?(:show, s) } unless include_invisible
       schools
-    end
-
-    # TODO need to improve chart display so it has a proper title and subtitle like our other charts,
-    # that will be handled in a new chart component or view
-    #
-    # Other improvements: disable legend clicking, ensuring colour coding matches what we use elsewhere?
-    def create_chart_configuration(config_name:, title: nil, chart_data: {}, series_name: nil, y_axis_label: nil)
-      {
-        title: title,
-        x_axis: chart_data.keys.map(&:name),
-        x_axis_ranges: nil,
-        x_data: { series_name => chart_data.values },
-        y_axis_label: y_axis_label,
-        chart1_type: :bar,
-        chart1_subtype: :stacked,
-        config_name: config_name
-      }
     end
   end
 end

--- a/app/controllers/comparisons/baseload_per_pupil_controller.rb
+++ b/app/controllers/comparisons/baseload_per_pupil_controller.rb
@@ -14,7 +14,7 @@ module Comparisons
       Comparison::BaseloadPerPupil.where(school: @schools).where.not(one_year_baseload_per_pupil_kw: nil).order(one_year_baseload_per_pupil_kw: :desc)
     end
 
-    def create_chart(results)
+    def create_charts(results)
       chart_data = {}
 
       # Some charts also set x_max_value to 100 if there are metric values > 100
@@ -30,10 +30,14 @@ module Comparisons
         chart_data[baseload_per_pupil.school] = metric * 1000.0
       end
 
-      create_chart_configuration(config_name: :baseload_per_pupil,
-        chart_data: chart_data,
-        series_name: I18n.t('analytics.benchmarking.configuration.column_headings.baseload_per_pupil_w'),
-        y_axis_label: I18n.t('chart_configuration.y_axis_label_name.kw'))
+      series_name = I18n.t('analytics.benchmarking.configuration.column_headings.baseload_per_pupil_w')
+
+      [{
+        id: :baseload_per_pupil,
+        x_axis: chart_data.keys.map(&:name),
+        x_data: { series_name => chart_data.values },
+        y_axis_label: I18n.t('chart_configuration.y_axis_label_name.kw')
+      }]
     end
   end
 end

--- a/app/views/comparisons/base/_charts.html.erb
+++ b/app/views/comparisons/base/_charts.html.erb
@@ -1,1 +1,3 @@
-<%= benchmark_chart_tag(chart[:config_name], chart) %>
+<% @charts.each do |chart| %>
+  <%= component 'comparison_chart', **chart %>
+<% end %>

--- a/spec/components/comparison_chart_component_spec.rb
+++ b/spec/components/comparison_chart_component_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ComparisonChartComponent, type: :component, include_url_helpers: true do
+  subject(:html) { render_inline(described_class.new(**params)) }
+
+  let(:params) do
+    {
+      id: :test_chart,
+      x_axis: %w[one two],
+      x_data: { 'Comparison': [10, 20] },
+      y_axis_label: 'Series label'
+    }
+  end
+
+
+  it { expect(html).not_to have_selector('h4') }
+  it { expect(html).not_to have_selector('h5.chart-subtitle') }
+  it { expect(html).to have_selector('div', id: 'chart_wrapper_test_chart') }
+
+  context 'when it adds the chart-config data attribute' do
+    def parse_config(config)
+      JSON.parse(config['data-chart-config'])
+    end
+
+    it 'adds the type' do
+      expect(html).to have_selector('div', id: 'chart_test_chart') do |d|
+        parse_config(d)['type'] == 'test_chart'
+      end
+    end
+
+    it 'adds the x_axis' do
+      expect(html).to have_selector('div', id: 'chart_test_chart') do |d|
+        parse_config(d)['jsonData']['x_axis_categories'] == params[:x_axis]
+      end
+    end
+
+    it 'adds the x_axis data' do
+      expect(html).to have_selector('div', id: 'chart_test_chart') do |d|
+        !parse_config(d)['jsonData']['series_data'].empty?
+      end
+    end
+
+    it 'adds the y_axis_label' do
+      expect(html).to have_selector('div', id: 'chart_test_chart') do |d|
+        parse_config(d)['jsonData']['y_axis_label'] == params[:y_axis_label]
+      end
+    end
+  end
+
+  context 'with title and subtitle slots' do
+    let(:html) do
+      render_inline described_class.new(**params) do |c|
+        c.with_title    { "I'm a title" }
+        c.with_subtitle { "I'm a subtitle" }
+      end
+    end
+
+    it { expect(html).to have_selector('h4', text: "I'm a title") }
+    it { expect(html).to have_selector('h4', id: 'chart-section-test_chart') }
+    it { expect(html).to have_selector('h5.chart-subtitle', text: "I'm a subtitle") }
+  end
+end

--- a/spec/components/previews/comparison_chart_component_preview.rb
+++ b/spec/components/previews/comparison_chart_component_preview.rb
@@ -1,0 +1,9 @@
+class ComparisonChartComponentPreview < ViewComponent::Preview
+  def with_schools
+    x_axis = School.all.sample(10).map(&:name)
+    x_data = {
+      'Demo': Array.new(10) { rand(1..10) }.sort.reverse
+    }
+    render(ComparisonChartComponent.new(id: :demo, x_axis: x_axis, x_data: x_data, y_axis_label: 'Demo Chart'))
+  end
+end


### PR DESCRIPTION
Adds a view component for creating stacked barcharts for use in the school comparison report. This will replace the `benchmark_chart` helper once we retire the old pages.

Includes: 

- support for adding a title and subtitle to align display with other charts on the site.
- a basic preview
- reworks the existing baseload_per_pupil report and its base class to use the component
- adds support for displaying multiple charts (if needed) in the comparison page template

