### PR TITLE
Annual saving through 1C reduction in thermostat temperature

### DIFF
--- a/app/controllers/comparisons/thermostat_sensitivity_controller.rb
+++ b/app/controllers/comparisons/thermostat_sensitivity_controller.rb
@@ -1,0 +1,28 @@
+module Comparisons
+  class ThermostatSensitivityController < BaseController
+    private
+
+    def headers
+      [
+        t('analytics.benchmarking.configuration.column_headings.school'),
+        t('analytics.benchmarking.configuration.column_headings.last_year_saving_per_1c_reduction_in_thermostat')
+      ]
+    end
+
+    def key
+      :thermostat_sensitivity
+    end
+
+    def advice_page_key
+      :heating_control
+    end
+
+    def load_data
+      Comparison::ThermostatSensitivity.for_schools(@schools).with_data.sort_default
+    end
+
+    def create_charts(results)
+      create_single_number_chart(results, :annual_saving_1_C_change_gbp, nil, :last_year_saving_per_1c_reduction_in_thermostat, :£)
+    end
+  end
+end

--- a/app/models/comparison/thermostat_sensitivity.rb
+++ b/app/models/comparison/thermostat_sensitivity.rb
@@ -1,0 +1,13 @@
+# == Schema Information
+#
+# Table name: thermostat_sensitivities
+#
+#  alert_generation_run_id      :bigint(8)
+#  annual_saving_1_C_change_gbp :float
+#  id                           :bigint(8)
+#  school_id                    :bigint(8)
+#
+class Comparison::ThermostatSensitivity < Comparison::View
+  scope :with_data, -> { where.not(annual_saving_1_C_change_gbp: nil) }
+  scope :sort_default, -> { order(annual_saving_1_C_change_gbp: :desc) }
+end

--- a/app/views/comparisons/hot_water_efficiency/_table.html.erb
+++ b/app/views/comparisons/hot_water_efficiency/_table.html.erb
@@ -7,7 +7,7 @@
       <% r.with_var val: result.avg_gas_per_pupil_gbp, unit: :£ %>
       <% r.with_var val: result.benchmark_existing_gas_efficiency, unit: :percent %>
       <% r.with_var val: result.benchmark_gas_better_control_saving_gbp, unit: :£ %>
-      <% r.with_var val: result.benchmark_point_of_use_electric_saving_gbp, unit: :£ %>
+      <% r.with_var val: result.benchmark_point_of_use_electric_saving_gbp, unit: :£, change: true %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/views/comparisons/thermostat_sensitivity/_table.csv.ruby
+++ b/app/views/comparisons/thermostat_sensitivity/_table.csv.ruby
@@ -1,0 +1,10 @@
+CSV.generate do |csv|
+  # headers
+  csv << @headers
+  @results.each do |result|
+    csv << [
+      result.school.name,
+      format_unit(result.annual_saving_1_C_change_gbp, Float, true, :benchmark)
+    ]
+  end
+end.html_safe

--- a/app/views/comparisons/thermostat_sensitivity/_table.html.erb
+++ b/app/views/comparisons/thermostat_sensitivity/_table.html.erb
@@ -1,0 +1,10 @@
+<%= component 'comparison_table',
+              report: report, advice_page: advice_page, table_name: table_name, index_params: index_params,
+              headers: headers, colgroups: colgroups, advice_page_tab: advice_page_tab do |c| %>
+  <% @results.each do |result| %>
+    <% c.with_row do |r| %>
+      <% r.with_school school: result.school %>
+      <% r.with_var val: result.annual_saving_1_C_change_gbp, unit: :£ %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/comparisons/thermostat_sensitivity/_table.html.erb
+++ b/app/views/comparisons/thermostat_sensitivity/_table.html.erb
@@ -4,7 +4,7 @@
   <% @results.each do |result| %>
     <% c.with_row do |r| %>
       <% r.with_school school: result.school %>
-      <% r.with_var val: result.annual_saving_1_C_change_gbp, unit: :£ %>
+      <% r.with_var val: result.annual_saving_1_C_change_gbp, unit: :£, change: true %>
     <% end %>
   <% end %>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -85,6 +85,7 @@ Rails.application.routes.draw do
     resources :solar_generation_summary, only: [:index]
     resources :solar_pv_benefit_estimate, only: [:index]
     resources :thermostatic_control, only: [:index]
+    resources :thermostat_sensitivity, only: [:index]
     resources :weekday_baseload_variation, only: [:index]
 
     resources :change_in_gas_consumption_recent_school_weeks, only: [:index]

--- a/db/migrate/20240315093822_create_thermostat_sensitivities.rb
+++ b/db/migrate/20240315093822_create_thermostat_sensitivities.rb
@@ -1,0 +1,5 @@
+class CreateThermostatSensitivities < ActiveRecord::Migration[6.1]
+  def change
+    create_view :thermostat_sensitivities
+  end
+end

--- a/db/views/thermostat_sensitivities_v01.sql
+++ b/db/views/thermostat_sensitivities_v01.sql
@@ -1,0 +1,17 @@
+SELECT latest_runs.id,
+       data.*
+FROM
+  (
+    SELECT alert_generation_run_id, school_id, data.*
+    FROM alerts, alert_types, jsonb_to_record(variables) AS data(
+      "annual_saving_1_C_change_gbp" float
+    )
+    WHERE alerts.alert_type_id = alert_types.id and alert_types.class_name='AlertHeatingSensitivityAdvice'
+  ) AS data,
+  (
+    SELECT DISTINCT ON (school_id) id
+    FROM alert_generation_runs
+    ORDER BY school_id, created_at DESC
+  ) latest_runs
+WHERE
+  data.alert_generation_run_id = latest_runs.id;

--- a/spec/system/comparisons/thermostat_sensitivity_spec.rb
+++ b/spec/system/comparisons/thermostat_sensitivity_spec.rb
@@ -6,9 +6,7 @@ describe 'thermostat_sensitivity' do
   let(:advice_page_key) { :heating_control }
 
   let(:variables) do
-    {
-      annual_saving_1_C_change_gbp: 389.6826792646185
-    }
+    { annual_saving_1_C_change_gbp: 389.6826792646185 }
   end
 
   let(:alert_type) { create(:alert_type, class_name: 'AlertHeatingSensitivityAdvice') }
@@ -33,23 +31,15 @@ describe 'thermostat_sensitivity' do
       let(:advice_page_path) { polymorphic_path([:insights, expected_school, :advice, advice_page_key]) }
 
       let(:headers) do
-        ['School',
-         'Saving per 1C reduction in thermostat']
+        ['School', 'Saving per 1C reduction in thermostat']
       end
 
       let(:expected_table) do
-        [headers,
-         [school.name,
-          '£390'
-         ]
-        ]
+        [headers, [school.name, '£390']]
       end
 
       let(:expected_csv) do
-        [headers,
-         [school.name,
-          '390']
-        ]
+        [headers, [school.name, '390']]
       end
     end
 

--- a/spec/system/comparisons/thermostat_sensitivity_spec.rb
+++ b/spec/system/comparisons/thermostat_sensitivity_spec.rb
@@ -1,0 +1,58 @@
+require 'rails_helper'
+
+describe 'thermostat_sensitivity' do
+  let!(:school) { create(:school) }
+  let(:key) { :thermostat_sensitivity }
+  let(:advice_page_key) { :heating_control }
+
+  let(:variables) do
+    {
+      annual_saving_1_C_change_gbp: 389.6826792646185
+    }
+  end
+
+  let(:alert_type) { create(:alert_type, class_name: 'AlertHeatingSensitivityAdvice') }
+  let(:alert_run) { create(:alert_generation_run, school: school) }
+  let!(:report) { create(:report, key: key) }
+
+  before do
+    create(:advice_page, key: advice_page_key)
+    create(:alert, school: school, alert_generation_run: alert_run, alert_type: alert_type, variables: variables)
+  end
+
+  context 'when viewing report' do
+    before { visit "/comparisons/#{key}" }
+
+    it_behaves_like 'a school comparison report' do
+      let(:expected_report) { report }
+    end
+
+    it_behaves_like 'a school comparison report with a table' do
+      let(:expected_report) { report }
+      let(:expected_school) { school }
+      let(:advice_page_path) { polymorphic_path([:insights, expected_school, :advice, advice_page_key]) }
+
+      let(:headers) do
+        ['School',
+         'Saving per 1C reduction in thermostat']
+      end
+
+      let(:expected_table) do
+        [headers,
+         [school.name,
+          '£390'
+         ]
+        ]
+      end
+
+      let(:expected_csv) do
+        [headers,
+         [school.name,
+          '390']
+        ]
+      end
+    end
+
+    it_behaves_like 'a school comparison report with a chart'
+  end
+end


### PR DESCRIPTION
The original report has up_downify arrows on the column, which results in green down arrows for a negative number. I don't think down is positive from reading the report description but I could be wrong: 

> A negative value is indicative of very poor thermostatic control, where Energy Sparks’ modelling cannot make sense of the relationship between the school's gas consumption and outside temperature.

Have left it as the original for now, but wondered if we need to update up_downify to have the option to switch negative to be red if need be?

![image](https://github.com/Energy-Sparks/energy-sparks/assets/6051/1e758031-e4bd-4939-b289-e52a5ebd8f7d)
