### PR TITLE
DataTables alerts

### DIFF
--- a/app/assets/javascripts/table_sorting.js
+++ b/app/assets/javascripts/table_sorting.js
@@ -1,6 +1,8 @@
 "use strict"
 
 $(document).ready(function() {
+  DataTable.ext.errMode = 'throw';
+
   $('.table-sorted').DataTable({
     'columnDefs': [{ targets: 'no-sort', orderable: false }],
     'order': [],        // Default do not sort

--- a/app/components/energy_tariff_table_component/energy_tariff_table_component.html.erb
+++ b/app/components/energy_tariff_table_component/energy_tariff_table_component.html.erb
@@ -1,4 +1,4 @@
-<table class="table advice-table <%=table_sorted%>" id="<%= @id %>">
+<table class="table advice-table <%= table_sorted %>" id="<%= @id %>">
   <thead>
     <tr>
       <th class="col-1 text-right"><%= t('schools.user_tariffs.tariff_partial.start_date') %></th>
@@ -6,45 +6,51 @@
       <th class="col-3 text-left"><%= t('schools.user_tariffs.name') %></th>
       <th class="col-1 text-left"><%= t('schools.user_tariffs.tariff_partial.type') %></th>
       <% if show_prices? %>
-        <th class="col-3 text-right" data-orderable="false"><%= t('schools.user_tariffs.tariff_partial.consumption_charges') %></th>
+        <th class="col-3 text-right" data-orderable="false">
+          <%= t('schools.user_tariffs.tariff_partial.consumption_charges') %>
+        </th>
       <% end %>
       <% if show_meters? %>
         <th class="col-1 text-left" data-orderable="false"><%= t('schools.user_tariffs.meters.meter_list') %></th>
       <% end %>
-      <th class="col-2 text-right" data-orderable="false"></th>
+      <% if show_actions? %>
+        <th class="col-2 text-right" data-orderable="false"></th>
+      <% end %>
     </tr>
   </thead>
   <tbody>
     <% @tariffs.each do |energy_tariff| %>
-      <tr class="<%= class_for_tariff(energy_tariff) %>" id="energy-tariff-<%=energy_tariff.id%>">
+      <tr class="<%= class_for_tariff(energy_tariff) %>" id="energy-tariff-<%= energy_tariff.id %>">
         <td class="text-right" data-order="<%= start_date_sortable(energy_tariff) %>"><%= start_date(energy_tariff) %></td>
         <td class="text-right" data-order="<%= end_date_sortable(energy_tariff) %>"><%= end_date(energy_tariff) %></td>
-        <td class="text-left" >
+        <td class="text-left">
           <% if show_actions? && can?(:manage, energy_tariff) %>
-            <%= link_to energy_tariff.name, energy_tariffs_path(energy_tariff)  %>
+            <%= link_to energy_tariff.name, energy_tariffs_path(energy_tariff) %>
           <% else %>
             <%= energy_tariff.name %>
           <% end %>
         </td>
-        <td class="text-left" >
+        <td class="text-left">
           <%= flat_rate_label(energy_tariff) %>
         </td>
         <% if show_prices? %>
-          <td class="text-right" >
+          <td class="text-right">
             <ul style="list-style: none; padding-left: 0px;">
               <% energy_tariff.energy_tariff_prices.order(start_time: :asc).each do |price| %>
                 <li>
                   <% if energy_tariff.differential? %>
-                    <%= t('schools.user_tariffs.tariff_partial.price_from_to', price_start_time: start_time(price), price_end_time: end_time(price)) %>
+                    <%= t('schools.user_tariffs.tariff_partial.price_from_to', price_start_time: start_time(price),
+                                                                               price_end_time: end_time(price)) %>
                   <% end %>
-                  <%= t('schools.user_tariffs.rates_table.price_per_kwh', price_value: convert_value_to_long_currency(price.value)) %>
+                  <%= t('schools.user_tariffs.rates_table.price_per_kwh',
+                        price_value: convert_value_to_long_currency(price.value)) %>
                 </li>
               <% end %>
             </ul>
           </td>
         <% end %>
         <% if show_meters? %>
-          <td class="text-left" >
+          <td class="text-left">
             <% if energy_tariff.meters.any? %>
               <ul style="list-style: none; padding-left: 0px;">
                 <% energy_tariff.meters.each do |meter| %>
@@ -56,44 +62,41 @@
             <% end %>
           </td>
         <% end %>
-        <% if show_actions? && can?(:manage, energy_tariff) %>
+        <% if show_actions? %>
           <td class="text-right">
-            <% if energy_tariff.dcc? %>
-              <%= link_to t('schools.user_tariff_charges.edit_charges'),
-                  energy_tariffs_path(energy_tariff, [:energy_tariff_charges]),
-                  class: 'btn btn-sm'
-              %>
-            <% else %>
-              <%= link_to energy_tariff.usable? ? t('common.labels.edit') : t('common.labels.finish'),
-                  energy_tariffs_path(energy_tariff),
-                  class: 'btn btn-sm'
-              %>
-            <% end %>
-            <% if can_toggle_status?(energy_tariff) %>
-              <%= link_to energy_tariff.enabled ? t('common.labels.disable') : t('common.labels.enable'),
-                  energy_tariffs_path(energy_tariff, [], { action: :toggle_enabled }),
-                  class: 'btn btn-sm',
-                  id: "energy-tariff-#{energy_tariff.id}-toggle",
-                  remote: true, method: :post, data: { confirm: t('common.confirm') }
-              %>
-              <% if !energy_tariff.dcc? %>
-                <%= link_to t('common.labels.delete'),
-                    energy_tariffs_path(energy_tariff),
-                    method: :delete,
-                    data: {confirm: t('common.confirm') },
-                    class: 'btn btn-sm btn-danger',
-                    style: energy_tariff.enabled ? 'display: none' : '',
-                    id: "energy-tariff-#{energy_tariff.id}-delete"
-                %>
+            <% if can?(:manage, energy_tariff) %>
+              <% if energy_tariff.dcc? %>
+                <%= link_to t('schools.user_tariff_charges.edit_charges'),
+                            energy_tariffs_path(energy_tariff, [:energy_tariff_charges]),
+                            class: 'btn btn-sm' %>
+              <% else %>
+                <%= link_to energy_tariff.usable? ? t('common.labels.edit') : t('common.labels.finish'),
+                            energy_tariffs_path(energy_tariff),
+                            class: 'btn btn-sm' %>
               <% end %>
-            <% elsif can_delete?(energy_tariff) %>
-              <%= link_to t('common.labels.delete'),
-                  energy_tariffs_path(energy_tariff),
-                  method: :delete,
-                  data: {confirm: t('common.confirm') },
-                  class: 'btn btn-sm btn-danger',
-                  id: "energy-tariff-#{energy_tariff.id}-delete"
-              %>
+              <% if can_toggle_status?(energy_tariff) %>
+                <%= link_to energy_tariff.enabled ? t('common.labels.disable') : t('common.labels.enable'),
+                            energy_tariffs_path(energy_tariff, [], { action: :toggle_enabled }),
+                            class: 'btn btn-sm',
+                            id: "energy-tariff-#{energy_tariff.id}-toggle",
+                            remote: true, method: :post, data: { confirm: t('common.confirm') } %>
+                <% if !energy_tariff.dcc? %>
+                  <%= link_to t('common.labels.delete'),
+                              energy_tariffs_path(energy_tariff),
+                              method: :delete,
+                              data: { confirm: t('common.confirm') },
+                              class: 'btn btn-sm btn-danger',
+                              style: energy_tariff.enabled ? 'display: none' : '',
+                              id: "energy-tariff-#{energy_tariff.id}-delete" %>
+                <% end %>
+              <% elsif can_delete?(energy_tariff) %>
+                <%= link_to t('common.labels.delete'),
+                            energy_tariffs_path(energy_tariff),
+                            method: :delete,
+                            data: { confirm: t('common.confirm') },
+                            class: 'btn btn-sm btn-danger',
+                            id: "energy-tariff-#{energy_tariff.id}-delete" %>
+              <% end %>
             <% end %>
           </td>
         <% end %>


### PR DESCRIPTION
The upgraded DataTables component is still creating alerts due to table errors. I think the default way of reporting errors may have changed in the upgrade which is why we're seeing them now.

The errors fixed before and the tariff table error fixed here are due to inconsistencies between number of cols in the `thead` vs `tbody`. The fix is to ensure they're consistent.

There are also errors in the baseload page when we are creating a row for a meter that doesn't have enough data for all columns. In this case we just add a `<td colspan="X">...</td>` with a message to say when that data will be available.

It turns out that DataTables doesn't support `colspan` or `rowspan` in the `tbody` so the table doesnt initialise properly. Presumably this was just silently failing before.

While I decide how best to handle the UX changes, I've changed the default error mode to throwing an exception which is added to the JS console rather than an alert. This will avoid users seeing other messages while we fix up this issue.

It would also allow us to write system tests that use `:js` that check that there are no errors when rendering tables.

Note: the majority of the tariff component template changes are ERB lint fixes. The main change is adding a conditional in the header and reworking the conditional in the body so that there's always a cell, even if empty.