### PR TITLE
Add Rollbar warning for multiple devices in HAN

### DIFF
--- a/app/services/amr/n3rgy_downloader.rb
+++ b/app/services/amr/n3rgy_downloader.rb
@@ -81,6 +81,7 @@ module Amr
       # within the SMETS standard for there to be up to 5 devices of the same type,
       # e.g. 5 electricity meters. But this is an edge case and in practice they
       # would all have MPANs.
+      warn_if_multiple_devices(response)
       #
       # The responses may also contain a secondaryValue which we are also ignoring
       # for the moment. These are for Twin Element Electricity Meters which monitor
@@ -105,6 +106,15 @@ module Amr
 
     def api_client
       DataFeeds::N3rgy::DataApiClient.production_client
+    end
+
+    def warn_if_multiple_devices(response)
+      if response['devices'].length > 1
+        Rollbar.warning("Multiple devices (#{response['devices'].length}) present in n3rgy readings API",
+                      meter: @meter.mpan_mprn,
+                      school: @meter.school.name
+                    )
+      end
     end
   end
 end

--- a/spec/services/amr/n3rgy_downloader_spec.rb
+++ b/spec/services/amr/n3rgy_downloader_spec.rb
@@ -107,6 +107,25 @@ describe Amr::N3rgyDownloader do
             expect(readings_by_day[start_date].kwh_data_x48).to eq(adjusted)
           end
         end
+
+        context 'when there are multiple devices' do
+          let(:response) do
+            original = JSON.parse(File.read('spec/fixtures/n3rgy/get-reading-type-consumption.json'))
+            original['devices'] << original['devices'][0] # duplicate the entries
+            original
+          end
+
+          it 'still extract readings from first device' do
+            readings_by_day = readings[meter.meter_type][:readings]
+            # Match readings from fixture
+            expect(readings_by_day[start_date].kwh_data_x48).to eq(fixture_readings)
+          end
+
+          it 'logs to Rollbar' do
+            expect(Rollbar).to receive(:warning).with(anything, meter: meter.mpan_mprn, school: meter.school.name)
+            readings
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
The new n3rgy API is designed to support a wider range of metering scenarios than v1. Specifically it allows for a scenario where a HAN (Home Area Network) has multiple devices for the same type. E.g. multiple electricity meters.

In a domestic setting this is very unlikely to happen and, so far, it doesn't seem to be the case with schools. All currently schools only have one meter of each type (gas, electricity).

This PR adds a Rollbar warning if, after retrieving data, we find readings for multiple meters. It still continues to return readings but warns us so we can investigate.

This seems an unlikely scenario. It's more likely that any additional meters will have their own MPANs and, presumably, networks. But this should reduce the likelihood of us incorrectly loading data if it does happen.