### PR TITLE
Migrate benchmark info to new report model

### DIFF
--- a/app/models/comparison/report.rb
+++ b/app/models/comparison/report.rb
@@ -35,7 +35,10 @@ class Comparison::Report < ApplicationRecord
   before_validation -> { custom_period.try(:mark_for_destruction) if not_custom? }
 
   validates :custom_period, presence: true, if: :custom?
-  validates :title, :reporting_period, presence: true
+  validates :title, presence: true
+
+  # Don't require this for now
+  # validates :reporting_period, presence: true
   validates :key, presence: true, uniqueness: true
 
   scope :by_key, ->(order = :asc) { order(key: order) }

--- a/app/views/admin/comparisons/reports/index.html.erb
+++ b/app/views/admin/comparisons/reports/index.html.erb
@@ -6,6 +6,7 @@
       <th>Key</th>
       <th>Title</th>
       <th>Reporting period</th>
+      <th>Public</th>
       <th>Actions</th>
     </tr>
   </thead>
@@ -13,20 +14,22 @@
   <tbody>
     <% @reports.each do |report| %>
       <tr>
-        <td><%= report.key %></td>
+        <td><span class="badge badge-secondary"><%= report.key %></span></td>
         <td><%= report.title %></td>
         <td>
-          <%= report.reporting_period.humanize %>
+          <%= report.reporting_period.try(:humanize) %>
           <%= "(#{report.custom_period})" if report.custom_period %>
+        </td>
+        <td><%= checkmark(report.public?) %>
         </td>
         <td>
           <div class="btn-group">
             <%= link_to 'Edit', edit_admin_comparisons_report_path(report),
-                        class: 'btn btn-info' %>
+                        class: 'btn btn-info btn-sm' %>
             <%= link_to 'Delete', admin_comparisons_report_path(report),
                         method: :delete,
                         data: { confirm: 'Are you sure?' },
-                        class: 'btn btn-info' %>
+                        class: 'btn btn-info btn-sm' %>
           </div>
         </td>
       </tr>

--- a/lib/tasks/deployment/20240223113901_migrate_benchmark_content_to_reports.rake
+++ b/lib/tasks/deployment/20240223113901_migrate_benchmark_content_to_reports.rake
@@ -3,9 +3,6 @@ namespace :after_party do
   task migrate_benchmark_content_to_reports: :environment do
     puts "Running deploy task 'migrate_benchmark_content_to_reports'"
 
-#    benchmarks = Benchmarking::BenchmarkManager.available_pages # returns 68, think this includes the sub-benchmarks though
-#    benchmarks = I18n.t("analytics.benchmarking.content").keys # returns 56, also includes footnotes etc
-
     # get all benchmarks for all user types
     # we aren't making use of the benchmark group information here, might we need this at some point?
     benchmark_groups = Benchmarking::BenchmarkManager.structured_pages(user_role: :admin)

--- a/lib/tasks/deployment/20240223113901_migrate_benchmark_content_to_reports.rake
+++ b/lib/tasks/deployment/20240223113901_migrate_benchmark_content_to_reports.rake
@@ -1,0 +1,42 @@
+namespace :after_party do
+  desc 'Deployment task: migrate_benchmark_content_to_reports'
+  task migrate_benchmark_content_to_reports: :environment do
+    puts "Running deploy task 'migrate_benchmark_content_to_reports'"
+
+#    benchmarks = Benchmarking::BenchmarkManager.available_pages # returns 68, think this includes the sub-benchmarks though
+#    benchmarks = I18n.t("analytics.benchmarking.content").keys # returns 56, also includes footnotes etc
+
+    # get all benchmarks for all user types
+    # we aren't making use of the benchmark group information here, might we need this at some point?
+    benchmark_groups = Benchmarking::BenchmarkManager.structured_pages(user_role: :admin)
+    benchmarks = benchmark_groups.inject({}) { |hash, group| hash.merge(group[:benchmarks]) }
+
+    benchmarks.each_key do |key|
+      # If we wanted to include the caveat text etc we could use this instead for intro text:
+      # benchmark_instance = Benchmarking::BenchmarkContentManager.new(nil).send(:content_handler, nil, key, false)
+      # report.introduction_en = benchmark_instance.send(:introduction_text)
+
+      report = Comparison::Report.find_or_initialize_by(key: key)
+      report.public = !Benchmarking::BenchmarkManager.chart_table_config(key)[:admin_only]
+
+      # This benchmark has the wrong key for the introduction text (works though because analytics also uses this key)
+      intro_key = (key == :jan_august_2022_2023_energy_comparison ? :jan_august_2023_2023_energy_comparison : key)
+
+      I18n.with_locale(:en) do
+        report.title_en = I18n.t("analytics.benchmarking.chart_table_config.#{key}")
+        report.introduction_en = I18n.t("analytics.benchmarking.content.#{intro_key}.introduction_text_html")
+      end
+      I18n.with_locale(:cy) do
+        report.title_cy = I18n.t("analytics.benchmarking.chart_table_config.#{key}")
+        report.introduction_cy = I18n.t("analytics.benchmarking.content.#{intro_key}.introduction_text_html")
+      end
+
+      report.save!
+    end
+
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord
+      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+  end
+end

--- a/spec/models/comparison/report_spec.rb
+++ b/spec/models/comparison/report_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Comparison::Report, type: :model do
       it { expect(report).to validate_presence_of(:title) }
       it { expect(report).not_to validate_presence_of(:introduction) }
       it { expect(report).not_to validate_presence_of(:notes) }
-      it { expect(report).to validate_presence_of(:reporting_period) }
+      it { expect(report).not_to validate_presence_of(:reporting_period) }
     end
   end
 

--- a/spec/system/admin/comparisons/reports_spec.rb
+++ b/spec/system/admin/comparisons/reports_spec.rb
@@ -20,7 +20,8 @@ shared_examples 'a report page with valid attributes' do |action:|
   end
 
   it { expect(page).to have_content("Report was successfully #{action}") }
-  it { expect(page).to have_selector(:table_row, { 'Key' => 'New key', 'Title' => 'New title', 'Reporting period' => 'Custom (comparing Current label to Previous label' }) }
+  it { expect(page).to have_selector(:table_row, { 'Key' => 'New key', 'Title' => 'New title', 'Reporting period' => 'Custom (comparing Current label to Previous label', 'Public' => '' }) }
+  it { expect(page).to have_css("i[class*='fa-check-circle']") }
 end
 
 shared_examples 'a report page with invalid attributes' do
@@ -82,8 +83,9 @@ describe 'admin comparisons reports', type: :system, include_application_helper:
 
       it 'lists report' do
         within('table') do
-          expect(page).to have_selector(:table_row, { 'Key' => report.key, 'Reporting period' => report.reporting_period.humanize, 'Title' => report.title })
+          expect(page).to have_selector(:table_row, { 'Key' => report.key, 'Reporting period' => report.reporting_period.humanize, 'Title' => report.title, 'Public' => '' })
         end
+        expect(page).to have_css("i[class*='fa-check-circle']")
       end
 
       it { expect(page).to have_link('Edit') }


### PR DESCRIPTION
Tried a few different ways of getting the benchmark keys, hopefully the way I have settled on gets all the ones we need.
For the purposes of this import, the title and introduction text have come straight from the yaml, however, analytics also seems to occasionally include other text (such as caveat_text) for some benchmarks along with the introduction_text. However have left it has the pure introduction from the yaml for now, let me know if this is right @ldodds 🙏 

Also makes some minor changes to the reports admin index now we have content:
![image](https://github.com/Energy-Sparks/energy-sparks/assets/6051/61d3fe08-873b-4321-9079-e85faf4551e4)

Makes the reporting_period optional for now too.
