### PR TITLE
Recent change in baseload

### DIFF
--- a/app/components/comparison_table_component.rb
+++ b/app/components/comparison_table_component.rb
@@ -98,7 +98,7 @@ class ComparisonTableComponent < ViewComponent::Base
       # Otherwise format and present data values
       formatted_value = helpers.format_unit(@val, @unit, true, :benchmark)
       # Wrap columns showing percentage change in up/down indicator
-      rendered_value = @change ? helpers.up_downify(formatted_value) : formatted_value
+      rendered_value = @change ? helpers.up_downify(formatted_value, sanitize: false) : formatted_value
 
       content_tag :td, rendered_value, { class: @classes }
     end

--- a/app/components/comparison_table_component.rb
+++ b/app/components/comparison_table_component.rb
@@ -98,6 +98,7 @@ class ComparisonTableComponent < ViewComponent::Base
       # Otherwise format and present data values
       formatted_value = helpers.format_unit(@val, @unit, true, :benchmark)
       # Wrap columns showing percentage change in up/down indicator
+      # Don't sanitize values, as values can already be sanitized (e.g. '20&percnt;')
       rendered_value = @change ? helpers.up_downify(formatted_value, sanitize: false) : formatted_value
 
       content_tag :td, rendered_value, { class: @classes }

--- a/app/controllers/comparisons/recent_change_in_baseload_controller.rb
+++ b/app/controllers/comparisons/recent_change_in_baseload_controller.rb
@@ -1,0 +1,23 @@
+module Comparisons
+  class RecentChangeInBaseloadController < BaseController
+    private
+
+    def key
+      :recent_change_in_baseload
+    end
+
+    def advice_page_key
+      :your_advice_page_key
+    end
+
+    def load_data
+      # change as needed
+      Comparison::RecentChangeInBaseload.where(school: @schools).where.not(variable_name: nil).order(variable_name: :desc)
+    end
+
+    def create_charts(results)
+      # change as appropriate!
+      create_single_number_chart(results, :current_year_percent_of_target_relative, :percent_above_or_below_target_since_target_set, :percent)
+    end
+  end
+end

--- a/app/controllers/comparisons/recent_change_in_baseload_controller.rb
+++ b/app/controllers/comparisons/recent_change_in_baseload_controller.rb
@@ -2,22 +2,31 @@ module Comparisons
   class RecentChangeInBaseloadController < BaseController
     private
 
+    def headers
+      [
+        t('analytics.benchmarking.configuration.column_headings.school'),
+        t('analytics.benchmarking.configuration.column_headings.change_in_baseload_last_week_v_year_pct'),
+        t('analytics.benchmarking.configuration.column_headings.average_baseload_last_year_kw'),
+        t('analytics.benchmarking.configuration.column_headings.average_baseload_last_week_kw'),
+        t('analytics.benchmarking.configuration.column_headings.change_in_baseload_last_week_v_year_kw'),
+        t('analytics.benchmarking.configuration.column_headings.cost_of_change_in_baseload'),
+      ]
+    end
+
     def key
       :recent_change_in_baseload
     end
 
     def advice_page_key
-      :your_advice_page_key
+      :baseload
     end
 
     def load_data
-      # change as needed
-      Comparison::RecentChangeInBaseload.where(school: @schools).where.not(variable_name: nil).order(variable_name: :desc)
+      Comparison::RecentChangeInBaseload.with_data.sort_default
     end
 
     def create_charts(results)
-      # change as appropriate!
-      create_single_number_chart(results, :current_year_percent_of_target_relative, :percent_above_or_below_target_since_target_set, :percent)
+      create_single_number_chart(results, :predicted_percent_increase_in_usage, nil, :change_in_baseload_last_week_v_year_pct, :percent)
     end
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -293,7 +293,7 @@ module ApplicationHelper
      Array.new(empty_stars) { far_icon('star') }).compact.inject(&:+)
   end
 
-  def up_downify(text)
+  def up_downify(text, sanitize: true)
     return if text.nil? || text == '-'
     icon = if text.match?(/^\+/)
              fa_icon('arrow-circle-up')
@@ -306,7 +306,8 @@ module ApplicationHelper
            else
              ''
            end
-    (sanitize(text) + ' ' + icon).html_safe
+    text = sanitize(text) if sanitize
+    text + ' ' + icon.html_safe
   end
 
   def safely

--- a/app/models/comparison/recent_change_in_baseload.rb
+++ b/app/models/comparison/recent_change_in_baseload.rb
@@ -1,0 +1,16 @@
+# == Schema Information
+#
+# Table name: recent_change_in_baseloads
+#
+#  alert_generation_run_id                       :bigint(8)
+#  average_baseload_last_week_kw                 :float
+#  average_baseload_last_year_kw                 :float
+#  change_in_baseload_kw                         :float
+#  electricity_economic_tariff_changed_this_year :boolean
+#  id                                            :bigint(8)
+#  next_year_change_in_baseload_gbpcurrent       :float
+#  predicted_percent_increase_in_usage           :float
+#  school_id                                     :bigint(8)
+#
+class Comparison::RecentChangeInBaseload < Comparison::View
+end

--- a/app/models/comparison/recent_change_in_baseload.rb
+++ b/app/models/comparison/recent_change_in_baseload.rb
@@ -13,4 +13,6 @@
 #  school_id                                     :bigint(8)
 #
 class Comparison::RecentChangeInBaseload < Comparison::View
+  scope :with_data, -> { where.not(predicted_percent_increase_in_usage: nil) }
+  scope :sort_default, -> { order(predicted_percent_increase_in_usage: :desc) }
 end

--- a/app/views/comparisons/recent_change_in_baseload/_introduction.html.erb
+++ b/app/views/comparisons/recent_change_in_baseload/_introduction.html.erb
@@ -1,0 +1,3 @@
+<%= @report.introduction %>
+
+<%= t('analytics.benchmarking.caveat_text.es_exclude_storage_heaters_and_solar_pv').html_safe %>

--- a/app/views/comparisons/recent_change_in_baseload/_table.csv.ruby
+++ b/app/views/comparisons/recent_change_in_baseload/_table.csv.ruby
@@ -1,0 +1,11 @@
+CSV.generate do |csv|
+  # headers
+  csv << [
+    t('analytics.benchmarking.configuration.column_headings.school')
+  ]
+  @results.each do |row|
+    csv << [
+      row.school.name
+    ]
+  end
+end.html_safe

--- a/app/views/comparisons/recent_change_in_baseload/_table.csv.ruby
+++ b/app/views/comparisons/recent_change_in_baseload/_table.csv.ruby
@@ -1,11 +1,14 @@
 CSV.generate do |csv|
   # headers
-  csv << [
-    t('analytics.benchmarking.configuration.column_headings.school')
-  ]
-  @results.each do |row|
+  csv << @headers
+  @results.each do |result|
     csv << [
-      row.school.name
+      result.school.name,
+      format_unit(result.predicted_percent_increase_in_usage * 100, Float, true, :benchmark),
+      format_unit(result.average_baseload_last_year_kw, Float, true, :benchmark),
+      format_unit(result.average_baseload_last_week_kw, Float, true, :benchmark),
+      format_unit(result.change_in_baseload_kw, Float, true, :benchmark),
+      format_unit(result.next_year_change_in_baseload_gbpcurrent, Float, true, :benchmark),
     ]
   end
 end.html_safe

--- a/app/views/comparisons/recent_change_in_baseload/_table.html.erb
+++ b/app/views/comparisons/recent_change_in_baseload/_table.html.erb
@@ -1,0 +1,36 @@
+<div class='text-right mt-2'>
+  <%= download_link(report, table_name, index_params) %>
+</div>
+
+<table id="<%= comparison_table_id(report, table_name) %>" class="table advice-table table-sorted">
+  <thead>
+    <tr>
+      <th><%= t('analytics.benchmarking.configuration.column_headings.school') %></th>
+      <th class="text-right">
+        More headings like this
+      </th>
+    </tr>
+  </thead>
+  <tbody>
+    <% results.each do |row| %>
+      <tr>
+        <td>
+          <%= link_to row.school.name,
+                      advice_page_path(row.school, advice_page, :insights) %>
+        </td>
+        <td class="text-right">
+          More data like this
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+  <tfoot>
+    <tr>
+      <td colspan="6">
+        <p>
+          <strong><%= t('analytics.benchmarking.content.footnotes.notes') %></strong>
+        </p>
+      </td>
+    </tr>
+  </tfoot>
+</table>

--- a/app/views/comparisons/recent_change_in_baseload/_table.html.erb
+++ b/app/views/comparisons/recent_change_in_baseload/_table.html.erb
@@ -10,7 +10,7 @@
             <a href="#electricity_economic_tariff_changed_this_year">[t]</a>
         <% end %>
       <% end %>
-      <%= r.with_var val: result.predicted_percent_increase_in_usage, unit: :percent, change: true %>
+      <% r.with_var val: result.predicted_percent_increase_in_usage, unit: :percent, change: true %>
       <% r.with_var val: result.average_baseload_last_year_kw, unit: :kw %>
       <% r.with_var val: result.average_baseload_last_week_kw, unit: :kw %>
       <% r.with_var val: result.change_in_baseload_kw, unit: :kw, change: true %>

--- a/app/views/comparisons/recent_change_in_baseload/_table.html.erb
+++ b/app/views/comparisons/recent_change_in_baseload/_table.html.erb
@@ -1,36 +1,32 @@
-<div class='text-right mt-2'>
-  <%= download_link(report, table_name, index_params) %>
-</div>
+<%= component 'comparison_table',
+              report: report, advice_page: advice_page, table_name: table_name, index_params: index_params,
+              headers: headers, colgroups: colgroups, advice_page_tab: advice_page_tab do |c| %>
 
-<table id="<%= comparison_table_id(report, table_name) %>" class="table advice-table table-sorted">
-  <thead>
-    <tr>
-      <th><%= t('analytics.benchmarking.configuration.column_headings.school') %></th>
-      <th class="text-right">
-        More headings like this
-      </th>
-    </tr>
-  </thead>
-  <tbody>
-    <% results.each do |row| %>
-      <tr>
-        <td>
-          <%= link_to row.school.name,
-                      advice_page_path(row.school, advice_page, :insights) %>
-        </td>
-        <td class="text-right">
-          More data like this
-        </td>
-      </tr>
+  <% @results.each do |result| %>
+    <% c.with_row do |r| %>
+      <% r.with_school school: result.school %>
+      <% if result.electricity_economic_tariff_changed_this_year %>
+        <% r.with_reference do %>
+            <a href="#electricity_economic_tariff_changed_this_year">[t]</a>
+        <% end %>
+      <% end %>
+      <%= r.with_var val: result.predicted_percent_increase_in_usage, unit: :percent, change: true %>
+      <% r.with_var val: result.average_baseload_last_year_kw, unit: :kw %>
+      <% r.with_var val: result.average_baseload_last_week_kw, unit: :kw %>
+      <% r.with_var val: result.change_in_baseload_kw, unit: :kw, change: true %>
+      <% r.with_var val: result.next_year_change_in_baseload_gbpcurrent, unit: :£current, change: true %>
     <% end %>
-  </tbody>
-  <tfoot>
+  <% end %>
+  <% c.with_footer do %>
     <tr>
-      <td colspan="6">
+      <td colspan="<%= headers.count %>">
         <p>
           <strong><%= t('analytics.benchmarking.content.footnotes.notes') %></strong>
         </p>
+        <a name="electricity_economic_tariff_changed_this_year">[t]</a>
+        <%= t('analytics.benchmarking.configuration.the_tariff_has_changed_during_the_last_year_html') %>
+        <%= t('analytics.benchmarking.configuration.column_heading_explanation.last_year_definition_html') %>
       </td>
     </tr>
-  </tfoot>
-</table>
+  <% end %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -72,6 +72,7 @@ Rails.application.routes.draw do
     resources :electricity_consumption_during_holiday, only: [:index]
     resources :electricity_peak_kw_per_pupil, only: [:index]
     resources :electricity_targets, only: [:index]
+    resources :recent_change_in_baseload, only: [:index]
     resources :solar_generation_summary, only: [:index]
     resources :solar_pv_benefit_estimate, only: [:index]
     resources :weekday_baseload_variation, only: [:index]

--- a/db/migrate/20240307163123_create_recent_change_in_baseloads.rb
+++ b/db/migrate/20240307163123_create_recent_change_in_baseloads.rb
@@ -1,0 +1,5 @@
+class CreateRecentChangeInBaseloads < ActiveRecord::Migration[6.1]
+  def change
+    create_view :recent_change_in_baseloads
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -2117,6 +2117,46 @@ ActiveRecord::Schema.define(version: 2024_03_07_181846) do
   add_foreign_key "users", "staff_roles", on_delete: :restrict
   add_foreign_key "weather_observations", "weather_stations", on_delete: :cascade
 
+  create_view "annual_change_in_electricity_out_of_hours_uses", sql_definition: <<-SQL
+      SELECT latest_runs.id,
+      usage.alert_generation_run_id,
+      usage.school_id,
+      usage.out_of_hours_kwh,
+      usage.out_of_hours_co2,
+      usage.out_of_hours_gbpcurrent,
+      usage_previous_year.previous_out_of_hours_kwh,
+      usage_previous_year.previous_out_of_hours_co2,
+      usage_previous_year.previous_out_of_hours_gbpcurrent,
+      additional.electricity_economic_tariff_changed_this_year
+     FROM ( SELECT alerts.alert_generation_run_id,
+              alerts.school_id,
+              data.out_of_hours_kwh,
+              data.out_of_hours_co2,
+              data.out_of_hours_gbpcurrent
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) data(out_of_hours_kwh double precision, out_of_hours_co2 double precision, out_of_hours_gbpcurrent double precision)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertOutOfHoursElectricityUsage'::text))) usage,
+      ( SELECT alerts.alert_generation_run_id,
+              alerts.school_id,
+              data.out_of_hours_kwh AS previous_out_of_hours_kwh,
+              data.out_of_hours_co2 AS previous_out_of_hours_co2,
+              data.out_of_hours_gbpcurrent AS previous_out_of_hours_gbpcurrent
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) data(out_of_hours_kwh double precision, out_of_hours_co2 double precision, out_of_hours_gbpcurrent double precision)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertOutOfHoursElectricityUsagePreviousYear'::text))) usage_previous_year,
+      ( SELECT alerts.alert_generation_run_id,
+              data.electricity_economic_tariff_changed_this_year
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) data(electricity_economic_tariff_changed_this_year boolean)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertAdditionalPrioritisationData'::text))) additional,
+      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
+             FROM alert_generation_runs
+            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
+    WHERE ((usage.alert_generation_run_id = latest_runs.id) AND (usage_previous_year.alert_generation_run_id = latest_runs.id) AND (additional.alert_generation_run_id = latest_runs.id));
+  SQL
   create_view "baseload_per_pupils", sql_definition: <<-SQL
       SELECT latest_runs.id,
       additional.school_id,
@@ -2177,6 +2217,27 @@ ActiveRecord::Schema.define(version: 2024_03_07_181846) do
             ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
     WHERE (enba.alert_generation_run_id = latest_runs.id);
   SQL
+  create_view "electricity_consumption_during_holidays", sql_definition: <<-SQL
+      SELECT latest_runs.id,
+      data.alert_generation_run_id,
+      data.school_id,
+      data.holiday_projected_usage_gbp,
+      data.holiday_usage_to_date_gbp,
+      data.holiday_name
+     FROM ( SELECT alerts.alert_generation_run_id,
+              alerts.school_id,
+              data_1.holiday_projected_usage_gbp,
+              data_1.holiday_usage_to_date_gbp,
+              data_1.holiday_name
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) data_1(holiday_projected_usage_gbp double precision, holiday_usage_to_date_gbp double precision, holiday_name text)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertElectricityUsageDuringCurrentHoliday'::text))) data,
+      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
+             FROM alert_generation_runs
+            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
+    WHERE (data.alert_generation_run_id = latest_runs.id);
+  SQL
   create_view "electricity_peak_kw_per_pupils", sql_definition: <<-SQL
       SELECT latest_runs.id,
       data.alert_generation_run_id,
@@ -2234,92 +2295,6 @@ ActiveRecord::Schema.define(version: 2024_03_07_181846) do
             ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
     WHERE (data.alert_generation_run_id = latest_runs.id);
   SQL
-  create_view "annual_change_in_electricity_out_of_hours_uses", sql_definition: <<-SQL
-      SELECT latest_runs.id,
-      usage.alert_generation_run_id,
-      usage.school_id,
-      usage.out_of_hours_kwh,
-      usage.out_of_hours_co2,
-      usage.out_of_hours_gbpcurrent,
-      usage_previous_year.previous_out_of_hours_kwh,
-      usage_previous_year.previous_out_of_hours_co2,
-      usage_previous_year.previous_out_of_hours_gbpcurrent,
-      additional.electricity_economic_tariff_changed_this_year
-     FROM ( SELECT alerts.alert_generation_run_id,
-              alerts.school_id,
-              data.out_of_hours_kwh,
-              data.out_of_hours_co2,
-              data.out_of_hours_gbpcurrent
-             FROM alerts,
-              alert_types,
-              LATERAL jsonb_to_record(alerts.variables) data(out_of_hours_kwh double precision, out_of_hours_co2 double precision, out_of_hours_gbpcurrent double precision)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertOutOfHoursElectricityUsage'::text))) usage,
-      ( SELECT alerts.alert_generation_run_id,
-              alerts.school_id,
-              data.out_of_hours_kwh AS previous_out_of_hours_kwh,
-              data.out_of_hours_co2 AS previous_out_of_hours_co2,
-              data.out_of_hours_gbpcurrent AS previous_out_of_hours_gbpcurrent
-             FROM alerts,
-              alert_types,
-              LATERAL jsonb_to_record(alerts.variables) data(out_of_hours_kwh double precision, out_of_hours_co2 double precision, out_of_hours_gbpcurrent double precision)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertOutOfHoursElectricityUsagePreviousYear'::text))) usage_previous_year,
-      ( SELECT alerts.alert_generation_run_id,
-              data.electricity_economic_tariff_changed_this_year
-             FROM alerts,
-              alert_types,
-              LATERAL jsonb_to_record(alerts.variables) data(electricity_economic_tariff_changed_this_year boolean)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertAdditionalPrioritisationData'::text))) additional,
-      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
-             FROM alert_generation_runs
-            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
-    WHERE ((usage.alert_generation_run_id = latest_runs.id) AND (usage_previous_year.alert_generation_run_id = latest_runs.id) AND (additional.alert_generation_run_id = latest_runs.id));
-  SQL
-  create_view "electricity_consumption_during_holidays", sql_definition: <<-SQL
-      SELECT latest_runs.id,
-      data.alert_generation_run_id,
-      data.school_id,
-      data.holiday_projected_usage_gbp,
-      data.holiday_usage_to_date_gbp,
-      data.holiday_name
-     FROM ( SELECT alerts.alert_generation_run_id,
-              alerts.school_id,
-              data_1.holiday_projected_usage_gbp,
-              data_1.holiday_usage_to_date_gbp,
-              data_1.holiday_name
-             FROM alerts,
-              alert_types,
-              LATERAL jsonb_to_record(alerts.variables) data_1(holiday_projected_usage_gbp double precision, holiday_usage_to_date_gbp double precision, holiday_name text)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertElectricityUsageDuringCurrentHoliday'::text))) data,
-      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
-             FROM alert_generation_runs
-            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
-    WHERE (data.alert_generation_run_id = latest_runs.id);
-  SQL
-  create_view "solar_generation_summaries", sql_definition: <<-SQL
-      SELECT latest_runs.id,
-      solar_generation.alert_generation_run_id,
-      solar_generation.school_id,
-      solar_generation.annual_electricity_kwh,
-      solar_generation.annual_mains_consumed_kwh,
-      solar_generation.annual_solar_pv_kwh,
-      solar_generation.annual_exported_solar_pv_kwh,
-      solar_generation.annual_solar_pv_consumed_onsite_kwh
-     FROM ( SELECT alerts.alert_generation_run_id,
-              alerts.school_id,
-              data.annual_electricity_kwh,
-              data.annual_mains_consumed_kwh,
-              data.annual_solar_pv_kwh,
-              data.annual_exported_solar_pv_kwh,
-              data.annual_solar_pv_consumed_onsite_kwh
-             FROM alerts,
-              alert_types,
-              LATERAL jsonb_to_record(alerts.variables) data(annual_electricity_kwh double precision, annual_mains_consumed_kwh double precision, annual_solar_pv_kwh double precision, annual_exported_solar_pv_kwh double precision, annual_solar_pv_consumed_onsite_kwh double precision)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertSolarGeneration'::text))) solar_generation,
-      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
-             FROM alert_generation_runs
-            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
-    WHERE (solar_generation.alert_generation_run_id = latest_runs.id);
-  SQL
   create_view "change_in_electricity_holiday_consumption_previous_years_holida", sql_definition: <<-SQL
       SELECT latest_runs.id,
       data.alert_generation_run_id,
@@ -2358,119 +2333,6 @@ ActiveRecord::Schema.define(version: 2024_03_07_181846) do
              FROM alert_generation_runs
             ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
     WHERE (data.alert_generation_run_id = latest_runs.id);
-  SQL
-  create_view "solar_pv_benefit_estimates", sql_definition: <<-SQL
-      SELECT latest_runs.id,
-      additional.school_id,
-      benefit_estimate.alert_generation_run_id,
-      benefit_estimate.optimum_kwp,
-      benefit_estimate.optimum_payback_years,
-      benefit_estimate.optimum_mains_reduction_percent,
-      benefit_estimate.one_year_saving_gbpcurrent,
-      additional.electricity_economic_tariff_changed_this_year
-     FROM ( SELECT alerts.alert_generation_run_id,
-              data.optimum_kwp,
-              data.optimum_payback_years,
-              data.optimum_mains_reduction_percent,
-              data.one_year_saving_gbpcurrent
-             FROM alerts,
-              alert_types,
-              LATERAL jsonb_to_record(alerts.variables) data(optimum_kwp double precision, optimum_payback_years double precision, optimum_mains_reduction_percent double precision, one_year_saving_gbpcurrent double precision)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertSolarPVBenefitEstimator'::text))) benefit_estimate,
-      ( SELECT alerts.alert_generation_run_id,
-              alerts.school_id,
-              data.electricity_economic_tariff_changed_this_year
-             FROM alerts,
-              alert_types,
-              LATERAL jsonb_to_record(alerts.variables) data(electricity_economic_tariff_changed_this_year boolean)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertAdditionalPrioritisationData'::text))) additional,
-      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
-             FROM alert_generation_runs
-            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
-    WHERE ((benefit_estimate.alert_generation_run_id = latest_runs.id) AND (additional.alert_generation_run_id = latest_runs.id));
-  SQL
-  create_view "annual_electricity_out_of_hours_uses", sql_definition: <<-SQL
-      SELECT latest_runs.id,
-      data.alert_generation_run_id,
-      data.school_id,
-      data.schoolday_open_percent,
-      data.schoolday_closed_percent,
-      data.holidays_percent,
-      data.weekends_percent,
-      data.community_percent,
-      data.community_gbp,
-      data.out_of_hours_gbp,
-      data.potential_saving_gbp,
-      additional.electricity_economic_tariff_changed_this_year
-     FROM ( SELECT alerts.alert_generation_run_id,
-              alerts.school_id,
-              data_1.schoolday_open_percent,
-              data_1.schoolday_closed_percent,
-              data_1.holidays_percent,
-              data_1.weekends_percent,
-              data_1.community_percent,
-              data_1.community_gbp,
-              data_1.out_of_hours_gbp,
-              data_1.potential_saving_gbp
-             FROM alerts,
-              alert_types,
-              LATERAL jsonb_to_record(alerts.variables) data_1(schoolday_open_percent double precision, schoolday_closed_percent double precision, holidays_percent double precision, weekends_percent double precision, community_percent double precision, community_gbp double precision, out_of_hours_gbp double precision, potential_saving_gbp double precision)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertOutOfHoursElectricityUsage'::text))) data,
-      ( SELECT alerts.alert_generation_run_id,
-              data_1.electricity_economic_tariff_changed_this_year
-             FROM alerts,
-              alert_types,
-              LATERAL jsonb_to_record(alerts.variables) data_1(electricity_economic_tariff_changed_this_year boolean)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertAdditionalPrioritisationData'::text))) additional,
-      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
-             FROM alert_generation_runs
-            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
-    WHERE ((data.alert_generation_run_id = latest_runs.id) AND (additional.alert_generation_run_id = latest_runs.id));
-  SQL
-  create_view "annual_electricity_costs_per_pupils", sql_definition: <<-SQL
-      SELECT latest_runs.id,
-      data.alert_generation_run_id,
-      data.school_id,
-      data.one_year_electricity_per_pupil_gbp,
-      data.last_year_gbp,
-      data.one_year_saving_versus_exemplar_gbpcurrent
-     FROM ( SELECT alerts.alert_generation_run_id,
-              alerts.school_id,
-              data_1.one_year_electricity_per_pupil_gbp,
-              data_1.last_year_gbp,
-              data_1.one_year_saving_versus_exemplar_gbpcurrent
-             FROM alerts,
-              alert_types,
-              LATERAL jsonb_to_record(alerts.variables) data_1(one_year_electricity_per_pupil_gbp double precision, last_year_gbp double precision, one_year_saving_versus_exemplar_gbpcurrent double precision)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertElectricityAnnualVersusBenchmark'::text))) data,
-      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
-             FROM alert_generation_runs
-            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
-    WHERE (data.alert_generation_run_id = latest_runs.id);
-  SQL
-  create_view "change_in_solar_pv_since_last_years", sql_definition: <<-SQL
-      SELECT latest_runs.id,
-      versus_benchmark.school_id,
-      versus_benchmark.previous_year_solar_pv_kwh,
-      versus_benchmark.current_year_solar_pv_kwh,
-      versus_benchmark.previous_year_solar_pv_co2,
-      versus_benchmark.current_year_solar_pv_co2,
-      versus_benchmark.solar_type
-     FROM ( SELECT alerts.alert_generation_run_id,
-              alerts.school_id,
-              data.previous_year_solar_pv_kwh,
-              data.current_year_solar_pv_kwh,
-              data.previous_year_solar_pv_co2,
-              data.current_year_solar_pv_co2,
-              data.solar_type
-             FROM alerts,
-              alert_types,
-              LATERAL jsonb_to_record(alerts.variables) data(previous_year_solar_pv_kwh double precision, current_year_solar_pv_kwh double precision, previous_year_solar_pv_co2 double precision, current_year_solar_pv_co2 double precision, solar_type text)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertEnergyAnnualVersusBenchmark'::text))) versus_benchmark,
-      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
-             FROM alert_generation_runs
-            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
-    WHERE (versus_benchmark.alert_generation_run_id = latest_runs.id);
   SQL
   create_view "change_in_electricity_holiday_consumption_previous_holidays", sql_definition: <<-SQL
       SELECT latest_runs.id,
@@ -2536,6 +2398,65 @@ ActiveRecord::Schema.define(version: 2024_03_07_181846) do
             ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
     WHERE (data.alert_generation_run_id = latest_runs.id);
   SQL
+  create_view "annual_electricity_costs_per_pupils", sql_definition: <<-SQL
+      SELECT latest_runs.id,
+      data.alert_generation_run_id,
+      data.school_id,
+      data.one_year_electricity_per_pupil_gbp,
+      data.last_year_gbp,
+      data.one_year_saving_versus_exemplar_gbpcurrent
+     FROM ( SELECT alerts.alert_generation_run_id,
+              alerts.school_id,
+              data_1.one_year_electricity_per_pupil_gbp,
+              data_1.last_year_gbp,
+              data_1.one_year_saving_versus_exemplar_gbpcurrent
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) data_1(one_year_electricity_per_pupil_gbp double precision, last_year_gbp double precision, one_year_saving_versus_exemplar_gbpcurrent double precision)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertElectricityAnnualVersusBenchmark'::text))) data,
+      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
+             FROM alert_generation_runs
+            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
+    WHERE (data.alert_generation_run_id = latest_runs.id);
+  SQL
+  create_view "annual_electricity_out_of_hours_uses", sql_definition: <<-SQL
+      SELECT latest_runs.id,
+      data.alert_generation_run_id,
+      data.school_id,
+      data.schoolday_open_percent,
+      data.schoolday_closed_percent,
+      data.holidays_percent,
+      data.weekends_percent,
+      data.community_percent,
+      data.community_gbp,
+      data.out_of_hours_gbp,
+      data.potential_saving_gbp,
+      additional.electricity_economic_tariff_changed_this_year
+     FROM ( SELECT alerts.alert_generation_run_id,
+              alerts.school_id,
+              data_1.schoolday_open_percent,
+              data_1.schoolday_closed_percent,
+              data_1.holidays_percent,
+              data_1.weekends_percent,
+              data_1.community_percent,
+              data_1.community_gbp,
+              data_1.out_of_hours_gbp,
+              data_1.potential_saving_gbp
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) data_1(schoolday_open_percent double precision, schoolday_closed_percent double precision, holidays_percent double precision, weekends_percent double precision, community_percent double precision, community_gbp double precision, out_of_hours_gbp double precision, potential_saving_gbp double precision)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertOutOfHoursElectricityUsage'::text))) data,
+      ( SELECT alerts.alert_generation_run_id,
+              data_1.electricity_economic_tariff_changed_this_year
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) data_1(electricity_economic_tariff_changed_this_year boolean)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertAdditionalPrioritisationData'::text))) additional,
+      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
+             FROM alert_generation_runs
+            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
+    WHERE ((data.alert_generation_run_id = latest_runs.id) AND (additional.alert_generation_run_id = latest_runs.id));
+  SQL
   create_view "weekday_baseload_variations", sql_definition: <<-SQL
       SELECT latest_runs.id,
       additional.school_id,
@@ -2569,5 +2490,116 @@ ActiveRecord::Schema.define(version: 2024_03_07_181846) do
              FROM alert_generation_runs
             ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
     WHERE ((data.alert_generation_run_id = latest_runs.id) AND (additional.alert_generation_run_id = latest_runs.id));
+  SQL
+  create_view "solar_generation_summaries", sql_definition: <<-SQL
+      SELECT latest_runs.id,
+      solar_generation.alert_generation_run_id,
+      solar_generation.school_id,
+      solar_generation.annual_electricity_kwh,
+      solar_generation.annual_mains_consumed_kwh,
+      solar_generation.annual_solar_pv_kwh,
+      solar_generation.annual_exported_solar_pv_kwh,
+      solar_generation.annual_solar_pv_consumed_onsite_kwh
+     FROM ( SELECT alerts.alert_generation_run_id,
+              alerts.school_id,
+              data.annual_electricity_kwh,
+              data.annual_mains_consumed_kwh,
+              data.annual_solar_pv_kwh,
+              data.annual_exported_solar_pv_kwh,
+              data.annual_solar_pv_consumed_onsite_kwh
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) data(annual_electricity_kwh double precision, annual_mains_consumed_kwh double precision, annual_solar_pv_kwh double precision, annual_exported_solar_pv_kwh double precision, annual_solar_pv_consumed_onsite_kwh double precision)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertSolarGeneration'::text))) solar_generation,
+      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
+             FROM alert_generation_runs
+            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
+    WHERE (solar_generation.alert_generation_run_id = latest_runs.id);
+  SQL
+  create_view "solar_pv_benefit_estimates", sql_definition: <<-SQL
+      SELECT latest_runs.id,
+      additional.school_id,
+      benefit_estimate.alert_generation_run_id,
+      benefit_estimate.optimum_kwp,
+      benefit_estimate.optimum_payback_years,
+      benefit_estimate.optimum_mains_reduction_percent,
+      benefit_estimate.one_year_saving_gbpcurrent,
+      additional.electricity_economic_tariff_changed_this_year
+     FROM ( SELECT alerts.alert_generation_run_id,
+              data.optimum_kwp,
+              data.optimum_payback_years,
+              data.optimum_mains_reduction_percent,
+              data.one_year_saving_gbpcurrent
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) data(optimum_kwp double precision, optimum_payback_years double precision, optimum_mains_reduction_percent double precision, one_year_saving_gbpcurrent double precision)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertSolarPVBenefitEstimator'::text))) benefit_estimate,
+      ( SELECT alerts.alert_generation_run_id,
+              alerts.school_id,
+              data.electricity_economic_tariff_changed_this_year
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) data(electricity_economic_tariff_changed_this_year boolean)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertAdditionalPrioritisationData'::text))) additional,
+      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
+             FROM alert_generation_runs
+            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
+    WHERE ((benefit_estimate.alert_generation_run_id = latest_runs.id) AND (additional.alert_generation_run_id = latest_runs.id));
+  SQL
+  create_view "recent_change_in_baseloads", sql_definition: <<-SQL
+      SELECT latest_runs.id,
+      data.alert_generation_run_id,
+      data.school_id,
+      data.predicted_percent_increase_in_usage,
+      data.average_baseload_last_year_kw,
+      data.average_baseload_last_week_kw,
+      data.change_in_baseload_kw,
+      data.next_year_change_in_baseload_gbpcurrent,
+      additional.electricity_economic_tariff_changed_this_year
+     FROM ( SELECT alerts.alert_generation_run_id,
+              alerts.school_id,
+              data_1.predicted_percent_increase_in_usage,
+              data_1.average_baseload_last_year_kw,
+              data_1.average_baseload_last_week_kw,
+              data_1.change_in_baseload_kw,
+              data_1.next_year_change_in_baseload_gbpcurrent
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) data_1(predicted_percent_increase_in_usage double precision, average_baseload_last_year_kw double precision, average_baseload_last_week_kw double precision, change_in_baseload_kw double precision, next_year_change_in_baseload_gbpcurrent double precision)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertChangeInElectricityBaseloadShortTerm'::text))) data,
+      ( SELECT alerts.alert_generation_run_id,
+              data_1.electricity_economic_tariff_changed_this_year
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) data_1(electricity_economic_tariff_changed_this_year boolean)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertAdditionalPrioritisationData'::text))) additional,
+      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
+             FROM alert_generation_runs
+            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
+    WHERE ((data.alert_generation_run_id = latest_runs.id) AND (additional.alert_generation_run_id = latest_runs.id));
+  SQL
+  create_view "change_in_solar_pv_since_last_years", sql_definition: <<-SQL
+      SELECT latest_runs.id,
+      versus_benchmark.school_id,
+      versus_benchmark.previous_year_solar_pv_kwh,
+      versus_benchmark.current_year_solar_pv_kwh,
+      versus_benchmark.previous_year_solar_pv_co2,
+      versus_benchmark.current_year_solar_pv_co2,
+      versus_benchmark.solar_type
+     FROM ( SELECT alerts.alert_generation_run_id,
+              alerts.school_id,
+              data.previous_year_solar_pv_kwh,
+              data.current_year_solar_pv_kwh,
+              data.previous_year_solar_pv_co2,
+              data.current_year_solar_pv_co2,
+              data.solar_type
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) data(previous_year_solar_pv_kwh double precision, current_year_solar_pv_kwh double precision, previous_year_solar_pv_co2 double precision, current_year_solar_pv_co2 double precision, solar_type text)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertEnergyAnnualVersusBenchmark'::text))) versus_benchmark,
+      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
+             FROM alert_generation_runs
+            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
+    WHERE (versus_benchmark.alert_generation_run_id = latest_runs.id);
   SQL
 end

--- a/db/views/recent_change_in_baseloads_v01.sql
+++ b/db/views/recent_change_in_baseloads_v01.sql
@@ -1,0 +1,28 @@
+SELECT latest_runs.id,
+       data.*,
+       additional.electricity_economic_tariff_changed_this_year
+FROM
+  (
+    SELECT alert_generation_run_id, school_id, data.*
+    FROM alerts, alert_types, jsonb_to_record(variables) AS data(
+      predicted_percent_increase_in_usage float,
+      average_baseload_last_year_kw float,
+      average_baseload_last_week_kw float,
+      change_in_baseload_kw float,
+      next_year_change_in_baseload_gbpcurrent float
+    )
+    WHERE alerts.alert_type_id = alert_types.id and alert_types.class_name='AlertChangeInElectricityBaseloadShortTerm'
+  ) AS data,
+  (
+    SELECT alert_generation_run_id, data.*
+    FROM alerts, alert_types, jsonb_to_record(variables) AS data(electricity_economic_tariff_changed_this_year boolean)
+    WHERE alerts.alert_type_id = alert_types.id and alert_types.class_name='AlertAdditionalPrioritisationData'
+  ) AS additional,
+  (
+    SELECT DISTINCT ON (school_id) id
+    FROM alert_generation_runs
+    ORDER BY school_id, created_at DESC
+  ) latest_runs
+WHERE
+  data.alert_generation_run_id = latest_runs.id AND
+  additional.alert_generation_run_id = latest_runs.id;

--- a/lib/generators/comparison_report/templates/_table.csv.ruby.tt
+++ b/lib/generators/comparison_report/templates/_table.csv.ruby.tt
@@ -1,11 +1,9 @@
 CSV.generate do |csv|
   # headers
-  csv << [
-    t('analytics.benchmarking.configuration.column_headings.school')
-  ]
-  @results.each do |row|
+  csv << @headers
+  @results.each do |result|
     csv << [
-      row.school.name
+      result.school.name
     ]
   end
 end.html_safe

--- a/lib/generators/comparison_report/templates/_table.html.erb.tt
+++ b/lib/generators/comparison_report/templates/_table.html.erb.tt
@@ -6,7 +6,7 @@
       <%% r.with_school school: result.school %>
 
       <%%# replace these with correct values, in correct order %>
-      <%%#= r.with_var val: result.one_year_baseload_per_pupil_kw * 1000.0, unit: :kw %>
+      <%%# r.with_var val: result.one_year_baseload_per_pupil_kw * 1000.0, unit: :kw %>
     <%% end %>
   <%% end %>
   <%% c.with_footer do %>

--- a/lib/generators/comparison_report/templates/controller.rb.tt
+++ b/lib/generators/comparison_report/templates/controller.rb.tt
@@ -2,6 +2,14 @@ module Comparisons
   class <%= class_name %>Controller < BaseController
     private
 
+    def headers
+      [
+        t('analytics.benchmarking.configuration.column_headings.school'),
+        ## add your headers in here
+        # t('analytics.benchmarking.configuration.column_headings.percent_above_or_below_target_since_target_set'),
+      ]
+    end
+
     def key
       :<%= file_name %>
     end

--- a/lib/generators/comparison_report/templates/system_spec.rb.tt
+++ b/lib/generators/comparison_report/templates/system_spec.rb.tt
@@ -25,6 +25,11 @@ describe '<%= file_name %>' do
   before do
     create(:advice_page, key: advice_page_key)
     create(:alert, school: school, alert_generation_run: alert_run, alert_type: alert_type, variables: variables)
+    # the following alert is often only required for the tariff changed footnote
+    # delete or amend as appropriate:
+    create(:alert, school: school, alert_generation_run: alert_run,
+                   alert_type: create(:alert_type, class_name: 'AlertAdditionalPrioritisationData'),
+                   variables: { electricity_economic_tariff_changed_this_year: true })
   end
 
   context 'when viewing report' do
@@ -73,6 +78,9 @@ describe '<%= file_name %>' do
           '2024-01-01']
         ]
       end
+    end
+    it_behaves_like 'a school comparison report with a chart' do
+      let(:chart) { '#chart_comparison' }
     end
   end
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -26,6 +26,16 @@ describe ApplicationHelper do
       expect(helper.up_downify('hello')).not_to include('<i')
       expect(helper.up_downify('hello + goodbye')).not_to include('<i')
     end
+
+    context 'with sanitize set to true (default)' do
+      it { expect(helper.up_downify('10.1&percnt;')).to eq('10.1&amp;percnt; ') } # we don't want this!
+      it { expect(helper.up_downify('10.1%')).to eq('10.1% ') }
+    end
+
+    context 'with sanitize set to false' do
+      it { expect(helper.up_downify('10.1&percnt;', sanitize: false)).to eq('10.1&percnt; ') }
+      it { expect(helper.up_downify('10.1%', sanitize: false)).to eq('10.1% ') }
+    end
   end
 
   describe 'last signed in helper' do

--- a/spec/system/comparisons/recent_change_in_baseload_spec.rb
+++ b/spec/system/comparisons/recent_change_in_baseload_spec.rb
@@ -1,0 +1,78 @@
+require 'rails_helper'
+
+describe 'recent_change_in_baseload' do
+  let!(:school) { create(:school) }
+  let(:key) { :recent_change_in_baseload }
+  let(:advice_page_key) { :your_advice_page_key }
+
+  # change to your variables
+  let(:variables) do
+    {
+      current_year_percent_of_target_relative: +0.18699995372972533,
+      current_year_unscaled_percent_of_target_relative: -0.4799985149375391,
+      current_year_kwh: 1284.7,
+      current_year_target_kwh: 2281.8825833333326,
+      unscaled_target_kwh_to_date: 2401.9816666666666,
+      tracking_start_date: '2024-01-01'
+    }
+  end
+
+  # change to your alert type (there may be more than one!)
+  let(:alert_type) { create(:alert_type, class_name: 'AlertElectricityTargetAnnual') }
+  let(:alert_run) { create(:alert_generation_run, school: school) }
+  let!(:report) { create(:report, key: key) }
+
+  before do
+    create(:advice_page, key: advice_page_key)
+    create(:alert, school: school, alert_generation_run: alert_run, alert_type: alert_type, variables: variables)
+  end
+
+  context 'when viewing report' do
+    before { visit "/comparisons/#{key}" }
+
+    it_behaves_like 'a school comparison report' do
+      let(:expected_report) { report }
+    end
+
+    it_behaves_like 'a school comparison report' do
+      let(:expected_report) { report }
+      let(:expected_school) { school }
+      let(:advice_page_path) { polymorphic_path([:insights, expected_school, :advice, advice_page_key]) }
+      let(:expected_table) do
+        [['School',
+          'Percent above or below target since target set',
+          'Percent above or below last year',
+          'kWh consumption since target set',
+          'Target kWh consumption',
+          'Last year kWh consumption',
+          'Start date for target'],
+         [school.name,
+          '+18.7%',
+          '-48%',
+          '1,280',
+          '2,280',
+          '2,400',
+          'Monday 1 Jan 2024'],
+         ["Notes\nIn school comparisons 'last year' is defined as this year to date."]
+        ]
+      end
+      let(:expected_csv) do
+        [['School',
+          'Percent above or below target since target set',
+          'Percent above or below last year',
+          'kWh consumption since target set',
+          'Target kWh consumption',
+          'Last year kWh consumption',
+          'Start date for target'],
+         [school.name,
+          '18.7',
+          '-48',
+          '1,280',
+          '2,280',
+          '2,400',
+          '2024-01-01']
+        ]
+      end
+    end
+  end
+end


### PR DESCRIPTION
Had a wee issue with up_downify sanitizing formatted values containing the `"&percnt;"` html symbol and them becoming double encoded (e.g. `"&amp;percnt;"`)

Analytics is inconsistent in how it presents it's percent symbols for :html formatted values:
```
> FormatEnergyUnit.format(:percent, 0.123, :html)
=> "12&percnt;"
> FormatEnergyUnit.format(:relative_percent, 0.123, :html)
=> "+12%"
> FormatEnergyUnit.format(:relative_percent_0dp, 0.123, :html)
=> "+12%"
> FormatEnergyUnit.format(:percent_0dp, 0.123, :html)
=> "12%"
> FormatEnergyUnit.format(:comparison_percent, 0.123, :html)
=> "+12&percnt;"

```
This looks to be an issue with how FormatEnergyUnit.format does it's translations paired with how our translations are configured. When asking for a :html formatted value, FormatEnergyUnit.format will first look for a translation key ending in _html and if there isn't one, fall back to the normal (non _html suffixed key). Only :percent has a key for percent_html, the others do not (ignore comparison_percent, the :comparison_percent format actually uses the :percent and :percent_html translation keys):

```
      percent: "%{value}%"
      percent_0dp: "%{value}%"
      percent_html: "%{value}&percnt;"
      comparison_percent: "%"
      relative_percent: "%{sign}%{value}%"
      relative_percent_0dp: "%{sign}%{value}%"
```
So to be consistent, we should have _html keys for all types of percent (or change analytics to have less of them).

In the short term, I've added an option to up_downify so we can opt not to sanitize a value when calling up_downify inside the comparison_table component for 'change' values.


