### PR TITLE
Rework cookie preference buttons

### DIFF
--- a/app/assets/javascripts/cookie_banner.js
+++ b/app/assets/javascripts/cookie_banner.js
@@ -2,6 +2,11 @@
 
 const COOKIE_BANNER_ID = 'cookie-banner';
 const COOKIE_PREFERENCE_NAME = 'cookie_preference';
+const COOKIE_PREFERENCE_BTNS = 'cookie-preference-buttons';
+const COOKIE_PREFERENCE_ACCEPT_BTN = 'cookie-preference-accept';
+const COOKIE_PREFERENCE_REJECT_BTN = 'cookie-preference-reject';
+const COOKIE_PREFERENCE_ACCEPT_MSG = 'cookie-preference-accepted-message';
+const COOKIE_PREFERENCE_REJECT_MSG = 'cookie-preference-rejected-message';
 const ACCEPTED = 'Accepted';
 const REJECTED = 'Rejected';
 
@@ -17,7 +22,7 @@ function initializeCookieBanner() {
    // preference cookie is current and user has refused
    setAnalyticsConsent('denied');
  }
- let preferenceButtons = document.getElementById('cookie-preference-buttons');
+ let preferenceButtons = document.getElementById(COOKIE_PREFERENCE_BTNS);
  if(preferenceButtons != null) {
    setPreferenceButtonState();
  }
@@ -63,10 +68,10 @@ function setAnalyticsConsent(permission) {
 function updateCookiePreference(status) {
   hideBanner();
   setPreferenceCookie(status);
-  let accept = document.getElementById('cookie-preference-accept');
-  let reject = document.getElementById('cookie-preference-reject');
-  let accept_msg = document.getElementById('cookie-preference-accepted-message');
-  let reject_msg = document.getElementById('cookie-preference-rejected-message');
+  let accept = document.getElementById(COOKIE_PREFERENCE_ACCEPT_BTN);
+  let reject = document.getElementById(COOKIE_PREFERENCE_REJECT_BTN);
+  let accept_msg = document.getElementById(COOKIE_PREFERENCE_ACCEPT_MSG);
+  let reject_msg = document.getElementById(COOKIE_PREFERENCE_REJECT_MSG);
   if(status === 'Accepted') {
     accept.style.display = 'none';
     reject.style.display = 'inline';
@@ -82,8 +87,8 @@ function updateCookiePreference(status) {
 
 function setPreferenceButtonState() {
   let cookieStatus = Cookies.get(COOKIE_PREFERENCE_NAME);
-  let accept = document.getElementById('cookie-preference-accept');
-  let reject = document.getElementById('cookie-preference-reject');
+  let accept = document.getElementById(COOKIE_PREFERENCE_ACCEPT_BTN);
+  let reject = document.getElementById(COOKIE_PREFERENCE_REJECT_BTN);
 
   if(cookieStatus === undefined) {
     // user has not accepted or refused; or preference cookie expired

--- a/app/assets/javascripts/cookie_banner.js
+++ b/app/assets/javascripts/cookie_banner.js
@@ -17,6 +17,10 @@ function initializeCookieBanner() {
    // preference cookie is current and user has refused
    setAnalyticsConsent('denied');
  }
+ let preferenceButtons = document.getElementById('cookie-preference-buttons');
+ if(preferenceButtons != null) {
+   setPreferenceButtonState();
+ }
 }
 
 function showCookieBanner() {
@@ -54,6 +58,46 @@ function setAnalyticsConsent(permission) {
      'analytics_storage': permission
    });
   }
+}
+
+function updateCookiePreference(status) {
+  hideBanner();
+  setPreferenceCookie(status);
+  let accept = document.getElementById('cookie-preference-accept');
+  let reject = document.getElementById('cookie-preference-reject');
+  let accept_msg = document.getElementById('cookie-preference-accepted-message');
+  let reject_msg = document.getElementById('cookie-preference-rejected-message');
+  if(status === 'Accepted') {
+    accept.style.display = 'none';
+    reject.style.display = 'inline';
+    accept_msg.style.display = 'block';
+    reject_msg.style.display = 'none';
+  } else {
+    accept.style.display = 'inline';
+    reject.style.display = 'none';
+    accept_msg.style.display = 'none';
+    reject_msg.style.display = 'block';
+  }
+}
+
+function setPreferenceButtonState() {
+  let cookieStatus = Cookies.get(COOKIE_PREFERENCE_NAME);
+  let accept = document.getElementById('cookie-preference-accept');
+  let reject = document.getElementById('cookie-preference-reject');
+
+  if(cookieStatus === undefined) {
+    // user has not accepted or refused; or preference cookie expired
+    accept.style.display = 'inline';
+    reject.style.display = 'inline';
+  } else if (cookieStatus == ACCEPTED) {
+    // preference cookie is current and user has accepted
+    reject.style.display = 'inline';
+  } else {
+    // preference cookie is current and user has refused
+    accept.style.display = 'inline';
+  }
+
+  window.updateCookiePreference = updateCookiePreference;
 }
 
 $(document).ready(initializeCookieBanner);

--- a/app/assets/stylesheets/cookie_banner.scss
+++ b/app/assets/stylesheets/cookie_banner.scss
@@ -13,3 +13,19 @@
     color: $white;
   }
 }
+
+#cookie-preference-accepted-message {
+  display: none;
+}
+
+#cookie-preference-rejected-message {
+  display: none;
+}
+
+#cookie-preference-accept {
+  display: none;
+}
+
+#cookie-preference-reject {
+  display: none;
+}

--- a/app/views/home/cookies.html.erb
+++ b/app/views/home/cookies.html.erb
@@ -84,8 +84,24 @@
         <%= t('cookies.analytics.explain') %>
       </p>
 
-      <%= render 'shared/cookie_buttons' %>
+      <div id="cookie-preference-buttons">
+        <button id="cookie-preference-accept" type="button" class="btn btn-primary btn-sm ms-3" onclick="window.updateCookiePreference('Accepted')">
+          <%= I18n.t('cookie_banner.accept') %>
+        </button>
 
+        <button id="cookie-preference-reject" type="button" class="btn btn-primary btn-sm ms-3" onclick="window.updateCookiePreference('Rejected')">
+          <%= I18n.t('cookie_banner.reject') %>
+        </button>
+
+        <div id="cookie-preference-rejected-message" class="mt-2">
+          <p><%= t('cookies.analytics.rejected_msg') %></p>
+        </div>
+
+        <div id="cookie-preference-accepted-message" class="mt-2">
+          <p><%= t('cookies.analytics.accepted_msg') %></p>
+        </div>
+
+      </div>
     </div>
   </div>
 </div>

--- a/app/views/shared/_cookie_banner.html.erb
+++ b/app/views/shared/_cookie_banner.html.erb
@@ -1,5 +1,10 @@
 <div id="cookie-banner" class="alert text-center mb-0" role="alert">
   <%= I18n.t('cookie_banner.notice') %>
   <%= link_to I18n.t('cookie_banner.learn_more'), cookies_path %>
-  <%= render 'shared/cookie_buttons' %>
+  <button type="button" class="btn btn-primary btn-sm ms-3" onclick="window.acceptCookies()">
+    <%= I18n.t('cookie_banner.accept') %>
+  </button>
+  <button type="button" class="btn btn-primary btn-sm ms-3" onclick="window.rejectCookies()">
+    <%= I18n.t('cookie_banner.reject') %>
+  </button>
 </div>

--- a/app/views/shared/_cookie_buttons.html.erb
+++ b/app/views/shared/_cookie_buttons.html.erb
@@ -1,6 +1,0 @@
-<button type="button" class="btn btn-primary btn-sm ms-3" onclick="window.acceptCookies()">
-  <%= I18n.t('cookie_banner.accept') %>
-</button>
-<button type="button" class="btn btn-primary btn-sm ms-3" onclick="window.rejectCookies()">
-  <%= I18n.t('cookie_banner.reject') %>
-</button>

--- a/config/locales/views/home/cookies.yml
+++ b/config/locales/views/home/cookies.yml
@@ -7,7 +7,8 @@ en:
     reject: Reject
   cookies:
     analytics:
-      explain: Choose an option to immediately update your preference.
+      accepted_msg: Your cookie preference has been updated. You have accepted analytics cookies
+      explain: Update or change your preference.
       ga:
         expires: 2 years
         purpose: Checks if you’ve visited Energy Sparks before. This helps us count how many people visit our site.
@@ -25,6 +26,7 @@ en:
         Google Analytics stores anonymised information about how you got to Energy Sparks, the pages you visit on Energy Sparks, and how long you spend on them.
         </p>
       question: Do you want to accept analytics cookies?
+      rejected_msg: Your cookie preference has been updated. You have rejected analytics cookies
       title: Google Analytics cookies (optional)
     essential:
       intro_html: |-

--- a/spec/system/cookie_banner_spec.rb
+++ b/spec/system/cookie_banner_spec.rb
@@ -104,4 +104,75 @@ describe 'cookie banner' do
       it_behaves_like 'a dismissable cookie banner'
     end
   end
+
+  context 'when visiting the cookies page', :js do
+    before do
+      visit cookies_path
+    end
+
+    it 'displays the basic content' do
+      expect(page).to have_content(I18n.t('cookies.title'))
+      expect(page).to have_content(I18n.t('cookies.essential.title'))
+      expect(page).to have_content(I18n.t('cookies.analytics.title'))
+    end
+
+    it 'displays both preference buttons when there is no existing preference' do
+      within('#cookie-preference-buttons') do
+        expect(page).to have_button(I18n.t('cookie_banner.accept'))
+        expect(page).to have_button(I18n.t('cookie_banner.reject'))
+      end
+    end
+
+    context 'when clicking accept button', :js do
+      before do
+        within('#cookie-preference-buttons') do
+          click_on(I18n.t('cookie_banner.accept'))
+        end
+      end
+
+      it 'updates page state correctly' do
+        # accept button is hidden
+        expect(page).to have_css('#cookie-preference-accept', visible: :hidden)
+        # reject button is visible
+        expect(page).to have_css('#cookie-preference-reject')
+
+        # accepted message is visible
+        expect(page).to have_css('#cookie-preference-accepted-message')
+        # rejected message is hidden
+        expect(page).to have_css('#cookie-preference-rejected-message', visible: :hidden)
+      end
+
+      it 'updates the cookie' do
+        expect(cookie_preference[:value]).to eq('Accepted')
+      end
+
+      context 'when toggling the preference', :js do
+        before do
+          within('#cookie-preference-buttons') do
+            click_on(I18n.t('cookie_banner.reject'))
+          end
+        end
+
+        it 'updates page state correctly' do
+          # reject button is hidden
+          expect(page).to have_css('#cookie-preference-reject', visible: :hidden)
+          # accept button is visible
+          expect(page).to have_css('#cookie-preference-accept')
+
+          # rejected message is visible
+          expect(page).to have_css('#cookie-preference-rejected-message')
+          # accepted message is hidden
+          expect(page).to have_css('#cookie-preference-accepted-message', visible: :hidden)
+        end
+
+        it 'updates the cookie' do
+          expect(cookie_preference[:value]).to eq('Rejected')
+        end
+      end
+
+      it 'hides the cookie banner' do
+        expect(page).to have_css('#cookie-banner', visible: :hidden)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Reworks the cookie preference buttons on the cookies page. These are separate to the banner and allow someone to change their preference after the banner has been dismissed.

The buttons will now toggle between showing the Accept / Reject button based on the current state of the cookie and will hide the banner if it is still being displayed (e.g. if the user has clicked 'learn more' in the banner and then used the buttons).