### PR TITLE
Ensure meter review service uses v2 of n3rgy

### DIFF
--- a/app/services/meter_review_service.rb
+++ b/app/services/meter_review_service.rb
@@ -36,7 +36,11 @@ class MeterReviewService
   end
 
   def is_meter_known_to_n3rgy?(meter)
-    MeterManagement.new(meter).is_meter_known_to_n3rgy?
+    if EnergySparks::FeatureFlags.active?(:n3rgy_v2)
+      Meters::N3rgyMeteringService.new(meter).available?
+    else
+      MeterManagement.new(meter).is_meter_known_to_n3rgy?
+    end
   end
 
   def current_consent

--- a/spec/services/meter_review_service_spec.rb
+++ b/spec/services/meter_review_service_spec.rb
@@ -20,70 +20,149 @@ RSpec.describe MeterReviewService do
     end
   end
 
-  context 'when completing a review' do
-    before do
-      allow_any_instance_of(MeterManagement).to receive(:is_meter_known_to_n3rgy?).and_return(true)
+  describe '#complete_review!' do
+    around do |example|
+      ClimateControl.modify FEATURE_FLAG_N3RGY_V2: flag do
+        example.run
+      end
     end
 
-    context 'and school has consent' do
-      let!(:consent_grant) { create(:consent_grant, consent_statement: consent_statement, school: school) }
+    context 'with v1' do
+      let(:flag) { 'false' }
 
-      it 'records the review' do
-        expect do
-          service.complete_review!([dcc_meter])
-        end.to change(MeterReview, :count).from(0).to(1)
+      before do
+        allow_any_instance_of(MeterManagement).to receive(:is_meter_known_to_n3rgy?).and_return(true)
       end
 
-      it 'captures current context' do
-        review = service.complete_review!([dcc_meter])
-        expect(review.user).to eql(admin)
-        expect(review.school).to eql(school)
-        expect(review.consent_grant).to eql(consent_grant)
+      context 'when school has consent' do
+        let!(:consent_grant) { create(:consent_grant, consent_statement: consent_statement, school: school) }
+
+        it 'records the review' do
+          expect do
+            service.complete_review!([dcc_meter])
+          end.to change(MeterReview, :count).from(0).to(1)
+        end
+
+        it 'captures current context' do
+          review = service.complete_review!([dcc_meter])
+          expect(review.user).to eql(admin)
+          expect(review.school).to eql(school)
+          expect(review.consent_grant).to eql(consent_grant)
+        end
+
+        it 'associates the meters' do
+          review = service.complete_review!([dcc_meter])
+          expect(review.meters).to match([dcc_meter])
+        end
+
+        context 'and documents are checked' do
+          let!(:consent_document) { create(:consent_document, school: school) }
+
+          it 'records which documents are checked' do
+            review = service.complete_review!([dcc_meter], [consent_document])
+            expect(review.consent_documents).to match([consent_document])
+          end
+        end
       end
 
-      it 'associates the meters' do
-        review = service.complete_review!([dcc_meter])
-        expect(review.meters).to match([dcc_meter])
+      context 'when school has no current consent' do
+        it 'does not allow review to be completed' do
+          expect do
+            service.complete_review!([dcc_meter])
+          end.to raise_error(ActiveRecord::RecordInvalid)
+        end
       end
 
-      context 'and documents are checked' do
-        let!(:consent_document) { create(:consent_document, school: school) }
+      context 'when meter configuration is incorrect' do
+        it 'raises error if no meters' do
+          expect do
+            service.complete_review!([])
+          end.to raise_error(MeterReviewService::MeterReviewError)
+        end
 
-        it 'records which documents are checked' do
-          review = service.complete_review!([dcc_meter], [consent_document])
-          expect(review.consent_documents).to match([consent_document])
+        it 'raises error if meter not flagged as DCC' do
+          dcc_meter.update(dcc_meter: false)
+          expect do
+            service.complete_review!([dcc_meter])
+          end.to raise_error(MeterReviewService::MeterReviewError)
+        end
+
+        it 'raises error if meter not found in DCC api' do
+          expect_any_instance_of(MeterManagement).to receive(:is_meter_known_to_n3rgy?).and_return(false)
+          expect do
+            service.complete_review!([dcc_meter])
+          end.to raise_error(MeterReviewService::MeterReviewError)
         end
       end
     end
 
-    context 'and school has no current consent' do
-      it 'does not allow review to be completed' do
-        expect do
-          service.complete_review!([dcc_meter])
-        end.to raise_error(ActiveRecord::RecordInvalid)
+    context 'with v2' do
+      let(:flag) { 'true' }
+
+      before do
+        allow_any_instance_of(Meters::N3rgyMeteringService).to receive(:available?).and_return(true)
       end
-    end
-  end
 
-  context 'when checking meters' do
-    it 'raises error if no meters' do
-      expect do
-        service.complete_review!([])
-      end.to raise_error(MeterReviewService::MeterReviewError)
-    end
+      context 'when school has consent' do
+        let!(:consent_grant) { create(:consent_grant, consent_statement: consent_statement, school: school) }
 
-    it 'raises error if meter not flagged as DCC' do
-      dcc_meter.update(dcc_meter: false)
-      expect do
-        service.complete_review!([dcc_meter])
-      end.to raise_error(MeterReviewService::MeterReviewError)
-    end
+        it 'records the review' do
+          expect do
+            service.complete_review!([dcc_meter])
+          end.to change(MeterReview, :count).from(0).to(1)
+        end
 
-    it 'raises error if meter not found in DCC api' do
-      expect_any_instance_of(MeterManagement).to receive(:is_meter_known_to_n3rgy?).and_return(false)
-      expect do
-        service.complete_review!([dcc_meter])
-      end.to raise_error(MeterReviewService::MeterReviewError)
+        it 'captures current context' do
+          review = service.complete_review!([dcc_meter])
+          expect(review.user).to eql(admin)
+          expect(review.school).to eql(school)
+          expect(review.consent_grant).to eql(consent_grant)
+        end
+
+        it 'associates the meters' do
+          review = service.complete_review!([dcc_meter])
+          expect(review.meters).to match([dcc_meter])
+        end
+
+        context 'and documents are checked' do
+          let!(:consent_document) { create(:consent_document, school: school) }
+
+          it 'records which documents are checked' do
+            review = service.complete_review!([dcc_meter], [consent_document])
+            expect(review.consent_documents).to match([consent_document])
+          end
+        end
+      end
+
+      context 'when school has no current consent' do
+        it 'does not allow review to be completed' do
+          expect do
+            service.complete_review!([dcc_meter])
+          end.to raise_error(ActiveRecord::RecordInvalid)
+        end
+      end
+
+      context 'when meter configuration is incorrect' do
+        it 'raises error if no meters' do
+          expect do
+            service.complete_review!([])
+          end.to raise_error(MeterReviewService::MeterReviewError)
+        end
+
+        it 'raises error if meter not flagged as DCC' do
+          dcc_meter.update(dcc_meter: false)
+          expect do
+            service.complete_review!([dcc_meter])
+          end.to raise_error(MeterReviewService::MeterReviewError)
+        end
+
+        it 'raises error if meter not found in DCC api' do
+          allow_any_instance_of(Meters::N3rgyMeteringService).to receive(:available?).and_return(false)
+          expect do
+            service.complete_review!([dcc_meter])
+          end.to raise_error(MeterReviewService::MeterReviewError)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
I missed a place in the code where we call n3rgy, prior to completing the meter review service. So its still using v1 and not working for the meters that are only accessible via v2.

Adds a conditional check for feature flag and specs.

Later in the week I'm going to remove all v1 code but wanted to give it another day or two.