### PR TITLE
Pass UTM parameters through workflow

### DIFF
--- a/app/controllers/landing_pages_controller.rb
+++ b/app/controllers/landing_pages_controller.rb
@@ -72,7 +72,7 @@ class LandingPagesController < ApplicationController
   end
 
   def contact_for_capsule
-    contact = contact_params.except('request_type')
+    contact = contact_params.except('request_type', 'utm_source', 'utm_medium', 'utm_campaign')
     contact['consent'] = ActiveModel::Type::Boolean.new.cast(contact['consent'])
     contact.to_h
   end
@@ -98,7 +98,10 @@ class LandingPagesController < ApplicationController
 
   def redirect_params(request_type, contact)
     params = {
-      request_type: request_type
+      request_type: request_type,
+      utm_source: contact_params['utm_source'],
+      utm_medium: contact_params['utm_medium'],
+      utm_campaign: contact_params['utm_campaign']
     }
     case request_type
     when :book_demo
@@ -135,7 +138,9 @@ class LandingPagesController < ApplicationController
   end
 
   def contact_params
-    params.require(:contact).permit(:first_name, :last_name, :job_title, :organisation, { org_type: [] }, :email, :tel, :consent, :request_type)
+    params.require(:contact).permit(:first_name, :last_name,
+      :job_title, :organisation, { org_type: [] }, :email, :tel, :consent, :request_type,
+      :utm_source, :utm_medium, :utm_campaign)
   end
 
   def find_example_school

--- a/app/views/landing_pages/_form.html.erb
+++ b/app/views/landing_pages/_form.html.erb
@@ -52,5 +52,8 @@
     </div>
   </div>
   <%= f.hidden_field :request_type, value: request_type %>
+  <%= f.hidden_field :utm_source, value: params[:utm_source] %>
+  <%= f.hidden_field :utm_medium, value: params[:utm_medium] %>
+  <%= f.hidden_field :utm_campaign, value: params[:utm_campaign] %>
   <%= f.submit t('campaigns.form.fields.submit'), class: 'btn btn-primary' %>
 <% end %>

--- a/app/views/landing_pages/find_out_more.html.erb
+++ b/app/views/landing_pages/find_out_more.html.erb
@@ -39,8 +39,11 @@
       </div>
       <div class="row">
         <div class="col-md-12 pt-2 text-center cta">
-          <%= link_to t('campaigns.find_out_more.book_demo'), book_demo_campaigns_path, class: 'btn bg-positive' %>
-          <%= link_to t('campaigns.find_out_more.find_out_more'), more_information_campaigns_path,
+          <%= link_to t('campaigns.find_out_more.book_demo'),
+                      book_demo_campaigns_path(utm_params_for_redirect),
+                      class: 'btn bg-positive' %>
+          <%= link_to t('campaigns.find_out_more.find_out_more'),
+                      more_information_campaigns_path(utm_params_for_redirect),
                       class: 'btn bg-positive' %>
         </div>
       </div>
@@ -251,8 +254,11 @@
       </div>
       <div class="row">
         <div class="col-md-12 pt-2 text-center cta">
-          <%= link_to t('campaigns.find_out_more.book_demo'), book_demo_campaigns_path, class: 'btn bg-positive' %>
-          <%= link_to t('campaigns.find_out_more.find_out_more'), more_information_campaigns_path,
+          <%= link_to t('campaigns.find_out_more.book_demo'),
+                      book_demo_campaigns_path(utm_params_for_redirect),
+                      class: 'btn bg-positive' %>
+          <%= link_to t('campaigns.find_out_more.find_out_more'),
+                      more_information_campaigns_path(utm_params_for_redirect),
                       class: 'btn bg-positive' %>
         </div>
       </div>


### PR DESCRIPTION
When a user hits the campaign landing page, ensure that the UTM codes are:

- passed on to the next page which has the contact form
- submitted with the form to the controller
- added to the redirect to the final page

This will allow us to track the codes through to conversion in all situations.