### PR TITLE
Progress against electricity target

### DIFF
--- a/app/controllers/comparisons/base_controller.rb
+++ b/app/controllers/comparisons/base_controller.rb
@@ -95,32 +95,5 @@ module Comparisons
       schools.select {|s| can?(:show, s) } unless include_invisible
       schools
     end
-
-    # borrowed from Tristan's code that's not yet merged yet :-)
-    def create_single_number_chart(results, name, multiplier, series_name, y_axis_label)
-      chart_data = {}
-
-      # Some charts also set x_max_value to 100 if there are metric values > 100
-      # Removes issues with schools with large % changes breaking the charts
-      #
-      # This could be done by clipping values to 100.0 if the metric has a
-      # unit of percentage/relative_percent
-      results.each do |result|
-        metric = result.send(name)
-        next if metric.nil? || metric.nan? || metric.infinite?
-
-        # for a percentage metric we'd multiply * 100.0
-        # for converting from kW to W 1000.0
-        metric *= multiplier unless multiplier.nil?
-        chart_data[result.school.name] = metric
-      end
-
-      [{
-        id: :comparison,
-        x_axis: chart_data.keys,
-        x_data: { I18n.t("analytics.benchmarking.configuration.column_headings.#{series_name}") => chart_data.values },
-        y_axis_label: I18n.t("chart_configuration.y_axis_label_name.#{y_axis_label}")
-      }]
-    end
   end
 end

--- a/app/controllers/comparisons/base_controller.rb
+++ b/app/controllers/comparisons/base_controller.rb
@@ -95,5 +95,31 @@ module Comparisons
       schools.select {|s| can?(:show, s) } unless include_invisible
       schools
     end
+
+    def create_single_number_chart(results, name, multiplier, series_name, y_axis_label)
+      chart_data = {}
+
+      # Some charts also set x_max_value to 100 if there are metric values > 100
+      # Removes issues with schools with large % changes breaking the charts
+      #
+      # This could be done by clipping values to 100.0 if the metric has a
+      # unit of percentage/relative_percent
+      results.each do |result|
+        metric = result.send(name)
+        next if metric.nil? || metric.nan? || metric.infinite?
+
+        # for a percentage metric we'd multiply * 100.0
+        # for converting from kW to W 1000.0
+        metric *= multiplier unless multiplier.nil?
+        chart_data[result.school.name] = metric
+      end
+
+      [{
+        id: :comparison,
+        x_axis: chart_data.keys,
+        x_data: { I18n.t("analytics.benchmarking.configuration.column_headings.#{series_name}") => chart_data.values },
+        y_axis_label: I18n.t("chart_configuration.y_axis_label_name.#{y_axis_label}")
+      }]
+    end
   end
 end

--- a/app/controllers/comparisons/base_controller.rb
+++ b/app/controllers/comparisons/base_controller.rb
@@ -96,6 +96,7 @@ module Comparisons
       schools
     end
 
+    # borrowed from Tristan's code that's not yet merged yet :-)
     def create_single_number_chart(results, name, multiplier, series_name, y_axis_label)
       chart_data = {}
 

--- a/app/controllers/comparisons/electricity_targets_controller.rb
+++ b/app/controllers/comparisons/electricity_targets_controller.rb
@@ -15,7 +15,7 @@ module Comparisons
     end
 
     def create_charts(results)
-      create_single_number_chart(results, :current_year_percent_of_target_relative, nil, :percent_above_or_below_target_since_target_set, 'percent')
+      create_single_number_chart(results, :current_year_percent_of_target_relative, :percent_above_or_below_target_since_target_set, :percent)
     end
   end
 end

--- a/app/controllers/comparisons/electricity_targets_controller.rb
+++ b/app/controllers/comparisons/electricity_targets_controller.rb
@@ -1,0 +1,24 @@
+module Comparisons
+  class ElectricityTargetsController < BaseController
+    private
+
+    def key
+      :electricity_targets
+    end
+
+    def advice_page_key
+      :your_advice_page_key
+    end
+
+    def load_data
+      Comparison::ElectricityTargets.where(school: @schools).where.not(variable_name: nil).order(variable_name: :desc)
+    end
+
+    def create_charts(results)
+      chart_data = {}
+
+      puts chart_data.inspect
+      puts results.inspect
+    end
+  end
+end

--- a/app/controllers/comparisons/electricity_targets_controller.rb
+++ b/app/controllers/comparisons/electricity_targets_controller.rb
@@ -11,7 +11,7 @@ module Comparisons
     end
 
     def load_data
-      Comparison::ElectricityTargets.where(school: @schools).with_data.default_sort
+      Comparison::ElectricityTargets.where(school: @schools).with_data.sort_default
     end
 
     def create_charts(results)

--- a/app/controllers/comparisons/electricity_targets_controller.rb
+++ b/app/controllers/comparisons/electricity_targets_controller.rb
@@ -7,18 +7,15 @@ module Comparisons
     end
 
     def advice_page_key
-      :your_advice_page_key
+      :electricity_long_term
     end
 
     def load_data
-      Comparison::ElectricityTargets.where(school: @schools).where.not(variable_name: nil).order(variable_name: :desc)
+      Comparison::ElectricityTargets.where(school: @schools).with_data.default_sort
     end
 
     def create_charts(results)
-      chart_data = {}
-
-      puts chart_data.inspect
-      puts results.inspect
+      create_single_number_chart(results, :current_year_percent_of_target_relative, nil, 'percent_above_or_below_target_since_target_set', 'percent')
     end
   end
 end

--- a/app/controllers/comparisons/electricity_targets_controller.rb
+++ b/app/controllers/comparisons/electricity_targets_controller.rb
@@ -15,7 +15,7 @@ module Comparisons
     end
 
     def create_charts(results)
-      create_single_number_chart(results, :current_year_percent_of_target_relative, nil, 'percent_above_or_below_target_since_target_set', 'percent')
+      create_single_number_chart(results, :current_year_percent_of_target_relative, nil, :percent_above_or_below_target_since_target_set, 'percent')
     end
   end
 end

--- a/app/models/comparison/electricity_targets.rb
+++ b/app/models/comparison/electricity_targets.rb
@@ -14,5 +14,5 @@
 #
 class Comparison::ElectricityTargets < Comparison::View
   scope :with_data, -> { where.not(current_year_kwh: nil, current_year_target_kwh: nil) }
-  scope :default_sort, -> { order(current_year_percent_of_target_relative: :desc) }
+  scope :sort_default, -> { order(current_year_percent_of_target_relative: :desc) }
 end

--- a/app/models/comparison/electricity_targets.rb
+++ b/app/models/comparison/electricity_targets.rb
@@ -1,0 +1,2 @@
+class Comparison::ElectricityTargets < Comparison::View
+end

--- a/app/models/comparison/electricity_targets.rb
+++ b/app/models/comparison/electricity_targets.rb
@@ -1,2 +1,18 @@
+# == Schema Information
+#
+# Table name: electricity_targets
+#
+#  alert_generation_run_id                          :bigint(8)
+#  current_year_kwh                                 :float
+#  current_year_percent_of_target_relative          :float
+#  current_year_target_kwh                          :float
+#  current_year_unscaled_percent_of_target_relative :float
+#  id                                               :bigint(8)
+#  school_id                                        :bigint(8)
+#  tracking_start_date                              :date
+#  unscaled_target_kwh_to_date                      :float
+#
 class Comparison::ElectricityTargets < Comparison::View
+  scope :with_data, -> { where.not(current_year_kwh: nil, current_year_target_kwh: nil) }
+  scope :default_sort, -> { order(current_year_percent_of_target_relative: :desc) }
 end

--- a/app/views/comparisons/electricity_targets/_tables.html.erb
+++ b/app/views/comparisons/electricity_targets/_tables.html.erb
@@ -3,19 +3,51 @@
     <tr>
       <th><%= t('analytics.benchmarking.configuration.column_headings.school') %></th>
       <th class="text-right">
-        More headings like this
+        <%= t('analytics.benchmarking.configuration.column_headings.percent_above_or_below_target_since_target_set') %>
+      </th>
+      <th class="text-right">
+        <%= t('analytics.benchmarking.configuration.column_headings.percent_above_or_below_last_year') %>
+      </th>
+      <th class="text-right">
+        <%= t('analytics.benchmarking.configuration.column_headings.kwh_consumption_since_target_set') %>
+      </th>
+      <th class="text-right">
+        <%= t('analytics.benchmarking.configuration.column_headings.target_kwh_consumption') %>
+      </th>
+      <th class="text-right">
+        <%= t('analytics.benchmarking.configuration.column_headings.last_year_kwh_consumption') %>
+      </th>
+      <th class="text-right">
+        <%= t('analytics.benchmarking.configuration.column_headings.start_date_for_target') %>
       </th>
     </tr>
   </thead>
   <tbody>
-    <% results.each do |electricity_targets| %>
+    <% results.each do |row| %>
       <tr>
         <td>
-          <%= link_to electricity_targets.school.name,
-                      advice_page_path(electricity_targets.school, advice_page, :insights) %>
+          <%= link_to row.school.name,
+                      advice_page_path(row.school, advice_page, :insights) %>
         </td>
         <td class="text-right">
-          More data like this
+          <%= up_downify(format_unit(row.current_year_percent_of_target_relative, :relative_percent, true, :benchmark)) %>
+        </td>
+        <td class="text-right">
+          <%= up_downify(format_unit(
+                           row.current_year_unscaled_percent_of_target_relative, :relative_percent, true, :benchmark
+                         )) %>
+        </td>
+        <td class="text-right">
+          <%= format_unit(row.current_year_kwh, :kwh, true, :benchmark) %>
+        </td>
+        <td class="text-right">
+          <%= format_unit(row.current_year_target_kwh, :kwh, true, :benchmark) %>
+        </td>
+        <td class="text-right">
+          <%= format_unit(row.unscaled_target_kwh_to_date, :kwh, true, :benchmark) %>
+        </td>
+        <td class="text-right">
+          <%= format_unit(row.tracking_start_date, :date, true, :benchmark) %>
         </td>
       </tr>
     <% end %>
@@ -26,6 +58,7 @@
         <p>
           <strong><%= t('analytics.benchmarking.content.footnotes.notes') %></strong>
         </p>
+        <%= t('analytics.benchmarking.configuration.column_heading_explanation.last_year_definition_html') %>
       </td>
     </tr>
   </tfoot>

--- a/app/views/comparisons/electricity_targets/_tables.html.erb
+++ b/app/views/comparisons/electricity_targets/_tables.html.erb
@@ -1,0 +1,32 @@
+<table id="comparison-table" class="table advice-table table-sorted">
+  <thead>
+    <tr>
+      <th><%= t('analytics.benchmarking.configuration.column_headings.school') %></th>
+      <th class="text-right">
+        More headings like this
+      </th>
+    </tr>
+  </thead>
+  <tbody>
+    <% results.each do |electricity_targets| %>
+      <tr>
+        <td>
+          <%= link_to electricity_targets.school.name,
+                      advice_page_path(electricity_targets.school, advice_page, :insights) %>
+        </td>
+        <td class="text-right">
+          More data like this
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+  <tfoot>
+    <tr>
+      <td colspan="6">
+        <p>
+          <strong><%= t('analytics.benchmarking.content.footnotes.notes') %></strong>
+        </p>
+      </td>
+    </tr>
+  </tfoot>
+</table>

--- a/config/initializers/rails_7/generators_actions.rb
+++ b/config/initializers/rails_7/generators_actions.rb
@@ -1,0 +1,531 @@
+# frozen_string_literal: true
+
+require "shellwords"
+require "active_support/core_ext/kernel/reporting"
+require "active_support/core_ext/string/strip"
+
+
+### REMOVE WHEN UPGRADING TO RAILS 7 ###
+
+module Rails
+  module Generators
+    module Actions
+      def initialize(*) # :nodoc:
+        super
+        @indentation = 0
+      end
+
+      # Adds a +gem+ declaration to the +Gemfile+ for the specified gem.
+      #
+      #   gem "rspec", group: :test
+      #   gem "technoweenie-restful-authentication", lib: "restful-authentication", source: "http://gems.github.com/"
+      #   gem "rails", "3.0", git: "https://github.com/rails/rails"
+      #   gem "RedCloth", ">= 4.1.0", "< 4.2.0"
+      #   gem "rspec", comment: "Put this comment above the gem declaration"
+      #
+      # Note that this method only adds the gem to the +Gemfile+; it does not
+      # install the gem.
+      #
+      # ==== Options
+      #
+      # [+:version+]
+      #   The version constraints for the gem, specified as a string or an
+      #   array of strings:
+      #
+      #     gem "my_gem", version: "~> 1.1"
+      #     gem "my_gem", version: [">= 1.1", "< 2.0"]
+      #
+      #   Alternatively, can be specified as one or more arguments following the
+      #   gem name:
+      #
+      #     gem "my_gem", ">= 1.1", "< 2.0"
+      #
+      # [+:comment+]
+      #   Outputs a comment above the +gem+ declaration in the +Gemfile+.
+      #
+      #     gem "my_gem", comment: "First line.\nSecond line."
+      #
+      #   Outputs:
+      #
+      #     # First line.
+      #     # Second line.
+      #     gem "my_gem"
+      #
+      # [+:group+]
+      #   The gem group in the +Gemfile+ that the gem belongs to.
+      #
+      # [+:git+]
+      #   The URL of the git repository for the gem.
+      #
+      # Any additional options passed to this method will be appended to the
+      # +gem+ declaration in the +Gemfile+. For example:
+      #
+      #   gem "my_gem", comment: "Edge my_gem", git: "https://example.com/my_gem.git", branch: "master"
+      #
+      # Outputs:
+      #
+      #   # Edge my_gem
+      #   gem "my_gem", git: "https://example.com/my_gem.git", branch: "master"
+      #
+      def gem(*args)
+        options = args.extract_options!
+        name, *versions = args
+
+        # Set the message to be shown in logs. Uses the git repo if one is given,
+        # otherwise use name (version).
+        parts, message = [ quote(name) ], name.dup
+
+        # Output a comment above the gem declaration.
+        comment = options.delete(:comment)
+
+        if versions = versions.any? ? versions : options.delete(:version)
+          _versions = Array(versions)
+          _versions.each do |version|
+            parts << quote(version)
+          end
+          message << " (#{_versions.join(", ")})"
+        end
+        message = options[:git] if options[:git]
+
+        log :gemfile, message
+
+        parts << quote(options) unless options.empty?
+
+        in_root do
+          str = []
+          if comment
+            comment.each_line do |comment_line|
+              str << indentation
+              str << "# #{comment_line}"
+            end
+            str << "\n"
+          end
+          str << indentation
+          str << "gem #{parts.join(", ")}"
+          append_file_with_newline "Gemfile", str.join, verbose: false
+        end
+      end
+
+      # Wraps gem entries inside a group.
+      #
+      #   gem_group :development, :test do
+      #     gem "rspec-rails"
+      #   end
+      def gem_group(*names, &block)
+        options = names.extract_options!
+        str = names.map(&:inspect)
+        str << quote(options) unless options.empty?
+        str = str.join(", ")
+        log :gemfile, "group #{str}"
+
+        in_root do
+          append_file_with_newline "Gemfile", "\ngroup #{str} do", force: true
+          with_indentation(&block)
+          append_file_with_newline "Gemfile", "end", force: true
+        end
+      end
+
+      def github(repo, options = {}, &block)
+        str = [quote(repo)]
+        str << quote(options) unless options.empty?
+        str = str.join(", ")
+        log :github, "github #{str}"
+
+        in_root do
+          if @indentation.zero?
+            append_file_with_newline "Gemfile", "\ngithub #{str} do", force: true
+          else
+            append_file_with_newline "Gemfile", "#{indentation}github #{str} do", force: true
+          end
+          with_indentation(&block)
+          append_file_with_newline "Gemfile", "#{indentation}end", force: true
+        end
+      end
+
+      # Add the given source to +Gemfile+
+      #
+      # If block is given, gem entries in block are wrapped into the source group.
+      #
+      #   add_source "http://gems.github.com/"
+      #
+      #   add_source "http://gems.github.com/" do
+      #     gem "rspec-rails"
+      #   end
+      def add_source(source, options = {}, &block)
+        log :source, source
+
+        in_root do
+          if block
+            append_file_with_newline "Gemfile", "\nsource #{quote(source)} do", force: true
+            with_indentation(&block)
+            append_file_with_newline "Gemfile", "end", force: true
+          else
+            prepend_file "Gemfile", "source #{quote(source)}\n", verbose: false
+          end
+        end
+      end
+
+      # Adds configuration code to a \Rails runtime environment.
+      #
+      # By default, adds code inside the +Application+ class in
+      # +config/application.rb+ so that it applies to all environments.
+      #
+      #   environment %(config.asset_host = "cdn.provider.com")
+      #
+      # Results in:
+      #
+      #   # config/application.rb
+      #   class Application < Rails::Application
+      #     config.asset_host = "cdn.provider.com"
+      #     # ...
+      #   end
+      #
+      # If the +:env+ option is specified, the code will be added to the
+      # corresponding file in +config/environments+ instead.
+      #
+      #   environment %(config.asset_host = "localhost:3000"), env: "development"
+      #
+      # Results in:
+      #
+      #   # config/environments/development.rb
+      #   Rails.application.configure do
+      #     config.asset_host = "localhost:3000"
+      #     # ...
+      #   end
+      #
+      # +:env+ can also be an array. In which case, the code is added to each
+      # corresponding file in +config/environments+.
+      #
+      # The code can also be specified as the return value of the block:
+      #
+      #   environment do
+      #     %(config.asset_host = "cdn.provider.com")
+      #   end
+      #
+      #   environment(nil, env: "development") do
+      #     %(config.asset_host = "localhost:3000")
+      #   end
+      #
+      def environment(data = nil, options = {})
+        sentinel = "class Application < Rails::Application\n"
+        env_file_sentinel = "Rails.application.configure do\n"
+        data ||= yield if block_given?
+
+        in_root do
+          if options[:env].nil?
+            inject_into_file "config/application.rb", optimize_indentation(data, 4), after: sentinel, verbose: false
+          else
+            Array(options[:env]).each do |env|
+              inject_into_file "config/environments/#{env}.rb", optimize_indentation(data, 2), after: env_file_sentinel, verbose: false
+            end
+          end
+        end
+      end
+      alias :application :environment
+
+      # Runs one or more git commands.
+      #
+      #   git :init
+      #   # => runs `git init`
+      #
+      #   git add: "this.file that.rb"
+      #   # => runs `git add this.file that.rb`
+      #
+      #   git commit: "-m 'First commit'"
+      #   # => runs `git commit -m 'First commit'`
+      #
+      #   git add: "good.rb", rm: "bad.cxx"
+      #   # => runs `git add good.rb; git rm bad.cxx`
+      #
+      def git(commands = {})
+        if commands.is_a?(Symbol)
+          run "git #{commands}"
+        else
+          commands.each do |cmd, options|
+            run "git #{cmd} #{options}"
+          end
+        end
+      end
+
+      # Creates a file in +vendor/+. The contents can be specified as an
+      # argument or as the return value of the block.
+      #
+      #   vendor "foreign.rb", <<~RUBY
+      #     # Foreign code is fun
+      #   RUBY
+      #
+      #   vendor "foreign.rb" do
+      #     "# Foreign code is fun"
+      #   end
+      #
+      def vendor(filename, data = nil)
+        log :vendor, filename
+        data ||= yield if block_given?
+        create_file("vendor/#{filename}", optimize_indentation(data), verbose: false)
+      end
+
+      # Creates a file in +lib/+. The contents can be specified as an argument
+      # or as the return value of the block.
+      #
+      #   lib "foreign.rb", <<~RUBY
+      #     # Foreign code is fun
+      #   RUBY
+      #
+      #   lib "foreign.rb" do
+      #     "# Foreign code is fun"
+      #   end
+      #
+      def lib(filename, data = nil)
+        log :lib, filename
+        data ||= yield if block_given?
+        create_file("lib/#{filename}", optimize_indentation(data), verbose: false)
+      end
+
+      # Creates a Rake tasks file in +lib/tasks/+. The code can be specified as
+      # an argument or as the return value of the block.
+      #
+      #   rakefile "bootstrap.rake", <<~RUBY
+      #     task :bootstrap do
+      #       puts "Boots! Boots! Boots!"
+      #     end
+      #   RUBY
+      #
+      #   rakefile "bootstrap.rake" do
+      #     project = ask("What is the UNIX name of your project?")
+      #
+      #     <<~RUBY
+      #       namespace :#{project} do
+      #         task :bootstrap do
+      #           puts "Boots! Boots! Boots!"
+      #         end
+      #       end
+      #     RUBY
+      #   end
+      #
+      def rakefile(filename, data = nil)
+        log :rakefile, filename
+        data ||= yield if block_given?
+        create_file("lib/tasks/#{filename}", optimize_indentation(data), verbose: false)
+      end
+
+      # Creates an initializer file in +config/initializers/+. The code can be
+      # specified as an argument or as the return value of the block.
+      #
+      #   initializer "api.rb", <<~RUBY
+      #     API_KEY = "123456"
+      #   RUBY
+      #
+      #   initializer "api.rb" do
+      #     %(API_KEY = "123456")
+      #   end
+      #
+      def initializer(filename, data = nil)
+        log :initializer, filename
+        data ||= yield if block_given?
+        create_file("config/initializers/#{filename}", optimize_indentation(data), verbose: false)
+      end
+
+      # Runs another generator.
+      #
+      #   generate "scaffold", "Post title:string body:text"
+      #   generate "scaffold", "Post", "title:string", "body:text"
+      #
+      # The first argument is the generator name, and the remaining arguments
+      # are joined together and passed to the generator.
+      def generate(what, *args)
+        log :generate, what
+
+        options = args.extract_options!
+        options[:abort_on_failure] = !options[:inline]
+
+        rails_command "generate #{what} #{args.join(" ")}", options
+      end
+
+      # Runs the specified Rake task.
+      #
+      #   rake "db:migrate"
+      #   rake "db:migrate", env: "production"
+      #   rake "db:migrate", abort_on_failure: true
+      #   rake "stats", capture: true
+      #   rake "gems:install", sudo: true
+      #
+      # ==== Options
+      #
+      # [+:env+]
+      #   The \Rails environment in which to run the task. Defaults to
+      #   <tt>ENV["RAILS_ENV"] || "development"</tt>.
+      #
+      # [+:abort_on_failure+]
+      #   Whether to halt the generator if the task exits with a non-success
+      #   exit status.
+      #
+      # [+:capture+]
+      #   Whether to capture and return the output of the task.
+      #
+      # [+:sudo+]
+      #   Whether to run the task using +sudo+.
+      def rake(command, options = {})
+        execute_command :rake, command, options
+      end
+
+      # Runs the specified \Rails command.
+      #
+      #   rails_command "db:migrate"
+      #   rails_command "db:migrate", env: "production"
+      #   rails_command "db:migrate", abort_on_failure: true
+      #   rails_command "stats", capture: true
+      #   rails_command "gems:install", sudo: true
+      #
+      # ==== Options
+      #
+      # [+:env+]
+      #   The \Rails environment in which to run the command. Defaults to
+      #   <tt>ENV["RAILS_ENV"] || "development"</tt>.
+      #
+      # [+:abort_on_failure+]
+      #   Whether to halt the generator if the command exits with a non-success
+      #   exit status.
+      #
+      # [+:capture+]
+      #   Whether to capture and return the output of the command.
+      #
+      # [+:sudo+]
+      #   Whether to run the command using +sudo+.
+      def rails_command(command, options = {})
+        if options[:inline]
+          log :rails, command
+          command, *args = Shellwords.split(command)
+          in_root do
+            silence_warnings do
+              ::Rails::Command.invoke(command, args, **options)
+            end
+          end
+        else
+          execute_command :rails, command, options
+        end
+      end
+
+      # Make an entry in \Rails routing file <tt>config/routes.rb</tt>
+      #
+      #   route "root 'welcome#index'"
+      #   route "root 'admin#index'", namespace: :admin
+      def route(routing_code, namespace: nil)
+        namespace = Array(namespace)
+        namespace_pattern = route_namespace_pattern(namespace)
+        routing_code = namespace.reverse.reduce(routing_code) do |code, name|
+          "namespace :#{name} do\n#{rebase_indentation(code, 2)}end"
+        end
+
+        log :route, routing_code
+
+        in_root do
+          if namespace_match = match_file("config/routes.rb", namespace_pattern)
+            base_indent, *, existing_block_indent = namespace_match.captures.compact.map(&:length)
+            existing_line_pattern = /^[ ]{,#{existing_block_indent}}\S.+\n?/
+            routing_code = rebase_indentation(routing_code, base_indent + 2).gsub(existing_line_pattern, "")
+            namespace_pattern = /#{Regexp.escape namespace_match.to_s}/
+          end
+
+          inject_into_file "config/routes.rb", routing_code, after: namespace_pattern, verbose: false, force: false
+
+          if behavior == :revoke && namespace.any? && namespace_match
+            empty_block_pattern = /(#{namespace_pattern})((?:\s*end\n){1,#{namespace.size}})/
+            gsub_file "config/routes.rb", empty_block_pattern, verbose: false, force: true do |matched|
+              beginning, ending = empty_block_pattern.match(matched).captures
+              ending.sub!(/\A\s*end\n/, "") while !ending.empty? && beginning.sub!(/^[ ]*namespace .+ do\n\s*\z/, "")
+              beginning + ending
+            end
+          end
+        end
+      end
+
+      # Reads the given file at the source root and prints it in the console.
+      #
+      #   readme "README"
+      def readme(path)
+        log File.read(find_in_source_paths(path))
+      end
+
+      private
+        # Define log for backwards compatibility. If just one argument is sent,
+        # invoke say, otherwise invoke say_status. Differently from say and
+        # similarly to say_status, this method respects the quiet? option given.
+        def log(*args) # :doc:
+          if args.size == 1
+            say args.first.to_s unless options.quiet?
+          else
+            args << (behavior == :invoke ? :green : :red)
+            say_status(*args)
+          end
+        end
+
+        # Runs the supplied command using either "rake ..." or "rails ..."
+        # based on the executor parameter provided.
+        def execute_command(executor, command, options = {}) # :doc:
+          log executor, command
+          sudo = options[:sudo] && !Gem.win_platform? ? "sudo " : ""
+          config = {
+            env: { "RAILS_ENV" => (options[:env] || ENV["RAILS_ENV"] || "development") },
+            verbose: false,
+            capture: options[:capture],
+            abort_on_failure: options[:abort_on_failure],
+          }
+
+          in_root { run("#{sudo}#{Shellwords.escape Gem.ruby} bin/#{executor} #{command}", config) }
+        end
+
+        # Always returns value in double quotes.
+        def quote(value) # :doc:
+          if value.respond_to? :each_pair
+            return value.map do |k, v|
+              "#{k}: #{quote(v)}"
+            end.join(", ")
+          end
+          return value.inspect unless value.is_a? String
+
+          "\"#{value.tr("'", '"')}\""
+        end
+
+        # Returns optimized string with indentation
+        def optimize_indentation(value, amount = 0) # :doc:
+          return "#{value}\n" unless value.is_a?(String)
+          "#{value.strip_heredoc.indent(amount).chomp}\n"
+        end
+        alias rebase_indentation optimize_indentation
+
+        # Indent the +Gemfile+ to the depth of @indentation
+        def indentation # :doc:
+          "  " * @indentation
+        end
+
+        # Manage +Gemfile+ indentation for a DSL action block
+        def with_indentation(&block) # :doc:
+          @indentation += 1
+          instance_eval(&block)
+        ensure
+          @indentation -= 1
+        end
+
+        # Append string to a file with a newline if necessary
+        def append_file_with_newline(path, str, options = {})
+          gsub_file path, /\n?\z/, options do |match|
+            match.end_with?("\n") ? "" : "\n#{str}\n"
+          end
+        end
+
+        def match_file(path, pattern)
+          File.read(path).match(pattern) if File.exist?(path)
+        end
+
+        def route_namespace_pattern(namespace)
+          namespace.each_with_index.reverse_each.reduce(nil) do |pattern, (name, i)|
+            cummulative_margin = "\\#{i + 1}[ ]{2}"
+            blank_or_indented_line = "^[ ]*\n|^#{cummulative_margin}.*\n"
+            "(?:(?:#{blank_or_indented_line})*?^(#{cummulative_margin})namespace :#{name} do\n#{pattern})?"
+          end.then do |pattern|
+            /^([ ]*).+\.routes\.draw do[ ]*\n#{pattern}/
+          end
+        end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -60,6 +60,7 @@ Rails.application.routes.draw do
   end
 
   namespace :comparisons do
+    resources :electricity_targets, only: [:index]
     resources :baseload_per_pupil, only: [:index]
     resources :change_in_electricity_since_last_year, only: [:index]
     resources :electricity_peak_kw_per_pupil, only: [:index]

--- a/db/migrate/20240229162518_create_electricity_targets.rb
+++ b/db/migrate/20240229162518_create_electricity_targets.rb
@@ -1,0 +1,5 @@
+class CreateElectricityTargets < ActiveRecord::Migration[6.1]
+  def change
+    create_view :electricity_targets
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_02_22_163429) do
+ActiveRecord::Schema.define(version: 2024_02_29_162518) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
@@ -2206,5 +2206,32 @@ ActiveRecord::Schema.define(version: 2024_02_22_163429) do
              FROM alert_generation_runs
             ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
     WHERE ((data.alert_generation_run_id = latest_runs.id) AND (additional.alert_generation_run_id = latest_runs.id));
+  SQL
+  create_view "electricity_targets", sql_definition: <<-SQL
+      SELECT latest_runs.id,
+      data.alert_generation_run_id,
+      data.school_id,
+      data.current_year_percent_of_target_relative,
+      data.current_year_unscaled_percent_of_target_relative,
+      data.current_year_kwh,
+      data.current_year_target_kwh,
+      data.unscaled_target_kwh_to_date,
+      data.tracking_start_date
+     FROM ( SELECT alerts.alert_generation_run_id,
+              alerts.school_id,
+              data_1.current_year_percent_of_target_relative,
+              data_1.current_year_unscaled_percent_of_target_relative,
+              data_1.current_year_kwh,
+              data_1.current_year_target_kwh,
+              data_1.unscaled_target_kwh_to_date,
+              data_1.tracking_start_date
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) data_1(current_year_percent_of_target_relative double precision, current_year_unscaled_percent_of_target_relative double precision, current_year_kwh double precision, current_year_target_kwh double precision, unscaled_target_kwh_to_date double precision, tracking_start_date date)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertElectricityTargetAnnual'::text))) data,
+      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
+             FROM alert_generation_runs
+            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
+    WHERE (data.alert_generation_run_id = latest_runs.id);
   SQL
 end

--- a/db/views/baseload_per_pupils_v01.sql
+++ b/db/views/baseload_per_pupils_v01.sql
@@ -16,9 +16,7 @@ FROM
   ) AS baseload,
   (
     SELECT alert_generation_run_id, school_id, data.*
-    FROM alerts, alert_types, jsonb_to_record(variables) AS data(
-      electricity_economic_tariff_changed_this_year boolean
-    )
+    FROM alerts, alert_types, jsonb_to_record(variables) AS data(electricity_economic_tariff_changed_this_year boolean)
     WHERE alerts.alert_type_id = alert_types.id and alert_types.class_name='AlertAdditionalPrioritisationData'
   ) AS additional,
   (

--- a/db/views/electricity_targets_v01.sql
+++ b/db/views/electricity_targets_v01.sql
@@ -1,0 +1,22 @@
+SELECT latest_runs.id,
+       data.*
+FROM
+  (
+    SELECT alert_generation_run_id, school_id, data.*
+    FROM alerts, alert_types, jsonb_to_record(variables) AS data(
+      current_year_percent_of_target_relative float,
+      current_year_unscaled_percent_of_target_relative float,
+      current_year_kwh float,
+      current_year_target_kwh float,
+      unscaled_target_kwh_to_date float,
+      tracking_start_date date
+    )
+    WHERE alerts.alert_type_id = alert_types.id and alert_types.class_name='AlertElectricityTargetAnnual'
+  ) AS data,
+  (
+    SELECT DISTINCT ON (school_id) id
+    FROM alert_generation_runs
+    ORDER BY school_id, created_at DESC
+  ) latest_runs
+WHERE
+  data.alert_generation_run_id = latest_runs.id;

--- a/lib/generators/comparison_report/USAGE
+++ b/lib/generators/comparison_report/USAGE
@@ -2,7 +2,12 @@ Description:
     Explain the generator
 
 Example:
-    bin/rails generate comparison_report Thing
+    bin/rails generate comparison_report benchmark_key
 
     This will create:
-        what/will/it/create
+        scenic view for benchmark_key
+        model: app/models/comparison/#{benchmark_key}.rb
+        view: app/views/comparisons/#{benchmark_key}/_tables.html.erb
+        controller: comparisons/#{benchmark_key}_controller.rb
+        spec: spec/system/comparisons/#{benchmark_key}_spec.rb
+        route for benchmark_key in config/routes.rb

--- a/lib/generators/comparison_report/USAGE
+++ b/lib/generators/comparison_report/USAGE
@@ -1,0 +1,8 @@
+Description:
+    Explain the generator
+
+Example:
+    bin/rails generate comparison_report Thing
+
+    This will create:
+        what/will/it/create

--- a/lib/generators/comparison_report/USAGE
+++ b/lib/generators/comparison_report/USAGE
@@ -1,5 +1,5 @@
 Description:
-    Explain the generator
+    Generator to create all the files required for a benchmark
 
 Example:
     bin/rails generate comparison_report benchmark_key

--- a/lib/generators/comparison_report/comparison_report_generator.rb
+++ b/lib/generators/comparison_report/comparison_report_generator.rb
@@ -1,0 +1,35 @@
+class ComparisonReportGenerator < Rails::Generators::NamedBase
+  source_root File.expand_path('templates', __dir__)
+
+  desc 'Generates a comparison report with the given NAME.'
+
+  def generate_scenic_view
+    if File.exist?("db/views/#{file_path}_v01.sql")
+      if yes?("It looks like db/views/#{file_path}_v01.sql has already been generated. Do you want to create the next version?")
+        generate 'scenic:view', file_name
+      end
+    else
+      generate 'scenic:view', file_name
+    end
+  end
+
+  def create_controller
+    template 'controller.rb.tt', "app/controllers/comparisons/#{file_path}_controller.rb"
+  end
+
+  def create_model
+    template 'model.rb.tt', "app/models/comparison/#{file_path}.rb"
+  end
+
+  def create_view
+    template '_tables.html.erb.tt', "app/views/comparisons/#{file_path}/_tables.html.erb"
+  end
+
+  def create_spec
+    template 'system_spec.rb.tt', "spec/system/comparisons/#{file_path}_spec.rb"
+  end
+
+  def add_route
+    route "resources :#{file_name}, only: [:index]", namespace: :comparisons
+  end
+end

--- a/lib/generators/comparison_report/comparison_report_generator.rb
+++ b/lib/generators/comparison_report/comparison_report_generator.rb
@@ -14,6 +14,7 @@ class ComparisonReportGenerator < Rails::Generators::NamedBase
   end
 
   def create_controller
+    # Benchmarking::BenchmarkManager.chart_table_config(file_name)
     template 'controller.rb.tt', "app/controllers/comparisons/#{file_path}_controller.rb"
   end
 

--- a/lib/generators/comparison_report/templates/_tables.html.erb.tt
+++ b/lib/generators/comparison_report/templates/_tables.html.erb.tt
@@ -1,0 +1,32 @@
+<table id="comparison-table" class="table advice-table table-sorted">
+  <thead>
+    <tr>
+      <th><%%= t('analytics.benchmarking.configuration.column_headings.school') %></th>
+      <th class="text-right">
+        More headings like this
+      </th>
+    </tr>
+  </thead>
+  <tbody>
+    <%% results.each do |<%= file_name %>| %>
+      <tr>
+        <td>
+          <%%= link_to <%= file_name %>.school.name,
+                      advice_page_path(<%= file_name %>.school, advice_page, :insights) %>
+        </td>
+        <td class="text-right">
+          More data like this
+        </td>
+      </tr>
+    <%% end %>
+  </tbody>
+  <tfoot>
+    <tr>
+      <td colspan="6">
+        <p>
+          <strong><%%= t('analytics.benchmarking.content.footnotes.notes') %></strong>
+        </p>
+      </td>
+    </tr>
+  </tfoot>
+</table>

--- a/lib/generators/comparison_report/templates/_tables.html.erb.tt
+++ b/lib/generators/comparison_report/templates/_tables.html.erb.tt
@@ -8,11 +8,11 @@
     </tr>
   </thead>
   <tbody>
-    <%% results.each do |<%= file_name %>| %>
+    <%% results.each do |row| %>
       <tr>
         <td>
-          <%%= link_to <%= file_name %>.school.name,
-                      advice_page_path(<%= file_name %>.school, advice_page, :insights) %>
+          <%%= link_to row.school.name,
+                      advice_page_path(row.school, advice_page, :insights) %>
         </td>
         <td class="text-right">
           More data like this

--- a/lib/generators/comparison_report/templates/controller.rb.tt
+++ b/lib/generators/comparison_report/templates/controller.rb.tt
@@ -11,14 +11,13 @@ module Comparisons
     end
 
     def load_data
+      # change as needed
       Comparison::<%= class_name %>.where(school: @schools).where.not(variable_name: nil).order(variable_name: :desc)
     end
 
     def create_charts(results)
-      chart_data = {}
-
-      puts chart_data.inspect
-      puts results.inspect
+      # change as appropriate!
+      create_single_number_chart(results, :current_year_percent_of_target_relative, nil, :percent_above_or_below_target_since_target_set, 'percent')
     end
   end
 end

--- a/lib/generators/comparison_report/templates/controller.rb.tt
+++ b/lib/generators/comparison_report/templates/controller.rb.tt
@@ -17,7 +17,7 @@ module Comparisons
 
     def create_charts(results)
       # change as appropriate!
-      create_single_number_chart(results, :current_year_percent_of_target_relative, nil, :percent_above_or_below_target_since_target_set, 'percent')
+      create_single_number_chart(results, :current_year_percent_of_target_relative, :percent_above_or_below_target_since_target_set, :percent)
     end
   end
 end

--- a/lib/generators/comparison_report/templates/controller.rb.tt
+++ b/lib/generators/comparison_report/templates/controller.rb.tt
@@ -1,0 +1,24 @@
+module Comparisons
+  class <%= class_name %>Controller < BaseController
+    private
+
+    def key
+      :<%= file_name %>
+    end
+
+    def advice_page_key
+      :your_advice_page_key
+    end
+
+    def load_data
+      Comparison::<%= class_name %>.where(school: @schools).where.not(variable_name: nil).order(variable_name: :desc)
+    end
+
+    def create_charts(results)
+      chart_data = {}
+
+      puts chart_data.inspect
+      puts results.inspect
+    end
+  end
+end

--- a/lib/generators/comparison_report/templates/model.rb.tt
+++ b/lib/generators/comparison_report/templates/model.rb.tt
@@ -1,0 +1,2 @@
+class Comparison::<%= class_name %> < Comparison::View
+end

--- a/lib/generators/comparison_report/templates/system_spec.rb.tt
+++ b/lib/generators/comparison_report/templates/system_spec.rb.tt
@@ -34,20 +34,24 @@ describe '<%= file_name %>' do
       let(:title) { report.title }
       let(:chart) { '#chart_comparison' } # there may be more than one chart!
       let(:expected_school) { school }
-      let(:advice_page_path) { polymorphic_path([:insights, expected_school, :advice, advice_page_key] }
-    end
-
-    it 'displays the expected data' do
-      within('#tables') do
-        within('#comparison-table') do
-          # change to your data!
-          expect(page).to have_content('+18.7%') # Percent above or below target since target set
-          expect(page).to have_content('-48%') # Percent above or below last year
-          expect(page).to have_content('1,280') # kWh consumption since target set
-          expect(page).to have_content('2,280') # Target kWh consumption
-          expect(page).to have_content('2,400') # Last year kWh consumption
-          expect(page).to have_content('Monday 1 Jan 2024') # Start date for target
-        end
+      let(:advice_page_path) { polymorphic_path([:insights, expected_school, :advice, advice_page_key]) }
+      let(:expected_table) do
+        [['School',
+          'Percent above or below target since target set',
+          'Percent above or below last year',
+          'kWh consumption since target set',
+          'Target kWh consumption',
+          'Last year kWh consumption',
+          'Start date for target'],
+         [school.name,
+          '+18.7%',
+          '-48%',
+          '1,280',
+          '2,280',
+          '2,400',
+          'Monday 1 Jan 2024'],
+         ["Notes\nIn school comparisons 'last year' is defined as this year to date."]
+        ]
       end
     end
   end

--- a/lib/generators/comparison_report/templates/system_spec.rb.tt
+++ b/lib/generators/comparison_report/templates/system_spec.rb.tt
@@ -1,29 +1,54 @@
-# frozen_string_literal: true
-
 require 'rails_helper'
 
 describe '<%= file_name %>' do
-  let(:school) { create(:school) }
+  let!(:school) { create(:school) }
+  let(:key) { :<%= file_name %> }
+  let(:advice_page_key) { :your_advice_page_key }
+
+  # change to your variables
+  let(:variables) do
+    {
+      current_year_percent_of_target_relative: +0.18699995372972533,
+      current_year_unscaled_percent_of_target_relative: -0.4799985149375391,
+      current_year_kwh: 1284.7,
+      current_year_target_kwh: 2281.8825833333326,
+      unscaled_target_kwh_to_date: 2401.9816666666666,
+      tracking_start_date: '2024-01-01'
+    }
+  end
+
+  # change to your alert type (there may be more than one!)
+  let(:alert_type) { create(:alert_type, class_name: 'AlertElectricityTargetAnnual') }
+  let(:alert_run) { create(:alert_generation_run, school: school) }
+  let!(:report) { create(:report, key: key) }
 
   before do
-    alert_run = create(:alert_generation_run, school: school)
-
-    ## change to your alert details ##
-    create(:alert, school: school, alert_generation_run: alert_run,
-                   alert_type: create(:alert_type, class_name: 'AlertElectricityUsageDuringCurrentHoliday'),
-                   variables: {
-                     holiday_projected_usage_gbp: 1,
-                     holiday_usage_to_date_gbp: 2,
-                     holiday_name: 'Holiday 1'
-                   })
+    create(:advice_page, key: advice_page_key)
+    create(:alert, school: school, alert_generation_run: alert_run, alert_type: alert_type, variables: variables)
   end
 
   context 'when viewing report' do
-    before { visit comparisons_<%= file_name %>_index_path }
+    before { visit "/comparisons/#{key}" }
 
-    it_behaves_like 'a school comparison report', advice_page: true do
-      let(:title) { I18n.t('analytics.benchmarking.chart_table_config.<%= file_name %>') }
+    it_behaves_like 'a school comparison report' do
+      let(:title) { report.title }
+      let(:chart) { '#chart_comparison' } # there may be more than one chart!
       let(:expected_school) { school }
+      let(:advice_page_path) { polymorphic_path([:insights, expected_school, :advice, advice_page_key] }
+    end
+
+    it 'displays the expected data' do
+      within('#tables') do
+        within('#comparison-table') do
+          # change to your data!
+          expect(page).to have_content('+18.7%') # Percent above or below target since target set
+          expect(page).to have_content('-48%') # Percent above or below last year
+          expect(page).to have_content('1,280') # kWh consumption since target set
+          expect(page).to have_content('2,280') # Target kWh consumption
+          expect(page).to have_content('2,400') # Last year kWh consumption
+          expect(page).to have_content('Monday 1 Jan 2024') # Start date for target
+        end
+      end
     end
   end
 end

--- a/lib/generators/comparison_report/templates/system_spec.rb.tt
+++ b/lib/generators/comparison_report/templates/system_spec.rb.tt
@@ -7,6 +7,8 @@ describe '<%= file_name %>' do
 
   before do
     alert_run = create(:alert_generation_run, school: school)
+
+    ## change to your alert details ##
     create(:alert, school: school, alert_generation_run: alert_run,
                    alert_type: create(:alert_type, class_name: 'AlertElectricityUsageDuringCurrentHoliday'),
                    variables: {

--- a/lib/generators/comparison_report/templates/system_spec.rb.tt
+++ b/lib/generators/comparison_report/templates/system_spec.rb.tt
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe '<%= file_name %>' do
+  let(:school) { create(:school) }
+
+  before do
+    alert_run = create(:alert_generation_run, school: school)
+    create(:alert, school: school, alert_generation_run: alert_run,
+                   alert_type: create(:alert_type, class_name: 'AlertElectricityUsageDuringCurrentHoliday'),
+                   variables: {
+                     holiday_projected_usage_gbp: 1,
+                     holiday_usage_to_date_gbp: 2,
+                     holiday_name: 'Holiday 1'
+                   })
+  end
+
+  context 'when viewing report' do
+    before { visit comparisons_<%= file_name %>_index_path }
+
+    it_behaves_like 'a school comparison report', advice_page: true do
+      let(:title) { I18n.t('analytics.benchmarking.chart_table_config.<%= file_name %>') }
+      let(:expected_school) { school }
+    end
+  end
+end

--- a/spec/system/comparisons/electricity_peak_kw_per_pupil_spec.rb
+++ b/spec/system/comparisons/electricity_peak_kw_per_pupil_spec.rb
@@ -26,7 +26,6 @@ describe 'electricity_peak_kw_per_pupil' do
     before { visit comparisons_electricity_peak_kw_per_pupil_index_path }
 
     it_behaves_like 'a school comparison report' do
-      let(:title) { I18n.t('analytics.benchmarking.chart_table_config.electricity_peak_kw_per_pupil') }
       let(:title) { report.title }
       let(:expected_school) { school }
       let(:chart) { true }

--- a/spec/system/comparisons/electricity_targets_spec.rb
+++ b/spec/system/comparisons/electricity_targets_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'electricity_targets' do
+  let(:school) { create(:school) }
+
+  before do
+    alert_run = create(:alert_generation_run, school: school)
+    create(:alert, school: school, alert_generation_run: alert_run,
+                   alert_type: create(:alert_type, class_name: 'AlertElectricityUsageDuringCurrentHoliday'),
+                   variables: {
+                     holiday_projected_usage_gbp: 1,
+                     holiday_usage_to_date_gbp: 2,
+                     holiday_name: 'Holiday 1'
+                   })
+  end
+
+  context 'when viewing report' do
+    before { visit comparisons_electricity_targets_index_path }
+
+    it_behaves_like 'a school comparison report', advice_page: true do
+      let(:title) { I18n.t('analytics.benchmarking.chart_table_config.electricity_targets') }
+      let(:expected_school) { school }
+    end
+  end
+end

--- a/spec/system/comparisons/electricity_targets_spec.rb
+++ b/spec/system/comparisons/electricity_targets_spec.rb
@@ -1,27 +1,51 @@
-# frozen_string_literal: true
-
 require 'rails_helper'
 
 describe 'electricity_targets' do
-  let(:school) { create(:school) }
+  let!(:school) { create(:school) }
+  let(:key) { :electricity_targets }
+  let(:advice_page_key) { :electricity_long_term }
+
+  let(:variables) do
+    {
+      current_year_percent_of_target_relative: +0.18699995372972533,
+      current_year_unscaled_percent_of_target_relative: -0.4799985149375391,
+      current_year_kwh: 1284.7,
+      current_year_target_kwh: 2281.8825833333326,
+      unscaled_target_kwh_to_date: 2401.9816666666666,
+      tracking_start_date: '2024-01-01'
+    }
+  end
+
+  let(:alert_type) { create(:alert_type, class_name: 'AlertElectricityTargetAnnual') }
+  let(:alert_run) { create(:alert_generation_run, school: school) }
+  let!(:report) { create(:report, key: key) }
 
   before do
-    alert_run = create(:alert_generation_run, school: school)
-    create(:alert, school: school, alert_generation_run: alert_run,
-                   alert_type: create(:alert_type, class_name: 'AlertElectricityUsageDuringCurrentHoliday'),
-                   variables: {
-                     holiday_projected_usage_gbp: 1,
-                     holiday_usage_to_date_gbp: 2,
-                     holiday_name: 'Holiday 1'
-                   })
+    create(:advice_page, key: advice_page_key)
+    create(:alert, school: school, alert_generation_run: alert_run, alert_type: alert_type, variables: variables)
   end
 
   context 'when viewing report' do
-    before { visit comparisons_electricity_targets_index_path }
+    before { visit "/comparisons/#{key}" }
 
-    it_behaves_like 'a school comparison report', advice_page: true do
-      let(:title) { I18n.t('analytics.benchmarking.chart_table_config.electricity_targets') }
+    it_behaves_like 'a school comparison report' do
+      let(:title) { report.title }
+      let(:chart) { '#chart_comparison' }
       let(:expected_school) { school }
+      let(:advice_page_path) { polymorphic_path([:insights, expected_school, :advice, advice_page_key]) }
+    end
+
+    it 'displays the expected data' do
+      within('#tables') do
+        within('#comparison-table') do
+          expect(page).to have_content('+18.7%') # Percent above or below target since target set
+          expect(page).to have_content('-48%') # Percent above or below last year
+          expect(page).to have_content('1,280') # kWh consumption since target set
+          expect(page).to have_content('2,280') # Target kWh consumption
+          expect(page).to have_content('2,400') # Last year kWh consumption
+          expect(page).to have_content('Monday 1 Jan 2024') # Start date for target
+        end
+      end
     end
   end
 end

--- a/spec/system/comparisons/electricity_targets_spec.rb
+++ b/spec/system/comparisons/electricity_targets_spec.rb
@@ -33,18 +33,23 @@ describe 'electricity_targets' do
       let(:chart) { '#chart_comparison' }
       let(:expected_school) { school }
       let(:advice_page_path) { polymorphic_path([:insights, expected_school, :advice, advice_page_key]) }
-    end
-
-    it 'displays the expected data' do
-      within('#tables') do
-        within('#comparison-table') do
-          expect(page).to have_content('+18.7%') # Percent above or below target since target set
-          expect(page).to have_content('-48%') # Percent above or below last year
-          expect(page).to have_content('1,280') # kWh consumption since target set
-          expect(page).to have_content('2,280') # Target kWh consumption
-          expect(page).to have_content('2,400') # Last year kWh consumption
-          expect(page).to have_content('Monday 1 Jan 2024') # Start date for target
-        end
+      let(:expected_table) do
+        [['School',
+          'Percent above or below target since target set',
+          'Percent above or below last year',
+          'kWh consumption since target set',
+          'Target kWh consumption',
+          'Last year kWh consumption',
+          'Start date for target'],
+         [school.name,
+          '+18.7%',
+          '-48%',
+          '1,280',
+          '2,280',
+          '2,400',
+          'Monday 1 Jan 2024'],
+         ["Notes\nIn school comparisons 'last year' is defined as this year to date."]
+        ]
       end
     end
   end


### PR DESCRIPTION
Includes a generator to make the files required for a benchmark. It puts some code in there that can be used as an example, not sure how useful it is. Please modify as you see fit!

To use:
`rails generate comparison_report benchmark_key`

Also brings in rails 7 version of generator actions - this is because the route generator didn't have the ability to add to a namespace without writing out a whole new namespace every-time.