### PR TITLE
Fix calendar links in book demo workflow

### DIFF
--- a/app/controllers/landing_pages_controller.rb
+++ b/app/controllers/landing_pages_controller.rb
@@ -2,7 +2,7 @@ class LandingPagesController < ApplicationController
   TRUST = 'multi_academy_trust'.freeze
   LA = 'local_authority'.freeze
   # Needs to be aligned with values in set_org_types
-  GROUP_TYPES = %w[TRUST LA].freeze
+  GROUP_TYPES = [TRUST, LA].freeze
 
   skip_before_action :authenticate_user!
   before_action :set_marketing_case_studies


### PR DESCRIPTION
At the end of the workflow MATs and Schools should get different booking links.

A change I made last week broke the logic for this so everyone is getting the school booking link.

I've fixed the issue and added explicit checks that the right URLs are added to the page.