### PR TITLE
HTML percent issues

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -307,7 +307,7 @@ module ApplicationHelper
              ''
            end
     text = sanitize(text) if sanitize
-    text + ' ' + icon.html_safe
+    (text + ' ' + icon).html_safe
   end
 
   def safely

--- a/app/views/management/schools/_overview_data.html.erb
+++ b/app/views/management/schools/_overview_data.html.erb
@@ -19,7 +19,7 @@
       <tr>
         <% if data.period == I18n.t('classes.tables.summary_table_data.last_week') %>
           <td class="icon"><%= fa_icon fuel_type_icon(data.fuel_type) %></td>
-          <td class="text-left"><%= t('common.' + data.fuel_type.to_s) %></td>
+          <td class="text-left"><%= t("common.#{data.fuel_type}") %></td>
         <% else %>
           <td></td>
           <td></td>
@@ -32,7 +32,7 @@
           <% if local_assigns[:show_savings].nil? || local_assigns[:shows_savings] == true %>
             <td class="text-right <%= data.message_class %>"><%= data.savings %></td>
           <% end %>
-          <td class="text-right"><%= up_downify(data.change) %></td>
+          <td class="text-right"><%= up_downify(data.change, sanitize: false) %></td>
         <% else %>
           <td class="text-center <%= data.message_class %>" colspan='5'><%= data.message %></td>
         <% end %>

--- a/app/views/schools/advice/baseload/_current_baseload.html.erb
+++ b/app/views/schools/advice/baseload/_current_baseload.html.erb
@@ -19,7 +19,7 @@
         <% if analysis_dates.recent_data %>
           <td class="text-right"><%= format_unit(current_baseload.average_baseload_kw_last_week, :kw) %></td>
           <td class="text-right">
-            <%= up_downify(format_unit(current_baseload.percentage_change_week, :relative_percent)) %>
+            <%= up_downify(format_unit(current_baseload.percentage_change_week, :relative_percent), sanitize: false) %>
           </td>
         <% else %>
           <td class="text-right old-data">
@@ -39,7 +39,7 @@
         <td class="text-right"><%= format_unit(current_baseload.average_baseload_kw_last_year, :kw) %></td>
         <td class="text-right">
           <% if analysis_dates.one_years_data? %>
-            <%= up_downify(format_unit(current_baseload.percentage_change_year, :relative_percent)) %>
+            <%= up_downify(format_unit(current_baseload.percentage_change_year, :relative_percent), sanitize: false) %>
           <% else %>
             -
           <% end %>

--- a/app/views/schools/advice/electricity_intraday/_insights_your_current_peak_electricity_use_table.html.erb
+++ b/app/views/schools/advice/electricity_intraday/_insights_your_current_peak_electricity_use_table.html.erb
@@ -19,7 +19,7 @@
     </td>
     <% if peak_kw_usage_percentage_change %>
       <td class="text-right">
-        <%= up_downify(format_unit(peak_kw_usage_percentage_change, :relative_percent)) %>
+        <%= up_downify(format_unit(peak_kw_usage_percentage_change, :relative_percent), sanitize: false) %>
       </td>
     <% end %>
   </tr>

--- a/app/views/schools/advice/long_term/_current_usage.html.erb
+++ b/app/views/schools/advice/long_term/_current_usage.html.erb
@@ -27,7 +27,8 @@
       <td class="text-right"><%= format_unit(annual_usage.£, :£) %></td>
       <td class="text-right">
         <% if annual_usage_change_since_last_year.present? %>
-          <%= up_downify(format_unit(annual_usage_change_since_last_year.percent, :relative_percent, false)) %>
+          <%= up_downify(format_unit(annual_usage_change_since_last_year.percent, :relative_percent, false),
+                         sanitize: false) %>
         <% else %>
           -
         <% end %>

--- a/app/views/schools/school_targets/_limited_data.html.erb
+++ b/app/views/schools/school_targets/_limited_data.html.erb
@@ -6,7 +6,8 @@
     <div class="d-flex justify-content-center mt-2">
       <h4 class="text-center">
         <% if overview_data.present? && overview_data.work_week(fuel_type).has_data %>
-              <%= up_downify(overview_data.work_week(fuel_type).change) %> last week against target of <%= -target %>%
+          <%= up_downify(overview_data.work_week(fuel_type).change, sanitize: false) %>
+          last week against target of <%= -target %>%
         <% else %>
           Target reduction of <%= target %>%
         <% end %>

--- a/app/views/schools/school_targets/_target_table_row.html.erb
+++ b/app/views/schools/school_targets/_target_table_row.html.erb
@@ -3,13 +3,18 @@
   <td><%= fuel_type.to_s.humanize %></td>
   <td class="text-right"><%= -school_target[fuel_type] %>%</td>
   <% if fuel_progress.present? && fuel_progress.valid? %>
-      <td class="text-right"><%= up_downify(format_target(fuel_progress.progress, :relative_percent), sanitize: false) %></td>
-      <td class="text-right"><%= link_to t('schools.school_targets.target_table_row.view_monthly_report'), report_link,
-                                         class: 'btn btn-outline-dark font-weight-bold' %></td>
+      <td class="text-right">
+        <%= up_downify(format_target(fuel_progress.progress, :relative_percent), sanitize: false) %>
+      </td>
+      <td class="text-right">
+        <%= link_to t('schools.school_targets.target_table_row.view_monthly_report'),
+                    report_link,
+                    class: 'btn btn-outline-dark font-weight-bold' %>
+      </td>
   <% else %>
       <td class="text-right">
         <% if overview_data.present? && overview_data.work_week(fuel_type).has_data %>
-          <%= up_downify(overview_data.work_week(fuel_type).change, sanitize: false) %>
+          <%= up_downify(overview_data.work_week(fuel_type).change) %>
           <%= t('schools.school_targets.target_table_row.last_week') %>
         <% else %>
           <%= t('schools.school_targets.target_table_row.not_applicable') %>

--- a/app/views/schools/school_targets/_target_table_row.html.erb
+++ b/app/views/schools/school_targets/_target_table_row.html.erb
@@ -1,14 +1,16 @@
-<tr id="<%=fuel_type%>-row">
-  <td class="icon"><span class="<%=fuel_type_class(fuel_type)%>"><%= fa_icon fuel_type_icon(fuel_type) %></span></td>
+<tr id="<%= fuel_type %>-row">
+  <td class="icon"><span class="<%= fuel_type_class(fuel_type) %>"><%= fa_icon fuel_type_icon(fuel_type) %></span></td>
   <td><%= fuel_type.to_s.humanize %></td>
   <td class="text-right"><%= -school_target[fuel_type] %>%</td>
   <% if fuel_progress.present? && fuel_progress.valid? %>
-      <td class="text-right"><%= up_downify(format_target(fuel_progress.progress, :relative_percent)) %></td>
-      <td class="text-right"><%= link_to t('schools.school_targets.target_table_row.view_monthly_report'), report_link, class: "btn btn-outline-dark font-weight-bold" %></td>
+      <td class="text-right"><%= up_downify(format_target(fuel_progress.progress, :relative_percent), sanitize: false) %></td>
+      <td class="text-right"><%= link_to t('schools.school_targets.target_table_row.view_monthly_report'), report_link,
+                                         class: 'btn btn-outline-dark font-weight-bold' %></td>
   <% else %>
       <td class="text-right">
         <% if overview_data.present? && overview_data.work_week(fuel_type).has_data %>
-          <%= up_downify(overview_data.work_week(fuel_type).change) %> <%= t('schools.school_targets.target_table_row.last_week') %>
+          <%= up_downify(overview_data.work_week(fuel_type).change, sanitize: false) %>
+          <%= t('schools.school_targets.target_table_row.last_week') %>
         <% else %>
           <%= t('schools.school_targets.target_table_row.not_applicable') %>
         <% end %>

--- a/app/views/schools/school_targets/progress/current.html.erb
+++ b/app/views/schools/school_targets/progress/current.html.erb
@@ -27,13 +27,13 @@
       <p>
         <%= t('schools.school_targets.progress.current.unfortunately_more_than_last_year',
               fuel_type: human_fuel_type(@fuel_type),
-              relative_percent: format_target(@latest_progress, :relative_percent)) %>.
+              relative_percent: format_target(@latest_progress, :relative_percent)).html_safe %>.
       </p>
     <% else %>
       <p>
         <%= t('schools.school_targets.progress.current.well_done_less_than_last_year',
               fuel_type: human_fuel_type(@fuel_type),
-              relative_percent: format_target(@latest_progress, :relative_percent)) %>.
+              relative_percent: format_target(@latest_progress, :relative_percent)).html_safe %>.
       </p>
     <% end %>
   <% end %>

--- a/app/views/schools/school_targets/progress/expired.html.erb
+++ b/app/views/schools/school_targets/progress/expired.html.erb
@@ -1,25 +1,37 @@
 <div class="d-flex justify-content-between align-items-center">
   <h1>
-    <%= t('schools.school_targets.progress.expired.results_of_reducing_your_usage', fuel_type: @fuel_type.to_s.humanize(capitalize: false), target_date: I18n.l(@school_target.target_date, format: '%b %Y')) %>
+    <%= t('schools.school_targets.progress.expired.results_of_reducing_your_usage',
+          fuel_type: @fuel_type.to_s.humanize(capitalize: false),
+          target_date: I18n.l(@school_target.target_date, format: '%b %Y')) %>
   </h1>
   <div>
-    <%= link_to t('schools.school_targets.progress.expired.review_targets'), school_school_target_path(@school, @school_target), class: "btn btn-outline-dark rounded-pill font-weight-bold" %>
-    <%= link_to_help_for_feature :school_targets, css: "btn btn-outline-dark rounded-pill font-weight-bold" %>
+    <%= link_to t('schools.school_targets.progress.expired.review_targets'),
+                school_school_target_path(@school, @school_target),
+                class: 'btn btn-outline-dark rounded-pill font-weight-bold' %>
+    <%= link_to_help_for_feature :school_targets, css: 'btn btn-outline-dark rounded-pill font-weight-bold' %>
   </div>
 </div>
 
 <p>
-  <%= t('schools.school_targets.progress.expired.your_school_set_a_target_to_reduce_its_usage_html', fuel_type: @fuel_type.to_s.humanize(capitalize: false), school_target_attributes: @school_target.attributes[@fuel_type.to_s], start_date: nice_dates(@school_target.start_date), target_date: nice_dates(@school_target.target_date)) %>.
+  <%= t('schools.school_targets.progress.expired.your_school_set_a_target_to_reduce_its_usage_html',
+        fuel_type: @fuel_type.to_s.humanize(capitalize: false),
+        school_target_attributes: @school_target.attributes[@fuel_type.to_s],
+        start_date: nice_dates(@school_target.start_date),
+        target_date: nice_dates(@school_target.target_date)) %>.
 </p>
 
 <% if @latest_progress %>
   <% if @latest_progress >= 0.0 %>
     <p>
-      <%= t('schools.school_targets.progress.expired.you_didnt_achieve_your_goal_to_reduce', fuel_type: human_fuel_type(@fuel_type)) %>
+      <%= t('schools.school_targets.progress.expired.you_didnt_achieve_your_goal_to_reduce',
+            fuel_type: human_fuel_type(@fuel_type)) %>
     </p>
   <% else %>
     <p>
-      <%= t('schools.school_targets.progress.expired.you_managed_to_reduce_your_usage', fuel_type: human_fuel_type(@fuel_type), relative_percent: format_target(@latest_progress, :relative_percent)) %>.
+      <%= t('schools.school_targets.progress.expired.you_managed_to_reduce_your_usage',
+            fuel_type: human_fuel_type(@fuel_type),
+            relative_percent: format_target(@latest_progress,
+                                            :relative_percent)).html_safe %>.
     </p>
   <% end %>
 <% end %>
@@ -41,9 +53,21 @@
     </tr>
     </thead>
     <tbody>
-    <%= render 'row', title: t('schools.school_targets.progress.expired.target_consumption_kwh'), progress: @progress, data: @progress.monthly_targets_kwh, keys: @reporting_months, partial_months: {}, percentage_synthetic: @progress.percentage_synthetic, units: :kwh, final_row: false %>
-    <%= render 'row', title: t('schools.school_targets.progress.expired.actual_consumption_kwh'), progress: @progress, data: @progress.monthly_usage_kwh, keys: @reporting_months, partial_months: @progress.partial_months, percentage_synthetic: {}, units: :kwh, final_row: false %>
-    <%= render 'row', title: t('schools.school_targets.progress.expired.overall_change_since_last_year'), progress: @progress, data: @progress.monthly_performance_versus_synthetic_last_year, keys: @reporting_months, partial_months: @progress.partial_months, percentage_synthetic: {}, units: :relative_percent, final_row: true %>
+    <%= render 'row', title: t('schools.school_targets.progress.expired.target_consumption_kwh'),
+                      progress: @progress,
+                      data: @progress.monthly_targets_kwh, keys: @reporting_months,
+                      partial_months: {}, percentage_synthetic: @progress.percentage_synthetic,
+                      units: :kwh, final_row: false %>
+    <%= render 'row', title: t('schools.school_targets.progress.expired.actual_consumption_kwh'),
+                      progress: @progress,
+                      data: @progress.monthly_usage_kwh, keys: @reporting_months,
+                      partial_months: @progress.partial_months, percentage_synthetic: {},
+                      units: :kwh, final_row: false %>
+    <%= render 'row', title: t('schools.school_targets.progress.expired.overall_change_since_last_year'),
+                      progress: @progress,
+                      data: @progress.monthly_performance_versus_synthetic_last_year,
+                      keys: @reporting_months, partial_months: @progress.partial_months, percentage_synthetic: {},
+                      units: :relative_percent, final_row: true %>
     </tbody>
   </table>
 
@@ -63,12 +87,22 @@
     </tr>
     </thead>
     <tbody>
-    <%= render 'row', title: t('schools.school_targets.progress.expired.target_consumption_kwh'), data: @progress.cumulative_targets_kwh, keys: @reporting_months, partial_months: {}, percentage_synthetic: @progress.percentage_synthetic, units: :kwh, final_row: false %>
-    <%= render 'row', title: t('schools.school_targets.progress.expired.actual_consumption_kwh'), data: @progress.cumulative_usage_kwh, keys: @reporting_months, partial_months: @progress.partial_months, percentage_synthetic: {}, units: :kwh, final_row: false %>
-    <%= render 'row', title: t('schools.school_targets.progress.expired.overall_performance_since_last_year'), data: @progress.cumulative_performance_versus_synthetic_last_year, keys: @reporting_months, partial_months: @progress.partial_months, percentage_synthetic: {}, units: :relative_percent, final_row: true %>
+    <%= render 'row', title: t('schools.school_targets.progress.expired.target_consumption_kwh'),
+                      data: @progress.cumulative_targets_kwh, keys: @reporting_months,
+                      partial_months: {}, percentage_synthetic: @progress.percentage_synthetic,
+                      units: :kwh, final_row: false %>
+    <%= render 'row', title: t('schools.school_targets.progress.expired.actual_consumption_kwh'),
+                      data: @progress.cumulative_usage_kwh, keys: @reporting_months,
+                      partial_months: @progress.partial_months, percentage_synthetic: {},
+                      units: :kwh, final_row: false %>
+    <%= render 'row', title: t('schools.school_targets.progress.expired.overall_performance_since_last_year'),
+                      data: @progress.cumulative_performance_versus_synthetic_last_year, keys: @reporting_months,
+                      partial_months: @progress.partial_months, percentage_synthetic: {},
+                      units: :relative_percent, final_row: true %>
     </tbody>
   </table>
 
-  <%= render 'footnotes', fuel_type: @fuel_type, school_target: @school_target, show_storage_heater_notes: @show_storage_heater_notes, progress: @progress %>
+  <%= render 'footnotes', fuel_type: @fuel_type, school_target: @school_target,
+                          show_storage_heater_notes: @show_storage_heater_notes, progress: @progress %>
 
 <% end %>


### PR DESCRIPTION
The format_unit helper requests :html formatted values from analytics - so now all html formatted percent values include `&percnt;`, where as before they were inconsistently `%` or `&percnt;` depending on the type of percentage format requested.

i.e. the format_unit helper calls:
`
    FormatEnergyUnit.format(units, value, :html, false, in_table, user_numeric_comprehension_level).html_safe
`

The main issue was that up_downify by default calls sanitize on values, so now that it is being passed values containing `&percnt;` rather than `%` in some cases, it was outputting: `&amp;percnt;` which is rendered as `&percnt;`.

I've fixed these in the app by not sanitizing in this situation, assuming this is ok to do anyway.

The other issue we were having in a couple of places was that when passing a value containing html percentage symbol as a parameter to the translate helper, that it wasn't expecting html, (i.e. the translation key didn't end in _html or html_safe wasn't called on the output).

There are also a bunch of changes here for erblint...