### PR TITLE
Fix static 404 page

### DIFF
--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -42,7 +42,7 @@
               <a href="//www.facebook.com/EnergySparksUK/" class=""><%= fab_icon('facebook-square fa-2x') %></a>
             </li>
             <li class="list-inline-item p-2">
-              <a href="//github.com/BathHacked/energy-sparks" class=""><%= fab_icon('github fa-2x') %></a>
+              <a href="//github.com/energy-sparks/energy-sparks" class=""><%= fab_icon('github fa-2x') %></a>
             </li>
           </ul>
         </div>

--- a/public/404.html
+++ b/public/404.html
@@ -1,10 +1,14 @@
 <!DOCTYPE html>
-<html lang="<%= I18n.locale %>">
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-    <meta name="google-site-verification" content="XV9Bt0UF-LWMNqtPSOz_Sjm9tZYDmI7jTe1NUpAIeZ4" />
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <meta name="description"
+          content="We help schools become more energy efficient and fight climate change, through an online,
+          school-specific energy analysis tool and energy education programme.">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="google-site-verification" content="XV9Bt0UF-LWMNqtPSOz_Sjm9tZYDmI7jTe1NUpAIeZ4">
     <link rel="stylesheet" media="all" href="/error.min.css">
     <link rel="stylesheet" media="all" href="/error-font-awesome.css">
     <link rel='shortcut icon' href='/favicon.ico'>
@@ -67,6 +71,8 @@
     </section>
 
     <!-- Footer -->
+
+
     <footer>
       <div class="footer-above">
         <div class="container">
@@ -91,23 +97,14 @@
               <div class="row">
                 <div class="col">
                   <ul class="list-unstyled">
-                    <li><a href="/for-teachers">Energy Sparks for Teachers</a></li>
-                    <li><a href="/for-pupils">Energy Sparks For Pupils</a></li>
-                    <li><a href="/contact">Contact us</a></li>
-                    <li><a href="/enrol">Register your school</a></li>
-                  </ul>
-                </div>
-                <div class="col justify-center">
-                   <ul class="list-unstyled">
-                    <li><a href="/team">Team</a></li>
-                    <li><a href="/team#partners">Partners</a></li>
-                    <li><a href="/datasets">Open data</a></li>
-                    <li><a href="/privacy_policy">Privacy policy</a></li>
+                    <li><a href="/terms_and_conditions">Terms and conditions</a></li>
+                    <li><a href="/cookies">Cookies</a></li>
+                    <li><a href="/privacy_and_cookie_policy">Privacy policy</a></li>
+                    <li><a href="/child-safeguarding-policy">Child safeguarding policy</a></li>
                   </ul>
                 </div>
               </div>
             </div>
-
             <div class="col-3">
               <h6>Follow Energy Sparks</h6>
               <ul class="list-inline">

--- a/public/404.html
+++ b/public/404.html
@@ -32,26 +32,6 @@
             <li class="nav-item">
               <a href="http://blog.energysparks.uk" class="nav-link" target="_blank">Blog</a>
             </li>
-            <li class="nav-item dropdown">
-              <a class="nav-link dropdown-toggle" href="#" id="aboutDropDown" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">About</a>
-              <div class="dropdown-menu" aria-labelledby="aboutDropDown">
-                <a class="dropdown-item" href="/for-teachers">For Teachers</a>
-                <a class="dropdown-item" href="/for-pupils">For Pupils</a>
-                <a class="dropdown-item" href="/for-management">For Management</a>
-                <a class="dropdown-item" href="/enrol">Enrol</a>
-                <a class="dropdown-item" href="/activity_categories">Activities</a>
-              </div>
-            </li>
-            <li class="nav-item">
-              <a class="nav-link" href="/contact">Contact</a>
-            </li>
-
-            <span class="nav-lozenge nav-lozenge-little-padding">
-              <li class="nav-item">
-                <a class="nav-link" href="/enrol">Register your school</a>
-                <a class="btn btn-sm" href="/users/sign_in">Sign In</a>
-              </li>
-            </span>
           </ul>
         </div>
       </div>

--- a/public/404.html
+++ b/public/404.html
@@ -32,7 +32,7 @@
             <li class="nav-item">
               <a href="http://blog.energysparks.uk" class="nav-link" target="_blank">Blog</a>
             </li>
-          </ul>
+            </ul>
         </div>
       </div>
     </nav>
@@ -51,8 +51,6 @@
     </section>
 
     <!-- Footer -->
-
-
     <footer>
       <div class="footer-above">
         <div class="container">
@@ -95,14 +93,13 @@
                   <a href="https://www.facebook.com/EnergySparksUK/" class=""><i class="fab fa-facebook-square fa-2x"></i></a>
                 </li>
                 <li class="list-inline-item p-2">
-                  <a href="https://github.com/BathHacked/energy-sparks" class=""><i class="fab fa-github fa-2x"></i></a>
+                  <a href="https://github.com/energy-sparks/energy-sparks" class=""><i class="fab fa-github fa-2x"></i></a>
                 </li>
               </ul>
             </div>
           </div>
         </div>
       </div>
-
     </footer>
   </body>
 </html>

--- a/public/422.html
+++ b/public/422.html
@@ -1,10 +1,14 @@
 <!DOCTYPE html>
-<html lang="<%= I18n.locale %>">
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-    <meta name="google-site-verification" content="XV9Bt0UF-LWMNqtPSOz_Sjm9tZYDmI7jTe1NUpAIeZ4" />
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <meta name="description"
+          content="We help schools become more energy efficient and fight climate change, through an online,
+          school-specific energy analysis tool and energy education programme.">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="google-site-verification" content="XV9Bt0UF-LWMNqtPSOz_Sjm9tZYDmI7jTe1NUpAIeZ4">
     <link rel="stylesheet" media="all" href="/error.min.css">
     <link rel="stylesheet" media="all" href="/error-font-awesome.css">
     <link rel='shortcut icon' href='/favicon.ico'>
@@ -28,27 +32,7 @@
             <li class="nav-item">
               <a href="http://blog.energysparks.uk" class="nav-link" target="_blank">Blog</a>
             </li>
-            <li class="nav-item dropdown">
-              <a class="nav-link dropdown-toggle" href="#" id="aboutDropDown" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">About</a>
-              <div class="dropdown-menu" aria-labelledby="aboutDropDown">
-                <a class="dropdown-item" href="/for-teachers">For Teachers</a>
-                <a class="dropdown-item" href="/for-pupils">For Pupils</a>
-                <a class="dropdown-item" href="/for-management">For Management</a>
-                <a class="dropdown-item" href="/enrol">Enrol</a>
-                <a class="dropdown-item" href="/activity_categories">Activities</a>
-              </div>
-            </li>
-            <li class="nav-item">
-              <a class="nav-link" href="/contact">Contact</a>
-            </li>
-
-            <span class="nav-lozenge nav-lozenge-little-padding">
-              <li class="nav-item">
-                <a class="nav-link" href="/enrol">Register your school</a>
-                <a class="btn btn-sm" href="/users/sign_in">Sign In</a>
-              </li>
-            </span>
-          </ul>
+            </ul>
         </div>
       </div>
     </nav>
@@ -92,23 +76,14 @@
               <div class="row">
                 <div class="col">
                   <ul class="list-unstyled">
-                    <li><a href="/for-teachers">Energy Sparks for Teachers</a></li>
-                    <li><a href="/for-pupils">Energy Sparks For Pupils</a></li>
-                    <li><a href="/contact">Contact us</a></li>
-                    <li><a href="/enrol">Register your school</a></li>
-                  </ul>
-                </div>
-                <div class="col justify-center">
-                   <ul class="list-unstyled">
-                    <li><a href="/team">Team</a></li>
-                    <li><a href="/team#partners">Partners</a></li>
-                    <li><a href="/datasets">Open data</a></li>
-                    <li><a href="/privacy_policy">Privacy policy</a></li>
+                    <li><a href="/terms_and_conditions">Terms and conditions</a></li>
+                    <li><a href="/cookies">Cookies</a></li>
+                    <li><a href="/privacy_and_cookie_policy">Privacy policy</a></li>
+                    <li><a href="/child-safeguarding-policy">Child safeguarding policy</a></li>
                   </ul>
                 </div>
               </div>
             </div>
-
             <div class="col-3">
               <h6>Follow Energy Sparks</h6>
               <ul class="list-inline">
@@ -119,15 +94,13 @@
                   <a href="https://www.facebook.com/EnergySparksUK/" class=""><i class="fab fa-facebook-square fa-2x"></i></a>
                 </li>
                 <li class="list-inline-item p-2">
-                  <a href="https://github.com/BathHacked/energy-sparks" class=""><i class="fab fa-github fa-2x"></i></a>
+                  <a href="https://github.com/energy-sparks/energy-sparks" class=""><i class="fab fa-github fa-2x"></i></a>
                 </li>
               </ul>
             </div>
           </div>
         </div>
       </div>
-
     </footer>
   </body>
 </html>
-

--- a/public/500.html
+++ b/public/500.html
@@ -1,10 +1,14 @@
 <!DOCTYPE html>
-<html lang="<%= I18n.locale %>">
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-    <meta name="google-site-verification" content="XV9Bt0UF-LWMNqtPSOz_Sjm9tZYDmI7jTe1NUpAIeZ4" />
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <meta name="description"
+          content="We help schools become more energy efficient and fight climate change, through an online,
+          school-specific energy analysis tool and energy education programme.">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="google-site-verification" content="XV9Bt0UF-LWMNqtPSOz_Sjm9tZYDmI7jTe1NUpAIeZ4">
     <link rel="stylesheet" media="all" href="/error.min.css">
     <link rel="stylesheet" media="all" href="/error-font-awesome.css">
     <link rel='shortcut icon' href='/favicon.ico'>
@@ -28,27 +32,7 @@
             <li class="nav-item">
               <a href="http://blog.energysparks.uk" class="nav-link" target="_blank">Blog</a>
             </li>
-            <li class="nav-item dropdown">
-              <a class="nav-link dropdown-toggle" href="#" id="aboutDropDown" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">About</a>
-              <div class="dropdown-menu" aria-labelledby="aboutDropDown">
-                <a class="dropdown-item" href="/for-teachers">For Teachers</a>
-                <a class="dropdown-item" href="/for-pupils">For Pupils</a>
-                <a class="dropdown-item" href="/for-management">For Management</a>
-                <a class="dropdown-item" href="/enrol">Enrol</a>
-                <a class="dropdown-item" href="/activity_categories">Activities</a>
-              </div>
-            </li>
-            <li class="nav-item">
-              <a class="nav-link" href="/contact">Contact</a>
-            </li>
-
-            <span class="nav-lozenge nav-lozenge-little-padding">
-              <li class="nav-item">
-                <a class="nav-link" href="/enrol">Register your school</a>
-                <a class="btn btn-sm" href="/users/sign_in">Sign In</a>
-              </li>
-            </span>
-          </ul>
+            </ul>
         </div>
       </div>
     </nav>
@@ -91,23 +75,14 @@
               <div class="row">
                 <div class="col">
                   <ul class="list-unstyled">
-                    <li><a href="/for-teachers">Energy Sparks for Teachers</a></li>
-                    <li><a href="/for-pupils">Energy Sparks For Pupils</a></li>
-                    <li><a href="/contact">Contact us</a></li>
-                    <li><a href="/enrol">Register your school</a></li>
-                  </ul>
-                </div>
-                <div class="col justify-center">
-                   <ul class="list-unstyled">
-                    <li><a href="/team">Team</a></li>
-                    <li><a href="/team#partners">Partners</a></li>
-                    <li><a href="/datasets">Open data</a></li>
-                    <li><a href="/privacy_policy">Privacy policy</a></li>
+                    <li><a href="/terms_and_conditions">Terms and conditions</a></li>
+                    <li><a href="/cookies">Cookies</a></li>
+                    <li><a href="/privacy_and_cookie_policy">Privacy policy</a></li>
+                    <li><a href="/child-safeguarding-policy">Child safeguarding policy</a></li>
                   </ul>
                 </div>
               </div>
             </div>
-
             <div class="col-3">
               <h6>Follow Energy Sparks</h6>
               <ul class="list-inline">
@@ -118,15 +93,13 @@
                   <a href="https://www.facebook.com/EnergySparksUK/" class=""><i class="fab fa-facebook-square fa-2x"></i></a>
                 </li>
                 <li class="list-inline-item p-2">
-                  <a href="https://github.com/BathHacked/energy-sparks" class=""><i class="fab fa-github fa-2x"></i></a>
+                  <a href="https://github.com/energy-sparks/energy-sparks" class=""><i class="fab fa-github fa-2x"></i></a>
                 </li>
               </ul>
             </div>
           </div>
         </div>
       </div>
-
     </footer>
   </body>
 </html>
-


### PR DESCRIPTION
We currently use static 404, 422 and 500 pages for routing and server errors in prod. These haven't been updated in some time so the header and footer are out of date.

As an interim improvement I've removed the old nav links and updated the footer.

Ideally these would share the same partials, but presumably this is to avoid recursive errors in layouts, etc.