### PR TITLE
Add support for m3 conversion and cns file upload

### DIFF
--- a/app/models/amr_data_feed_config.rb
+++ b/app/models/amr_data_feed_config.rb
@@ -4,6 +4,7 @@
 #
 #  column_row_filters      :jsonb
 #  column_separator        :text             default(","), not null
+#  convert_to_kwh          :boolean          default(FALSE)
 #  created_at              :datetime         not null
 #  date_format             :text             not null
 #  description             :text             not null

--- a/app/services/amr/data_feed_translator.rb
+++ b/app/services/amr/data_feed_translator.rb
@@ -9,6 +9,7 @@ module Amr
 
     def perform
       hash_rows = @array_of_rows.map { |row| translate_row_to_hash(row) }
+      puts hash_rows.inspect
       check_units(hash_rows)
     end
 
@@ -23,7 +24,7 @@ module Amr
       data_feed_reading_hash[:units] = fetch_from_row(:units_index, row)
       data_feed_reading_hash[:description] = fetch_from_row(:description_index, row)
       data_feed_reading_hash[:provider_record_id] = fetch_from_row(:provider_record_id_index, row)
-      data_feed_reading_hash[:readings] = readings_as_array(row)
+      data_feed_reading_hash[:readings] = readings_as_array(data_feed_reading_hash, row)
       data_feed_reading_hash[:period] = fetch_from_row(:period_index, row) if @config.positional_index
       data_feed_reading_hash
     end
@@ -50,10 +51,21 @@ module Amr
       row[map_of_fields_to_indexes[index_symbol]]
     end
 
-    def readings_as_array(amr_data_feed_row)
-      @config.array_of_reading_indexes.map { |reading_index| amr_data_feed_row[reading_index] }
+    def readings_as_array(data_feed_reading_hash, amr_data_feed_row)
+      array_of_readings = @config.array_of_reading_indexes.map { |reading_index| amr_data_feed_row[reading_index] }
+      return array_of_readings if array_of_readings.all?(&:blank?) || !@config.convert_to_kwh
+
+      # if no units specified for each row, assume m3 and convert
+      # if units are specified, then only convert if they are m3
+      if data_feed_reading_hash[:units].blank? || data_feed_reading_hash[:units].casecmp?('m3')
+        data_feed_reading_hash[:units] = 'kwh'
+        array_of_readings.map { |r| r.to_f * Amr::N3rgyDownloader::KWH_PER_M3_GAS }
+      else
+        array_of_readings
+      end
     end
 
+    # Applies a filter to the translated rows, excluding those that dont match the expected units
     def check_units(rows)
       return rows if @config.expected_units.blank?
       rows.select {|row| row[:units] == @config.expected_units}

--- a/app/services/amr/data_feed_translator.rb
+++ b/app/services/amr/data_feed_translator.rb
@@ -9,7 +9,6 @@ module Amr
 
     def perform
       hash_rows = @array_of_rows.map { |row| translate_row_to_hash(row) }
-      puts hash_rows.inspect
       check_units(hash_rows)
     end
 

--- a/app/services/amr/single_read_converter.rb
+++ b/app/services/amr/single_read_converter.rb
@@ -55,8 +55,6 @@ module Amr
         end
       end
 
-      puts @results_array.inspect
-
       truncate_too_many_readings
       reject_any_low_reading_days
     end

--- a/app/services/amr/single_read_converter.rb
+++ b/app/services/amr/single_read_converter.rb
@@ -55,6 +55,8 @@ module Amr
         end
       end
 
+      puts @results_array.inspect
+
       truncate_too_many_readings
       reject_any_low_reading_days
     end

--- a/app/views/admin/amr_uploaded_readings/new.html.erb
+++ b/app/views/admin/amr_uploaded_readings/new.html.erb
@@ -1,18 +1,24 @@
 <div class="d-flex justify-content-between align-items-center">
   <h1>Manually load data</h1>
   <div>
-    <%= link_to "All data feed configurations", admin_amr_data_feed_configs_path, class: "btn btn-outline-dark font-weight-bold" %>
+    <%= link_to 'All data feed configurations', admin_amr_data_feed_configs_path,
+                class: 'btn btn-outline-dark font-weight-bold' %>
   </div>
 </div>
 
-<p>Upload a .csv, .xlsx or .xls file containing AMR data using the <strong><%= @amr_data_feed_config.description %></strong> configuration and preview the results before deciding on whether to import the data or not</p>
+<p>Upload a .csv, .xlsx or .xls file containing AMR data using the
+  <strong><%= @amr_data_feed_config.description %></strong> configuration and preview the
+  results before deciding on whether to import the data or not
+</p>
 
 <ul class="nav nav-tabs" id="manual-loading" role="tablist">
   <li class="nav-item">
-    <a class="nav-link active" id='loading-tab' data-toggle="tab" href="#loading" role="tab" aria-controls="loading" aria-selected="true">Preview and load</a>
+    <a class="nav-link active" id='loading-tab' data-toggle="tab"
+       href="#loading" role="tab" aria-controls="loading" aria-selected="true">Preview and load</a>
   </li>
   <li class="nav-item">
-    <a class="nav-link" id='config-tab' data-toggle="tab" href="#config" role="tab" aria-controls="config" aria-selected="false">Configuration</a>
+    <a class="nav-link"
+       id='config-tab' data-toggle="tab" href="#config" role="tab" aria-controls="config" aria-selected="false">Configuration</a>
   </li>
 </ul>
 <div class="tab-content" id="manual-loading-tabs">
@@ -47,12 +53,14 @@
         <p>Note: There were no warnings for this file</p>
       <% end %>
 
-      <%= render 'first_ten_reading_rows', valid_reading_data: @valid_reading_data if @valid_reading_data.present? && @valid_reading_data.any? %>
+      <%= if @valid_reading_data.present? && @valid_reading_data.any?
+            render 'first_ten_reading_rows', valid_reading_data: @valid_reading_data
+          end %>
     <% end %>
 
     <div class="alert alert-secondary">
       <%= simple_form_for [:admin, @amr_data_feed_config, @amr_uploaded_reading] do |f| %>
-        <%= f.input :data_file, label: 'Upload a file', as: :file, input_html: {accept: '.csv, .xls, .xlsx'} %>
+        <%= f.input :data_file, label: 'Upload a file', as: :file, input_html: { accept: '.csv, .xls, .xlsx, .cns' } %>
         <%= f.submit 'Preview', class: 'btn' %>
       <% end %>
     </div>
@@ -83,24 +91,30 @@
         <% end %>
 
         <% if @amr_data_feed_config.row_per_reading && (@amr_data_feed_config.reading_time_field.nil? && @amr_data_feed_config.period_field.nil?) %>
-          <li>The date and time for the reading date to be in a column labelled <b><%= @amr_data_feed_config.reading_date_field %></b></li>
+          <li>The date and time for the reading date to be in a column
+            labelled <b><%= @amr_data_feed_config.reading_date_field %></b></li>
         <% else %>
           <li>The reading date to be in a column labelled <b><%= @amr_data_feed_config.reading_date_field %></b></li>
         <% end %>
 
-        <li>Dates formatted like this <b><%= DateTime.now.strftime(@amr_data_feed_config.date_format) %></b> (<code><%= @amr_data_feed_config.date_format %></code>)</li>
+        <li>Dates formatted like this <b><%= DateTime.now.strftime(@amr_data_feed_config.date_format) %></b>
+          (<code><%= @amr_data_feed_config.date_format %></code>)</li>
 
         <% if @amr_data_feed_config.row_per_reading %>
           <li>A reading field column labelled  <b><%= @amr_data_feed_config.reading_fields.first %></b></li>
           <% if @amr_data_feed_config.positional_index && @amr_data_feed_config.period_field %>
-            <li>A <b>numbered</b> half-hourly period in a column labelled <b><%= @amr_data_feed_config.period_field %></b>, e.g. 1, 2, 3, 4 </li>
+            <li>A <b>numbered</b> half-hourly period in a column labelled
+              <b><%= @amr_data_feed_config.period_field %></b>, e.g. 1, 2, 3, 4 </li>
           <% end %>
           <% if @amr_data_feed_config.reading_time_field %>
-            <li>The reading times to specified in a separate column labelled <b><%= @amr_data_feed_config.reading_time_field %></b></li>
-            <li>The separate reading times to be formatted like this <b>01:30</b>, <b>23:30</b> but this format is also supported: <b>130</b>, <b>2330</b></li>
+            <li>The reading times to specified in a separate column labelled
+              <b><%= @amr_data_feed_config.reading_time_field %></b></li>
+            <li>The separate reading times to be formatted like this
+              <b>01:30</b>, <b>23:30</b> but this format is also supported: <b>130</b>, <b>2330</b></li>
           <% end %>
         <% else %>
-          <li>Reading fields to be in columns labelled <b><%= @amr_data_feed_config.reading_fields.join(',').truncate(70) %></b></li>
+          <li>Reading fields to be in columns labelled
+            <b><%= @amr_data_feed_config.reading_fields.join(',').truncate(70) %></b></li>
         <% end %>
 
         <% if @amr_data_feed_config.handle_off_by_one %>

--- a/db/migrate/20240311110540_add_convert_to_kwh_to_data_feed_config.rb
+++ b/db/migrate/20240311110540_add_convert_to_kwh_to_data_feed_config.rb
@@ -1,0 +1,5 @@
+class AddConvertToKwhToDataFeedConfig < ActiveRecord::Migration[6.1]
+  def change
+    add_column :amr_data_feed_configs, :convert_to_kwh, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_03_07_181846) do
+ActiveRecord::Schema.define(version: 2024_03_11_110540) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
@@ -406,6 +406,7 @@ ActiveRecord::Schema.define(version: 2024_03_07_181846) do
     t.string "period_field"
     t.boolean "enabled", default: true, null: false
     t.text "reading_time_field"
+    t.boolean "convert_to_kwh", default: false
     t.index ["description"], name: "index_amr_data_feed_configs_on_description", unique: true
     t.index ["identifier"], name: "index_amr_data_feed_configs_on_identifier", unique: true
   end

--- a/lib/tasks/deployment/20240311105041_ems_format.rake
+++ b/lib/tasks/deployment/20240311105041_ems_format.rake
@@ -1,0 +1,30 @@
+namespace :after_party do
+  desc 'Deployment task: ems_format'
+  task ems_format: :environment do
+    puts "Running deploy task 'ems_format'"
+
+    config = {}
+    config['description'] = "EMS Gas (CNS) format"
+    config['identifier'] = 'ems-gas-cns'
+    config['notes'] = "CNS format files containing m3 readings that are automatically convered to kWh when loaded"
+    config['number_of_header_rows'] = 1
+    config['row_per_reading'] = true
+    config['date_format'] = "%Y%m%d" # 20240212
+
+    config['header_example'] = "Type,MPRN,Serial,Date,Time,Reading,Ignore"
+    config['mpan_mprn_field'] = 'MPRN'
+    config['reading_date_field'] = 'Date'
+    config['reading_time_field'] = 'Time'
+    config['msn_field'] = 'Serial'
+    config['reading_fields'] = ["Reading"]
+    config['convert_to_kwh'] = true
+    config['positional_index'] = true
+
+    AmrDataFeedConfig.create!(config)
+
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord
+      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+  end
+end


### PR DESCRIPTION
Adds a flag to the data feed config model to indicate if values should be converted from m3 to kwh. Then updates the data feed translator to apply it.

Currently will just apply it to all readings if set and there is no reading type defined in the CSV. Or, if there is, then only to those marked as m3/M3.

Also adds a new config that uses this support and adds the `.cns` file type to the manual upload form.

CNS seems to be a pseudo CSV format used by gas suppliers.