### PR TITLE
Tweaks for _table files

### DIFF
--- a/lib/generators/comparison_report/templates/_table.csv.ruby.tt
+++ b/lib/generators/comparison_report/templates/_table.csv.ruby.tt
@@ -1,6 +1,11 @@
 CSV.generate do |csv|
-  csv << [] #headers
-  @results.each do |result|
-    csv << [] #values
+  # headers
+  csv << [
+    t('analytics.benchmarking.configuration.column_headings.school')
+  ]
+  @results.each do |row|
+    csv << [
+      row.school.name
+    ]
   end
 end.html_safe

--- a/lib/generators/comparison_report/templates/_table.html.erb.tt
+++ b/lib/generators/comparison_report/templates/_table.html.erb.tt
@@ -1,8 +1,8 @@
 <div class='text-right mt-2'>
-  <%%= download_link(report, index_params) %>
+  <%%= download_link(report, table_name, index_params) %>
 </div>
 
-<table id="<%%= comparison_table_id(report) %>" class="table advice-table table-sorted">
+<table id="<%%= comparison_table_id(report, table_name) %>" class="table advice-table table-sorted">
   <thead>
     <tr>
       <th><%%= t('analytics.benchmarking.configuration.column_headings.school') %></th>


### PR DESCRIPTION
Fixes a bug in the table template
Makes the loop variable names consistent
Adds a default header and column to the CSV download