### PR TITLE
Remove sort on org types in contact forms

### DIFF
--- a/app/controllers/landing_pages_controller.rb
+++ b/app/controllers/landing_pages_controller.rb
@@ -140,7 +140,7 @@ class LandingPagesController < ApplicationController
       I18n.t('campaigns.form.org_types.special') => :special,
       I18n.t('campaigns.form.org_types.independent') => :independent,
       I18n.t('campaigns.form.org_types.local_authority') => :local_authority
-    }.sort
+    }
   end
 
   def contact_params


### PR DESCRIPTION
Rather than sort alphabetically, sort the org type based on who likelihood of use