### PR TITLE
Cookie banner

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -470,6 +470,13 @@ source_lang  = en
 type         = YML
 minimum_perc = 100
 
+[o:energy-sparks:p:energy-sparks:r:views-home-cookies-yml]
+file_filter  = config/locales/<lang>/views/home/cookies.yml
+source_file  = config/locales/views/home/cookies.yml
+source_lang  = en
+type         = YML
+minimum_perc = 100
+
 [o:energy-sparks:p:energy-sparks:r:views-home-datasets-yml]
 file_filter  = config/locales/<lang>/views/home/datasets.yml
 source_file  = config/locales/views/home/datasets.yml

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -64,3 +64,4 @@
 //= require gtag
 //= require cocoon
 //= require loading
+//= require cookie_banner

--- a/app/assets/javascripts/cookie_banner.js
+++ b/app/assets/javascripts/cookie_banner.js
@@ -1,11 +1,16 @@
 "use strict"
 
+const COOKIE_BANNER_ID = 'cookie-banner';
+const COOKIE_PREFERENCE_NAME = 'cookie_preference';
+const ACCEPTED = 'Accepted';
+const REJECTED = 'Rejected';
+
 function initializeCookieBanner() {
- let cookieStatus = Cookies.get('cookie_preference');
+ let cookieStatus = Cookies.get(COOKIE_PREFERENCE_NAME);
  if(cookieStatus === undefined) {
    // user has not accepted or refused; or preference cookie expired
    showCookieBanner();
- } else if (cookieStatus == 'Accepted') {
+ } else if (cookieStatus == ACCEPTED) {
    // preference cookie is current and user has accepted
    setAnalyticsConsent('granted');
  } else {
@@ -15,30 +20,30 @@ function initializeCookieBanner() {
 }
 
 function showCookieBanner() {
- let cookieBanner = document.getElementById("cookie-banner");
- cookieBanner.style.display = "block";
+ let cookieBanner = document.getElementById(COOKIE_BANNER_ID);
+ cookieBanner.style.display = 'block';
  window.acceptCookies = acceptCookies;
  window.rejectCookies = rejectCookies;
 }
 
 function hideBanner() {
-  let cookieBanner = document.getElementById("cookie-banner");
-  cookieBanner.style.display = "none";
+  let cookieBanner = document.getElementById(COOKIE_BANNER_ID);
+  cookieBanner.style.display = 'none';
 }
 
 function setPreferenceCookie(status) {
-  Cookies.remove('cookie_preference');
-  Cookies.set('cookie_preference', status, { expires: 365 });
+  Cookies.remove(COOKIE_PREFERENCE_NAME);
+  Cookies.set(COOKIE_PREFERENCE_NAME, status, { expires: 365 });
 }
 
 function acceptCookies() {
- setPreferenceCookie('Accepted');
+ setPreferenceCookie(ACCEPTED);
  setAnalyticsConsent('granted');
  hideBanner();
 }
 
 function rejectCookies() {
- setPreferenceCookie('Rejected');
+ setPreferenceCookie(REJECTED);
  setAnalyticsConsent('denied');
  hideBanner();
 }

--- a/app/assets/javascripts/cookie_banner.js
+++ b/app/assets/javascripts/cookie_banner.js
@@ -1,0 +1,54 @@
+"use strict"
+
+function initializeCookieBanner() {
+ let cookieStatus = Cookies.get('cookie_preference');
+ if(cookieStatus === undefined) {
+   // user has not accepted or refused; or preference cookie expired
+   showCookieBanner();
+ } else if (cookieStatus == 'Accepted') {
+   // preference cookie is current and user has accepted
+   setAnalyticsConsent('granted');
+ } else {
+   // preference cookie is current and user has refused
+   setAnalyticsConsent('denied');
+ }
+}
+
+function showCookieBanner() {
+ let cookieBanner = document.getElementById("cookie-banner");
+ cookieBanner.style.display = "block";
+ window.acceptCookies = acceptCookies;
+ window.rejectCookies = rejectCookies;
+}
+
+function hideBanner() {
+  let cookieBanner = document.getElementById("cookie-banner");
+  cookieBanner.style.display = "none";
+}
+
+function setPreferenceCookie(status) {
+  Cookies.remove('cookie_preference');
+  Cookies.set('cookie_preference', status, { expires: 365 });
+}
+
+function acceptCookies() {
+ setPreferenceCookie('Accepted');
+ setAnalyticsConsent('granted');
+ hideBanner();
+}
+
+function rejectCookies() {
+ setPreferenceCookie('Rejected');
+ setAnalyticsConsent('denied');
+ hideBanner();
+}
+
+function setAnalyticsConsent(permission) {
+  if (typeof gtag !== 'undefined') {
+    gtag('consent', 'update', {
+     'analytics_storage': permission
+   });
+  }
+}
+
+$(document).ready(initializeCookieBanner);

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -55,5 +55,6 @@
 @import "compare";
 @import "comparisons";
 @import "standout";
+@import "cookie_banner";
 
 @import "../../components/**/*"; // loaded here so bootstrap SASS variables are available

--- a/app/assets/stylesheets/cookie_banner.scss
+++ b/app/assets/stylesheets/cookie_banner.scss
@@ -1,0 +1,15 @@
+#cookie-banner {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  z-index: 999;
+  border-radius: 0;
+  display: none;
+  background-color: $dark;
+  color: $white;
+
+  a {
+    color: $white;
+  }
+}

--- a/app/assets/stylesheets/cookie_banner.scss
+++ b/app/assets/stylesheets/cookie_banner.scss
@@ -3,7 +3,7 @@
   bottom: 0;
   left: 0;
   width: 100%;
-  z-index: 999;
+  z-index: 9999;
   border-radius: 0;
   display: none;
   background-color: $dark;

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -48,6 +48,9 @@ class HomeController < ApplicationController
   def enrol_our_local_authority
   end
 
+  def cookies
+  end
+
   def privacy_and_cookie_policy
   end
 

--- a/app/models/video.rb
+++ b/app/models/video.rb
@@ -18,6 +18,6 @@ class Video < ApplicationRecord
   scope :featured, -> { where(featured: true) }
 
   def embed_url
-    "https://www.youtube.com/embed/#{youtube_id}"
+    "https://www.youtube-nocookie.com/embed/#{youtube_id}"
   end
 end

--- a/app/views/home/cookies.html.erb
+++ b/app/views/home/cookies.html.erb
@@ -75,6 +75,13 @@
         <%= t('cookies.analytics.question') %>
       </h3>
 
+      <button type="button" class="btn btn-primary btn-sm ms-3" onclick="window.acceptCookies()">
+        <%= I18n.t('cookie_banner.accept') %>
+      </button>
+      <button type="button" class="btn btn-primary btn-sm ms-3" onclick="window.rejectCookies()">
+        <%= I18n.t('cookie_banner.reject') %>
+      </button>
+
     </div>
   </div>
 </div>

--- a/app/views/home/cookies.html.erb
+++ b/app/views/home/cookies.html.erb
@@ -32,6 +32,11 @@
             <td><%= t('cookies.essential.session.expires') %></td>
           </tr>
           <tr>
+            <td class="col-3"><code>remember_user_token</code></td>
+            <td><%= t('cookies.essential.remember.purpose') %></td>
+            <td><%= t('cookies.essential.remember.expires') %></td>
+          </tr>
+          <tr>
             <td class="col-3"><code>cookie_preference</code></td>
             <td><%= t('cookies.essential.preference.purpose') %></td>
             <td><%= t('cookies.essential.preference.expires') %></td>

--- a/app/views/home/cookies.html.erb
+++ b/app/views/home/cookies.html.erb
@@ -1,0 +1,80 @@
+<% content_for :page_title, t('cookies.title') %>
+
+<div class="application container ">
+  <div class="row">
+    <div class="col col-md-10 col-lg-8">
+      <h1><%= t('cookies.title') %></h1>
+
+      <%= t('cookies.intro_html', privacy_and_cookie_policy: privacy_and_cookie_policy_path) %>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="col col-md-10 col-lg-8">
+      <h2><%= t('cookies.essential.title') %></h2>
+
+      <p>
+        <%= t('cookies.essential.intro_html') %>
+      </p>
+
+      <table class="table table-sm">
+        <thead>
+          <tr>
+            <th><%= t('cookies.name') %></th>
+            <th><%= t('cookies.purpose') %></th>
+            <th><%= t('cookies.expires') %></th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td class="col-3"><code>_energy-sparks_session</code></td>
+            <td><%= t('cookies.essential.session.purpose') %></td>
+            <td><%= t('cookies.essential.session.expires') %></td>
+          </tr>
+          <tr>
+            <td class="col-3"><code>cookie_preference</code></td>
+            <td><%= t('cookies.essential.preference.purpose') %></td>
+            <td><%= t('cookies.essential.preference.expires') %></td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="col col-md-10 col-lg-8">
+      <h2><%= t('cookies.analytics.title') %></h2>
+
+      <p>
+        <%= t('cookies.analytics.intro_html') %>
+      </p>
+
+      <table class="table table-sm">
+        <thead>
+          <tr>
+            <th><%= t('cookies.name') %></th>
+            <th><%= t('cookies.purpose') %></th>
+            <th><%= t('cookies.expires') %></th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td class="col-1"><code>_ga</code></td>
+            <td><%= t('cookies.analytics.ga.purpose') %></td>
+            <td><%= t('cookies.analytics.ga.expires') %></td>
+          </tr>
+          <tr>
+            <td class="col-1"><code>_gid</code></td>
+            <td><%= t('cookies.analytics.gid.purpose') %></td>
+            <td><%= t('cookies.analytics.gid.expires') %></td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h3>
+        <%= t('cookies.analytics.question') %>
+      </h3>
+
+    </div>
+  </div>
+</div>

--- a/app/views/home/cookies.html.erb
+++ b/app/views/home/cookies.html.erb
@@ -75,12 +75,11 @@
         <%= t('cookies.analytics.question') %>
       </h3>
 
-      <button type="button" class="btn btn-primary btn-sm ms-3" onclick="window.acceptCookies()">
-        <%= I18n.t('cookie_banner.accept') %>
-      </button>
-      <button type="button" class="btn btn-primary btn-sm ms-3" onclick="window.rejectCookies()">
-        <%= I18n.t('cookie_banner.reject') %>
-      </button>
+      <p>
+        <%= t('cookies.analytics.explain') %>
+      </p>
+
+      <%= render 'shared/cookie_buttons' %>
 
     </div>
   </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,6 +13,7 @@
     <% if show_partner_footer?(@school) %>
       <%= render 'shared/partners' %>
     <% end %>
+    <%= render 'shared/cookie_banner' %>
     <%= render 'shared/footer' %>
   </body>
   <%= render 'layouts/set_mobility_locale' %>

--- a/app/views/layouts/home.html.erb
+++ b/app/views/layouts/home.html.erb
@@ -14,6 +14,7 @@
     <% end %>
     <!-- don't render application container as you do for the other pages -->
     <%= yield %>
+    <%= render 'shared/cookie_banner' %>
     <%= render 'shared/footer' %>
   </body>
 </html>

--- a/app/views/shared/_cookie_banner.html.erb
+++ b/app/views/shared/_cookie_banner.html.erb
@@ -1,6 +1,6 @@
 <div id="cookie-banner" class="alert text-center mb-0" role="alert">
   <%= I18n.t('cookie_banner.notice') %>
-  <a href="https://www.cookiesandyou.com/" target="blank"><%= I18n.t('cookie_banner.learn_more') %></a>
+  <%= link_to I18n.t('cookie_banner.learn_more'), cookies_path %>
   <button type="button" class="btn btn-primary btn-sm ms-3" onclick="window.acceptCookies()">
     <%= I18n.t('cookie_banner.accept') %>
   </button>

--- a/app/views/shared/_cookie_banner.html.erb
+++ b/app/views/shared/_cookie_banner.html.erb
@@ -1,0 +1,10 @@
+<div id="cookie-banner" class="alert text-center mb-0" role="alert">
+  <%= I18n.t('cookie_banner.notice') %>
+  <a href="https://www.cookiesandyou.com/" target="blank"><%= I18n.t('cookie_banner.learn_more') %></a>
+  <button type="button" class="btn btn-primary btn-sm ms-3" onclick="window.acceptCookies()">
+    <%= I18n.t('cookie_banner.accept') %>
+  </button>
+  <button type="button" class="btn btn-primary btn-sm ms-3" onclick="window.rejectCookies()">
+    <%= I18n.t('cookie_banner.reject') %>
+  </button>
+</div>

--- a/app/views/shared/_cookie_banner.html.erb
+++ b/app/views/shared/_cookie_banner.html.erb
@@ -1,10 +1,5 @@
 <div id="cookie-banner" class="alert text-center mb-0" role="alert">
   <%= I18n.t('cookie_banner.notice') %>
   <%= link_to I18n.t('cookie_banner.learn_more'), cookies_path %>
-  <button type="button" class="btn btn-primary btn-sm ms-3" onclick="window.acceptCookies()">
-    <%= I18n.t('cookie_banner.accept') %>
-  </button>
-  <button type="button" class="btn btn-primary btn-sm ms-3" onclick="window.rejectCookies()">
-    <%= I18n.t('cookie_banner.reject') %>
-  </button>
+  <%= render 'shared/cookie_buttons' %>
 </div>

--- a/app/views/shared/_cookie_buttons.html.erb
+++ b/app/views/shared/_cookie_buttons.html.erb
@@ -1,0 +1,6 @@
+<button type="button" class="btn btn-primary btn-sm ms-3" onclick="window.acceptCookies()">
+  <%= I18n.t('cookie_banner.accept') %>
+</button>
+<button type="button" class="btn btn-primary btn-sm ms-3" onclick="window.rejectCookies()">
+  <%= I18n.t('cookie_banner.reject') %>
+</button>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -25,7 +25,7 @@
               <ul class="list-unstyled">
                 <li><%= link_to t('footer.terms_and_conditions'), terms_and_conditions_path %></li>
                 <li><%= link_to t('cookies.title'), cookies_path %></li>
-                <li><%= link_to t('footer.privacy_and_cookie_policy'), privacy_and_cookie_policy_path %></li>
+                <li><%= link_to t('about_menu.privacy_policy'), privacy_and_cookie_policy_path %></li>
                 <li><%= link_to t('footer.child_safeguarding_policy'), child_safeguarding_policy_path %></li>
               </ul>
             </div>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -24,6 +24,7 @@
             <div class="col">
               <ul class="list-unstyled">
                 <li><%= link_to t('footer.terms_and_conditions'), terms_and_conditions_path %></li>
+                <li><%= link_to t('cookies.title'), cookies_path %></li>
                 <li><%= link_to t('footer.privacy_and_cookie_policy'), privacy_and_cookie_policy_path %></li>
                 <li><%= link_to t('footer.child_safeguarding_policy'), child_safeguarding_policy_path %></li>
               </ul>
@@ -51,4 +52,6 @@
 
 </footer>
 
-<%= render 'shared/google_analytics', analytics_code: @analytics_code if Rails.env.production? && !@analytics_code.blank? %>
+<%= if Rails.env.production? && @analytics_code.present?
+      render 'shared/google_analytics', analytics_code: @analytics_code
+    end %>

--- a/app/views/shared/_google_analytics.html.erb
+++ b/app/views/shared/_google_analytics.html.erb
@@ -1,10 +1,19 @@
-<!-- Global Site Tag (gtag.js) - Google Analytics -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=<%= analytics_code %>"></script>
 <script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
+window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
 
+// Set default consent to 'denied' as a placeholder
+gtag('consent', 'default', {
+  'ad_storage': 'denied',
+  'ad_user_data': 'denied',
+  'ad_personalization': 'denied',
+  'analytics_storage': 'denied'
+});
+</script>
+<script async src="https://www.googletagmanager.com/gtag/js?id=<%= analytics_code %>"></script>
+
+<script>
+  gtag('js', new Date());
   gtag('config', '<%= analytics_code %>', {
     'custom_map': {'dimension1': 'user_role', 'dimension2': 'user_school', 'dimension3': 'advice_page', 'dimension4': 'advice_page_tab'}
   });

--- a/app/views/shared/_head.html.erb
+++ b/app/views/shared/_head.html.erb
@@ -1,14 +1,16 @@
 <meta charset="utf-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
-<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<meta name="description" content="We help schools become more energy efficient and fight climate change, through an online, school-specific energy analysis tool and energy education programme.">
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+<meta name="description"
+      content="We help schools become more energy efficient and fight climate change, through an online,
+      school-specific energy analysis tool and energy education programme.">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<meta name="google-site-verification" content="XV9Bt0UF-LWMNqtPSOz_Sjm9tZYDmI7jTe1NUpAIeZ4" />
+<meta name="google-site-verification" content="XV9Bt0UF-LWMNqtPSOz_Sjm9tZYDmI7jTe1NUpAIeZ4">
 
 <title>
   <% if content_for?(:page_title) %>
     <%= content_for(:page_title) %> |
-  <% end  %>
+  <% end %>
   <%= t('common.application') %>
 </title>
 
@@ -16,19 +18,20 @@
 
 <%= render 'shared/favicon' %>
 
-<%= stylesheet_link_tag "//cdn.jsdelivr.net/npm/select2@4.0.13/dist/css/select2.min.css" %>
-<%= stylesheet_link_tag "//cdnjs.cloudflare.com/ajax/libs/select2-bootstrap-theme/0.1.0-beta.10/select2-bootstrap.min.css" %>
-<%= stylesheet_link_tag "//fonts.googleapis.com/css?family=Open+Sans|Quicksand:300&display=swap" %>
-<%= stylesheet_link_tag "//fonts.googleapis.com/css?family=Open+Sans|Quicksand:500&display=swap" %>
-<%= stylesheet_link_tag "//fonts.googleapis.com/css?family=Open+Sans|Quicksand:700&display=swap" %>
-<%= stylesheet_link_tag "//cdn.datatables.net/2.0.2/css/dataTables.bootstrap4.min.css" %>
+<%= stylesheet_link_tag '//cdn.jsdelivr.net/npm/select2@4.0.13/dist/css/select2.min.css' %>
+<%= stylesheet_link_tag '//cdnjs.cloudflare.com/ajax/libs/select2-bootstrap-theme/0.1.0-beta.10/select2-bootstrap.min.css' %>
+<%= stylesheet_link_tag '//fonts.googleapis.com/css?family=Open+Sans|Quicksand:300&display=swap' %>
+<%= stylesheet_link_tag '//fonts.googleapis.com/css?family=Open+Sans|Quicksand:500&display=swap' %>
+<%= stylesheet_link_tag '//fonts.googleapis.com/css?family=Open+Sans|Quicksand:700&display=swap' %>
+<%= stylesheet_link_tag '//cdn.datatables.net/2.0.2/css/dataTables.bootstrap4.min.css' %>
 
-<%= stylesheet_link_tag    'application', media: 'all' %>
-<%= javascript_pack_tag    'application' %>
+<%= stylesheet_link_tag 'application', media: 'all' %>
+<%= javascript_pack_tag 'application' %>
 <%= javascript_include_tag 'application' %>
-<%= javascript_include_tag "//cdn.jsdelivr.net/npm/select2@4.0.13/dist/js/select2.min.js" %>
-<%= javascript_include_tag "//cdn.datatables.net/2.0.2/js/dataTables.min.js" %>
-<%= javascript_include_tag "//cdn.datatables.net/2.0.2/js/dataTables.bootstrap4.min.js" %>
+<%= javascript_include_tag '//cdn.jsdelivr.net/npm/select2@4.0.13/dist/js/select2.min.js' %>
+<%= javascript_include_tag '//cdn.datatables.net/2.0.2/js/dataTables.min.js' %>
+<%= javascript_include_tag '//cdn.datatables.net/2.0.2/js/dataTables.bootstrap4.min.js' %>
+<%= javascript_include_tag '//cdn.jsdelivr.net/npm/js-cookie@3.0.5/dist/js.cookie.min.js' %>
 
 <!--js and css for leaflet -->
 <%= render 'shared/leaflet' %>

--- a/config/locales/cy/views/shared/shared.yml
+++ b/config/locales/cy/views/shared/shared.yml
@@ -53,7 +53,6 @@ cy:
     child_safeguarding_policy: Polisi diogelu plant
     follow_energy_sparks: Dilyn Sbarcynni
     more_information: Rhagor o wybodaeth
-    privacy_and_cookie_policy: Polisi preifatrwydd a chwcis
     registered_charity_notice: Mae Sbarcynni yn elusen gofrestredig yng Nghymru a Lloegr, cofrestriad 1189273
     terms_and_conditions: Telerau ac amodau
   manage_menu:

--- a/config/locales/views/home/cookies.yml
+++ b/config/locales/views/home/cookies.yml
@@ -1,0 +1,53 @@
+---
+en:
+  cookie_banner:
+    accept: Accept
+    learn_more: Learn more
+    notice: We use some essential cookies to make Energy Sparks work. We'd also like to use analytics cookies so we can understand how you use the service and make improvements.
+    reject: Reject
+  cookies:
+    analytics:
+      ga:
+        expires: 2 years
+        purpose: Checks if you’ve visited Energy Sparks before. This helps us count how many people visit our site.
+      gid:
+        expires: 24 hours
+        purpose: Checks if you’ve visited Energy Sparks before. This helps us count how many people visit our site.
+      intro_html: |-
+        <p>
+        With your permission, we use Google Analytics cookies to collect data about how you use Energy Sparks. This information helps us to improve our service.
+        </p>
+        <p>
+        Google is not allowed to use or share our analytics data with anyone.
+        </p>
+        <p>
+        Google Analytics stores anonymised information about how you got to Energy Sparks, the pages you visit on Energy Sparks, and how long you spend on them.
+        </p>
+      question: Do you want to accept analytics cookies?
+      title: Google Analytics cookies (optional)
+    essential:
+      intro_html: |-
+        <p>Essential cookies keep your information secure while you use Energy Sparks. We do not need to ask permission to use them.
+        </p>
+      preference:
+        expires: 1 year
+        purpose: Saves your cookie consent settings
+      session:
+        expires: When you close the browser or sign out. Or in 2 weeks if you choose to "Stay signed in".
+        purpose: Used to keep you signed in
+      title: Essential cookies
+    expires: Expires
+    intro_html: |-
+      <p>
+        Cookies are small files saved on your phone, tablet or computer when you visit a website.
+      </p>
+      <p>
+        We use cookies to make Energy Sparks work and collect information about how you use our service.
+      </p>
+      <p>
+        For further information, visit <a href="https://allaboutcookies.org">allaboutcookies.org</a>. Or
+        view our detailed <a href="%{privacy_and_cookie_policy}">privacy and cookie policy</a>.
+      </p>
+    name: Name
+    purpose: Purpose
+    title: Cookies

--- a/config/locales/views/home/cookies.yml
+++ b/config/locales/views/home/cookies.yml
@@ -7,6 +7,7 @@ en:
     reject: Reject
   cookies:
     analytics:
+      explain: Choose an option to immediately update your preference.
       ga:
         expires: 2 years
         purpose: Checks if you’ve visited Energy Sparks before. This helps us count how many people visit our site.

--- a/config/locales/views/home/cookies.yml
+++ b/config/locales/views/home/cookies.yml
@@ -33,8 +33,11 @@ en:
       preference:
         expires: 1 year
         purpose: Saves your cookie consent settings
+      remember:
+        expires: After 2 weeks, or when you sign out.
+        purpose: Used to keep you signed in for longer, if you choose to "Stay signed in".
       session:
-        expires: When you close the browser or sign out. Or in 2 weeks if you choose to "Stay signed in".
+        expires: When you close the browser.
         purpose: Used to keep you signed in
       title: Essential cookies
     expires: Expires

--- a/config/locales/views/shared/shared.yml
+++ b/config/locales/views/shared/shared.yml
@@ -44,11 +44,6 @@ en:
         <li>let you know if you are doing well compared to other schools and your past performance</li>
       </ul>
     title: 'Energy Sparks alerts:'
-  cookie_banner:
-    accept: Accept
-    learn_more: Learn more
-    notice: We use some essential cookies to make Energy Sparks work. We'd also like to use analytics cookies so we can understand how you use the service and make improvements.
-    reject: Reject
   dashboards:
     adult_dashboard: Adult dashboard
     pupil_dashboard: Pupil dashboard

--- a/config/locales/views/shared/shared.yml
+++ b/config/locales/views/shared/shared.yml
@@ -44,6 +44,11 @@ en:
         <li>let you know if you are doing well compared to other schools and your past performance</li>
       </ul>
     title: 'Energy Sparks alerts:'
+  cookie_banner:
+    accept: Accept
+    learn_more: Learn more
+    notice: We use some essential cookies to make Energy Sparks work. We'd also like to use analytics cookies so we can understand how you use the service and make improvements.
+    reject: Reject
   dashboards:
     adult_dashboard: Adult dashboard
     pupil_dashboard: Pupil dashboard

--- a/config/locales/views/shared/shared.yml
+++ b/config/locales/views/shared/shared.yml
@@ -52,7 +52,6 @@ en:
     child_safeguarding_policy: Child safeguarding policy
     follow_energy_sparks: Follow Energy Sparks
     more_information: More information
-    privacy_and_cookie_policy: Privacy and cookie policy
     registered_charity_notice: Energy Sparks is a registered charity in England and Wales, registration 1189273
     terms_and_conditions: Terms and conditions
   manage_menu:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -40,6 +40,7 @@ Rails.application.routes.draw do
 
   get 'team', to: 'home#team'
   get 'funders', to: 'home#funders'
+  get 'cookies', to: 'home#cookies'
   get 'privacy_and_cookie_policy', to: 'home#privacy_and_cookie_policy', as: :privacy_and_cookie_policy
   get 'support_us', to: 'home#support_us', as: :support_us
   get 'terms_and_conditions', to: 'home#terms_and_conditions', as: :terms_and_conditions

--- a/spec/models/video_spec.rb
+++ b/spec/models/video_spec.rb
@@ -4,6 +4,6 @@ RSpec.describe Video, type: :model do
   it 'created correct embed url' do
     video = Video.new(youtube_id: 12345, title: 'test')
 
-    expect(video.embed_url).to eql 'https://www.youtube.com/embed/12345'
+    expect(video.embed_url).to eql 'https://www.youtube-nocookie.com/embed/12345'
   end
 end

--- a/spec/support/system.rb
+++ b/spec/support/system.rb
@@ -43,13 +43,17 @@ RSpec.configure do |config|
     options.add_argument('disable-gpu')
     options.add_argument('disable-dev-shm-usage')
     options.add_argument('window-size=1400,10000')
+    # Uncomment to make all console entries available via
+    # page.driver.browser.logs.get(:browser) if needed for debugging.
+    # options.add_option("goog:loggingPrefs", {browser: 'ALL'})
     Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)
   end
 
   config.before(:each, type: :system, js: true) do
     @supports_js = true
 
-    driven_by :headless_chrome
+    # driven_by :headless_chrome
+    driven_by :selenium_chrome_headless
     # driven_by :headless_firefox
     # page.driver.browser.manage.window.resize_to(2800,10000)
   end

--- a/spec/support/system.rb
+++ b/spec/support/system.rb
@@ -52,8 +52,11 @@ RSpec.configure do |config|
   config.before(:each, type: :system, js: true) do
     @supports_js = true
 
-    # driven_by :headless_chrome
-    driven_by :selenium_chrome_headless
+    # register our custom driver configuration as a known adapter to allow access to
+    # cookies in specs that use JS
+    ShowMeTheCookies.register_adapter(:headless_chrome, ShowMeTheCookies::Selenium)
+
+    driven_by :headless_chrome
     # driven_by :headless_firefox
     # page.driver.browser.manage.window.resize_to(2800,10000)
   end

--- a/spec/system/cookie_banner_spec.rb
+++ b/spec/system/cookie_banner_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe 'cookie banner', type: :system do
+describe 'cookie banner' do
   def cookie_preference
     get_me_the_cookie('cookie_preference')
   end
@@ -60,7 +60,7 @@ describe 'cookie banner', type: :system do
   end
 
   shared_examples 'a dismissable cookie banner' do
-    context 'when banner is accepted', js: true do
+    context 'when banner is accepted', :js do
       before do
         within('#cookie-banner') do
           click_on(I18n.t('cookie_banner.accept'))
@@ -72,7 +72,7 @@ describe 'cookie banner', type: :system do
       end
     end
 
-    context 'when banner is rejected', js: true do
+    context 'when banner is rejected', :js do
       before do
         within('#cookie-banner') do
           click_on(I18n.t('cookie_banner.reject'))

--- a/spec/system/cookie_banner_spec.rb
+++ b/spec/system/cookie_banner_spec.rb
@@ -14,7 +14,29 @@ describe 'cookie banner', type: :system do
       expect(page).to have_css('#cookie-banner')
       within('#cookie-banner') do
         expect(page).to have_content(I18n.t('cookie_banner.notice'))
-        expect(page).to have_link(I18n.t('cookie_banner.learn_more'))
+        expect(page).to have_link(I18n.t('cookie_banner.learn_more'), href: cookies_path)
+        expect(page).to have_button(I18n.t('cookie_banner.accept'))
+        expect(page).to have_button(I18n.t('cookie_banner.reject'))
+      end
+    end
+
+    context 'when following learn more link' do
+      before do
+        within('#cookie-banner') do
+          click_on(I18n.t('cookie_banner.learn_more'))
+        end
+      end
+
+      it 'displays the cookies page' do
+        expect(page).to have_content(I18n.t('cookies.title'))
+        expect(page).to have_content(I18n.t('cookies.essential.title'))
+        expect(page).to have_content(I18n.t('cookies.essential.session.purpose'))
+        expect(page).to have_content(I18n.t('cookies.essential.preference.purpose'))
+
+        expect(page).to have_content(I18n.t('cookies.analytics.title'))
+        expect(page).to have_content(I18n.t('cookies.analytics.ga.purpose'))
+        expect(page).to have_content(I18n.t('cookies.analytics.gid.purpose'))
+        expect(page).to have_content(I18n.t('cookies.analytics.question'))
         expect(page).to have_button(I18n.t('cookie_banner.accept'))
         expect(page).to have_button(I18n.t('cookie_banner.reject'))
       end

--- a/spec/system/cookie_banner_spec.rb
+++ b/spec/system/cookie_banner_spec.rb
@@ -1,0 +1,85 @@
+require 'rails_helper'
+
+describe 'cookie banner', type: :system do
+  def cookie_preference
+    get_me_the_cookie('cookie_preference')
+  end
+
+  shared_examples 'a visible cookie banner' do
+    it 'does not have cookie' do
+      expect(cookie_preference).to be_nil
+    end
+
+    it 'includes expected content and links' do
+      expect(page).to have_css('#cookie-banner')
+      within('#cookie-banner') do
+        expect(page).to have_content(I18n.t('cookie_banner.notice'))
+        expect(page).to have_link(I18n.t('cookie_banner.learn_more'))
+        expect(page).to have_button(I18n.t('cookie_banner.accept'))
+        expect(page).to have_button(I18n.t('cookie_banner.reject'))
+      end
+    end
+  end
+
+  shared_examples 'a preference has been set' do
+    it 'hides banner' do
+      expect(page).to have_css('#cookie-banner', visible: :hidden)
+    end
+
+    it 'sets cookie' do
+      expect(cookie_preference[:value]).to eq(expected_preference)
+      expect(cookie_preference[:expires].to_date).to eq(Time.zone.today + 1.year)
+    end
+
+    it 'does not show banner when page refreshed' do
+      refresh
+      expect(page).to have_css('#cookie-banner', visible: :hidden)
+    end
+  end
+
+  shared_examples 'a dismissable cookie banner' do
+    context 'when banner is accepted', js: true do
+      before do
+        within('#cookie-banner') do
+          click_on(I18n.t('cookie_banner.accept'))
+        end
+      end
+
+      it_behaves_like 'a preference has been set' do
+        let(:expected_preference) { 'Accepted' }
+      end
+    end
+
+    context 'when banner is rejected', js: true do
+      before do
+        within('#cookie-banner') do
+          click_on(I18n.t('cookie_banner.reject'))
+        end
+      end
+
+      it_behaves_like 'a preference has been set' do
+        let(:expected_preference) { 'Rejected' }
+      end
+    end
+  end
+
+  context 'when no cookie has been set' do
+    context 'when visiting pages that use the home layout' do
+      before do
+        visit root_path
+      end
+
+      it_behaves_like 'a visible cookie banner'
+      it_behaves_like 'a dismissable cookie banner'
+    end
+
+    context 'when visiting pages that use the application layout' do
+      before do
+        visit schools_path
+      end
+
+      it_behaves_like 'a visible cookie banner'
+      it_behaves_like 'a dismissable cookie banner'
+    end
+  end
+end


### PR DESCRIPTION
Implements a cookie banner for Energy Sparks.

The banner is shown at the bottom of the browser window until user accepts or rejects analytics cookies. We then store their preference for one year and make calls to the Google Analytics consent API to update the consent status which by default is 'denied' for all options. This means GA will only set cookies if user has agreed.

For more clarity on our cookie policy I've added a separate Cookies page, as [recommended by this pattern](https://design-system.service.gov.uk/patterns/cookies-page/). This summarises what cookies are used and when they are expired. It also allows a user to update their preference after dismissing the cookie banner. Otherwise the banner isn't shown for a year.

I've added to register a new adapter for `show_me_the_cookies` to allow that to be used from within JS tests.

I've also switched the YouTube video embeds over to the "no cookies" domain which should reduce number of cookies set by them. As I understand it, they wont set cookies unless a user has already agreed via YT directly.