### PR TITLE
Ensure non public schools are filtered

### DIFF
--- a/app/controllers/compare_controller.rb
+++ b/app/controllers/compare_controller.rb
@@ -73,7 +73,7 @@ class CompareController < ApplicationController
 
     school_params = filter.slice(:school_group_ids, :school_types, :school_type, :country, :funder).merge(include_invisible: include_invisible)
 
-    schools = SchoolFilter.new(**school_params).filter
+    schools = SchoolFilter.new(**school_params).filter.to_a
     schools = schools.select {|s| can?(:show, s) } unless include_invisible
     schools
   end

--- a/app/controllers/compare_controller.rb
+++ b/app/controllers/compare_controller.rb
@@ -5,6 +5,7 @@ class CompareController < ApplicationController
   before_action :filter
   before_action :benchmark_groups, only: [:benchmarks]
 
+  before_action :set_school_groups, only: [:index]
   before_action :set_included_schools, only: [:benchmarks, :show]
   helper_method :index_params
 
@@ -69,10 +70,11 @@ class CompareController < ApplicationController
   def included_schools
     # wonder if this can be replaced by a use of the scope accessible_by(current_ability)
     include_invisible = can? :show, :all_schools
+
     school_params = filter.slice(:school_group_ids, :school_types, :school_type, :country, :funder).merge(include_invisible: include_invisible)
 
     schools = SchoolFilter.new(**school_params).filter
-    schools.select {|s| can?(:show, s) } unless include_invisible
+    schools = schools.select {|s| can?(:show, s) } unless include_invisible
     schools
   end
 
@@ -91,5 +93,10 @@ class CompareController < ApplicationController
 
   def extract_title_from_benchmark(benchmark)
     benchmark_groups.find {|group| group[:benchmarks]}.dig(:benchmarks, benchmark)
+  end
+
+  # Set list of school groups visible to this user
+  def set_school_groups
+    @school_groups = ComparisonService.new(current_user).list_school_groups.select(&:has_visible_schools?)
   end
 end

--- a/app/controllers/comparisons/base_controller.rb
+++ b/app/controllers/comparisons/base_controller.rb
@@ -153,12 +153,14 @@ module Comparisons
     end
 
     def included_schools
-      # wonder if this can be replaced by a use of the scope accessible_by(current_ability)
       include_invisible = can? :show, :all_schools
-      school_params = filter.slice(:school_group_ids, :school_types, :school_type, :country, :funder).merge(include_invisible: include_invisible, pluck: :id)
+      school_params = filter.slice(:school_group_ids, :school_types, :school_type, :country, :funder).merge(include_invisible: include_invisible)
 
-      schools = SchoolFilter.new(**school_params).filter
-      schools = schools.select {|s| can?(:show, s) } unless include_invisible
+      schools = if include_invisible
+                  SchoolFilter.new(**school_params).filter.pluck(:id)
+                else
+                  SchoolFilter.new(**school_params).filter.accessible_by(current_ability, :show).pluck(:id)
+                end
       schools
     end
   end

--- a/app/controllers/comparisons/base_controller.rb
+++ b/app/controllers/comparisons/base_controller.rb
@@ -156,12 +156,9 @@ module Comparisons
       include_invisible = can? :show, :all_schools
       school_params = filter.slice(:school_group_ids, :school_types, :school_type, :country, :funder).merge(include_invisible: include_invisible)
 
-      schools = if include_invisible
-                  SchoolFilter.new(**school_params).filter.pluck(:id)
-                else
-                  SchoolFilter.new(**school_params).filter.accessible_by(current_ability, :show).pluck(:id)
-                end
-      schools
+      filter = SchoolFilter.new(**school_params).filter
+      filter = filter.accessible_by(current_ability, :show) unless include_invisible
+      filter.pluck(:id)
     end
   end
 end

--- a/app/controllers/comparisons/base_controller.rb
+++ b/app/controllers/comparisons/base_controller.rb
@@ -158,7 +158,7 @@ module Comparisons
       school_params = filter.slice(:school_group_ids, :school_types, :school_type, :country, :funder).merge(include_invisible: include_invisible, pluck: :id)
 
       schools = SchoolFilter.new(**school_params).filter
-      schools.select {|s| can?(:show, s) } unless include_invisible
+      schools = schools.select {|s| can?(:show, s) } unless include_invisible
       schools
     end
   end

--- a/app/services/school_filter.rb
+++ b/app/services/school_filter.rb
@@ -1,12 +1,11 @@
 class SchoolFilter
-  def initialize(school_group_ids: [], scoreboard_ids: [], school_types: [], school_type: nil, country: nil, funder: nil, include_invisible: false, pluck: nil)
+  def initialize(school_group_ids: [], scoreboard_ids: [], school_types: [], school_type: nil, country: nil, funder: nil, include_invisible: false)
     @school_group_ids = school_group_ids.reject(&:blank?)
     @scoreboard_ids = scoreboard_ids.reject(&:blank?)
     @school_types = school_type.present? ? [school_type] : school_types
     @funders = funder.present? ? [funder] : []
     @country = country
     @default_scope = include_invisible ? School.process_data.data_enabled : School.process_data.data_enabled.visible
-    @pluck = pluck
   end
 
   def filter
@@ -16,8 +15,7 @@ class SchoolFilter
     schools = schools_with_school_type(schools) if @school_types.any?
     schools = schools_with_country(schools) if @country.present?
     schools = schools_with_funder(schools) if @funders.present?
-    schools = schools.pluck(@pluck) if @pluck.present?
-    schools.to_a
+    schools
   end
 
   private

--- a/app/views/compare/tab_content/_groups.html.erb
+++ b/app/views/compare/tab_content/_groups.html.erb
@@ -5,7 +5,10 @@
       <%= hidden_field_tag(:search, 'groups') %>
       <div class="form-group">
         <%= label_tag 'school_group_ids', t('compare.filter.school_groups') %>
-        <%= select_tag('school_group_ids', options_from_collection_for_select(SchoolGroup.all.by_name.select(&:has_visible_schools?), "id", "name", @filter[:school_group_ids]), multiple: true, class: 'form-control select2') %>
+        <%= select_tag('school_group_ids',
+                       options_from_collection_for_select(@school_groups, 'id', 'name', @filter[:school_group_ids]),
+                       multiple: true,
+                       class: 'form-control select2') %>
       </div>
       <%= render 'school_type_filter', type: 'groups' %>
       <div class="pt-2">

--- a/spec/services/school_filter_spec.rb
+++ b/spec/services/school_filter_spec.rb
@@ -58,8 +58,4 @@ describe SchoolFilter do
     expect(SchoolFilter.new(funder: funder_1.id).filter).to eq [school_1]
     expect(SchoolFilter.new(funder: funder_2.id).filter).to eq []
   end
-
-  it 'plucks columns if required' do
-    expect(SchoolFilter.new(school_group_ids: [school_group_a.id, school_group_b.id], pluck: :id).filter).to match_array [school_1.id, school_2.id]
-  end
 end

--- a/spec/system/compare_spec.rb
+++ b/spec/system/compare_spec.rb
@@ -172,9 +172,6 @@ describe 'compare pages', :compare, type: :system do
     it { expect(page).to have_content('There are no schools to report using this filter') }
   end
 
-  shared_examples 'a filtered list of groups' do |id:, school_groups:|
-  end
-
   ## contexts ##
 
   shared_context 'index page context' do |feature_flag: false|

--- a/spec/system/compare_spec.rb
+++ b/spec/system/compare_spec.rb
@@ -6,7 +6,7 @@ describe 'compare pages', :compare, type: :system do
       expect(page).to have_content 'School Comparison Tool'
       expect(page).to have_content 'Identify examples of best practice'
       expect(page).to have_content 'View how schools within the same MAT'
-      expect(page).to have_content 'Use options below to compare 2 schools against 1 benchmarks'
+      expect(page).to have_content 'Use options below to compare 3 schools against 1 benchmarks'
     end
 
     it 'has standard tabs' do
@@ -85,7 +85,7 @@ describe 'compare pages', :compare, type: :system do
     it { expect(page).to have_link('Change benchmark') }
   end
 
-  shared_examples 'a form filter' do |id:, school_types_excluding: nil, school_type: nil, country: nil, funder: nil, school_groups: nil|
+  shared_examples 'a form filter' do |id:, school_types_excluding: nil, school_type: nil, country: nil, funder: nil, school_groups: nil, school_group_list: nil|
     let(:all_school_types) { School.school_types.keys }
 
     it 'has school_type checkbox fields', if: school_types_excluding do
@@ -117,9 +117,15 @@ describe 'compare pages', :compare, type: :system do
       end
     end
 
-    it 'has school group select', if: school_groups do
+    it 'has school groups selected', if: school_groups do
       within id.to_s do
         expect(page).to have_select('school_group_ids', selected: school_groups)
+      end
+    end
+
+    it 'has school groups available', if: school_group_list do
+      within id.to_s do
+        expect(page).to have_select('school_group_ids', options: school_group_list)
       end
     end
   end
@@ -164,6 +170,9 @@ describe 'compare pages', :compare, type: :system do
 
   shared_examples 'an empty filter notice' do
     it { expect(page).to have_content('There are no schools to report using this filter') }
+  end
+
+  shared_examples 'a filtered list of groups' do |id:, school_groups:|
   end
 
   ## contexts ##
@@ -246,6 +255,7 @@ describe 'compare pages', :compare, type: :system do
   let!(:school)          { create(:school, country: :scotland, postcode: 'EH99 1SP', school_group: school_group, funder: funder)}
   let!(:school_group_2)  { create(:school_group, name: 'Group 2') }
   let!(:school_2)        { create(:school, country: :scotland, postcode: 'EH99 1SP', school_group: school_group_2)}
+  let!(:school_3)        { create(:school, country: :scotland, school_group: create(:school_group, name: 'Not Public', public: false)) }
 
   let(:benchmark_groups) { [{ name: 'Benchmark group name', description: 'Benchmark description', benchmarks: { baseload_per_pupil: 'Baseload per pupil' } }] }
 
@@ -413,7 +423,7 @@ describe 'compare pages', :compare, type: :system do
 
           it_behaves_like 'an index page', tab: 'Choose groups'
           it { expect(page).to have_content 'Compare schools in groups' }
-          it_behaves_like 'a form filter', id: '#groups', school_groups: [], school_types_excluding: [] # show all
+          it_behaves_like 'a form filter', id: '#groups', school_group_list: ['Group 1', 'Group 2'], school_groups: [], school_types_excluding: [] # show all
 
           context 'Benchmark page' do
             include_context 'benchmarks page context', feature_flag: feature_flag
@@ -434,7 +444,7 @@ describe 'compare pages', :compare, type: :system do
               before { click_on 'Change options' }
 
               it_behaves_like 'an index page', tab: 'Choose groups'
-              it_behaves_like 'a form filter', id: '#groups', school_groups: ['Group 1', 'Group 2'], school_types_excluding: ['infant']
+              it_behaves_like 'a form filter', id: '#groups', school_group_list: ['Group 1', 'Group 2'], school_groups: ['Group 1', 'Group 2'], school_types_excluding: ['infant']
             end
 
             context 'Filtering all schools' do
@@ -479,6 +489,7 @@ describe 'compare pages', :compare, type: :system do
         let(:user) {}
 
         it_behaves_like 'an index page', tab: 'Choose country', show_your_group_tab: false
+        it_behaves_like 'a form filter', id: '#groups', school_group_list: ['Group 1', 'Group 2']
       end
 
       context 'Admin user' do
@@ -492,6 +503,7 @@ describe 'compare pages', :compare, type: :system do
           it { expect(page).to have_content 'Limit to funder (admin only option)'}
 
           it_behaves_like 'a form filter', id: '#country', country: 'All countries'
+          it_behaves_like 'a form filter', id: '#groups', school_group_list: ['Group 1', 'Group 2', 'Not Public']
 
           context 'Benchmark page' do
             include_context 'benchmarks page context', feature_flag: feature_flag


### PR DESCRIPTION
Some school groups and schools are not visible on the site.

This PR:

- ensures those groups are not listed in the filters on the comparison index page, unless the user is a member of that group. This involved just changing how the control was populated.
- non-public schools are filtered from the list of results. There was an existing ability check but this wasn't actually returning the filtered schools, so wasn't being applied. For the newer controller I've used `accessible_by` which seems to do the right thing.

I've had to refactor the SchoolFilter slightly to allow for both this check and the `.pluck` optimisation to work.