### PR TITLE
Add redirect for incorrect urls

### DIFF
--- a/app/controllers/schools/interventions_controller.rb
+++ b/app/controllers/schools/interventions_controller.rb
@@ -46,6 +46,11 @@ module Schools
     end
 
     def show
+      if @observation.observation_type == 'activity'
+        redirect_to school_activity_path(@school, @observation.activity_id)
+      else
+        render :show
+      end
     end
 
     def completed

--- a/app/controllers/schools/interventions_controller.rb
+++ b/app/controllers/schools/interventions_controller.rb
@@ -47,7 +47,7 @@ module Schools
 
     def show
       if @observation.observation_type == 'activity'
-        redirect_to school_activity_path(@school, @observation.activity_id)
+        redirect_to school_activity_path(@school, @observation.activity_id), :status => :moved_permanently
       else
         render :show
       end

--- a/spec/system/interventions_spec.rb
+++ b/spec/system/interventions_spec.rb
@@ -184,6 +184,14 @@ describe 'viewing and recording action', type: :system do
       end
     end
 
+    context 'when requesting an incorrect url' do
+      let!(:observation) { create(:observation, :activity, school: school, activity: create(:activity, school: school))}
+
+      it 'redirects to activity' do
+        visit school_intervention_path(school, observation.id)
+      end
+    end
+
     context 'when recording an action' do
       let(:today) { Time.zone.today }
 


### PR DESCRIPTION
We're getting errors from a crawler hitting the interventions page with the id for an activity (for the same school).

Either there's a problem with our internal linking or we previously had issues and the crawler is still fetching old/incorrect urls. I can't find any obviously incorrect urls in templates or redirects in our routes.rb.

As an interim fix, this PR checks to see if the observation that is loaded is actually an activity and, if so, redirects to the right location with a 301 Moved Permanently response.