### PR TITLE
Fix benchmark links

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -478,8 +478,4 @@ module ApplicationHelper
   def live_data_path
     ActivityCategory.live_data.any? ? activity_category_path(ActivityCategory.live_data.last) : activity_categories_path
   end
-
-  def comparison_exists?(key)
-    Rails.application.routes.url_helpers.respond_to?("comparisons_#{key}_index_path")
-  end
 end

--- a/app/helpers/comparisons_helper.rb
+++ b/app/helpers/comparisons_helper.rb
@@ -13,4 +13,12 @@ module ComparisonsHelper
     val = data.sum
     to_nil_if_sum_zero && val == 0.0 ? nil : val
   end
+
+  def comparison_page_exists?(key)
+    begin
+      "Comparisons::#{key.to_s.camelcase}Controller".constantize
+    rescue
+      false
+    end
+  end
 end

--- a/app/helpers/comparisons_helper.rb
+++ b/app/helpers/comparisons_helper.rb
@@ -15,10 +15,6 @@ module ComparisonsHelper
   end
 
   def comparison_page_exists?(key)
-    begin
-      "Comparisons::#{key.to_s.camelcase}Controller".constantize
-    rescue
-      false
-    end
+    Object.const_defined?("Comparisons::#{key.to_s.camelcase}Controller")
   end
 end

--- a/app/views/compare/benchmarks.html.erb
+++ b/app/views/compare/benchmarks.html.erb
@@ -16,14 +16,14 @@
           <% benchmark_group[:benchmarks].each do |key, title| %>
             <li class="pt-1">
               <i class="fa-li fas fa-check"></i>
-                <% if comparison_exists?(key) %>
+                <% if comparison_page_exists?(key) %>
                   <%= link_to Comparison::Report.find_by(key: key).try(:title),
-                              polymorphic_path([:comparisons, key, :index], @filter) %>
+                              url_for({ controller: "/comparisons/#{key}" }.merge(@filter)) %>
                 <% else %>
                   <%= Comparison::Report.find_by(key: key).try(:title) %>
                 <% end %>
                 <% if EnergySparks::FeatureFlags.active?(:comparison_reports_link_to_old) %>
-                  [<%= link_to 'current', compare_path(key, @filter) %>]
+                  <%= link_to 'current', compare_path(key, @filter), class: 'badge badge-light' %>
                 <% end %>
             </li>
           <% end %>

--- a/app/views/compare/benchmarks.html.erb
+++ b/app/views/compare/benchmarks.html.erb
@@ -18,7 +18,7 @@
               <i class="fa-li fas fa-check"></i>
                 <% if comparison_page_exists?(key) %>
                   <%= link_to Comparison::Report.find_by(key: key).try(:title),
-                              url_for({ controller: "/comparisons/#{key}" }.merge(@filter)) %>
+                              { controller: "/comparisons/#{key}" }.merge(@filter) %>
                 <% else %>
                   <%= Comparison::Report.find_by(key: key).try(:title) %>
                 <% end %>

--- a/spec/helpers/comparisons_helperer_spec.rb
+++ b/spec/helpers/comparisons_helperer_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+describe ComparisonsHelper do
+  describe '#comparison_page_exists?' do
+    it 'returns true if controller exists' do
+      expect(comparison_page_exists?(:baseload_per_pupil)).to be_truthy
+    end
+
+    it 'returns false if controller does not exist' do
+      expect(comparison_page_exists?(:never_ever_going_to_exist)).to be_falsey
+    end
+  end
+end

--- a/spec/helpers/comparisons_helperer_spec.rb
+++ b/spec/helpers/comparisons_helperer_spec.rb
@@ -3,11 +3,11 @@ require 'rails_helper'
 describe ComparisonsHelper do
   describe '#comparison_page_exists?' do
     it 'returns true if controller exists' do
-      expect(comparison_page_exists?(:baseload_per_pupil)).to be_truthy
+      expect(comparison_page_exists?(:baseload_per_pupil)).to be true
     end
 
     it 'returns false if controller does not exist' do
-      expect(comparison_page_exists?(:never_ever_going_to_exist)).to be_falsey
+      expect(comparison_page_exists?(:never_ever_going_to_exist)).to be false
     end
   end
 end


### PR DESCRIPTION
Rails route helpers append _index only for singular named routes to the collection resource. This does not apply for plural named routes which was assumed when linking to benchmarks. This changes the link to work for both kinds.