### PR TITLE
Initial version of comparison table component

### DIFF
--- a/app/components/comparison_table_component.rb
+++ b/app/components/comparison_table_component.rb
@@ -11,15 +11,22 @@ class ComparisonTableComponent < ViewComponent::Base
   include AdvicePageHelper
   include ComparisonsHelper
 
-  def initialize(report:, table_name:, index_params:, headers: [], colgroups: [])
+  def initialize(report:, advice_page:, table_name:, index_params:, headers: [], colgroups: [], advice_page_tab: :insights)
     @report = report
-    @colgroups = colgroups
-    @headers = headers
+    @advice_page = advice_page
     @table_name = table_name
     @index_params = index_params
+    @headers = headers
+    @colgroups = colgroups
+    @advice_page_tab = advice_page_tab
   end
 
-  renders_many :rows, 'RowComponent'
+  renders_many :rows, ->(**args) do
+    args[:advice_page] = @advice_page
+    args[:advice_page_tab] = @advice_page_tab
+    RowComponent.new(**args)
+  end
+
   renders_one :footer
 
   # For providing information for each row in the comparison table
@@ -32,16 +39,18 @@ class ComparisonTableComponent < ViewComponent::Base
   #
   # The variable columns are specified as additional slots
   class RowComponent < ViewComponent::Base
-    def initialize(classes: '')
+    def initialize(advice_page: nil, advice_page_tab: :insights, classes: '')
+      @advice_page = advice_page
+      @advice_page_tab = advice_page_tab
       @classes = classes
     end
 
     # First column, showing school name and a link
-    renders_one :school, ->(school:, advice_page: nil, tab: :insights, params: {}, anchor: nil) do
-      path = if advice_page.present?
-               helpers.advice_page_path(school, advice_page, tab, params: params, anchor: anchor)
+    renders_one :school, ->(school:) do
+      path = if @advice_page.present?
+               helpers.advice_page_path(school, @advice_page, @advice_page_tab)
              else
-               school_advice_path(school, params: params, anchor: anchor)
+               school_advice_path(school)
              end
       link_to school.name, path
     end

--- a/app/components/comparison_table_component.rb
+++ b/app/components/comparison_table_component.rb
@@ -1,10 +1,19 @@
+# A comparison table consists
+#
+# Column headings, which may be organised into column groupings (e.g. all columns relating to
+# gas consumption)
+#
+# Rows. One per school with first column being the school name, then one or more data columns
+# A row may refer to footnotes
+#
+# A footnote section that provides the detail for individual footnotes
 class ComparisonTableComponent < ViewComponent::Base
   include AdvicePageHelper
   include ComparisonsHelper
 
-  def initialize(report:, headers: [], col_groups: [], table_name:, index_params:)
+  def initialize(report:, headers: [], colgroups: [], table_name:, index_params:)
     @report = report
-    @col_groups = col_groups
+    @colgroups = colgroups
     @headers = headers
     @table_name = table_name
     @index_params = index_params
@@ -12,27 +21,43 @@ class ComparisonTableComponent < ViewComponent::Base
 
   renders_many :rows, 'RowComponent'
   renders_one :footer
-  renders_many :colgroup, 'ColumnGroupComponent'
 
-  class ColumnGroupComponent < ViewComponent::Base
-    def initialize(label: '', colspan: 1)
-      @label = label
-      @colspan = colspan
-    end
-
-    def call
-      content_tag :th, @label, { colspan: @colspan }
-    end
-  end
-
+  # For providing information for each row in the comparison table
+  #
+  # The school column links to a specific advice page, or the advice homepage for a school. The
+  # school and advice page, along with any linking parameters should be provided as a slot.
+  #
+  # The school name can be followed by one or more references to footnotes. These references are
+  # provided as slots
+  #
+  # The variable columns are specified as additional slots
   class RowComponent < ViewComponent::Base
-    renders_one :school
+    def initialize(classes: '')
+      @classes = classes
+    end
+
+    # First column, showing school name and a link
+    renders_one :school, ->(school:, advice_page: nil, tab: :insights, params: {}, anchor: nil) do
+      path = if advice_page.present?
+               helpers.advice_page_path(school, advice_page, tab, params: params, anchor: anchor)
+             else
+               school_advice_path(school, params: params, anchor: anchor)
+             end
+      link_to school.name, path
+    end
+
+    # Footnote references
+    renders_many :references
+    # Data columns
     renders_many :vars, 'ComparisonTableComponent::VarColumnComponent'
 
     erb_template <<-ERB
-      <tr>
+      <tr class="<%= @classes %>">
         <td>
           <%= school %>
+          <% references.each do |ref| %>
+            <%= ref %>
+          <% end %>
         </td>
         <% vars.each do |var| %>
           <%= var %>
@@ -41,25 +66,37 @@ class ComparisonTableComponent < ViewComponent::Base
     ERB
   end
 
+  # The contents of a table cell. Provides support for:
+  #
+  # Displaying a formatted variable. Pass in the `val:` and `unit:`
+  # Displaying a change column. Pass in the `val:`, `unit:` and set the `:change` flag.
+  # Displaying a text value. E.g. a simple translated value Pass in the `text:`
+  # Displaying arbitrary content. Just pass a block to the var and ERB will be rendered to cell
+  #
+  # Custom classes can be provided via the classes keyword.
+  # By default data columns are right aligned
   class VarColumnComponent < ViewComponent::Base
-    def initialize(val: nil, unit: nil, change: false, classes: 'text-right')
+    def initialize(val: nil, unit: :kwh, change: false, text: nil, classes: 'text-right')
       @val = val
       @unit = unit
       @change = change
+      @text = text
       @classes = classes
     end
 
     def call
-      if content?
-        return content_tag :td, content, { class: @classes }
-      end
+      # Render content of the block if providing, adding classes to td
+      return content_tag :td, content, { class: @classes } if content?
 
-      if @change
-        value = helpers.format_unit(@val, @unit, true, :benchmark)
-        content_tag :td, helpers.up_downify(value), { class: @classes }
-      else
-        content_tag :td, helpers.format_unit(@val, @unit, true, :benchmark), { class: @classes }
-      end
+      # Render the provided text if provided
+      return content_tag :td, @text, { class: @classes } if @text.present?
+
+      # Otherwise format and present data values
+      formatted_value = helpers.format_unit(@val, @unit, true, :benchmark)
+      # Wrap columns showing percentage change in up/down indicator
+      rendered_value = @change ? helpers.up_downify(formatted_value) : formatted_value
+
+      content_tag :td, rendered_value, { class: @classes }
     end
   end
 end

--- a/app/components/comparison_table_component.rb
+++ b/app/components/comparison_table_component.rb
@@ -1,0 +1,76 @@
+class ComparisonTableComponent < ViewComponent::Base
+  include AdvicePageHelper
+  include ComparisonsHelper
+
+  def initialize(report:, headers: [], col_groups: [], table_name:, index_params:)
+    @report = report
+    @col_groups = col_groups
+    @headers = headers
+    @table_name = table_name
+    @index_params = index_params
+  end
+
+  renders_many :rows, 'RowComponent'
+  renders_one :footer
+  renders_many :colgroup, 'ColumnGroupComponent'
+
+  class ColumnGroupComponent < ViewComponent::Base
+    def initialize(label: '', colspan: 1)
+      @label = label
+      @colspan = colspan
+    end
+
+    def call
+      content_tag :th, @label, { colspan: @colspan }
+    end
+  end
+
+  class RowComponent < ViewComponent::Base
+    renders_one :school
+    renders_many :vars, 'ComparisonTableComponent::VarColumnComponent'
+
+    erb_template <<-ERB
+      <tr>
+        <td>
+          <%= school %>
+        </td>
+        <% vars.each do |var| %>
+          <%= var %>
+        <% end %>
+      </tr>
+    ERB
+  end
+
+  class VarColumnComponent < ViewComponent::Base
+    def initialize(val: nil, unit: nil, change: false, classes: 'text-right')
+      @val = val
+      @unit = unit
+      @change = change
+      @classes = classes
+    end
+
+    def call
+      if content?
+        return content_tag :td, content, { class: @classes }
+      end
+
+      if @change
+        value = helpers.format_unit(@val, @unit, true, :benchmark)
+        content_tag :td, helpers.up_downify(value), { class: @classes }
+      else
+        content_tag :td, helpers.format_unit(@val, @unit, true, :benchmark), { class: @classes }
+      end
+    end
+  end
+
+  class ChangeColumnComponent < ViewComponent::Base
+    def initialize(val:, classes: 'text-right')
+      @val = val
+      @classes = classes
+    end
+
+    def call
+      content_tag :td, helpers.updownify(@val), { class: @classes }
+    end
+  end
+end

--- a/app/components/comparison_table_component.rb
+++ b/app/components/comparison_table_component.rb
@@ -62,15 +62,4 @@ class ComparisonTableComponent < ViewComponent::Base
       end
     end
   end
-
-  class ChangeColumnComponent < ViewComponent::Base
-    def initialize(val:, classes: 'text-right')
-      @val = val
-      @classes = classes
-    end
-
-    def call
-      content_tag :td, helpers.updownify(@val), { class: @classes }
-    end
-  end
 end

--- a/app/components/comparison_table_component.rb
+++ b/app/components/comparison_table_component.rb
@@ -11,7 +11,7 @@ class ComparisonTableComponent < ViewComponent::Base
   include AdvicePageHelper
   include ComparisonsHelper
 
-  def initialize(report:, headers: [], colgroups: [], table_name:, index_params:)
+  def initialize(report:, table_name:, index_params:, headers: [], colgroups: [])
     @report = report
     @colgroups = colgroups
     @headers = headers
@@ -70,26 +70,21 @@ class ComparisonTableComponent < ViewComponent::Base
   #
   # Displaying a formatted variable. Pass in the `val:` and `unit:`
   # Displaying a change column. Pass in the `val:`, `unit:` and set the `:change` flag.
-  # Displaying a text value. E.g. a simple translated value Pass in the `text:`
   # Displaying arbitrary content. Just pass a block to the var and ERB will be rendered to cell
   #
   # Custom classes can be provided via the classes keyword.
   # By default data columns are right aligned
   class VarColumnComponent < ViewComponent::Base
-    def initialize(val: nil, unit: :kwh, change: false, text: nil, classes: 'text-right')
+    def initialize(val: nil, unit: :kwh, change: false, classes: 'text-right')
       @val = val
       @unit = unit
       @change = change
-      @text = text
       @classes = classes
     end
 
     def call
       # Render content of the block if providing, adding classes to td
       return content_tag :td, content, { class: @classes } if content?
-
-      # Render the provided text if provided
-      return content_tag :td, @text, { class: @classes } if @text.present?
 
       # Otherwise format and present data values
       formatted_value = helpers.format_unit(@val, @unit, true, :benchmark)

--- a/app/components/comparison_table_component/comparison_table_component.html.erb
+++ b/app/components/comparison_table_component/comparison_table_component.html.erb
@@ -1,0 +1,28 @@
+<div class='text-right mt-2'>
+  <%= download_link(@report, @table_name, @index_params) %>
+</div>
+
+<table id="<%= comparison_table_id(@report, @table_name) %>" class="table advice-table table-sorted">
+  <thead class="sticky-heading">
+    <% if @col_groups.any? %>
+      <tr>
+        <% @col_groups.each do |col_group| %>
+          <th colspan="<%= col_group[:colspan] || 1 %>"><%= col_group[:label] %></th>
+        <% end %>
+      </tr>
+    <% end %>
+    <tr>
+      <% @headers.each do |header| %>
+        <th><%= header %></th>
+      <% end %>
+    </tr>
+  </thead>
+  <tbody>
+    <% rows.each do |row| %>
+      <%= row %>
+    <% end %>
+  </tbody>
+  <tfoot>
+    <%= footer %>
+  </tfoot>
+</table>

--- a/app/components/comparison_table_component/comparison_table_component.html.erb
+++ b/app/components/comparison_table_component/comparison_table_component.html.erb
@@ -4,10 +4,10 @@
 
 <table id="<%= comparison_table_id(@report, @table_name) %>" class="table advice-table table-sorted">
   <thead class="sticky-heading">
-    <% if @col_groups.any? %>
+    <% if @colgroups.any? %>
       <tr>
-        <% @col_groups.each do |col_group| %>
-          <th colspan="<%= col_group[:colspan] || 1 %>"><%= col_group[:label] %></th>
+        <% @colgroups.each do |colgroup| %>
+          <th colspan="<%= colgroup[:colspan] || 1 %>"><%= colgroup[:label] %></th>
         <% end %>
       </tr>
     <% end %>

--- a/app/controllers/comparisons/base_controller.rb
+++ b/app/controllers/comparisons/base_controller.rb
@@ -12,6 +12,8 @@ module Comparisons
     before_action :set_report
 
     def index
+      @col_groups = col_groups
+      @headers = headers
       @results = load_data
       respond_to do |format|
         format.html do
@@ -28,6 +30,14 @@ module Comparisons
     end
 
     private
+
+    def col_groups
+      []
+    end
+
+    def headers
+      []
+    end
 
     def set_report
       @report = Comparison::Report.find_by_key(key) if key

--- a/app/controllers/comparisons/base_controller.rb
+++ b/app/controllers/comparisons/base_controller.rb
@@ -10,10 +10,9 @@ module Comparisons
     helper_method :index_params
     before_action :set_advice_page
     before_action :set_report
+    before_action :set_headers
 
     def index
-      @colgroups = colgroups
-      @headers = headers
       @results = load_data
       respond_to do |format|
         format.html do
@@ -39,12 +38,18 @@ module Comparisons
       []
     end
 
+    def set_headers
+      @colgroups = colgroups
+      @headers = headers
+    end
+
     def set_report
       @report = Comparison::Report.find_by_key(key) if key
     end
 
     def set_advice_page
       @advice_page = AdvicePage.find_by_key(advice_page_key) if advice_page_key
+      @advice_page_tab = advice_page_tab
     end
 
     # Key for the Comparison::Report
@@ -55,6 +60,11 @@ module Comparisons
     # Key for the AdvicePage used to link to school analysis
     def advice_page_key
       nil
+    end
+
+    # Tab of the advice page to link to by default
+    def advice_page_tab
+      :insights
     end
 
     # Load the results from the view

--- a/app/controllers/comparisons/base_controller.rb
+++ b/app/controllers/comparisons/base_controller.rb
@@ -12,7 +12,7 @@ module Comparisons
     before_action :set_report
 
     def index
-      @col_groups = col_groups
+      @colgroups = colgroups
       @headers = headers
       @results = load_data
       respond_to do |format|
@@ -31,7 +31,7 @@ module Comparisons
 
     private
 
-    def col_groups
+    def colgroups
       []
     end
 

--- a/app/controllers/comparisons/baseload_per_pupil_controller.rb
+++ b/app/controllers/comparisons/baseload_per_pupil_controller.rb
@@ -4,6 +4,17 @@ module Comparisons
   class BaseloadPerPupilController < BaseController
     private
 
+    def headers
+      [
+        t('analytics.benchmarking.configuration.column_headings.school'),
+        t('analytics.benchmarking.configuration.column_headings.baseload_per_pupil_w'),
+        t('analytics.benchmarking.configuration.column_headings.last_year_cost_of_baseload'),
+        t('analytics.benchmarking.configuration.column_headings.average_baseload_kw'),
+        t('analytics.benchmarking.configuration.column_headings.baseload_percent'),
+        t('analytics.benchmarking.configuration.column_headings.saving_if_matched_exemplar_school')
+      ]
+    end
+
     def key
       :baseload_per_pupil
     end

--- a/app/controllers/comparisons/change_in_electricity_since_last_year_controller.rb
+++ b/app/controllers/comparisons/change_in_electricity_since_last_year_controller.rb
@@ -2,7 +2,7 @@ module Comparisons
   class ChangeInElectricitySinceLastYearController < BaseController
     private
 
-    def col_groups
+    def colgroups
       [
         { label: '' },
         { label: t('analytics.benchmarking.configuration.column_groups.kwh'), colspan: 3 },

--- a/app/controllers/comparisons/change_in_electricity_since_last_year_controller.rb
+++ b/app/controllers/comparisons/change_in_electricity_since_last_year_controller.rb
@@ -2,6 +2,32 @@ module Comparisons
   class ChangeInElectricitySinceLastYearController < BaseController
     private
 
+    def col_groups
+      [
+        { label: '' },
+        { label: t('analytics.benchmarking.configuration.column_groups.kwh'), colspan: 3 },
+        { label: t('analytics.benchmarking.configuration.column_groups.co2_kg'), colspan: 3 },
+        { label: t('analytics.benchmarking.configuration.column_groups.gbp'), colspan: 3 },
+        { label: t('analytics.benchmarking.configuration.column_groups.solar_self_consumption') }
+      ]
+    end
+
+    def headers
+      [
+        t('analytics.benchmarking.configuration.column_headings.school'),
+        t('analytics.benchmarking.configuration.column_headings.previous_year'),
+        t('analytics.benchmarking.configuration.column_headings.last_year'),
+        t('analytics.benchmarking.configuration.column_headings.change_pct'),
+        t('analytics.benchmarking.configuration.column_headings.previous_year'),
+        t('analytics.benchmarking.configuration.column_headings.last_year'),
+        t('analytics.benchmarking.configuration.column_headings.change_pct'),
+        t('analytics.benchmarking.configuration.column_headings.previous_year'),
+        t('analytics.benchmarking.configuration.column_headings.last_year'),
+        t('analytics.benchmarking.configuration.column_headings.change_pct'),
+        t('analytics.benchmarking.configuration.column_headings.estimated')
+      ]
+    end
+
     def advice_page_key
       :electricity_long_term
     end

--- a/app/views/comparisons/base/_tables.html.erb
+++ b/app/views/comparisons/base/_tables.html.erb
@@ -1,5 +1,6 @@
 <% @table_names.each_with_index do |table_name, index| %>
   <%= render table_name.to_s,
-             report: report, advice_page: advice_page, results: results,
-             table_name: table_name, table_number: index + 1 %>
+             results: results, report: report, advice_page: advice_page, table_name: table_name,
+             index_params: index_params, headers: headers, colgroups: colgroups,
+             advice_page_tab: advice_page_tab, table_number: index + 1 %>
 <% end %>

--- a/app/views/comparisons/base/index.html.erb
+++ b/app/views/comparisons/base/index.html.erb
@@ -23,7 +23,8 @@
   <div class="tab-pane fade show active" id="tables" role="tabpanel" aria-labelledby="tables-tab">
     <div class="row">
       <div class="col-sm-12">
-        <%= render 'tables', results: @results, advice_page: @advice_page, report: @report %>
+        <%= render 'tables', results: @results, advice_page: @advice_page, report: @report,
+                             headers: @headers, colgroups: @colgroups, advice_page_tab: @advice_page_tab %>
       </div>
     </div>
   </div>

--- a/app/views/comparisons/baseload_per_pupil/_table.csv.ruby
+++ b/app/views/comparisons/baseload_per_pupil/_table.csv.ruby
@@ -1,12 +1,5 @@
 CSV.generate do |csv|
-  csv << [
-    t('analytics.benchmarking.configuration.column_headings.school'),
-    t('analytics.benchmarking.configuration.column_headings.baseload_per_pupil_w'),
-    t('analytics.benchmarking.configuration.column_headings.last_year_cost_of_baseload'),
-    t('analytics.benchmarking.configuration.column_headings.average_baseload_kw'),
-    t('analytics.benchmarking.configuration.column_headings.baseload_percent'),
-    t('analytics.benchmarking.configuration.column_headings.saving_if_matched_exemplar_school')
-  ]
+  csv << @headers
 
   @results.each do |result|
     csv << [result.school.name,

--- a/app/views/comparisons/baseload_per_pupil/_table.html.erb
+++ b/app/views/comparisons/baseload_per_pupil/_table.html.erb
@@ -1,7 +1,9 @@
-<%= component 'comparison_table', headers: @headers, report: report, table_name: table_name, index_params: index_params do |c| %>
+<%= component 'comparison_table',
+              report: report, advice_page: advice_page, table_name: table_name, index_params: index_params,
+              headers: headers, colgroups: colgroups, advice_page_tab: advice_page_tab do |c| %>
   <% @results.each do |result| %>
     <% c.with_row do |r| %>
-      <% r.with_school school: result.school, advice_page: advice_page %>
+      <% r.with_school school: result.school %>
 
       <% if result.electricity_economic_tariff_changed_this_year %>
         <% r.with_reference do %>

--- a/app/views/comparisons/baseload_per_pupil/_table.html.erb
+++ b/app/views/comparisons/baseload_per_pupil/_table.html.erb
@@ -1,58 +1,21 @@
-<div class='text-right mt-2'>
-  <%= download_link(report, table_name, index_params) %>
-</div>
-
-<table id="<%= comparison_table_id(report, table_name) %>" class="table advice-table table-sorted">
-  <thead class="sticky-heading">
-    <tr>
-      <th><%= t('analytics.benchmarking.configuration.column_headings.school') %></th>
-      <th class="text-right">
-        <%= t('analytics.benchmarking.configuration.column_headings.baseload_per_pupil_w') %>
-      </th>
-      <th class="text-right">
-        <%= t('analytics.benchmarking.configuration.column_headings.last_year_cost_of_baseload') %>
-      </th>
-      <th class="text-right">
-        <%= t('analytics.benchmarking.configuration.column_headings.average_baseload_kw') %>
-      </th>
-      <th class="text-right">
-        <%= t('analytics.benchmarking.configuration.column_headings.baseload_percent') %>
-      </th>
-      <th class="text-right">
-        <%= t('analytics.benchmarking.configuration.column_headings.saving_if_matched_exemplar_school') %>
-      </th>
-    </tr>
-  </thead>
-  <tbody>
-    <% results.each do |baseload_per_pupil| %>
-      <tr>
-        <td>
-          <%= link_to baseload_per_pupil.school.name,
-                      advice_page_path(baseload_per_pupil.school, advice_page, :insights) %>
-          <% if baseload_per_pupil.electricity_economic_tariff_changed_this_year %>
-            <a href="#electricity_economic_tariff_changed_this_year">[t]</a>
-          <% end %>
-        </td>
-        <td class="text-right">
-          <%= format_unit(baseload_per_pupil.one_year_baseload_per_pupil_kw * 1000.0, :kw, true, :benchmark) %>
-        </td>
-        <td class="text-right">
-          <%= format_unit(baseload_per_pupil.average_baseload_last_year_gbp, :£, true, :benchmark) %>
-        </td>
-        <td class="text-right">
-          <%= format_unit(baseload_per_pupil.average_baseload_last_year_kw, :kw, true, :benchmark) %>
-        </td>
-        <td class="text-right">
-          <%= format_unit(baseload_per_pupil.annual_baseload_percent, :percent, true, :benchmark) %>
-        </td>
-        <td class="text-right">
-          <%= format_unit([0.0, baseload_per_pupil.one_year_saving_versus_exemplar_gbp].max, :£, true,
-                          :benchmark) %>
-        </td>
-      </tr>
+<%= component 'comparison_table', headers: @headers, report: report, table_name: table_name, index_params: index_params do |c| %>
+  <% @results.each do |result| %>
+    <% c.with_row do |r| %>
+      <% r.with_school do %>
+        <%= link_to result.school.name,
+                    advice_page_path(result.school, advice_page, :insights) %>
+        <% if result.electricity_economic_tariff_changed_this_year %>
+          <a href="#electricity_economic_tariff_changed_this_year">[t]</a>
+        <% end %>
+      <% end %>
+      <%= r.with_var val: result.one_year_baseload_per_pupil_kw * 1000.0, unit: :kw %>
+      <%= r.with_var val: result.average_baseload_last_year_gbp, unit: :£ %>
+      <%= r.with_var val: result.average_baseload_last_year_kw, unit: :kw %>
+      <%= r.with_var val: result.annual_baseload_percent, unit: :percent %>
+      <%= r.with_var val: [0.0, result.one_year_saving_versus_exemplar_gbp].max, unit: :£ %>
     <% end %>
-  </tbody>
-  <tfoot>
+  <% end %>
+  <% c.with_footer do %>
     <tr>
       <td colspan="6">
         <p>
@@ -63,5 +26,5 @@
         <%= t('analytics.benchmarking.configuration.column_heading_explanation.last_year_definition_html') %>
       </td>
     </tr>
-  </tfoot>
-</table>
+  <% end %>
+<% end %>

--- a/app/views/comparisons/baseload_per_pupil/_table.html.erb
+++ b/app/views/comparisons/baseload_per_pupil/_table.html.erb
@@ -1,13 +1,14 @@
 <%= component 'comparison_table', headers: @headers, report: report, table_name: table_name, index_params: index_params do |c| %>
   <% @results.each do |result| %>
     <% c.with_row do |r| %>
-      <% r.with_school do %>
-        <%= link_to result.school.name,
-                    advice_page_path(result.school, advice_page, :insights) %>
-        <% if result.electricity_economic_tariff_changed_this_year %>
-          <a href="#electricity_economic_tariff_changed_this_year">[t]</a>
+      <% r.with_school school: result.school, advice_page: advice_page %>
+
+      <% if result.electricity_economic_tariff_changed_this_year %>
+        <% r.with_reference do %>
+            <a href="#electricity_economic_tariff_changed_this_year">[t]</a>
         <% end %>
       <% end %>
+
       <%= r.with_var val: result.one_year_baseload_per_pupil_kw * 1000.0, unit: :kw %>
       <%= r.with_var val: result.average_baseload_last_year_gbp, unit: :£ %>
       <%= r.with_var val: result.average_baseload_last_year_kw, unit: :kw %>

--- a/app/views/comparisons/change_in_electricity_since_last_year/_table.csv.ruby
+++ b/app/views/comparisons/change_in_electricity_since_last_year/_table.csv.ruby
@@ -13,19 +13,7 @@ CSV.generate do |csv|
     t('analytics.benchmarking.configuration.column_groups.solar_self_consumption')
   ]
 
-  csv << [
-      t('analytics.benchmarking.configuration.column_headings.school'),
-      t('analytics.benchmarking.configuration.column_headings.previous_year'),
-      t('analytics.benchmarking.configuration.column_headings.last_year'),
-      t('analytics.benchmarking.configuration.column_headings.change_pct'),
-      t('analytics.benchmarking.configuration.column_headings.previous_year'),
-      t('analytics.benchmarking.configuration.column_headings.last_year'),
-      t('analytics.benchmarking.configuration.column_headings.change_pct'),
-      t('analytics.benchmarking.configuration.column_headings.previous_year'),
-      t('analytics.benchmarking.configuration.column_headings.last_year'),
-      t('analytics.benchmarking.configuration.column_headings.change_pct'),
-      t('analytics.benchmarking.configuration.column_headings.estimated')
-    ]
+  csv << @headers
 
   @results.each do |result|
    csv << [

--- a/app/views/comparisons/change_in_electricity_since_last_year/_table.html.erb
+++ b/app/views/comparisons/change_in_electricity_since_last_year/_table.html.erb
@@ -1,17 +1,16 @@
 <%= component 'comparison_table',
-              col_groups: @col_groups, headers: @headers, report: report,
+              colgroups: @colgroups, headers: @headers, report: report,
               table_name: table_name, index_params: index_params do |c| %>
   <% @results.each do |result| %>
     <% c.with_row do |r| %>
-      <% r.with_school do %>
-        <%= link_to result.school.name,
-                    advice_page_path(result.school, advice_page, :insights) %>
-      <% end %>
+      <% r.with_school school: result.school, advice_page: advice_page %>
+
       <%= r.with_var val: result.previous_year_electricity_kwh, unit: :kwh %>
       <%= r.with_var val: result.current_year_electricity_kwh, unit: :kwh %>
       <%= r.with_var change: true,
                      val: percent_change(result.previous_year_electricity_kwh, result.current_year_electricity_kwh),
                      unit: :relative_percent_0dp %>
+
       <%= r.with_var val: result.previous_year_electricity_co2, unit: :co2 %>
       <%= r.with_var val: result.current_year_electricity_co2, unit: :co2 %>
       <%= r.with_var change: true,
@@ -24,13 +23,7 @@
                      val: percent_change(result.previous_year_electricity_gbp, result.current_year_electricity_gbp),
                      unit: :relative_percent_0dp %>
 
-      <%= r.with_var do %>
-        <% if result.solar_type == 'synthetic' %>
-          <%= t('common.labels.yes_label') %>
-        <% else %>
-          <%= t('common.labels.no_label') %>
-        <% end %>
-      <% end %>
+      <%= r.with_var text: result.solar_type == 'synthetic' ? t('common.labels.yes_label') : t('common.labels.no_label') %>
     <% end %>
   <% end %>
   <% c.with_footer do %>

--- a/app/views/comparisons/change_in_electricity_since_last_year/_table.html.erb
+++ b/app/views/comparisons/change_in_electricity_since_last_year/_table.html.erb
@@ -23,7 +23,7 @@
                      val: percent_change(result.previous_year_electricity_gbp, result.current_year_electricity_gbp),
                      unit: :relative_percent_0dp %>
 
-      <%= r.with_var text: result.solar_type == 'synthetic' ? t('common.labels.yes_label') : t('common.labels.no_label') %>
+      <%= r.with_var { result.solar_type == 'synthetic' ? t('common.labels.yes_label') : t('common.labels.no_label') } %>
     <% end %>
   <% end %>
   <% c.with_footer do %>

--- a/app/views/comparisons/change_in_electricity_since_last_year/_table.html.erb
+++ b/app/views/comparisons/change_in_electricity_since_last_year/_table.html.erb
@@ -1,9 +1,9 @@
 <%= component 'comparison_table',
-              colgroups: @colgroups, headers: @headers, report: report,
-              table_name: table_name, index_params: index_params do |c| %>
+              report: report, advice_page: advice_page, table_name: table_name, index_params: index_params,
+              headers: headers, colgroups: colgroups, advice_page_tab: advice_page_tab  do |c| %>
   <% @results.each do |result| %>
     <% c.with_row do |r| %>
-      <% r.with_school school: result.school, advice_page: advice_page %>
+      <% r.with_school school: result.school %>
 
       <%= r.with_var val: result.previous_year_electricity_kwh, unit: :kwh %>
       <%= r.with_var val: result.current_year_electricity_kwh, unit: :kwh %>
@@ -23,7 +23,7 @@
                      val: percent_change(result.previous_year_electricity_gbp, result.current_year_electricity_gbp),
                      unit: :relative_percent_0dp %>
 
-      <%= r.with_var { result.solar_type == 'synthetic' ? t('common.labels.yes_label') : t('common.labels.no_label') } %>
+      <%= r.with_var { y_n(result.solar_type == 'synthetic') } %>
     <% end %>
   <% end %>
   <% c.with_footer do %>

--- a/app/views/comparisons/change_in_electricity_since_last_year/_table.html.erb
+++ b/app/views/comparisons/change_in_electricity_since_last_year/_table.html.erb
@@ -1,106 +1,39 @@
-<div class='text-right mt-2'>
-  <%= download_link(report, table_name, index_params) %>
-</div>
+<%= component 'comparison_table',
+              col_groups: @col_groups, headers: @headers, report: report,
+              table_name: table_name, index_params: index_params do |c| %>
+  <% @results.each do |result| %>
+    <% c.with_row do |r| %>
+      <% r.with_school do %>
+        <%= link_to result.school.name,
+                    advice_page_path(result.school, advice_page, :insights) %>
+      <% end %>
+      <%= r.with_var val: result.previous_year_electricity_kwh, unit: :kwh %>
+      <%= r.with_var val: result.current_year_electricity_kwh, unit: :kwh %>
+      <%= r.with_var change: true,
+                     val: percent_change(result.previous_year_electricity_kwh, result.current_year_electricity_kwh),
+                     unit: :relative_percent_0dp %>
+      <%= r.with_var val: result.previous_year_electricity_co2, unit: :co2 %>
+      <%= r.with_var val: result.current_year_electricity_co2, unit: :co2 %>
+      <%= r.with_var change: true,
+                     val: percent_change(result.previous_year_electricity_co2, result.current_year_electricity_co2),
+                     unit: :relative_percent_0dp %>
 
-<table id="<%= comparison_table_id(report, table_name) %>" class="table advice-table table-sorted">
-  <thead class="sticky-heading">
-    <tr>
-      <th></th>
-      <th colspan="3" class="text-center"><%= t('analytics.benchmarking.configuration.column_groups.kwh') %></th>
-      <th colspan="3" class="text-center"><%= t('analytics.benchmarking.configuration.column_groups.co2_kg') %></th>
-      <th colspan="3" class="text-center"><%= t('analytics.benchmarking.configuration.column_groups.gbp') %></th>
-      <th class="text-center">
-        <%= t('analytics.benchmarking.configuration.column_groups.solar_self_consumption') %>
-      </th>
-    </tr>
-    <tr>
-      <th><%= t('analytics.benchmarking.configuration.column_headings.school') %></th>
-      <th class="text-right">
-        <%= t('analytics.benchmarking.configuration.column_headings.previous_year') %>
-      </th>
-      <th class="text-right">
-        <%= t('analytics.benchmarking.configuration.column_headings.last_year') %>
-      </th>
-      <th class="text-right">
-        <%= t('analytics.benchmarking.configuration.column_headings.change_pct') %>
-      </th>
-      <th class="text-right">
-        <%= t('analytics.benchmarking.configuration.column_headings.previous_year') %>
-      </th>
-      <th class="text-right">
-        <%= t('analytics.benchmarking.configuration.column_headings.last_year') %>
-      </th>
-      <th class="text-right">
-        <%= t('analytics.benchmarking.configuration.column_headings.change_pct') %>
-      </th>
-      <th class="text-right">
-        <%= t('analytics.benchmarking.configuration.column_headings.previous_year') %>
-      </th>
-      <th class="text-right">
-        <%= t('analytics.benchmarking.configuration.column_headings.last_year') %>
-      </th>
-      <th class="text-right">
-        <%= t('analytics.benchmarking.configuration.column_headings.change_pct') %>
-      </th>
-      <th class="text-right">
-        <%= t('analytics.benchmarking.configuration.column_headings.estimated') %>
-      </th>
-    </tr>
-  </thead>
-  <tbody>
-    <% results.each do |change_in_electricity_since_last_year| %>
-      <tr>
-        <td>
-          <%= link_to change_in_electricity_since_last_year.school.name,
-                      advice_page_path(change_in_electricity_since_last_year.school, advice_page, :insights) %>
-        </td>
+      <%= r.with_var val: result.previous_year_electricity_gbp, unit: :£ %>
+      <%= r.with_var val: result.current_year_electricity_gbp, unit: :£ %>
+      <%= r.with_var change: true,
+                     val: percent_change(result.previous_year_electricity_gbp, result.current_year_electricity_gbp),
+                     unit: :relative_percent_0dp %>
 
-        <td class="text-right">
-          <%= format_unit(change_in_electricity_since_last_year.previous_year_electricity_kwh, :kwh, true, :benchmark) %>
-        </td>
-        <td class="text-right">
-          <%= format_unit(change_in_electricity_since_last_year.current_year_electricity_kwh, :kwh, true, :benchmark) %>
-        </td>
-        <td class="text-right">
-          <% percent_change = percent_change(change_in_electricity_since_last_year.previous_year_electricity_kwh,
-                                             change_in_electricity_since_last_year.current_year_electricity_kwh) %>
-          <%= up_downify(format_unit(percent_change, :relative_percent_0dp, true, :benchmark)) %>
-        </td>
-
-        <td class="text-right">
-          <%= format_unit(change_in_electricity_since_last_year.previous_year_electricity_co2, :co2, true, :benchmark) %>
-        </td>
-        <td class="text-right">
-          <%= format_unit(change_in_electricity_since_last_year.current_year_electricity_co2, :co2, true, :benchmark) %>
-        </td>
-        <td class="text-right">
-          <% percent_change = percent_change(change_in_electricity_since_last_year.previous_year_electricity_co2,
-                                             change_in_electricity_since_last_year.current_year_electricity_co2) %>
-          <%= up_downify(format_unit(percent_change, :relative_percent_0dp, true, :benchmark)) %>
-        </td>
-
-        <td class="text-right">
-          <%= format_unit(change_in_electricity_since_last_year.previous_year_electricity_gbp, :£, true, :benchmark) %>
-        </td>
-        <td class="text-right">
-          <%= format_unit(change_in_electricity_since_last_year.current_year_electricity_gbp, :£, true, :benchmark) %>
-        </td>
-        <td class="text-right">
-          <% percent_change = percent_change(change_in_electricity_since_last_year.previous_year_electricity_gbp,
-                                             change_in_electricity_since_last_year.current_year_electricity_gbp) %>
-          <%= up_downify(format_unit(percent_change, :relative_percent_0dp, true, :benchmark)) %>
-        </td>
-        <td class="text-right">
-          <% if change_in_electricity_since_last_year.solar_type == 'synthetic' %>
-            <%= t('common.labels.yes_label') %>
-          <% else %>
-            <%= t('common.labels.no_label') %>
-          <% end %>
-        </td>
-      </tr>
+      <%= r.with_var do %>
+        <% if result.solar_type == 'synthetic' %>
+          <%= t('common.labels.yes_label') %>
+        <% else %>
+          <%= t('common.labels.no_label') %>
+        <% end %>
+      <% end %>
     <% end %>
-  </tbody>
-  <tfoot>
+  <% end %>
+  <% c.with_footer do %>
     <tr>
       <td colspan="6">
         <p>
@@ -109,5 +42,5 @@
         <%= t('analytics.benchmarking.configuration.column_heading_explanation.last_year_definition_html') %>
       </td>
     </tr>
-  </tfoot>
-</table>
+  <% end %>
+<% end %>

--- a/lib/generators/comparison_report/templates/_table.html.erb.tt
+++ b/lib/generators/comparison_report/templates/_table.html.erb.tt
@@ -1,36 +1,13 @@
-<div class='text-right mt-2'>
-  <%%= download_link(report, table_name, index_params) %>
-</div>
+<%= component 'comparison_table', headers: @headers, colgroups: @colgroups, report: report, table_name: table_name,
+                                  index_params: index_params do |c| %>
+  <% @results.each do |result| %>
+    <% c.with_row do |r| %>
+      <% r.with_school school: result.school, advice_page: nil %>
 
-<table id="<%%= comparison_table_id(report, table_name) %>" class="table advice-table table-sorted">
-  <thead>
-    <tr>
-      <th><%%= t('analytics.benchmarking.configuration.column_headings.school') %></th>
-      <th class="text-right">
-        More headings like this
-      </th>
-    </tr>
-  </thead>
-  <tbody>
-    <%% results.each do |row| %>
-      <tr>
-        <td>
-          <%%= link_to row.school.name,
-                      advice_page_path(row.school, advice_page, :insights) %>
-        </td>
-        <td class="text-right">
-          More data like this
-        </td>
-      </tr>
-    <%% end %>
-  </tbody>
-  <tfoot>
-    <tr>
-      <td colspan="6">
-        <p>
-          <strong><%%= t('analytics.benchmarking.content.footnotes.notes') %></strong>
-        </p>
-      </td>
-    </tr>
-  </tfoot>
-</table>
+      <%# replace these with correct values, in correct order %>
+      <%#= r.with_var val: result.one_year_baseload_per_pupil_kw * 1000.0, unit: :kw %>
+    <% end %>
+  <% end %>
+  <% c.with_footer do %>
+  <% end %>
+<% end %>

--- a/lib/generators/comparison_report/templates/_table.html.erb.tt
+++ b/lib/generators/comparison_report/templates/_table.html.erb.tt
@@ -1,8 +1,9 @@
-<%= component 'comparison_table', headers: @headers, colgroups: @colgroups, report: report, table_name: table_name,
-                                  index_params: index_params do |c| %>
+<%= component 'comparison_table',
+              report: report, advice_page: advice_page, table_name: table_name, index_params: index_params,
+              headers: headers, colgroups: colgroups, advice_page_tab: advice_page_tab do |c| %>
   <% @results.each do |result| %>
     <% c.with_row do |r| %>
-      <% r.with_school school: result.school, advice_page: nil %>
+      <% r.with_school school: result.school %>
 
       <%# replace these with correct values, in correct order %>
       <%#= r.with_var val: result.one_year_baseload_per_pupil_kw * 1000.0, unit: :kw %>

--- a/spec/components/comparison_table_component_spec.rb
+++ b/spec/components/comparison_table_component_spec.rb
@@ -1,0 +1,195 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ComparisonTableComponent, type: :component, include_url_helpers: true do
+  subject(:html) { render_inline(described_class.new(**params)) }
+
+  # need to use key present in the routes
+  let!(:report)  { create(:report, key: :baseload_per_pupil) }
+  let(:table_name) { 'table' }
+  let(:headers) { ['Col 1', 'Col 2'] }
+  let(:colgroups) { [] }
+
+  let(:params) do
+    {
+      report: report,
+      table_name: table_name,
+      index_params: {},
+      headers: headers,
+      colgroups: colgroups
+    }
+  end
+
+  it 'renders a download link' do
+    expect(html).to have_link(I18n.t('school_groups.download_as_csv'))
+  end
+
+  it 'inserts the table correctly' do
+    expect(html).to have_css('table.advice-table')
+    expect(html).to have_css('table.table-sorted')
+    expect(html).to have_css('table thead.sticky-heading')
+    expect(html).to have_css("##{report.key}-#{table_name}")
+  end
+
+  it 'inserts the headers' do
+    headers.each do |header|
+      expect(html).to have_selector('th', text: header)
+    end
+  end
+
+  context 'with column groups' do
+    let(:colgroups) do
+      [{ label: '', colspan: 1 }, { label: 'Group 1', colspan: 2 }]
+    end
+
+    it 'adds the column groups' do
+      colgroups.each do |group|
+        expect(html).to have_selector("th[colspan=#{group[:colspan]}]", text: group[:label])
+      end
+    end
+  end
+
+  context 'with footer' do
+    let(:footer) { 'This is the footer' }
+
+    subject(:html) do
+      render_inline(described_class.new(**params)) do |c|
+        c.with_footer do
+          footer
+        end
+      end
+    end
+
+    it 'adds the footer' do
+      within('table tfoot') do
+        expect(html).to have_content(footer)
+      end
+    end
+  end
+
+  context 'when rendering rows' do
+    context 'with school' do
+      subject(:html) do
+        render_inline(described_class.new(**params)) do |c|
+          c.with_row do |r|
+            r.with_school school: school, advice_page: advice_page, tab: tab
+          end
+        end
+      end
+
+      let(:school) { create(:school) }
+      let(:advice_page) { nil }
+      let(:tab) { :insights }
+
+      it 'renders a link to advice page index' do
+        expect(html).to have_link(school.name, href: school_advice_path(school))
+      end
+
+      context 'with advice page provided' do
+        let(:advice_page) { create(:advice_page, key: :baseload) }
+
+        it 'adds link to school advice page' do
+          expect(html).to have_link(school.name, href: insights_school_advice_baseload_path(school))
+        end
+
+        context 'when tab is specified' do
+          let(:tab) { :analysis }
+
+          it 'links to the tab' do
+            expect(html).to have_link(school.name, href: analysis_school_advice_baseload_path(school))
+          end
+        end
+      end
+    end
+
+    context 'with reference' do
+      let(:reference) { 'This is the reference' }
+
+      subject(:html) do
+        render_inline(described_class.new(**params)) do |c|
+          c.with_row do |r|
+            r.with_reference do
+              reference
+            end
+          end
+        end
+      end
+
+      it 'adds the reference' do
+        expect(html).to have_content(reference)
+      end
+    end
+
+    context 'with var as a block' do
+      let(:var) { 'Data' }
+
+      subject(:html) do
+        render_inline(described_class.new(**params)) do |c|
+          c.with_row do |r|
+            r.with_var do
+              var
+            end
+          end
+        end
+      end
+
+      it 'adds the variable' do
+        expect(html).to have_content(var)
+      end
+
+      it 'adds the default classes' do
+        expect(html).to have_css('td.text-right')
+      end
+
+      context 'when adding classes' do
+        subject(:html) do
+          render_inline(described_class.new(**params)) do |c|
+            c.with_row do |r|
+              r.with_var classes: 'text-left' do
+                'Test'
+              end
+            end
+          end
+        end
+
+        it 'adds the classes' do
+          expect(html).to have_css('td.text-left')
+        end
+      end
+    end
+
+    context 'with var to be formatted' do
+      let(:value) { 100 }
+
+      subject(:html) do
+        render_inline(described_class.new(**params)) do |c|
+          c.with_row do |r|
+            r.with_var val: value, unit: :£
+          end
+        end
+      end
+
+      it 'adds the formatted value' do
+        expect(html).to have_content('£100')
+      end
+    end
+
+    context 'with var to be formatted as a change' do
+      let(:value) { 0.5 }
+
+      subject(:html) do
+        render_inline(described_class.new(**params)) do |c|
+          c.with_row do |r|
+            r.with_var val: value, unit: :relative_percent_0dp, change: true
+          end
+        end
+      end
+
+      it 'adds the formatted value' do
+        expect(html).to have_content('+50%')
+        expect(html).to have_css('i.fa-arrow-circle-up')
+      end
+    end
+  end
+end

--- a/spec/components/comparison_table_component_spec.rb
+++ b/spec/components/comparison_table_component_spec.rb
@@ -6,7 +6,9 @@ RSpec.describe ComparisonTableComponent, type: :component, include_url_helpers: 
   subject(:html) { render_inline(described_class.new(**params)) }
 
   # need to use key present in the routes
-  let!(:report)  { create(:report, key: :baseload_per_pupil) }
+  let(:report) { create(:report, key: :baseload_per_pupil) }
+  let(:advice_page) { nil }
+  let(:advice_page_tab) { :insights }
   let(:table_name) { 'table' }
   let(:headers) { ['Col 1', 'Col 2'] }
   let(:colgroups) { [] }
@@ -14,10 +16,12 @@ RSpec.describe ComparisonTableComponent, type: :component, include_url_helpers: 
   let(:params) do
     {
       report: report,
+      advice_page: advice_page,
       table_name: table_name,
       index_params: {},
       headers: headers,
-      colgroups: colgroups
+      colgroups: colgroups,
+      advice_page_tab: advice_page_tab
     }
   end
 
@@ -73,14 +77,12 @@ RSpec.describe ComparisonTableComponent, type: :component, include_url_helpers: 
       subject(:html) do
         render_inline(described_class.new(**params)) do |c|
           c.with_row do |r|
-            r.with_school school: school, advice_page: advice_page, tab: tab
+            r.with_school school: school
           end
         end
       end
 
       let(:school) { create(:school) }
-      let(:advice_page) { nil }
-      let(:tab) { :insights }
 
       it 'renders a link to advice page index' do
         expect(html).to have_link(school.name, href: school_advice_path(school))
@@ -94,7 +96,7 @@ RSpec.describe ComparisonTableComponent, type: :component, include_url_helpers: 
         end
 
         context 'when tab is specified' do
-          let(:tab) { :analysis }
+          let(:advice_page_tab) { :analysis }
 
           it 'links to the tab' do
             expect(html).to have_link(school.name, href: analysis_school_advice_baseload_path(school))


### PR DESCRIPTION
This is a draft to illustrate an alternate approach, to see if we prefer the syntax/setup. We don't have to use this, but I thought a concrete example would be helpful.

Adds a view component for handling formatting of comparison tables.

- headers are defined in the controller and passed to the component and reused across both the HTML and CSV views
- for tables with multi-line headers, controllers can implement `col_group` to provide an array of column group configuration. Used in the component only currently, but could be used in CSV too
- supports a `school` slot for providing the school name and footnote text in the first column
- supports a `footer` slot for content to be added to the table footer
- supports row and column formatting, with cell contents specified using a `var` slot. This is flexible enough to format content, optionally wrap it in `updownify` or just pass the provided content through without further processing

I've reworked 2 views one simpler one and one with multi-line headers, alternate cell formatting and plain text columns.

The pros:

- views are a bit easier to read?
- easier to manage common table elements and styling as now centralised in the component
- helps to enforce common formatting conventions, ensure cells and headers are aligned correctly
- seems relatively easy to extend, although the `VarComponent` will potentially end up doing a lot of things

The cons:

- headers are now defined in separate class so need to cross-check between files to ensure things are ordered correctly
- ...?
