### PR TITLE
Add geographic area form fields to school configuration

### DIFF
--- a/app/controllers/schools/configuration_controller.rb
+++ b/app/controllers/schools/configuration_controller.rb
@@ -41,7 +41,10 @@ module Schools
         :scoreboard_id,
         :school_group_id,
         :weather_station_id,
-        :funder_id
+        :funder_id,
+        :region,
+        :local_authority_area_id,
+        :country
       )
     end
 

--- a/app/views/schools/configuration/_form.html.erb
+++ b/app/views/schools/configuration/_form.html.erb
@@ -1,47 +1,143 @@
-<h1>Configuration: <%= school.name %> </h1>
+<h1><%= school.name %> Configuration</h1>
+
+<p>
+  This form provides information that is used internally by Energy Sparks to support data analysis and
+  reporting for the school. With the exception of the country field, these settings are not available to users.
+</p>
 
 <%= form_for(school, url: school_configuration_path, method: method) do |f| %>
-  <p>Energy sparks uses a variety of data feeds to analyse energy usage for your school. The data is more accurate if the correct areas are used for gathering the data.</p>
+
+  <h3>Basic Configuration</h3>
   <div class="form-row">
     <div class="form-group col-md-6">
       <%= f.label :school_group_id, 'School group' %>
-      <%= f.select :school_group_id, options_from_collection_for_select(SchoolGroup.order(:name), 'id', 'name', (@school.school_group.id if @school.school_group)),{}, { class: 'form-control' }%>
-    </div>
-  </div>
-  <div class="form-group">
-    <%= f.label :template_calendar_id, 'Template calendar' %>
-    <%= f.select :template_calendar_id, options_from_collection_for_select(Calendar.regional.order(:title), 'id', 'title', (@school.template_calendar_id if @school.template_calendar)),{},{ disabled: !edit_template_calendar, class: 'form-control' }%>
-  </div>
-  <div class="form-row">
-    <div class="form-group col-md-6">
-      <%= f.label :solar_pv_tuos_area_id, 'Solar PV from The University of Sheffield Data Feed Area' %>
-      <%= f.select :solar_pv_tuos_area_id, options_from_collection_for_select(SolarPvTuosArea.all.active.order(:title), 'id', 'title', (@school.solar_pv_tuos_area.id if @school.solar_pv_tuos_area)),{}, { class: 'form-control' }%>
-    </div>
-  </div>
-  <div class="form-row">
-    <div class="form-group col-md-6">
-      <%= f.label :dark_sky_area_id, 'Dark Sky Data Feed Area' %>
-      <%= f.select :dark_sky_area_id, options_from_collection_for_select(DarkSkyArea.order(:title), 'id', 'title', (@school.dark_sky_area.id if @school.dark_sky_area)),{include_blank: true}, { class: 'form-control' }%>
+      <%= f.select :school_group_id,
+                   options_from_collection_for_select(
+                     SchoolGroup.order(:name),
+                     'id',
+                     'name',
+                     @school&.school_group&.id
+                   ),
+                   {},
+                   { class: 'form-control' } %>
     </div>
   </div>
   <div class="form-row">
     <div class="form-group col-md-6">
-      <%= f.label :weather_station_id, 'Weather Station' %>
-      <%= f.select :weather_station_id, options_from_collection_for_select(WeatherStation.by_title, 'id', 'title', (@school.weather_station_id if @school.weather_station)), { }, { class: 'form-control' }%>
+      <%= f.label :template_calendar_id, 'Template calendar' %>
+      <%= f.select :template_calendar_id,
+                   options_from_collection_for_select(
+                     Calendar.regional.order(:title), 'id', 'title', @school&.template_calendar&.id
+                   ),
+                   {},
+                   { disabled: !edit_template_calendar, class: 'form-control' } %>
     </div>
   </div>
   <div class="form-row">
     <div class="form-group col-md-6">
       <%= f.label :scoreboard_id, 'Scoreboard' %>
-      <%= f.select :scoreboard_id, options_from_collection_for_select(@scoreboards, 'id', 'name', (@school.scoreboard.id if @school.scoreboard)),{}, { class: 'form-control' }%>
+      <%= f.select :scoreboard_id,
+                    options_from_collection_for_select(
+                      @scoreboards,
+                      'id',
+                      'name',
+                      @school&.scoreboard&.id
+                    ),
+                    {},
+                    { class: 'form-control' } %>
     </div>
   </div>
   <div class="form-row">
     <div class="form-group col-md-6">
       <%= f.label :funder_id, 'Funder' %>
-      <%= f.select :funder_id, options_for_select(Funder.all.order(name: :asc).pluck(:name, :id), school.funder_id), { include_blank: true }, { class: 'form-control' } %>
+      <%= f.select :funder_id,
+                   options_for_select(Funder.all.order(name: :asc).pluck(:name, :id), school.funder_id),
+                   { include_blank: true },
+                   { class: 'form-control' } %>
     </div>
   </div>
+
+  <h3>Weather and Solar Data Feeds</h3>
+  <p>Select the right data sources to support analysis of school data.</p>
+
+  <div class="form-row">
+    <div class="form-group col-md-6">
+      <%= f.label :solar_pv_tuos_area_id, 'The University of Sheffield Solar Data Feed Area' %>
+      <%= f.select :solar_pv_tuos_area_id,
+                   options_from_collection_for_select(
+                     SolarPvTuosArea.all.active.order(:title),
+                     'id',
+                     'title',
+                     @school&.solar_pv_tuos_area&.id
+                   ),
+                   {},
+                   { class: 'form-control' } %>
+    </div>
+  </div>
+  <div class="form-row">
+    <div class="form-group col-md-6">
+      <%= f.label :weather_station_id, 'Weather Station' %>
+      <%= f.select :weather_station_id,
+                   options_from_collection_for_select(
+                     WeatherStation.by_title, 'id', 'title', @school&.weather_station&.id
+                   ),
+                   {},
+                   { class: 'form-control' } %>
+    </div>
+  </div>
+  <div class="form-row">
+    <div class="form-group col-md-6">
+      <%= f.label :dark_sky_area_id, 'Dark Sky Data Feed Area' %>
+      <%= f.select :dark_sky_area_id,
+                   options_from_collection_for_select(
+                     DarkSkyArea.order(:title), 'id', 'title', @school&.dark_sky_area&.id
+                   ),
+                   { include_blank: true },
+                   { class: 'form-control' } %>
+      <small class="form-text text-muted">Provided for historical data access for older schools</small>
+    </div>
+  </div>
+
+  <h3>Geographic areas</h3>
+  <p>These areas are used for reporting and allocations schools to funders.</p>
+
+  <div class="form-row">
+    <div class="form-group col-md-6">
+      <%= f.label :local_authority_area_id, 'Local Authority Area' %>
+      <%= f.select :local_authority_area_id,
+                   options_for_select(
+                     LocalAuthorityArea.all.order(name: :asc).pluck(:name, :id), school.local_authority_area_id
+                   ),
+                   { include_blank: false },
+                   { class: 'form-control' } %>
+      <small class="form-text text-muted">Local authority areas cover the whole of England, Wales and Scotland</small>
+    </div>
+  </div>
+  <div class="form-row">
+    <div class="form-group col-md-6">
+      <%= f.label :region, 'Region' %>
+      <%= f.select :region,
+                   options_for_select(School.regions.map { |key, _value| [key.humanize, key] }, f.object.region),
+                   { include_blank: true },
+                   { class: 'form-control' } %>
+      <small class="form-text text-muted">Government Office Regions don't cover Scotland or Wales, so leave
+        bank for schools in those countries</small>
+    </div>
+  </div>
+  <div class="form-row">
+    <div class="form-group col-md-6">
+      <%= f.label :country %>
+      <%= f.select :country,
+                   options_for_select(
+                     School.countries.map { |key, _value| [t("school_statistics.#{key}"), key] }, f.object.country
+                   ),
+                   { include_blank: false },
+                   { class: 'form-control' } %>
+      <small class="form-text text-muted">Note: this option is available to school admins on the school details form.
+        <br>It will be automatically populated based on the school postcode</small>
+    </div>
+  </div>
+
   <div class="actions">
     <%= f.submit submit_text, class: 'btn btn-primary' %>
   </div>

--- a/app/views/schools/configuration/_form.html.erb
+++ b/app/views/schools/configuration/_form.html.erb
@@ -87,7 +87,7 @@
   </div>
   <div class="form-row">
     <div class="form-group col-md-6">
-      <%= f.label :dark_sky_area_id, 'Dark Sky Data Feed Area' %>
+      <%= f.label :dark_sky_area_id, 'Dark Sky Area' %>
       <%= f.select :dark_sky_area_id,
                    options_from_collection_for_select(
                      DarkSkyArea.order(:title), 'id', 'title', @school&.dark_sky_area&.id

--- a/spec/system/admin/school_configuration_spec.rb
+++ b/spec/system/admin/school_configuration_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'editing school details', type: :system do
+RSpec.describe 'editing school configuration', type: :system do
   let!(:admin)              { create(:admin)}
   let!(:school)             { create(:school)}
 

--- a/spec/system/admin/school_configuration_spec.rb
+++ b/spec/system/admin/school_configuration_spec.rb
@@ -1,0 +1,103 @@
+require 'rails_helper'
+
+RSpec.describe 'editing school details', type: :system do
+  let!(:admin)              { create(:admin)}
+  let!(:school)             { create(:school)}
+
+  before do
+    sign_in(admin)
+    visit school_path(school)
+  end
+
+  context 'when editing basic configuration' do
+    let!(:school_group) { create(:school_group) }
+    let!(:scoreboard) { create(:scoreboard) }
+    let!(:funder) { create(:funder) }
+
+    before do
+      click_on('School configuration')
+    end
+
+    it 'allows school group to be updated' do
+      select school_group.name, from: 'School group'
+      click_on('Update configuration')
+      school.reload
+      expect(school.school_group).to eq school_group
+    end
+
+    it 'allows scoreboard to be updated' do
+      select scoreboard.name, from: 'Scoreboard'
+      click_on('Update configuration')
+      school.reload
+      expect(school.scoreboard).to eq scoreboard
+    end
+
+    it 'allows funder to be updated' do
+      select funder.name, from: 'Funder'
+      click_on('Update configuration')
+      school.reload
+      expect(school.funder).to eq funder
+    end
+  end
+
+  context 'when editing data feeds' do
+    let!(:weather_station) { create(:weather_station) }
+    let!(:solar_pv_tuos_area) { create(:solar_pv_tuos_area) }
+    let!(:dark_sky_area) { create(:dark_sky_area) }
+
+    before do
+      click_on('School configuration')
+    end
+
+    it 'allows weather station to be updated' do
+      select weather_station.title, from: 'Weather Station'
+      click_on('Update configuration')
+      school.reload
+      expect(school.weather_station).to eq weather_station
+    end
+
+    it 'allows dark sky area to be updated' do
+      select dark_sky_area.title, from: 'Dark Sky Area'
+      click_on('Update configuration')
+      school.reload
+      expect(school.dark_sky_area).to eq dark_sky_area
+    end
+
+    it 'allows solar area to be updated' do
+      select solar_pv_tuos_area.title, from: 'The University of Sheffield Solar Data Feed Area'
+      click_on('Update configuration')
+      school.reload
+      expect(school.solar_pv_tuos_area).to eq solar_pv_tuos_area
+    end
+  end
+
+  context 'when editing geographic areas' do
+    let!(:local_authority_area) { create(:local_authority_area) }
+
+    before do
+      click_on('School configuration')
+    end
+
+    it 'allows region to be updated' do
+      select 'London', from: 'Region'
+      click_on('Update configuration')
+      school.reload
+      expect(school.region).to eq('london')
+    end
+
+    it 'allows local authority area to be updated' do
+      select local_authority_area.name, from: 'Local Authority Area'
+      click_on('Update configuration')
+      school.reload
+      expect(school.local_authority_area).to eq(local_authority_area)
+    end
+
+    it 'allows country to be updated' do
+      expect(school.country).to eq('england')
+      select 'Wales', from: 'Country'
+      click_on('Update configuration')
+      school.reload
+      expect(school.country).to eq('wales')
+    end
+  end
+end

--- a/spec/system/admin/school_editing_spec.rb
+++ b/spec/system/admin/school_editing_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'manage school configuration', type: :system do
+RSpec.describe 'editing school details', type: :system do
   let!(:admin)              { create(:admin)}
 
   let!(:ks1)                { KeyStage.create(name: 'KS1') }
@@ -13,9 +13,7 @@ RSpec.describe 'manage school configuration', type: :system do
   before do
     sign_in(admin)
     visit root_path
-    expect(page.has_content?('Sign Out')).to be true
     click_on('View schools')
-    expect(page.has_content?('Energy Sparks schools across the UK')).to be true
   end
 
   it 'I can set up a school for KS1' do
@@ -113,7 +111,7 @@ RSpec.describe 'manage school configuration', type: :system do
     expect(school.enable_targets_feature?).to be false
   end
 
-  context 'can update storage heaters' do
+  context 'when updating storage heaters' do
     it 'and changes are saved' do
       click_on(school_name)
       click_on('Edit school details')


### PR DESCRIPTION
The School model has fields for region (Government Office Region) and local authority area (Local Authority Districts). These currently don't support any direct functionality and are just used to support funder allocation and reporting.

The fields were originally populated by matching school geographic areas to the region polygons in QGIS. There's a separate PR refreshing that data.

This PR makes the fields available for admins to manage in the School Configuration page.

The functional changes are:

- add fields for region, local authority area and country to allow these to be managed in one place
- updates to controller
- added a basic set of tests to confirm form fields work
 
Non-functional changes:

- adding some sub-headings and comments to the configuration page to improve the layout slightly
- moved the existing file called `school_configuration_spec.rb` to be called `school_editing_spec.rb` as its testing a different form
- extensive tidying of the configuration form to try and make ERB Lint happy (didn't entirely succeed, but couldn't fix final indent requirement and autocorrect just broken the file formatting)
