### PR TITLE
Annual change in solar PV production and resulting CO2 savings

### DIFF
--- a/app/controllers/comparisons/change_in_electricity_since_last_year_controller.rb
+++ b/app/controllers/comparisons/change_in_electricity_since_last_year_controller.rb
@@ -37,7 +37,7 @@ module Comparisons
     end
 
     def load_data
-      Comparison::ChangeInElectricitySinceLastYear.where(school: @schools).with_data.by_percentage_change
+      Comparison::ChangeInElectricitySinceLastYear.where(school: @schools).with_data.by_percentage_change(:previous_year_electricity_kwh, :current_year_electricity_kwh)
     end
   end
 end

--- a/app/controllers/comparisons/change_in_solar_pv_since_last_year_controller.rb
+++ b/app/controllers/comparisons/change_in_solar_pv_since_last_year_controller.rb
@@ -33,7 +33,7 @@ module Comparisons
     end
 
     def load_data
-      Comparison::ChangeInSolarPvSinceLastYear.where(school: @schools).with_data.by_percentage_change
+      Comparison::ChangeInSolarPvSinceLastYear.where(school: @schools).with_data.by_percentage_change(:previous_year_solar_pv_kwh, :current_year_solar_pv_kwh)
     end
   end
 end

--- a/app/controllers/comparisons/change_in_solar_pv_since_last_year_controller.rb
+++ b/app/controllers/comparisons/change_in_solar_pv_since_last_year_controller.rb
@@ -1,0 +1,39 @@
+module Comparisons
+  class ChangeInSolarPvSinceLastYearController < BaseController
+    private
+
+    def colgroups
+      [
+        { label: '' },
+        { label: t('analytics.benchmarking.configuration.column_groups.kwh'), colspan: 3 },
+        { label: t('analytics.benchmarking.configuration.column_groups.co2_kg'), colspan: 3 },
+        { label: t('analytics.benchmarking.configuration.column_groups.solar_self_consumption') }
+      ]
+    end
+
+    def headers
+      [
+        t('analytics.benchmarking.configuration.column_headings.school'),
+        t('analytics.benchmarking.configuration.column_headings.previous_year'),
+        t('analytics.benchmarking.configuration.column_headings.last_year'),
+        t('analytics.benchmarking.configuration.column_headings.change_pct'),
+        t('analytics.benchmarking.configuration.column_headings.previous_year'),
+        t('analytics.benchmarking.configuration.column_headings.last_year'),
+        t('analytics.benchmarking.configuration.column_headings.change_pct'),
+        t('analytics.benchmarking.configuration.column_headings.estimated')
+      ]
+    end
+
+    def key
+      :change_in_solar_pv_since_last_year
+    end
+
+    def advice_page_key
+      :solar_pv
+    end
+
+    def load_data
+      Comparison::ChangeInSolarPvSinceLastYear.where(school: @schools).with_data.by_percentage_change
+    end
+  end
+end

--- a/app/models/comparison/change_in_electricity_since_last_year.rb
+++ b/app/models/comparison/change_in_electricity_since_last_year.rb
@@ -14,7 +14,4 @@
 #
 class Comparison::ChangeInElectricitySinceLastYear < Comparison::View
   scope :with_data, -> { where.not(previous_year_electricity_kwh: nil, current_year_electricity_kwh: nil) }
-  scope :by_percentage_change, -> do
-    order(Arel.sql('NULLIF(previous_year_electricity_kwh,0) / NULLIF(current_year_electricity_kwh,0)'))
-  end
 end

--- a/app/models/comparison/change_in_solar_pv_since_last_year.rb
+++ b/app/models/comparison/change_in_solar_pv_since_last_year.rb
@@ -12,7 +12,4 @@
 #
 class Comparison::ChangeInSolarPvSinceLastYear < Comparison::View
   scope :with_data, -> { where.not(previous_year_solar_pv_kwh: nil) }
-  scope :by_percentage_change, -> do
-    order(Arel.sql('NULLIF(previous_year_solar_pv_kwh,0) / NULLIF(current_year_solar_pv_kwh,0)'))
-  end
 end

--- a/app/models/comparison/change_in_solar_pv_since_last_year.rb
+++ b/app/models/comparison/change_in_solar_pv_since_last_year.rb
@@ -1,0 +1,18 @@
+# == Schema Information
+#
+# Table name: change_in_solar_pv_since_last_years
+#
+#  current_year_solar_pv_co2  :float
+#  current_year_solar_pv_kwh  :float
+#  id                         :bigint(8)
+#  previous_year_solar_pv_co2 :float
+#  previous_year_solar_pv_kwh :float
+#  school_id                  :bigint(8)
+#  solar_type                 :text
+#
+class Comparison::ChangeInSolarPvSinceLastYear < Comparison::View
+  scope :with_data, -> { where.not(previous_year_solar_pv_kwh: nil) }
+  scope :by_percentage_change, -> do
+    order(Arel.sql('NULLIF(previous_year_solar_pv_kwh,0) / NULLIF(current_year_solar_pv_kwh,0)'))
+  end
+end

--- a/app/models/comparison/view.rb
+++ b/app/models/comparison/view.rb
@@ -10,6 +10,11 @@ class Comparison::View < ApplicationRecord
 
   belongs_to :school
 
+  # E.g. previous_year, current_year
+  scope :by_percentage_change, ->(base, new_val) do
+    order(Arel.sql("(NULLIF(#{new_val},0.0) - NULLIF(#{base},0.0)) / NULLIF(#{base},0.0) DESC NULLS FIRST"))
+  end
+
   def readonly?
     true
   end

--- a/app/models/comparison/view.rb
+++ b/app/models/comparison/view.rb
@@ -12,7 +12,7 @@ class Comparison::View < ApplicationRecord
 
   # E.g. previous_year, current_year
   scope :by_percentage_change, ->(base, new_val) do
-    order(Arel.sql("(NULLIF(#{new_val},0.0) - NULLIF(#{base},0.0)) / NULLIF(#{base},0.0) DESC NULLS FIRST"))
+    order(Arel.sql(sanitize_sql_array("(NULLIF(#{new_val},0.0) - NULLIF(#{base},0.0)) / NULLIF(#{base},0.0) DESC NULLS FIRST")))
   end
 
   def readonly?

--- a/app/views/comparisons/change_in_solar_pv_since_last_year/_table.csv.ruby
+++ b/app/views/comparisons/change_in_solar_pv_since_last_year/_table.csv.ruby
@@ -1,0 +1,17 @@
+CSV.generate do |csv|
+  csv << @headers
+  @results.each do |result|
+    csv << [
+      result.school.name,
+      format_unit(result.previous_year_solar_pv_kwh, Float, true, :benchmark),
+      format_unit(result.current_year_solar_pv_kwh, Float, true, :benchmark),
+      format_unit(percent_change(result.previous_year_solar_pv_kwh, result.current_year_solar_pv_kwh) * 100,
+                  Float, true, :benchmark),
+      format_unit(result.previous_year_solar_pv_co2, Float, true, :benchmark),
+      format_unit(result.current_year_solar_pv_co2, Float, true, :benchmark),
+      format_unit(percent_change(result.previous_year_solar_pv_co2, result.current_year_solar_pv_co2) * 100,
+                  Float, true, :benchmark),
+      result.solar_type == 'synthetic' ? t('common.labels.yes_label') : t('common.labels.no_label')
+    ]
+  end
+end.html_safe

--- a/app/views/comparisons/change_in_solar_pv_since_last_year/_table.csv.ruby
+++ b/app/views/comparisons/change_in_solar_pv_since_last_year/_table.csv.ruby
@@ -1,4 +1,15 @@
 CSV.generate do |csv|
+  csv << [
+    "",
+    t('analytics.benchmarking.configuration.column_groups.kwh'),
+    "",
+    "",
+    t('analytics.benchmarking.configuration.column_groups.co2_kg'),
+    "",
+    "",
+    t('analytics.benchmarking.configuration.column_groups.solar_self_consumption')
+  ]
+
   csv << @headers
   @results.each do |result|
     csv << [

--- a/app/views/comparisons/change_in_solar_pv_since_last_year/_table.html.erb
+++ b/app/views/comparisons/change_in_solar_pv_since_last_year/_table.html.erb
@@ -1,0 +1,33 @@
+<%= component 'comparison_table',
+              report: report, advice_page: advice_page, table_name: table_name, index_params: index_params,
+              headers: headers, colgroups: colgroups, advice_page_tab: advice_page_tab do |c| %>
+  <% @results.each do |result| %>
+    <% c.with_row do |r| %>
+      <% r.with_school school: result.school %>
+
+      <%= r.with_var val: result.previous_year_solar_pv_kwh, unit: :kwh %>
+      <%= r.with_var val: result.current_year_solar_pv_kwh, unit: :kwh %>
+      <%= r.with_var change: true,
+                     val: percent_change(result.previous_year_solar_pv_kwh, result.current_year_solar_pv_kwh),
+                     unit: :relative_percent_0dp %>
+
+      <%= r.with_var val: result.previous_year_solar_pv_co2, unit: :co2 %>
+      <%= r.with_var val: result.current_year_solar_pv_co2, unit: :co2 %>
+      <%= r.with_var change: true,
+                     val: percent_change(result.previous_year_solar_pv_co2, result.current_year_solar_pv_co2),
+                     unit: :relative_percent_0dp %>
+
+      <%= r.with_var { y_n(result.solar_type == 'synthetic') } %>
+    <% end %>
+  <% end %>
+  <% c.with_footer do %>
+    <tr>
+      <td colspan="6">
+        <p>
+          <strong><%= t('analytics.benchmarking.content.footnotes.notes') %></strong>
+        </p>
+        <%= t('analytics.benchmarking.configuration.column_heading_explanation.last_year_definition_html') %>
+      </td>
+    </tr>
+  <% end %>
+<% end %>

--- a/app/views/comparisons/change_in_solar_pv_since_last_year/_table.html.erb
+++ b/app/views/comparisons/change_in_solar_pv_since_last_year/_table.html.erb
@@ -5,17 +5,17 @@
     <% c.with_row do |r| %>
       <% r.with_school school: result.school %>
 
-      <%= r.with_var val: result.previous_year_solar_pv_kwh, unit: :kwh %>
-      <%= r.with_var val: result.current_year_solar_pv_kwh, unit: :kwh %>
-      <%= r.with_var change: true,
-                     val: percent_change(result.previous_year_solar_pv_kwh, result.current_year_solar_pv_kwh),
-                     unit: :relative_percent_0dp %>
+      <% r.with_var val: result.previous_year_solar_pv_kwh, unit: :kwh %>
+      <% r.with_var val: result.current_year_solar_pv_kwh, unit: :kwh %>
+      <% r.with_var change: true,
+                    val: percent_change(result.previous_year_solar_pv_kwh, result.current_year_solar_pv_kwh),
+                    unit: :relative_percent_0dp %>
 
-      <%= r.with_var val: result.previous_year_solar_pv_co2, unit: :co2 %>
-      <%= r.with_var val: result.current_year_solar_pv_co2, unit: :co2 %>
-      <%= r.with_var change: true,
-                     val: percent_change(result.previous_year_solar_pv_co2, result.current_year_solar_pv_co2),
-                     unit: :relative_percent_0dp %>
+      <% r.with_var val: result.previous_year_solar_pv_co2, unit: :co2 %>
+      <% r.with_var val: result.current_year_solar_pv_co2, unit: :co2 %>
+      <% r.with_var change: true,
+                    val: percent_change(result.previous_year_solar_pv_co2, result.current_year_solar_pv_co2),
+                    unit: :relative_percent_0dp %>
 
       <%= r.with_var { y_n(result.solar_type == 'synthetic') } %>
     <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -62,6 +62,7 @@ Rails.application.routes.draw do
   namespace :comparisons do
     resources :solar_pv_benefit_estimate, only: [:index]
     resources :annual_electricity_costs_per_pupil, only: [:index]
+    resources :change_in_solar_pv_since_last_year, only: [:index]
     resources :electricity_targets, only: [:index]
     resources :baseload_per_pupil, only: [:index]
     resources :change_in_electricity_since_last_year, only: [:index]

--- a/db/migrate/20240307181846_create_change_in_solar_pv_since_last_years.rb
+++ b/db/migrate/20240307181846_create_change_in_solar_pv_since_last_years.rb
@@ -1,0 +1,5 @@
+class CreateChangeInSolarPvSinceLastYears < ActiveRecord::Migration[6.1]
+  def change
+    create_view :change_in_solar_pv_since_last_years
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_03_06_163820) do
+ActiveRecord::Schema.define(version: 2024_03_07_181846) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
@@ -2295,27 +2295,6 @@ ActiveRecord::Schema.define(version: 2024_03_06_163820) do
             ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
     WHERE (data.alert_generation_run_id = latest_runs.id);
   SQL
-  create_view "annual_electricity_costs_per_pupils", sql_definition: <<-SQL
-      SELECT latest_runs.id,
-      data.alert_generation_run_id,
-      data.school_id,
-      data.one_year_electricity_per_pupil_gbp,
-      data.last_year_gbp,
-      data.one_year_saving_versus_exemplar_gbpcurrent
-     FROM ( SELECT alerts.alert_generation_run_id,
-              alerts.school_id,
-              data_1.one_year_electricity_per_pupil_gbp,
-              data_1.last_year_gbp,
-              data_1.one_year_saving_versus_exemplar_gbpcurrent
-             FROM alerts,
-              alert_types,
-              LATERAL jsonb_to_record(alerts.variables) data_1(one_year_electricity_per_pupil_gbp double precision, last_year_gbp double precision, one_year_saving_versus_exemplar_gbpcurrent double precision)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertElectricityAnnualVersusBenchmark'::text))) data,
-      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
-             FROM alert_generation_runs
-            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
-    WHERE (data.alert_generation_run_id = latest_runs.id);
-  SQL
   create_view "solar_generation_summaries", sql_definition: <<-SQL
       SELECT latest_runs.id,
       solar_generation.alert_generation_run_id,
@@ -2370,6 +2349,27 @@ ActiveRecord::Schema.define(version: 2024_03_06_163820) do
              FROM alert_generation_runs
             ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
     WHERE ((benefit_estimate.alert_generation_run_id = latest_runs.id) AND (additional.alert_generation_run_id = latest_runs.id));
+  SQL
+  create_view "annual_electricity_costs_per_pupils", sql_definition: <<-SQL
+      SELECT latest_runs.id,
+      data.alert_generation_run_id,
+      data.school_id,
+      data.one_year_electricity_per_pupil_gbp,
+      data.last_year_gbp,
+      data.one_year_saving_versus_exemplar_gbpcurrent
+     FROM ( SELECT alerts.alert_generation_run_id,
+              alerts.school_id,
+              data_1.one_year_electricity_per_pupil_gbp,
+              data_1.last_year_gbp,
+              data_1.one_year_saving_versus_exemplar_gbpcurrent
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) data_1(one_year_electricity_per_pupil_gbp double precision, last_year_gbp double precision, one_year_saving_versus_exemplar_gbpcurrent double precision)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertElectricityAnnualVersusBenchmark'::text))) data,
+      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
+             FROM alert_generation_runs
+            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
+    WHERE (data.alert_generation_run_id = latest_runs.id);
   SQL
   create_view "change_in_solar_pv_since_last_years", sql_definition: <<-SQL
       SELECT latest_runs.id,

--- a/db/views/change_in_solar_pv_since_last_years_v01.sql
+++ b/db/views/change_in_solar_pv_since_last_years_v01.sql
@@ -1,0 +1,26 @@
+SELECT latest_runs.id,
+       versus_benchmark.school_id,
+       versus_benchmark.previous_year_solar_pv_kwh,
+       versus_benchmark.current_year_solar_pv_kwh,
+       versus_benchmark.previous_year_solar_pv_co2,
+       versus_benchmark.current_year_solar_pv_co2,
+       versus_benchmark.solar_type
+FROM
+  (
+    SELECT alert_generation_run_id, school_id, data.*
+    FROM alerts, alert_types, jsonb_to_record(variables) AS data(
+      previous_year_solar_pv_kwh float,
+      current_year_solar_pv_kwh float,
+      previous_year_solar_pv_co2 float,
+      current_year_solar_pv_co2 float,
+      solar_type text
+    )
+    WHERE alerts.alert_type_id = alert_types.id and alert_types.class_name='AlertEnergyAnnualVersusBenchmark'
+  ) AS versus_benchmark,
+  (
+    SELECT DISTINCT ON (school_id) id
+    FROM alert_generation_runs
+    ORDER BY school_id, created_at DESC
+  ) latest_runs
+WHERE
+  versus_benchmark.alert_generation_run_id = latest_runs.id;

--- a/lib/generators/comparison_report/templates/system_spec.rb.tt
+++ b/lib/generators/comparison_report/templates/system_spec.rb.tt
@@ -34,7 +34,7 @@ describe '<%= file_name %>' do
       let(:expected_report) { report }
     end
 
-    it_behaves_like 'a school comparison report' do
+    it_behaves_like 'a school comparison report with a table' do
       let(:expected_report) { report }
       let(:expected_school) { school }
       let(:advice_page_path) { polymorphic_path([:insights, expected_school, :advice, advice_page_key]) }

--- a/spec/system/comparisons/change_in_solar_pv_since_last_year_spec.rb
+++ b/spec/system/comparisons/change_in_solar_pv_since_last_year_spec.rb
@@ -1,0 +1,78 @@
+require 'rails_helper'
+
+describe 'change_in_solar_pv_since_last_year' do
+  let!(:school) { create(:school) }
+  let(:key) { :change_in_solar_pv_since_last_year }
+  let(:advice_page_key) { :your_advice_page_key }
+
+  # change to your variables
+  let(:variables) do
+    {
+      current_year_percent_of_target_relative: +0.18699995372972533,
+      current_year_unscaled_percent_of_target_relative: -0.4799985149375391,
+      current_year_kwh: 1284.7,
+      current_year_target_kwh: 2281.8825833333326,
+      unscaled_target_kwh_to_date: 2401.9816666666666,
+      tracking_start_date: '2024-01-01'
+    }
+  end
+
+  # change to your alert type (there may be more than one!)
+  let(:alert_type) { create(:alert_type, class_name: 'AlertElectricityTargetAnnual') }
+  let(:alert_run) { create(:alert_generation_run, school: school) }
+  let!(:report) { create(:report, key: key) }
+
+  before do
+    create(:advice_page, key: advice_page_key)
+    create(:alert, school: school, alert_generation_run: alert_run, alert_type: alert_type, variables: variables)
+  end
+
+  context 'when viewing report' do
+    before { visit "/comparisons/#{key}" }
+
+    it_behaves_like 'a school comparison report' do
+      let(:expected_report) { report }
+    end
+
+    it_behaves_like 'a school comparison report' do
+      let(:expected_report) { report }
+      let(:expected_school) { school }
+      let(:advice_page_path) { polymorphic_path([:insights, expected_school, :advice, advice_page_key]) }
+      let(:expected_table) do
+        [['School',
+          'Percent above or below target since target set',
+          'Percent above or below last year',
+          'kWh consumption since target set',
+          'Target kWh consumption',
+          'Last year kWh consumption',
+          'Start date for target'],
+         [school.name,
+          '+18.7%',
+          '-48%',
+          '1,280',
+          '2,280',
+          '2,400',
+          'Monday 1 Jan 2024'],
+         ["Notes\nIn school comparisons 'last year' is defined as this year to date."]
+        ]
+      end
+      let(:expected_csv) do
+        [['School',
+          'Percent above or below target since target set',
+          'Percent above or below last year',
+          'kWh consumption since target set',
+          'Target kWh consumption',
+          'Last year kWh consumption',
+          'Start date for target'],
+         [school.name,
+          '18.7',
+          '-48',
+          '1,280',
+          '2,280',
+          '2,400',
+          '2024-01-01']
+        ]
+      end
+    end
+  end
+end

--- a/spec/system/comparisons/change_in_solar_pv_since_last_year_spec.rb
+++ b/spec/system/comparisons/change_in_solar_pv_since_last_year_spec.rb
@@ -3,22 +3,21 @@ require 'rails_helper'
 describe 'change_in_solar_pv_since_last_year' do
   let!(:school) { create(:school) }
   let(:key) { :change_in_solar_pv_since_last_year }
-  let(:advice_page_key) { :your_advice_page_key }
+  let(:advice_page_key) { :solar_pv }
 
   # change to your variables
   let(:variables) do
     {
-      current_year_percent_of_target_relative: +0.18699995372972533,
-      current_year_unscaled_percent_of_target_relative: -0.4799985149375391,
-      current_year_kwh: 1284.7,
-      current_year_target_kwh: 2281.8825833333326,
-      unscaled_target_kwh_to_date: 2401.9816666666666,
-      tracking_start_date: '2024-01-01'
+      previous_year_solar_pv_kwh: 1000.0,
+      current_year_solar_pv_kwh: 1100.0,
+      previous_year_solar_pv_co2: 800.0,
+      current_year_solar_pv_co2: 900.0,
+      solar_type: 'synthetic'
     }
   end
 
   # change to your alert type (there may be more than one!)
-  let(:alert_type) { create(:alert_type, class_name: 'AlertElectricityTargetAnnual') }
+  let(:alert_type) { create(:alert_type, class_name: 'AlertEnergyAnnualVersusBenchmark') }
   let(:alert_run) { create(:alert_generation_run, school: school) }
   let!(:report) { create(:report, key: key) }
 
@@ -34,43 +33,49 @@ describe 'change_in_solar_pv_since_last_year' do
       let(:expected_report) { report }
     end
 
-    it_behaves_like 'a school comparison report' do
+    it_behaves_like 'a school comparison report with a table' do
       let(:expected_report) { report }
       let(:expected_school) { school }
       let(:advice_page_path) { polymorphic_path([:insights, expected_school, :advice, advice_page_key]) }
+      let(:headers) do
+        [
+          I18n.t('analytics.benchmarking.configuration.column_headings.school'),
+          I18n.t('analytics.benchmarking.configuration.column_headings.previous_year'),
+          I18n.t('analytics.benchmarking.configuration.column_headings.last_year'),
+          I18n.t('analytics.benchmarking.configuration.column_headings.change_pct'),
+          I18n.t('analytics.benchmarking.configuration.column_headings.previous_year'),
+          I18n.t('analytics.benchmarking.configuration.column_headings.last_year'),
+          I18n.t('analytics.benchmarking.configuration.column_headings.change_pct'),
+          I18n.t('analytics.benchmarking.configuration.column_headings.estimated')
+        ]
+      end
       let(:expected_table) do
-        [['School',
-          'Percent above or below target since target set',
-          'Percent above or below last year',
-          'kWh consumption since target set',
-          'Target kWh consumption',
-          'Last year kWh consumption',
-          'Start date for target'],
-         [school.name,
-          '+18.7%',
-          '-48%',
-          '1,280',
-          '2,280',
-          '2,400',
-          'Monday 1 Jan 2024'],
-         ["Notes\nIn school comparisons 'last year' is defined as this year to date."]
+        [
+          ['', 'kWh', 'CO2 (kg)', 'Solar self consumption'],
+          headers,
+          [school.name,
+           '1,000',
+           '1,100',
+           '+10%',
+           '800',
+           '900',
+           '+13%',
+           'Yes'],
+          ["Notes\nIn school comparisons 'last year' is defined as this year to date."]
         ]
       end
       let(:expected_csv) do
-        [['School',
-          'Percent above or below target since target set',
-          'Percent above or below last year',
-          'kWh consumption since target set',
-          'Target kWh consumption',
-          'Last year kWh consumption',
-          'Start date for target'],
-         [school.name,
-          '18.7',
-          '-48',
-          '1,280',
-          '2,280',
-          '2,400',
-          '2024-01-01']
+        [
+          ['', 'kWh', '', '', 'CO2 (kg)', '', '', 'Solar self consumption'],
+          headers,
+          [school.name,
+           '1,000',
+           '1,100',
+           '10',
+           '800',
+           '900',
+           '12.5',
+           'Yes']
         ]
       end
     end

--- a/spec/system/comparisons/solar_generation_summary_spec.rb
+++ b/spec/system/comparisons/solar_generation_summary_spec.rb
@@ -34,7 +34,7 @@ describe 'solar_generation_summary' do
     it_behaves_like 'a school comparison report with a table' do
       let(:expected_report) { report }
       let(:expected_school) { school }
-      let(:headers) { ['School', 'Generation (kWh)', 'Self consumption (kWh), Export (kWh)', 'Mains consumption (kWh)', 'Total onsite consumption (kWh)']}
+      let(:headers) { ['School', 'Generation (kWh)', 'Self consumption (kWh)', 'Export (kWh)', 'Mains consumption (kWh)', 'Total onsite consumption (kWh)']}
       let(:advice_page_path) { polymorphic_path([:insights, expected_school, :advice, advice_page_key]) }
       let(:expected_table) do
         [
@@ -51,11 +51,11 @@ describe 'solar_generation_summary' do
         [
           headers,
           [school.name,
-           '2500',
-           '2000',
+           '2,500',
+           '2,000',
            '500',
-           '1000',
-           '4000']
+           '1,000',
+           '4,000']
         ]
       end
     end

--- a/spec/system/comparisons/solar_generation_summary_spec.rb
+++ b/spec/system/comparisons/solar_generation_summary_spec.rb
@@ -31,7 +31,7 @@ describe 'solar_generation_summary' do
       let(:expected_report) { report }
     end
 
-    it_behaves_like 'a school comparison report' do
+    it_behaves_like 'a school comparison report with a table' do
       let(:expected_report) { report }
       let(:expected_school) { school }
       let(:headers) { ['School', 'Generation (kWh)', 'Self consumption (kWh), Export (kWh)', 'Mains consumption (kWh)', 'Total onsite consumption (kWh)']}

--- a/spec/system/comparisons/solar_pv_benefit_estimate_spec.rb
+++ b/spec/system/comparisons/solar_pv_benefit_estimate_spec.rb
@@ -8,7 +8,7 @@ describe 'solar_pv_benefit_estimate' do
   let(:variables) do
     {
       optimum_kwp: 44.2,
-      optimum_payback_years: 2.99,
+      optimum_payback_years: 2.5,
       optimum_mains_reduction_percent: 0.15,
       one_year_saving_gbpcurrent: 1000
     }
@@ -42,30 +42,38 @@ describe 'solar_pv_benefit_estimate' do
       let(:expected_report) { report }
       let(:expected_school) { school }
       let(:headers) do
-        ['School', 'Size: kWp', 'Reduction in mains consumption %',
-         'Annual saving at latest tariff if optimal panel size installed']
+        [
+          I18n.t('analytics.benchmarking.configuration.column_headings.school'),
+          I18n.t('analytics.benchmarking.configuration.column_headings.size_kwp'),
+          I18n.t('analytics.benchmarking.configuration.column_headings.payback_years'),
+          I18n.t('analytics.benchmarking.configuration.column_headings.reduction_in_mains_consumption_pct'),
+          I18n.t('analytics.benchmarking.configuration.column_headings.saving_optimal_panels')
+        ]
       end
       let(:advice_page_path) { polymorphic_path([:insights, expected_school, :advice, advice_page_key]) }
       let(:expected_table) do
-        [headers,
-         [school.name,
-          '44.2',
-          '2 years 9 months',
-          '15&percnt;',
-          '£1,000'],
-         ["Notes\n[t]\n" \
-          '(*5) The tariff has changed during the last year for this school. Savings are calculated using the latest ' \
-          'tariff but other £ values are calculated using the relevant tariff at the time']
-]
+        [
+          headers,
+          ["#{school.name} [t]",
+           '44.2',
+           '2 years 6 months',
+           '15&percnt;',
+           '£1,000'],
+          ["Notes\n[t]\n" \
+           '(*5) The tariff has changed during the last year for this school. Savings are calculated using the latest ' \
+           'tariff but other £ values are calculated using the relevant tariff at the time' \
+            "\nIn school comparisons 'last year' is defined as this year to date."]
+        ]
       end
       let(:expected_csv) do
-        [headers,
-         [school.name,
-          '44.2',
-          '2.9',
-          '15',
-          '1000']
-]
+        [
+          headers,
+          [school.name,
+           '44.2',
+           '2.5',
+           '15',
+           '1,000']
+        ]
       end
     end
   end

--- a/spec/system/comparisons/solar_pv_benefit_estimate_spec.rb
+++ b/spec/system/comparisons/solar_pv_benefit_estimate_spec.rb
@@ -38,7 +38,7 @@ describe 'solar_pv_benefit_estimate' do
       let(:expected_report) { report }
     end
 
-    it_behaves_like 'a school comparison report' do
+    it_behaves_like 'a school comparison report with a table' do
       let(:expected_report) { report }
       let(:expected_school) { school }
       let(:headers) do


### PR DESCRIPTION
Implements the annual change in solar production table, but also sorts a couple of other issues:

* There was a bug in the generator template, so the specs had the wrong shared context name, this was masking test failures
* Fixed failing spec for other report 
* Adds a shared scope to `Comparison::View` for doing percentage changes, allowing for NULL values. Should be consistent with the function currently used to sort values