### PR TITLE
Misc bug fixes for n3rgy consent and meter review workflow

### DIFF
--- a/app/models/meter.rb
+++ b/app/models/meter.rb
@@ -82,7 +82,7 @@ class Meter < ApplicationRecord
   scope :not_dcc, -> { where(dcc_meter: false) }
   scope :dcc, -> { where(dcc_meter: true) }
   scope :consented, -> { where(dcc_meter: true, consent_granted: true) }
-  scope :not_recently_checked, -> { where('dcc_checked_at is NULL OR dcc_checked_at < ?', 1.month.ago) }
+  scope :not_recently_checked, -> { where('dcc_checked_at is NULL OR dcc_checked_at < ?', 7.days.ago) }
   scope :meters_to_check_against_dcc, -> { main_meter.not_dcc.not_recently_checked }
   scope :data_source_known, -> { where.not(data_source: nil) }
   scope :procurement_route_known, -> { where.not(procurement_route: nil) }

--- a/app/services/meter_review_service.rb
+++ b/app/services/meter_review_service.rb
@@ -9,7 +9,7 @@ class MeterReviewService
   end
 
   def self.find_schools_needing_review
-    Meter.unreviewed_dcc_meter.map(&:school).sort_by(&:name).uniq
+    Meter.unreviewed_dcc_meter.from_active_schools.map(&:school).sort_by(&:name).uniq
   end
 
   def complete_review!(meters, consent_documents = [])

--- a/lib/data_feeds/n3rgy/consent_api_client.rb
+++ b/lib/data_feeds/n3rgy/consent_api_client.rb
@@ -12,7 +12,7 @@ module DataFeeds
       end
 
       def self.production_client
-        ConsentApiClient.new(api_key: ENV['N3RGY_API_KEY'], base_url: ENV['N3RGY_DATA_URL_V2'])
+        ConsentApiClient.new(api_key: ENV['N3RGY_API_KEY'], base_url: ENV['N3RGY_CONSENT_URL_V2'])
       end
 
       def add_trusted_consent(mpxn, reference, move_in_date = '2012-01-01')

--- a/lib/tasks/deployment/20240229143940_remove_sandbox_meters.rake
+++ b/lib/tasks/deployment/20240229143940_remove_sandbox_meters.rake
@@ -1,0 +1,19 @@
+namespace :after_party do
+  desc 'Deployment task: remove_sandbox_meters'
+  task remove_sandbox_meters: :environment do
+    puts "Running deploy task 'remove_sandbox_meters'"
+
+    # Remove all of the old v1 n3rgy api sandbox meters
+    Meter.where(dcc_meter: true, sandbox: true).each do |meter|
+      manager = MeterManagement.new(meter)
+      manager.deactivate_meter!
+      manager.remove_data!
+      manager.delete_meter!
+    end
+
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord
+      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+  end
+end

--- a/spec/services/meter_review_service_spec.rb
+++ b/spec/services/meter_review_service_spec.rb
@@ -11,6 +11,15 @@ RSpec.describe MeterReviewService do
 
   let!(:service)               { MeterReviewService.new(school, admin) }
 
+  describe '.find_schools_needing_review' do
+    let!(:inactive) { create(:school, active: false) }
+
+    it 'lists only active schools' do
+      create(:electricity_meter, school: inactive, dcc_meter: true, consent_granted: false)
+      expect(MeterReviewService.find_schools_needing_review).to match_array([school])
+    end
+  end
+
   context 'when completing a review' do
     before do
       allow_any_instance_of(MeterManagement).to receive(:is_meter_known_to_n3rgy?).and_return(true)


### PR DESCRIPTION
- fixed environment variable name in consent api client. I obviously hadn't pushed this fix to my previous branch
- changes frequency at which we check whether a meter is in n3rgy to 1 week from 1 month, so they'll be ready for review quicker
- only include active schools in list of meter reviews as a quality of live improvement for admins
- remove the 'sandbox' meters we had configured for v1 of the n3rgy API. These are no longer needed.