### PR TITLE
Upgrade data tables

### DIFF
--- a/app/assets/javascripts/table_sorting.js
+++ b/app/assets/javascripts/table_sorting.js
@@ -6,7 +6,8 @@ $(document).ready(function() {
     'order': [],        // Default do not sort
     'paging': false,
     'searching': false, // Switch off search field
-    'info': false       // Switch off the summary of rows at the bottom of the page
+    'info': false,       // Switch off the summary of rows at the bottom of the page
+    'orderCellsTop': false
   });
 
   $('.table-large').DataTable({

--- a/app/assets/javascripts/table_sorting.js
+++ b/app/assets/javascripts/table_sorting.js
@@ -7,7 +7,8 @@ $(document).ready(function() {
     'paging': false,
     'searching': false, // Switch off search field
     'info': false,       // Switch off the summary of rows at the bottom of the page
-    'orderCellsTop': false
+    'orderCellsTop': false, // Switch off adding sorting to first header row
+    'autoWidth': false // Switch off auto resizing
   });
 
   $('.table-large').DataTable({

--- a/app/components/comparison_table_component/comparison_table_component.html.erb
+++ b/app/components/comparison_table_component/comparison_table_component.html.erb
@@ -2,7 +2,7 @@
   <%= download_link(@report, @table_name, @index_params) %>
 </div>
 
-<table id="<%= comparison_table_id(@report, @table_name) %>" class="table advice-table table-sorted">
+<table id="<%= comparison_table_id(@report, @table_name) %>" class="table advice-table table-sorted table-hover">
   <thead class="sticky-heading">
     <% if @colgroups.any? %>
       <tr>

--- a/app/views/admin/reports/activity_types/index.html.erb
+++ b/app/views/admin/reports/activity_types/index.html.erb
@@ -31,7 +31,7 @@
     <tr>
       <th colspan="2"></th>
       <th colspan="2">Recorded</th>
-      <th colspan="3">Referenced</th>
+      <th colspan="4">Referenced</th>
       <th></th>
     </tr>
     <tr>

--- a/app/views/shared/_head.html.erb
+++ b/app/views/shared/_head.html.erb
@@ -21,14 +21,14 @@
 <%= stylesheet_link_tag "//fonts.googleapis.com/css?family=Open+Sans|Quicksand:300&display=swap" %>
 <%= stylesheet_link_tag "//fonts.googleapis.com/css?family=Open+Sans|Quicksand:500&display=swap" %>
 <%= stylesheet_link_tag "//fonts.googleapis.com/css?family=Open+Sans|Quicksand:700&display=swap" %>
-<%= stylesheet_link_tag "//cdn.datatables.net/1.10.20/css/dataTables.bootstrap4.min.css" %>
+<%= stylesheet_link_tag "//cdn.datatables.net/2.0.2/css/dataTables.bootstrap4.min.css" %>
 
 <%= stylesheet_link_tag    'application', media: 'all' %>
 <%= javascript_pack_tag    'application' %>
 <%= javascript_include_tag 'application' %>
 <%= javascript_include_tag "//cdn.jsdelivr.net/npm/select2@4.0.13/dist/js/select2.min.js" %>
-<%= javascript_include_tag "//cdn.datatables.net/1.10.20/js/jquery.dataTables.min.js" %>
-<%= javascript_include_tag "//cdn.datatables.net/1.10.20/js/dataTables.bootstrap4.min.js" %>
+<%= javascript_include_tag "//cdn.datatables.net/2.0.2/js/dataTables.min.js" %>
+<%= javascript_include_tag "//cdn.datatables.net/2.0.2/js/dataTables.bootstrap4.min.js" %>
 
 <!--js and css for leaflet -->
 <%= render 'shared/leaflet' %>


### PR DESCRIPTION
Upgrades DataTables (which we use for showing sorted tables) to the latest version.

Have manually tested all the user facing tables and the majority of the admin reports (which is where this is mostly used) and all looks OK with updated options.

The new version has slightly better styling but, more importantly, includes some additional options. I've enabled table row hover on the new comparison reports. There's some other options which we could make use of to improve display further, e.g. adding paging to handle large tables; scrolling in place (via `scrollX`) to avoid long pages; hiding columns on mobile, etc.

The older version includes some of those options but this version has more options for styling and placement of any additional controls added to the table.