### PR TITLE
Gas and storage heaters used out of school hours

### DIFF
--- a/app/controllers/comparisons/annual_gas_out_of_hours_use_controller.rb
+++ b/app/controllers/comparisons/annual_gas_out_of_hours_use_controller.rb
@@ -1,0 +1,41 @@
+module Comparisons
+  class AnnualGasOutOfHoursUseController < BaseController
+    private
+
+    def headers
+      [
+        t('analytics.benchmarking.configuration.column_headings.school'),
+        t('analytics.benchmarking.configuration.column_headings.school_day_open'),
+        t('analytics.benchmarking.configuration.column_headings.school_day_closed'),
+        t('analytics.benchmarking.configuration.column_headings.holiday'),
+        t('analytics.benchmarking.configuration.column_headings.weekend'),
+        t('analytics.benchmarking.configuration.column_headings.community'),
+        t('analytics.benchmarking.configuration.column_headings.community_usage_cost'),
+        t('analytics.benchmarking.configuration.column_headings.last_year_out_of_hours_cost'),
+        t('analytics.benchmarking.configuration.column_headings.saving_if_improve_to_exemplar'),
+      ]
+    end
+
+    def key
+      :annual_gas_out_of_hours_use
+    end
+
+    def advice_page_key
+      :gas_out_of_hours
+    end
+
+    def load_data
+      Comparison::AnnualGasOutOfHoursUse.for_schools(@schools).with_data.sort_default
+    end
+
+    def create_charts(results)
+      create_multi_chart(results, {
+        schoolday_open_percent: :school_day_open,
+        schoolday_closed_percent: :school_day_closed,
+        holidays_percent: :holiday,
+        weekends_percent: :weekend,
+        community_percent: :community
+        }, 100.0, :percent)
+    end
+  end
+end

--- a/app/controllers/comparisons/annual_storage_heater_out_of_hours_use_controller.rb
+++ b/app/controllers/comparisons/annual_storage_heater_out_of_hours_use_controller.rb
@@ -28,7 +28,7 @@ module Comparisons
     def create_charts(results)
       create_multi_chart(results, {
         schoolday_open_percent: :school_day_open,
-        schoolday_closed_percent: :school_day_closed,
+        schoolday_closed_percent: :overnight_charging,
         holidays_percent: :holiday,
         weekends_percent: :weekend,
         }, 100.0, :percent)

--- a/app/controllers/comparisons/annual_storage_heater_out_of_hours_use_controller.rb
+++ b/app/controllers/comparisons/annual_storage_heater_out_of_hours_use_controller.rb
@@ -1,0 +1,37 @@
+module Comparisons
+  class AnnualStorageHeaterOutOfHoursUseController < BaseController
+    private
+
+    def headers
+      [
+        t('analytics.benchmarking.configuration.column_headings.school'),
+        t('analytics.benchmarking.configuration.column_headings.school_day_open'),
+        t('analytics.benchmarking.configuration.column_headings.overnight_charging'),
+        t('analytics.benchmarking.configuration.column_headings.holiday'),
+        t('analytics.benchmarking.configuration.column_headings.weekend'),
+        t('analytics.benchmarking.configuration.column_headings.last_year_weekend_and_holiday_costs')
+      ]
+    end
+
+    def key
+      :annual_storage_heater_out_of_hours_use
+    end
+
+    def advice_page_key
+      :storage_heaters
+    end
+
+    def load_data
+      Comparison::AnnualStorageHeaterOutOfHoursUse.for_schools(@schools).with_data.sort_default
+    end
+
+    def create_charts(results)
+      create_multi_chart(results, {
+        schoolday_open_percent: :school_day_open,
+        schoolday_closed_percent: :school_day_closed,
+        holidays_percent: :holiday,
+        weekends_percent: :weekend,
+        }, 100.0, :percent)
+    end
+  end
+end

--- a/app/models/comparison/annual_gas_out_of_hours_use.rb
+++ b/app/models/comparison/annual_gas_out_of_hours_use.rb
@@ -1,0 +1,21 @@
+# == Schema Information
+#
+# Table name: annual_gas_out_of_hours_uses
+#
+#  alert_generation_run_id               :bigint(8)
+#  community_gbp                         :float
+#  community_percent                     :float
+#  gas_economic_tariff_changed_this_year :boolean
+#  holidays_percent                      :float
+#  id                                    :bigint(8)
+#  out_of_hours_gbp                      :float
+#  potential_saving_gbp                  :float
+#  school_id                             :bigint(8)
+#  schoolday_closed_percent              :float
+#  schoolday_open_percent                :float
+#  weekends_percent                      :float
+#
+class Comparison::AnnualGasOutOfHoursUse < Comparison::View
+  scope :with_data, -> { where.not(schoolday_open_percent: nil) }
+  scope :sort_default, -> { order(schoolday_open_percent: :desc) }
+end

--- a/app/models/comparison/annual_storage_heater_out_of_hours_use.rb
+++ b/app/models/comparison/annual_storage_heater_out_of_hours_use.rb
@@ -1,0 +1,22 @@
+# == Schema Information
+#
+# Table name: annual_storage_heater_out_of_hours_uses
+#
+#  alert_generation_run_id  :bigint(8)
+#  holidays_gbp             :float
+#  holidays_percent         :float
+#  id                       :bigint(8)
+#  school_id                :bigint(8)
+#  schoolday_closed_percent :float
+#  schoolday_open_percent   :float
+#  weekends_gbp             :float
+#  weekends_percent         :float
+#
+class Comparison::AnnualStorageHeaterOutOfHoursUse < Comparison::View
+  scope :with_data, -> { where.not(schoolday_open_percent: nil) }
+  scope :sort_default, -> { order(schoolday_open_percent: :desc) }
+
+  def weekend_and_holiday_gbp
+    [weekends_gbp, holidays_gbp].compact.sum
+  end
+end

--- a/app/views/comparisons/annual_gas_out_of_hours_use/_table.csv.ruby
+++ b/app/views/comparisons/annual_gas_out_of_hours_use/_table.csv.ruby
@@ -1,0 +1,16 @@
+CSV.generate do |csv|
+  csv << @headers
+  @results.each do |result|
+    csv << [
+      result.school.name,
+      format_unit(result.schoolday_open_percent * 100, Float, true, :benchmark),
+      format_unit(result.schoolday_closed_percent * 100, Float, true, :benchmark),
+      format_unit(result.holidays_percent * 100, Float, true, :benchmark),
+      format_unit(result.weekends_percent * 100, Float, true, :benchmark),
+      format_unit(result.community_percent * 100, Float, true, :benchmark),
+      format_unit(result.community_gbp, Float, true, :benchmark),
+      format_unit(result.out_of_hours_gbp, Float, true, :benchmark),
+      format_unit(result.potential_saving_gbp, Float, true, :benchmark)
+    ]
+  end
+end.html_safe

--- a/app/views/comparisons/annual_gas_out_of_hours_use/_table.html.erb
+++ b/app/views/comparisons/annual_gas_out_of_hours_use/_table.html.erb
@@ -1,0 +1,34 @@
+<%= component 'comparison_table',
+              report: report, advice_page: advice_page, table_name: table_name, index_params: index_params,
+              headers: headers, colgroups: colgroups, advice_page_tab: advice_page_tab do |c| %>
+  <% @results.each do |result| %>
+    <% c.with_row do |r| %>
+      <% r.with_school school: result.school %>
+      <% if result.gas_economic_tariff_changed_this_year %>
+        <% r.with_reference do %>
+            <a href="#gas_economic_tariff_changed_this_year">[t]</a>
+        <% end %>
+      <% end %>
+      <% r.with_var val: result.schoolday_open_percent, unit: :percent %>
+      <% r.with_var val: result.schoolday_closed_percent, unit: :percent %>
+      <% r.with_var val: result.holidays_percent, unit: :percent %>
+      <% r.with_var val: result.weekends_percent, unit: :percent %>
+      <% r.with_var val: result.community_percent, unit: :percent %>
+      <% r.with_var val: result.community_gbp, unit: :£ %>
+      <% r.with_var val: result.out_of_hours_gbp, unit: :£ %>
+      <% r.with_var val: result.potential_saving_gbp, unit: :£ %>
+    <% end %>
+  <% end %>
+  <% c.with_footer do %>
+    <tr>
+      <td colspan="<%= headers.count %>">
+        <p>
+          <strong><%= t('analytics.benchmarking.content.footnotes.notes') %></strong>
+        </p>
+        <a name="gas_economic_tariff_changed_this_year">[t]</a>
+        <%= t('analytics.benchmarking.configuration.the_tariff_has_changed_during_the_last_year_html') %>
+        <%= t('analytics.benchmarking.configuration.column_heading_explanation.last_year_definition_html') %>
+      </td>
+    </tr>
+  <% end %>
+<% end %>

--- a/app/views/comparisons/annual_storage_heater_out_of_hours_use/_table.csv.ruby
+++ b/app/views/comparisons/annual_storage_heater_out_of_hours_use/_table.csv.ruby
@@ -1,0 +1,14 @@
+CSV.generate do |csv|
+  # headers
+  csv << @headers
+  @results.each do |result|
+    csv << [
+      result.school.name,
+      format_unit(result.schoolday_open_percent * 100, Float, true, :benchmark),
+      format_unit(result.schoolday_closed_percent * 100, Float, true, :benchmark),
+      format_unit(result.holidays_percent * 100, Float, true, :benchmark),
+      format_unit(result.weekends_percent * 100, Float, true, :benchmark),
+      format_unit(result.weekend_and_holiday_gbp, Float, true, :benchmark)
+    ]
+  end
+end.html_safe

--- a/app/views/comparisons/annual_storage_heater_out_of_hours_use/_table.html.erb
+++ b/app/views/comparisons/annual_storage_heater_out_of_hours_use/_table.html.erb
@@ -1,0 +1,24 @@
+<%= component 'comparison_table',
+              report: report, advice_page: advice_page, table_name: table_name, index_params: index_params,
+              headers: headers, colgroups: colgroups, advice_page_tab: advice_page_tab do |c| %>
+  <% @results.each do |result| %>
+    <% c.with_row do |r| %>
+      <% r.with_school school: result.school %>
+      <% r.with_var val: result.schoolday_open_percent, unit: :percent %>
+      <% r.with_var val: result.schoolday_closed_percent, unit: :percent %>
+      <% r.with_var val: result.holidays_percent, unit: :percent %>
+      <% r.with_var val: result.weekends_percent, unit: :percent %>
+      <% r.with_var val: result.weekend_and_holiday_gbp, unit: :£ %>
+    <% end %>
+  <% end %>
+  <% c.with_footer do %>
+    <tr>
+      <td colspan="<%= headers.count %>">
+        <p>
+          <strong><%= t('analytics.benchmarking.content.footnotes.notes') %></strong>
+        </p>
+        <%= t('analytics.benchmarking.configuration.column_heading_explanation.last_year_definition_html') %>
+      </td>
+    </tr>
+  <% end %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -65,6 +65,7 @@ Rails.application.routes.draw do
     resources :annual_electricity_out_of_hours_use, only: [:index]
     resources :annual_gas_out_of_hours_use, only: [:index]
     resources :annual_heating_costs_per_floor_area, only: [:index]
+    resources :annual_storage_heater_out_of_hours_use, only: [:index]
     resources :baseload_per_pupil, only: [:index]
     resources :change_in_electricity_consumption_recent_school_weeks, only: [:index]
     resources :change_in_electricity_holiday_consumption_previous_holiday, only: [:index]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -63,6 +63,7 @@ Rails.application.routes.draw do
     resources :annual_change_in_electricity_out_of_hours_use, only: [:index]
     resources :annual_electricity_costs_per_pupil, only: [:index]
     resources :annual_electricity_out_of_hours_use, only: [:index]
+    resources :annual_gas_out_of_hours_use, only: [:index]
     resources :annual_heating_costs_per_floor_area, only: [:index]
     resources :baseload_per_pupil, only: [:index]
     resources :change_in_electricity_consumption_recent_school_weeks, only: [:index]

--- a/db/migrate/20240314151022_create_annual_gas_out_of_hours_uses.rb
+++ b/db/migrate/20240314151022_create_annual_gas_out_of_hours_uses.rb
@@ -1,0 +1,5 @@
+class CreateAnnualGasOutOfHoursUses < ActiveRecord::Migration[6.1]
+  def change
+    create_view :annual_gas_out_of_hours_uses
+  end
+end

--- a/db/migrate/20240314165231_create_annual_storage_heater_out_of_hours_uses.rb
+++ b/db/migrate/20240314165231_create_annual_storage_heater_out_of_hours_uses.rb
@@ -1,0 +1,5 @@
+class CreateAnnualStorageHeaterOutOfHoursUses < ActiveRecord::Migration[6.1]
+  def change
+    create_view :annual_storage_heater_out_of_hours_uses
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_03_13_142445) do
+ActiveRecord::Schema.define(version: 2024_03_14_151022) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
@@ -2218,31 +2218,6 @@ ActiveRecord::Schema.define(version: 2024_03_13_142445) do
             ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
     WHERE (enba.alert_generation_run_id = latest_runs.id);
   SQL
-  create_view "electricity_consumption_during_holidays", sql_definition: <<-SQL
-      SELECT latest_runs.id,
-      data.alert_generation_run_id,
-      data.school_id,
-      data.holiday_projected_usage_gbp,
-      data.holiday_usage_to_date_gbp,
-      data.holiday_type,
-      data.holiday_start_date,
-      data.holiday_end_date
-     FROM ( SELECT alerts.alert_generation_run_id,
-              alerts.school_id,
-              data_1.holiday_projected_usage_gbp,
-              data_1.holiday_usage_to_date_gbp,
-              data_1.holiday_type,
-              data_1.holiday_start_date,
-              data_1.holiday_end_date
-             FROM alerts,
-              alert_types,
-              LATERAL jsonb_to_record(alerts.variables) data_1(holiday_projected_usage_gbp double precision, holiday_usage_to_date_gbp double precision, holiday_type text, holiday_start_date date, holiday_end_date date)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertElectricityUsageDuringCurrentHoliday'::text))) data,
-      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
-             FROM alert_generation_runs
-            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
-    WHERE (data.alert_generation_run_id = latest_runs.id);
-  SQL
   create_view "electricity_peak_kw_per_pupils", sql_definition: <<-SQL
       SELECT latest_runs.id,
       data.alert_generation_run_id,
@@ -2765,6 +2740,31 @@ ActiveRecord::Schema.define(version: 2024_03_13_142445) do
             ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
     WHERE (data.alert_generation_run_id = latest_runs.id);
   SQL
+  create_view "electricity_consumption_during_holidays", sql_definition: <<-SQL
+      SELECT latest_runs.id,
+      data.alert_generation_run_id,
+      data.school_id,
+      data.holiday_projected_usage_gbp,
+      data.holiday_usage_to_date_gbp,
+      data.holiday_type,
+      data.holiday_start_date,
+      data.holiday_end_date
+     FROM ( SELECT alerts.alert_generation_run_id,
+              alerts.school_id,
+              data_1.holiday_projected_usage_gbp,
+              data_1.holiday_usage_to_date_gbp,
+              data_1.holiday_type,
+              data_1.holiday_start_date,
+              data_1.holiday_end_date
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) data_1(holiday_projected_usage_gbp double precision, holiday_usage_to_date_gbp double precision, holiday_type text, holiday_start_date date, holiday_end_date date)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertElectricityUsageDuringCurrentHoliday'::text))) data,
+      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
+             FROM alert_generation_runs
+            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
+    WHERE (data.alert_generation_run_id = latest_runs.id);
+  SQL
   create_view "gas_consumption_during_holidays", sql_definition: <<-SQL
       SELECT latest_runs.id,
       data.alert_generation_run_id,
@@ -2839,5 +2839,43 @@ ActiveRecord::Schema.define(version: 2024_03_13_142445) do
        JOIN additional ON ((latest_runs.id = additional.alert_generation_run_id)))
        LEFT JOIN gas ON ((latest_runs.id = gas.alert_generation_run_id)))
        LEFT JOIN storage_heaters ON ((latest_runs.id = storage_heaters.alert_generation_run_id)));
+  SQL
+  create_view "annual_gas_out_of_hours_uses", sql_definition: <<-SQL
+      SELECT latest_runs.id,
+      data.alert_generation_run_id,
+      data.school_id,
+      data.schoolday_open_percent,
+      data.schoolday_closed_percent,
+      data.holidays_percent,
+      data.weekends_percent,
+      data.community_percent,
+      data.community_gbp,
+      data.out_of_hours_gbp,
+      data.potential_saving_gbp,
+      additional.gas_economic_tariff_changed_this_year
+     FROM ( SELECT alerts.alert_generation_run_id,
+              alerts.school_id,
+              data_1.schoolday_open_percent,
+              data_1.schoolday_closed_percent,
+              data_1.holidays_percent,
+              data_1.weekends_percent,
+              data_1.community_percent,
+              data_1.community_gbp,
+              data_1.out_of_hours_gbp,
+              data_1.potential_saving_gbp
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) data_1(schoolday_open_percent double precision, schoolday_closed_percent double precision, holidays_percent double precision, weekends_percent double precision, community_percent double precision, community_gbp double precision, out_of_hours_gbp double precision, potential_saving_gbp double precision)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertOutOfHoursGasUsage'::text))) data,
+      ( SELECT alerts.alert_generation_run_id,
+              data_1.gas_economic_tariff_changed_this_year
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) data_1(gas_economic_tariff_changed_this_year boolean)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertAdditionalPrioritisationData'::text))) additional,
+      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
+             FROM alert_generation_runs
+            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
+    WHERE ((data.alert_generation_run_id = latest_runs.id) AND (additional.alert_generation_run_id = latest_runs.id));
   SQL
 end

--- a/db/views/annual_gas_out_of_hours_uses_v01.sql
+++ b/db/views/annual_gas_out_of_hours_uses_v01.sql
@@ -1,0 +1,34 @@
+SELECT latest_runs.id,
+       data.*,
+       additional.gas_economic_tariff_changed_this_year
+FROM
+  (
+    SELECT alert_generation_run_id, school_id, data.*
+    FROM alerts, alert_types, jsonb_to_record(variables) AS data(
+      schoolday_open_percent float,
+      schoolday_closed_percent float,
+      holidays_percent float,
+      weekends_percent float,
+      community_percent float,
+      community_gbp float,
+      out_of_hours_gbp float,
+      potential_saving_gbp float
+    )
+    WHERE alerts.alert_type_id = alert_types.id and alert_types.class_name='AlertOutOfHoursGasUsage'
+  ) AS data,
+  (
+    SELECT alert_generation_run_id, data.*
+    FROM alerts, alert_types, jsonb_to_record(variables) AS data(
+      gas_economic_tariff_changed_this_year boolean
+    )
+    WHERE alerts.alert_type_id = alert_types.id and alert_types.class_name='AlertAdditionalPrioritisationData'
+  ) AS additional,
+  (
+    SELECT DISTINCT ON (school_id) id
+    FROM alert_generation_runs
+    ORDER BY school_id, created_at DESC
+  ) latest_runs
+WHERE
+  data.alert_generation_run_id = latest_runs.id AND
+  additional.alert_generation_run_id = latest_runs.id;
+

--- a/db/views/annual_gas_out_of_hours_uses_v01.sql
+++ b/db/views/annual_gas_out_of_hours_uses_v01.sql
@@ -1,6 +1,6 @@
 SELECT latest_runs.id,
-       data.*,
-       additional.gas_economic_tariff_changed_this_year
+  data.*,
+  additional.gas_economic_tariff_changed_this_year
 FROM
   (
     SELECT alert_generation_run_id, school_id, data.*

--- a/db/views/annual_storage_heater_out_of_hours_uses_v01.sql
+++ b/db/views/annual_storage_heater_out_of_hours_uses_v01.sql
@@ -1,0 +1,23 @@
+SELECT latest_runs.id,
+  data.*
+FROM
+  (
+    SELECT alert_generation_run_id, school_id, data.*
+    FROM alerts, alert_types, jsonb_to_record(variables) AS data(
+      schoolday_open_percent float,
+      schoolday_closed_percent float,
+      holidays_percent float,
+      weekends_percent float,
+      holidays_gbp float,
+      weekends_gbp float
+    )
+    WHERE alerts.alert_type_id = alert_types.id and alert_types.class_name='AlertStorageHeaterOutOfHours'
+  ) AS data,
+  (
+    SELECT DISTINCT ON (school_id) id
+    FROM alert_generation_runs
+    ORDER BY school_id, created_at DESC
+  ) latest_runs
+WHERE
+  data.alert_generation_run_id = latest_runs.id;
+

--- a/spec/system/comparisons/annual_electricity_out_of_hours_use_spec.rb
+++ b/spec/system/comparisons/annual_electricity_out_of_hours_use_spec.rb
@@ -71,8 +71,6 @@ describe 'annual_electricity_out_of_hours_use' do
       end
     end
 
-    it_behaves_like 'a school comparison report with a chart' do
-      let(:chart) { '#chart_comparison' }
-    end
+    it_behaves_like 'a school comparison report with a chart'
   end
 end

--- a/spec/system/comparisons/annual_electricity_out_of_hours_use_spec.rb
+++ b/spec/system/comparisons/annual_electricity_out_of_hours_use_spec.rb
@@ -14,8 +14,7 @@ describe 'annual_electricity_out_of_hours_use' do
       community_percent: 0.0,
       community_gbp: 0.0,
       out_of_hours_gbp: 41347.98790211005,
-      potential_saving_gbp: 13006.849331677073,
-      rating: 0.0
+      potential_saving_gbp: 13006.849331677073
     }
   end
 

--- a/spec/system/comparisons/annual_gas_out_of_hours_use_spec.rb
+++ b/spec/system/comparisons/annual_gas_out_of_hours_use_spec.rb
@@ -14,8 +14,7 @@ describe 'annual_gas_out_of_hours_use' do
       community_percent: 0.0,
       community_gbp: 0.0,
       out_of_hours_gbp: 41347.98790211005,
-      potential_saving_gbp: 13006.849331677073,
-      rating: 0.0
+      potential_saving_gbp: 13006.849331677073
     }
   end
 

--- a/spec/system/comparisons/annual_gas_out_of_hours_use_spec.rb
+++ b/spec/system/comparisons/annual_gas_out_of_hours_use_spec.rb
@@ -1,0 +1,80 @@
+require 'rails_helper'
+
+describe 'annual_gas_out_of_hours_use' do
+  let!(:school) { create(:school) }
+  let(:key) { :annual_gas_out_of_hours_use }
+  let(:advice_page_key) { :gas_out_of_hours }
+
+  let(:variables) do
+    {
+      schoolday_open_percent: 0.2783819813845588,
+      schoolday_closed_percent: 0.3712268903038169,
+      holidays_percent: 0.21123782178479827,
+      weekends_percent: 0.13915330652682595,
+      community_percent: 0.0,
+      community_gbp: 0.0,
+      out_of_hours_gbp: 41347.98790211005,
+      potential_saving_gbp: 13006.849331677073,
+      rating: 0.0
+    }
+  end
+
+  # change to your alert type (there may be more than one!)
+  let(:alert_type) { create(:alert_type, class_name: 'AlertOutOfHoursGasUsage') }
+  let(:alert_run) { create(:alert_generation_run, school: school) }
+  let!(:report) { create(:report, key: key) }
+
+  before do
+    create(:advice_page, key: advice_page_key)
+    create(:alert, school: school, alert_generation_run: alert_run, alert_type: alert_type, variables: variables)
+    create(:alert, school: school, alert_generation_run: alert_run,
+                   alert_type: create(:alert_type, class_name: 'AlertAdditionalPrioritisationData'),
+                   variables: { electricity_economic_tariff_changed_this_year: true })
+  end
+
+  context 'when viewing report' do
+    before { visit "/comparisons/#{key}" }
+
+    it_behaves_like 'a school comparison report' do
+      let(:expected_report) { report }
+    end
+
+    it_behaves_like 'a school comparison report with a table' do
+      let(:headers) do
+        ['School',
+         'School Day Open',
+         'School Day Closed',
+         'Holiday',
+         'Weekend',
+         'Community',
+         'Community usage cost',
+         'Last year out of hours cost',
+         'Saving if improve to exemplar (at latest tariff)'
+        ]
+      end
+
+      let(:expected_report) { report }
+      let(:expected_school) { school }
+      let(:advice_page_path) { polymorphic_path([:insights, expected_school, :advice, advice_page_key]) }
+
+      let(:expected_table) do
+        [headers,
+         ["#{school.name} [t]", '27.8&percnt;', '37.1&percnt;', '21.1&percnt;', '13.9&percnt;', '0&percnt;', '0p', '£41,300', '£13,000'],
+         ["Notes\n[t]\n" \
+          '(*5) The tariff has changed during the last year for this school. Savings are calculated using the latest ' \
+          "tariff but other £ values are calculated using the relevant tariff at the time\nIn school comparisons " \
+          "'last year' is defined as this year to date."]]
+      end
+
+      let(:expected_csv) do
+        [headers,
+         [school.name, '27.8', '37.1', '21.1', '13.9', '0', '0', '41,300', '13,000']
+        ]
+      end
+    end
+
+    it_behaves_like 'a school comparison report with a chart' do
+      let(:chart) { '#chart_comparison' }
+    end
+  end
+end

--- a/spec/system/comparisons/annual_gas_out_of_hours_use_spec.rb
+++ b/spec/system/comparisons/annual_gas_out_of_hours_use_spec.rb
@@ -18,7 +18,6 @@ describe 'annual_gas_out_of_hours_use' do
     }
   end
 
-  # change to your alert type (there may be more than one!)
   let(:alert_type) { create(:alert_type, class_name: 'AlertOutOfHoursGasUsage') }
   let(:alert_run) { create(:alert_generation_run, school: school) }
   let!(:report) { create(:report, key: key) }
@@ -72,8 +71,6 @@ describe 'annual_gas_out_of_hours_use' do
       end
     end
 
-    it_behaves_like 'a school comparison report with a chart' do
-      let(:chart) { '#chart_comparison' }
-    end
+    it_behaves_like 'a school comparison report with a chart'
   end
 end

--- a/spec/system/comparisons/annual_gas_out_of_hours_use_spec.rb
+++ b/spec/system/comparisons/annual_gas_out_of_hours_use_spec.rb
@@ -29,7 +29,7 @@ describe 'annual_gas_out_of_hours_use' do
     create(:alert, school: school, alert_generation_run: alert_run, alert_type: alert_type, variables: variables)
     create(:alert, school: school, alert_generation_run: alert_run,
                    alert_type: create(:alert_type, class_name: 'AlertAdditionalPrioritisationData'),
-                   variables: { electricity_economic_tariff_changed_this_year: true })
+                   variables: { gas_economic_tariff_changed_this_year: true })
   end
 
   context 'when viewing report' do

--- a/spec/system/comparisons/annual_storage_heater_out_of_hours_use_spec.rb
+++ b/spec/system/comparisons/annual_storage_heater_out_of_hours_use_spec.rb
@@ -38,7 +38,7 @@ describe 'annual_storage_heater_out_of_hours_use' do
       let(:headers) do
         ['School',
          'School Day Open',
-         'School Day Closed',
+         'Overnight charging',
          'Holiday',
          'Weekend',
          'Last year weekend and holiday costs'
@@ -52,7 +52,7 @@ describe 'annual_storage_heater_out_of_hours_use' do
       let(:expected_table) do
         [headers,
          [school.name, '27.8&percnt;', '37.1&percnt;', '21.1&percnt;', '13.9&percnt;', '£417'],
-         ["Notes\n[t]\n" \
+         ["Notes\n" \
           "In school comparisons 'last year' is defined as this year to date."]]
       end
 

--- a/spec/system/comparisons/annual_storage_heater_out_of_hours_use_spec.rb
+++ b/spec/system/comparisons/annual_storage_heater_out_of_hours_use_spec.rb
@@ -1,0 +1,68 @@
+require 'rails_helper'
+
+describe 'annual_storage_heater_out_of_hours_use' do
+  let!(:school) { create(:school) }
+  let(:key) { :annual_storage_heater_out_of_hours_use }
+  let(:advice_page_key) { :your_advice_page_key }
+
+  # change to your variables
+  let(:variables) do
+    {
+      schoolday_open_percent: 0.2783819813845588,
+      schoolday_closed_percent: 0.3712268903038169,
+      holidays_percent: 0.21123782178479827,
+      weekends_percent: 0.13915330652682595,
+      holidays_gbp: 201,
+      weekends_gbp: 216
+    }
+  end
+
+  # change to your alert type (there may be more than one!)
+  let(:alert_type) { create(:alert_type, class_name: 'AlertStorageHeaterOutOfHours') }
+  let(:alert_run) { create(:alert_generation_run, school: school) }
+  let!(:report) { create(:report, key: key) }
+
+  before do
+    create(:advice_page, key: advice_page_key)
+    create(:alert, school: school, alert_generation_run: alert_run, alert_type: alert_type, variables: variables)
+  end
+
+  context 'when viewing report' do
+    before { visit "/comparisons/#{key}" }
+
+    it_behaves_like 'a school comparison report' do
+      let(:expected_report) { report }
+    end
+
+    it_behaves_like 'a school comparison report with a table' do
+      let(:headers) do
+        ['School',
+         'School Day Open',
+         'School Day Closed',
+         'Holiday',
+         'Weekend',
+         'Last year weekend and holiday costs'
+        ]
+      end
+
+      let(:expected_report) { report }
+      let(:expected_school) { school }
+      let(:advice_page_path) { polymorphic_path([:insights, expected_school, :advice, advice_page_key]) }
+
+      let(:expected_table) do
+        [headers,
+         [school.name, '27.8&percnt;', '37.1&percnt;', '21.1&percnt;', '13.9&percnt;', '£417'],
+         ["Notes\n[t]\n" \
+          "In school comparisons 'last year' is defined as this year to date."]]
+      end
+
+      let(:expected_csv) do
+        [headers,
+         [school.name, '27.8', '37.1', '21.1', '13.9', '417']
+        ]
+      end
+    end
+
+    it_behaves_like 'a school comparison report with a chart'
+  end
+end

--- a/spec/system/comparisons/electricity_targets_spec.rb
+++ b/spec/system/comparisons/electricity_targets_spec.rb
@@ -70,8 +70,6 @@ describe 'electricity_targets' do
       end
     end
 
-    it_behaves_like 'a school comparison report with a chart' do
-      let(:chart) { '#chart_comparison' }
-    end
+    it_behaves_like 'a school comparison report with a chart'
   end
 end

--- a/spec/system/comparisons/recent_change_in_baseload_spec.rb
+++ b/spec/system/comparisons/recent_change_in_baseload_spec.rb
@@ -62,8 +62,6 @@ describe 'recent_change_in_baseload' do
         [headers, [school.name, '-14.4', '2.94', '2.52', '-0.424', '-557']]
       end
     end
-    it_behaves_like 'a school comparison report with a chart' do
-      let(:chart) { '#chart_comparison' }
-    end
+    it_behaves_like 'a school comparison report with a chart'
   end
 end


### PR DESCRIPTION
This adds `annual_gas_out_of_hours_use` and `annual_storage_heater_out_of_hours_use` at the same time (as I thought the storage heater one would be very similar but it's too different to share any functionality).

`annual_gas_out_of_hours_use` has many similarities to `annual_electricity_out_of_hours_use` though, however I have kept them separate for now as not all three fuels are the same.