### PR TITLE
Annual change in electricity since last year report

### DIFF
--- a/app/assets/stylesheets/comparisons.scss
+++ b/app/assets/stylesheets/comparisons.scss
@@ -1,3 +1,8 @@
 .comparisons .trix-content p {
   margin-bottom: 1rem;
 }
+
+thead.sticky-heading {
+  position: sticky;
+  top: 0;
+}

--- a/app/controllers/comparisons/base_controller.rb
+++ b/app/controllers/comparisons/base_controller.rb
@@ -41,7 +41,7 @@ module Comparisons
 
     # Create the chart configuration used to display chart
     def create_charts(_results)
-      nil
+      []
     end
 
     def filter

--- a/app/controllers/comparisons/change_in_electricity_since_last_year_controller.rb
+++ b/app/controllers/comparisons/change_in_electricity_since_last_year_controller.rb
@@ -1,0 +1,18 @@
+module Comparisons
+  class ChangeInElectricitySinceLastYearController < BaseController
+    private
+
+    def advice_page_key
+      :electricity_long_term
+    end
+
+    def title_key
+      'analytics.benchmarking.chart_table_config.change_in_electricity_since_last_year'
+    end
+
+    def load_data
+      # TODO
+      Comparison::ChangeInElectricitySinceLastYear.where(school: @schools).where.not(previous_year_electricity_kwh: nil, current_year_electricity_kwh: nil).order(current_year_electricity_kwh: :desc)
+    end
+  end
+end

--- a/app/controllers/comparisons/change_in_electricity_since_last_year_controller.rb
+++ b/app/controllers/comparisons/change_in_electricity_since_last_year_controller.rb
@@ -6,13 +6,12 @@ module Comparisons
       :electricity_long_term
     end
 
-    def title_key
-      'analytics.benchmarking.chart_table_config.change_in_electricity_since_last_year'
+    def key
+      :change_in_electricity_since_last_year
     end
 
     def load_data
-      # TODO
-      Comparison::ChangeInElectricitySinceLastYear.where(school: @schools).where.not(previous_year_electricity_kwh: nil, current_year_electricity_kwh: nil).order(current_year_electricity_kwh: :desc)
+      Comparison::ChangeInElectricitySinceLastYear.where(school: @schools).with_data.by_percentage_change
     end
   end
 end

--- a/app/helpers/comparisons_helper.rb
+++ b/app/helpers/comparisons_helper.rb
@@ -1,0 +1,16 @@
+module ComparisonsHelper
+  # Calculate percentage change across two values or sum of values in two arrays
+  def percent_change(base, new_val, to_nil_if_sum_zero = false)
+    return nil if to_nil_if_sum_zero && sum_data(base) == 0.0
+    return 0.0 if sum_data(base) == 0.0
+    change = (sum_data(new_val) - sum_data(base)) / sum_data(base)
+    to_nil_if_sum_zero && change == 0.0 ? nil : change
+  end
+
+  def sum_data(data, to_nil_if_sum_zero = false)
+    data = Array(data)
+    data.map! { |value| value || 0.0 } # create array 1st to avoid statsample map/sum bug
+    val = data.sum
+    to_nil_if_sum_zero && val == 0.0 ? nil : val
+  end
+end

--- a/app/models/comparison/change_in_electricity_since_last_year.rb
+++ b/app/models/comparison/change_in_electricity_since_last_year.rb
@@ -13,4 +13,8 @@
 #  solar_type                    :text
 #
 class Comparison::ChangeInElectricitySinceLastYear < Comparison::View
+  scope :with_data, -> { where.not(previous_year_electricity_kwh: nil, current_year_electricity_kwh: nil) }
+  scope :by_percentage_change, -> do
+    order(Arel.sql('NULLIF(previous_year_electricity_kwh,0) / NULLIF(current_year_electricity_kwh,0)'))
+  end
 end

--- a/app/models/comparison/change_in_electricity_since_last_year.rb
+++ b/app/models/comparison/change_in_electricity_since_last_year.rb
@@ -1,0 +1,16 @@
+# == Schema Information
+#
+# Table name: change_in_electricity_since_last_years
+#
+#  current_year_electricity_co2  :float
+#  current_year_electricity_gbp  :float
+#  current_year_electricity_kwh  :float
+#  id                            :bigint(8)
+#  previous_year_electricity_co2 :float
+#  previous_year_electricity_gbp :float
+#  previous_year_electricity_kwh :float
+#  school_id                     :bigint(8)
+#  solar_type                    :text
+#
+class Comparison::ChangeInElectricitySinceLastYear < Comparison::View
+end

--- a/app/views/comparisons/base/index.html.erb
+++ b/app/views/comparisons/base/index.html.erb
@@ -11,10 +11,12 @@
       <a class="nav-link active" id="tables-tab" data-toggle="tab" href="#tables"
         role="tab" aria-controls="tables-content"><%= t('compare.show.tables') %></a>
     </li>
-    <li class="nav-item">
-      <a class="nav-link" id="charts-tab" data-toggle="tab" href="#charts"
-        role="tab" aria-controls="charts-content"><%= t('compare.show.charts') %></a>
-    </li>
+    <% if @charts.any? %>
+      <li class="nav-item">
+        <a class="nav-link" id="charts-tab" data-toggle="tab" href="#charts"
+          role="tab" aria-controls="charts-content"><%= t('compare.show.charts') %></a>
+      </li>
+    <% end %>
 </ul>
 
 <div class="tab-content" id="compare-results-content">
@@ -25,7 +27,9 @@
       </div>
     </div>
   </div>
-  <div class="tab-pane fade show" id="charts" role="tabpanel" aria-labelledby="charts-tab">
-    <%= render 'charts', chart: @chart %>
-  </div>
+  <% if @charts.any? %>
+    <div class="tab-pane fade show" id="charts" role="tabpanel" aria-labelledby="charts-tab">
+      <%= render 'charts', chart: @chart %>
+    </div>
+  <% end %>
 </div>

--- a/app/views/comparisons/change_in_electricity_since_last_year/_introduction.html.erb
+++ b/app/views/comparisons/change_in_electricity_since_last_year/_introduction.html.erb
@@ -1,3 +1,0 @@
-<%= t('analytics.benchmarking.content.change_in_electricity_since_last_year.introduction_text_html') %>
-
-<%= t('analytics.benchmarking.caveat_text.covid_lockdown').html_safe %>

--- a/app/views/comparisons/change_in_electricity_since_last_year/_introduction.html.erb
+++ b/app/views/comparisons/change_in_electricity_since_last_year/_introduction.html.erb
@@ -1,0 +1,3 @@
+<%= t('analytics.benchmarking.content.change_in_electricity_since_last_year.introduction_text_html') %>
+
+<%= t('analytics.benchmarking.caveat_text.covid_lockdown').html_safe %>

--- a/app/views/comparisons/change_in_electricity_since_last_year/_tables.html.erb
+++ b/app/views/comparisons/change_in_electricity_since_last_year/_tables.html.erb
@@ -1,0 +1,109 @@
+<table id="comparison-table" class="table advice-table table-sorted">
+  <thead>
+    <tr>
+      <th></th>
+      <th colspan="3" class="text-center"><%= t('analytics.benchmarking.configuration.column_groups.kwh') %></th>
+      <th colspan="3" class="text-center"><%= t('analytics.benchmarking.configuration.column_groups.co2_kg') %></th>
+      <th colspan="3" class="text-center"><%= t('analytics.benchmarking.configuration.column_groups.gbp') %></th>
+      <th class="text-center">
+        <%= t('analytics.benchmarking.configuration.column_groups.solar_self_consumption') %>
+      </th>
+    </tr>
+    <tr>
+      <th><%= t('analytics.benchmarking.configuration.column_headings.school') %></th>
+      <th class="text-right">
+        <%= t('analytics.benchmarking.configuration.column_headings.previous_year') %>
+      </th>
+      <th class="text-right">
+        <%= t('analytics.benchmarking.configuration.column_headings.last_year') %>
+      </th>
+      <th class="text-right">
+        <%= t('analytics.benchmarking.configuration.column_headings.change_pct') %>
+      </th>
+      <th class="text-right">
+        <%= t('analytics.benchmarking.configuration.column_headings.previous_year') %>
+      </th>
+      <th class="text-right">
+        <%= t('analytics.benchmarking.configuration.column_headings.last_year') %>
+      </th>
+      <th class="text-right">
+        <%= t('analytics.benchmarking.configuration.column_headings.change_pct') %>
+      </th>
+      <th class="text-right">
+        <%= t('analytics.benchmarking.configuration.column_headings.previous_year') %>
+      </th>
+      <th class="text-right">
+        <%= t('analytics.benchmarking.configuration.column_headings.last_year') %>
+      </th>
+      <th class="text-right">
+        <%= t('analytics.benchmarking.configuration.column_headings.change_pct') %>
+      </th>
+      <th class="text-right">
+        <%= t('analytics.benchmarking.configuration.column_headings.estimated') %>
+      </th>
+    </tr>
+  </thead>
+  <tbody>
+    <% results.each do |change_in_electricity_since_last_year| %>
+      <tr>
+        <td>
+          <%= link_to change_in_electricity_since_last_year.school.name,
+                      advice_page_path(change_in_electricity_since_last_year.school, advice_page, :insights) %>
+        </td>
+
+        <td class="text-right">
+          <%= format_unit(change_in_electricity_since_last_year.previous_year_electricity_kwh, :kwh, true, :benchmark) %>
+        </td>
+        <td class="text-right">
+          <%= format_unit(change_in_electricity_since_last_year.current_year_electricity_kwh, :kwh, true, :benchmark) %>
+        </td>
+        <td class="text-right">
+          <% percent_change = percent_change(change_in_electricity_since_last_year.previous_year_electricity_kwh,
+                                             change_in_electricity_since_last_year.current_year_electricity_kwh) %>
+          <%= up_downify(format_unit(percent_change, :relative_percent_0dp, true, :benchmark)) %>
+        </td>
+
+        <td class="text-right">
+          <%= format_unit(change_in_electricity_since_last_year.previous_year_electricity_co2, :kwh, true, :benchmark) %>
+        </td>
+        <td class="text-right">
+          <%= format_unit(change_in_electricity_since_last_year.current_year_electricity_co2, :kwh, true, :benchmark) %>
+        </td>
+        <td class="text-right">
+          <% percent_change = percent_change(change_in_electricity_since_last_year.previous_year_electricity_co2,
+                                             change_in_electricity_since_last_year.current_year_electricity_co2) %>
+          <%= up_downify(format_unit(percent_change, :relative_percent_0dp, true, :benchmark)) %>
+        </td>
+
+        <td class="text-right">
+          <%= format_unit(change_in_electricity_since_last_year.previous_year_electricity_gbp, :kwh, true, :benchmark) %>
+        </td>
+        <td class="text-right">
+          <%= format_unit(change_in_electricity_since_last_year.current_year_electricity_gbp, :kwh, true, :benchmark) %>
+        </td>
+        <td class="text-right">
+          <% percent_change = percent_change(change_in_electricity_since_last_year.previous_year_electricity_gbp,
+                                             change_in_electricity_since_last_year.current_year_electricity_gbp) %>
+          <%= up_downify(format_unit(percent_change, :relative_percent_0dp, true, :benchmark)) %>
+        </td>
+        <td class="text-right">
+          <% if change_in_electricity_since_last_year.solar_type == 'synthetic' %>
+            <%= t('common.labels.yes_label') %>
+          <% else %>
+            <%= t('common.labels.no_label') %>
+          <% end %>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+  <tfoot>
+    <tr>
+      <td colspan="6">
+        <p>
+          <strong><%= t('analytics.benchmarking.content.footnotes.notes') %></strong>
+        </p>
+        <%= t('analytics.benchmarking.configuration.column_heading_explanation.last_year_definition_html') %>
+      </td>
+    </tr>
+  </tfoot>
+</table>

--- a/app/views/comparisons/change_in_electricity_since_last_year/_tables.html.erb
+++ b/app/views/comparisons/change_in_electricity_since_last_year/_tables.html.erb
@@ -1,5 +1,5 @@
 <table id="comparison-table" class="table advice-table table-sorted">
-  <thead>
+  <thead class="sticky-heading">
     <tr>
       <th></th>
       <th colspan="3" class="text-center"><%= t('analytics.benchmarking.configuration.column_groups.kwh') %></th>

--- a/app/views/comparisons/change_in_electricity_since_last_year/_tables.html.erb
+++ b/app/views/comparisons/change_in_electricity_since_last_year/_tables.html.erb
@@ -64,10 +64,10 @@
         </td>
 
         <td class="text-right">
-          <%= format_unit(change_in_electricity_since_last_year.previous_year_electricity_co2, :kwh, true, :benchmark) %>
+          <%= format_unit(change_in_electricity_since_last_year.previous_year_electricity_co2, :co2, true, :benchmark) %>
         </td>
         <td class="text-right">
-          <%= format_unit(change_in_electricity_since_last_year.current_year_electricity_co2, :kwh, true, :benchmark) %>
+          <%= format_unit(change_in_electricity_since_last_year.current_year_electricity_co2, :co2, true, :benchmark) %>
         </td>
         <td class="text-right">
           <% percent_change = percent_change(change_in_electricity_since_last_year.previous_year_electricity_co2,
@@ -76,10 +76,10 @@
         </td>
 
         <td class="text-right">
-          <%= format_unit(change_in_electricity_since_last_year.previous_year_electricity_gbp, :kwh, true, :benchmark) %>
+          <%= format_unit(change_in_electricity_since_last_year.previous_year_electricity_gbp, :£, true, :benchmark) %>
         </td>
         <td class="text-right">
-          <%= format_unit(change_in_electricity_since_last_year.current_year_electricity_gbp, :kwh, true, :benchmark) %>
+          <%= format_unit(change_in_electricity_since_last_year.current_year_electricity_gbp, :£, true, :benchmark) %>
         </td>
         <td class="text-right">
           <% percent_change = percent_change(change_in_electricity_since_last_year.previous_year_electricity_gbp,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -61,6 +61,7 @@ Rails.application.routes.draw do
 
   namespace :comparisons do
     resources :baseload_per_pupil, only: [:index]
+    resources :change_in_electricity_since_last_year, only: [:index]
   end
 
   # redirect old benchmark URLs

--- a/db/migrate/20240221154525_create_change_in_electricity_since_last_years.rb
+++ b/db/migrate/20240221154525_create_change_in_electricity_since_last_years.rb
@@ -1,0 +1,5 @@
+class CreateChangeInElectricitySinceLastYears < ActiveRecord::Migration[6.1]
+  def change
+    create_view :change_in_electricity_since_last_years
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -2149,4 +2149,32 @@ ActiveRecord::Schema.define(version: 2024_02_22_163429) do
             ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
     WHERE ((baseload.alert_generation_run_id = latest_runs.id) AND (additional.alert_generation_run_id = latest_runs.id));
   SQL
+  create_view "change_in_electricity_since_last_years", sql_definition: <<-SQL
+      SELECT latest_runs.id,
+      enba.school_id,
+      enba.previous_year_electricity_kwh,
+      enba.current_year_electricity_kwh,
+      enba.previous_year_electricity_co2,
+      enba.current_year_electricity_co2,
+      enba.previous_year_electricity_gbp,
+      enba.current_year_electricity_gbp,
+      enba.solar_type
+     FROM ( SELECT alerts.alert_generation_run_id,
+              alerts.school_id,
+              data.previous_year_electricity_kwh,
+              data.current_year_electricity_kwh,
+              data.previous_year_electricity_co2,
+              data.current_year_electricity_co2,
+              data.previous_year_electricity_gbp,
+              data.current_year_electricity_gbp,
+              data.solar_type
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) data(previous_year_electricity_kwh double precision, current_year_electricity_kwh double precision, previous_year_electricity_co2 double precision, current_year_electricity_co2 double precision, previous_year_electricity_gbp double precision, current_year_electricity_gbp double precision, solar_type text)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertEnergyAnnualVersusBenchmark'::text))) enba,
+      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
+             FROM alert_generation_runs
+            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
+    WHERE (enba.alert_generation_run_id = latest_runs.id);
+  SQL
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -2149,32 +2149,4 @@ ActiveRecord::Schema.define(version: 2024_02_22_163429) do
             ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
     WHERE ((baseload.alert_generation_run_id = latest_runs.id) AND (additional.alert_generation_run_id = latest_runs.id));
   SQL
-  create_view "change_in_electricity_since_last_years", sql_definition: <<-SQL
-      SELECT latest_runs.id,
-      enba.school_id,
-      enba.previous_year_electricity_kwh,
-      enba.current_year_electricity_kwh,
-      enba.previous_year_electricity_co2,
-      enba.current_year_electricity_co2,
-      enba.previous_year_electricity_gbp,
-      enba.current_year_electricity_gbp,
-      enba.solar_type
-     FROM ( SELECT alerts.alert_generation_run_id,
-              alerts.school_id,
-              data.previous_year_electricity_kwh,
-              data.current_year_electricity_kwh,
-              data.previous_year_electricity_co2,
-              data.current_year_electricity_co2,
-              data.previous_year_electricity_gbp,
-              data.current_year_electricity_gbp,
-              data.solar_type
-             FROM alerts,
-              alert_types,
-              LATERAL jsonb_to_record(alerts.variables) data(previous_year_electricity_kwh double precision, current_year_electricity_kwh double precision, previous_year_electricity_co2 double precision, current_year_electricity_co2 double precision, previous_year_electricity_gbp double precision, current_year_electricity_gbp double precision, solar_type text)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertEnergyAnnualVersusBenchmark'::text))) enba,
-      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
-             FROM alert_generation_runs
-            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
-    WHERE (enba.alert_generation_run_id = latest_runs.id);
-  SQL
 end

--- a/db/views/change_in_electricity_since_last_years_v01.sql
+++ b/db/views/change_in_electricity_since_last_years_v01.sql
@@ -1,0 +1,30 @@
+SELECT latest_runs.id,
+       enba.school_id,
+       enba.previous_year_electricity_kwh,
+       enba.current_year_electricity_kwh,
+       enba.previous_year_electricity_co2,
+       enba.current_year_electricity_co2,
+       enba.previous_year_electricity_gbp,
+       enba.current_year_electricity_gbp,
+       enba.solar_type
+FROM
+  (
+    SELECT alert_generation_run_id, school_id, data.*
+    FROM alerts, alert_types, jsonb_to_record(variables) AS data(
+      previous_year_electricity_kwh float,
+      current_year_electricity_kwh float,
+      previous_year_electricity_co2 float,
+      current_year_electricity_co2 float,
+      previous_year_electricity_gbp float,
+      current_year_electricity_gbp float,
+      solar_type text
+    )
+    WHERE alerts.alert_type_id = alert_types.id and alert_types.class_name='AlertEnergyAnnualVersusBenchmark'
+  ) AS enba,
+  (
+    SELECT DISTINCT ON (school_id) id
+    FROM alert_generation_runs
+    ORDER BY school_id, created_at DESC
+  ) latest_runs
+WHERE
+  enba.alert_generation_run_id = latest_runs.id;

--- a/spec/support/shared_examples/school_comparison_reports.rb
+++ b/spec/support/shared_examples/school_comparison_reports.rb
@@ -4,8 +4,10 @@ RSpec.shared_examples 'a school comparison report' do
   end
 
   it 'includes a chart' do
-    within '#charts' do
-      expect(page).to have_css(chart)
+    if defined?(chart)
+      within '#charts' do
+        expect(page).to have_css(chart)
+      end
     end
   end
 

--- a/spec/system/comparisons/baseload_per_pupil_spec.rb
+++ b/spec/system/comparisons/baseload_per_pupil_spec.rb
@@ -18,6 +18,7 @@ describe 'baseload_per_pupil', type: :system do
   end
 
   let!(:school) { create(:school) }
+  let!(:report) { create(:report, key: :baseload_per_pupil)}
 
   before do
     create(:advice_page, key: :baseload)
@@ -39,7 +40,7 @@ describe 'baseload_per_pupil', type: :system do
     end
 
     it_behaves_like 'a school comparison report' do
-      let(:title) { I18n.t('analytics.benchmarking.chart_table_config.baseload_per_pupil') }
+      let(:title) { report.title }
       let(:chart) { '#chart_baseload_per_pupil' }
       let(:expected_school) { school }
       let(:advice_page_path) { insights_school_advice_baseload_path(expected_school) }

--- a/spec/system/comparisons/baseload_per_pupil_spec.rb
+++ b/spec/system/comparisons/baseload_per_pupil_spec.rb
@@ -1,0 +1,60 @@
+require 'rails_helper'
+
+describe 'baseload_per_pupil', type: :system do
+  let(:baseload_variables) do
+    {
+      average_baseload_last_year_kw: 20.0,
+      average_baseload_last_year_gbp: 1000.0,
+      one_year_baseload_per_pupil_kw: 0.002,
+      annual_baseload_percent: 0.1,
+      one_year_saving_versus_exemplar_gbp: 200.0
+    }
+  end
+
+  let(:additional_data_variables) do
+    {
+      electricity_economic_tariff_changed_this_year: true
+    }
+  end
+
+  let!(:school) { create(:school) }
+
+  before do
+    create(:advice_page, key: :baseload)
+
+    alert_run = create(:alert_generation_run, school: school)
+
+    baseload_alert = create(:alert_type, class_name: 'AlertElectricityBaseloadVersusBenchmark')
+    create(:alert, school: school, alert_generation_run: alert_run, alert_type: baseload_alert,
+      variables: baseload_variables)
+
+    additional_data_alert = create(:alert_type, class_name: 'AlertAdditionalPrioritisationData')
+    create(:alert, school: school, alert_generation_run: alert_run, alert_type: additional_data_alert,
+      variables: additional_data_variables)
+  end
+
+  context 'when viewing report' do
+    before do
+      visit comparisons_baseload_per_pupil_index_path
+    end
+
+    it_behaves_like 'a school comparison report' do
+      let(:title) { I18n.t('analytics.benchmarking.chart_table_config.baseload_per_pupil') }
+      let(:chart) { '#chart_baseload_per_pupil' }
+      let(:expected_school) { school }
+      let(:advice_page_path) { insights_school_advice_baseload_path(expected_school) }
+    end
+
+    it 'displays the expected data' do
+      within('#tables') do
+        within('#comparison-table') do
+          expect(page).to have_content('2') # baseload per pupil
+          expect(page).to have_content('£1,000') # cost
+          expect(page).to have_content('20') # average
+          expect(page).to have_content('10&percnt;') # %
+          expect(page).to have_content('£200') # savings
+        end
+      end
+    end
+  end
+end

--- a/spec/system/comparisons/change_in_electricity_since_last_year_spec.rb
+++ b/spec/system/comparisons/change_in_electricity_since_last_year_spec.rb
@@ -1,0 +1,56 @@
+require 'rails_helper'
+
+describe 'change_in_electricity_since_last_year', type: :system do
+  let(:variables) do
+    {
+      previous_year_electricity_kwh: 1000.0,
+      current_year_electricity_kwh: 500.0,
+      previous_year_electricity_co2: 800.0,
+      current_year_electricity_co2: 400.0,
+      previous_year_electricity_gbp: 2000.0,
+      current_year_electricity_gbp: 1200.0,
+      solar_type: 'synthetic'
+    }
+  end
+
+  let!(:school) { create(:school) }
+  let!(:report) { create(:report, key: :change_in_electricity_since_last_year)}
+
+  before do
+    create(:advice_page, key: :electricity_long_term)
+
+    alert_run = create(:alert_generation_run, school: school)
+
+    alert = create(:alert_type, class_name: 'AlertEnergyAnnualVersusBenchmark')
+    create(:alert, school: school, alert_generation_run: alert_run, alert_type: alert, variables: variables)
+  end
+
+  context 'when viewing report' do
+    before do
+      visit comparisons_change_in_electricity_since_last_year_index_path
+    end
+
+    it_behaves_like 'a school comparison report' do
+      let(:title) { report.title }
+      let(:expected_school) { school }
+      let(:advice_page_path) { insights_school_advice_electricity_long_term_path(expected_school) }
+    end
+
+    it 'displays the expected data' do
+      within('#tables') do
+        within('#comparison-table') do
+          expect(page).to have_content('1,000') # previous_year_electricity_kwh per pupil
+          expect(page).to have_content('500') # current_year_electricity_kwh
+
+          expect(page).to have_content('800') # previous_year_electricity_co2
+          expect(page).to have_content('400') # current_year_electricity_co2
+
+          expect(page).to have_content('£2,000') # previous_year_electricity_gbp
+          expect(page).to have_content('£1,200') # previous_year_electricity_gbp
+
+          expect(page).to have_content('Yes') # solar
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Implements the `change_in_electricity_since_last_year` (Annual change in electricity) report.

# Changes to common code:

- adjusted base templates to make tabs option is no charts are provided by the controller, as this comparison doesn't have a chart currently
- added a `sticky-heading` style that can be applied to `thead` this [makes the table header sticky](https://btxx.org/posts/Please_Make_Your_Table_Headings_Sticky/) so if a user scrolls with a long table the heading stays visible. it doesn't work so well for tables with multiple header rows but have left in place here, will be fine with others.

# Things to note for other comparisons:

- I've pushed the sorting into the database by calculating the percentage change in the order by clause
- I've center aligned the column groups so they display better
- replace the values in the "Estimated" column with yes/no values that are translated rather than the hard-coded Y/N we use currently, not sure if other tables have hard-coded text, but be aware of those
- I've copied some helper functions from `Benchmarking::BenchmarkManager` into `ComparisonsHelper`. I've reworked them slightly but otherwise left unchanged. Suggest we copy over what we need then tidy and add tests.

# Change to report behaviour

The current where condition for the report does this:

```
!enba_ken.nil? && enba_peap != ManagementSummaryTable::NO_RECENT_DATA_MESSAGE
```

This equates to schools that have a previous year electricity value but the text "no recent data" for the value of their `activationyear_electricity_gbp_relative_percent` attribute. This didn't seem right to me as I think the report is trying to remove schools that don't have recent data, not no recent data for their first year on the site. We also don't display that column. 

So I'll be changing the condition to confirm we have current and previous year instead. 
