### PR TITLE
Optimise comparison filter and load

### DIFF
--- a/app/controllers/comparisons/annual_change_in_electricity_out_of_hours_use_controller.rb
+++ b/app/controllers/comparisons/annual_change_in_electricity_out_of_hours_use_controller.rb
@@ -37,7 +37,7 @@ module Comparisons
     end
 
     def load_data
-      Comparison::AnnualChangeInElectricityOutOfHoursUse.where(school: @schools)
+      Comparison::AnnualChangeInElectricityOutOfHoursUse.for_schools(@schools)
                                                         .where.not(previous_out_of_hours_kwh: nil)
                                                         .order(previous_out_of_hours_kwh: :desc)
     end

--- a/app/controllers/comparisons/annual_electricity_costs_per_pupil_controller.rb
+++ b/app/controllers/comparisons/annual_electricity_costs_per_pupil_controller.rb
@@ -20,7 +20,7 @@ module Comparisons
     end
 
     def load_data
-      Comparison::AnnualElectricityCostsPerPupil.where(school: @schools).with_data.sort_default
+      Comparison::AnnualElectricityCostsPerPupil.for_schools(@schools).with_data.sort_default
     end
   end
 end

--- a/app/controllers/comparisons/annual_electricity_out_of_hours_use_controller.rb
+++ b/app/controllers/comparisons/annual_electricity_out_of_hours_use_controller.rb
@@ -25,7 +25,7 @@ module Comparisons
     end
 
     def load_data
-      Comparison::AnnualElectricityOutOfHoursUse.where(school: @schools).with_data.sort_default
+      Comparison::AnnualElectricityOutOfHoursUse.for_schools(@schools).with_data.sort_default
     end
 
     def create_charts(results)

--- a/app/controllers/comparisons/base_controller.rb
+++ b/app/controllers/comparisons/base_controller.rb
@@ -155,7 +155,7 @@ module Comparisons
     def included_schools
       # wonder if this can be replaced by a use of the scope accessible_by(current_ability)
       include_invisible = can? :show, :all_schools
-      school_params = filter.slice(:school_group_ids, :school_types, :school_type, :country, :funder).merge(include_invisible: include_invisible)
+      school_params = filter.slice(:school_group_ids, :school_types, :school_type, :country, :funder).merge(include_invisible: include_invisible, pluck: :id)
 
       schools = SchoolFilter.new(**school_params).filter
       schools.select {|s| can?(:show, s) } unless include_invisible

--- a/app/controllers/comparisons/baseload_per_pupil_controller.rb
+++ b/app/controllers/comparisons/baseload_per_pupil_controller.rb
@@ -24,7 +24,7 @@ module Comparisons
     end
 
     def load_data
-      Comparison::BaseloadPerPupil.where(school: @schools).where.not(one_year_baseload_per_pupil_kw: nil).order(one_year_baseload_per_pupil_kw: :desc)
+      Comparison::BaseloadPerPupil.for_schools(@schools).where.not(one_year_baseload_per_pupil_kw: nil).order(one_year_baseload_per_pupil_kw: :desc)
     end
 
     def create_charts(results)

--- a/app/controllers/comparisons/change_in_electricity_consumption_recent_school_weeks_controller.rb
+++ b/app/controllers/comparisons/change_in_electricity_consumption_recent_school_weeks_controller.rb
@@ -17,7 +17,7 @@ module Comparisons
 
     def load_data
       Comparison::ChangeInElectricityConsumptionRecentSchoolWeeks
-        .where(school: @schools).where.not(difference_percent: nil).order(difference_percent: :desc)
+        .for_schools(@schools).where.not(difference_percent: nil).order(difference_percent: :desc)
     end
 
     def create_charts(results)

--- a/app/controllers/comparisons/change_in_electricity_holiday_consumption_previous_holiday_controller.rb
+++ b/app/controllers/comparisons/change_in_electricity_holiday_consumption_previous_holiday_controller.rb
@@ -11,7 +11,7 @@ module Comparisons
 
     def load_data
       Comparison::ChangeInElectricityHolidayConsumptionPreviousHoliday
-        .where(school: @schools).where.not(difference_percent: nil).order(difference_percent: :desc)
+        .for_schools(@schools).where.not(difference_percent: nil).order(difference_percent: :desc)
     end
   end
 end

--- a/app/controllers/comparisons/change_in_electricity_holiday_consumption_previous_years_holiday_controller.rb
+++ b/app/controllers/comparisons/change_in_electricity_holiday_consumption_previous_years_holiday_controller.rb
@@ -19,7 +19,7 @@ module Comparisons
 
     def load_data
       Comparison::ChangeInElectricityHolidayConsumptionPreviousYearsHoliday
-        .where(school: @schools).where.not(difference_percent: nil).order(difference_percent: :desc)
+        .for_schools(@schools).where.not(difference_percent: nil).order(difference_percent: :desc)
     end
 
     def create_charts(results)

--- a/app/controllers/comparisons/change_in_electricity_since_last_year_controller.rb
+++ b/app/controllers/comparisons/change_in_electricity_since_last_year_controller.rb
@@ -39,7 +39,7 @@ module Comparisons
     end
 
     def load_data
-      Comparison::ChangeInElectricitySinceLastYear.where(school: @schools).with_data.by_percentage_change(:previous_year_electricity_kwh, :current_year_electricity_kwh)
+      Comparison::ChangeInElectricitySinceLastYear.for_schools(@schools).with_data.by_percentage_change(:previous_year_electricity_kwh, :current_year_electricity_kwh)
     end
   end
 end

--- a/app/controllers/comparisons/change_in_solar_pv_since_last_year_controller.rb
+++ b/app/controllers/comparisons/change_in_solar_pv_since_last_year_controller.rb
@@ -33,7 +33,7 @@ module Comparisons
     end
 
     def load_data
-      Comparison::ChangeInSolarPvSinceLastYear.where(school: @schools).with_data.by_percentage_change(:previous_year_solar_pv_kwh, :current_year_solar_pv_kwh)
+      Comparison::ChangeInSolarPvSinceLastYear.for_schools(@schools).with_data.by_percentage_change(:previous_year_solar_pv_kwh, :current_year_solar_pv_kwh)
     end
   end
 end

--- a/app/controllers/comparisons/electricity_consumption_during_holiday_controller.rb
+++ b/app/controllers/comparisons/electricity_consumption_during_holiday_controller.rb
@@ -18,7 +18,7 @@ module Comparisons
     end
 
     def load_data
-      Comparison::ElectricityConsumptionDuringHoliday.where(school: @schools)
+      Comparison::ElectricityConsumptionDuringHoliday.for_schools(@schools)
                                                      .where.not(holiday_projected_usage_gbp: nil)
                                                      .order(holiday_projected_usage_gbp: :desc)
     end

--- a/app/controllers/comparisons/electricity_peak_kw_per_pupil_controller.rb
+++ b/app/controllers/comparisons/electricity_peak_kw_per_pupil_controller.rb
@@ -23,7 +23,7 @@ module Comparisons
     end
 
     def load_data
-      Comparison::ElectricityPeakKwPerPupil.where(school: @schools)
+      Comparison::ElectricityPeakKwPerPupil.for_schools(@schools)
                                            .where.not(average_school_day_last_year_kw_per_floor_area: nil)
                                            .order(average_school_day_last_year_kw_per_floor_area: :desc)
     end

--- a/app/controllers/comparisons/electricity_targets_controller.rb
+++ b/app/controllers/comparisons/electricity_targets_controller.rb
@@ -23,7 +23,7 @@ module Comparisons
     end
 
     def load_data
-      Comparison::ElectricityTargets.where(school: @schools).with_data.sort_default
+      Comparison::ElectricityTargets.for_schools(@schools).with_data.sort_default
     end
 
     def create_charts(results)

--- a/app/controllers/comparisons/solar_generation_summary_controller.rb
+++ b/app/controllers/comparisons/solar_generation_summary_controller.rb
@@ -22,7 +22,7 @@ module Comparisons
     end
 
     def load_data
-      Comparison::SolarGenerationSummary.where(school: @schools).with_data.sort_default
+      Comparison::SolarGenerationSummary.for_schools(@schools).with_data.sort_default
     end
   end
 end

--- a/app/controllers/comparisons/solar_pv_benefit_estimate_controller.rb
+++ b/app/controllers/comparisons/solar_pv_benefit_estimate_controller.rb
@@ -21,7 +21,7 @@ module Comparisons
     end
 
     def load_data
-      Comparison::SolarPvBenefitEstimate.where(school: @schools).with_data.sort_default
+      Comparison::SolarPvBenefitEstimate.for_schools(@schools).with_data.sort_default
     end
   end
 end

--- a/app/controllers/comparisons/weekday_baseload_variation_controller.rb
+++ b/app/controllers/comparisons/weekday_baseload_variation_controller.rb
@@ -22,7 +22,7 @@ module Comparisons
 
     def load_data
       Comparison::WeekdayBaseloadVariation
-        .where(school: @schools).where.not(percent_intraday_variation: nil).order(percent_intraday_variation: :desc)
+        .for_schools(@schools).where.not(percent_intraday_variation: nil).order(percent_intraday_variation: :desc)
     end
 
     def create_charts(results)

--- a/app/models/comparison/view.rb
+++ b/app/models/comparison/view.rb
@@ -10,6 +10,9 @@ class Comparison::View < ApplicationRecord
 
   belongs_to :school
 
+  scope :with_school, -> { includes(:school) }
+  scope :for_schools, ->(schools) { where(school: schools).with_school }
+
   # E.g. previous_year, current_year
   scope :by_percentage_change, ->(base, new_val) do
     order(Arel.sql(sanitize_sql_array("(NULLIF(#{new_val},0.0) - NULLIF(#{base},0.0)) / NULLIF(#{base},0.0) DESC NULLS FIRST")))

--- a/app/services/school_filter.rb
+++ b/app/services/school_filter.rb
@@ -1,11 +1,12 @@
 class SchoolFilter
-  def initialize(school_group_ids: [], scoreboard_ids: [], school_types: [], school_type: nil, country: nil, funder: nil, include_invisible: false)
+  def initialize(school_group_ids: [], scoreboard_ids: [], school_types: [], school_type: nil, country: nil, funder: nil, include_invisible: false, pluck: nil)
     @school_group_ids = school_group_ids.reject(&:blank?)
     @scoreboard_ids = scoreboard_ids.reject(&:blank?)
     @school_types = school_type.present? ? [school_type] : school_types
     @funders = funder.present? ? [funder] : []
     @country = country
     @default_scope = include_invisible ? School.process_data.data_enabled : School.process_data.data_enabled.visible
+    @pluck = pluck
   end
 
   def filter
@@ -15,6 +16,7 @@ class SchoolFilter
     schools = schools_with_school_type(schools) if @school_types.any?
     schools = schools_with_country(schools) if @country.present?
     schools = schools_with_funder(schools) if @funders.present?
+    schools = schools.pluck(@pluck) if @pluck.present?
     schools.to_a
   end
 

--- a/lib/generators/comparison_report/templates/controller.rb.tt
+++ b/lib/generators/comparison_report/templates/controller.rb.tt
@@ -12,7 +12,7 @@ module Comparisons
 
     def load_data
       # change as needed
-      Comparison::<%= class_name %>.where(school: @schools).where.not(variable_name: nil).order(variable_name: :desc)
+      Comparison::<%= class_name %>.for_schools(@schools).where.not(variable_name: nil).order(variable_name: :desc)
     end
 
     def create_charts(results)

--- a/spec/services/school_filter_spec.rb
+++ b/spec/services/school_filter_spec.rb
@@ -58,4 +58,8 @@ describe SchoolFilter do
     expect(SchoolFilter.new(funder: funder_1.id).filter).to eq [school_1]
     expect(SchoolFilter.new(funder: funder_2.id).filter).to eq []
   end
+
+  it 'plucks columns if required' do
+    expect(SchoolFilter.new(school_group_ids: [school_group_a.id, school_group_b.id], pluck: :id).filter).to match_array [school_1.id, school_2.id]
+  end
 end


### PR DESCRIPTION
Optimise loading of school data for the comparison reports:

- adds a `.for_schools` scope to `Comparison:View` which loads data for a list of schools and includes the school model in the results. This avoids n+1 queries when loading data, e.g. for the chart
- adds an option to the `SchoolFilter` to just pluck specific columns. For the comparison reports we just need the ids, not the full model
