### PR TITLE
Create basic integration with CapsuleCRM

### DIFF
--- a/app/jobs/campaign_contact_handler_job.rb
+++ b/app/jobs/campaign_contact_handler_job.rb
@@ -1,0 +1,13 @@
+class CampaignContactHandlerJob < ApplicationJob
+  queue_as :default
+
+  def priority
+    5
+  end
+
+  def perform(request_type, contact)
+    Campaigns::ContactHandlerService.new(request_type, contact).perform
+  rescue => e
+    Rollbar.error(e, job: :campaign_contact_handler)
+  end
+end

--- a/app/mailers/campaign_mailer.rb
+++ b/app/mailers/campaign_mailer.rb
@@ -1,0 +1,16 @@
+class CampaignMailer < LocaleMailer
+  def notify_admin
+    @request_type, @contact, @party, @opportunity = params.values_at(:request_type, :contact, :party, :opportunity)
+    make_bootstrap_mail(to: 'hello@energysparks.uk', subject: subject(@contact[:organisation], @request_type))
+  end
+
+  private
+
+  def env
+    ENV['ENVIRONMENT_IDENTIFIER'] || 'unknown'
+  end
+
+  def subject(organisation, request_type)
+    "[energy-sparks-#{env}] Campaign form: #{organisation} - #{request_type.to_s.humanize}"
+  end
+end

--- a/app/services/campaigns/contact_handler_service.rb
+++ b/app/services/campaigns/contact_handler_service.rb
@@ -1,0 +1,77 @@
+module Campaigns
+  class ContactHandlerService
+    def initialize(request_type, contact)
+      @request_type = request_type
+      @contact = contact
+    end
+
+    def perform
+      party = create_party
+      opportunity = create_opportunity(party)
+      notify_admin(party, opportunity)
+    end
+
+    private
+
+    def create_party
+      party = create_party_from_contact
+      CapsuleCrm::Client.new.create_party(party)
+    rescue => e
+      Rails.logger.error("Error: #{e.message} when creating party in CapsuleCRM")
+      Rollbar.warning(e, job: :capsulecrm)
+      nil
+    end
+
+    def create_party_from_contact
+      tags = [
+        { name: 'Campaign' },
+        { name: @request_type.to_s.humanize }
+      ]
+      tags = tags + @contact[:org_type].map { |t| { name: t } }
+      {
+        party: {
+          type: :person,
+          firstName: @contact[:first_name],
+          lastName: @contact[:last_name],
+          jobTitle: @contact[:job_title],
+          organisation: { name: @contact[:organisation] },
+          emailAddresses: [{ address: @contact[:email] }],
+          phoneNumbers: [{ number: @contact[:tel] }],
+          tags: tags
+        }
+      }
+    end
+
+    def create_opportunity(party)
+      return nil unless party.present?
+      opportunity = create_opportunity_for_party(party)
+      CapsuleCrm::Client.new.create_opportunity(opportunity)
+    rescue => e
+      Rails.logger.error("Error: #{e.message} when creating opportunity in CapsuleCRM")
+      Rollbar.warning(e, job: :capsulecrm)
+      nil
+    end
+
+    def create_opportunity_for_party(party)
+      {
+        opportunity: {
+          name: "New Opportunity - #{@contact[:organisation]}",
+          description: 'Auto-generated opportunity from campaign contact form',
+          party: {
+            id: party['party']['id']
+          },
+          tags: [
+            { name: @request_type.to_s.humanize }
+          ]
+        }
+      }
+    end
+
+    def notify_admin(party, opportunity)
+      CampaignMailer.with(request_type: @request_type,
+                       contact: @contact,
+                       party: party,
+                       opportunity: opportunity).notify_admin.deliver_now
+    end
+  end
+end

--- a/app/services/campaigns/contact_handler_service.rb
+++ b/app/services/campaigns/contact_handler_service.rb
@@ -3,6 +3,7 @@ module Campaigns
     # Unique identifier for the custom field created in Capsule for capturing
     # consent to receive marketing emails
     MARKETING_CONSENT_FIELD_ID = 830129
+    NEW_MILESTONE_ID = 2041588
 
     def initialize(request_type, contact)
       @request_type = request_type
@@ -43,7 +44,7 @@ module Campaigns
           phoneNumbers: [{ number: @contact[:tel] }],
           tags: tags,
           fields: [
-            { id: MARKETING_CONSENT_FIELD_ID, value: @contact[:consent] }
+            { definition: { id: MARKETING_CONSENT_FIELD_ID }, value: @contact[:consent] }
           ]
         }
       }
@@ -62,12 +63,14 @@ module Campaigns
     def create_opportunity_for_party(party)
       {
         opportunity: {
-          name: "New Opportunity - #{@contact[:organisation]}",
+          name: @contact[:organisation],
           description: 'Auto-generated opportunity from campaign contact form',
+          milestone: { id: NEW_MILESTONE_ID },
           party: {
             id: party['party']['id']
           },
           tags: [
+            { name: 'Campaign' },
             { name: @request_type.to_s.humanize }
           ]
         }

--- a/app/services/campaigns/contact_handler_service.rb
+++ b/app/services/campaigns/contact_handler_service.rb
@@ -1,5 +1,9 @@
 module Campaigns
   class ContactHandlerService
+    # Unique identifier for the custom field created in Capsule for capturing
+    # consent to receive marketing emails
+    MARKETING_CONSENT_FIELD_ID = 830129
+
     def initialize(request_type, contact)
       @request_type = request_type
       @contact = contact
@@ -37,7 +41,10 @@ module Campaigns
           organisation: { name: @contact[:organisation] },
           emailAddresses: [{ address: @contact[:email] }],
           phoneNumbers: [{ number: @contact[:tel] }],
-          tags: tags
+          tags: tags,
+          fields: [
+            { id: MARKETING_CONSENT_FIELD_ID, value: @contact[:consent] }
+          ]
         }
       }
     end

--- a/app/views/campaign_mailer/notify_admin.html.erb
+++ b/app/views/campaign_mailer/notify_admin.html.erb
@@ -1,0 +1,29 @@
+<h1 class="mb-3">
+  <%= @request_type.to_s.humanize %>
+</h1>
+
+<h2>Submitted Details</h2>
+
+<ul>
+<li>Name: <%= @contact[:first_name] %> <%= @contact[:last_name] %></li>
+<li>Email: <%= @contact[:email] %></li>
+<li>Tel: <%= @contact[:tel] %></li>
+<li>Job Title: <%= @contact[:job_title] %></li>
+<li>Organisation: <%= @contact[:organisation] %></li>
+<li>Organisation Type: <%= @contact[:org_type].to_s.humanize %></li>
+<li>Marketing Consent: <%= @contact[:consent] %></li>
+</ul>
+
+<% if @party.present? %>
+  <h2>Capsule Links</h2>
+
+  <%= link_to 'View Contact',
+              "https://energysparks.capsulecrm.com/party/#{@party['party']['id']}",
+              class: 'btn btn-primary mt-3 mb-3' %>
+
+  <% if @opportunity.present? %>
+    <%= link_to 'View Opportunity',
+                "https://energysparks.capsulecrm.com/opportunity/#{@opportunity['opportunity']['id']}",
+                class: 'btn btn-primary mt-3 mb-3' %>
+  <% end %>
+<% end %>

--- a/app/views/campaign_mailer/notify_admin.html.erb
+++ b/app/views/campaign_mailer/notify_admin.html.erb
@@ -10,7 +10,7 @@
 <li>Tel: <%= @contact[:tel] %></li>
 <li>Job Title: <%= @contact[:job_title] %></li>
 <li>Organisation: <%= @contact[:organisation] %></li>
-<li>Organisation Type: <%= @contact[:org_type].to_s.humanize %></li>
+<li>Organisation Type: <%= @contact[:org_type].map { |t| t }.join(',') %></li>
 <li>Marketing Consent: <%= @contact[:consent] %></li>
 </ul>
 

--- a/lib/capsule_crm/client.rb
+++ b/lib/capsule_crm/client.rb
@@ -1,12 +1,14 @@
 module CapsuleCrm
   # other unexpected errors
   class ApiFailure < StandardError; end
+  # 400 incorrect request body
+  class BadRequest < ApiFailure; end
   # 401 invalid api key
   class NotAuthorised < ApiFailure; end
   # 403 operation not permitted
   class NotAllowed < ApiFailure; end
-  # 400 incorrect request body
-  class BadRequest < ApiFailure; end
+  # 404 incorrect url
+  class NotFound < ApiFailure; end
   # 422 field validation failed
   class ValidationFailed < ApiFailure; end
 
@@ -16,6 +18,10 @@ module CapsuleCrm
     def initialize(api_key: ENV['CAPSULECRM_API_KEY'], connection: nil)
       @api_key = api_key
       @connection = connection || Faraday.new(BASE_URL, headers: headers)
+    end
+
+    def field_definitions(entity = :parties)
+      get_data("/#{entity}/fields/definitions")
     end
 
     def users

--- a/lib/capsule_crm/client.rb
+++ b/lib/capsule_crm/client.rb
@@ -1,0 +1,81 @@
+module CapsuleCrm
+  # 401 invalid api key
+  class NotAuthorised < StandardError; end
+  # 403 operation not permitted
+  class NotAllowed < StandardError; end
+  # 400 incorrect request body
+  class BadRequest < StandardError; end
+  # 422 field validation failed
+  class ValidationFailed < StandardError; end
+  # other unexpected errors
+  class ApiFailure < StandardError; end
+
+  class Client
+    BASE_URL = 'https://api.capsulecrm.com/api/v2'.freeze
+
+    def initialize(api_key: ENV['CAPSULECRM_API_KEY'], connection: nil)
+      @api_key = api_key
+      @connection = connection || Faraday.new(BASE_URL, headers: headers)
+    end
+
+    def users
+      get_data('/users')
+    end
+
+    def create_party(party)
+      post_data('/parties', party)
+    end
+
+    def create_opportunity(opportunity)
+      post_data('/opportunities', opportunity)
+    end
+
+    private
+
+    def get_data(path, params = nil)
+      response = @connection.get("#{BASE_URL}#{path}", params)
+      return JSON.parse(response.body) if response.success?
+      handle_error(response)
+    end
+
+    def post_data(path, body)
+      response = @connection.post("#{BASE_URL}#{path}", JSON.generate(body))
+      return JSON.parse(response.body) if response.success?
+      handle_error(response)
+    end
+
+    def handle_error(response)
+      raise BadRequest.new(error_message(response)) if response.status == 400
+      raise NotAuthorised.new(error_message(response)) if response.status == 401
+      raise NotAllowed.new(error_message(response)) if response.status == 403
+      raise NotFound.new(error_message(response)) if response.status == 404
+      raise ValidationFailed.new(error_message(response)) if response.status == 422
+      raise ApiFailure.new(error_message(response)) # fallback
+    end
+
+    def error_message(response)
+      data = JSON.parse(response.body)
+      # field validation error response contain a message and an
+      # array of errors, so include all messages
+      if data['errors']
+        errors = data['errors'].map {|e| e['message'] }
+        "#{data['message']}, #{errors.join(',')}"
+      elsif data['message']
+        data['message']
+      else
+        response.body
+      end
+    rescue
+      # problem parsing or traversing json, return original api error
+      response.body
+    end
+
+    def headers
+      {
+        'Authorization': "Bearer #{@api_key}",
+        'Content-Type': 'application/json',
+        'Accept': 'application/json'
+      }
+    end
+  end
+end

--- a/lib/capsule_crm/client.rb
+++ b/lib/capsule_crm/client.rb
@@ -1,14 +1,14 @@
 module CapsuleCrm
-  # 401 invalid api key
-  class NotAuthorised < StandardError; end
-  # 403 operation not permitted
-  class NotAllowed < StandardError; end
-  # 400 incorrect request body
-  class BadRequest < StandardError; end
-  # 422 field validation failed
-  class ValidationFailed < StandardError; end
   # other unexpected errors
   class ApiFailure < StandardError; end
+  # 401 invalid api key
+  class NotAuthorised < ApiFailure; end
+  # 403 operation not permitted
+  class NotAllowed < ApiFailure; end
+  # 400 incorrect request body
+  class BadRequest < ApiFailure; end
+  # 422 field validation failed
+  class ValidationFailed < ApiFailure; end
 
   class Client
     BASE_URL = 'https://api.capsulecrm.com/api/v2'.freeze

--- a/lib/capsule_crm/client.rb
+++ b/lib/capsule_crm/client.rb
@@ -20,6 +20,10 @@ module CapsuleCrm
       @connection = connection || Faraday.new(BASE_URL, headers: headers)
     end
 
+    def milestones
+      get_data('/milestones')
+    end
+
     def field_definitions(entity = :parties)
       get_data("/#{entity}/fields/definitions")
     end

--- a/spec/lib/capsule_crm/client_spec.rb
+++ b/spec/lib/capsule_crm/client_spec.rb
@@ -1,0 +1,127 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'faraday/adapter/test'
+
+describe CapsuleCrm::Client do
+  subject(:client) do
+    described_class.new(api_key: api_key, connection: connection)
+  end
+
+  let(:stubs)       { Faraday::Adapter::Test::Stubs.new }
+  let(:connection)  { Faraday.new { |b| b.adapter(:test, stubs) } }
+  let(:api_key)     { 'bearer_token' }
+
+  after do
+    Faraday.default_connection = nil
+  end
+
+  shared_examples 'a successfully handled error' do
+    it 'by throwing the expected exception' do
+      expect do
+        client.send(method, *params)
+      end.to raise_error(expected_error, expected_message)
+      stubs.verify_stubbed_calls
+    end
+  end
+
+  describe '#create_party' do
+    context 'when API returns an error' do
+      let(:method) { :create_party }
+      let(:party)  { {} }
+      let(:message) { 'Expected message' }
+      let(:response) do
+        {
+          'message': message
+        }
+      end
+      let(:url) { 'https://api.capsulecrm.com/api/v2/parties' }
+
+      context 'with authorisation error' do
+        it_behaves_like 'a successfully handled error' do
+          let(:stubs) do
+            Faraday::Adapter::Test::Stubs.new do |stubs|
+              stubs.post(url) do |_env|
+                [401, party, response.to_json]
+              end
+            end
+          end
+          let(:params) { [party] }
+          let(:expected_error) { CapsuleCrm::NotAuthorised }
+          let(:expected_message) { message }
+        end
+      end
+
+      context 'with permission error' do
+        it_behaves_like 'a successfully handled error' do
+          let(:stubs) do
+            Faraday::Adapter::Test::Stubs.new do |stubs|
+              stubs.post(url) do |_env|
+                [403, party, response.to_json]
+              end
+            end
+          end
+          let(:params) { [party] }
+          let(:expected_error) { CapsuleCrm::NotAllowed }
+          let(:expected_message) { message }
+        end
+      end
+
+      context 'with bad request' do
+        it_behaves_like 'a successfully handled error' do
+          let(:stubs) do
+            Faraday::Adapter::Test::Stubs.new do |stubs|
+              stubs.post(url) do |_env|
+                [400, party, response.to_json]
+              end
+            end
+          end
+          let(:params) { [party] }
+          let(:expected_error) { CapsuleCrm::BadRequest }
+          let(:expected_message) { message }
+        end
+      end
+
+      context 'with validation failure' do
+        let(:response) do
+          {
+            'message': message,
+            'errors': [
+              'message': 'name is required',
+              'resource': 'party',
+              'field': 'name'
+            ]
+          }
+        end
+
+        it_behaves_like 'a successfully handled error' do
+          let(:stubs) do
+            Faraday::Adapter::Test::Stubs.new do |stubs|
+              stubs.post(url) do |_env|
+                [422, party, response.to_json]
+              end
+            end
+          end
+          let(:params) { [party] }
+          let(:expected_error) { CapsuleCrm::ValidationFailed }
+          let(:expected_message) { 'Expected message, name is required' }
+        end
+      end
+
+      context 'with server error' do
+        it_behaves_like 'a successfully handled error' do
+          let(:stubs) do
+            Faraday::Adapter::Test::Stubs.new do |stubs|
+              stubs.post(url) do |_env|
+                [500, party, response.to_json]
+              end
+            end
+          end
+          let(:params) { [party] }
+          let(:expected_error) { CapsuleCrm::ApiFailure }
+          let(:expected_message) { message }
+        end
+      end
+    end
+  end
+end

--- a/spec/mailers/campaign_mailer_spec.rb
+++ b/spec/mailers/campaign_mailer_spec.rb
@@ -1,0 +1,80 @@
+require 'rails_helper'
+
+RSpec.describe CampaignMailer do
+  let(:email) { ActionMailer::Base.deliveries.last }
+  let(:body) { email.html_part.body.raw_source }
+
+  around do |example|
+    ClimateControl.modify ENVIRONMENT_IDENTIFIER: 'unknown' do
+      example.run
+    end
+  end
+
+  describe '#notify_admin' do
+    let(:request_type) { :book_demo }
+    let(:contact) do
+      {
+        first_name: 'Jane',
+        last_name: 'Smith',
+        email: 'jane@example.org',
+        tel: '01225 444444',
+        job_title: 'CFO',
+        organisation: 'Fake Academies',
+        org_type: :mat,
+        consent: true
+      }
+    end
+    let(:party) do
+      {
+        'party' => {
+          'id' => 1234
+        }
+      }
+    end
+    let(:opportunity) do
+      {
+        'opportunity' => {
+          'id' => 5678
+        }
+      }
+    end
+
+    before do
+      CampaignMailer.with(request_type: request_type,
+                          contact: contact,
+                          party: party,
+                          opportunity: opportunity).notify_admin.deliver
+    end
+
+    it 'send email with expected subject' do
+      expect(email.subject).to eq('[energy-sparks-unknown] Campaign form: Fake Academies - Book demo')
+    end
+
+    it 'includes contact details in email' do
+      expect(email.html_part.decoded).to include('Jane Smith')
+      expect(email.html_part.decoded).to include('jane@example.org')
+      expect(email.html_part.decoded).to include('01225 444444')
+      expect(email.html_part.decoded).to include('CFO')
+      expect(email.html_part.decoded).to include('Mat')
+      expect(email.html_part.decoded).to include('true')
+    end
+
+    it 'includes request type in email' do
+      expect(email.html_part.decoded).to include('Book demo')
+    end
+
+    it 'includes capsule links' do
+      expect(body).to have_link('View Contact', href: 'https://energysparks.capsulecrm.com/party/1234')
+      expect(body).to have_link('View Opportunity', href: 'https://energysparks.capsulecrm.com/opportunity/5678')
+    end
+
+    context 'with no capsule information' do
+      let(:party) { nil }
+      let(:opportunity) { nil }
+
+      it 'omits the links' do
+        expect(email.html_part.decoded).not_to include('Capsule Links')
+      end
+    end
+  end
+end

--- a/spec/mailers/campaign_mailer_spec.rb
+++ b/spec/mailers/campaign_mailer_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe CampaignMailer do
         tel: '01225 444444',
         job_title: 'CFO',
         organisation: 'Fake Academies',
-        org_type: :mat,
+        org_type: ['Multi-Academy Trust'],
         consent: true
       }
     end
@@ -55,7 +55,7 @@ RSpec.describe CampaignMailer do
       expect(email.html_part.decoded).to include('jane@example.org')
       expect(email.html_part.decoded).to include('01225 444444')
       expect(email.html_part.decoded).to include('CFO')
-      expect(email.html_part.decoded).to include('Mat')
+      expect(email.html_part.decoded).to include('Multi-Academy Trust')
       expect(email.html_part.decoded).to include('true')
     end
 

--- a/spec/mailers/previews/campaign_mailer_preview.rb
+++ b/spec/mailers/previews/campaign_mailer_preview.rb
@@ -1,0 +1,29 @@
+class CampaignMailerPreview < ActionMailer::Preview
+  def notify_admin
+    request_type = :book_now
+    contact = {
+      first_name: 'Jane',
+      last_name: 'Smith',
+      email: 'jane@example.org',
+      tel: '01225 444444',
+      job_title: 'CFO',
+      organisation: 'Fake Academies',
+      org_type: :mat,
+      consent: true
+    }
+    party = {
+      'party' => {
+        'id' => 1234
+      }
+    }
+    opportunity = {
+      'opportunity' => {
+        'id' => 1234
+      }
+    }
+    CampaignMailer.with(request_type: request_type,
+                     contact: contact,
+                     party: party,
+                     opportunity: opportunity).notify_admin
+  end
+end

--- a/spec/mailers/previews/campaign_mailer_preview.rb
+++ b/spec/mailers/previews/campaign_mailer_preview.rb
@@ -1,6 +1,6 @@
 class CampaignMailerPreview < ActionMailer::Preview
   def notify_admin
-    request_type = :book_now
+    request_type = :book_demo
     contact = {
       first_name: 'Jane',
       last_name: 'Smith',
@@ -8,7 +8,7 @@ class CampaignMailerPreview < ActionMailer::Preview
       tel: '01225 444444',
       job_title: 'CFO',
       organisation: 'Fake Academies',
-      org_type: :mat,
+      org_type: ['Primary school (state)', 'Secondary school (state)'],
       consent: true
     }
     party = {

--- a/spec/services/campaigns/contact_handler_service_spec.rb
+++ b/spec/services/campaigns/contact_handler_service_spec.rb
@@ -127,6 +127,9 @@ describe Campaigns::ContactHandlerService do
             { name: 'Book demo' },
             { name: 'Primary school (state)' },
             { name: 'Secondary school (state)' }
+          ],
+          fields: [
+            { id: described_class::MARKETING_CONSENT_FIELD_ID, value: true }
           ]
         }
       })

--- a/spec/services/campaigns/contact_handler_service_spec.rb
+++ b/spec/services/campaigns/contact_handler_service_spec.rb
@@ -1,0 +1,162 @@
+require 'rails_helper'
+
+describe Campaigns::ContactHandlerService do
+  subject(:service) { described_class.new(request_type, contact) }
+
+  let(:request_type) { :book_demo }
+  let(:contact) do
+    {
+      first_name: 'Jane',
+      last_name: 'Smith',
+      email: 'jane@example.org',
+      tel: '01225 444444',
+      job_title: 'CFO',
+      organisation: 'Fake Academies',
+      org_type: ['Primary school (state)', 'Secondary school (state)'],
+      consent: true
+    }
+  end
+
+  let(:capsule) { instance_double(CapsuleCrm::Client) }
+
+  before do
+    allow(CapsuleCrm::Client).to receive(:new).and_return(capsule)
+  end
+
+  describe '#perform' do
+    let(:email) { ActionMailer::Base.deliveries.last }
+
+    context 'with successful party creation in Capsule' do
+      let(:party) do
+        {
+          'party' => {
+            'id' => 1234
+          }
+        }
+      end
+
+      before do
+        allow(capsule).to receive(:create_party).and_return(party)
+      end
+
+      context 'with failed opportunity creation' do
+        before do
+          allow(capsule).to receive(:create_opportunity).and_raise(CapsuleCrm::ApiFailure)
+        end
+
+        it 'sends an email' do
+          expect { service.perform }.to change(ActionMailer::Base.deliveries, :count)
+        end
+
+        it 'includes capsule link to contact' do
+          service.perform
+          expect(email.html_part.decoded).to include('View Contact')
+          expect(email.html_part.decoded).not_to include('View Opportunity')
+        end
+
+        it 'logs warning in Rollbar' do
+          expect(Rollbar).to receive(:warning)
+          service.perform
+        end
+      end
+
+      context 'with successful opportunity creation' do
+        let(:opportunity) do
+          {
+            'opportunity' => {
+              'id' => 5678
+            }
+          }
+        end
+
+        before do
+          allow(capsule).to receive(:create_opportunity).and_return(opportunity)
+        end
+
+        it 'sends an email' do
+          expect { service.perform }.to change(ActionMailer::Base.deliveries, :count)
+        end
+
+        it 'includes capsule links' do
+          service.perform
+          expect(email.html_part.decoded).to include('View Contact')
+          expect(email.html_part.decoded).to include('View Opportunity')
+        end
+      end
+    end
+
+    context 'with failed party creation in Capsule' do
+      before do
+        allow(capsule).to receive(:create_party).and_raise(CapsuleCrm::ApiFailure)
+      end
+
+      it 'logs warning in Rollbar' do
+        expect(Rollbar).to receive(:warning)
+        service.perform
+      end
+
+      it 'sends an email' do
+        expect { service.perform }.to change(ActionMailer::Base.deliveries, :count)
+      end
+
+      it 'does not include capsule links' do
+        service.perform
+        expect(email.html_part.decoded).not_to include('View Contact')
+        expect(email.html_part.decoded).not_to include('View Opportunity')
+      end
+    end
+  end
+
+  describe '#create_party_from_contact' do
+    subject(:capsule_data) do
+      service.send(:create_party_from_contact)
+    end
+
+    it 'creates expected format for CapsuleCRM' do
+      expect(capsule_data).to eq({
+        party: {
+          type: :person,
+          firstName: 'Jane',
+          lastName: 'Smith',
+          jobTitle: 'CFO',
+          organisation: { name: 'Fake Academies' },
+          emailAddresses: [{ address: 'jane@example.org' }],
+          phoneNumbers: [{ number: '01225 444444' }],
+          tags: [
+            { name: 'Campaign' },
+            { name: 'Book demo' },
+            { name: 'Primary school (state)' },
+            { name: 'Secondary school (state)' }
+          ]
+        }
+      })
+    end
+  end
+
+  describe '#create_opportunity_for_party' do
+    subject(:capsule_data) do
+      service.send(:create_opportunity_for_party, party)
+    end
+
+    let(:party) do
+      {
+        'party' => {
+          'id' => 12345
+        }
+      }
+    end
+
+    it 'creates expected hash' do
+      expect(capsule_data).to eq({
+        opportunity: {
+          party: { id: 12345 },
+          name: 'New Opportunity - Fake Academies',
+          description: 'Auto-generated opportunity from campaign contact form',
+          tags: [
+            { name: 'Book demo' }
+          ]
+        }
+      })
+    end
+  end
+end

--- a/spec/services/campaigns/contact_handler_service_spec.rb
+++ b/spec/services/campaigns/contact_handler_service_spec.rb
@@ -129,7 +129,7 @@ describe Campaigns::ContactHandlerService do
             { name: 'Secondary school (state)' }
           ],
           fields: [
-            { id: described_class::MARKETING_CONSENT_FIELD_ID, value: true }
+            { definition: { id: described_class::MARKETING_CONSENT_FIELD_ID }, value: true }
           ]
         }
       })
@@ -153,9 +153,11 @@ describe Campaigns::ContactHandlerService do
       expect(capsule_data).to eq({
         opportunity: {
           party: { id: 12345 },
-          name: 'New Opportunity - Fake Academies',
+          name: 'Fake Academies',
           description: 'Auto-generated opportunity from campaign contact form',
+          milestone: { id: described_class::NEW_MILESTONE_ID },
           tags: [
+            { name: 'Campaign' },
             { name: 'Book demo' }
           ]
         }


### PR DESCRIPTION
To support marketing efforts we will have a form on the webpage to allow prospective users to book a demo or request more information. To capture this we will be storing the information in CapsuleCRM.

This PR:

- Adds a basic CapsuleCRM client capable of creating a new Party (contact) and Opportunity (sales lead). This allows us to capture some basic information provided by users plus some tagging and a custom field value to support internal workflow
- A mailer to send an internal email when someone completes the form, with the provided details and links to Capsule
- A mailer preview for the above
- A service to coordinate creating parties and opportunities in Capsule and sending an email notification. If there are API/comms errors with capsule then the service ensures that the email is still sent
- A background job to run the service asynchronously

The are specs for the client, mailer and service. Manual testing of the service has also been done to confirm that the API calls are successful.

Follow-on PR will have changes to add the web pages and form for submitting information.