### PR TITLE
Implement v2 of the n3rgy API

### DIFF
--- a/app/controllers/admin/reports/dcc_status_controller.rb
+++ b/app/controllers/admin/reports/dcc_status_controller.rb
@@ -11,7 +11,11 @@ module Admin
       private
 
       def set_consented_mpxns
-        @mpxns = MeterReadingsFeeds::N3rgy.new(api_key: ENV['N3RGY_API_KEY'], production: true).mpxns
+        if EnergySparks::FeatureFlags.active?(:n3rgy_v2)
+          @mpxns = Meters::N3rgyMeteringService.consented_meters
+        else
+          @mpxns = MeterReadingsFeeds::N3rgy.new(api_key: ENV['N3RGY_API_KEY'], production: true).mpxns
+        end
         @consent_lookup_error = false
       rescue
         @mpxns = []

--- a/app/controllers/admin/reports/tariffs_controller.rb
+++ b/app/controllers/admin/reports/tariffs_controller.rb
@@ -2,7 +2,7 @@ module Admin
   module Reports
     class TariffsController < AdminController
       def index
-        school_meters = Meter.where(dcc_meter: true).group_by(&:school)
+        school_meters = Meter.where(dcc_meter: true, consent_granted: true, sandbox: false).group_by(&:school)
         @group_meters = school_meters.group_by { |school, _meters| school.area_name }
       end
 

--- a/app/helpers/meters_helper.rb
+++ b/app/helpers/meters_helper.rb
@@ -1,7 +1,7 @@
 module MetersHelper
   def consented_in_n3rgy?(list_of_consented_mpans, meter)
     return nil if list_of_consented_mpans.empty?
-    list_of_consented_mpans.include? meter.mpan_mprn
+    list_of_consented_mpans.include? meter.mpan_mprn.to_s
   end
 
   def highlight_consent_mismatch?(list_of_consented_mpans, meter)

--- a/app/services/amr/n3rgy_downloader.rb
+++ b/app/services/amr/n3rgy_downloader.rb
@@ -77,17 +77,17 @@ module Amr
     def extract_readings(response)
       return [] unless response.dig('devices', 0, 'values').present?
 
-      puts "#{@meter.mpan_mprn}: #{response['devices'].map { |d| d['deviceId'] }}"
-
-      # v2 returns an array of readings for each 'device' Unclear what these
-      # map to in realiy. In practice all meters we are using have a single
-      # device.
+      # v2 returns an array of readings for each 'device'. It is technically possible
+      # within the SMETS standard for there to be up to 5 devices of the same type,
+      # e.g. 5 electricity meters. But this is an edge case and in practice they
+      # would all have MPANs.
       #
       # The responses may also contain a secondaryValue which we are also ignoring
-      # for the moment.
+      # for the moment. These are for Twin Element Electricity Meters which monitor
+      # two circuits.
       #
-      # Individual values can also include an additionalInformation key which we
-      # are not using either.
+      # Individual values can also include an additionalInformation key, to indicate
+      # why data is missing which we are not currently using either.
       response['devices'][0]['values'].map do |half_hourly_reading|
         value = case response['unit']
                 when 'm3'

--- a/app/services/amr/n3rgy_downloader.rb
+++ b/app/services/amr/n3rgy_downloader.rb
@@ -2,6 +2,8 @@ require 'dashboard'
 
 module Amr
   class N3rgyDownloader
+    KWH_PER_M3_GAS = 11.1 # this depends on the calorifc value of the gas and so is an approximate average
+
     def initialize(meter:, start_date:, end_date:, n3rgy_api: MeterReadingsFeeds::N3rgyData.new)
       @meter = meter
       @n3rgy_api = n3rgy_api
@@ -10,11 +12,96 @@ module Amr
     end
 
     def readings
-      @n3rgy_api.readings(@meter.mpan_mprn, @meter.meter_type, @start_date, @end_date)
+      if EnergySparks::FeatureFlags.active?(:n3rgy_v2)
+        download_readings
+      else
+        @n3rgy_api.readings(@meter.mpan_mprn, @meter.meter_type, @start_date, @end_date)
+      end
     end
 
     def tariffs
       @n3rgy_api.tariffs(@meter.mpan_mprn, @meter.meter_type, @start_date, @end_date)
+    end
+
+    private
+
+    def download_readings
+      # Turn the array of [DateTime, value] into a hash
+      readings_by_date_time = fetch_all_readings
+
+      # Creates a hash of { readings: {date => x48 array}, missing_readings: [date_time] }
+      meter_readings = X48Formatter.convert_dt_to_v_to_date_to_v_x48(@start_date.to_date,
+        @end_date.to_date, readings_by_date_time, true, nil)
+
+      # This return format matches the existing v1 code. This can be simplified as there is no
+      # need to create the one day readings to then just throw them away in the next step
+      {
+        @meter.fuel_type =>
+          {
+            mpan_mprn:        @meter.mpan_mprn,
+            readings:         make_one_day_readings(meter_readings[:readings], @meter.mpan_mprn),
+            missing_readings: meter_readings[:missing_readings]
+          }
+      }
+    end
+
+    # TODO remove, unnecessary, see note above
+    def make_one_day_readings(meter_readings_by_date, mpan_mprn)
+      meter_readings_by_date.map do |date, readings|
+        [date.to_date, OneDayAMRReading.new(mpan_mprn, date.to_date, 'ORIG', nil, DateTime.now, readings, true)]
+      end.to_h
+    end
+
+    # Query the n3rgy API in blocks of up to 90 days to fetch all of the readings
+    #
+    # Extracts the readings from each API response, adjusting units as required
+    #
+    # Returns a single hash of DateTime => half hourly reading value
+    def fetch_all_readings
+      readings = []
+      (@start_date..@end_date).each_slice(90) do |date_range_max_90days|
+        response = api_client.readings(@meter.mpan_mprn,
+          @meter.fuel_type.to_s,
+          DataFeeds::N3rgy::DataApiClient::READING_TYPE_CONSUMPTION,
+          date_range_max_90days.first,
+          date_range_max_90days.last)
+        readings += extract_readings(response)
+      end
+      readings.to_h
+    end
+
+    # Convert an n3rgy v2 API response into an array of [DateTime, value] values
+    #
+    # For gas readings, values are converted from cubic meters to kWh using
+    # a fixed conversion value.
+    def extract_readings(response)
+      return [] unless response.dig('devices', 0, 'values').present?
+
+      # TODO
+      # v2 returns an array of readings for each 'device' Unclear what these
+      # map to in practice. Needs further testing.
+      #
+      # The responses may also contain a secondaryValue which we are also ignoring
+      #
+      # Individual values can also include an additionalInformation key which we
+      # are not using
+      response['devices'][0]['values'].map do |half_hourly_reading|
+        value = case response['unit']
+                when 'm3'
+                  to_kwh(half_hourly_reading['primaryValue'])
+                else
+                  half_hourly_reading['primaryValue']
+                end
+        [DateTime.parse(half_hourly_reading['timestamp']), value]
+      end
+    end
+
+    def to_kwh(value)
+      value.nil? ? nil : KWH_PER_M3_GAS * value
+    end
+
+    def api_client
+      DataFeeds::N3rgy::DataApiClient.production_client
     end
   end
 end

--- a/app/services/amr/n3rgy_downloader.rb
+++ b/app/services/amr/n3rgy_downloader.rb
@@ -36,7 +36,7 @@ module Amr
       # This return format matches the existing v1 code. This can be simplified as there is no
       # need to create the one day readings to then just throw them away in the next step
       {
-        @meter.fuel_type =>
+        @meter.meter_type =>
           {
             mpan_mprn:        @meter.mpan_mprn,
             readings:         make_one_day_readings(meter_readings[:readings], @meter.mpan_mprn),
@@ -77,14 +77,17 @@ module Amr
     def extract_readings(response)
       return [] unless response.dig('devices', 0, 'values').present?
 
-      # TODO
+      puts "#{@meter.mpan_mprn}: #{response['devices'].map { |d| d['deviceId'] }}"
+
       # v2 returns an array of readings for each 'device' Unclear what these
-      # map to in practice. Needs further testing.
+      # map to in realiy. In practice all meters we are using have a single
+      # device.
       #
       # The responses may also contain a secondaryValue which we are also ignoring
+      # for the moment.
       #
       # Individual values can also include an additionalInformation key which we
-      # are not using
+      # are not using either.
       response['devices'][0]['values'].map do |half_hourly_reading|
         value = case response['unit']
                 when 'm3'

--- a/app/services/amr/n3rgy_energy_tariff_inserter.rb
+++ b/app/services/amr/n3rgy_energy_tariff_inserter.rb
@@ -187,7 +187,8 @@ module Amr
       [
         EnergyTariffCharge.new(
           charge_type: :standing_charge,
-          value: standing_charge
+          value: standing_charge,
+          units: :day
         )
       ]
     end

--- a/app/services/amr/n3rgy_energy_tariff_loader.rb
+++ b/app/services/amr/n3rgy_energy_tariff_loader.rb
@@ -19,7 +19,7 @@ module Amr
           start_date: start_date,
           tariff: todays_tariff,
           import_log: import_log).perform
-        end
+      end
     rescue => e
       msg = "Exception: downloading N3rgy tariffs for #{@meter.mpan_mprn} from #{start_date} to #{end_date} : #{e.class} #{e.message}"
       import_log.update!(error_messages: msg) if import_log

--- a/app/services/amr/n3rgy_energy_tariff_loader.rb
+++ b/app/services/amr/n3rgy_energy_tariff_loader.rb
@@ -7,12 +7,16 @@ module Amr
 
     def perform
       if EnergySparks::FeatureFlags.active?(:n3rgy_v2)
-        todays_tariff = N3rgyTariffDownloader(meter: @meter).current_tariff
+        todays_tariff = N3rgyTariffDownloader.new(meter: @meter).current_tariff
 
-        N3rgyTariffManager.new(meter: @meter, current_n3rgy_tariff: todays_tariff,
-        import_log: import_log).perform
+        N3rgyTariffManager.new(meter: @meter,
+          current_n3rgy_tariff: todays_tariff,
+          import_log: import_log).perform
       else
-        todays_tariff = N3rgyDownloader.new(meter: @meter, start_date: start_date, end_date: end_date, n3rgy_api: n3rgy_api).tariffs
+        todays_tariff = N3rgyDownloader.new(meter: @meter,
+          start_date: start_date,
+          end_date: end_date,
+          n3rgy_api: n3rgy_api).tariffs
 
         N3rgyEnergyTariffInserter.new(
           meter: @meter,

--- a/app/services/amr/n3rgy_energy_tariff_loader.rb
+++ b/app/services/amr/n3rgy_energy_tariff_loader.rb
@@ -6,11 +6,20 @@ module Amr
     end
 
     def perform
-      N3rgyEnergyTariffInserter.new(
-        meter: @meter,
-        start_date: start_date,
-        tariff: download_todays_tariff,
+      if EnergySparks::FeatureFlags.active?(:n3rgy_v2)
+        todays_tariff = N3rgyTariffDownloader(meter: @meter).current_tariff
+
+        N3rgyTariffManager.new(meter: @meter, current_n3rgy_tariff: todays_tariff,
         import_log: import_log).perform
+      else
+        todays_tariff = N3rgyDownloader.new(meter: @meter, start_date: start_date, end_date: end_date, n3rgy_api: n3rgy_api).tariffs
+
+        N3rgyEnergyTariffInserter.new(
+          meter: @meter,
+          start_date: start_date,
+          tariff: todays_tariff,
+          import_log: import_log).perform
+        end
     rescue => e
       msg = "Exception: downloading N3rgy tariffs for #{@meter.mpan_mprn} from #{start_date} to #{end_date} : #{e.class} #{e.message}"
       import_log.update!(error_messages: msg) if import_log
@@ -27,10 +36,6 @@ module Amr
 
     def end_date
       @end_date ||= DateTime.now.yesterday.end_of_day
-    end
-
-    def download_todays_tariff
-      N3rgyDownloader.new(meter: @meter, start_date: start_date, end_date: end_date, n3rgy_api: n3rgy_api).tariffs
     end
 
     def n3rgy_api

--- a/app/services/amr/n3rgy_readings_download_and_upsert.rb
+++ b/app/services/amr/n3rgy_readings_download_and_upsert.rb
@@ -46,7 +46,11 @@ module Amr
     end
 
     def n3rgy_api
-      @n3rgy_api ||= @n3rgy_api_factory.data_api(@meter)
+      if EnergySparks::FeatureFlags.active?(:n3rgy_v2)
+        nil
+      else
+        @n3rgy_api ||= @n3rgy_api_factory.data_api(@meter)
+      end
     end
 
     def create_import_log

--- a/app/services/amr/n3rgy_readings_download_and_upsert.rb
+++ b/app/services/amr/n3rgy_readings_download_and_upsert.rb
@@ -16,7 +16,7 @@ module Amr
 
     def perform
       unless @start_date && @end_date
-        available_dates = n3rgy_api.readings_available_date_range(@meter.mpan_mprn, @meter.fuel_type)
+        available_dates = fetch_cached_dates
         current_dates = readings_current_date_range(@meter)
       end
 
@@ -36,6 +36,14 @@ module Amr
     end
 
     private
+
+    def fetch_cached_dates
+      if EnergySparks::FeatureFlags.active?(:n3rgy_v2)
+        Meters::N3rgyMeteringService.new(@meter).available_data
+      else
+        n3rgy_api.readings_available_date_range(@meter.mpan_mprn, @meter.fuel_type)
+      end
+    end
 
     def n3rgy_api
       @n3rgy_api ||= @n3rgy_api_factory.data_api(@meter)

--- a/app/services/amr/n3rgy_tariff_downloader.rb
+++ b/app/services/amr/n3rgy_tariff_downloader.rb
@@ -1,0 +1,143 @@
+module Amr
+  # Response for fetching latest tariff data for a meter, then interpreting the
+  # response so its ready for processing
+  #
+  # Because of the way v2 of n3rgy API works we can't request tariffs for specific
+  # dates, just the tariffs as they are on the meter at the moment.
+  #
+  # The API always responds with the tariff information for yesterday and today.
+  #
+  # So we poll the tariffs on a daily basis and cannot access any historical tariffs.
+  class N3rgyTariffDownloader
+    def initialize(meter:)
+      @meter = meter
+    end
+
+    # Returns parsed version of current tariff for meter. Or nil if there are
+    # no tariffs on meter, or tariffs are unsupported.
+    #
+    # Returned hash has one of two forms:
+    # {
+    #   standingCharge: 0.0, flat_rate: 0.0
+    # }
+    #
+    # OR
+    #
+    # { standingCharge: 0.0,
+    #   differential: [{ start: "00:00", end: "07:00" value: 0.0, units: 'kwh'}]
+    # }
+    def current_tariff
+      response = api_client.tariff(@meter.mpan_mprn, @meter.meter_type)
+      return parse_tariff(response)
+    end
+
+    private
+
+    # Parses an n3rgy API response for tariffs into a simpler structure compatible
+    # with how we store tariff Information.
+    #
+    def parse_tariff(response)
+      # Ignore if response isn't as expected
+      return nil unless valid_response?(response)
+      # Ignore if no tariffs stored on meter
+      return nil unless tariffs_for_meter?(response)
+
+      periods = yesterdays_price_periods(response)
+      # Ignore if the tariffs aren't flat rate or differential
+      # generates warning in Rollbar
+      return nil unless supported_pricing?(periods)
+
+      standing_charge = standing_charge(response)
+      if periods.count == 1
+        flat_rate = to_pounds(periods.first.dig('prices', 0, 'value'))
+        {
+          standing_charge: standing_charge,
+          flat_rate: flat_rate
+        }
+      else
+        {
+          standing_charge: standing_charge,
+          differential: differential_prices(periods)
+        }
+      end
+    end
+
+    def valid_response?(response)
+      valid = response.dig('devices', 0, 'tariffs').present? &&
+              response.dig('devices', 0, 'months').present?
+      Rollbar.error('Unexpected/incomplete tariff response from n3rgy API', meter: @meter.mpan_mprn, school: @meter.school.name) unless valid
+      valid
+    end
+
+    def standing_charge(response)
+      to_pounds(fetch_tariff_key(response, 'standingCharge'))
+    end
+
+    # Accepts array of hashes of form:
+    # { start: "00:00", end: "07:00", type: "TOU", value: 0.0 }
+    #
+    # Returns hash with adjusted time periods, value in pounds and
+    # with units
+    def differential_prices(periods)
+      periods.map do |period|
+        # Adjust to end of day
+        end_time = period['end'] == '23:59' ? '00:00' : period['end']
+        {
+          start_time: period['start'],
+          end_time: end_time,
+          value: to_pounds(period['prices'][0]['value']),
+          units: 'kwh'
+        }
+      end
+    end
+
+    # When the supplier has not pushed tariffs to the meter, then we
+    # get a zero price from n3rgy rather than an empty or missing response.
+    def tariffs_for_meter?(response)
+      return false if nil_or_zero?(response, 'primaryActiveTariffPrice') || nil_or_zero?(response, 'standingCharge')
+      true
+    end
+
+    def nil_or_zero?(response, key)
+      val = fetch_tariff_key(response, key)
+      val.nil? || val == 0.0
+    end
+
+    def fetch_tariff_key(response, key)
+      response.dig('devices', 0, 'tariffs', 0, key)
+    end
+
+    # API response returns 2 days of tariffs. Yesterday and today
+    # So fetch the time periods for the first day
+    def yesterdays_price_periods(response)
+      response.dig('devices', 0, 'months', 0, 'days', 0, 'timePeriods')
+    end
+
+    def supported_pricing?(periods)
+      return false if periods.nil?
+      return true if all_tou_prices?(periods)
+      # Warn that school has non-TOU tariff
+      Rollbar.warning('None TOU tariff returned by n3rgy API', meter: @meter.mpan_mprn, school: @meter.school.name)
+      false
+    end
+
+    # We currently only support TOU (time of use) tariffs, not Block or others
+    # Check the type associated with every price in every period
+    def all_tou_prices?(periods)
+      periods.all? do |period|
+        period['prices'].present? && period['prices'].all? do |price|
+          price['type'] == 'TOU'
+        end
+      end
+    end
+
+    # ROUNDING?
+    def to_pounds(val)
+      val.nil? ? nil : val / 100.0
+    end
+
+    def api_client
+      DataFeeds::N3rgy::DataApiClient.production_client
+    end
+  end
+end

--- a/app/services/amr/n3rgy_tariff_manager.rb
+++ b/app/services/amr/n3rgy_tariff_manager.rb
@@ -13,7 +13,7 @@ module Amr
       # parsing response.
       #
       # In this case consider any existing tariff to have ended
-      if @current_n3rgy_tariff.nil?
+      if @current_n3rgy_tariff.nil? || invalid_n3rgy_tariff?
         expire_existing_tariff
         return
       end
@@ -25,6 +25,13 @@ module Amr
     end
 
     private
+
+    # Some meters seem to end up with a negative standing charge. We can't use these
+    # even if the rest of the tariff might be ok (and we have no way of knowing)
+    # so treat as invalid
+    def invalid_n3rgy_tariff?
+      @current_n3rgy_tariff[:standing_charge] < 0.0
+    end
 
     def latest_energy_tariff
       @meter.energy_tariffs.dcc.where(end_date: nil).order(created_at: :desc).first

--- a/app/services/amr/n3rgy_tariff_manager.rb
+++ b/app/services/amr/n3rgy_tariff_manager.rb
@@ -1,0 +1,123 @@
+module Amr
+  class N3rgyTariffManager
+    def initialize(meter:, current_n3rgy_tariff:, import_log:)
+      @meter = meter
+      @current_n3rgy_tariff = current_n3rgy_tariff
+      @import_log = import_log
+      @energy_tariff = latest_energy_tariff
+    end
+
+    def perform
+      # n3rgy tariffs will be nil if no tariffs have been stored on the
+      # meter, tariffs are in an unsupported format, or other problems
+      # parsing response.
+      #
+      # In this case consider any existing tariff to have ended
+      expire_existing_tariff && return if @current_n3rgy_tariff.nil?
+
+      if @energy_tariff.nil? || tariff_changed?
+        create_new_tariff
+        expire_existing_tariff
+      end
+    end
+
+    private
+
+    def latest_energy_tariff
+      @meter.energy_tariffs.dcc.where(end_date: nil).order(created_at: :desc).first
+    end
+
+    def expire_existing_tariff
+      return unless @energy_tariff.present?
+      @energy_tariff.update!(end_date: Time.zone.yesterday)
+    end
+
+    # Change means:
+    #  Different type of tariff
+    #  Different standing charge, but same type of tariff
+    #  Different prices, but same type of tariff
+    #  Different differential periods
+    def tariff_changed?
+      return true unless same_tariff_type?
+      return true unless same_standing_charge?
+      return true unless same_prices?
+      false
+    end
+
+    def same_tariff_type?
+      @energy_tariff.flat_rate? && @current_n3rgy_tariff[:flat_rate].present?
+    end
+
+    def same_standing_charge?
+      @energy_tariff.energy_tariff_charges.where(charge_type: :standing_charge, value: @current_n3rgy_tariff[:standing_charge], units: :day).any?
+    end
+
+    # Should already have checked if existing and new tariff are same type
+    def same_prices?
+      if @energy_tariff.flat_rate?
+        @energy_tariff.energy_tariff_prices.first.value == @current_n3rgy_tariff[:flat_rate]
+      elsif @energy_tariff.energy_tariff_prices.count == @current_n3rgy_tariff[:differential].values
+        @current_n3rgy_tariff[:differential].each_value do |period|
+          return false unless energy_tariff.energy_tariff_prices.where(
+            start_time: to_time(period[:start_time]),
+            end_time: to_time(period[:end_time]),
+            value: period[:value]).any?
+        end
+      else
+        false
+      end
+    end
+
+    def to_time(time)
+      hours, mins = time.split(':')[0, 1]
+      Time.zone.local(2000, 1, 1, hours, mins)
+    end
+
+    def create_new_tariff
+      EnergyTariff.create!(
+        ccl: false,
+        enabled: true,
+        end_date: nil,
+        meter_type: @meter.meter_type,
+        name: "Tariff from SMETS2 meter #{@meter.mpan_mprn}",
+        source: :dcc,
+        start_date: Time.zone.yesterday,
+        tariff_holder: @meter.school,
+        tariff_type: @current_n3rgy_tariff[:flat_rate].present? ? :flat_rate : :differential,
+        tnuos: false,
+        vat_rate: nil,
+        energy_tariff_prices: energy_tariff_prices,
+        energy_tariff_charges: energy_tariff_charges,
+        meters: [@meter]
+      )
+    end
+
+    def energy_tariff_prices
+      if @current_n3rgy_tariff[:flat_rate]
+        [EnergyTariffPrice.new(
+          units: :kwh,
+          value: @current_n3rgy_tariff[:flat_rate]
+        )]
+      else
+        @current_n3rgy_tariff[:differential].map do |period|
+          EnergyTariffPrice.new(
+            start_time: to_time(period[:start_time]),
+            end_time: to_time(period[:end_time]),
+            units: period[:units],
+            value: period[:value]
+          )
+        end
+      end
+    end
+
+    def energy_tariff_charges
+      [
+        EnergyTariffCharge.new(
+          charge_type: :standing_charge,
+          value: @current_n3rgy_tariff[:standing_charge],
+          units: :day
+        )
+      ]
+    end
+  end
+end

--- a/app/services/amr/n3rgy_tariff_manager.rb
+++ b/app/services/amr/n3rgy_tariff_manager.rb
@@ -13,7 +13,10 @@ module Amr
       # parsing response.
       #
       # In this case consider any existing tariff to have ended
-      expire_existing_tariff && return if @current_n3rgy_tariff.nil?
+      if @current_n3rgy_tariff.nil?
+        expire_existing_tariff
+        return
+      end
 
       if @energy_tariff.nil? || tariff_changed?
         create_new_tariff

--- a/app/services/meter_management.rb
+++ b/app/services/meter_management.rb
@@ -48,16 +48,6 @@ class MeterManagement
     return :api_error
   end
 
-  def elements
-    return nil unless @meter.dcc_meter?
-    @n3rgy_api_factory.data_api(@meter).elements(@meter.mpan_mprn, @meter.meter_type)
-  rescue => e
-    Rails.logger.warn "Exception: checking elements of meter #{@meter.mpan_mprn} : #{e.class} #{e.message}"
-    Rails.logger.warn e.backtrace.join("\n")
-    Rollbar.warning(e)
-    return :api_error
-  end
-
   def process_creation!
     assign_amr_data_feed_readings
     DccCheckerJob.perform_later(@meter) if Meter.main_meter.exists?(@meter.id)

--- a/app/services/meters/dcc_checker.rb
+++ b/app/services/meters/dcc_checker.rb
@@ -10,7 +10,11 @@ module Meters
       @meters.each do |meter|
         begin
           fields = { dcc_checked_at: DateTime.now }
-          status = @n3rgy_api_factory.data_api(meter).find(meter.mpan_mprn)
+          if EnergySparks::FeatureFlags.active?(:n3rgy_v2)
+            status = Meters::N3rgyMeteringService.new(meter).available?
+          else
+            status = @n3rgy_api_factory.data_api(meter).find(meter.mpan_mprn)
+          end
           fields[:dcc_meter] = status
           meter.update!(fields)
           updated_meters << meter if meter.saved_change_to_dcc_meter?

--- a/app/services/meters/dcc_grant_trusted_consents.rb
+++ b/app/services/meters/dcc_grant_trusted_consents.rb
@@ -12,7 +12,11 @@ module Meters
       @meters.each do |meter|
         begin
           reference = meter.meter_review.consent_grant.guid
-          @n3rgy_api_factory.consent_api(meter).grant_trusted_consent(meter.mpan_mprn, reference)
+          if EnergySparks::FeatureFlags.active?(:n3rgy_v2)
+            DataFeeds::N3rgy::ConsentApiClient.production_client.add_trusted_consent(meter.mpan_mprn, reference)
+          else
+            @n3rgy_api_factory.consent_api(meter).grant_trusted_consent(meter.mpan_mprn, reference)
+          end
           meter.update(consent_granted: true)
         rescue => e
           @errors << e

--- a/app/services/meters/dcc_withdraw_trusted_consents.rb
+++ b/app/services/meters/dcc_withdraw_trusted_consents.rb
@@ -12,7 +12,11 @@ module Meters
       @meters.each do |meter|
         begin
           meter.update(consent_granted: false)
-          @n3rgy_api_factory.consent_api(meter).withdraw_trusted_consent(meter.mpan_mprn)
+          if EnergySparks::FeatureFlags.active?(:n3rgy_v2)
+            DataFeeds::N3rgy::ConsentApiClient.production_client.withdraw_consent(meter.mpan_mprn)
+          else
+            @n3rgy_api_factory.consent_api(meter).withdraw_trusted_consent(meter.mpan_mprn)
+          end
         rescue => e
           @errors << e
           Rails.logger.error("#{e.message} for mpxn #{meter.mpan_mprn}, school #{meter.school.name}")

--- a/app/services/meters/n3rgy_metering_service.rb
+++ b/app/services/meters/n3rgy_metering_service.rb
@@ -1,0 +1,79 @@
+module Meters
+  # Provides a set of useful methods for interacting with the n3rgy API to fetch
+  # information about meters
+  class N3rgyMeteringService
+    RETRY_INTERVAL = 2
+    MAX_RETRIES = 4
+
+    def initialize(meter)
+      @meter = meter
+    end
+
+    def self.consented_meters
+      api_client = DataFeeds::N3rgy::DataApiClient.production_client
+      response = api_client.list_consented_meters
+      response['entries']
+    rescue => e
+      Rollbar.error(e)
+      []
+    end
+
+    def status
+      api_client.find_mpxn(@meter.mpan_mprn)
+      :available
+    rescue MeterReadingsFeeds::N3rgyDataApi::NotFound
+      :unknown
+    rescue MeterReadingsFeeds::N3rgyDataApi::NotAllowed
+      :consent_required
+    end
+
+    def available?
+      api_client.find_mpxn(@meter.mpan_mprn)
+      true
+    rescue
+      false
+    end
+
+    def consented?
+      return unless available?
+      # need to be consented to call this successfully
+      api_client.utilities(@meter.mpan_mprn)
+      true
+    rescue
+      false
+    end
+
+    def find_mpxn
+      api_client.find_mpxn(@meter.mpan_mprn)
+    rescue => e
+      Rollbar.warning(e, meter: @meter.id, mpan: @meter.mpan_mprn)
+      {}
+    end
+
+    def available_data
+      return [] unless @meter.dcc_meter?
+      response = api_client.consumption(@meter.mpan_mprn, @meter.fuel_type)
+      return [DateTime.parse(response['availableCacheRange']['start']), DateTime.parse(response['availableCacheRange']['end'])]
+    rescue => e
+      Rollbar.warning(e, meter: @meter.id, mpan: @meter.mpan_mprn)
+      return []
+    end
+
+    def inventory
+      details = api_client.read_inventory(device_type, mpxns: @meter.mpan_mprn)
+      api_client.fetch_with_retry(details['uri'], RETRY_INTERVAL, MAX_RETRIES)
+    rescue
+      nil
+    end
+
+    private
+
+    def device_type
+      @meter.gas? ? 'GSME' : 'ESME'
+    end
+
+    def api_client
+      DataFeeds::N3rgy::DataApiClient.production_client
+    end
+  end
+end

--- a/app/services/meters/n3rgy_metering_service.rb
+++ b/app/services/meters/n3rgy_metering_service.rb
@@ -56,7 +56,7 @@ module Meters
       return [DateTime.parse(response['availableCacheRange']['start']), DateTime.parse(response['availableCacheRange']['end'])]
     rescue => e
       Rollbar.warning(e, meter: @meter.id, mpan: @meter.mpan_mprn)
-      return []
+      return [:api_error]
     end
 
     def inventory

--- a/lib/data_feeds/n3rgy/base_client.rb
+++ b/lib/data_feeds/n3rgy/base_client.rb
@@ -12,7 +12,7 @@ module DataFeeds
       end
 
       def http_connection(connection)
-        connection ||= Faraday.new(@base_url, headers: headers)
+        connection || Faraday.new(@base_url, headers: headers)
       end
 
       # The n3rgy API returns errors in two ways. Either

--- a/lib/data_feeds/n3rgy/base_client.rb
+++ b/lib/data_feeds/n3rgy/base_client.rb
@@ -11,8 +11,8 @@ module DataFeeds
         }
       end
 
-      def connection
-        @connection ||= Faraday.new(@base_url, headers: headers)
+      def http_connection
+        @http_connection ||= Faraday.new(@base_url, headers: headers)
       end
 
       # The n3rgy API returns errors in two ways. Either

--- a/lib/data_feeds/n3rgy/base_client.rb
+++ b/lib/data_feeds/n3rgy/base_client.rb
@@ -11,8 +11,8 @@ module DataFeeds
         }
       end
 
-      def http_connection
-        @http_connection ||= Faraday.new(@base_url, headers: headers)
+      def http_connection(connection)
+        connection ||= Faraday.new(@base_url, headers: headers)
       end
 
       # The n3rgy API returns errors in two ways. Either

--- a/lib/data_feeds/n3rgy/base_client.rb
+++ b/lib/data_feeds/n3rgy/base_client.rb
@@ -6,7 +6,8 @@ module DataFeeds
       def headers
         {
           'x-api-key': @api_key,
-          'Content-Type': 'application/json'
+          'Content-Type': 'application/json',
+          'Accept': 'application/json'
         }
       end
 

--- a/lib/data_feeds/n3rgy/base_client.rb
+++ b/lib/data_feeds/n3rgy/base_client.rb
@@ -1,0 +1,36 @@
+module DataFeeds
+  module N3rgy
+    class BaseClient
+      private
+
+      def headers
+        {
+          'x-api-key': @api_key,
+          'Content-Type': 'application/json'
+        }
+      end
+
+      def connection
+        @connection ||= Faraday.new(@base_url, headers: headers)
+      end
+
+      # The n3rgy API returns errors in two ways. Either
+      # a JSON response with a single message key, or an
+      # array of errors, one per MPXN.
+      def error_message(response)
+        data = JSON.parse(response.body)
+        if data['errors']
+          error = data['errors'].first
+          error['message']
+        elsif data['message']
+          data['message']
+        else
+          response.body
+        end
+      rescue
+        # problem parsing or traversing json, return original api error
+        response.body
+      end
+    end
+  end
+end

--- a/lib/data_feeds/n3rgy/consent_api_client.rb
+++ b/lib/data_feeds/n3rgy/consent_api_client.rb
@@ -30,9 +30,9 @@ module DataFeeds
       end
 
       def withdraw_consent(mpxn)
-        url = 'consents/withdraw-consent/' + mpxn.to_s
+        url = "consents/withdraw-consent/#{mpxn}"
 
-        response = connection.delete(url)
+        response = @connection.delete(url)
         raise ConsentFailure.new(error_message(response)) unless response.success?
         true
       end

--- a/lib/data_feeds/n3rgy/consent_api_client.rb
+++ b/lib/data_feeds/n3rgy/consent_api_client.rb
@@ -32,7 +32,7 @@ module DataFeeds
       def withdraw_consent(mpxn)
         url = "consents/withdraw-consent/#{mpxn}"
 
-        response = @connection.delete(url)
+        response = http_connection.delete(url)
         raise ConsentFailure.new(error_message(response)) unless response.success?
         true
       end

--- a/lib/data_feeds/n3rgy/consent_api_client.rb
+++ b/lib/data_feeds/n3rgy/consent_api_client.rb
@@ -1,0 +1,41 @@
+module DataFeeds
+  module N3rgy
+    class ConsentFailure < StandardError; end
+
+    class ConsentApiClient < BaseClient
+      def initialize(api_key: ENV['N3RGY_SANDBOX_API_KEY'],
+                     base_url: ENV['N3RGY_SANDBOX_CONSENT_URL_V2'],
+                     connection: nil)
+        @api_key = api_key
+        @base_url = base_url
+        @connection = connection
+      end
+
+      def self.production_client
+        ConsentApiClient.new(api_key: ENV['N3RGY_API_KEY'], base_url: ENV['N3RGY_DATA_URL_V2'])
+      end
+
+      def add_trusted_consent(mpxn, reference, move_in_date = '2012-01-01')
+        url = 'consents/add-trusted-consent'
+        config = {
+          'mpxn'        => mpxn.to_s,
+          'evidence'    => reference,
+          'moveInDate'  => move_in_date
+        }
+        response = connection.post(url) do |req|
+          req.body = config.to_json
+        end
+        raise ConsentFailure, error_message(response) unless response.success?
+        true
+      end
+
+      def withdraw_consent(mpxn)
+        url = 'consents/withdraw-consent/' + mpxn.to_s
+
+        response = connection.delete(url)
+        raise ConsentFailure.new(error_message(response)) unless response.success?
+        true
+      end
+    end
+  end
+end

--- a/lib/data_feeds/n3rgy/consent_api_client.rb
+++ b/lib/data_feeds/n3rgy/consent_api_client.rb
@@ -8,7 +8,7 @@ module DataFeeds
                      connection: nil)
         @api_key = api_key
         @base_url = base_url
-        @connection = connection
+        @connection = http_connection(connection)
       end
 
       def self.production_client
@@ -22,7 +22,7 @@ module DataFeeds
           'evidence'    => reference,
           'moveInDate'  => move_in_date
         }
-        response = connection.post(url) do |req|
+        response = @connection.post(url) do |req|
           req.body = config.to_json
         end
         raise ConsentFailure, error_message(response) unless response.success?
@@ -32,7 +32,7 @@ module DataFeeds
       def withdraw_consent(mpxn)
         url = "consents/withdraw-consent/#{mpxn}"
 
-        response = http_connection.delete(url)
+        response = @connection.delete(url)
         raise ConsentFailure.new(error_message(response)) unless response.success?
         true
       end

--- a/lib/data_feeds/n3rgy/data_api_client.rb
+++ b/lib/data_feeds/n3rgy/data_api_client.rb
@@ -6,6 +6,12 @@ module DataFeeds
     class NotAuthorised < StandardError; end
 
     class DataApiClient < BaseClient
+      READING_TYPE_PRODUCTION = 'production'.freeze
+      READING_TYPE_CONSUMPTION = 'consumption'.freeze
+      READING_TYPE_IMPORT = 'import'.freeze
+      READING_TYPE_EXPORT = 'export'.freeze
+      READING_TYPE_TARIFF = 'tariff'.freeze
+
       def initialize(api_key: ENV['N3RGY_SANDBOX_API_KEY'],
                      base_url: ENV['N3RGY_SANDBOX_CONSENT_URL_V2'],
                      connection: nil)
@@ -18,19 +24,113 @@ module DataFeeds
         DataApiClient.new(api_key: ENV['N3RGY_API_KEY'], base_url: ENV['N3RGY_DATA_URL_V2'])
       end
 
+      # Returns a paged list of MPxNs for which we have consent to access
+      # the data. Consent is granted or withdrawn via the ConsentApiClient
       def list_consented_meters(start_at: 0, max_results: 100)
         get_data('/', { 'startAt': start_at, 'maxResults': max_results })
       end
 
+      # Checks to see if an MPxN is known to n3rgy. E.g. is it a SMETS-2
+      # meter in the DCC?
+      #
+      # Does not require consent to return a response
+      def find_mpxn(mpxn)
+        get_data("/find-mpxn/#{mpxn}")
+      end
+
+      # Retrieve the list of utilities (fuel types) for the meter.
+      def utilities(mpxn)
+        get_data("/mpxn/#{mpxn}")
+      end
+
+      # Retrieve the list of reading types (e.g. consumption, production) for
+      # a specific utility (fuel type)
+      def reading_types(mpxn, fuel_type)
+        get_data("/mpxn/#{mpxn}/utility/#{fuel_type}")
+      end
+
+      # Read the n3rgy consumption for a fuel type
+      def consumption(mpxn, fuel_type, start_date = nil, end_date = nil)
+        readings(mpxn, fuel_type, READING_TYPE_CONSUMPTION, start_date, end_date)
+      end
+
+      # Read the n3rgy production for a fuel type
+      def production(mpxn, fuel_type, start_date = nil, end_date = nil)
+        readings(mpxn, fuel_type, READING_TYPE_PRODUCTION, start_date, end_date)
+      end
+
+      # Fetch readings for a given MPxn, fuel type and reading type for a specified
+      # date range
+      #
+      # Maximum 90 day window between start and end
+      #
+      # If not provided then their API will return the last 24 hours of data
+      def readings(mpxn, fuel_type, reading_type, start_date = nil, end_date = nil)
+        params = {
+          'granularity': 'halfhour',
+          'outputFormat': 'json'
+        }
+        params['start'] = url_date(start_date) if start_date.present?
+        params['end'] = url_date(end_date) if end_date.present?
+        get_data("/mpxn/#{mpxn}/utility/#{fuel_type}/readingtype/#{reading_type}", params)
+      end
+
+      # Fetch some diagnostic information about one or more meters identified by
+      # their MPxN, UPRN (address) or their device id
+      def read_inventory(device_type, mpxns: nil, uprns: nil, device_ids: nil)
+        raise if mpxns.nil? && uprns.nil? && device_ids.nil?
+        body = create_inventory_body(mpxns: mpxns, uprns: uprns, device_ids: device_ids)
+        response = connection.post('/read-inventory', { 'deviceType': device_type }) do |req|
+          req.body = body.to_json
+        end
+        JSON.parse(response.body)
+      end
+
+      # This is intended to be used with a URI returned by the read_inventory call.
+      #
+      # That methods triggers a message to the actual meter to fetch some information
+      # The URI in the response will be available for download a short time afterwards
+      #
+      # Initially the URL will return an error before returning a JSON document
+      # once the background task as n3rgy is completed.
+      def fetch_with_retry(url, retry_interval = 0, max_retries = 0)
+        begin
+          retries ||= 0
+          sleep(retry_interval)
+          get_data(url)
+        rescue NotAllowed => e
+          retry if (retries += 1) <= max_retries
+          raise e
+        end
+      end
+
       private
 
-      def get_data(url)
-        response = connection.get(url)
+      def url_date(date)
+        date.strftime('%Y%m%d%H%M')
+      end
+
+      def get_data(url, params = {})
+        response = connection.get(url, params)
         raise NotAuthorised.new(error_message(response)) if response.status == 401
         raise NotAllowed.new(error_message(response)) if response.status == 403
         raise NotFound.new(error_message(response)) if response.status == 404
         raise ApiFailure.new(error_message(response)) unless response.success?
         JSON.parse(response.body)
+      end
+
+      def create_inventory_body(mpxns: nil, uprns: nil, device_ids: nil)
+        body = {}
+        unless mpxns.nil?
+          body[:mpxns] = mpxns.is_a?(Array) ? mpxns : [mpxns]
+        end
+        unless uprns.nil?
+          body[:uprns] = uprns.is_a?(Array) ? uprns : [uprns]
+        end
+        unless device_ids.nil?
+          body[:deviceIds] = device_ids.is_a?(Array) ? device_ids : [device_ids]
+        end
+        body
       end
     end
   end

--- a/lib/data_feeds/n3rgy/data_api_client.rb
+++ b/lib/data_feeds/n3rgy/data_api_client.rb
@@ -80,7 +80,7 @@ module DataFeeds
       def read_inventory(device_type, mpxns: nil, uprns: nil, device_ids: nil)
         raise if mpxns.nil? && uprns.nil? && device_ids.nil?
         body = create_inventory_body(mpxns: mpxns, uprns: uprns, device_ids: device_ids)
-        response = connection.post('/read-inventory', { 'deviceType': device_type }) do |req|
+        response = http_connection.post('/read-inventory', { 'deviceType': device_type }) do |req|
           req.body = body.to_json
         end
         JSON.parse(response.body)
@@ -111,7 +111,7 @@ module DataFeeds
       end
 
       def get_data(url, params = {})
-        response = @connection.get(url, params)
+        response = http_connection.get(url, params)
         raise NotAuthorised.new(error_message(response)) if response.status == 401
         raise NotAllowed.new(error_message(response)) if response.status == 403
         raise NotFound.new(error_message(response)) if response.status == 404

--- a/lib/data_feeds/n3rgy/data_api_client.rb
+++ b/lib/data_feeds/n3rgy/data_api_client.rb
@@ -111,7 +111,7 @@ module DataFeeds
       end
 
       def get_data(url, params = {})
-        response = connection.get(url, params)
+        response = @connection.get(url, params)
         raise NotAuthorised.new(error_message(response)) if response.status == 401
         raise NotAllowed.new(error_message(response)) if response.status == 403
         raise NotFound.new(error_message(response)) if response.status == 404

--- a/lib/data_feeds/n3rgy/data_api_client.rb
+++ b/lib/data_feeds/n3rgy/data_api_client.rb
@@ -59,6 +59,11 @@ module DataFeeds
         readings(mpxn, fuel_type, READING_TYPE_PRODUCTION, start_date, end_date)
       end
 
+      # Read the tariff for the fuel type
+      def tariff(mpxn, fuel_type)
+        readings(mpxn, fuel_type, READING_TYPE_TARIFF)
+      end
+
       # Fetch readings for a given MPxn, fuel type and reading type for a specified
       # date range
       #

--- a/lib/data_feeds/n3rgy/data_api_client.rb
+++ b/lib/data_feeds/n3rgy/data_api_client.rb
@@ -1,0 +1,37 @@
+module DataFeeds
+  module N3rgy
+    class ApiFailure < StandardError; end
+    class NotFound < StandardError; end
+    class NotAllowed < StandardError; end
+    class NotAuthorised < StandardError; end
+
+    class DataApiClient < BaseClient
+      def initialize(api_key: ENV['N3RGY_SANDBOX_API_KEY'],
+                     base_url: ENV['N3RGY_SANDBOX_CONSENT_URL_V2'],
+                     connection: nil)
+        @api_key = api_key
+        @base_url = base_url
+        @connection = connection
+      end
+
+      def self.production_client
+        DataApiClient.new(api_key: ENV['N3RGY_API_KEY'], base_url: ENV['N3RGY_DATA_URL_V2'])
+      end
+
+      def list_consented_meters(start_at: 0, max_results: 100)
+        get_data('/', { 'startAt': start_at, 'maxResults': max_results })
+      end
+
+      private
+
+      def get_data(url)
+        response = connection.get(url)
+        raise NotAuthorised.new(error_message(response)) if response.status == 401
+        raise NotAllowed.new(error_message(response)) if response.status == 403
+        raise NotFound.new(error_message(response)) if response.status == 404
+        raise ApiFailure.new(error_message(response)) unless response.success?
+        JSON.parse(response.body)
+      end
+    end
+  end
+end

--- a/lib/data_feeds/n3rgy/data_api_client.rb
+++ b/lib/data_feeds/n3rgy/data_api_client.rb
@@ -13,7 +13,7 @@ module DataFeeds
       READING_TYPE_TARIFF = 'tariff'.freeze
 
       def initialize(api_key: ENV['N3RGY_SANDBOX_API_KEY'],
-                     base_url: ENV['N3RGY_SANDBOX_CONSENT_URL_V2'],
+                     base_url: ENV['N3RGY_SANDBOX_DATA_URL_V2'],
                      connection: nil)
         @api_key = api_key
         @base_url = base_url

--- a/lib/data_feeds/n3rgy/data_api_client.rb
+++ b/lib/data_feeds/n3rgy/data_api_client.rb
@@ -17,7 +17,7 @@ module DataFeeds
                      connection: nil)
         @api_key = api_key
         @base_url = base_url
-        @connection = connection
+        @connection = http_connection(connection)
       end
 
       def self.production_client
@@ -80,7 +80,7 @@ module DataFeeds
       def read_inventory(device_type, mpxns: nil, uprns: nil, device_ids: nil)
         raise if mpxns.nil? && uprns.nil? && device_ids.nil?
         body = create_inventory_body(mpxns: mpxns, uprns: uprns, device_ids: device_ids)
-        response = http_connection.post('/read-inventory', { 'deviceType': device_type }) do |req|
+        response = @connection.post('/read-inventory', { 'deviceType': device_type }) do |req|
           req.body = body.to_json
         end
         JSON.parse(response.body)
@@ -111,7 +111,7 @@ module DataFeeds
       end
 
       def get_data(url, params = {})
-        response = http_connection.get(url, params)
+        response = @connection.get(url, params)
         raise NotAuthorised.new(error_message(response)) if response.status == 401
         raise NotAllowed.new(error_message(response)) if response.status == 403
         raise NotFound.new(error_message(response)) if response.status == 404

--- a/lib/tasks/utility.rake
+++ b/lib/tasks/utility.rake
@@ -104,14 +104,4 @@ namespace :utility do
   task custom_rollbar_reports: :environment do
     RollbarNotifierService.new.perform
   end
-
-  desc 'Check elements of DCC meters'
-  task check_elements: :environment do
-    api_factory = Amr::N3rgyApiFactory.new
-    Meter.where(dcc_meter: true).order(:mpan_mprn).each do |meter|
-      api = api_factory.data_api(meter)
-      elements = api.elements(meter.mpan_mprn, meter.meter_type)
-      puts "#{meter.mpan_mprn}, #{meter.school.name}, #{elements.size}"
-    end
-  end
 end

--- a/spec/fixtures/n3rgy/get-reading-type-consumption.json
+++ b/spec/fixtures/n3rgy/get-reading-type-consumption.json
@@ -1,0 +1,143 @@
+{
+  "resource": "/mpxn/1234567891000/utility/electricity/readingtype/consumption?outputFormat=json&end=20120428&start=20120427&granularity=halfhour",
+  "responseTimestamp": "2024-02-23T11:17:01.055Z",
+  "availableCacheRange": {
+    "start": "201204270900",
+    "end": "201402280000"
+  },
+  "start": "201204270030",
+  "end": "201204280000",
+  "granularity": "halfhour",
+  "unit": "kWh",
+  "devices": [
+    {
+      "deviceId": "01-00-00-00-00-00-01-01",
+      "values": [
+        {
+          "primaryValue": 0.214,
+          "timestamp": "2012-04-27 09:00"
+        },
+        {
+          "primaryValue": 0.158,
+          "timestamp": "2012-04-27 09:30"
+        },
+        {
+          "primaryValue": 0.064,
+          "timestamp": "2012-04-27 10:00"
+        },
+        {
+          "primaryValue": 0.062,
+          "timestamp": "2012-04-27 10:30"
+        },
+        {
+          "primaryValue": 0.1,
+          "timestamp": "2012-04-27 11:00"
+        },
+        {
+          "primaryValue": 0.096,
+          "timestamp": "2012-04-27 11:30"
+        },
+        {
+          "primaryValue": 0.061,
+          "timestamp": "2012-04-27 12:00"
+        },
+        {
+          "primaryValue": 0.097,
+          "timestamp": "2012-04-27 12:30"
+        },
+        {
+          "primaryValue": 0.102,
+          "timestamp": "2012-04-27 13:00"
+        },
+        {
+          "primaryValue": 0.129,
+          "timestamp": "2012-04-27 13:30"
+        },
+        {
+          "primaryValue": 0.1,
+          "timestamp": "2012-04-27 14:00"
+        },
+        {
+          "primaryValue": 0.101,
+          "timestamp": "2012-04-27 14:30"
+        },
+        {
+          "primaryValue": 0.123,
+          "timestamp": "2012-04-27 15:00"
+        },
+        {
+          "primaryValue": 0.245,
+          "timestamp": "2012-04-27 15:30"
+        },
+        {
+          "primaryValue": 0.109,
+          "timestamp": "2012-04-27 16:00"
+        },
+        {
+          "primaryValue": 0.018,
+          "timestamp": "2012-04-27 16:30"
+        },
+        {
+          "primaryValue": 0.058,
+          "timestamp": "2012-04-27 17:00"
+        },
+        {
+          "primaryValue": 0.057,
+          "timestamp": "2012-04-27 17:30"
+        },
+        {
+          "primaryValue": 0.019,
+          "timestamp": "2012-04-27 18:00"
+        },
+        {
+          "primaryValue": 0.03,
+          "timestamp": "2012-04-27 18:30"
+        },
+        {
+          "primaryValue": 0.107,
+          "timestamp": "2012-04-27 19:00"
+        },
+        {
+          "primaryValue": 0.058,
+          "timestamp": "2012-04-27 19:30"
+        },
+        {
+          "primaryValue": 0.025,
+          "timestamp": "2012-04-27 20:00"
+        },
+        {
+          "primaryValue": 0.019,
+          "timestamp": "2012-04-27 20:30"
+        },
+        {
+          "primaryValue": 0.1,
+          "timestamp": "2012-04-27 21:00"
+        },
+        {
+          "primaryValue": 0.219,
+          "timestamp": "2012-04-27 21:30"
+        },
+        {
+          "primaryValue": 0.132,
+          "timestamp": "2012-04-27 22:00"
+        },
+        {
+          "primaryValue": 0.091,
+          "timestamp": "2012-04-27 22:30"
+        },
+        {
+          "primaryValue": 0.105,
+          "timestamp": "2012-04-27 23:00"
+        },
+        {
+          "primaryValue": 0.11,
+          "timestamp": "2012-04-27 23:30"
+        },
+        {
+          "primaryValue": 0.09,
+          "timestamp": "2012-04-28 00:00"
+        }
+      ]
+    }
+  ]
+}

--- a/spec/fixtures/n3rgy/get-reading-type-tariff.json
+++ b/spec/fixtures/n3rgy/get-reading-type-tariff.json
@@ -1,0 +1,60 @@
+{
+  "resource": "/mpxn/1234567891000/utility/electricity/readingtype/tariff?outputFormat=json&start=202402270000&granularity=halfhour&end=202402272359",
+  "responseTimestamp": "2024-02-28T09:40:09.835Z",
+  "devices": [
+    {
+      "deviceId": "44-11-02-00-00-1C-7F-52",
+      "tariffs": [
+        {
+          "firstReading": "20240117012220",
+          "lastReading": "20240228012827",
+          "primaryActiveTariffPrice": 62.411,
+          "currencyUnitsName": "Millipence",
+          "currencyUnitsLabel": "GB Pounds",
+          "standingCharge": 125.246
+        }
+      ],
+      "months": [
+        {
+          "monthName": "February",
+          "days": [
+            {
+              "dayNumber": 27,
+              "timePeriods": [
+                {
+                  "start": "00:00:00",
+                  "end": "23:59",
+                  "prices": [
+                    {
+                      "type": "TOU",
+                      "value": 5.648
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "dayNumber": 28,
+              "timePeriods": [
+                {
+                  "start": "00:00:00",
+                  "end": "23:59",
+                  "prices": [
+                    {
+                      "type": "TOU",
+                      "value": 5.648
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "availableCacheRange": {
+        "start": "202311211735",
+        "end": "202402280940"
+      }
+    }
+  ]
+}

--- a/spec/lib/data_feeds/n3rgy/consent_api_client_spec.rb
+++ b/spec/lib/data_feeds/n3rgy/consent_api_client_spec.rb
@@ -1,0 +1,174 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'faraday/adapter/test'
+
+describe DataFeeds::N3rgy::ConsentApiClient do
+  subject(:client) do
+    described_class.new(api_key: api_key, base_url: base_url, connection: connection)
+  end
+
+  let(:stubs)       { Faraday::Adapter::Test::Stubs.new }
+  let(:connection)  { Faraday.new { |b| b.adapter(:test, stubs) } }
+  let(:base_url)    { 'https://api.example.org' }
+  let(:api_key)     { 'token' }
+
+  let(:mpxn) { '1234567891000' }
+
+  after do
+    Faraday.default_connection = nil
+  end
+
+  shared_examples 'a stubbed call that errors' do
+    it 'handles the error' do
+      expect do
+        client.send(method, *params)
+      end.to raise_error(error,
+        message)
+      stubs.verify_stubbed_calls
+    end
+  end
+
+  describe '#add_trusted_consent' do
+    let(:ref)     { 'some random guid' }
+
+    context 'when API returns success' do
+      let(:response) do
+        {
+          "resource": 'consents/add-trusted-consent',
+          "responseTimestamp": '2020-11-10T17:07:01.580Z',
+          "mpxn": '1234567891000',
+          "status": {
+            "code": 'OK',
+            "message": 'Request to register the consent was successful.'
+          }
+        }
+      end
+
+      it 'returns true' do
+        stubs.post('/consents/add-trusted-consent') do |_env|
+          [200, {}, response.to_json]
+        end
+        expect(client.add_trusted_consent(mpxn, ref)).to eq(true)
+        stubs.verify_stubbed_calls
+      end
+    end
+
+    context 'when API returns an error' do
+      let(:response) do
+        {
+          "errors": [
+            {
+              "code": 400,
+              "message": 'Unsuccessful trusted consent to property'
+            }
+          ]
+        }
+      end
+
+      before do
+        stubs.post('/consents/add-trusted-consent') do |_env|
+          [400, {}, response.to_json]
+        end
+      end
+
+      it_behaves_like 'a stubbed call that errors' do
+        let(:method) { :add_trusted_consent }
+        let(:params) { [mpxn, ref] }
+        let(:error)  { DataFeeds::N3rgy::ConsentFailure }
+        let(:message) { 'Unsuccessful trusted consent to property' }
+      end
+    end
+
+    context 'when API returns an authorization error' do
+      let(:response) do
+        {
+          "message": 'User is not authorized to access this resource with an explicit deny.'
+        }
+      end
+
+      before do
+        stubs.post('/consents/add-trusted-consent') do |_env|
+          [403, {}, response.to_json]
+        end
+      end
+
+      it_behaves_like 'a stubbed call that errors' do
+        let(:method) { :add_trusted_consent }
+        let(:params) { [mpxn, ref] }
+        let(:error)  { DataFeeds::N3rgy::ConsentFailure }
+        let(:message) { 'User is not authorized to access this resource with an explicit deny.' }
+      end
+    end
+  end
+
+  describe '#withdraw_consent' do
+    context 'when success' do
+      let(:response) do
+        {
+          "resource": 'consents/withdraw-consent/1234567891000',
+          "responseTimestamp": '2020-11-10T17:07:01.580Z',
+          "status": {
+            "code": 'OK',
+            "message": 'Request to withdraw the consent was successful.'
+          }
+        }
+      end
+
+      it 'returns true' do
+        stubs.delete('/consents/withdraw-consent/1234567891000') do |_env|
+          [200, {}, response.to_json]
+        end
+        expect(client.withdraw_consent(mpxn)).to be true
+        stubs.verify_stubbed_calls
+      end
+    end
+
+    context 'when failed' do
+      let(:response) do
+        {
+          "errors": [
+            {
+              "code": 400,
+              "message": 'message'
+            }
+          ]
+        }
+      end
+
+      before do
+        stubs.delete('/consents/withdraw-consent/1234567891000') do |_env|
+          [400, {}, response.to_json]
+        end
+      end
+
+      it_behaves_like 'a stubbed call that errors' do
+        let(:method) { :withdraw_consent }
+        let(:params) { [mpxn] }
+        let(:error)  { DataFeeds::N3rgy::ConsentFailure }
+        let(:message) { 'message' }
+      end
+    end
+
+    context 'when authorisation error' do
+      let(:response) do
+        {
+          "message": 'User is not authorized to access this resource with an explicit deny.'
+        }
+      end
+
+      before do
+        stubs.delete('/consents/withdraw-consent/1234567891000') do |_env|
+          [403, {}, response.to_json]
+        end
+      end
+
+      it_behaves_like 'a stubbed call that errors' do
+        let(:method) { :withdraw_consent }
+        let(:params) { [mpxn] }
+        let(:error)  { DataFeeds::N3rgy::ConsentFailure }
+        let(:message) { 'User is not authorized to access this resource with an explicit deny.' }
+      end
+    end
+  end
+end

--- a/spec/lib/data_feeds/n3rgy/consent_api_client_spec.rb
+++ b/spec/lib/data_feeds/n3rgy/consent_api_client_spec.rb
@@ -19,12 +19,11 @@ describe DataFeeds::N3rgy::ConsentApiClient do
     Faraday.default_connection = nil
   end
 
-  shared_examples 'a stubbed call that errors' do
-    it 'handles the error' do
+  shared_examples 'a successfully handled error' do
+    it 'by throwing the expected exception' do
       expect do
         client.send(method, *params)
-      end.to raise_error(error,
-        message)
+      end.to raise_error(DataFeeds::N3rgy::ConsentFailure, message)
       stubs.verify_stubbed_calls
     end
   end
@@ -66,16 +65,16 @@ describe DataFeeds::N3rgy::ConsentApiClient do
         }
       end
 
-      before do
-        stubs.post('/consents/add-trusted-consent') do |_env|
-          [400, {}, response.to_json]
+      it_behaves_like 'a successfully handled error' do
+        let(:stubs) do
+          Faraday::Adapter::Test::Stubs.new do |stubs|
+            stubs.post('/consents/add-trusted-consent') do |_env|
+              [400, {}, response.to_json]
+            end
+          end
         end
-      end
-
-      it_behaves_like 'a stubbed call that errors' do
         let(:method) { :add_trusted_consent }
         let(:params) { [mpxn, ref] }
-        let(:error)  { DataFeeds::N3rgy::ConsentFailure }
         let(:message) { 'Unsuccessful trusted consent to property' }
       end
     end
@@ -87,16 +86,16 @@ describe DataFeeds::N3rgy::ConsentApiClient do
         }
       end
 
-      before do
-        stubs.post('/consents/add-trusted-consent') do |_env|
-          [403, {}, response.to_json]
+      it_behaves_like 'a successfully handled error' do
+        let(:stubs) do
+          Faraday::Adapter::Test::Stubs.new do |stubs|
+            stubs.post('/consents/add-trusted-consent') do |_env|
+              [403, {}, response.to_json]
+            end
+          end
         end
-      end
-
-      it_behaves_like 'a stubbed call that errors' do
         let(:method) { :add_trusted_consent }
         let(:params) { [mpxn, ref] }
-        let(:error)  { DataFeeds::N3rgy::ConsentFailure }
         let(:message) { 'User is not authorized to access this resource with an explicit deny.' }
       end
     end
@@ -136,16 +135,16 @@ describe DataFeeds::N3rgy::ConsentApiClient do
         }
       end
 
-      before do
-        stubs.delete('/consents/withdraw-consent/1234567891000') do |_env|
-          [400, {}, response.to_json]
+      it_behaves_like 'a successfully handled error' do
+        let(:stubs) do
+          Faraday::Adapter::Test::Stubs.new do |stubs|
+            stubs.delete('/consents/withdraw-consent/1234567891000') do |_env|
+              [400, {}, response.to_json]
+            end
+          end
         end
-      end
-
-      it_behaves_like 'a stubbed call that errors' do
         let(:method) { :withdraw_consent }
         let(:params) { [mpxn] }
-        let(:error)  { DataFeeds::N3rgy::ConsentFailure }
         let(:message) { 'message' }
       end
     end
@@ -157,16 +156,16 @@ describe DataFeeds::N3rgy::ConsentApiClient do
         }
       end
 
-      before do
-        stubs.delete('/consents/withdraw-consent/1234567891000') do |_env|
-          [403, {}, response.to_json]
+      it_behaves_like 'a successfully handled error' do
+        let(:stubs) do
+          Faraday::Adapter::Test::Stubs.new do |stubs|
+            stubs.delete('/consents/withdraw-consent/1234567891000') do |_env|
+              [403, {}, response.to_json]
+            end
+          end
         end
-      end
-
-      it_behaves_like 'a stubbed call that errors' do
         let(:method) { :withdraw_consent }
         let(:params) { [mpxn] }
-        let(:error)  { DataFeeds::N3rgy::ConsentFailure }
         let(:message) { 'User is not authorized to access this resource with an explicit deny.' }
       end
     end

--- a/spec/lib/data_feeds/n3rgy/data_api_client_spec.rb
+++ b/spec/lib/data_feeds/n3rgy/data_api_client_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'faraday/adapter/test'
+
+describe DataFeeds::N3rgy::DataApiClient do
+  subject(:client) do
+    described_class.new(api_key: api_key, base_url: base_url, connection: connection)
+  end
+
+  let(:stubs)       { Faraday::Adapter::Test::Stubs.new }
+  let(:connection)  { Faraday.new { |b| b.adapter(:test, stubs) } }
+  let(:base_url)    { 'https://api.example.org' }
+  let(:api_key)     { 'token' }
+
+  after do
+    Faraday.default_connection = nil
+  end
+
+  shared_examples 'a stubbed call that errors' do
+    it 'handles the error' do
+      expect do
+        client.send(method, *params)
+      end.to raise_error(error,
+        message)
+      stubs.verify_stubbed_calls
+    end
+  end
+
+  describe '#list_consented_meters' do
+    context 'with a successful response' do
+      let(:response) do
+        {
+          "resource": '/',
+          "responseTimestamp": '2020-11-10T17:07:01.580Z',
+          "startAt": 0,
+          "maxResults": 100,
+          "total": 1,
+          "entries": [
+            '1230267891094'
+          ]
+        }
+      end
+
+      it 'returns the results'
+    end
+  end
+end

--- a/spec/lib/data_feeds/n3rgy/data_api_client_spec.rb
+++ b/spec/lib/data_feeds/n3rgy/data_api_client_spec.rb
@@ -17,18 +17,17 @@ describe DataFeeds::N3rgy::DataApiClient do
     Faraday.default_connection = nil
   end
 
-  shared_examples 'a stubbed call that errors' do
-    it 'handles the error' do
+  shared_examples 'a successfully handled error' do
+    it 'by throwing the expected exception' do
       expect do
         client.send(method, *params)
-      end.to raise_error(error,
-        message)
+      end.to raise_error(error, message)
       stubs.verify_stubbed_calls
     end
   end
 
   describe '#list_consented_meters' do
-    context 'with a successful response' do
+    context 'with a successful request' do
       let(:response) do
         {
           "resource": '/',
@@ -42,7 +41,190 @@ describe DataFeeds::N3rgy::DataApiClient do
         }
       end
 
-      it 'returns the results'
+      it 'returns the response' do
+        stubs.get('/?startAt=0&maxResults=100') do |_env|
+          [200, {}, response.to_json]
+        end
+        api_response = client.list_consented_meters
+        expect(api_response).to eq(response.with_indifferent_access)
+        stubs.verify_stubbed_calls
+      end
+
+      context 'with passed parameters' do
+        it 'queries the right url' do
+          stubs.get('/?startAt=5&maxResults=10') do |_env|
+            [200, {}, response.to_json]
+          end
+          client.list_consented_meters(start_at: 5, max_results: 10)
+          stubs.verify_stubbed_calls
+        end
+      end
+    end
+  end
+
+  describe '#find_mpxn' do
+    let(:response) do
+      {
+        "resource": '/find-mpxn/1234567891002',
+        "responseTimestamp": '2024-02-23T11:03:23.040Z',
+        "mpxn": '1234567891002',
+        "deviceType": 'ESME',
+        "deviceId": '02-00-00-00-00-00-02-01',
+        "deviceStatus": 'COMMISSIONED',
+        "deviceManufacturer": '123E',
+        "deviceModel": 'Model-XYZ',
+        "propertyFilter": {
+          "postCode": 'C2A 2EE',
+          "addressIdentifier": '22A, SOMEWHERE'
+        }
+      }
+    end
+
+    it 'returns the response' do
+      stubs.get('/find-mpxn/1234567891002') do |_env|
+        [200, {}, response.to_json]
+      end
+      api_response = client.find_mpxn('1234567891002')
+      expect(api_response).to eq(response.with_indifferent_access)
+      stubs.verify_stubbed_calls
+    end
+  end
+
+  describe '#utilities' do
+    let(:response) do
+      {
+        "resource": '/mpxn/1234567891012',
+        "responseTimestamp": '2022-04-10T17:07:01.580Z',
+        "entries": "['electricity', 'gas']"
+      }
+    end
+
+    it 'returns the response' do
+      stubs.get('/mpxn/1234567891012') do |_env|
+        [200, {}, response.to_json]
+      end
+      api_response = client.utilities('1234567891012')
+      expect(api_response).to eq(response.with_indifferent_access)
+      stubs.verify_stubbed_calls
+    end
+  end
+
+  describe '#reading_types' do
+    let(:response) do
+      {
+        "resource": '/mpxn/1234567891002/utility/electricity',
+        "responseTimestamp": '2024-02-23T12:36:47.056Z',
+        "devices": [
+          {
+            "deviceId": '02-00-00-00-00-00-02-01',
+            "availableDataTypes": %w[
+              consumption
+              tariff
+            ]
+          }
+        ]
+      }
+    end
+
+    it 'returns the response' do
+      stubs.get('/mpxn/1234567891002/utility/electricity') do |_env|
+        [200, {}, response.to_json]
+      end
+      api_response = client.reading_types('1234567891002', :electricity)
+      expect(api_response).to eq(response.with_indifferent_access)
+      stubs.verify_stubbed_calls
+    end
+  end
+
+  describe '#readings' do
+    context 'with a successful request' do
+      let(:response) { JSON.parse(File.read('spec/fixtures/n3rgy/get-reading-type-consumption.json')) }
+
+      it 'returns the response' do
+        stubs.get('/mpxn/1234567891000/utility/electricity/readingtype/consumption?granularity=halfhour&outputFormat=json') do |_env|
+          [200, {}, response.to_json]
+        end
+        api_response = client.readings('1234567891000', :electricity, 'consumption')
+        expect(api_response).to eq(response.with_indifferent_access)
+        stubs.verify_stubbed_calls
+      end
+
+      context 'with date parameters' do
+        it 'queries the right url' do
+          url = '/mpxn/1234567891000/utility/electricity/readingtype/consumption'
+          url = url + '?granularity=halfhour&outputFormat=json&start=202401010000&end=202401020000'
+          stubs.get(url) do |_env|
+            [200, {}, response.to_json]
+          end
+          client.readings('1234567891000', :electricity, 'consumption', Date.new(2024, 1, 1), Date.new(2024, 1, 2))
+          stubs.verify_stubbed_calls
+        end
+      end
+    end
+  end
+
+  describe '#read_inventory' do
+    let(:uri) { 'https://read-inventory.data.n3rgy.com/files/767c1f42-9d52-43c1-8909-f61c78aa1916.json' }
+    let(:response) do
+      {
+        "status": 200,
+        "uuid": '767c1f42-9d52-43c1-8909-f61c78aa1916',
+        "uri": uri
+      }
+    end
+
+    it 'requests correct url' do
+      stubs.post('/read-inventory') do |env|
+        expect(env.body).to eql({
+          mpxns: ['1100000000024']
+        }.to_json)
+        [200, {}, response.to_json]
+      end
+      api_response = client.read_inventory('ESME', mpxns: '1100000000024')
+      expect(api_response).to eq(response.with_indifferent_access)
+      stubs.verify_stubbed_calls
+    end
+  end
+
+  describe '#fetch_with_retry' do
+    context 'with auth failure' do
+      let(:response) { { "message": 'Unauthorized' } }
+
+      it 'raises error' do
+        stubs.get('some-inventory-file') do |_env|
+          [401, {}, 'no way']
+        end
+        expect do
+          client.fetch_with_retry('some-inventory-file')
+        end.to raise_error(DataFeeds::N3rgy::NotAuthorised, 'no way')
+        stubs.verify_stubbed_calls
+      end
+    end
+
+    context 'with retry' do
+      context 'when it works' do
+        let(:response) { { 'result' => 'your data' } }
+
+        it 'returns contents' do
+          stubs.get('some-inventory-file') do |_env|
+            [200, {}, response.to_json]
+          end
+          contents = client.fetch_with_retry('some-inventory-file', 0.1, 3)
+          expect(contents).to eq(response)
+          stubs.verify_stubbed_calls
+        end
+      end
+
+      context 'when it fails' do
+        it 'retries and then raises error' do
+          stubs.get('some-inventory-file') do |_env|
+            [403, {}, 'not ready']
+          end
+          expect do
+            client.fetch_with_retry('some-inventory-file', 0.1, 3)
+          end.to raise_error(DataFeeds::N3rgy::NotAllowed, 'not ready')
+        end
+      end
     end
   end
 end

--- a/spec/services/amr/n3rgy_downloader_spec.rb
+++ b/spec/services/amr/n3rgy_downloader_spec.rb
@@ -68,7 +68,7 @@ module Amr
           it 'returns empty results' do
             allow(stub).to receive(:readings).with(meter.mpan_mprn, meter.fuel_type.to_s, DataFeeds::N3rgy::DataApiClient::READING_TYPE_CONSUMPTION, anything, anything).and_return(response)
             readings = service.readings
-            expect(readings[meter.fuel_type][:readings]).to be_empty
+            expect(readings[meter.meter_type][:readings]).to be_empty
           end
         end
 
@@ -90,7 +90,7 @@ module Amr
           end
 
           it 'extracts the readings' do
-            readings_by_day = readings[meter.fuel_type][:readings]
+            readings_by_day = readings[meter.meter_type][:readings]
             # Match readings from fixture
             expect(readings_by_day[start_date].kwh_data_x48).to eq(fixture_readings)
           end
@@ -104,7 +104,7 @@ module Amr
 
             it 'converts to kWh' do
               adjusted = fixture_readings.map { |r| r.nil? ? nil : r * Amr::N3rgyDownloader::KWH_PER_M3_GAS}
-              readings_by_day = readings[meter.fuel_type][:readings]
+              readings_by_day = readings[meter.meter_type][:readings]
               expect(readings_by_day[start_date].kwh_data_x48).to eq(adjusted)
             end
           end

--- a/spec/services/amr/n3rgy_downloader_spec.rb
+++ b/spec/services/amr/n3rgy_downloader_spec.rb
@@ -2,22 +2,114 @@ require 'rails_helper'
 
 module Amr
   describe N3rgyDownloader do
-    let(:n3rgy_api) { double('n3rgy_api') }
-    let(:meter)     { create(:electricity_meter) }
-    let(:config)    { create(:amr_data_feed_config)}
-    let(:today)     { Time.zone.today }
-    let(:yesterday) { today - 1 }
-
-    it 'invokes the api' do
-      expect(n3rgy_api).to receive(:readings)
-      loader = Amr::N3rgyDownloader.new(n3rgy_api: n3rgy_api, meter: meter, start_date: nil, end_date: nil)
-      loader.readings
+    subject(:service) do
+      Amr::N3rgyDownloader.new(n3rgy_api: n3rgy_api, meter: meter, start_date: start_date, end_date: end_date)
     end
 
-    it 'passes in correct params' do
-      expect(n3rgy_api).to receive(:readings).with(meter.mpan_mprn, meter.meter_type, today, yesterday)
-      loader = Amr::N3rgyDownloader.new(n3rgy_api: n3rgy_api, meter: meter, start_date: today, end_date: yesterday)
-      loader.readings
+    let(:meter)     { create(:electricity_meter) }
+    let(:config)    { create(:amr_data_feed_config)}
+    let(:end_date)  { Time.zone.today }
+    let(:start_date) { end_date - 1 }
+
+    around do |example|
+      ClimateControl.modify FEATURE_FLAG_N3RGY_V2: flag do
+        example.run
+      end
+    end
+
+    describe '#readings' do
+      context 'with v1' do
+        let(:flag) { 'false' }
+        let(:n3rgy_api) { double('n3rgy_api') }
+
+        it 'invokes the api' do
+          expect(n3rgy_api).to receive(:readings)
+          service.readings
+        end
+
+        it 'passes in correct params' do
+          expect(n3rgy_api).to receive(:readings).with(meter.mpan_mprn, meter.meter_type, start_date, end_date)
+          service.readings
+        end
+      end
+
+      context 'with v2' do
+        let(:flag) { 'true' }
+        let(:n3rgy_api) { nil }
+
+        let(:stub) { double('data-api-client') }
+
+        before do
+          allow(DataFeeds::N3rgy::DataApiClient).to receive(:production_client).and_return(stub)
+        end
+
+        context 'with a period of more than 90 days' do
+          let(:start_date) { Date.new(2023, 1, 1) }
+          let(:end_date) { start_date + 100.days }
+          let(:response) do
+            {
+              'devices' => [{ 'values' => [] }]
+            }
+          end
+
+          it 'makes multiple API requests' do
+            expect(stub).to receive(:readings).at_least(:twice).with(meter.mpan_mprn, meter.fuel_type.to_s, DataFeeds::N3rgy::DataApiClient::READING_TYPE_CONSUMPTION, anything, anything).and_return(response)
+            service.readings
+          end
+        end
+
+        context 'with no device readings' do
+          let(:response) do
+            {
+              'devices' => []
+            }
+          end
+
+          it 'returns empty results' do
+            allow(stub).to receive(:readings).with(meter.mpan_mprn, meter.fuel_type.to_s, DataFeeds::N3rgy::DataApiClient::READING_TYPE_CONSUMPTION, anything, anything).and_return(response)
+            readings = service.readings
+            expect(readings[meter.fuel_type][:readings]).to be_empty
+          end
+        end
+
+        context 'with successful results' do
+          subject(:readings) { service.readings }
+
+          # Match dates in fixture
+          let(:start_date) { Date.new(2012, 4, 27)}
+          let(:end_date) { Date.new(2012, 4, 28)}
+
+          let(:response) { JSON.parse(File.read('spec/fixtures/n3rgy/get-reading-type-consumption.json')) }
+
+          let(:fixture_readings) do
+            [nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, 0.214, 0.158, 0.064, 0.062, 0.1, 0.096, 0.061, 0.097, 0.102, 0.129, 0.1, 0.101, 0.123, 0.245, 0.109, 0.018, 0.058, 0.057, 0.019, 0.03, 0.107, 0.058, 0.025, 0.019, 0.1, 0.219, 0.132, 0.091, 0.105, 0.11, 0.09]
+          end
+
+          before do
+            allow(stub).to receive(:readings).with(meter.mpan_mprn, meter.fuel_type.to_s, DataFeeds::N3rgy::DataApiClient::READING_TYPE_CONSUMPTION, anything, anything).and_return(response.with_indifferent_access)
+          end
+
+          it 'extracts the readings' do
+            readings_by_day = readings[meter.fuel_type][:readings]
+            # Match readings from fixture
+            expect(readings_by_day[start_date].kwh_data_x48).to eq(fixture_readings)
+          end
+
+          context 'when returned readings are in m3' do
+            let(:response) do
+              original = JSON.parse(File.read('spec/fixtures/n3rgy/get-reading-type-consumption.json'))
+              original['unit'] = 'm3'
+              original
+            end
+
+            it 'converts to kWh' do
+              adjusted = fixture_readings.map { |r| r.nil? ? nil : r * Amr::N3rgyDownloader::KWH_PER_M3_GAS}
+              readings_by_day = readings[meter.fuel_type][:readings]
+              expect(readings_by_day[start_date].kwh_data_x48).to eq(adjusted)
+            end
+          end
+        end
+      end
     end
   end
 end

--- a/spec/services/amr/n3rgy_downloader_spec.rb
+++ b/spec/services/amr/n3rgy_downloader_spec.rb
@@ -1,112 +1,110 @@
 require 'rails_helper'
 
-module Amr
-  describe N3rgyDownloader do
-    subject(:service) do
-      Amr::N3rgyDownloader.new(n3rgy_api: n3rgy_api, meter: meter, start_date: start_date, end_date: end_date)
+describe Amr::N3rgyDownloader do
+  subject(:service) do
+    described_class.new(n3rgy_api: n3rgy_api, meter: meter, start_date: start_date, end_date: end_date)
+  end
+
+  let(:meter)     { create(:electricity_meter) }
+  let(:config)    { create(:amr_data_feed_config)}
+  let(:end_date)  { Time.zone.today }
+  let(:start_date) { end_date - 1 }
+
+  around do |example|
+    ClimateControl.modify FEATURE_FLAG_N3RGY_V2: flag do
+      example.run
     end
+  end
 
-    let(:meter)     { create(:electricity_meter) }
-    let(:config)    { create(:amr_data_feed_config)}
-    let(:end_date)  { Time.zone.today }
-    let(:start_date) { end_date - 1 }
+  describe '#readings' do
+    context 'with v1' do
+      let(:flag) { 'false' }
+      let(:n3rgy_api) { double('n3rgy_api') }
 
-    around do |example|
-      ClimateControl.modify FEATURE_FLAG_N3RGY_V2: flag do
-        example.run
+      it 'invokes the api' do
+        expect(n3rgy_api).to receive(:readings)
+        service.readings
+      end
+
+      it 'passes in correct params' do
+        expect(n3rgy_api).to receive(:readings).with(meter.mpan_mprn, meter.meter_type, start_date, end_date)
+        service.readings
       end
     end
 
-    describe '#readings' do
-      context 'with v1' do
-        let(:flag) { 'false' }
-        let(:n3rgy_api) { double('n3rgy_api') }
+    context 'with v2' do
+      let(:flag) { 'true' }
+      let(:n3rgy_api) { nil }
 
-        it 'invokes the api' do
-          expect(n3rgy_api).to receive(:readings)
-          service.readings
+      let(:stub) { double('data-api-client') }
+
+      before do
+        allow(DataFeeds::N3rgy::DataApiClient).to receive(:production_client).and_return(stub)
+      end
+
+      context 'with a period of more than 90 days' do
+        let(:start_date) { Date.new(2023, 1, 1) }
+        let(:end_date) { start_date + 100.days }
+        let(:response) do
+          {
+            'devices' => [{ 'values' => [] }]
+          }
         end
 
-        it 'passes in correct params' do
-          expect(n3rgy_api).to receive(:readings).with(meter.mpan_mprn, meter.meter_type, start_date, end_date)
+        it 'makes multiple API requests' do
+          expect(stub).to receive(:readings).at_least(:twice).with(meter.mpan_mprn, meter.fuel_type.to_s, DataFeeds::N3rgy::DataApiClient::READING_TYPE_CONSUMPTION, anything, anything).and_return(response)
           service.readings
         end
       end
 
-      context 'with v2' do
-        let(:flag) { 'true' }
-        let(:n3rgy_api) { nil }
+      context 'with no device readings' do
+        let(:response) do
+          {
+            'devices' => []
+          }
+        end
 
-        let(:stub) { double('data-api-client') }
+        it 'returns empty results' do
+          allow(stub).to receive(:readings).with(meter.mpan_mprn, meter.fuel_type.to_s, DataFeeds::N3rgy::DataApiClient::READING_TYPE_CONSUMPTION, anything, anything).and_return(response)
+          readings = service.readings
+          expect(readings[meter.meter_type][:readings]).to be_empty
+        end
+      end
+
+      context 'with successful results' do
+        subject(:readings) { service.readings }
+
+        # Match dates in fixture
+        let(:start_date) { Date.new(2012, 4, 27)}
+        let(:end_date) { Date.new(2012, 4, 28)}
+
+        let(:response) { JSON.parse(File.read('spec/fixtures/n3rgy/get-reading-type-consumption.json')) }
+
+        let(:fixture_readings) do
+          [nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, 0.214, 0.158, 0.064, 0.062, 0.1, 0.096, 0.061, 0.097, 0.102, 0.129, 0.1, 0.101, 0.123, 0.245, 0.109, 0.018, 0.058, 0.057, 0.019, 0.03, 0.107, 0.058, 0.025, 0.019, 0.1, 0.219, 0.132, 0.091, 0.105, 0.11, 0.09]
+        end
 
         before do
-          allow(DataFeeds::N3rgy::DataApiClient).to receive(:production_client).and_return(stub)
+          allow(stub).to receive(:readings).with(meter.mpan_mprn, meter.fuel_type.to_s, DataFeeds::N3rgy::DataApiClient::READING_TYPE_CONSUMPTION, anything, anything).and_return(response.with_indifferent_access)
         end
 
-        context 'with a period of more than 90 days' do
-          let(:start_date) { Date.new(2023, 1, 1) }
-          let(:end_date) { start_date + 100.days }
+        it 'extracts the readings' do
+          readings_by_day = readings[meter.meter_type][:readings]
+          # Match readings from fixture
+          expect(readings_by_day[start_date].kwh_data_x48).to eq(fixture_readings)
+        end
+
+        context 'when returned readings are in m3' do
           let(:response) do
-            {
-              'devices' => [{ 'values' => [] }]
-            }
+            original = JSON.parse(File.read('spec/fixtures/n3rgy/get-reading-type-consumption.json'))
+            original['unit'] = 'm3'
+            original
           end
 
-          it 'makes multiple API requests' do
-            expect(stub).to receive(:readings).at_least(:twice).with(meter.mpan_mprn, meter.fuel_type.to_s, DataFeeds::N3rgy::DataApiClient::READING_TYPE_CONSUMPTION, anything, anything).and_return(response)
-            service.readings
-          end
-        end
-
-        context 'with no device readings' do
-          let(:response) do
-            {
-              'devices' => []
-            }
-          end
-
-          it 'returns empty results' do
-            allow(stub).to receive(:readings).with(meter.mpan_mprn, meter.fuel_type.to_s, DataFeeds::N3rgy::DataApiClient::READING_TYPE_CONSUMPTION, anything, anything).and_return(response)
-            readings = service.readings
-            expect(readings[meter.meter_type][:readings]).to be_empty
-          end
-        end
-
-        context 'with successful results' do
-          subject(:readings) { service.readings }
-
-          # Match dates in fixture
-          let(:start_date) { Date.new(2012, 4, 27)}
-          let(:end_date) { Date.new(2012, 4, 28)}
-
-          let(:response) { JSON.parse(File.read('spec/fixtures/n3rgy/get-reading-type-consumption.json')) }
-
-          let(:fixture_readings) do
-            [nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, 0.214, 0.158, 0.064, 0.062, 0.1, 0.096, 0.061, 0.097, 0.102, 0.129, 0.1, 0.101, 0.123, 0.245, 0.109, 0.018, 0.058, 0.057, 0.019, 0.03, 0.107, 0.058, 0.025, 0.019, 0.1, 0.219, 0.132, 0.091, 0.105, 0.11, 0.09]
-          end
-
-          before do
-            allow(stub).to receive(:readings).with(meter.mpan_mprn, meter.fuel_type.to_s, DataFeeds::N3rgy::DataApiClient::READING_TYPE_CONSUMPTION, anything, anything).and_return(response.with_indifferent_access)
-          end
-
-          it 'extracts the readings' do
+          it 'converts to kWh' do
+            adjusted = fixture_readings.map { |r| r.nil? ? nil : r * Amr::N3rgyDownloader::KWH_PER_M3_GAS}
             readings_by_day = readings[meter.meter_type][:readings]
-            # Match readings from fixture
-            expect(readings_by_day[start_date].kwh_data_x48).to eq(fixture_readings)
-          end
-
-          context 'when returned readings are in m3' do
-            let(:response) do
-              original = JSON.parse(File.read('spec/fixtures/n3rgy/get-reading-type-consumption.json'))
-              original['unit'] = 'm3'
-              original
-            end
-
-            it 'converts to kWh' do
-              adjusted = fixture_readings.map { |r| r.nil? ? nil : r * Amr::N3rgyDownloader::KWH_PER_M3_GAS}
-              readings_by_day = readings[meter.meter_type][:readings]
-              expect(readings_by_day[start_date].kwh_data_x48).to eq(adjusted)
-            end
+            expect(readings_by_day[start_date].kwh_data_x48).to eq(adjusted)
           end
         end
       end

--- a/spec/services/amr/n3rgy_readings_download_and_upsert_spec.rb
+++ b/spec/services/amr/n3rgy_readings_download_and_upsert_spec.rb
@@ -2,9 +2,7 @@ require 'rails_helper'
 
 module Amr
   describe N3rgyReadingsDownloadAndUpsert do
-    let(:n3rgy_api)         { double(:n3rgy_api) }
-    let(:n3rgy_api_factory) { double(:n3rgy_api_factory, data_api: n3rgy_api) }
-    let(:earliest)          { DateTime.parse('2019-01-01T00:00') }
+    let(:earliest) { DateTime.parse('2019-01-01T00:00') }
     let(:thirteen_months_ago) { DateTime.now - 13.months }
     let(:meter)             { create(:electricity_meter, earliest_available_data: earliest) }
     let(:config)            { create(:amr_data_feed_config)}
@@ -22,92 +20,273 @@ module Amr
       }
     end
 
-    context 'when downloading data' do
-      it 'handles and log exceptions' do
-        expect(AmrDataFeedImportLog.count).to be 0
-        expect(n3rgy_api).to receive(:readings).and_raise(StandardError)
-        upserter = Amr::N3rgyReadingsDownloadAndUpsert.new(n3rgy_api_factory: n3rgy_api_factory, config: config, meter: meter, start_date: start_date, end_date: end_date)
-        upserter.perform
-        expect(AmrDataFeedImportLog.count).to be 1
-        expect(AmrDataFeedImportLog.first.error_messages).not_to be_blank
+    around do |example|
+      ClimateControl.modify FEATURE_FLAG_N3RGY_V2: flag do
+        example.run
       end
+    end
 
-      it 'uses provided date window' do
-        expect(n3rgy_api).to receive(:readings).with(meter.mpan_mprn, meter.meter_type, start_date, end_date).and_return(readings)
-        upserter = Amr::N3rgyReadingsDownloadAndUpsert.new(n3rgy_api_factory: n3rgy_api_factory, config: config, meter: meter, start_date: start_date, end_date: end_date)
-        upserter.perform
-      end
+    context 'with v1' do
+      let(:flag) { 'false' }
 
-      it 'uses earliest available data if no date window' do
-        available_range = (earliest..yesterday)
-        expect(n3rgy_api).to receive(:readings_available_date_range).with(meter.mpan_mprn, meter.fuel_type).and_return(available_range)
-        expect(n3rgy_api).to receive(:readings).with(meter.mpan_mprn, meter.meter_type, earliest, yesterday).and_return(readings)
-        upserter = Amr::N3rgyReadingsDownloadAndUpsert.new(n3rgy_api_factory: n3rgy_api_factory, config: config, meter: meter, start_date: nil, end_date: nil)
-        upserter.perform
-      end
+      let(:n3rgy_api)         { double(:n3rgy_api) }
+      let(:n3rgy_api_factory) { double(:n3rgy_api_factory, data_api: n3rgy_api) }
 
-      it 'requests 12 months if no earliest data is unknown and no readings' do
-        expect(n3rgy_api).to receive(:readings_available_date_range).with(meter.mpan_mprn, meter.fuel_type).and_return(nil)
-        expect(n3rgy_api).to receive(:readings).with(meter.mpan_mprn, meter.meter_type, thirteen_months_ago, yesterday).and_return(readings)
-
-        meter.update!({
-          earliest_available_data: nil
-        })
-
-        upserter = Amr::N3rgyReadingsDownloadAndUpsert.new(n3rgy_api_factory: n3rgy_api_factory, config: config, meter: meter, start_date: nil, end_date: nil)
-        upserter.perform
-      end
-
-      context 'when there are readings' do
-        # Note: this is a Date object as the reading date needs to be stored in the database in ISO 8601 format e.g. 2023-06-29
-        let(:last_week) { Time.zone.today - 7 }
-
-        before do
-          create(:amr_data_feed_reading, meter: meter, reading_date: last_week)
-          create(:amr_data_feed_reading, meter: meter, reading_date: last_week + 1)
-          create(:amr_data_feed_reading, meter: meter, reading_date: last_week + 2)
+      context 'when downloading data' do
+        it 'handles and log exceptions' do
+          expect(AmrDataFeedImportLog.count).to be 0
+          expect(n3rgy_api).to receive(:readings).and_raise(StandardError)
+          upserter = Amr::N3rgyReadingsDownloadAndUpsert.new(n3rgy_api_factory: n3rgy_api_factory, config: config, meter: meter, start_date: start_date, end_date: end_date)
+          upserter.perform
+          expect(AmrDataFeedImportLog.count).to be 1
+          expect(AmrDataFeedImportLog.first.error_messages).not_to be_blank
         end
 
-        it 'requests data from first available date if that was earlier than current first reading' do
-          available_range = (last_week - 1..yesterday)
+        it 'uses provided date window' do
+          expect(n3rgy_api).to receive(:readings).with(meter.mpan_mprn, meter.meter_type, start_date, end_date).and_return(readings)
+          upserter = Amr::N3rgyReadingsDownloadAndUpsert.new(n3rgy_api_factory: n3rgy_api_factory, config: config, meter: meter, start_date: start_date, end_date: end_date)
+          upserter.perform
+        end
+
+        it 'uses earliest available data if no date window' do
+          available_range = (earliest..yesterday)
           expect(n3rgy_api).to receive(:readings_available_date_range).with(meter.mpan_mprn, meter.fuel_type).and_return(available_range)
-          expect(n3rgy_api).to receive(:readings).with(meter.mpan_mprn, meter.meter_type, last_week - 1, yesterday).and_return(readings)
-
-          # maximum and minimum amr data feed readings reading date should be in ISO 8601 format e.g. '2023-06-29'
-          expect(meter.amr_data_feed_readings.minimum(:reading_date)).to match(/^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])$/)
-          expect(meter.amr_data_feed_readings.maximum(:reading_date)).to match(/^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])$/)
-
+          expect(n3rgy_api).to receive(:readings).with(meter.mpan_mprn, meter.meter_type, earliest, yesterday).and_return(readings)
           upserter = Amr::N3rgyReadingsDownloadAndUpsert.new(n3rgy_api_factory: n3rgy_api_factory, config: config, meter: meter, start_date: nil, end_date: nil)
           upserter.perform
         end
 
-        it 'requests data from current last reading if first available date is equal to current first reading' do
-          available_range = (last_week..yesterday)
-          expect(n3rgy_api).to receive(:readings_available_date_range).with(meter.mpan_mprn, meter.fuel_type).and_return(available_range)
-          expect(n3rgy_api).to receive(:readings).with(meter.mpan_mprn, meter.meter_type, last_week + 2, yesterday).and_return(readings)
-
-          upserter = Amr::N3rgyReadingsDownloadAndUpsert.new(n3rgy_api_factory: n3rgy_api_factory, config: config, meter: meter, start_date: nil, end_date: nil)
-          upserter.perform
-        end
-
-        it 'requests data from 13 months ago if no available date range' do
+        it 'requests 12 months if no earliest data is unknown and no readings' do
           expect(n3rgy_api).to receive(:readings_available_date_range).with(meter.mpan_mprn, meter.fuel_type).and_return(nil)
           expect(n3rgy_api).to receive(:readings).with(meter.mpan_mprn, meter.meter_type, thirteen_months_ago, yesterday).and_return(readings)
 
+          meter.update!({
+            earliest_available_data: nil
+          })
+
           upserter = Amr::N3rgyReadingsDownloadAndUpsert.new(n3rgy_api_factory: n3rgy_api_factory, config: config, meter: meter, start_date: nil, end_date: nil)
           upserter.perform
+        end
+
+        context 'when there are readings' do
+          # Note: this is a Date object as the reading date needs to be stored in the database in ISO 8601 format e.g. 2023-06-29
+          let(:last_week) { Time.zone.today - 7 }
+
+          before do
+            create(:amr_data_feed_reading, meter: meter, reading_date: last_week)
+            create(:amr_data_feed_reading, meter: meter, reading_date: last_week + 1)
+            create(:amr_data_feed_reading, meter: meter, reading_date: last_week + 2)
+          end
+
+          it 'requests data from first available date if that was earlier than current first reading' do
+            available_range = (last_week - 1..yesterday)
+            expect(n3rgy_api).to receive(:readings_available_date_range).with(meter.mpan_mprn, meter.fuel_type).and_return(available_range)
+            expect(n3rgy_api).to receive(:readings).with(meter.mpan_mprn, meter.meter_type, last_week - 1, yesterday).and_return(readings)
+
+            # maximum and minimum amr data feed readings reading date should be in ISO 8601 format e.g. '2023-06-29'
+            expect(meter.amr_data_feed_readings.minimum(:reading_date)).to match(/^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])$/)
+            expect(meter.amr_data_feed_readings.maximum(:reading_date)).to match(/^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])$/)
+
+            upserter = Amr::N3rgyReadingsDownloadAndUpsert.new(n3rgy_api_factory: n3rgy_api_factory, config: config, meter: meter, start_date: nil, end_date: nil)
+            upserter.perform
+          end
+
+          it 'requests data from current last reading if first available date is equal to current first reading' do
+            available_range = (last_week..yesterday)
+            expect(n3rgy_api).to receive(:readings_available_date_range).with(meter.mpan_mprn, meter.fuel_type).and_return(available_range)
+            expect(n3rgy_api).to receive(:readings).with(meter.mpan_mprn, meter.meter_type, last_week + 2, yesterday).and_return(readings)
+
+            upserter = Amr::N3rgyReadingsDownloadAndUpsert.new(n3rgy_api_factory: n3rgy_api_factory, config: config, meter: meter, start_date: nil, end_date: nil)
+            upserter.perform
+          end
+
+          it 'requests data from 13 months ago if no available date range' do
+            expect(n3rgy_api).to receive(:readings_available_date_range).with(meter.mpan_mprn, meter.fuel_type).and_return(nil)
+            expect(n3rgy_api).to receive(:readings).with(meter.mpan_mprn, meter.meter_type, thirteen_months_ago, yesterday).and_return(readings)
+
+            upserter = Amr::N3rgyReadingsDownloadAndUpsert.new(n3rgy_api_factory: n3rgy_api_factory, config: config, meter: meter, start_date: nil, end_date: nil)
+            upserter.perform
+          end
+        end
+      end
+
+      context 'when upserting data' do
+        it 'results in new readings' do
+          expect(n3rgy_api).to receive(:readings).with(meter.mpan_mprn, meter.meter_type, start_date, end_date).and_return(readings)
+          upserter = Amr::N3rgyReadingsDownloadAndUpsert.new(n3rgy_api_factory: n3rgy_api_factory, config: config, meter: meter, start_date: start_date, end_date: end_date)
+          upserter.perform
+
+          expect(AmrDataFeedImportLog.count).to be 1
+          expect(AmrDataFeedReading.count).to be 1
         end
       end
     end
 
-    context 'when upserting data' do
-      it 'results in new readings' do
-        expect(n3rgy_api).to receive(:readings).with(meter.mpan_mprn, meter.meter_type, start_date, end_date).and_return(readings)
-        upserter = Amr::N3rgyReadingsDownloadAndUpsert.new(n3rgy_api_factory: n3rgy_api_factory, config: config, meter: meter, start_date: start_date, end_date: end_date)
-        upserter.perform
+    context 'with v2' do
+      let(:flag) { 'true' }
 
-        expect(AmrDataFeedImportLog.count).to be 1
-        expect(AmrDataFeedReading.count).to be 1
+      let(:downloader) { instance_double(Amr::N3rgyDownloader) }
+      let(:n3rgy_api_factory) { nil }
+
+      describe '#perform' do
+        context 'with an error downloading data' do
+          it 'handles and log exceptions' do
+            expect(AmrDataFeedImportLog.count).to be 0
+            allow(Amr::N3rgyDownloader).to receive(:new).and_return(downloader)
+            expect(downloader).to receive(:readings).and_raise(StandardError)
+
+            upserter = Amr::N3rgyReadingsDownloadAndUpsert.new(n3rgy_api_factory: n3rgy_api_factory, config: config, meter: meter, start_date: start_date, end_date: end_date)
+            upserter.perform
+
+            expect(AmrDataFeedImportLog.count).to be 1
+            expect(AmrDataFeedImportLog.first.error_messages).not_to be_blank
+          end
+        end
+
+        context 'when downloading data' do
+          let(:readings) { {} }
+
+          it 'uses start and end dates if provided' do
+            expect(Amr::N3rgyDownloader).to receive(:new).with(
+              meter: meter,
+              start_date: start_date,
+              end_date: end_date,
+              n3rgy_api: anything
+            ).and_return(downloader)
+            expect(downloader).to receive(:readings).and_return(readings)
+
+            upserter = Amr::N3rgyReadingsDownloadAndUpsert.new(n3rgy_api_factory: n3rgy_api_factory, config: config, meter: meter, start_date: start_date, end_date: end_date)
+            upserter.perform
+          end
+
+          it 'loads all available data if no dates specified' do
+            available_range = (earliest..yesterday)
+
+            metering_service_stub = double('metering-service')
+            expect(Meters::N3rgyMeteringService).to receive(:new).and_return(metering_service_stub)
+            expect(metering_service_stub).to receive(:available_data).and_return(available_range)
+
+            expect(Amr::N3rgyDownloader).to receive(:new).with(
+              meter: meter,
+              start_date: earliest,
+              end_date: yesterday,
+              n3rgy_api: anything
+            ).and_return(downloader)
+            expect(downloader).to receive(:readings).and_return(readings)
+
+            upserter = Amr::N3rgyReadingsDownloadAndUpsert.new(n3rgy_api_factory: n3rgy_api_factory, config: config, meter: meter, start_date: nil, end_date: nil)
+            upserter.perform
+          end
+
+          it 'requests 12 months by default if no other dates available' do
+            metering_service_stub = double('metering-service')
+            expect(Meters::N3rgyMeteringService).to receive(:new).and_return(metering_service_stub)
+            expect(metering_service_stub).to receive(:available_data).and_return(nil)
+
+            expect(Amr::N3rgyDownloader).to receive(:new).with(
+              meter: meter,
+              start_date: thirteen_months_ago,
+              end_date: yesterday,
+              n3rgy_api: anything
+            ).and_return(downloader)
+            expect(downloader).to receive(:readings).and_return(readings)
+
+            meter.update!({
+              earliest_available_data: nil
+            })
+
+            upserter = Amr::N3rgyReadingsDownloadAndUpsert.new(n3rgy_api_factory: n3rgy_api_factory, config: config, meter: meter, start_date: nil, end_date: nil)
+            upserter.perform
+          end
+
+          context 'when some readings have already been loaded' do
+            # Note: this is a Date object as the reading date needs to be stored in the database in ISO 8601 format e.g. 2023-06-29
+            let(:last_week) { Time.zone.today - 7 }
+
+            before do
+              create(:amr_data_feed_reading, meter: meter, reading_date: last_week)
+              create(:amr_data_feed_reading, meter: meter, reading_date: last_week + 1)
+              create(:amr_data_feed_reading, meter: meter, reading_date: last_week + 2)
+            end
+
+            it 'requests earlier data from n3rgy if they have data prior to the first reading' do
+              available_range = (last_week - 1..yesterday)
+
+              metering_service_stub = double('metering-service')
+              expect(Meters::N3rgyMeteringService).to receive(:new).and_return(metering_service_stub)
+              expect(metering_service_stub).to receive(:available_data).and_return(available_range)
+
+              expect(Amr::N3rgyDownloader).to receive(:new).with(
+                meter: meter,
+                start_date: last_week - 1,
+                end_date: yesterday,
+                n3rgy_api: anything
+              ).and_return(downloader)
+              expect(downloader).to receive(:readings).and_return(readings)
+
+              # maximum and minimum amr data feed readings reading date should be in ISO 8601 format e.g. '2023-06-29'
+              expect(meter.amr_data_feed_readings.minimum(:reading_date)).to match(/^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])$/)
+              expect(meter.amr_data_feed_readings.maximum(:reading_date)).to match(/^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])$/)
+
+              upserter = Amr::N3rgyReadingsDownloadAndUpsert.new(n3rgy_api_factory: n3rgy_api_factory, config: config, meter: meter, start_date: nil, end_date: nil)
+              upserter.perform
+            end
+
+            it 'requests newer data if we have the earliest readings' do
+              available_range = (last_week..yesterday)
+
+              metering_service_stub = double('metering-service')
+              expect(Meters::N3rgyMeteringService).to receive(:new).and_return(metering_service_stub)
+              expect(metering_service_stub).to receive(:available_data).and_return(available_range)
+
+              expect(Amr::N3rgyDownloader).to receive(:new).with(
+                meter: meter,
+                start_date: last_week + 2,
+                end_date: yesterday,
+                n3rgy_api: anything
+              ).and_return(downloader)
+              expect(downloader).to receive(:readings).and_return(readings)
+
+              upserter = Amr::N3rgyReadingsDownloadAndUpsert.new(n3rgy_api_factory: n3rgy_api_factory, config: config, meter: meter, start_date: nil, end_date: nil)
+              upserter.perform
+            end
+
+            it 'requests data from 13 months ago if no date ranges available from n3rgy' do
+              metering_service_stub = double('metering-service')
+              expect(Meters::N3rgyMeteringService).to receive(:new).and_return(metering_service_stub)
+              expect(metering_service_stub).to receive(:available_data).and_return(nil)
+
+              expect(Amr::N3rgyDownloader).to receive(:new).with(
+                meter: meter,
+                start_date: thirteen_months_ago,
+                end_date: yesterday,
+                n3rgy_api: anything
+              ).and_return(downloader)
+              expect(downloader).to receive(:readings).and_return(readings)
+
+              upserter = Amr::N3rgyReadingsDownloadAndUpsert.new(n3rgy_api_factory: n3rgy_api_factory, config: config, meter: meter, start_date: nil, end_date: nil)
+              upserter.perform
+            end
+          end
+        end
+
+        context 'when data is returned' do
+          it 'is inserted into the database' do
+            expect(Amr::N3rgyDownloader).to receive(:new).with(
+              meter: meter,
+              start_date: start_date,
+              end_date: end_date,
+              n3rgy_api: anything
+            ).and_return(downloader)
+            expect(downloader).to receive(:readings).and_return(readings)
+
+            upserter = Amr::N3rgyReadingsDownloadAndUpsert.new(n3rgy_api_factory: n3rgy_api_factory, config: config, meter: meter, start_date: start_date, end_date: end_date)
+            upserter.perform
+
+            expect(AmrDataFeedImportLog.count).to be 1
+            expect(AmrDataFeedReading.count).to be 1
+          end
+        end
       end
     end
   end

--- a/spec/services/amr/n3rgy_tariff_downloader_spec.rb
+++ b/spec/services/amr/n3rgy_tariff_downloader_spec.rb
@@ -1,0 +1,177 @@
+require 'rails_helper'
+
+describe Amr::N3rgyTariffDownloader, type: :service do
+  subject(:service) do
+    described_class.new(meter: meter)
+  end
+
+  let(:meter)     { create(:electricity_meter) }
+  let(:config)    { create(:amr_data_feed_config)}
+
+  let(:stub) { instance_double(DataFeeds::N3rgy::DataApiClient) }
+
+  before do
+    allow(DataFeeds::N3rgy::DataApiClient).to receive(:production_client).and_return(stub)
+    allow(stub).to receive(:tariff).with(meter.mpan_mprn, meter.meter_type).and_return(response.with_indifferent_access)
+  end
+
+  context 'with an unexpected response format' do
+    let(:response) do
+      {
+        devices: []
+      }
+    end
+
+    it 'returns nothing' do
+      expect(service.current_tariff).to be_nil
+    end
+
+    it 'raises error via Rollbar' do
+      expect(Rollbar).to receive(:error).with(anything, meter: meter.mpan_mprn, school: meter.school.name)
+      service.current_tariff
+    end
+  end
+
+  context 'with missing tariffs on meter' do
+    let(:response) do
+      {
+        "devices": [
+          {
+            "deviceId": '1-2-3-4',
+            "tariffs": [
+              {
+                "firstReading": '20231114005424',
+                "lastReading": '20240227010457',
+                "primaryActiveTariffPrice": 0,
+                "currencyUnitsName": 'Millipence',
+                "currencyUnitsLabel": 'GB Pounds',
+                "standingCharge": 0
+              }
+            ],
+            "months": []
+          }
+        ]
+      }
+    end
+
+    it 'returns nothing' do
+      expect(service.current_tariff).to be_nil
+    end
+  end
+
+  context 'with flat rate tariffs' do
+    let(:response) { JSON.parse(File.read('spec/fixtures/n3rgy/get-reading-type-tariff.json')) }
+
+    it 'parses the standing charge' do
+      expect(service.current_tariff[:standing_charge]).to be_within(0.00001).of(1.25246)
+    end
+
+    it 'parses the flat rate' do
+      expect(service.current_tariff[:flat_rate]).to be_within(0.00001).of(0.05648)
+    end
+  end
+
+  context 'with unsupported tariffs' do
+    let(:response) do
+      {
+        "devices": [
+          {
+            "deviceId": '1-2-3-4',
+            "tariffs": [
+              {
+                "primaryActiveTariffPrice": 123,
+                "standingCharge": 2
+              }
+            ],
+            "months": [
+              {
+                "days": [{
+                  "timePeriods": [{
+                    "start": '00:00',
+                    "end": '23:59',
+                    "prices": [
+                      "type": 'Block',
+                      "limit": '10.000',
+                      "value": 0.0
+                    ]
+                  }]
+                }]
+              }
+            ]
+          }
+        ]
+      }
+    end
+
+    it 'returns nothing' do
+      expect(service.current_tariff).to be_nil
+    end
+
+    it 'warns via Rollbar' do
+      expect(Rollbar).to receive(:warning).with(anything, meter: meter.mpan_mprn, school: meter.school.name)
+      service.current_tariff
+    end
+  end
+
+  context 'with differential tariffs' do
+    let(:response) do
+      {
+        "devices": [
+          {
+            "deviceId": '1-2-3-4',
+            "tariffs": [
+              {
+                "primaryActiveTariffPrice": 123,
+                "standingCharge": 125.246
+              }
+            ],
+            "months": [
+              {
+                "days": [{
+                  "timePeriods": [{
+                    "start": '00:00',
+                    "end": '07:00',
+                    "prices": [
+                      "type": 'TOU',
+                      "value": 5.0
+                    ]
+                  }, {
+                    "start": '07:00',
+                    "end": '23:59',
+                    "prices": [
+                      "type": 'TOU',
+                      "value": 10.0
+                    ]
+                  }]
+                }]
+              }
+            ]
+          }
+        ]
+      }
+    end
+
+    it 'parses the standing charge' do
+      expect(service.current_tariff[:standing_charge]).to be_within(0.00001).of(1.25246)
+    end
+
+    it 'parses the time periods' do
+      differential_prices = service.current_tariff[:differential]
+      expect(differential_prices).not_to be_nil
+      expect(differential_prices).to match_array([
+                                                   {
+                                                     start_time: '00:00',
+                                                     end_time: '07:00',
+                                                     value: 0.05,
+                                                     units: 'kwh'
+                                                   },
+                                                   {
+                                                     start_time: '07:00',
+                                                     end_time: '00:00',
+                                                     value: 0.1,
+                                                     units: 'kwh'
+                                                   }
+                                                 ])
+    end
+  end
+end

--- a/spec/services/amr/n3rgy_tariff_manager_spec.rb
+++ b/spec/services/amr/n3rgy_tariff_manager_spec.rb
@@ -1,0 +1,255 @@
+require 'rails_helper'
+
+describe Amr::N3rgyTariffManager do
+  subject(:service) do
+    described_class.new(meter: meter,
+      current_n3rgy_tariff: n3rgy_tariff,
+      import_log: import_log)
+  end
+
+  let(:meter) { create(:electricity_meter) }
+  let(:import_log) { create(:tariff_import_log) }
+
+  let(:n3rgy_tariff) { nil }
+
+  context 'when there are no stored tariffs' do
+    let(:energy_tariff)  { EnergyTariff.first }
+    let(:prices)         { energy_tariff.energy_tariff_prices }
+    let(:charges)        { energy_tariff.energy_tariff_charges }
+
+    before do
+      service.perform
+    end
+
+    context 'with a flat_rate tariff from n3rgy' do
+      let(:n3rgy_tariff) do
+        {
+          standing_charge: 1.25,
+          flat_rate: 0.05
+        }
+      end
+
+      it 'creates a new tariff' do
+        expect(energy_tariff).not_to be_nil
+        expect(energy_tariff.source.to_sym).to eq :dcc
+        expect(energy_tariff.enabled).to be true
+        expect(energy_tariff.tariff_holder).to eq meter.school
+        expect(energy_tariff.meters).to match_array([meter])
+        expect(energy_tariff.tariff_type.to_sym).to eq :flat_rate
+        expect(energy_tariff.name).not_to be_nil
+      end
+
+      it 'creates the prices' do
+        expect(prices.count).to eq 1
+        expect(prices.first.value).to eq 0.05
+      end
+
+      it 'creates the charges' do
+        expect(charges.count).to eq 1
+        expect(charges.first.charge_type.to_sym).to eq :standing_charge
+        expect(charges.first.value).to eq 1.25
+      end
+    end
+
+    context 'with a differential tariff from n3rgy' do
+      let(:n3rgy_tariff) do
+        {
+          standing_charge: 1.25,
+          differential: [
+            { start_time: '00:00', end_time: '07:00', value: 0.05, units: 'kwh' },
+            { start_time: '07:00', end_time: '00:00', value: 0.10, units: 'kwh' },
+          ]
+        }
+      end
+
+      it 'creates a new tariff' do
+        expect(energy_tariff.tariff_type.to_sym).to eq :differential
+      end
+
+      it 'creates the prices' do
+        expect(prices.count).to eq 2
+        first = prices.order(start_time: :asc).first
+        expect(first.value).to eq 0.05
+        expect(first.start_time.strftime('%H:%M')).to eq '00:00'
+        expect(first.end_time.strftime('%H:%M')).to eq '07:00'
+
+        last = prices.order(start_time: :asc).last
+        expect(last.value).to eq 0.10
+        expect(last.start_time.strftime('%H:%M')).to eq '07:00'
+        expect(last.end_time.strftime('%H:%M')).to eq '00:00'
+      end
+
+      it 'creates the charges' do
+        expect(charges.count).to eq 1
+        expect(charges.first.charge_type.to_sym).to eq :standing_charge
+        expect(charges.first.value).to eq 1.25
+      end
+    end
+  end
+
+  context 'when there is a stored tariff' do
+    let!(:energy_tariff) do
+      create(:energy_tariff, :with_flat_price, source: :dcc, school: meter.school, meters: [meter], value: 0.1, end_date: nil)
+    end
+    let!(:existing_charge) do
+      create(:energy_tariff_charge, energy_tariff: energy_tariff, charge_type: :standing_charge, units: :day, value: 1.25)
+    end
+
+    context 'with no valid tariffs from n3rgy' do
+      it 'expires the current tariff' do
+        service.perform
+        energy_tariff.reload
+        expect(energy_tariff.end_date).not_to be_nil
+      end
+    end
+
+    context 'when flat rate tariff has not changed' do
+      let(:n3rgy_tariff) do
+        {
+          standing_charge: 1.25,
+          flat_rate: 0.1
+        }
+      end
+
+      it 'does not expire the tariff' do
+        expect { service.perform }.not_to change(EnergyTariff, :count)
+        energy_tariff.reload
+        expect(energy_tariff.end_date).to be_nil
+      end
+    end
+
+    context 'when the stored tariff has expired' do
+      let!(:energy_tariff) do
+        create(:energy_tariff, :with_flat_price, source: :dcc, school: meter.school, meters: [meter], value: 0.1, end_date: Time.zone.today - 2.days)
+      end
+      let(:n3rgy_tariff) do
+        {
+          standing_charge: 1.25,
+          flat_rate: 0.1
+        }
+      end
+
+      it 'adds a new tariff' do
+        expect { service.perform }.to change(EnergyTariff, :count).by(1)
+      end
+    end
+
+    context 'when standing charge has changed' do
+      let(:n3rgy_tariff) do
+        {
+          standing_charge: 1.00,
+          flat_rate: 0.1
+        }
+      end
+
+      it 'creates a new tariff' do
+        expect { service.perform }.to change(EnergyTariff, :count).by(1)
+        energy_tariff.reload
+        expect(energy_tariff.end_date).not_to be_nil
+      end
+    end
+
+    context 'when the type of tariff has changed' do
+      let(:n3rgy_tariff) do
+        {
+          standing_charge: 1.25,
+          differential: [
+            { start_time: '00:00', end_time: '07:00', value: 0.05, units: 'kwh' },
+            { start_time: '07:00', end_time: '00:00', value: 0.10, units: 'kwh' },
+          ]
+        }
+      end
+
+      it 'creates a new tariff' do
+        expect { service.perform }.to change(EnergyTariff, :count).by(1)
+        energy_tariff.reload
+        expect(energy_tariff.end_date).not_to be_nil
+      end
+    end
+
+    context 'when the differential prices have changed' do
+      let!(:existing_energy_tariff) do
+        create(:energy_tariff, tariff_type: :differential, source: :dcc, school: meter.school, meters: [meter], end_date: nil)
+      end
+      let!(:existing_period_1) do
+        create(:energy_tariff_price, energy_tariff: existing_energy_tariff, value: 0.44, units: :kwh, start_time: '00:00', end_time: '07:00')
+      end
+      let!(:existing_period_2) do
+        create(:energy_tariff_price, energy_tariff: existing_energy_tariff, value: 0.88, units: :kwh, start_time: '07:00', end_time: '00:00')
+      end
+
+      let(:n3rgy_tariff) do
+        {
+          standing_charge: 1.25,
+          differential: [
+            { start_time: '00:00', end_time: '07:00', value: 0.05, units: 'kwh' },
+            { start_time: '07:00', end_time: '00:00', value: 0.10, units: 'kwh' },
+          ]
+        }
+      end
+
+      it 'creates a new tariff' do
+        expect { service.perform }.to change(EnergyTariff, :count).by(1)
+        energy_tariff.reload
+        expect(energy_tariff.end_date).to be_nil
+      end
+    end
+
+    context 'when the differential period time ranges have changed' do
+      let!(:existing_energy_tariff) do
+        create(:energy_tariff, tariff_type: :differential, source: :dcc, school: meter.school, meters: [meter], end_date: nil)
+      end
+      let!(:existing_period_1) do
+        create(:energy_tariff_price, energy_tariff: existing_energy_tariff, value: 0.44, units: :kwh, start_time: '00:00', end_time: '07:00')
+      end
+      let!(:existing_period_2) do
+        create(:energy_tariff_price, energy_tariff: existing_energy_tariff, value: 0.88, units: :kwh, start_time: '07:00', end_time: '00:00')
+      end
+
+      let(:n3rgy_tariff) do
+        {
+          standing_charge: 1.25,
+          differential: [
+            { start_time: '00:00', end_time: '06:30', value: 0.44, units: 'kwh' },
+            { start_time: '06:30', end_time: '00:00', value: 0.88, units: 'kwh' },
+          ]
+        }
+      end
+
+      it 'creates a new tariff' do
+        expect { service.perform }.to change(EnergyTariff, :count).by(1)
+        energy_tariff.reload
+        expect(energy_tariff.end_date).to be_nil
+      end
+    end
+
+    context 'when the number of differential periods has changed' do
+      let!(:existing_energy_tariff) do
+        create(:energy_tariff, tariff_type: :differential, source: :dcc, school: meter.school, meters: [meter], end_date: nil)
+      end
+      let!(:existing_period_1) do
+        create(:energy_tariff_price, energy_tariff: existing_energy_tariff, value: 0.44, units: :kwh, start_time: '00:00', end_time: '07:00')
+      end
+      let!(:existing_period_2) do
+        create(:energy_tariff_price, energy_tariff: existing_energy_tariff, value: 0.88, units: :kwh, start_time: '07:00', end_time: '00:00')
+      end
+
+      let(:n3rgy_tariff) do
+        {
+          standing_charge: 1.25,
+          differential: [
+            { start_time: '00:00', end_time: '04:30', value: 0.44, units: 'kwh' },
+            { start_time: '04:30', end_time: '07:00', value: 0.88, units: 'kwh' },
+            { start_time: '07:00', end_time: '00:00', value: 0.55, units: 'kwh' },
+          ]
+        }
+      end
+
+      it 'creates a new tariff' do
+        expect { service.perform }.to change(EnergyTariff, :count).by(1)
+        energy_tariff.reload
+        expect(energy_tariff.end_date).to be_nil
+      end
+    end
+  end
+end

--- a/spec/services/amr/n3rgy_tariff_manager_spec.rb
+++ b/spec/services/amr/n3rgy_tariff_manager_spec.rb
@@ -21,6 +21,19 @@ describe Amr::N3rgyTariffManager do
       service.perform
     end
 
+    context 'with an invalid tariff' do
+      let(:n3rgy_tariff) do
+        {
+          standing_charge: -7.152,
+          flat_rate: 0.05
+        }
+      end
+
+      it 'does not create a tariff' do
+        expect(energy_tariff).to be_nil
+      end
+    end
+
     context 'with a flat_rate tariff from n3rgy' do
       let(:n3rgy_tariff) do
         {

--- a/spec/services/meters/dcc_checker_spec.rb
+++ b/spec/services/meters/dcc_checker_spec.rb
@@ -2,37 +2,97 @@ require 'rails_helper'
 
 module Meters
   describe DccChecker do
-    let(:n3rgy_api)         { double(:n3rgy_api) }
-    let(:n3rgy_api_factory) { double(:n3rgy_api_factory, data_api: n3rgy_api) }
+    subject(:service) do
+      Meters::DccChecker.new([meter], n3rgy_api_factory)
+    end
+
+    around do |example|
+      ClimateControl.modify FEATURE_FLAG_N3RGY_V2: flag do
+        example.run
+      end
+    end
 
     let(:meter) { create(:electricity_meter, dcc_meter: false) }
 
-    it 'sets dcc true and timestamp if found' do
-      expect(n3rgy_api).to receive(:find).with(meter.mpan_mprn).and_return(true)
-      Meters::DccChecker.new([meter], n3rgy_api_factory).perform
-      expect(meter.reload.dcc_meter).to be_truthy
-      expect(meter.reload.dcc_checked_at).not_to be nil
+    context 'with v1' do
+      let(:flag) {'false'}
+      let(:n3rgy_api)         { double(:n3rgy_api) }
+      let(:n3rgy_api_factory) { double(:n3rgy_api_factory, data_api: n3rgy_api) }
+
+      context 'when not found' do
+        it 'sets timestamp' do
+          expect(n3rgy_api).to receive(:find).with(meter.mpan_mprn).and_return(false)
+          service.perform
+          expect(meter.reload.dcc_meter).to be_falsey
+          expect(meter.reload.dcc_checked_at).not_to be nil
+        end
+
+        it 'does not generate an email' do
+          expect(n3rgy_api).to receive(:find).with(meter.mpan_mprn).and_return(false)
+          expect do
+            service.perform
+          end.not_to change(ActionMailer::Base.deliveries, :count)
+        end
+      end
+
+      context 'when found' do
+        it 'sets dcc true and timestamp if found' do
+          expect(n3rgy_api).to receive(:find).with(meter.mpan_mprn).and_return(true)
+          service.perform
+          expect(meter.reload.dcc_meter).to be_truthy
+          expect(meter.reload.dcc_checked_at).not_to be nil
+        end
+
+        it 'generates an email if status changed' do
+          expect(n3rgy_api).to receive(:find).with(meter.mpan_mprn).and_return(true)
+          expect do
+            service.perform
+          end.to change(ActionMailer::Base.deliveries, :count).from(0).to(1)
+        end
+      end
     end
 
-    it 'sets timestamp if not found' do
-      expect(n3rgy_api).to receive(:find).with(meter.mpan_mprn).and_return(false)
-      Meters::DccChecker.new([meter], n3rgy_api_factory).perform
-      expect(meter.reload.dcc_meter).to be_falsey
-      expect(meter.reload.dcc_checked_at).not_to be nil
-    end
+    context 'with v2' do
+      let(:flag) {'true'}
+      let(:n3rgy_api_factory) { nil }
 
-    it 'generates an email if status changed' do
-      expect(n3rgy_api).to receive(:find).with(meter.mpan_mprn).and_return(true)
-      expect do
-        Meters::DccChecker.new([meter], n3rgy_api_factory).perform
-      end.to change(ActionMailer::Base.deliveries, :count).from(0).to(1)
-    end
+      before do
+        allow(DataFeeds::N3rgy::DataApiClient).to receive(:production_client).and_return(n3rgy_data_api_client)
+      end
 
-    it 'does not generate an email if status not changed' do
-      expect(n3rgy_api).to receive(:find).with(meter.mpan_mprn).and_return(false)
-      expect do
-        Meters::DccChecker.new([meter], n3rgy_api_factory).perform
-      end.not_to change(ActionMailer::Base.deliveries, :count)
+      let(:n3rgy_data_api_client) { double(:n3rgy_data_api_client) }
+
+      context 'when not found' do
+        it 'sets timestamp' do
+          expect(n3rgy_data_api_client).to receive(:find_mpxn).with(meter.mpan_mprn).and_raise(DataFeeds::N3rgy::NotFound.new)
+          service.perform
+          expect(meter.reload.dcc_meter).to be_falsey
+          expect(meter.reload.dcc_checked_at).not_to be nil
+        end
+
+        it 'does not generate an email' do
+          expect(n3rgy_data_api_client).to receive(:find_mpxn).with(meter.mpan_mprn).and_raise(DataFeeds::N3rgy::NotFound.new)
+          expect do
+            service.perform
+          end.not_to change(ActionMailer::Base.deliveries, :count)
+        end
+      end
+
+      context 'when found' do
+        it 'sets dcc true and timestamp if found' do
+          expect(n3rgy_data_api_client).to receive(:find_mpxn).with(meter.mpan_mprn).and_return(true)
+          service.perform
+          expect(meter.reload.dcc_meter).to be_truthy
+          expect(meter.reload.dcc_checked_at).not_to be nil
+        end
+
+        it 'generates an email if status changed' do
+          expect(n3rgy_data_api_client).to receive(:find_mpxn).with(meter.mpan_mprn).and_return(true)
+          expect do
+            service.perform
+          end.to change(ActionMailer::Base.deliveries, :count).from(0).to(1)
+        end
+      end
     end
   end
 end

--- a/spec/services/meters/dcc_grant_trusted_consents_spec.rb
+++ b/spec/services/meters/dcc_grant_trusted_consents_spec.rb
@@ -2,16 +2,48 @@ require 'rails_helper'
 
 module Meters
   describe DccGrantTrustedConsents do
-    let(:n3rgy_api)         { double(:n3rgy_api) }
-    let(:n3rgy_api_factory) { double(:n3rgy_api_factory, consent_api: n3rgy_api) }
+    subject(:service) do
+      described_class.new([meter], n3rgy_api_factory)
+    end
+
+    around do |example|
+      ClimateControl.modify FEATURE_FLAG_N3RGY_V2: flag do
+        example.run
+      end
+    end
 
     let(:meter) { create(:electricity_meter, dcc_meter: true) }
     let(:meter_review) { create(:meter_review, meters: [meter]) }
 
-    it 'calls consent api and set consent_granted flag' do
-      expect(n3rgy_api).to receive(:grant_trusted_consent).with(meter.mpan_mprn, meter_review.consent_grant.guid).and_return(true)
-      Meters::DccGrantTrustedConsents.new([meter], n3rgy_api_factory).perform
-      expect(meter.reload.consent_granted).to be_truthy
+    context 'with v1' do
+      let(:flag) { 'false' }
+      let(:n3rgy_api)         { double(:n3rgy_api) }
+      let(:n3rgy_api_factory) { double(:n3rgy_api_factory, consent_api: n3rgy_api) }
+
+      it 'calls consent api and set consent_granted flag' do
+        expect(n3rgy_api).to receive(:grant_trusted_consent).with(meter.mpan_mprn,
+          meter_review.consent_grant.guid).and_return(true)
+        service.perform
+        expect(meter.reload.consent_granted).to be_truthy
+      end
+
+      context 'with v2' do
+        let(:flag) { 'true' }
+
+        before do
+          allow(DataFeeds::N3rgy::ConsentApiClient).to receive(:production_client).and_return(n3rgy_consent_api_client)
+        end
+
+        let(:n3rgy_consent_api_client) { double(:n3rgy_consent_api_client) }
+        let(:n3rgy_api_factory) { nil }
+
+        it 'calls consent api and set consent_granted flag' do
+          expect(n3rgy_consent_api_client).to receive(:add_trusted_consent).with(meter.mpan_mprn,
+            meter_review.consent_grant.guid).and_return(true)
+          service.perform
+          expect(meter.reload.consent_granted).to be_truthy
+        end
+      end
     end
   end
 end

--- a/spec/services/meters/dcc_withdraw_trusted_consents_spec.rb
+++ b/spec/services/meters/dcc_withdraw_trusted_consents_spec.rb
@@ -2,26 +2,66 @@ require 'rails_helper'
 
 module Meters
   describe DccWithdrawTrustedConsents do
-    let(:n3rgy_api)         { double(:n3rgy_api) }
-    let(:n3rgy_api_factory) { double(:n3rgy_api_factory, consent_api: n3rgy_api) }
+    subject(:service) do
+      described_class.new([meter], n3rgy_api_factory)
+    end
+
+    around do |example|
+      ClimateControl.modify FEATURE_FLAG_N3RGY_V2: flag do
+        example.run
+      end
+    end
 
     let(:meter) { create(:electricity_meter, dcc_meter: true, consent_granted: true) }
     let(:meter_review) { create(:meter_review, meters: [meter]) }
 
-    it 'calls consent api and set consent_granted flag' do
-      expect(n3rgy_api).to receive(:withdraw_trusted_consent)
-                             .with(meter.mpan_mprn)
-                             .and_return(true)
-      Meters::DccWithdrawTrustedConsents.new([meter], n3rgy_api_factory).perform
-      expect(meter.reload.consent_granted).to be_falsey
+    context 'with v1' do
+      let(:flag) { 'false' }
+      let(:n3rgy_api)         { double(:n3rgy_api) }
+      let(:n3rgy_api_factory) { double(:n3rgy_api_factory, consent_api: n3rgy_api) }
+
+      it 'calls consent api and set consent_granted flag' do
+        expect(n3rgy_api).to receive(:withdraw_trusted_consent)
+                               .with(meter.mpan_mprn)
+                               .and_return(true)
+        service.perform
+        expect(meter.reload.consent_granted).to be_falsey
+      end
+
+      it 'sets flag even if api raises an error' do
+        expect(n3rgy_api).to receive(:withdraw_trusted_consent)
+                               .with(meter.mpan_mprn)
+                               .and_raise(MeterReadingsFeeds::N3rgyConsentApi::ConsentFailed.new('No consent found'))
+        service.perform
+        expect(meter.reload.consent_granted).to be_falsey
+      end
     end
 
-    it 'sets flag even if api raises an error' do
-      expect(n3rgy_api).to receive(:withdraw_trusted_consent)
-                             .with(meter.mpan_mprn)
-                             .and_raise(MeterReadingsFeeds::N3rgyConsentApi::ConsentFailed.new('No consent found'))
-      Meters::DccWithdrawTrustedConsents.new([meter], n3rgy_api_factory).perform
-      expect(meter.reload.consent_granted).to be_falsey
+    context 'with v2' do
+      let(:flag) { 'true' }
+      let(:n3rgy_api_factory) { nil }
+
+      before do
+        allow(DataFeeds::N3rgy::ConsentApiClient).to receive(:production_client).and_return(n3rgy_consent_api_client)
+      end
+
+      let(:n3rgy_consent_api_client) { double(:n3rgy_consent_api_client) }
+
+      it 'calls consent api and set consent_granted flag' do
+        expect(n3rgy_consent_api_client).to receive(:withdraw_consent)
+                               .with(meter.mpan_mprn)
+                               .and_return(true)
+        service.perform
+        expect(meter.reload.consent_granted).to be_falsey
+      end
+
+      it 'sets flag even if api raises an error' do
+        expect(n3rgy_consent_api_client).to receive(:withdraw_consent)
+                               .with(meter.mpan_mprn)
+                               .and_raise(DataFeeds::N3rgy::ConsentFailure.new('No consent found'))
+        service.perform
+        expect(meter.reload.consent_granted).to be_falsey
+      end
     end
   end
 end

--- a/spec/system/admin/reports/tariffs_report_spec.rb
+++ b/spec/system/admin/reports/tariffs_report_spec.rb
@@ -6,9 +6,9 @@ describe 'TariffsReport', type: :system, include_application_helper: true do
   let(:school)                  { create(:school, school_group: school_group) }
   let(:school_without_group)    { create(:school) }
 
-  let!(:meter)                  { create(:electricity_meter, dcc_meter: true, school: school) }
+  let!(:meter)                  { create(:electricity_meter, dcc_meter: true, consent_granted: true, school: school) }
 
-  let!(:meter_without_group)    { create(:electricity_meter, dcc_meter: true, school: school_without_group) }
+  let!(:meter_without_group)    { create(:electricity_meter, dcc_meter: true, consent_granted: true, school: school_without_group) }
 
   # let!(:standing_charge_1) { create(:tariff_standing_charge, meter: meter, value: 1.23, start_date: Date.parse('2020-01-01')) }
   # let!(:standing_charge_2) { create(:tariff_standing_charge, meter: meter, value: 1.23, start_date: Date.parse('2020-01-02')) }


### PR DESCRIPTION
Version 2 of the n3rgy API makes some small and some larger changes to how we'll be retrieving data

Minor changes include:

- new base url
- new header for authentication
- some API paths have been altered
 
Larger changes:

- entirely new response format for the meter readings, which may now have multiple "devices" and a primary/second reading value
- entirely new response format for the tariff API which no longer offers a half-hourly breakdown so some custom code required to interpret the tariffs
- some method API methods which aren't relevant to us

This PR:

- [x] adds a new n3rgy API client in the application. The intention is retire the existing v1 code and utilities that are in the analytics. There's some duplicate code and its overly complicated. Trying to maintain the API client separately from the application is also too frustrating when testing and making changes. The client only implements the basic methods we need at the moment
- [x] creates a separate service `Meters::N3rgyMeteringService` to provide a utility layer over the basic API
- [x] changes the service that checks for whether a meter is available in the n3rgy API to use the new client
- [x] changes the services that grant/withdraw consent to use v2
- [x] changes the admin report on DCC meters to use v2
- [x] changes the diagnostic information on the meter pages to use v2
- [x] changes the data loader to use v2 API
- [x] reworks the tariff loader to use v2, via two new classes: `Amr::N3rgyTariffDownloader` and `Amr::N3rgyTariffManager`
- [x] fixes a bug in the old n3rgy tariff loader, which was causing creating of duplicate tariffs

The majority of these changes are behind a feature flag `FEATURE_FLAG_N3RGY_V2`.

Once we've activated the feature and everything looks OK we can retire some of the code in the application and [all of this code in the analytics](https://github.com/Energy-Sparks/energy-sparks_analytics/tree/4110-peak-school-day-electricity-use/lib/dashboard/data_sources/metering/n3rgy) as its either been replaced or made obsolete by the API changes.