### PR TITLE
Change when consent is withdrawn via n3rgy API

### DIFF
--- a/app/services/meter_management.rb
+++ b/app/services/meter_management.rb
@@ -64,6 +64,9 @@ class MeterManagement
   def delete_meter!
     @meter.transaction do
       AggregateSchoolService.new(@meter.school).invalidate_cache
+      if @meter.can_withdraw_consent?
+        Meters::DccWithdrawTrustedConsents.new([@meter]).perform
+      end
       @meter.destroy
     end
   end

--- a/app/services/meter_management.rb
+++ b/app/services/meter_management.rb
@@ -94,9 +94,7 @@ class MeterManagement
 
   def remove_data!(archive: false)
     result = true
-    if @meter.can_withdraw_consent?
-      Meters::DccWithdrawTrustedConsents.new([@meter]).perform
-    end
+    Meters::DccWithdrawTrustedConsents.new([@meter]).perform if @meter.can_withdraw_consent?
     @meter.transaction do
       @meter.amr_data_feed_readings.delete_all unless archive
       @meter.amr_validated_readings.delete_all

--- a/app/services/meter_management.rb
+++ b/app/services/meter_management.rb
@@ -84,9 +84,6 @@ class MeterManagement
     result = true
     @meter.transaction do
       @meter.update!(active: false)
-      if @meter.can_withdraw_consent?
-        result = Meters::DccWithdrawTrustedConsents.new([@meter]).perform
-      end
     end
     broadcast(:meter_deactivated, @meter)
     result
@@ -94,6 +91,9 @@ class MeterManagement
 
   def remove_data!(archive: false)
     result = true
+    if @meter.can_withdraw_consent?
+      Meters::DccWithdrawTrustedConsents.new([@meter]).perform
+    end
     @meter.transaction do
       @meter.amr_data_feed_readings.delete_all unless archive
       @meter.amr_validated_readings.delete_all

--- a/lib/tasks/amr_importer/import_n3rgy_readings.rake
+++ b/lib/tasks/amr_importer/import_n3rgy_readings.rake
@@ -9,7 +9,7 @@ namespace :amr do
     end_date = Date.parse(args[:end_date]) if args[:end_date].present?
 
     puts "#{DateTime.now.utc} #{config.description} start"
-    Meter.where(dcc_meter: true, consent_granted: true).each do |meter|
+    Meter.where(active: true, dcc_meter: true, consent_granted: true).each do |meter|
       Amr::N3rgyReadingsDownloadAndUpsert.new(meter: meter, config: config, start_date: start_date, end_date: end_date).perform
     end
     puts "#{DateTime.now.utc} #{config.description} end"

--- a/lib/tasks/amr_importer/import_n3rgy_tariffs.rake
+++ b/lib/tasks/amr_importer/import_n3rgy_tariffs.rake
@@ -4,7 +4,7 @@ namespace :amr do
     start_date = Date.parse(args[:start_date]) if args[:start_date].present?
     end_date = Date.parse(args[:end_date]) if args[:end_date].present?
 
-    meters = Meter.where(dcc_meter: true, consent_granted: true)
+    meters = Meter.where(active: true, dcc_meter: true, consent_granted: true)
 
     puts "#{DateTime.now.utc} import_n3rgy_tariffs start for #{meters.count} meters"
     meters.each do |meter|

--- a/spec/services/meter_management_spec.rb
+++ b/spec/services/meter_management_spec.rb
@@ -157,12 +157,13 @@ describe MeterManagement do
         expect(meter.active).to be_truthy
       end
 
-      it 'sets meter inactive and unconsents' do
-        expect_any_instance_of(Meters::DccWithdrawTrustedConsents).to receive(:perform).and_return(true)
+      it 'sets meter inactive' do
+        expect_any_instance_of(Meters::DccGrantTrustedConsents).not_to receive(:perform)
         meter.update(active: true, consent_granted: true)
         MeterManagement.new(meter).deactivate_meter!
         meter.reload
         expect(meter.active).to be_falsey
+        expect(meter.consent_granted).to be_truthy
       end
 
       it 'removes amr data feed readings' do
@@ -171,9 +172,10 @@ describe MeterManagement do
       end
 
       context 'when meter has validated readings' do
-        let!(:meter) { create(:electricity_meter_with_validated_reading, dcc_meter: true) }
+        let!(:meter) { create(:electricity_meter_with_validated_reading, dcc_meter: true, consent_granted: true) }
 
         it 'removes validated readings' do
+          expect_any_instance_of(Meters::DccWithdrawTrustedConsents).to receive(:perform).and_return(true)
           MeterManagement.new(meter).remove_data!
           expect(meter.amr_validated_readings.count).to eq 0
         end


### PR DESCRIPTION
Currently when we deactivate a meter we issue a "withdraw consent" request to the n3rgy API.

It turns out that n3rgy actually handle consent slightly differently to what we expected. Issuing consent for a given MPxN actually results in consent being granted for all meters at that address, not the specific meter used in the API request. So, for example, using the electricity meter MPAN will also grant consent to access the gas data. There's not a more granular way to grant/withdraw consent that for the whole address (or more accurately the HAN to which the MPxN is connected).

This means our current approach of removing consent if the electricity meter is disabled may end up removing access to the gas data, which isn't what was intended.

This PR changes the meter management service so that:

- if a meter is deleted, we withdraw consent
- if we remove all data for a meter, we withdraw consent
- if we deactivate a meter, then consent is not withdrawn
- if we activate a meter, and we can grant consent then we do so. This ensures that any outstanding requests are still made

The PR also changes the rake tasks that load readings and tariffs to only process active meters. Previously because consent was removed when a meter was made inactive it wouldn't have been picked up.