### PR TITLE
New report for Energy Sparks competition

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,8 +26,9 @@ gem 'pg'
 gem 'scenic'
 
 # Dashboard analytics
-gem 'energy-sparks_analytics', github: 'Energy-Sparks/energy-sparks_analytics', tag: '5.1.8'
-# gem 'energy-sparks_analytics', path: '../energy-sparks_analytics'
+#gem 'energy-sparks_analytics', github: 'Energy-Sparks/energy-sparks_analytics', tag: '5.1.8'
+gem 'energy-sparks_analytics', github: 'Energy-Sparks/energy-sparks_analytics', branch: '4069-create-new-comparison-for-new-energy-sparks-competition'
+#gem 'energy-sparks_analytics', path: '../energy-sparks_analytics'
 
 # Using master due to it having a patch which doesn't override Enumerable#sum if it's already defined
 # Last proper release does that, causing all kinds of weird behaviour (+ not defined etc)

--- a/Gemfile
+++ b/Gemfile
@@ -26,8 +26,7 @@ gem 'pg'
 gem 'scenic'
 
 # Dashboard analytics
-#gem 'energy-sparks_analytics', github: 'Energy-Sparks/energy-sparks_analytics', tag: '5.1.8'
-gem 'energy-sparks_analytics', github: 'Energy-Sparks/energy-sparks_analytics', branch: '4069-create-new-comparison-for-new-energy-sparks-competition'
+gem 'energy-sparks_analytics', github: 'Energy-Sparks/energy-sparks_analytics', tag: '5.1.9'
 #gem 'energy-sparks_analytics', path: '../energy-sparks_analytics'
 
 # Using master due to it having a patch which doesn't override Enumerable#sum if it's already defined

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/Energy-Sparks/energy-sparks_analytics.git
-  revision: 58f95e9befab4c04b12a33d93ab303399fe764fd
-  branch: 4069-create-new-comparison-for-new-energy-sparks-competition
+  revision: aa0cb5f912fb162d5da32d4c00451a47aced6d4f
+  tag: 5.1.9
   specs:
     energy-sparks_analytics (1.2.1)
       activesupport (>= 6.0, < 7.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/Energy-Sparks/energy-sparks_analytics.git
-  revision: c912a059b016689035eaf3b32ce122dc10e3eb61
-  tag: 5.1.8
+  revision: 58f95e9befab4c04b12a33d93ab303399fe764fd
+  branch: 4069-create-new-comparison-for-new-energy-sparks-competition
   specs:
     energy-sparks_analytics (1.2.1)
       activesupport (>= 6.0, < 7.1)
@@ -265,7 +265,7 @@ GEM
       faraday (>= 1, < 3)
     faraday-net_http (3.1.0)
       net-http
-    faraday-retry (2.2.0)
+    faraday-retry (2.2.1)
       faraday (~> 2.0)
     fasterer (0.11.0)
       ruby_parser (>= 3.19.1)
@@ -712,7 +712,7 @@ GEM
     websocket-extensions (0.1.5)
     wisper (2.0.1)
     wisper-rspec (1.1.0)
-    write_xlsx (1.11.2)
+    write_xlsx (1.12.1)
       nkf
       rubyzip (>= 1.0.0)
     xpath (3.2.0)
@@ -832,4 +832,4 @@ DEPENDENCIES
   wisper-rspec
 
 BUNDLED WITH
-   2.5.6
+   2.5.4

--- a/app/controllers/comparisons/heat_saver_march_2024_controller.rb
+++ b/app/controllers/comparisons/heat_saver_march_2024_controller.rb
@@ -96,7 +96,7 @@ module Comparisons
     end
 
     def load_data
-      Comparison::HeatSaverMarch2024.for_schools(@schools).where_any_present([:electricity_previous_period_kwh, :gas_previous_period_kwh, :storage_heater_current_period_kwh]).order('schools.name ASC')
+      Comparison::HeatSaverMarch2024.for_schools(@schools).where_any_present([:electricity_previous_period_kwh, :gas_previous_period_kwh, :storage_heater_previous_period_kwh]).order('schools.name ASC')
     end
 
     def table_names
@@ -104,9 +104,7 @@ module Comparisons
     end
 
     def create_charts(_results)
-      []
-      # change as appropriate!
-      # create_single_number_chart(results, name, multiplier, series_name, y_axis_label)
+      create_single_number_chart(@results, :total_percentage_change_kwh, nil, :change_kwh, :kwh)
     end
   end
 end

--- a/app/controllers/comparisons/heat_saver_march_2024_controller.rb
+++ b/app/controllers/comparisons/heat_saver_march_2024_controller.rb
@@ -5,6 +5,7 @@ module Comparisons
       @electricity_colgroups = electricity_colgroups
       @heating_colgroups = heating_colgroups
       @heating_headers = heating_headers
+      @period_type_string = I18n.t('comparisons.period_types.periods')
       super
     end
 
@@ -23,7 +24,7 @@ module Comparisons
         t('analytics.benchmarking.configuration.column_headings.change_pct'),
         t('comparisons.column_headings.previous_period'),
         t('comparisons.column_headings.current_period'),
-        t('analytics.benchmarking.configuration.column_headings.change_pct'),
+        t('analytics.benchmarking.configuration.column_headings.change_pct')
       ]
     end
 

--- a/app/controllers/comparisons/heat_saver_march_2024_controller.rb
+++ b/app/controllers/comparisons/heat_saver_march_2024_controller.rb
@@ -1,0 +1,112 @@
+module Comparisons
+  class HeatSaverMarch2024Controller < BaseController
+    def index
+      @electricity_headers = electricity_headers
+      @electricity_colgroups = electricity_colgroups
+      @heating_colgroups = heating_colgroups
+      @heating_headers = heating_headers
+      super
+    end
+
+    private
+
+    def headers
+      [
+        t('analytics.benchmarking.configuration.column_headings.school'),
+        t('analytics.benchmarking.configuration.column_headings.fuel'),
+        t('activerecord.attributes.school.activation_date'),
+        t('comparisons.column_headings.previous_period'),
+        t('comparisons.column_headings.current_period'),
+        t('analytics.benchmarking.configuration.column_headings.change_pct'),
+        t('comparisons.column_headings.previous_period'),
+        t('comparisons.column_headings.current_period'),
+        t('analytics.benchmarking.configuration.column_headings.change_pct'),
+        t('comparisons.column_headings.previous_period'),
+        t('comparisons.column_headings.current_period'),
+        t('analytics.benchmarking.configuration.column_headings.change_pct'),
+      ]
+    end
+
+    def electricity_headers
+      [
+        t('analytics.benchmarking.configuration.column_headings.school'),
+        t('activerecord.attributes.school.activation_date'),
+        t('comparisons.column_headings.previous_period'),
+        t('comparisons.column_headings.current_period'),
+        t('analytics.benchmarking.configuration.column_headings.change_pct'),
+        t('comparisons.column_headings.previous_period'),
+        t('comparisons.column_headings.current_period'),
+        t('analytics.benchmarking.configuration.column_headings.change_pct'),
+        t('comparisons.column_headings.previous_period'),
+        t('comparisons.column_headings.current_period'),
+        t('analytics.benchmarking.configuration.column_headings.change_pct')
+      ]
+    end
+
+    def heating_headers
+      [
+        t('analytics.benchmarking.configuration.column_headings.school'),
+        t('activerecord.attributes.school.activation_date'),
+        t('comparisons.column_headings.previous_period_unadjusted'),
+        t('comparisons.column_headings.previous_period'),
+        t('comparisons.column_headings.current_period'),
+        t('analytics.benchmarking.configuration.column_headings.change_pct'),
+        t('comparisons.column_headings.previous_period'),
+        t('comparisons.column_headings.current_period'),
+        t('analytics.benchmarking.configuration.column_headings.change_pct'),
+        t('comparisons.column_headings.previous_period'),
+        t('comparisons.column_headings.current_period'),
+        t('analytics.benchmarking.configuration.column_headings.change_pct')
+      ]
+    end
+
+    def colgroups
+      [
+        { label: '', colspan: 3 },
+        { label: t('analytics.benchmarking.configuration.column_groups.kwh'), colspan: 3 },
+        { label: t('analytics.benchmarking.configuration.column_groups.co2_kg'), colspan: 3 },
+        { label: t('analytics.benchmarking.configuration.column_groups.gbp'), colspan: 3 }
+      ]
+    end
+
+    def electricity_colgroups
+      [
+        { label: '', colspan: 2 },
+        { label: t('analytics.benchmarking.configuration.column_groups.kwh'), colspan: 3 },
+        { label: t('analytics.benchmarking.configuration.column_groups.co2_kg'), colspan: 3 },
+        { label: t('analytics.benchmarking.configuration.column_groups.gbp'), colspan: 3 }
+      ]
+    end
+
+    def heating_colgroups
+      [
+        { label: '', colspan: 2 },
+        { label: t('analytics.benchmarking.configuration.column_groups.kwh'), colspan: 4 },
+        { label: t('analytics.benchmarking.configuration.column_groups.co2_kg'), colspan: 3 },
+        { label: t('analytics.benchmarking.configuration.column_groups.gbp'), colspan: 3 }
+      ]
+    end
+
+    def key
+      :heat_saver_march_2024
+    end
+
+    def advice_page_key
+      :total_energy_use
+    end
+
+    def load_data
+      Comparison::HeatSaverMarch2024.for_schools(@schools).where_any_present([:electricity_previous_period_kwh, :gas_previous_period_kwh, :storage_heater_current_period_kwh]).order('schools.name ASC')
+    end
+
+    def table_names
+      [:total, :electricity, :gas, :storage_heater]
+    end
+
+    def create_charts(_results)
+      []
+      # change as appropriate!
+      # create_single_number_chart(results, name, multiplier, series_name, y_axis_label)
+    end
+  end
+end

--- a/app/controllers/comparisons/heat_saver_march_2024_controller.rb
+++ b/app/controllers/comparisons/heat_saver_march_2024_controller.rb
@@ -97,7 +97,7 @@ module Comparisons
     end
 
     def load_data
-      Comparison::HeatSaverMarch2024.for_schools(@schools).where_any_present([:electricity_previous_period_kwh, :gas_previous_period_kwh, :storage_heater_previous_period_kwh]).by_total_percentage_change([:electricity_previous_period_kwh, :gas_previous_period_kwh, :storage_heater_previous_period_kwh], [:electricity_current_period_kwh, :gas_current_period_kwh, :storage_heater_current_period_kwh]) # .order('schools.name ASC')
+      Comparison::HeatSaverMarch2024.for_schools(@schools).with_data_for_previous_period.by_total_percentage_change
     end
 
     def table_names

--- a/app/controllers/comparisons/heat_saver_march_2024_controller.rb
+++ b/app/controllers/comparisons/heat_saver_march_2024_controller.rb
@@ -97,7 +97,7 @@ module Comparisons
     end
 
     def load_data
-      Comparison::HeatSaverMarch2024.for_schools(@schools).where_any_present([:electricity_previous_period_kwh, :gas_previous_period_kwh, :storage_heater_previous_period_kwh]).order('schools.name ASC')
+      Comparison::HeatSaverMarch2024.for_schools(@schools).where_any_present([:electricity_previous_period_kwh, :gas_previous_period_kwh, :storage_heater_previous_period_kwh]).by_total_percentage_change([:electricity_previous_period_kwh, :gas_previous_period_kwh, :storage_heater_previous_period_kwh], [:electricity_current_period_kwh, :gas_current_period_kwh, :storage_heater_current_period_kwh]) # .order('schools.name ASC')
     end
 
     def table_names
@@ -105,7 +105,7 @@ module Comparisons
     end
 
     def create_charts(_results)
-      create_single_number_chart(@results, :total_percentage_change_kwh, nil, :change_kwh, :kwh)
+      create_single_number_chart(@results, :total_percentage_change_kwh, 100.0, :change_kwh, :percent)
     end
   end
 end

--- a/app/helpers/comparisons_helper.rb
+++ b/app/helpers/comparisons_helper.rb
@@ -18,47 +18,16 @@ module ComparisonsHelper
             id: "#{report.key}-#{table_name}-download"
   end
 
-  # Calculate percentage change across two values or sum of values in two arrays
   def percent_change(base, new_val, to_nil_if_sum_zero = false)
-    return nil if to_nil_if_sum_zero && sum_data(base) == 0.0
-    return 0.0 if sum_data(base) == 0.0
-
-    change = (sum_data(new_val) - sum_data(base)) / sum_data(base)
-    to_nil_if_sum_zero && change == 0.0 ? nil : change
+    EnergySparks::Calculator.percent_change(base, new_val, to_nil_if_sum_zero)
   end
 
   def sum_data(data, to_nil_if_sum_zero = false)
-    data = Array(data)
-    data.map! { |value| value || 0.0 } # create array 1st to avoid statsample map/sum bug
-    val = data.sum
-    to_nil_if_sum_zero && val == 0.0 ? nil : val
+    EnergySparks::Calculator.sum_data(data, to_nil_if_sum_zero)
   end
 
-  # Accepts 2 arrays of kwh, co2 or £ values.
-  # Expects first 2 values of each array to be the electricity and gas values
-  # Remainder of array can be storage heater and solar
-  #
-  # Only sums +previous_year_values+ if:
-  #
-  # there are values for both electricity and gas in years
-  # electricity (or gas) is missing in both years
-  #
-  # Returns nil if there's no value for previous year, but there is for the current
-  # year. As this indicates that the data coverage is incomplete and summing the values
-  # would produce a misleading figure.
-  #
-  # Storage heater values are (presumably) not checked because these are based on
-  # electricity data and will be missing if the electricity is missing.
-  #
-  # Solar is not checked as panels may not have been installed until this year.
-  #
   def sum_if_complete(previous_year_values, current_year_values)
-    eg_prev = previous_year_values[0..1].map(&:nil?)
-    eg_curr = current_year_values[0..1].map(&:nil?)
-
-    return nil if eg_prev != eg_curr
-
-    sum_data(previous_year_values)
+    EnergySparks::Calculator.sum_if_complete(previous_year_values, current_year_values)
   end
 
   def comparison_page_exists?(key)

--- a/app/helpers/comparisons_helper.rb
+++ b/app/helpers/comparisons_helper.rb
@@ -34,6 +34,33 @@ module ComparisonsHelper
     to_nil_if_sum_zero && val == 0.0 ? nil : val
   end
 
+  # Accepts 2 arrays of kwh, co2 or £ values.
+  # Expects first 2 values of each array to be the electricity and gas values
+  # Remainder of array can be storage heater and solar
+  #
+  # Only sums +previous_year_values+ if:
+  #
+  # there are values for both electricity and gas in years
+  # electricity (or gas) is missing in both years
+  #
+  # Returns nil if there's no value for previous year, but there is for the current
+  # year. As this indicates that the data coverage is incomplete and summing the values
+  # would produce a misleading figure.
+  #
+  # Storage heater values are (presumably) not checked because these are based on
+  # electricity data and will be missing if the electricity is missing.
+  #
+  # Solar is not checked as panels may not have been installed until this year.
+  #
+  def sum_if_complete(previous_year_values, current_year_values)
+    eg_prev = previous_year_values[0..1].map(&:nil?)
+    eg_curr = current_year_values[0..1].map(&:nil?)
+
+    return nil if eg_prev != eg_curr
+
+    sum_data(previous_year_values)
+  end
+
   def comparison_page_exists?(key)
     Object.const_defined?("Comparisons::#{key.to_s.camelcase}Controller")
   end

--- a/app/models/comparison/heat_saver_march_2024.rb
+++ b/app/models/comparison/heat_saver_march_2024.rb
@@ -33,34 +33,12 @@
 #  storage_heater_tariff_has_changed             :boolean
 #
 class Comparison::HeatSaverMarch2024 < Comparison::View
+  include MultipleFuelComparisonView
   self.table_name = 'heat_saver_march_2024s'
 
   def any_tariff_changed?
     electricity_tariff_has_changed ||
       gas_tariff_has_changed ||
       storage_heater_tariff_has_changed
-  end
-
-  def all_previous_period(unit: :kwh)
-    field_names(period: :previous_period, unit: unit).map do |field|
-      send(field)
-    end
-  end
-
-  def all_current_period(unit: :kwh)
-    field_names(period: :current_period, unit: unit).map do |field|
-      send(field)
-    end
-  end
-
-  private
-
-  def field_names(period: :previous_year, unit: :kwh)
-    unit = :gbp if unit == :£
-    field_names = []
-    %i[electricity gas storage_heater].each do |fuel_type|
-      field_names << :"#{fuel_type}_#{period}_#{unit}"
-    end
-    field_names
   end
 end

--- a/app/models/comparison/heat_saver_march_2024.rb
+++ b/app/models/comparison/heat_saver_march_2024.rb
@@ -42,13 +42,22 @@ class Comparison::HeatSaverMarch2024 < Comparison::View
       storage_heater_tariff_has_changed
   end
 
+  # For CSV export
+  def fuel_type_names
+    codes = []
+    codes << I18n.t('common.electricity') if electricity_previous_period_kwh
+    codes << I18n.t('common.gas') if gas_previous_period_kwh
+    codes << I18n.t('common.storage_heaters') if storage_heater_previous_period_kwh
+    codes.join(';')
+  end
+
   scope :with_data_for_previous_period, -> do
     where_any_present(
       [:electricity_previous_period_kwh, :gas_previous_period_kwh, :storage_heater_previous_period_kwh]
     )
   end
 
-  scope :by_total_percentage_change do
+  scope :by_total_percentage_change, -> do
     by_percentage_change_across_fields(
       [:electricity_previous_period_kwh, :gas_previous_period_kwh, :storage_heater_previous_period_kwh],
       [:electricity_current_period_kwh, :gas_current_period_kwh, :storage_heater_current_period_kwh]

--- a/app/models/comparison/heat_saver_march_2024.rb
+++ b/app/models/comparison/heat_saver_march_2024.rb
@@ -41,4 +41,9 @@ class Comparison::HeatSaverMarch2024 < Comparison::View
       gas_tariff_has_changed ||
       storage_heater_tariff_has_changed
   end
+
+  # E.g. previous_year, current_year
+  scope :by_total_percentage_change, ->(base_vals, new_vals) do
+    order(Arel.sql(sanitize_sql_array("(NULLIF(#{new_vals.map {|v| "COALESCE(#{v}, 0.0)" }.join('+')},0.0) - NULLIF(#{base_vals.map {|v| "COALESCE(#{v}, 0.0)" }.join('+')},0.0)) / NULLIF(#{base_vals.map {|v| "COALESCE(#{v}, 0.0)" }.join('+')},0.0) ASC NULLS FIRST")))
+  end
 end

--- a/app/models/comparison/heat_saver_march_2024.rb
+++ b/app/models/comparison/heat_saver_march_2024.rb
@@ -55,11 +55,16 @@ class Comparison::HeatSaverMarch2024 < Comparison::View
     )
   end
 
-  # E.g. previous_year, current_year
+  # Orders the results by a percentage change value that is calculated from summing together multiple attributes
+  #
+  # Uses COALESCE to convert nil values for an attribute to zero (e.g. if a school doesn't have gas or storage heaters)
+  #
+  # Uses NULLIF to convert a total of 0.0 for a set of attributes to NULL, so the order value becomes NULL.
+  # This avoids errors in the calculations. We then sort NULLs last
   scope :by_percentage_change_across_fields, ->(base_val_fields, new_val_fields) do
     order(
       Arel.sql(
-        sanitize_sql_array("(NULLIF(#{new_val_fields.map {|v| "COALESCE(#{v}, 0.0)" }.join('+')},0.0) - NULLIF(#{base_val_fields.map {|v| "COALESCE(#{v}, 0.0)" }.join('+')},0.0)) / NULLIF(#{base_val_fields.map {|v| "COALESCE(#{v}, 0.0)" }.join('+')},0.0) ASC NULLS FIRST")
+        sanitize_sql_array("(NULLIF(#{new_val_fields.map {|v| "COALESCE(#{v}, 0.0)" }.join('+')},0.0) - NULLIF(#{base_val_fields.map {|v| "COALESCE(#{v}, 0.0)" }.join('+')},0.0)) / NULLIF(#{base_val_fields.map {|v| "COALESCE(#{v}, 0.0)" }.join('+')},0.0) ASC NULLS LAST")
       )
     )
   end

--- a/app/models/comparison/heat_saver_march_2024.rb
+++ b/app/models/comparison/heat_saver_march_2024.rb
@@ -1,0 +1,66 @@
+# == Schema Information
+#
+# Table name: heat_saver_march_2024s
+#
+#  activation_date                               :date
+#  electricity_current_period_co2                :float
+#  electricity_current_period_gbp                :float
+#  electricity_current_period_kwh                :float
+#  electricity_previous_period_co2               :float
+#  electricity_previous_period_gbp               :float
+#  electricity_previous_period_kwh               :float
+#  electricity_tariff_has_changed                :boolean
+#  floor_area_changed                            :boolean
+#  gas_current_period_co2                        :float
+#  gas_current_period_gbp                        :float
+#  gas_current_period_kwh                        :float
+#  gas_previous_period_co2                       :float
+#  gas_previous_period_gbp                       :float
+#  gas_previous_period_kwh                       :float
+#  gas_previous_period_kwh_unadjusted            :float
+#  gas_tariff_has_changed                        :boolean
+#  id                                            :bigint(8)
+#  pupils_changed                                :boolean
+#  school_id                                     :bigint(8)
+#  solar_type                                    :text
+#  storage_heater_current_period_co2             :float
+#  storage_heater_current_period_gbp             :float
+#  storage_heater_current_period_kwh             :float
+#  storage_heater_previous_period_co2            :float
+#  storage_heater_previous_period_gbp            :float
+#  storage_heater_previous_period_kwh            :float
+#  storage_heater_previous_period_kwh_unadjusted :float
+#  storage_heater_tariff_has_changed             :boolean
+#
+class Comparison::HeatSaverMarch2024 < Comparison::View
+  self.table_name = 'heat_saver_march_2024s'
+
+  def any_tariff_changed?
+    electricity_tariff_has_changed ||
+      gas_tariff_has_changed ||
+      storage_heater_tariff_has_changed
+  end
+
+  def all_previous_period(unit: :kwh)
+    field_names(period: :previous_period, unit: unit).map do |field|
+      send(field)
+    end
+  end
+
+  def all_current_period(unit: :kwh)
+    field_names(period: :current_period, unit: unit).map do |field|
+      send(field)
+    end
+  end
+
+  private
+
+  def field_names(period: :previous_year, unit: :kwh)
+    unit = :gbp if unit == :£
+    field_names = []
+    %i[electricity gas storage_heater].each do |fuel_type|
+      field_names << :"#{fuel_type}_#{period}_#{unit}"
+    end
+    field_names
+  end
+end

--- a/app/models/concerns/multiple_fuel_comparison_view.rb
+++ b/app/models/concerns/multiple_fuel_comparison_view.rb
@@ -43,20 +43,29 @@ module MultipleFuelComparisonView
     percent_change(total_previous_period(unit: unit), total_current_period(unit: unit))
   end
 
-  # Returns an array of field names for the specified unit, for the previous period
-  # E.g. [:electricity_previous_period_kwh, :gas_previous_period_kwh]
+  # Returns an array of values for the specified unit, for the previous period
+  # E.g. by calling :electricity_previous_period_kwh, :gas_previous_period_kwh, etc
   def all_previous_period(unit: :kwh)
     field_names(period: :previous_period, unit: unit).map do |field|
       send(field)
     end
   end
 
-  # Returns an array of field names for the specified unit, for the current period
-  # E.g. [:electricity_current_period_kwh, :gas_current_period_kwh]
+  # Returns an array of values for the specified unit, for the current period
+  # E.g. by calling :electricity_current_period_kwh, :gas_current_period_kwh, etc
   def all_current_period(unit: :kwh)
     field_names(period: :current_period, unit: unit).map do |field|
       send(field)
     end
+  end
+
+  def field_names(period: :previous_period, unit: :kwh)
+    unit = :gbp if unit == :£
+    field_names = []
+    fuel_types.each do |fuel_type|
+      field_names << field_name(fuel_type, period, unit)
+    end
+    field_names
   end
 
   private
@@ -71,15 +80,6 @@ module MultipleFuelComparisonView
 
   def field_name(fuel_type, period, unit)
     :"#{fuel_type}_#{period}_#{unit}"
-  end
-
-  def field_names(period: :previous_year, unit: :kwh)
-    unit = :gbp if unit == :£
-    field_names = []
-    fuel_types.each do |fuel_type|
-      field_names << field_name(fuel_type, period, unit)
-    end
-    field_names
   end
 
   def percent_change(base, new_val, to_nil_if_sum_zero = false)

--- a/app/models/concerns/multiple_fuel_comparison_view.rb
+++ b/app/models/concerns/multiple_fuel_comparison_view.rb
@@ -19,7 +19,7 @@ module MultipleFuelComparisonView
   #
   # Simply totals the values across all kwh fields for each fuel type
   def total_current_period(unit: :kwh)
-    sum_data(all_current_period(unit: unit))
+    all_current_period(unit: unit).sum
   end
 
   # Returns total consumption for +unit+ in the current period
@@ -34,13 +34,13 @@ module MultipleFuelComparisonView
   #
   # See EnergySparks::Calculator.sum_if_complete
   def total_previous_period(unit: :kwh, mode: :strict)
-    return sum_data(all_previous_period(unit: unit)) unless mode == :strict
-    sum_if_complete(all_previous_period(unit: unit), all_current_period(unit: unit))
+    return all_previous_period(unit: unit).sum unless mode == :strict
+    EnergySparks::Calculator.sum_if_complete(all_previous_period(unit: unit), all_current_period(unit: unit))
   end
 
   # Calculate percentage change, for a specific unit across the two periods
   def total_percentage_change(unit:)
-    percent_change(total_previous_period(unit: unit), total_current_period(unit: unit))
+    EnergySparks::Calculator.percent_change(total_previous_period(unit: unit), total_current_period(unit: unit))
   end
 
   # Returns an array of values for the specified unit, for the previous period
@@ -80,17 +80,5 @@ module MultipleFuelComparisonView
 
   def field_name(fuel_type, period, unit)
     :"#{fuel_type}_#{period}_#{unit}"
-  end
-
-  def percent_change(base, new_val, to_nil_if_sum_zero = false)
-    EnergySparks::Calculator.percent_change(base, new_val, to_nil_if_sum_zero)
-  end
-
-  def sum_data(data, to_nil_if_sum_zero = false)
-    EnergySparks::Calculator.sum_data(data, to_nil_if_sum_zero)
-  end
-
-  def sum_if_complete(previous_year_values, current_year_values)
-    EnergySparks::Calculator.sum_if_complete(previous_year_values, current_year_values)
   end
 end

--- a/app/models/concerns/multiple_fuel_comparison_view.rb
+++ b/app/models/concerns/multiple_fuel_comparison_view.rb
@@ -1,0 +1,96 @@
+# Can be included by comparison models that have attributes for multiple fuel types
+# and units across two different periods (current and previous)
+#
+# e.g. electricity_previous_period_kwh
+#
+# Assumes, by default that fields are named according to +field_name+ but this can be
+# overridden
+module MultipleFuelComparisonView
+  extend ActiveSupport::Concern
+
+  DEFAULT_UNITS = %i[kwh co2 gbp].freeze
+  DEFAULT_FUEL_TYPES = %i[electricity gas storage_heater].freeze
+
+  def total_percentage_change_kwh
+    total_percentage_change(unit: :kwh)
+  end
+
+  # Returns total consumption for +unit+ in the current period
+  #
+  # Simply totals the values across all kwh fields for each fuel type
+  def total_current_period(unit: :kwh)
+    sum_data(all_current_period(unit: unit))
+  end
+
+  # Returns total consumption for +unit+ in the current period
+  #
+  # By default the method assumes that the total will be used in a comparison with
+  # the previous period and operates a "strict" policy for calculating the totals.
+  #
+  # Strict mode means a total is only returned if we have values for both electricity and
+  # gas in both years. Otherwise we assume data is incomplete and we return nil
+  #
+  # Change the model value to just return a simple sum
+  #
+  # See EnergySparks::Calculator.sum_if_complete
+  def total_previous_period(unit: :kwh, mode: :strict)
+    return sum_data(all_previous_period(unit: unit)) unless mode == :strict
+    sum_if_complete(all_previous_period(unit: unit), all_current_period(unit: unit))
+  end
+
+  # Calculate percentage change, for a specific unit across the two periods
+  def total_percentage_change(unit:)
+    percent_change(total_previous_period(unit: unit), total_current_period(unit: unit))
+  end
+
+  # Returns an array of field names for the specified unit, for the previous period
+  # E.g. [:electricity_previous_period_kwh, :gas_previous_period_kwh]
+  def all_previous_period(unit: :kwh)
+    field_names(period: :previous_period, unit: unit).map do |field|
+      send(field)
+    end
+  end
+
+  # Returns an array of field names for the specified unit, for the current period
+  # E.g. [:electricity_current_period_kwh, :gas_current_period_kwh]
+  def all_current_period(unit: :kwh)
+    field_names(period: :current_period, unit: unit).map do |field|
+      send(field)
+    end
+  end
+
+  private
+
+  def units
+    DEFAULT_UNITS
+  end
+
+  def fuel_types
+    DEFAULT_FUEL_TYPES
+  end
+
+  def field_name(fuel_type, period, unit)
+    :"#{fuel_type}_#{period}_#{unit}"
+  end
+
+  def field_names(period: :previous_year, unit: :kwh)
+    unit = :gbp if unit == :£
+    field_names = []
+    fuel_types.each do |fuel_type|
+      field_names << field_name(fuel_type, period, unit)
+    end
+    field_names
+  end
+
+  def percent_change(base, new_val, to_nil_if_sum_zero = false)
+    EnergySparks::Calculator.percent_change(base, new_val, to_nil_if_sum_zero)
+  end
+
+  def sum_data(data, to_nil_if_sum_zero = false)
+    EnergySparks::Calculator.sum_data(data, to_nil_if_sum_zero)
+  end
+
+  def sum_if_complete(previous_year_values, current_year_values)
+    EnergySparks::Calculator.sum_if_complete(previous_year_values, current_year_values)
+  end
+end

--- a/app/models/concerns/multiple_fuel_comparison_view.rb
+++ b/app/models/concerns/multiple_fuel_comparison_view.rb
@@ -19,7 +19,7 @@ module MultipleFuelComparisonView
   #
   # Simply totals the values across all kwh fields for each fuel type
   def total_current_period(unit: :kwh)
-    all_current_period(unit: unit).sum
+    all_current_period(unit: unit).sum(&:to_f)
   end
 
   # Returns total consumption for +unit+ in the current period

--- a/app/views/comparisons/heat_saver_march2024/_electricity.csv.ruby
+++ b/app/views/comparisons/heat_saver_march2024/_electricity.csv.ruby
@@ -1,0 +1,9 @@
+CSV.generate do |csv|
+  # headers
+  csv << @headers
+  @results.each do |result|
+    csv << [
+      result.school.name
+    ]
+  end
+end.html_safe

--- a/app/views/comparisons/heat_saver_march2024/_electricity.csv.ruby
+++ b/app/views/comparisons/heat_saver_march2024/_electricity.csv.ruby
@@ -1,9 +1,30 @@
 CSV.generate do |csv|
-  # headers
-  csv << @headers
+  csv << [
+    "", "",
+    t('analytics.benchmarking.configuration.column_groups.kwh'),
+    "",
+    "",
+    t('analytics.benchmarking.configuration.column_groups.co2_kg'),
+    "",
+    "",
+    t('analytics.benchmarking.configuration.column_groups.gbp'),
+    "",
+    ""
+  ]
+  csv << @electricity_headers
   @results.each do |result|
     csv << [
-      result.school.name
+      result.school.name,
+      result.activation_date.iso8601,
+      format_unit(result.electricity_previous_period_kwh, Float, true, :benchmark),
+      format_unit(result.electricity_current_period_kwh, Float, true, :benchmark),
+      format_unit(percent_change(result.electricity_previous_period_kwh, result.electricity_current_period_kwh) * 100, Float, true, :benchmark),
+      format_unit(result.electricity_previous_period_co2, Float, true, :benchmark),
+      format_unit(result.electricity_current_period_co2, Float, true, :benchmark),
+      format_unit(percent_change(result.electricity_previous_period_co2, result.electricity_current_period_co2) * 100, Float, true, :benchmark),
+      format_unit(result.electricity_previous_period_gbp, Float, true, :benchmark),
+      format_unit(result.electricity_current_period_gbp, Float, true, :benchmark),
+      format_unit(percent_change(result.electricity_previous_period_gbp, result.electricity_current_period_gbp) * 100, Float, true, :benchmark)
     ]
   end
 end.html_safe

--- a/app/views/comparisons/heat_saver_march2024/_electricity.html.erb
+++ b/app/views/comparisons/heat_saver_march2024/_electricity.html.erb
@@ -1,0 +1,32 @@
+<%= render 'table_title', table_number: table_number, table_title: t('comparisons.tables.electricity_usage') %>
+
+<%= component 'comparison_table',
+              report: report, advice_page: advice_page, table_name: table_name, index_params: index_params,
+              headers: @electricity_headers, colgroups: @electricity_colgroups,
+              advice_page_tab: advice_page_tab do |c| %>
+  <% @results.where.not(electricity_previous_period_kwh: nil).find_each do |result| %>
+    <% c.with_row do |r| %>
+      <% r.with_school school: result.school %>
+      <% r.with_reference key: 'tariff_changed_last_year',
+                          if: result.electricity_tariff_has_changed %>
+      <% r.with_var val: result.activation_date, unit: :date_mmm_yyyy %>
+      <% r.with_var val: result.electricity_previous_period_kwh, unit: :kwh %>
+      <% r.with_var val: result.electricity_current_period_kwh, unit: :kwh %>
+      <% r.with_var val: percent_change(result.electricity_previous_period_kwh, result.electricity_current_period_kwh),
+                    change: true,
+                    unit: :relative_percent_0dp %>
+
+      <% r.with_var val: result.electricity_previous_period_co2, unit: :co2 %>
+      <% r.with_var val: result.electricity_current_period_co2, unit: :co2 %>
+      <% r.with_var val: percent_change(result.electricity_previous_period_co2, result.electricity_current_period_co2),
+                    change: true,
+                    unit: :relative_percent_0dp %>
+
+      <% r.with_var val: result.electricity_previous_period_gbp, unit: :£ %>
+      <% r.with_var val: result.electricity_current_period_gbp, unit: :£ %>
+      <% r.with_var val: percent_change(result.electricity_previous_period_gbp, result.electricity_current_period_gbp),
+                    change: true,
+                    unit: :relative_percent_0dp %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/comparisons/heat_saver_march2024/_electricity.html.erb
+++ b/app/views/comparisons/heat_saver_march2024/_electricity.html.erb
@@ -4,7 +4,7 @@
               report: report, advice_page: advice_page, table_name: table_name, index_params: index_params,
               headers: @electricity_headers, colgroups: @electricity_colgroups,
               advice_page_tab: advice_page_tab do |c| %>
-  <% @results.where.not(electricity_previous_period_kwh: nil).find_each do |result| %>
+  <% @results.where.not(electricity_previous_period_kwh: nil).each do |result| %>
     <% c.with_row do |r| %>
       <% r.with_school school: result.school %>
       <% r.with_reference key: 'tariff_changed_last_year',

--- a/app/views/comparisons/heat_saver_march2024/_electricity.html.erb
+++ b/app/views/comparisons/heat_saver_march2024/_electricity.html.erb
@@ -9,6 +9,9 @@
       <% r.with_school school: result.school %>
       <% r.with_reference key: 'tariff_changed_last_year',
                           if: result.electricity_tariff_has_changed %>
+      <% r.with_reference key: 'electricity_change_rows',
+                          period_type_string: @period_type_string,
+                          if: result.pupils_changed %>
       <% r.with_var val: result.activation_date, unit: :date_mmm_yyyy %>
       <% r.with_var val: result.electricity_previous_period_kwh, unit: :kwh %>
       <% r.with_var val: result.electricity_current_period_kwh, unit: :kwh %>

--- a/app/views/comparisons/heat_saver_march2024/_gas.csv.ruby
+++ b/app/views/comparisons/heat_saver_march2024/_gas.csv.ruby
@@ -1,9 +1,32 @@
 CSV.generate do |csv|
-  # headers
-  csv << @headers
+  csv << [
+    "", "",
+    t('analytics.benchmarking.configuration.column_groups.kwh'),
+    "",
+    "",
+    "",
+    t('analytics.benchmarking.configuration.column_groups.co2_kg'),
+    "",
+    "",
+    t('analytics.benchmarking.configuration.column_groups.gbp'),
+    "",
+    ""
+  ]
+  csv << @heating_headers
   @results.each do |result|
     csv << [
-      result.school.name
+      result.school.name,
+      result.activation_date.iso8601,
+      format_unit(result.gas_previous_period_kwh_unadjusted, Float, true, :benchmark),
+      format_unit(result.gas_previous_period_kwh, Float, true, :benchmark),
+      format_unit(result.gas_current_period_kwh, Float, true, :benchmark),
+      format_unit(percent_change(result.gas_previous_period_kwh, result.gas_current_period_kwh) * 100, Float, true, :benchmark),
+      format_unit(result.gas_previous_period_co2, Float, true, :benchmark),
+      format_unit(result.gas_current_period_co2, Float, true, :benchmark),
+      format_unit(percent_change(result.gas_previous_period_co2, result.gas_current_period_co2) * 100, Float, true, :benchmark),
+      format_unit(result.gas_previous_period_gbp, Float, true, :benchmark),
+      format_unit(result.gas_current_period_gbp, Float, true, :benchmark),
+      format_unit(percent_change(result.gas_previous_period_gbp, result.gas_current_period_gbp) * 100, Float, true, :benchmark)
     ]
   end
 end.html_safe

--- a/app/views/comparisons/heat_saver_march2024/_gas.csv.ruby
+++ b/app/views/comparisons/heat_saver_march2024/_gas.csv.ruby
@@ -1,0 +1,9 @@
+CSV.generate do |csv|
+  # headers
+  csv << @headers
+  @results.each do |result|
+    csv << [
+      result.school.name
+    ]
+  end
+end.html_safe

--- a/app/views/comparisons/heat_saver_march2024/_gas.html.erb
+++ b/app/views/comparisons/heat_saver_march2024/_gas.html.erb
@@ -1,0 +1,35 @@
+<%= render 'table_title', table_number: table_number, table_title: t('comparisons.tables.gas_usage') %>
+
+<%= component 'comparison_table',
+              report: report, advice_page: advice_page, table_name: table_name, index_params: index_params,
+              headers: @heating_headers, colgroups: @heating_colgroups, advice_page_tab: advice_page_tab do |c| %>
+  <% @results.where.not(gas_previous_period_kwh: nil).find_each do |result| %>
+    <% c.with_row do |r| %>
+    <% r.with_school school: result.school %>
+    <% r.with_reference key: 'tariff_changed_last_year',
+                        if: result.gas_tariff_has_changed %>
+    <% r.with_var val: result.activation_date, unit: :date_mmm_yyyy %>
+
+    <% r.with_var val: result.gas_previous_period_kwh_unadjusted, unit: :kwh %>
+    <% r.with_var val: result.gas_previous_period_kwh, unit: :kwh %>
+    <% r.with_var val: result.gas_current_period_kwh, unit: :kwh %>
+    <% r.with_var val: percent_change(result.gas_previous_period_kwh, result.gas_current_period_kwh),
+                  change: true,
+                  unit: :relative_percent_0dp %>
+
+    <% r.with_var val: result.gas_previous_period_co2, unit: :kwh %>
+    <% r.with_var val: result.gas_current_period_co2, unit: :kwh %>
+    <% r.with_var val: percent_change(result.gas_previous_period_co2, result.gas_current_period_co2),
+                  change: true,
+                  unit: :relative_percent_0dp %>
+
+    <% r.with_var val: result.gas_previous_period_gbp, unit: :kwh %>
+    <% r.with_var val: result.gas_current_period_gbp, unit: :kwh %>
+    <% r.with_var val: percent_change(result.gas_previous_period_gbp, result.gas_current_period_gbp),
+                  change: true,
+                  unit: :relative_percent_0dp %>
+    <% end %>
+  <% end %>
+  <% c.with_note do %>
+  <% end %>
+<% end %>

--- a/app/views/comparisons/heat_saver_march2024/_gas.html.erb
+++ b/app/views/comparisons/heat_saver_march2024/_gas.html.erb
@@ -8,6 +8,10 @@
     <% r.with_school school: result.school %>
     <% r.with_reference key: 'tariff_changed_last_year',
                         if: result.gas_tariff_has_changed %>
+    <% r.with_reference key: 'gas_change_rows',
+                        period_type_string: @period_type_string,
+                        schools_to_sentence: 'some schools',
+                        if: result.floor_area_changed %>
     <% r.with_var val: result.activation_date, unit: :date_mmm_yyyy %>
 
     <% r.with_var val: result.gas_previous_period_kwh_unadjusted, unit: :kwh %>
@@ -17,14 +21,14 @@
                   change: true,
                   unit: :relative_percent_0dp %>
 
-    <% r.with_var val: result.gas_previous_period_co2, unit: :kwh %>
-    <% r.with_var val: result.gas_current_period_co2, unit: :kwh %>
+    <% r.with_var val: result.gas_previous_period_co2, unit: :co2 %>
+    <% r.with_var val: result.gas_current_period_co2, unit: :co2 %>
     <% r.with_var val: percent_change(result.gas_previous_period_co2, result.gas_current_period_co2),
                   change: true,
                   unit: :relative_percent_0dp %>
 
-    <% r.with_var val: result.gas_previous_period_gbp, unit: :kwh %>
-    <% r.with_var val: result.gas_current_period_gbp, unit: :kwh %>
+    <% r.with_var val: result.gas_previous_period_gbp, unit: :£ %>
+    <% r.with_var val: result.gas_current_period_gbp, unit: :£ %>
     <% r.with_var val: percent_change(result.gas_previous_period_gbp, result.gas_current_period_gbp),
                   change: true,
                   unit: :relative_percent_0dp %>

--- a/app/views/comparisons/heat_saver_march2024/_gas.html.erb
+++ b/app/views/comparisons/heat_saver_march2024/_gas.html.erb
@@ -3,7 +3,7 @@
 <%= component 'comparison_table',
               report: report, advice_page: advice_page, table_name: table_name, index_params: index_params,
               headers: @heating_headers, colgroups: @heating_colgroups, advice_page_tab: advice_page_tab do |c| %>
-  <% @results.where.not(gas_previous_period_kwh: nil).find_each do |result| %>
+  <% @results.where.not(gas_previous_period_kwh: nil).each do |result| %>
     <% c.with_row do |r| %>
     <% r.with_school school: result.school %>
     <% r.with_reference key: 'tariff_changed_last_year',

--- a/app/views/comparisons/heat_saver_march2024/_storage_heater.csv.ruby
+++ b/app/views/comparisons/heat_saver_march2024/_storage_heater.csv.ruby
@@ -1,9 +1,32 @@
 CSV.generate do |csv|
-  # headers
-  csv << @headers
+  csv << [
+    "", "",
+    t('analytics.benchmarking.configuration.column_groups.kwh'),
+    "",
+    "",
+    "",
+    t('analytics.benchmarking.configuration.column_groups.co2_kg'),
+    "",
+    "",
+    t('analytics.benchmarking.configuration.column_groups.gbp'),
+    "",
+    ""
+  ]
+  csv << @heating_headers
   @results.each do |result|
     csv << [
-      result.school.name
+      result.school.name,
+      result.activation_date.iso8601,
+      format_unit(result.storage_heater_previous_period_kwh_unadjusted, Float, true, :benchmark),
+      format_unit(result.storage_heater_previous_period_kwh, Float, true, :benchmark),
+      format_unit(result.storage_heater_current_period_kwh, Float, true, :benchmark),
+      format_unit(percent_change(result.storage_heater_previous_period_kwh, result.storage_heater_current_period_kwh) * 100, Float, true, :benchmark),
+      format_unit(result.storage_heater_previous_period_co2, Float, true, :benchmark),
+      format_unit(result.storage_heater_current_period_co2, Float, true, :benchmark),
+      format_unit(percent_change(result.storage_heater_previous_period_co2, result.storage_heater_current_period_co2) * 100, Float, true, :benchmark),
+      format_unit(result.storage_heater_previous_period_gbp, Float, true, :benchmark),
+      format_unit(result.storage_heater_current_period_gbp, Float, true, :benchmark),
+      format_unit(percent_change(result.storage_heater_previous_period_gbp, result.storage_heater_current_period_gbp) * 100, Float, true, :benchmark)
     ]
   end
 end.html_safe

--- a/app/views/comparisons/heat_saver_march2024/_storage_heater.csv.ruby
+++ b/app/views/comparisons/heat_saver_march2024/_storage_heater.csv.ruby
@@ -1,0 +1,9 @@
+CSV.generate do |csv|
+  # headers
+  csv << @headers
+  @results.each do |result|
+    csv << [
+      result.school.name
+    ]
+  end
+end.html_safe

--- a/app/views/comparisons/heat_saver_march2024/_storage_heater.html.erb
+++ b/app/views/comparisons/heat_saver_march2024/_storage_heater.html.erb
@@ -8,6 +8,9 @@
     <% r.with_school school: result.school %>
     <% r.with_reference key: 'tariff_changed_last_year',
                         if: result.storage_heater_tariff_has_changed %>
+    <% r.with_reference key: 'electricity_change_rows',
+                        period_type_string: @period_type_string,
+                        if: result.pupils_changed %>
     <% r.with_var val: result.activation_date, unit: :date_mmm_yyyy %>
 
     <% r.with_var val: result.storage_heater_previous_period_kwh_unadjusted, unit: :kwh %>
@@ -18,15 +21,15 @@
                   change: true,
                   unit: :relative_percent_0dp %>
 
-    <% r.with_var val: result.storage_heater_previous_period_co2, unit: :kwh %>
-    <% r.with_var val: result.storage_heater_current_period_co2, unit: :kwh %>
+    <% r.with_var val: result.storage_heater_previous_period_co2, unit: :co2 %>
+    <% r.with_var val: result.storage_heater_current_period_co2, unit: :co2 %>
     <% r.with_var val: percent_change(result.storage_heater_previous_period_co2,
                                       result.storage_heater_current_period_co2),
                   change: true,
                   unit: :relative_percent_0dp %>
 
-    <% r.with_var val: result.storage_heater_previous_period_gbp, unit: :kwh %>
-    <% r.with_var val: result.storage_heater_current_period_gbp, unit: :kwh %>
+    <% r.with_var val: result.storage_heater_previous_period_gbp, unit: :£ %>
+    <% r.with_var val: result.storage_heater_current_period_gbp, unit: :£ %>
     <% r.with_var val: percent_change(result.storage_heater_previous_period_gbp,
                                       result.storage_heater_current_period_gbp),
                   change: true,

--- a/app/views/comparisons/heat_saver_march2024/_storage_heater.html.erb
+++ b/app/views/comparisons/heat_saver_march2024/_storage_heater.html.erb
@@ -3,7 +3,7 @@
 <%= component 'comparison_table',
               report: report, advice_page: advice_page, table_name: table_name, index_params: index_params,
               headers: @heating_headers, colgroups: @heating_colgroups, advice_page_tab: advice_page_tab do |c| %>
-  <% @results.where.not(storage_heater_previous_period_kwh: nil).find_each do |result| %>
+  <% @results.where.not(storage_heater_previous_period_kwh: nil).each do |result| %>
     <% c.with_row do |r| %>
     <% r.with_school school: result.school %>
     <% r.with_reference key: 'tariff_changed_last_year',

--- a/app/views/comparisons/heat_saver_march2024/_storage_heater.html.erb
+++ b/app/views/comparisons/heat_saver_march2024/_storage_heater.html.erb
@@ -1,0 +1,39 @@
+<%= render 'table_title', table_number: table_number, table_title: t('comparisons.tables.storage_heater_usage') %>
+
+<%= component 'comparison_table',
+              report: report, advice_page: advice_page, table_name: table_name, index_params: index_params,
+              headers: @heating_headers, colgroups: @heating_colgroups, advice_page_tab: advice_page_tab do |c| %>
+  <% @results.where.not(storage_heater_previous_period_kwh: nil).find_each do |result| %>
+    <% c.with_row do |r| %>
+    <% r.with_school school: result.school %>
+    <% r.with_reference key: 'tariff_changed_last_year',
+                        if: result.storage_heater_tariff_has_changed %>
+    <% r.with_var val: result.activation_date, unit: :date_mmm_yyyy %>
+
+    <% r.with_var val: result.storage_heater_previous_period_kwh_unadjusted, unit: :kwh %>
+    <% r.with_var val: result.storage_heater_previous_period_kwh, unit: :kwh %>
+    <% r.with_var val: result.storage_heater_current_period_kwh, unit: :kwh %>
+    <% r.with_var val: percent_change(result.storage_heater_previous_period_kwh,
+                                      result.storage_heater_current_period_kwh),
+                  change: true,
+                  unit: :relative_percent_0dp %>
+
+    <% r.with_var val: result.storage_heater_previous_period_co2, unit: :kwh %>
+    <% r.with_var val: result.storage_heater_current_period_co2, unit: :kwh %>
+    <% r.with_var val: percent_change(result.storage_heater_previous_period_co2,
+                                      result.storage_heater_current_period_co2),
+                  change: true,
+                  unit: :relative_percent_0dp %>
+
+    <% r.with_var val: result.storage_heater_previous_period_gbp, unit: :kwh %>
+    <% r.with_var val: result.storage_heater_current_period_gbp, unit: :kwh %>
+    <% r.with_var val: percent_change(result.storage_heater_previous_period_gbp,
+                                      result.storage_heater_current_period_gbp),
+                  change: true,
+                  unit: :relative_percent_0dp %>
+
+    <% end %>
+  <% end %>
+  <% c.with_note do %>
+  <% end %>
+<% end %>

--- a/app/views/comparisons/heat_saver_march2024/_table_title.html.erb
+++ b/app/views/comparisons/heat_saver_march2024/_table_title.html.erb
@@ -1,0 +1,5 @@
+<h4>
+  <%= t('comparisons.tables.table_title',
+        table_number: table_number,
+        table_title: table_title) %>
+</h4>

--- a/app/views/comparisons/heat_saver_march2024/_total.csv.ruby
+++ b/app/views/comparisons/heat_saver_march2024/_total.csv.ruby
@@ -1,0 +1,9 @@
+CSV.generate do |csv|
+  # headers
+  csv << @headers
+  @results.each do |result|
+    csv << [
+      result.school.name
+    ]
+  end
+end.html_safe

--- a/app/views/comparisons/heat_saver_march2024/_total.csv.ruby
+++ b/app/views/comparisons/heat_saver_march2024/_total.csv.ruby
@@ -14,7 +14,8 @@ CSV.generate do |csv|
 
   csv << @headers
   @results.each do |result|
-    data = [result.school.name, '']
+    data = [result.school.name]
+    data << result.fuel_type_names
     data << result.activation_date.iso8601
     %i[kwh co2 £].each do |unit|
       data << format_unit(result.total_previous_period(unit: unit), Float, true, :benchmark)

--- a/app/views/comparisons/heat_saver_march2024/_total.csv.ruby
+++ b/app/views/comparisons/heat_saver_march2024/_total.csv.ruby
@@ -1,9 +1,26 @@
 CSV.generate do |csv|
-  # headers
+  csv << [
+    "", "", "",
+    t('analytics.benchmarking.configuration.column_groups.kwh'),
+    "",
+    "",
+    t('analytics.benchmarking.configuration.column_groups.co2_kg'),
+    "",
+    "",
+    t('analytics.benchmarking.configuration.column_groups.gbp'),
+    "",
+    ""
+  ]
+
   csv << @headers
   @results.each do |result|
-    csv << [
-      result.school.name
-    ]
+    data = [result.school.name, '']
+    data << result.activation_date.iso8601
+    %i[kwh co2 £].each do |unit|
+      data << format_unit(result.total_previous_period(unit: unit), Float, true, :benchmark)
+      data << format_unit(result.total_current_period(unit: unit), Float, true, :benchmark)
+      data << format_unit(result.total_percentage_change(unit: unit) * 100, Float, true, :benchmark)
+    end
+    csv << data
   end
 end.html_safe

--- a/app/views/comparisons/heat_saver_march2024/_total.html.erb
+++ b/app/views/comparisons/heat_saver_march2024/_total.html.erb
@@ -38,14 +38,11 @@
       <% r.with_var val: result.activation_date, unit: :date_mmm_yyyy %>
 
       <% %i[kwh co2 £].each do |unit| %>
-         <%= r.with_var val: sum_if_complete(result.all_previous_period(unit: unit),
-                                             result.all_current_period(unit: unit)),
+         <%= r.with_var val: result.total_current_period(unit: unit),
                         unit: unit %>
-         <%= r.with_var val: sum_data(result.all_current_period(unit: unit)), unit: unit %>
-         <%= r.with_var val: percent_change(
-               sum_if_complete(result.all_previous_period(unit: unit), result.all_current_period(unit: unit)),
-               sum_data(result.all_current_period(unit: unit))
-             ),
+         <%= r.with_var val: result.total_previous_period(unit: unit),
+                        unit: unit %>
+         <%= r.with_var val: result.total_percentage_change(unit: unit),
                         change: true,
                         unit: :relative_percent_0dp %>
      <% end %>

--- a/app/views/comparisons/heat_saver_march2024/_total.html.erb
+++ b/app/views/comparisons/heat_saver_march2024/_total.html.erb
@@ -1,0 +1,55 @@
+<%= render 'table_title', table_number: table_number, table_title: t('comparisons.tables.total_usage') %>
+
+<%= component 'comparison_table',
+              report: report, advice_page: advice_page, table_name: table_name, index_params: index_params,
+              headers: headers, colgroups: colgroups, advice_page_tab: advice_page_tab do |c| %>
+  <%= period_type_string = t('comparisons.period_types.periods') %>
+  <% @results.each do |result| %>
+    <% c.with_row do |r| %>
+
+      <% r.with_school school: result.school %>
+      <% r.with_reference key: 'tariff_changed_last_year',
+                          if: result.any_tariff_changed? %>
+      <% r.with_reference key: 'electricity_change_rows',
+                          period_type_string: period_type_string,
+                          if: result.pupils_changed %>
+      <% r.with_reference key: 'gas_change_rows',
+                          period_type_string: period_type_string,
+                          schools_to_sentence: 'some schools',
+                          if: result.floor_area_changed %>
+      <%= r.with_var do %>
+        <% if !result.electricity_current_period_kwh.nil? %>
+          <span class="<%= fuel_type_class(:electricity) %>">
+            <%= fa_icon(fuel_type_icon(:electricity)) %>
+          </span>
+        <% end %>
+        <% if !result.gas_current_period_kwh.nil? %>
+          <span class="<%= fuel_type_class(:gas) %>">
+            <%= fa_icon(fuel_type_icon(:gas)) %>
+          </span>
+        <% end %>
+        <% if !result.storage_heater_current_period_kwh.nil? %>
+          <span class="<%= fuel_type_class(:storage_heater) %>">
+            <%= fa_icon(fuel_type_icon(:storage_heater)) %>
+          </span>
+        <% end %>
+      <% end %>
+
+      <% r.with_var val: result.activation_date, unit: :date_mmm_yyyy %>
+
+      <% %i[kwh co2 £].each do |unit| %>
+         <%= r.with_var val: sum_if_complete(result.all_previous_period(unit: unit),
+                                             result.all_current_period(unit: unit)),
+                        unit: unit %>
+         <%= r.with_var val: sum_data(result.all_current_period(unit: unit)), unit: unit %>
+         <%= r.with_var val: percent_change(
+               sum_if_complete(result.all_previous_period(unit: unit), result.all_current_period(unit: unit)),
+               sum_data(result.all_current_period(unit: unit))
+             ),
+                        change: true,
+                        unit: :relative_percent_0dp %>
+     <% end %>
+
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/comparisons/heat_saver_march2024/_total.html.erb
+++ b/app/views/comparisons/heat_saver_march2024/_total.html.erb
@@ -3,18 +3,16 @@
 <%= component 'comparison_table',
               report: report, advice_page: advice_page, table_name: table_name, index_params: index_params,
               headers: headers, colgroups: colgroups, advice_page_tab: advice_page_tab do |c| %>
-  <%= period_type_string = t('comparisons.period_types.periods') %>
   <% @results.each do |result| %>
     <% c.with_row do |r| %>
-
       <% r.with_school school: result.school %>
       <% r.with_reference key: 'tariff_changed_last_year',
                           if: result.any_tariff_changed? %>
       <% r.with_reference key: 'electricity_change_rows',
-                          period_type_string: period_type_string,
+                          period_type_string: @period_type_string,
                           if: result.pupils_changed %>
       <% r.with_reference key: 'gas_change_rows',
-                          period_type_string: period_type_string,
+                          period_type_string: @period_type_string,
                           schools_to_sentence: 'some schools',
                           if: result.floor_area_changed %>
       <%= r.with_var do %>
@@ -38,9 +36,9 @@
       <% r.with_var val: result.activation_date, unit: :date_mmm_yyyy %>
 
       <% %i[kwh co2 £].each do |unit| %>
+        <%= r.with_var val: result.total_previous_period(unit: unit),
+                       unit: unit %>
          <%= r.with_var val: result.total_current_period(unit: unit),
-                        unit: unit %>
-         <%= r.with_var val: result.total_previous_period(unit: unit),
                         unit: unit %>
          <%= r.with_var val: result.total_percentage_change(unit: unit),
                         change: true,

--- a/config/locales/analytics/alerts/gas/boilercontrol.yml
+++ b/config/locales/analytics/alerts/gas/boilercontrol.yml
@@ -4,13 +4,10 @@ en:
     alert_heating_coming_on_too_early:
       timescale: 7 days
     alert_heating_hot_water_on_during_holiday_base:
-      both: the hot water has been left on on %{hotwater_days} and the heating on %{heating_days}
-      heating_not_on: Well done you have used no gas this holiday.
-      only_heating: the heating has been left on on %{heating_days}
-      only_hotwater: the hot water has been left on on %{hotwater_days}
+      heating_not_on: Well done your heating has not been on this holiday
       summary: |
         Your %{heating_type} has been left on over the %{holiday_name} holiday. Up
-        until %{date} %{left_on_message} costing %{cost}, and a projected %{project_cost} by the end of the holiday.
+        until %{date} this has cost %{cost}. With a projected cost of %{project_cost} by the end of the holiday.
       timescale: this holiday
     alert_heating_sensitivity_advice:
       timescale: year

--- a/config/locales/analytics/benchmarking/content_base.yml
+++ b/config/locales/analytics/benchmarking/content_base.yml
@@ -61,6 +61,7 @@ en:
         electricity_targets: Progress against electricity target
         gas_consumption_during_holiday: Gas use during current holiday
         gas_targets: Progress against gas target
+        heat_saver_march_2024: Heat Saver March 2024
         heating_coming_on_too_early: Heating start time
         heating_in_warm_weather: Heating used in warm weather
         holiday_usage_last_year: Cost of energy used in upcoming holiday last year

--- a/config/locales/views/comparisons/comparisons.yml
+++ b/config/locales/views/comparisons/comparisons.yml
@@ -2,8 +2,19 @@
 en:
   comparisons:
     column_headings:
+      current_period: Latest period
       last_year_electricity_kwh_floor_area: Last year electricity kWh/floor area
       last_year_energy_kgco2_floor_area: Last year energy kgCO2/floor area
       last_year_energy_kwh_floor_area: Last year energy kWh/floor area
       last_year_gas_kwh_floor_area: Last year gas kWh/floor area
       last_year_storage_heater_kwh_floor_area: Last year storage heater kWh/floor area
+      previous_period: Previous period
+      previous_period_unadjusted: Previous period (not adjusted)
+    period_types:
+      periods: periods
+    tables:
+      electricity_usage: Electricity usage comparison
+      gas_usage: Gas usage comparison
+      storage_heater_usage: Storage heater usage comparison
+      table_title: 'Table %{table_number}: %{table_title}'
+      total_usage: Total energy usage comparison

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -82,6 +82,7 @@ Rails.application.routes.draw do
   end
 
   namespace :comparisons do
+    resources :heat_saver_march_2024, only: [:index]
     resources :annual_change_in_electricity_out_of_hours_use, only: [:index]
     resources :annual_change_in_gas_out_of_hours_use, only: [:index]
     resources :annual_change_in_storage_heater_out_of_hours_use, only: [:index]

--- a/db/migrate/20240417104449_create_heat_saver_march_2024s.rb
+++ b/db/migrate/20240417104449_create_heat_saver_march_2024s.rb
@@ -1,0 +1,5 @@
+class CreateHeatSaverMarch2024s < ActiveRecord::Migration[6.1]
+  def change
+    create_view :heat_saver_march_2024s
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_03_25_112425) do
+ActiveRecord::Schema.define(version: 2024_04_17_104449) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
@@ -2119,225 +2119,125 @@ ActiveRecord::Schema.define(version: 2024_03_25_112425) do
   add_foreign_key "users", "staff_roles", on_delete: :restrict
   add_foreign_key "weather_observations", "weather_stations", on_delete: :cascade
 
-  create_view "baseload_per_pupils", sql_definition: <<-SQL
+  create_view "annual_change_in_electricity_out_of_hours_uses", sql_definition: <<-SQL
       SELECT latest_runs.id,
-      additional.school_id,
-      baseload.alert_generation_run_id,
-      baseload.average_baseload_last_year_kw,
-      baseload.average_baseload_last_year_gbp,
-      baseload.one_year_baseload_per_pupil_kw,
-      baseload.annual_baseload_percent,
-      baseload.one_year_saving_versus_exemplar_gbp,
-      additional.electricity_economic_tariff_changed_this_year
+      usage.alert_generation_run_id,
+      usage.school_id,
+      usage.out_of_hours_kwh,
+      usage.out_of_hours_co2,
+      usage.out_of_hours_gbpcurrent,
+      usage_previous_year.previous_out_of_hours_kwh,
+      usage_previous_year.previous_out_of_hours_co2,
+      usage_previous_year.previous_out_of_hours_gbpcurrent,
+      additional.economic_tariff_changed_this_year
      FROM ( SELECT alerts.alert_generation_run_id,
-              data.average_baseload_last_year_kw,
-              data.average_baseload_last_year_gbp,
-              data.one_year_baseload_per_pupil_kw,
-              data.annual_baseload_percent,
-              data.one_year_saving_versus_exemplar_gbp
+              alerts.school_id,
+              json.out_of_hours_kwh,
+              json.out_of_hours_co2,
+              json.out_of_hours_gbpcurrent
              FROM alerts,
               alert_types,
-              LATERAL jsonb_to_record(alerts.variables) data(average_baseload_last_year_kw double precision, average_baseload_last_year_gbp double precision, one_year_baseload_per_pupil_kw double precision, annual_baseload_percent double precision, one_year_saving_versus_exemplar_gbp double precision)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertElectricityBaseloadVersusBenchmark'::text))) baseload,
+              LATERAL jsonb_to_record(alerts.variables) json(out_of_hours_kwh double precision, out_of_hours_co2 double precision, out_of_hours_gbpcurrent double precision)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertOutOfHoursElectricityUsage'::text))) usage,
       ( SELECT alerts.alert_generation_run_id,
               alerts.school_id,
-              data.electricity_economic_tariff_changed_this_year
+              json.out_of_hours_kwh AS previous_out_of_hours_kwh,
+              json.out_of_hours_co2 AS previous_out_of_hours_co2,
+              json.out_of_hours_gbpcurrent AS previous_out_of_hours_gbpcurrent
              FROM alerts,
               alert_types,
-              LATERAL jsonb_to_record(alerts.variables) data(electricity_economic_tariff_changed_this_year boolean)
+              LATERAL jsonb_to_record(alerts.variables) json(out_of_hours_kwh double precision, out_of_hours_co2 double precision, out_of_hours_gbpcurrent double precision)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertOutOfHoursElectricityUsagePreviousYear'::text))) usage_previous_year,
+      ( SELECT alerts.alert_generation_run_id,
+              json.electricity_economic_tariff_changed_this_year AS economic_tariff_changed_this_year
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) json(electricity_economic_tariff_changed_this_year boolean)
             WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertAdditionalPrioritisationData'::text))) additional,
       ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
              FROM alert_generation_runs
             ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
-    WHERE ((baseload.alert_generation_run_id = latest_runs.id) AND (additional.alert_generation_run_id = latest_runs.id));
+    WHERE ((usage.alert_generation_run_id = latest_runs.id) AND (usage_previous_year.alert_generation_run_id = latest_runs.id) AND (additional.alert_generation_run_id = latest_runs.id));
   SQL
-  create_view "change_in_electricity_since_last_years", sql_definition: <<-SQL
+  create_view "annual_change_in_gas_out_of_hours_uses", sql_definition: <<-SQL
       SELECT latest_runs.id,
-      enba.school_id,
-      enba.previous_year_electricity_kwh,
-      enba.current_year_electricity_kwh,
-      enba.previous_year_electricity_co2,
-      enba.current_year_electricity_co2,
-      enba.previous_year_electricity_gbp,
-      enba.current_year_electricity_gbp,
-      enba.solar_type
+      usage.alert_generation_run_id,
+      usage.school_id,
+      usage.out_of_hours_kwh,
+      usage.out_of_hours_co2,
+      usage.out_of_hours_gbpcurrent,
+      usage_previous_year.previous_out_of_hours_kwh,
+      usage_previous_year.previous_out_of_hours_co2,
+      usage_previous_year.previous_out_of_hours_gbpcurrent,
+      additional.economic_tariff_changed_this_year
      FROM ( SELECT alerts.alert_generation_run_id,
               alerts.school_id,
-              data.previous_year_electricity_kwh,
-              data.current_year_electricity_kwh,
-              data.previous_year_electricity_co2,
-              data.current_year_electricity_co2,
-              data.previous_year_electricity_gbp,
-              data.current_year_electricity_gbp,
-              data.solar_type
+              json.out_of_hours_kwh,
+              json.out_of_hours_co2,
+              json.out_of_hours_gbpcurrent
              FROM alerts,
               alert_types,
-              LATERAL jsonb_to_record(alerts.variables) data(previous_year_electricity_kwh double precision, current_year_electricity_kwh double precision, previous_year_electricity_co2 double precision, current_year_electricity_co2 double precision, previous_year_electricity_gbp double precision, current_year_electricity_gbp double precision, solar_type text)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertEnergyAnnualVersusBenchmark'::text))) enba,
-      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
-             FROM alert_generation_runs
-            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
-    WHERE (enba.alert_generation_run_id = latest_runs.id);
-  SQL
-  create_view "electricity_peak_kw_per_pupils", sql_definition: <<-SQL
-      SELECT latest_runs.id,
-      data.alert_generation_run_id,
-      data.school_id,
-      data.average_school_day_last_year_kw_per_floor_area,
-      data.average_school_day_last_year_kw,
-      data.exemplar_kw,
-      data.one_year_saving_versus_exemplar_gbp,
-      additional.electricity_economic_tariff_changed_this_year
-     FROM ( SELECT alerts.alert_generation_run_id,
-              alerts.school_id,
-              data_1.average_school_day_last_year_kw_per_floor_area,
-              data_1.average_school_day_last_year_kw,
-              data_1.exemplar_kw,
-              data_1.one_year_saving_versus_exemplar_gbp
-             FROM alerts,
-              alert_types,
-              LATERAL jsonb_to_record(alerts.variables) data_1(average_school_day_last_year_kw_per_floor_area double precision, average_school_day_last_year_kw double precision, exemplar_kw double precision, one_year_saving_versus_exemplar_gbp double precision)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertElectricityPeakKWVersusBenchmark'::text))) data,
+              LATERAL jsonb_to_record(alerts.variables) json(out_of_hours_kwh double precision, out_of_hours_co2 double precision, out_of_hours_gbpcurrent double precision)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertOutOfHoursGasUsage'::text))) usage,
       ( SELECT alerts.alert_generation_run_id,
-              data_1.electricity_economic_tariff_changed_this_year
+              alerts.school_id,
+              json.out_of_hours_kwh AS previous_out_of_hours_kwh,
+              json.out_of_hours_co2 AS previous_out_of_hours_co2,
+              json.out_of_hours_gbpcurrent AS previous_out_of_hours_gbpcurrent
              FROM alerts,
               alert_types,
-              LATERAL jsonb_to_record(alerts.variables) data_1(electricity_economic_tariff_changed_this_year boolean)
+              LATERAL jsonb_to_record(alerts.variables) json(out_of_hours_kwh double precision, out_of_hours_co2 double precision, out_of_hours_gbpcurrent double precision)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertOutOfHoursGasUsagePreviousYear'::text))) usage_previous_year,
+      ( SELECT alerts.alert_generation_run_id,
+              json.gas_economic_tariff_changed_this_year AS economic_tariff_changed_this_year
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) json(gas_economic_tariff_changed_this_year boolean)
             WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertAdditionalPrioritisationData'::text))) additional,
       ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
              FROM alert_generation_runs
             ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
-    WHERE ((data.alert_generation_run_id = latest_runs.id) AND (additional.alert_generation_run_id = latest_runs.id));
+    WHERE ((usage.alert_generation_run_id = latest_runs.id) AND (usage_previous_year.alert_generation_run_id = latest_runs.id) AND (additional.alert_generation_run_id = latest_runs.id));
   SQL
-  create_view "electricity_targets", sql_definition: <<-SQL
+  create_view "annual_change_in_storage_heater_out_of_hours_uses", sql_definition: <<-SQL
       SELECT latest_runs.id,
-      data.alert_generation_run_id,
-      data.school_id,
-      data.current_year_percent_of_target_relative,
-      data.current_year_unscaled_percent_of_target_relative,
-      data.current_year_kwh,
-      data.current_year_target_kwh,
-      data.unscaled_target_kwh_to_date,
-      data.tracking_start_date
+      usage.alert_generation_run_id,
+      usage.school_id,
+      usage.out_of_hours_kwh,
+      usage.out_of_hours_co2,
+      usage.out_of_hours_gbpcurrent,
+      usage_previous_year.previous_out_of_hours_kwh,
+      usage_previous_year.previous_out_of_hours_co2,
+      usage_previous_year.previous_out_of_hours_gbpcurrent,
+      additional.economic_tariff_changed_this_year
      FROM ( SELECT alerts.alert_generation_run_id,
               alerts.school_id,
-              data_1.current_year_percent_of_target_relative,
-              data_1.current_year_unscaled_percent_of_target_relative,
-              data_1.current_year_kwh,
-              data_1.current_year_target_kwh,
-              data_1.unscaled_target_kwh_to_date,
-              data_1.tracking_start_date
+              json.out_of_hours_kwh,
+              json.out_of_hours_co2,
+              json.out_of_hours_gbpcurrent
              FROM alerts,
               alert_types,
-              LATERAL jsonb_to_record(alerts.variables) data_1(current_year_percent_of_target_relative double precision, current_year_unscaled_percent_of_target_relative double precision, current_year_kwh double precision, current_year_target_kwh double precision, unscaled_target_kwh_to_date double precision, tracking_start_date date)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertElectricityTargetAnnual'::text))) data,
+              LATERAL jsonb_to_record(alerts.variables) json(out_of_hours_kwh double precision, out_of_hours_co2 double precision, out_of_hours_gbpcurrent double precision)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertStorageHeaterOutOfHours'::text))) usage,
+      ( SELECT alerts.alert_generation_run_id,
+              alerts.school_id,
+              json.out_of_hours_kwh AS previous_out_of_hours_kwh,
+              json.out_of_hours_co2 AS previous_out_of_hours_co2,
+              json.out_of_hours_gbpcurrent AS previous_out_of_hours_gbpcurrent
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) json(out_of_hours_kwh double precision, out_of_hours_co2 double precision, out_of_hours_gbpcurrent double precision)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertOutOfHoursStorageHeaterUsagePreviousYear'::text))) usage_previous_year,
+      ( SELECT alerts.alert_generation_run_id,
+              json.electricity_economic_tariff_changed_this_year AS economic_tariff_changed_this_year
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) json(electricity_economic_tariff_changed_this_year boolean)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertAdditionalPrioritisationData'::text))) additional,
       ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
              FROM alert_generation_runs
             ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
-    WHERE (data.alert_generation_run_id = latest_runs.id);
-  SQL
-  create_view "change_in_electricity_holiday_consumption_previous_years_holida", sql_definition: <<-SQL
-      SELECT latest_runs.id,
-      data.alert_generation_run_id,
-      data.school_id,
-      data.current_period_type,
-      data.current_period_start_date,
-      data.current_period_end_date,
-      data.difference_gbpcurrent,
-      data.difference_kwh,
-      data.difference_percent,
-      data.previous_period_type,
-      data.previous_period_start_date,
-      data.previous_period_end_date,
-      data.pupils_changed,
-      data.tariff_has_changed,
-      data.truncated_current_period
-     FROM ( SELECT alerts.alert_generation_run_id,
-              alerts.school_id,
-              data_1.current_period_type,
-              data_1.current_period_start_date,
-              data_1.current_period_end_date,
-              data_1.difference_gbpcurrent,
-              data_1.difference_kwh,
-              data_1.difference_percent,
-              data_1.previous_period_type,
-              data_1.previous_period_start_date,
-              data_1.previous_period_end_date,
-              data_1.pupils_changed,
-              data_1.tariff_has_changed,
-              data_1.truncated_current_period
-             FROM alerts,
-              alert_types,
-              LATERAL jsonb_to_record(alerts.variables) data_1(current_period_type text, current_period_start_date date, current_period_end_date date, difference_gbpcurrent double precision, difference_kwh double precision, difference_percent double precision, previous_period_type text, previous_period_start_date date, previous_period_end_date date, pupils_changed boolean, tariff_has_changed boolean, truncated_current_period boolean)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertPreviousYearHolidayComparisonElectricity'::text))) data,
-      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
-             FROM alert_generation_runs
-            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
-    WHERE (data.alert_generation_run_id = latest_runs.id);
-  SQL
-  create_view "change_in_electricity_holiday_consumption_previous_holidays", sql_definition: <<-SQL
-      SELECT latest_runs.id,
-      data.alert_generation_run_id,
-      data.school_id,
-      data.difference_percent,
-      data.difference_gbpcurrent,
-      data.difference_kwh,
-      data.current_period_type,
-      data.current_period_start_date,
-      data.current_period_end_date,
-      data.truncated_current_period,
-      data.previous_period_type,
-      data.previous_period_start_date,
-      data.previous_period_end_date,
-      data.pupils_changed,
-      data.tariff_has_changed
-     FROM ( SELECT alerts.alert_generation_run_id,
-              alerts.school_id,
-              data_1.difference_percent,
-              data_1.difference_gbpcurrent,
-              data_1.difference_kwh,
-              data_1.current_period_type,
-              data_1.current_period_start_date,
-              data_1.current_period_end_date,
-              data_1.truncated_current_period,
-              data_1.previous_period_type,
-              data_1.previous_period_start_date,
-              data_1.previous_period_end_date,
-              data_1.pupils_changed,
-              data_1.tariff_has_changed
-             FROM alerts,
-              alert_types,
-              LATERAL jsonb_to_record(alerts.variables) data_1(difference_percent double precision, difference_gbpcurrent double precision, difference_kwh double precision, current_period_type text, current_period_start_date date, current_period_end_date date, truncated_current_period boolean, previous_period_type text, previous_period_start_date date, previous_period_end_date date, pupils_changed boolean, tariff_has_changed boolean)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertPreviousHolidayComparisonElectricity'::text))) data,
-      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
-             FROM alert_generation_runs
-            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
-    WHERE (data.alert_generation_run_id = latest_runs.id);
-  SQL
-  create_view "change_in_electricity_consumption_recent_school_weeks", sql_definition: <<-SQL
-      SELECT latest_runs.id,
-      data.alert_generation_run_id,
-      data.school_id,
-      data.difference_percent,
-      data.difference_gbpcurrent,
-      data.difference_kwh,
-      data.pupils_changed,
-      data.tariff_has_changed
-     FROM ( SELECT alerts.alert_generation_run_id,
-              alerts.school_id,
-              data_1.difference_percent,
-              data_1.difference_gbpcurrent,
-              data_1.difference_kwh,
-              data_1.pupils_changed,
-              data_1.tariff_has_changed
-             FROM alerts,
-              alert_types,
-              LATERAL jsonb_to_record(alerts.variables) data_1(difference_percent double precision, difference_gbpcurrent double precision, difference_kwh double precision, pupils_changed boolean, tariff_has_changed boolean)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertSchoolWeekComparisonElectricity'::text))) data,
-      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
-             FROM alert_generation_runs
-            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
-    WHERE (data.alert_generation_run_id = latest_runs.id);
+    WHERE ((usage.alert_generation_run_id = latest_runs.id) AND (usage_previous_year.alert_generation_run_id = latest_runs.id) AND (additional.alert_generation_run_id = latest_runs.id));
   SQL
   create_view "annual_electricity_costs_per_pupils", sql_definition: <<-SQL
       SELECT latest_runs.id,
@@ -2398,389 +2298,47 @@ ActiveRecord::Schema.define(version: 2024_03_25_112425) do
             ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
     WHERE ((data.alert_generation_run_id = latest_runs.id) AND (additional.alert_generation_run_id = latest_runs.id));
   SQL
-  create_view "weekday_baseload_variations", sql_definition: <<-SQL
-      SELECT latest_runs.id,
-      additional.school_id,
-      data.alert_generation_run_id,
-      data.percent_intraday_variation,
-      data.min_day_kw,
-      data.max_day_kw,
-      data.min_day,
-      data.max_day,
-      data.annual_cost_gbpcurrent,
-      additional.electricity_economic_tariff_changed_this_year
-     FROM ( SELECT alerts.alert_generation_run_id,
-              data_1.percent_intraday_variation,
-              data_1.min_day_kw,
-              data_1.max_day_kw,
-              data_1.min_day,
-              data_1.max_day,
-              data_1.annual_cost_gbpcurrent
-             FROM alerts,
-              alert_types,
-              LATERAL jsonb_to_record(alerts.variables) data_1(percent_intraday_variation double precision, min_day_kw double precision, max_day_kw double precision, min_day integer, max_day integer, annual_cost_gbpcurrent double precision)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertIntraweekBaseloadVariation'::text))) data,
-      ( SELECT alerts.alert_generation_run_id,
-              alerts.school_id,
-              data_1.electricity_economic_tariff_changed_this_year
-             FROM alerts,
-              alert_types,
-              LATERAL jsonb_to_record(alerts.variables) data_1(electricity_economic_tariff_changed_this_year boolean)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertAdditionalPrioritisationData'::text))) additional,
-      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
-             FROM alert_generation_runs
-            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
-    WHERE ((data.alert_generation_run_id = latest_runs.id) AND (additional.alert_generation_run_id = latest_runs.id));
-  SQL
-  create_view "solar_generation_summaries", sql_definition: <<-SQL
-      SELECT latest_runs.id,
-      solar_generation.alert_generation_run_id,
-      solar_generation.school_id,
-      solar_generation.annual_electricity_kwh,
-      solar_generation.annual_mains_consumed_kwh,
-      solar_generation.annual_solar_pv_kwh,
-      solar_generation.annual_exported_solar_pv_kwh,
-      solar_generation.annual_solar_pv_consumed_onsite_kwh
-     FROM ( SELECT alerts.alert_generation_run_id,
-              alerts.school_id,
-              data.annual_electricity_kwh,
-              data.annual_mains_consumed_kwh,
-              data.annual_solar_pv_kwh,
-              data.annual_exported_solar_pv_kwh,
-              data.annual_solar_pv_consumed_onsite_kwh
-             FROM alerts,
-              alert_types,
-              LATERAL jsonb_to_record(alerts.variables) data(annual_electricity_kwh double precision, annual_mains_consumed_kwh double precision, annual_solar_pv_kwh double precision, annual_exported_solar_pv_kwh double precision, annual_solar_pv_consumed_onsite_kwh double precision)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertSolarGeneration'::text))) solar_generation,
-      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
-             FROM alert_generation_runs
-            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
-    WHERE (solar_generation.alert_generation_run_id = latest_runs.id);
-  SQL
-  create_view "solar_pv_benefit_estimates", sql_definition: <<-SQL
-      SELECT latest_runs.id,
-      additional.school_id,
-      benefit_estimate.alert_generation_run_id,
-      benefit_estimate.optimum_kwp,
-      benefit_estimate.optimum_payback_years,
-      benefit_estimate.optimum_mains_reduction_percent,
-      benefit_estimate.one_year_saving_gbpcurrent,
-      additional.electricity_economic_tariff_changed_this_year
-     FROM ( SELECT alerts.alert_generation_run_id,
-              data.optimum_kwp,
-              data.optimum_payback_years,
-              data.optimum_mains_reduction_percent,
-              data.one_year_saving_gbpcurrent
-             FROM alerts,
-              alert_types,
-              LATERAL jsonb_to_record(alerts.variables) data(optimum_kwp double precision, optimum_payback_years double precision, optimum_mains_reduction_percent double precision, one_year_saving_gbpcurrent double precision)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertSolarPVBenefitEstimator'::text))) benefit_estimate,
-      ( SELECT alerts.alert_generation_run_id,
-              alerts.school_id,
-              data.electricity_economic_tariff_changed_this_year
-             FROM alerts,
-              alert_types,
-              LATERAL jsonb_to_record(alerts.variables) data(electricity_economic_tariff_changed_this_year boolean)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertAdditionalPrioritisationData'::text))) additional,
-      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
-             FROM alert_generation_runs
-            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
-    WHERE ((benefit_estimate.alert_generation_run_id = latest_runs.id) AND (additional.alert_generation_run_id = latest_runs.id));
-  SQL
-  create_view "recent_change_in_baseloads", sql_definition: <<-SQL
-      SELECT latest_runs.id,
-      data.alert_generation_run_id,
-      data.school_id,
-      data.predicted_percent_increase_in_usage,
-      data.average_baseload_last_year_kw,
-      data.average_baseload_last_week_kw,
-      data.change_in_baseload_kw,
-      data.next_year_change_in_baseload_gbpcurrent,
-      additional.electricity_economic_tariff_changed_this_year
-     FROM ( SELECT alerts.alert_generation_run_id,
-              alerts.school_id,
-              data_1.predicted_percent_increase_in_usage,
-              data_1.average_baseload_last_year_kw,
-              data_1.average_baseload_last_week_kw,
-              data_1.change_in_baseload_kw,
-              data_1.next_year_change_in_baseload_gbpcurrent
-             FROM alerts,
-              alert_types,
-              LATERAL jsonb_to_record(alerts.variables) data_1(predicted_percent_increase_in_usage double precision, average_baseload_last_year_kw double precision, average_baseload_last_week_kw double precision, change_in_baseload_kw double precision, next_year_change_in_baseload_gbpcurrent double precision)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertChangeInElectricityBaseloadShortTerm'::text))) data,
-      ( SELECT alerts.alert_generation_run_id,
-              data_1.electricity_economic_tariff_changed_this_year
-             FROM alerts,
-              alert_types,
-              LATERAL jsonb_to_record(alerts.variables) data_1(electricity_economic_tariff_changed_this_year boolean)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertAdditionalPrioritisationData'::text))) additional,
-      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
-             FROM alert_generation_runs
-            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
-    WHERE ((data.alert_generation_run_id = latest_runs.id) AND (additional.alert_generation_run_id = latest_runs.id));
-  SQL
-  create_view "change_in_solar_pv_since_last_years", sql_definition: <<-SQL
-      SELECT latest_runs.id,
-      versus_benchmark.school_id,
-      versus_benchmark.previous_year_solar_pv_kwh,
-      versus_benchmark.current_year_solar_pv_kwh,
-      versus_benchmark.previous_year_solar_pv_co2,
-      versus_benchmark.current_year_solar_pv_co2,
-      versus_benchmark.solar_type
-     FROM ( SELECT alerts.alert_generation_run_id,
-              alerts.school_id,
-              data.previous_year_solar_pv_kwh,
-              data.current_year_solar_pv_kwh,
-              data.previous_year_solar_pv_co2,
-              data.current_year_solar_pv_co2,
-              data.solar_type
-             FROM alerts,
-              alert_types,
-              LATERAL jsonb_to_record(alerts.variables) data(previous_year_solar_pv_kwh double precision, current_year_solar_pv_kwh double precision, previous_year_solar_pv_co2 double precision, current_year_solar_pv_co2 double precision, solar_type text)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertEnergyAnnualVersusBenchmark'::text))) versus_benchmark,
-      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
-             FROM alert_generation_runs
-            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
-    WHERE (versus_benchmark.alert_generation_run_id = latest_runs.id);
-  SQL
-  create_view "seasonal_baseload_variations", sql_definition: <<-SQL
-      SELECT latest_runs.id,
-      additional.school_id,
-      data.alert_generation_run_id,
-      data.percent_seasonal_variation,
-      data.summer_kw,
-      data.winter_kw,
-      data.annual_cost_gbpcurrent,
-      additional.electricity_economic_tariff_changed_this_year
-     FROM ( SELECT alerts.alert_generation_run_id,
-              data_1.percent_seasonal_variation,
-              data_1.summer_kw,
-              data_1.winter_kw,
-              data_1.annual_cost_gbpcurrent
-             FROM alerts,
-              alert_types,
-              LATERAL jsonb_to_record(alerts.variables) data_1(percent_seasonal_variation double precision, summer_kw double precision, winter_kw double precision, annual_cost_gbpcurrent double precision)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertSeasonalBaseloadVariation'::text))) data,
-      ( SELECT alerts.alert_generation_run_id,
-              alerts.school_id,
-              data_1.electricity_economic_tariff_changed_this_year
-             FROM alerts,
-              alert_types,
-              LATERAL jsonb_to_record(alerts.variables) data_1(electricity_economic_tariff_changed_this_year boolean)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertAdditionalPrioritisationData'::text))) additional,
-      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
-             FROM alert_generation_runs
-            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
-    WHERE ((data.alert_generation_run_id = latest_runs.id) AND (additional.alert_generation_run_id = latest_runs.id));
-  SQL
-  create_view "change_in_gas_holiday_consumption_previous_holidays", sql_definition: <<-SQL
-      SELECT latest_runs.id,
-      data.alert_generation_run_id,
-      data.school_id,
-      data.difference_percent,
-      data.difference_gbpcurrent,
-      data.difference_kwh,
-      data.current_period_type,
-      data.current_period_start_date,
-      data.current_period_end_date,
-      data.truncated_current_period,
-      data.previous_period_type,
-      data.previous_period_start_date,
-      data.previous_period_end_date,
-      data.pupils_changed,
-      data.tariff_has_changed
-     FROM ( SELECT alerts.alert_generation_run_id,
-              alerts.school_id,
-              data_1.difference_percent,
-              data_1.difference_gbpcurrent,
-              data_1.difference_kwh,
-              data_1.current_period_type,
-              data_1.current_period_start_date,
-              data_1.current_period_end_date,
-              data_1.truncated_current_period,
-              data_1.previous_period_type,
-              data_1.previous_period_start_date,
-              data_1.previous_period_end_date,
-              data_1.pupils_changed,
-              data_1.tariff_has_changed
-             FROM alerts,
-              alert_types,
-              LATERAL jsonb_to_record(alerts.variables) data_1(difference_percent double precision, difference_gbpcurrent double precision, difference_kwh double precision, current_period_type text, current_period_start_date date, current_period_end_date date, truncated_current_period boolean, previous_period_type text, previous_period_start_date date, previous_period_end_date date, pupils_changed boolean, tariff_has_changed boolean)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertPreviousHolidayComparisonGas'::text))) data,
-      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
-             FROM alert_generation_runs
-            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
-    WHERE (data.alert_generation_run_id = latest_runs.id);
-  SQL
-  create_view "change_in_gas_holiday_consumption_previous_years_holidays", sql_definition: <<-SQL
-      SELECT latest_runs.id,
-      data.alert_generation_run_id,
-      data.school_id,
-      data.difference_percent,
-      data.difference_gbpcurrent,
-      data.difference_kwh,
-      data.current_period_type,
-      data.current_period_start_date,
-      data.current_period_end_date,
-      data.truncated_current_period,
-      data.previous_period_type,
-      data.previous_period_start_date,
-      data.previous_period_end_date,
-      data.pupils_changed,
-      data.tariff_has_changed
-     FROM ( SELECT alerts.alert_generation_run_id,
-              alerts.school_id,
-              data_1.difference_percent,
-              data_1.difference_gbpcurrent,
-              data_1.difference_kwh,
-              data_1.current_period_type,
-              data_1.current_period_start_date,
-              data_1.current_period_end_date,
-              data_1.truncated_current_period,
-              data_1.previous_period_type,
-              data_1.previous_period_start_date,
-              data_1.previous_period_end_date,
-              data_1.pupils_changed,
-              data_1.tariff_has_changed
-             FROM alerts,
-              alert_types,
-              LATERAL jsonb_to_record(alerts.variables) data_1(difference_percent double precision, difference_gbpcurrent double precision, difference_kwh double precision, current_period_type text, current_period_start_date date, current_period_end_date date, truncated_current_period boolean, previous_period_type text, previous_period_start_date date, previous_period_end_date date, pupils_changed boolean, tariff_has_changed boolean)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertPreviousYearHolidayComparisonGas'::text))) data,
-      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
-             FROM alert_generation_runs
-            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
-    WHERE (data.alert_generation_run_id = latest_runs.id);
-  SQL
-  create_view "change_in_gas_consumption_recent_school_weeks", sql_definition: <<-SQL
-      SELECT latest_runs.id,
-      data.alert_generation_run_id,
-      data.school_id,
-      data.difference_percent,
-      data.difference_gbpcurrent,
-      data.difference_kwh,
-      data.pupils_changed,
-      data.tariff_has_changed
-     FROM ( SELECT alerts.alert_generation_run_id,
-              alerts.school_id,
-              data_1.difference_percent,
-              data_1.difference_gbpcurrent,
-              data_1.difference_kwh,
-              data_1.pupils_changed,
-              data_1.tariff_has_changed
-             FROM alerts,
-              alert_types,
-              LATERAL jsonb_to_record(alerts.variables) data_1(difference_percent double precision, difference_gbpcurrent double precision, difference_kwh double precision, pupils_changed boolean, tariff_has_changed boolean)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertSchoolWeekComparisonGas'::text))) data,
-      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
-             FROM alert_generation_runs
-            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
-    WHERE (data.alert_generation_run_id = latest_runs.id);
-  SQL
-  create_view "storage_heater_consumption_during_holidays", sql_definition: <<-SQL
-      SELECT latest_runs.id,
-      data.alert_generation_run_id,
-      data.school_id,
-      data.holiday_projected_usage_gbp,
-      data.holiday_usage_to_date_gbp,
-      data.holiday_type,
-      data.holiday_start_date,
-      data.holiday_end_date
-     FROM ( SELECT alerts.alert_generation_run_id,
-              alerts.school_id,
-              data_1.holiday_projected_usage_gbp,
-              data_1.holiday_usage_to_date_gbp,
-              data_1.holiday_type,
-              data_1.holiday_start_date,
-              data_1.holiday_end_date
-             FROM alerts,
-              alert_types,
-              LATERAL jsonb_to_record(alerts.variables) data_1(holiday_projected_usage_gbp double precision, holiday_usage_to_date_gbp double precision, holiday_type text, holiday_start_date date, holiday_end_date date)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertStorageHeaterHeatingOnDuringHoliday'::text))) data,
-      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
-             FROM alert_generation_runs
-            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
-    WHERE (data.alert_generation_run_id = latest_runs.id);
-  SQL
-  create_view "electricity_consumption_during_holidays", sql_definition: <<-SQL
-      SELECT latest_runs.id,
-      data.alert_generation_run_id,
-      data.school_id,
-      data.holiday_projected_usage_gbp,
-      data.holiday_usage_to_date_gbp,
-      data.holiday_type,
-      data.holiday_start_date,
-      data.holiday_end_date
-     FROM ( SELECT alerts.alert_generation_run_id,
-              alerts.school_id,
-              data_1.holiday_projected_usage_gbp,
-              data_1.holiday_usage_to_date_gbp,
-              data_1.holiday_type,
-              data_1.holiday_start_date,
-              data_1.holiday_end_date
-             FROM alerts,
-              alert_types,
-              LATERAL jsonb_to_record(alerts.variables) data_1(holiday_projected_usage_gbp double precision, holiday_usage_to_date_gbp double precision, holiday_type text, holiday_start_date date, holiday_end_date date)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertElectricityUsageDuringCurrentHoliday'::text))) data,
-      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
-             FROM alert_generation_runs
-            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
-    WHERE (data.alert_generation_run_id = latest_runs.id);
-  SQL
-  create_view "gas_consumption_during_holidays", sql_definition: <<-SQL
-      SELECT latest_runs.id,
-      data.alert_generation_run_id,
-      data.school_id,
-      data.holiday_projected_usage_gbp,
-      data.holiday_usage_to_date_gbp,
-      data.holiday_type,
-      data.holiday_start_date,
-      data.holiday_end_date
-     FROM ( SELECT alerts.alert_generation_run_id,
-              alerts.school_id,
-              data_1.holiday_projected_usage_gbp,
-              data_1.holiday_usage_to_date_gbp,
-              data_1.holiday_type,
-              data_1.holiday_start_date,
-              data_1.holiday_end_date
-             FROM alerts,
-              alert_types,
-              LATERAL jsonb_to_record(alerts.variables) data_1(holiday_projected_usage_gbp double precision, holiday_usage_to_date_gbp double precision, holiday_type text, holiday_start_date date, holiday_end_date date)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertGasHeatingHotWaterOnDuringHoliday'::text))) data,
-      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
-             FROM alert_generation_runs
-            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
-    WHERE (data.alert_generation_run_id = latest_runs.id);
-  SQL
-  create_view "annual_heating_costs_per_floor_areas", sql_definition: <<-SQL
-      WITH gas AS (
+  create_view "annual_energy_costs", sql_definition: <<-SQL
+      WITH electricity AS (
            SELECT alerts.alert_generation_run_id,
-              data.one_year_gas_per_floor_area_normalised_gbp,
-              data.last_year_gbp,
-              data.one_year_saving_versus_exemplar_gbpcurrent,
-              data.last_year_kwh,
-              data.last_year_co2
+              data.last_year_gbp
              FROM alerts,
               alert_types,
-              LATERAL jsonb_to_record(alerts.variables) data(one_year_gas_per_floor_area_normalised_gbp double precision, last_year_gbp double precision, one_year_saving_versus_exemplar_gbpcurrent double precision, last_year_kwh double precision, last_year_co2 double precision)
+              LATERAL jsonb_to_record(alerts.variables) data(last_year_gbp double precision)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertElectricityAnnualVersusBenchmark'::text))
+          ), gas AS (
+           SELECT alerts.alert_generation_run_id,
+              data.last_year_gbp
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) data(last_year_gbp double precision)
             WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertGasAnnualVersusBenchmark'::text))
           ), storage_heaters AS (
            SELECT alerts.alert_generation_run_id,
-              data.one_year_gas_per_floor_area_normalised_gbp,
-              data.last_year_gbp,
-              data.one_year_saving_versus_exemplar_gbpcurrent,
-              data.last_year_kwh,
-              data.last_year_co2
+              data.last_year_gbp
              FROM alerts,
               alert_types,
-              LATERAL jsonb_to_record(alerts.variables) data(one_year_gas_per_floor_area_normalised_gbp double precision, last_year_gbp double precision, one_year_saving_versus_exemplar_gbpcurrent double precision, last_year_kwh double precision, last_year_co2 double precision)
+              LATERAL jsonb_to_record(alerts.variables) data(last_year_gbp double precision)
             WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertStorageHeaterAnnualVersusBenchmark'::text))
+          ), energy AS (
+           SELECT alerts.alert_generation_run_id,
+              data.last_year_gbp,
+              data.one_year_energy_per_pupil_gbp,
+              data.last_year_co2_tonnes,
+              data.last_year_kwh
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) data(last_year_gbp double precision, one_year_energy_per_pupil_gbp double precision, last_year_co2_tonnes double precision, last_year_kwh double precision)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertEnergyAnnualVersusBenchmark'::text))
           ), additional AS (
            SELECT alerts.alert_generation_run_id,
               alerts.school_id,
-              data.gas_economic_tariff_changed_this_year
+              data.school_type_name,
+              data.pupils,
+              data.floor_area
              FROM alerts,
               alert_types,
-              LATERAL jsonb_to_record(alerts.variables) data(gas_economic_tariff_changed_this_year boolean)
+              LATERAL jsonb_to_record(alerts.variables) data(school_type_name text, pupils double precision, floor_area double precision)
             WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertAdditionalPrioritisationData'::text))
           ), latest_runs AS (
            SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
@@ -2788,83 +2346,24 @@ ActiveRecord::Schema.define(version: 2024_03_25_112425) do
             ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC
           )
    SELECT latest_runs.id,
+      electricity.last_year_gbp AS last_year_electricity,
+      gas.last_year_gbp AS last_year_gas,
+      storage_heaters.last_year_gbp AS last_year_storage_heaters,
+      energy.last_year_gbp,
+      energy.one_year_energy_per_pupil_gbp,
+      energy.last_year_co2_tonnes,
+      energy.last_year_kwh,
+      additional.alert_generation_run_id,
       additional.school_id,
-      (COALESCE(gas.one_year_gas_per_floor_area_normalised_gbp, (0)::double precision) + COALESCE(storage_heaters.one_year_gas_per_floor_area_normalised_gbp, (0)::double precision)) AS one_year_gas_per_floor_area_normalised_gbp,
-      (COALESCE(gas.last_year_gbp, (0)::double precision) + COALESCE(storage_heaters.last_year_gbp, (0)::double precision)) AS last_year_gbp,
-      (COALESCE(gas.one_year_saving_versus_exemplar_gbpcurrent, (0)::double precision) + COALESCE(storage_heaters.one_year_saving_versus_exemplar_gbpcurrent, (0)::double precision)) AS one_year_saving_versus_exemplar_gbpcurrent,
-      (COALESCE(gas.last_year_kwh, (0)::double precision) + COALESCE(storage_heaters.last_year_kwh, (0)::double precision)) AS last_year_kwh,
-      (COALESCE(gas.last_year_co2, (0)::double precision) + COALESCE(storage_heaters.last_year_co2, (0)::double precision)) AS last_year_co2,
-      gas.last_year_co2 AS gas_last_year_co2,
-      additional.gas_economic_tariff_changed_this_year
-     FROM (((latest_runs
+      additional.school_type_name,
+      additional.pupils,
+      additional.floor_area
+     FROM (((((latest_runs
        JOIN additional ON ((latest_runs.id = additional.alert_generation_run_id)))
+       LEFT JOIN electricity ON ((latest_runs.id = electricity.alert_generation_run_id)))
        LEFT JOIN gas ON ((latest_runs.id = gas.alert_generation_run_id)))
-       LEFT JOIN storage_heaters ON ((latest_runs.id = storage_heaters.alert_generation_run_id)));
-  SQL
-  create_view "annual_gas_out_of_hours_uses", sql_definition: <<-SQL
-      SELECT latest_runs.id,
-      data.alert_generation_run_id,
-      data.school_id,
-      data.schoolday_open_percent,
-      data.schoolday_closed_percent,
-      data.holidays_percent,
-      data.weekends_percent,
-      data.community_percent,
-      data.community_gbp,
-      data.out_of_hours_gbp,
-      data.potential_saving_gbp,
-      additional.gas_economic_tariff_changed_this_year
-     FROM ( SELECT alerts.alert_generation_run_id,
-              alerts.school_id,
-              data_1.schoolday_open_percent,
-              data_1.schoolday_closed_percent,
-              data_1.holidays_percent,
-              data_1.weekends_percent,
-              data_1.community_percent,
-              data_1.community_gbp,
-              data_1.out_of_hours_gbp,
-              data_1.potential_saving_gbp
-             FROM alerts,
-              alert_types,
-              LATERAL jsonb_to_record(alerts.variables) data_1(schoolday_open_percent double precision, schoolday_closed_percent double precision, holidays_percent double precision, weekends_percent double precision, community_percent double precision, community_gbp double precision, out_of_hours_gbp double precision, potential_saving_gbp double precision)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertOutOfHoursGasUsage'::text))) data,
-      ( SELECT alerts.alert_generation_run_id,
-              data_1.gas_economic_tariff_changed_this_year
-             FROM alerts,
-              alert_types,
-              LATERAL jsonb_to_record(alerts.variables) data_1(gas_economic_tariff_changed_this_year boolean)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertAdditionalPrioritisationData'::text))) additional,
-      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
-             FROM alert_generation_runs
-            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
-    WHERE ((data.alert_generation_run_id = latest_runs.id) AND (additional.alert_generation_run_id = latest_runs.id));
-  SQL
-  create_view "annual_storage_heater_out_of_hours_uses", sql_definition: <<-SQL
-      SELECT latest_runs.id,
-      data.alert_generation_run_id,
-      data.school_id,
-      data.schoolday_open_percent,
-      data.schoolday_closed_percent,
-      data.holidays_percent,
-      data.weekends_percent,
-      data.holidays_gbp,
-      data.weekends_gbp
-     FROM ( SELECT alerts.alert_generation_run_id,
-              alerts.school_id,
-              data_1.schoolday_open_percent,
-              data_1.schoolday_closed_percent,
-              data_1.holidays_percent,
-              data_1.weekends_percent,
-              data_1.holidays_gbp,
-              data_1.weekends_gbp
-             FROM alerts,
-              alert_types,
-              LATERAL jsonb_to_record(alerts.variables) data_1(schoolday_open_percent double precision, schoolday_closed_percent double precision, holidays_percent double precision, weekends_percent double precision, holidays_gbp double precision, weekends_gbp double precision)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertStorageHeaterOutOfHours'::text))) data,
-      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
-             FROM alert_generation_runs
-            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
-    WHERE (data.alert_generation_run_id = latest_runs.id);
+       LEFT JOIN storage_heaters ON ((latest_runs.id = storage_heaters.alert_generation_run_id)))
+       LEFT JOIN energy ON ((latest_runs.id = energy.alert_generation_run_id)));
   SQL
   create_view "annual_energy_costs_per_units", sql_definition: <<-SQL
       WITH electricity AS (
@@ -2949,197 +2448,74 @@ ActiveRecord::Schema.define(version: 2024_03_25_112425) do
        LEFT JOIN gas ON ((latest_runs.id = gas.alert_generation_run_id)))
        LEFT JOIN storage_heaters ON ((latest_runs.id = storage_heaters.alert_generation_run_id)));
   SQL
-  create_view "thermostat_sensitivities", sql_definition: <<-SQL
+  create_view "annual_gas_out_of_hours_uses", sql_definition: <<-SQL
       SELECT latest_runs.id,
       data.alert_generation_run_id,
       data.school_id,
-      data."annual_saving_1_C_change_gbp"
+      data.schoolday_open_percent,
+      data.schoolday_closed_percent,
+      data.holidays_percent,
+      data.weekends_percent,
+      data.community_percent,
+      data.community_gbp,
+      data.out_of_hours_gbp,
+      data.potential_saving_gbp,
+      additional.gas_economic_tariff_changed_this_year
      FROM ( SELECT alerts.alert_generation_run_id,
               alerts.school_id,
-              data_1."annual_saving_1_C_change_gbp"
+              data_1.schoolday_open_percent,
+              data_1.schoolday_closed_percent,
+              data_1.holidays_percent,
+              data_1.weekends_percent,
+              data_1.community_percent,
+              data_1.community_gbp,
+              data_1.out_of_hours_gbp,
+              data_1.potential_saving_gbp
              FROM alerts,
               alert_types,
-              LATERAL jsonb_to_record(alerts.variables) data_1("annual_saving_1_C_change_gbp" double precision)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertHeatingSensitivityAdvice'::text))) data,
+              LATERAL jsonb_to_record(alerts.variables) data_1(schoolday_open_percent double precision, schoolday_closed_percent double precision, holidays_percent double precision, weekends_percent double precision, community_percent double precision, community_gbp double precision, out_of_hours_gbp double precision, potential_saving_gbp double precision)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertOutOfHoursGasUsage'::text))) data,
+      ( SELECT alerts.alert_generation_run_id,
+              data_1.gas_economic_tariff_changed_this_year
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) data_1(gas_economic_tariff_changed_this_year boolean)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertAdditionalPrioritisationData'::text))) additional,
       ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
              FROM alert_generation_runs
             ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
-    WHERE (data.alert_generation_run_id = latest_runs.id);
+    WHERE ((data.alert_generation_run_id = latest_runs.id) AND (additional.alert_generation_run_id = latest_runs.id));
   SQL
-  create_view "heating_in_warm_weathers", sql_definition: <<-SQL
+  create_view "annual_heating_costs_per_floor_areas", sql_definition: <<-SQL
       WITH gas AS (
            SELECT alerts.alert_generation_run_id,
-              data.percent_of_annual_heating,
-              data.warm_weather_heating_days_all_days_kwh,
-              data.warm_weather_heating_days_all_days_co2,
-              data.warm_weather_heating_days_all_days_gbpcurrent,
-              data.warm_weather_heating_days_all_days_days
+              data.one_year_gas_per_floor_area_normalised_gbp,
+              data.last_year_gbp,
+              data.one_year_saving_versus_exemplar_gbpcurrent,
+              data.last_year_kwh,
+              data.last_year_co2
              FROM alerts,
               alert_types,
-              LATERAL jsonb_to_record(alerts.variables) data(percent_of_annual_heating double precision, warm_weather_heating_days_all_days_kwh double precision, warm_weather_heating_days_all_days_co2 double precision, warm_weather_heating_days_all_days_gbpcurrent double precision, warm_weather_heating_days_all_days_days double precision)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertSeasonalHeatingSchoolDays'::text))
-          ), storage_heaters AS (
-           SELECT alerts.alert_generation_run_id,
-              data.percent_of_annual_heating,
-              data.warm_weather_heating_days_all_days_kwh,
-              data.warm_weather_heating_days_all_days_co2,
-              data.warm_weather_heating_days_all_days_gbpcurrent,
-              data.warm_weather_heating_days_all_days_days
-             FROM alerts,
-              alert_types,
-              LATERAL jsonb_to_record(alerts.variables) data(percent_of_annual_heating double precision, warm_weather_heating_days_all_days_kwh double precision, warm_weather_heating_days_all_days_co2 double precision, warm_weather_heating_days_all_days_gbpcurrent double precision, warm_weather_heating_days_all_days_days double precision)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertSeasonalHeatingSchoolDaysStorageHeaters'::text))
-          ), additional AS (
-           SELECT alerts.alert_generation_run_id,
-              alerts.school_id
-             FROM alerts,
-              alert_types
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertAdditionalPrioritisationData'::text))
-          ), latest_runs AS (
-           SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
-             FROM alert_generation_runs
-            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC
-          )
-   SELECT latest_runs.id,
-      additional.school_id,
-      COALESCE(gas.percent_of_annual_heating, storage_heaters.percent_of_annual_heating) AS percent_of_annual_heating,
-      COALESCE(gas.warm_weather_heating_days_all_days_kwh, storage_heaters.warm_weather_heating_days_all_days_kwh) AS warm_weather_heating_days_all_days_kwh,
-      COALESCE(gas.warm_weather_heating_days_all_days_co2, storage_heaters.warm_weather_heating_days_all_days_co2) AS warm_weather_heating_days_all_days_co2,
-      COALESCE(gas.warm_weather_heating_days_all_days_gbpcurrent, storage_heaters.warm_weather_heating_days_all_days_gbpcurrent) AS warm_weather_heating_days_all_days_gbpcurrent,
-      COALESCE(gas.warm_weather_heating_days_all_days_days, storage_heaters.warm_weather_heating_days_all_days_days) AS warm_weather_heating_days_all_days_days
-     FROM (((latest_runs
-       JOIN additional ON ((latest_runs.id = additional.alert_generation_run_id)))
-       LEFT JOIN gas ON ((latest_runs.id = gas.alert_generation_run_id)))
-       LEFT JOIN storage_heaters ON ((latest_runs.id = storage_heaters.alert_generation_run_id)));
-  SQL
-  create_view "thermostatic_controls", sql_definition: <<-SQL
-      WITH gas AS (
-           SELECT alerts.alert_generation_run_id,
-              data.r2,
-              data.potential_saving_gbp
-             FROM alerts,
-              alert_types,
-              LATERAL jsonb_to_record(alerts.variables) data(r2 double precision, potential_saving_gbp double precision)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertThermostaticControl'::text))
-          ), storage_heaters AS (
-           SELECT alerts.alert_generation_run_id,
-              data.r2,
-              data.potential_saving_gbp
-             FROM alerts,
-              alert_types,
-              LATERAL jsonb_to_record(alerts.variables) data(r2 double precision, potential_saving_gbp double precision)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertStorageHeaterThermostatic'::text))
-          ), additional AS (
-           SELECT alerts.alert_generation_run_id,
-              alerts.school_id
-             FROM alerts,
-              alert_types
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertAdditionalPrioritisationData'::text))
-          ), latest_runs AS (
-           SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
-             FROM alert_generation_runs
-            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC
-          )
-   SELECT latest_runs.id,
-      additional.school_id,
-      COALESCE(gas.r2, storage_heaters.r2) AS r2,
-      NULLIF((COALESCE(gas.potential_saving_gbp, (0)::double precision) + COALESCE(storage_heaters.potential_saving_gbp, (0)::double precision)), (0)::double precision) AS potential_saving_gbp
-     FROM (((latest_runs
-       JOIN additional ON ((latest_runs.id = additional.alert_generation_run_id)))
-       LEFT JOIN gas ON ((latest_runs.id = gas.alert_generation_run_id)))
-       LEFT JOIN storage_heaters ON ((latest_runs.id = storage_heaters.alert_generation_run_id)));
-  SQL
-  create_view "hot_water_efficiencies", sql_definition: <<-SQL
-      SELECT latest_runs.id,
-      data.alert_generation_run_id,
-      data.school_id,
-      data.avg_gas_per_pupil_gbp,
-      data.benchmark_existing_gas_efficiency,
-      data.benchmark_gas_better_control_saving_gbp,
-      data.benchmark_point_of_use_electric_saving_gbp
-     FROM ( SELECT alerts.alert_generation_run_id,
-              alerts.school_id,
-              data_1.avg_gas_per_pupil_gbp,
-              data_1.benchmark_existing_gas_efficiency,
-              data_1.benchmark_gas_better_control_saving_gbp,
-              data_1.benchmark_point_of_use_electric_saving_gbp
-             FROM alerts,
-              alert_types,
-              LATERAL jsonb_to_record(alerts.variables) data_1(avg_gas_per_pupil_gbp double precision, benchmark_existing_gas_efficiency double precision, benchmark_gas_better_control_saving_gbp double precision, benchmark_point_of_use_electric_saving_gbp double precision)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertHotWaterEfficiency'::text))) data,
-      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
-             FROM alert_generation_runs
-            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
-    WHERE (data.alert_generation_run_id = latest_runs.id);
-  SQL
-  create_view "gas_targets", sql_definition: <<-SQL
-      SELECT latest_runs.id,
-      data.alert_generation_run_id,
-      data.school_id,
-      data.current_year_percent_of_target_relative,
-      data.current_year_unscaled_percent_of_target_relative,
-      data.current_year_kwh,
-      data.current_year_target_kwh,
-      data.unscaled_target_kwh_to_date,
-      data.tracking_start_date
-     FROM ( SELECT alerts.alert_generation_run_id,
-              alerts.school_id,
-              data_1.current_year_percent_of_target_relative,
-              data_1.current_year_unscaled_percent_of_target_relative,
-              data_1.current_year_kwh,
-              data_1.current_year_target_kwh,
-              data_1.unscaled_target_kwh_to_date,
-              data_1.tracking_start_date
-             FROM alerts,
-              alert_types,
-              LATERAL jsonb_to_record(alerts.variables) data_1(current_year_percent_of_target_relative double precision, current_year_unscaled_percent_of_target_relative double precision, current_year_kwh double precision, current_year_target_kwh double precision, unscaled_target_kwh_to_date double precision, tracking_start_date date)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertGasTargetAnnual'::text))) data,
-      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
-             FROM alert_generation_runs
-            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
-    WHERE (data.alert_generation_run_id = latest_runs.id);
-  SQL
-  create_view "annual_energy_costs", sql_definition: <<-SQL
-      WITH electricity AS (
-           SELECT alerts.alert_generation_run_id,
-              data.last_year_gbp
-             FROM alerts,
-              alert_types,
-              LATERAL jsonb_to_record(alerts.variables) data(last_year_gbp double precision)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertElectricityAnnualVersusBenchmark'::text))
-          ), gas AS (
-           SELECT alerts.alert_generation_run_id,
-              data.last_year_gbp
-             FROM alerts,
-              alert_types,
-              LATERAL jsonb_to_record(alerts.variables) data(last_year_gbp double precision)
+              LATERAL jsonb_to_record(alerts.variables) data(one_year_gas_per_floor_area_normalised_gbp double precision, last_year_gbp double precision, one_year_saving_versus_exemplar_gbpcurrent double precision, last_year_kwh double precision, last_year_co2 double precision)
             WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertGasAnnualVersusBenchmark'::text))
           ), storage_heaters AS (
            SELECT alerts.alert_generation_run_id,
-              data.last_year_gbp
-             FROM alerts,
-              alert_types,
-              LATERAL jsonb_to_record(alerts.variables) data(last_year_gbp double precision)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertStorageHeaterAnnualVersusBenchmark'::text))
-          ), energy AS (
-           SELECT alerts.alert_generation_run_id,
+              data.one_year_gas_per_floor_area_normalised_gbp,
               data.last_year_gbp,
-              data.one_year_energy_per_pupil_gbp,
-              data.last_year_co2_tonnes,
-              data.last_year_kwh
+              data.one_year_saving_versus_exemplar_gbpcurrent,
+              data.last_year_kwh,
+              data.last_year_co2
              FROM alerts,
               alert_types,
-              LATERAL jsonb_to_record(alerts.variables) data(last_year_gbp double precision, one_year_energy_per_pupil_gbp double precision, last_year_co2_tonnes double precision, last_year_kwh double precision)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertEnergyAnnualVersusBenchmark'::text))
+              LATERAL jsonb_to_record(alerts.variables) data(one_year_gas_per_floor_area_normalised_gbp double precision, last_year_gbp double precision, one_year_saving_versus_exemplar_gbpcurrent double precision, last_year_kwh double precision, last_year_co2 double precision)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertStorageHeaterAnnualVersusBenchmark'::text))
           ), additional AS (
            SELECT alerts.alert_generation_run_id,
               alerts.school_id,
-              data.school_type_name,
-              data.pupils,
-              data.floor_area
+              data.gas_economic_tariff_changed_this_year
              FROM alerts,
               alert_types,
-              LATERAL jsonb_to_record(alerts.variables) data(school_type_name text, pupils double precision, floor_area double precision)
+              LATERAL jsonb_to_record(alerts.variables) data(gas_economic_tariff_changed_this_year boolean)
             WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertAdditionalPrioritisationData'::text))
           ), latest_runs AS (
            SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
@@ -3147,24 +2523,311 @@ ActiveRecord::Schema.define(version: 2024_03_25_112425) do
             ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC
           )
    SELECT latest_runs.id,
-      electricity.last_year_gbp AS last_year_electricity,
-      gas.last_year_gbp AS last_year_gas,
-      storage_heaters.last_year_gbp AS last_year_storage_heaters,
-      energy.last_year_gbp,
-      energy.one_year_energy_per_pupil_gbp,
-      energy.last_year_co2_tonnes,
-      energy.last_year_kwh,
-      additional.alert_generation_run_id,
       additional.school_id,
-      additional.school_type_name,
-      additional.pupils,
-      additional.floor_area
-     FROM (((((latest_runs
+      (COALESCE(gas.one_year_gas_per_floor_area_normalised_gbp, (0)::double precision) + COALESCE(storage_heaters.one_year_gas_per_floor_area_normalised_gbp, (0)::double precision)) AS one_year_gas_per_floor_area_normalised_gbp,
+      (COALESCE(gas.last_year_gbp, (0)::double precision) + COALESCE(storage_heaters.last_year_gbp, (0)::double precision)) AS last_year_gbp,
+      (COALESCE(gas.one_year_saving_versus_exemplar_gbpcurrent, (0)::double precision) + COALESCE(storage_heaters.one_year_saving_versus_exemplar_gbpcurrent, (0)::double precision)) AS one_year_saving_versus_exemplar_gbpcurrent,
+      (COALESCE(gas.last_year_kwh, (0)::double precision) + COALESCE(storage_heaters.last_year_kwh, (0)::double precision)) AS last_year_kwh,
+      (COALESCE(gas.last_year_co2, (0)::double precision) + COALESCE(storage_heaters.last_year_co2, (0)::double precision)) AS last_year_co2,
+      gas.last_year_co2 AS gas_last_year_co2,
+      additional.gas_economic_tariff_changed_this_year
+     FROM (((latest_runs
        JOIN additional ON ((latest_runs.id = additional.alert_generation_run_id)))
-       LEFT JOIN electricity ON ((latest_runs.id = electricity.alert_generation_run_id)))
        LEFT JOIN gas ON ((latest_runs.id = gas.alert_generation_run_id)))
-       LEFT JOIN storage_heaters ON ((latest_runs.id = storage_heaters.alert_generation_run_id)))
-       LEFT JOIN energy ON ((latest_runs.id = energy.alert_generation_run_id)));
+       LEFT JOIN storage_heaters ON ((latest_runs.id = storage_heaters.alert_generation_run_id)));
+  SQL
+  create_view "annual_storage_heater_out_of_hours_uses", sql_definition: <<-SQL
+      SELECT latest_runs.id,
+      data.alert_generation_run_id,
+      data.school_id,
+      data.schoolday_open_percent,
+      data.schoolday_closed_percent,
+      data.holidays_percent,
+      data.weekends_percent,
+      data.holidays_gbp,
+      data.weekends_gbp
+     FROM ( SELECT alerts.alert_generation_run_id,
+              alerts.school_id,
+              data_1.schoolday_open_percent,
+              data_1.schoolday_closed_percent,
+              data_1.holidays_percent,
+              data_1.weekends_percent,
+              data_1.holidays_gbp,
+              data_1.weekends_gbp
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) data_1(schoolday_open_percent double precision, schoolday_closed_percent double precision, holidays_percent double precision, weekends_percent double precision, holidays_gbp double precision, weekends_gbp double precision)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertStorageHeaterOutOfHours'::text))) data,
+      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
+             FROM alert_generation_runs
+            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
+    WHERE (data.alert_generation_run_id = latest_runs.id);
+  SQL
+  create_view "baseload_per_pupils", sql_definition: <<-SQL
+      SELECT latest_runs.id,
+      additional.school_id,
+      baseload.alert_generation_run_id,
+      baseload.average_baseload_last_year_kw,
+      baseload.average_baseload_last_year_gbp,
+      baseload.one_year_baseload_per_pupil_kw,
+      baseload.annual_baseload_percent,
+      baseload.one_year_saving_versus_exemplar_gbp,
+      additional.electricity_economic_tariff_changed_this_year
+     FROM ( SELECT alerts.alert_generation_run_id,
+              data.average_baseload_last_year_kw,
+              data.average_baseload_last_year_gbp,
+              data.one_year_baseload_per_pupil_kw,
+              data.annual_baseload_percent,
+              data.one_year_saving_versus_exemplar_gbp
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) data(average_baseload_last_year_kw double precision, average_baseload_last_year_gbp double precision, one_year_baseload_per_pupil_kw double precision, annual_baseload_percent double precision, one_year_saving_versus_exemplar_gbp double precision)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertElectricityBaseloadVersusBenchmark'::text))) baseload,
+      ( SELECT alerts.alert_generation_run_id,
+              alerts.school_id,
+              data.electricity_economic_tariff_changed_this_year
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) data(electricity_economic_tariff_changed_this_year boolean)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertAdditionalPrioritisationData'::text))) additional,
+      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
+             FROM alert_generation_runs
+            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
+    WHERE ((baseload.alert_generation_run_id = latest_runs.id) AND (additional.alert_generation_run_id = latest_runs.id));
+  SQL
+  create_view "change_in_electricity_consumption_recent_school_weeks", sql_definition: <<-SQL
+      SELECT latest_runs.id,
+      data.alert_generation_run_id,
+      data.school_id,
+      data.difference_percent,
+      data.difference_gbpcurrent,
+      data.difference_kwh,
+      data.pupils_changed,
+      data.tariff_has_changed
+     FROM ( SELECT alerts.alert_generation_run_id,
+              alerts.school_id,
+              data_1.difference_percent,
+              data_1.difference_gbpcurrent,
+              data_1.difference_kwh,
+              data_1.pupils_changed,
+              data_1.tariff_has_changed
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) data_1(difference_percent double precision, difference_gbpcurrent double precision, difference_kwh double precision, pupils_changed boolean, tariff_has_changed boolean)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertSchoolWeekComparisonElectricity'::text))) data,
+      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
+             FROM alert_generation_runs
+            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
+    WHERE (data.alert_generation_run_id = latest_runs.id);
+  SQL
+  create_view "change_in_electricity_holiday_consumption_previous_holidays", sql_definition: <<-SQL
+      SELECT latest_runs.id,
+      data.alert_generation_run_id,
+      data.school_id,
+      data.difference_percent,
+      data.difference_gbpcurrent,
+      data.difference_kwh,
+      data.current_period_type,
+      data.current_period_start_date,
+      data.current_period_end_date,
+      data.truncated_current_period,
+      data.previous_period_type,
+      data.previous_period_start_date,
+      data.previous_period_end_date,
+      data.pupils_changed,
+      data.tariff_has_changed
+     FROM ( SELECT alerts.alert_generation_run_id,
+              alerts.school_id,
+              data_1.difference_percent,
+              data_1.difference_gbpcurrent,
+              data_1.difference_kwh,
+              data_1.current_period_type,
+              data_1.current_period_start_date,
+              data_1.current_period_end_date,
+              data_1.truncated_current_period,
+              data_1.previous_period_type,
+              data_1.previous_period_start_date,
+              data_1.previous_period_end_date,
+              data_1.pupils_changed,
+              data_1.tariff_has_changed
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) data_1(difference_percent double precision, difference_gbpcurrent double precision, difference_kwh double precision, current_period_type text, current_period_start_date date, current_period_end_date date, truncated_current_period boolean, previous_period_type text, previous_period_start_date date, previous_period_end_date date, pupils_changed boolean, tariff_has_changed boolean)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertPreviousHolidayComparisonElectricity'::text))) data,
+      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
+             FROM alert_generation_runs
+            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
+    WHERE (data.alert_generation_run_id = latest_runs.id);
+  SQL
+  create_view "change_in_electricity_holiday_consumption_previous_years_holida", sql_definition: <<-SQL
+      SELECT latest_runs.id,
+      data.alert_generation_run_id,
+      data.school_id,
+      data.current_period_type,
+      data.current_period_start_date,
+      data.current_period_end_date,
+      data.difference_gbpcurrent,
+      data.difference_kwh,
+      data.difference_percent,
+      data.previous_period_type,
+      data.previous_period_start_date,
+      data.previous_period_end_date,
+      data.pupils_changed,
+      data.tariff_has_changed,
+      data.truncated_current_period
+     FROM ( SELECT alerts.alert_generation_run_id,
+              alerts.school_id,
+              data_1.current_period_type,
+              data_1.current_period_start_date,
+              data_1.current_period_end_date,
+              data_1.difference_gbpcurrent,
+              data_1.difference_kwh,
+              data_1.difference_percent,
+              data_1.previous_period_type,
+              data_1.previous_period_start_date,
+              data_1.previous_period_end_date,
+              data_1.pupils_changed,
+              data_1.tariff_has_changed,
+              data_1.truncated_current_period
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) data_1(current_period_type text, current_period_start_date date, current_period_end_date date, difference_gbpcurrent double precision, difference_kwh double precision, difference_percent double precision, previous_period_type text, previous_period_start_date date, previous_period_end_date date, pupils_changed boolean, tariff_has_changed boolean, truncated_current_period boolean)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertPreviousYearHolidayComparisonElectricity'::text))) data,
+      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
+             FROM alert_generation_runs
+            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
+    WHERE (data.alert_generation_run_id = latest_runs.id);
+  SQL
+  create_view "change_in_electricity_since_last_years", sql_definition: <<-SQL
+      SELECT latest_runs.id,
+      enba.school_id,
+      enba.previous_year_electricity_kwh,
+      enba.current_year_electricity_kwh,
+      enba.previous_year_electricity_co2,
+      enba.current_year_electricity_co2,
+      enba.previous_year_electricity_gbp,
+      enba.current_year_electricity_gbp,
+      enba.solar_type
+     FROM ( SELECT alerts.alert_generation_run_id,
+              alerts.school_id,
+              data.previous_year_electricity_kwh,
+              data.current_year_electricity_kwh,
+              data.previous_year_electricity_co2,
+              data.current_year_electricity_co2,
+              data.previous_year_electricity_gbp,
+              data.current_year_electricity_gbp,
+              data.solar_type
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) data(previous_year_electricity_kwh double precision, current_year_electricity_kwh double precision, previous_year_electricity_co2 double precision, current_year_electricity_co2 double precision, previous_year_electricity_gbp double precision, current_year_electricity_gbp double precision, solar_type text)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertEnergyAnnualVersusBenchmark'::text))) enba,
+      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
+             FROM alert_generation_runs
+            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
+    WHERE (enba.alert_generation_run_id = latest_runs.id);
+  SQL
+  create_view "change_in_gas_consumption_recent_school_weeks", sql_definition: <<-SQL
+      SELECT latest_runs.id,
+      data.alert_generation_run_id,
+      data.school_id,
+      data.difference_percent,
+      data.difference_gbpcurrent,
+      data.difference_kwh,
+      data.pupils_changed,
+      data.tariff_has_changed
+     FROM ( SELECT alerts.alert_generation_run_id,
+              alerts.school_id,
+              data_1.difference_percent,
+              data_1.difference_gbpcurrent,
+              data_1.difference_kwh,
+              data_1.pupils_changed,
+              data_1.tariff_has_changed
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) data_1(difference_percent double precision, difference_gbpcurrent double precision, difference_kwh double precision, pupils_changed boolean, tariff_has_changed boolean)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertSchoolWeekComparisonGas'::text))) data,
+      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
+             FROM alert_generation_runs
+            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
+    WHERE (data.alert_generation_run_id = latest_runs.id);
+  SQL
+  create_view "change_in_gas_holiday_consumption_previous_holidays", sql_definition: <<-SQL
+      SELECT latest_runs.id,
+      data.alert_generation_run_id,
+      data.school_id,
+      data.difference_percent,
+      data.difference_gbpcurrent,
+      data.difference_kwh,
+      data.current_period_type,
+      data.current_period_start_date,
+      data.current_period_end_date,
+      data.truncated_current_period,
+      data.previous_period_type,
+      data.previous_period_start_date,
+      data.previous_period_end_date,
+      data.pupils_changed,
+      data.tariff_has_changed
+     FROM ( SELECT alerts.alert_generation_run_id,
+              alerts.school_id,
+              data_1.difference_percent,
+              data_1.difference_gbpcurrent,
+              data_1.difference_kwh,
+              data_1.current_period_type,
+              data_1.current_period_start_date,
+              data_1.current_period_end_date,
+              data_1.truncated_current_period,
+              data_1.previous_period_type,
+              data_1.previous_period_start_date,
+              data_1.previous_period_end_date,
+              data_1.pupils_changed,
+              data_1.tariff_has_changed
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) data_1(difference_percent double precision, difference_gbpcurrent double precision, difference_kwh double precision, current_period_type text, current_period_start_date date, current_period_end_date date, truncated_current_period boolean, previous_period_type text, previous_period_start_date date, previous_period_end_date date, pupils_changed boolean, tariff_has_changed boolean)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertPreviousHolidayComparisonGas'::text))) data,
+      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
+             FROM alert_generation_runs
+            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
+    WHERE (data.alert_generation_run_id = latest_runs.id);
+  SQL
+  create_view "change_in_gas_holiday_consumption_previous_years_holidays", sql_definition: <<-SQL
+      SELECT latest_runs.id,
+      data.alert_generation_run_id,
+      data.school_id,
+      data.difference_percent,
+      data.difference_gbpcurrent,
+      data.difference_kwh,
+      data.current_period_type,
+      data.current_period_start_date,
+      data.current_period_end_date,
+      data.truncated_current_period,
+      data.previous_period_type,
+      data.previous_period_start_date,
+      data.previous_period_end_date,
+      data.pupils_changed,
+      data.tariff_has_changed
+     FROM ( SELECT alerts.alert_generation_run_id,
+              alerts.school_id,
+              data_1.difference_percent,
+              data_1.difference_gbpcurrent,
+              data_1.difference_kwh,
+              data_1.current_period_type,
+              data_1.current_period_start_date,
+              data_1.current_period_end_date,
+              data_1.truncated_current_period,
+              data_1.previous_period_type,
+              data_1.previous_period_start_date,
+              data_1.previous_period_end_date,
+              data_1.pupils_changed,
+              data_1.tariff_has_changed
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) data_1(difference_percent double precision, difference_gbpcurrent double precision, difference_kwh double precision, current_period_type text, current_period_start_date date, current_period_end_date date, truncated_current_period boolean, previous_period_type text, previous_period_start_date date, previous_period_end_date date, pupils_changed boolean, tariff_has_changed boolean)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertPreviousYearHolidayComparisonGas'::text))) data,
+      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
+             FROM alert_generation_runs
+            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
+    WHERE (data.alert_generation_run_id = latest_runs.id);
   SQL
   create_view "change_in_gas_since_last_years", sql_definition: <<-SQL
       SELECT latest_runs.id,
@@ -3203,6 +2866,30 @@ ActiveRecord::Schema.define(version: 2024_03_25_112425) do
             ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
     WHERE ((energy.alert_generation_run_id = latest_runs.id) AND (gas.alert_generation_run_id = latest_runs.id));
   SQL
+  create_view "change_in_solar_pv_since_last_years", sql_definition: <<-SQL
+      SELECT latest_runs.id,
+      versus_benchmark.school_id,
+      versus_benchmark.previous_year_solar_pv_kwh,
+      versus_benchmark.current_year_solar_pv_kwh,
+      versus_benchmark.previous_year_solar_pv_co2,
+      versus_benchmark.current_year_solar_pv_co2,
+      versus_benchmark.solar_type
+     FROM ( SELECT alerts.alert_generation_run_id,
+              alerts.school_id,
+              data.previous_year_solar_pv_kwh,
+              data.current_year_solar_pv_kwh,
+              data.previous_year_solar_pv_co2,
+              data.current_year_solar_pv_co2,
+              data.solar_type
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) data(previous_year_solar_pv_kwh double precision, current_year_solar_pv_kwh double precision, previous_year_solar_pv_co2 double precision, current_year_solar_pv_co2 double precision, solar_type text)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertEnergyAnnualVersusBenchmark'::text))) versus_benchmark,
+      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
+             FROM alert_generation_runs
+            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
+    WHERE (versus_benchmark.alert_generation_run_id = latest_runs.id);
+  SQL
   create_view "change_in_storage_heaters_since_last_years", sql_definition: <<-SQL
       SELECT latest_runs.id,
       energy.alert_generation_run_id,
@@ -3240,85 +2927,139 @@ ActiveRecord::Schema.define(version: 2024_03_25_112425) do
             ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
     WHERE ((energy.alert_generation_run_id = latest_runs.id) AND (storage.alert_generation_run_id = latest_runs.id));
   SQL
-  create_view "annual_change_in_gas_out_of_hours_uses", sql_definition: <<-SQL
+  create_view "electricity_consumption_during_holidays", sql_definition: <<-SQL
       SELECT latest_runs.id,
-      usage.alert_generation_run_id,
-      usage.school_id,
-      usage.out_of_hours_kwh,
-      usage.out_of_hours_co2,
-      usage.out_of_hours_gbpcurrent,
-      usage_previous_year.previous_out_of_hours_kwh,
-      usage_previous_year.previous_out_of_hours_co2,
-      usage_previous_year.previous_out_of_hours_gbpcurrent,
-      additional.economic_tariff_changed_this_year
+      data.alert_generation_run_id,
+      data.school_id,
+      data.holiday_projected_usage_gbp,
+      data.holiday_usage_to_date_gbp,
+      data.holiday_type,
+      data.holiday_start_date,
+      data.holiday_end_date
      FROM ( SELECT alerts.alert_generation_run_id,
               alerts.school_id,
-              json.out_of_hours_kwh,
-              json.out_of_hours_co2,
-              json.out_of_hours_gbpcurrent
+              data_1.holiday_projected_usage_gbp,
+              data_1.holiday_usage_to_date_gbp,
+              data_1.holiday_type,
+              data_1.holiday_start_date,
+              data_1.holiday_end_date
              FROM alerts,
               alert_types,
-              LATERAL jsonb_to_record(alerts.variables) json(out_of_hours_kwh double precision, out_of_hours_co2 double precision, out_of_hours_gbpcurrent double precision)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertOutOfHoursGasUsage'::text))) usage,
-      ( SELECT alerts.alert_generation_run_id,
-              alerts.school_id,
-              json.out_of_hours_kwh AS previous_out_of_hours_kwh,
-              json.out_of_hours_co2 AS previous_out_of_hours_co2,
-              json.out_of_hours_gbpcurrent AS previous_out_of_hours_gbpcurrent
-             FROM alerts,
-              alert_types,
-              LATERAL jsonb_to_record(alerts.variables) json(out_of_hours_kwh double precision, out_of_hours_co2 double precision, out_of_hours_gbpcurrent double precision)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertOutOfHoursGasUsagePreviousYear'::text))) usage_previous_year,
-      ( SELECT alerts.alert_generation_run_id,
-              json.gas_economic_tariff_changed_this_year AS economic_tariff_changed_this_year
-             FROM alerts,
-              alert_types,
-              LATERAL jsonb_to_record(alerts.variables) json(gas_economic_tariff_changed_this_year boolean)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertAdditionalPrioritisationData'::text))) additional,
+              LATERAL jsonb_to_record(alerts.variables) data_1(holiday_projected_usage_gbp double precision, holiday_usage_to_date_gbp double precision, holiday_type text, holiday_start_date date, holiday_end_date date)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertElectricityUsageDuringCurrentHoliday'::text))) data,
       ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
              FROM alert_generation_runs
             ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
-    WHERE ((usage.alert_generation_run_id = latest_runs.id) AND (usage_previous_year.alert_generation_run_id = latest_runs.id) AND (additional.alert_generation_run_id = latest_runs.id));
+    WHERE (data.alert_generation_run_id = latest_runs.id);
   SQL
-  create_view "annual_change_in_storage_heater_out_of_hours_uses", sql_definition: <<-SQL
+  create_view "electricity_peak_kw_per_pupils", sql_definition: <<-SQL
       SELECT latest_runs.id,
-      usage.alert_generation_run_id,
-      usage.school_id,
-      usage.out_of_hours_kwh,
-      usage.out_of_hours_co2,
-      usage.out_of_hours_gbpcurrent,
-      usage_previous_year.previous_out_of_hours_kwh,
-      usage_previous_year.previous_out_of_hours_co2,
-      usage_previous_year.previous_out_of_hours_gbpcurrent,
-      additional.economic_tariff_changed_this_year
+      data.alert_generation_run_id,
+      data.school_id,
+      data.average_school_day_last_year_kw_per_floor_area,
+      data.average_school_day_last_year_kw,
+      data.exemplar_kw,
+      data.one_year_saving_versus_exemplar_gbp,
+      additional.electricity_economic_tariff_changed_this_year
      FROM ( SELECT alerts.alert_generation_run_id,
               alerts.school_id,
-              json.out_of_hours_kwh,
-              json.out_of_hours_co2,
-              json.out_of_hours_gbpcurrent
+              data_1.average_school_day_last_year_kw_per_floor_area,
+              data_1.average_school_day_last_year_kw,
+              data_1.exemplar_kw,
+              data_1.one_year_saving_versus_exemplar_gbp
              FROM alerts,
               alert_types,
-              LATERAL jsonb_to_record(alerts.variables) json(out_of_hours_kwh double precision, out_of_hours_co2 double precision, out_of_hours_gbpcurrent double precision)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertStorageHeaterOutOfHours'::text))) usage,
+              LATERAL jsonb_to_record(alerts.variables) data_1(average_school_day_last_year_kw_per_floor_area double precision, average_school_day_last_year_kw double precision, exemplar_kw double precision, one_year_saving_versus_exemplar_gbp double precision)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertElectricityPeakKWVersusBenchmark'::text))) data,
       ( SELECT alerts.alert_generation_run_id,
-              alerts.school_id,
-              json.out_of_hours_kwh AS previous_out_of_hours_kwh,
-              json.out_of_hours_co2 AS previous_out_of_hours_co2,
-              json.out_of_hours_gbpcurrent AS previous_out_of_hours_gbpcurrent
+              data_1.electricity_economic_tariff_changed_this_year
              FROM alerts,
               alert_types,
-              LATERAL jsonb_to_record(alerts.variables) json(out_of_hours_kwh double precision, out_of_hours_co2 double precision, out_of_hours_gbpcurrent double precision)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertOutOfHoursStorageHeaterUsagePreviousYear'::text))) usage_previous_year,
-      ( SELECT alerts.alert_generation_run_id,
-              json.electricity_economic_tariff_changed_this_year AS economic_tariff_changed_this_year
-             FROM alerts,
-              alert_types,
-              LATERAL jsonb_to_record(alerts.variables) json(electricity_economic_tariff_changed_this_year boolean)
+              LATERAL jsonb_to_record(alerts.variables) data_1(electricity_economic_tariff_changed_this_year boolean)
             WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertAdditionalPrioritisationData'::text))) additional,
       ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
              FROM alert_generation_runs
             ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
-    WHERE ((usage.alert_generation_run_id = latest_runs.id) AND (usage_previous_year.alert_generation_run_id = latest_runs.id) AND (additional.alert_generation_run_id = latest_runs.id));
+    WHERE ((data.alert_generation_run_id = latest_runs.id) AND (additional.alert_generation_run_id = latest_runs.id));
+  SQL
+  create_view "electricity_targets", sql_definition: <<-SQL
+      SELECT latest_runs.id,
+      data.alert_generation_run_id,
+      data.school_id,
+      data.current_year_percent_of_target_relative,
+      data.current_year_unscaled_percent_of_target_relative,
+      data.current_year_kwh,
+      data.current_year_target_kwh,
+      data.unscaled_target_kwh_to_date,
+      data.tracking_start_date
+     FROM ( SELECT alerts.alert_generation_run_id,
+              alerts.school_id,
+              data_1.current_year_percent_of_target_relative,
+              data_1.current_year_unscaled_percent_of_target_relative,
+              data_1.current_year_kwh,
+              data_1.current_year_target_kwh,
+              data_1.unscaled_target_kwh_to_date,
+              data_1.tracking_start_date
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) data_1(current_year_percent_of_target_relative double precision, current_year_unscaled_percent_of_target_relative double precision, current_year_kwh double precision, current_year_target_kwh double precision, unscaled_target_kwh_to_date double precision, tracking_start_date date)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertElectricityTargetAnnual'::text))) data,
+      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
+             FROM alert_generation_runs
+            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
+    WHERE (data.alert_generation_run_id = latest_runs.id);
+  SQL
+  create_view "gas_consumption_during_holidays", sql_definition: <<-SQL
+      SELECT latest_runs.id,
+      data.alert_generation_run_id,
+      data.school_id,
+      data.holiday_projected_usage_gbp,
+      data.holiday_usage_to_date_gbp,
+      data.holiday_type,
+      data.holiday_start_date,
+      data.holiday_end_date
+     FROM ( SELECT alerts.alert_generation_run_id,
+              alerts.school_id,
+              data_1.holiday_projected_usage_gbp,
+              data_1.holiday_usage_to_date_gbp,
+              data_1.holiday_type,
+              data_1.holiday_start_date,
+              data_1.holiday_end_date
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) data_1(holiday_projected_usage_gbp double precision, holiday_usage_to_date_gbp double precision, holiday_type text, holiday_start_date date, holiday_end_date date)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertGasHeatingHotWaterOnDuringHoliday'::text))) data,
+      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
+             FROM alert_generation_runs
+            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
+    WHERE (data.alert_generation_run_id = latest_runs.id);
+  SQL
+  create_view "gas_targets", sql_definition: <<-SQL
+      SELECT latest_runs.id,
+      data.alert_generation_run_id,
+      data.school_id,
+      data.current_year_percent_of_target_relative,
+      data.current_year_unscaled_percent_of_target_relative,
+      data.current_year_kwh,
+      data.current_year_target_kwh,
+      data.unscaled_target_kwh_to_date,
+      data.tracking_start_date
+     FROM ( SELECT alerts.alert_generation_run_id,
+              alerts.school_id,
+              data_1.current_year_percent_of_target_relative,
+              data_1.current_year_unscaled_percent_of_target_relative,
+              data_1.current_year_kwh,
+              data_1.current_year_target_kwh,
+              data_1.unscaled_target_kwh_to_date,
+              data_1.tracking_start_date
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) data_1(current_year_percent_of_target_relative double precision, current_year_unscaled_percent_of_target_relative double precision, current_year_kwh double precision, current_year_target_kwh double precision, unscaled_target_kwh_to_date double precision, tracking_start_date date)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertGasTargetAnnual'::text))) data,
+      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
+             FROM alert_generation_runs
+            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
+    WHERE (data.alert_generation_run_id = latest_runs.id);
   SQL
   create_view "heating_coming_on_too_early", sql_definition: <<-SQL
       WITH early AS (
@@ -3371,6 +3112,52 @@ ActiveRecord::Schema.define(version: 2024_03_25_112425) do
        LEFT JOIN early ON ((latest_runs.id = early.alert_generation_run_id)))
        LEFT JOIN optimum ON ((latest_runs.id = optimum.alert_generation_run_id)));
   SQL
+  create_view "heating_in_warm_weathers", sql_definition: <<-SQL
+      WITH gas AS (
+           SELECT alerts.alert_generation_run_id,
+              data.percent_of_annual_heating,
+              data.warm_weather_heating_days_all_days_kwh,
+              data.warm_weather_heating_days_all_days_co2,
+              data.warm_weather_heating_days_all_days_gbpcurrent,
+              data.warm_weather_heating_days_all_days_days
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) data(percent_of_annual_heating double precision, warm_weather_heating_days_all_days_kwh double precision, warm_weather_heating_days_all_days_co2 double precision, warm_weather_heating_days_all_days_gbpcurrent double precision, warm_weather_heating_days_all_days_days double precision)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertSeasonalHeatingSchoolDays'::text))
+          ), storage_heaters AS (
+           SELECT alerts.alert_generation_run_id,
+              data.percent_of_annual_heating,
+              data.warm_weather_heating_days_all_days_kwh,
+              data.warm_weather_heating_days_all_days_co2,
+              data.warm_weather_heating_days_all_days_gbpcurrent,
+              data.warm_weather_heating_days_all_days_days
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) data(percent_of_annual_heating double precision, warm_weather_heating_days_all_days_kwh double precision, warm_weather_heating_days_all_days_co2 double precision, warm_weather_heating_days_all_days_gbpcurrent double precision, warm_weather_heating_days_all_days_days double precision)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertSeasonalHeatingSchoolDaysStorageHeaters'::text))
+          ), additional AS (
+           SELECT alerts.alert_generation_run_id,
+              alerts.school_id
+             FROM alerts,
+              alert_types
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertAdditionalPrioritisationData'::text))
+          ), latest_runs AS (
+           SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
+             FROM alert_generation_runs
+            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC
+          )
+   SELECT latest_runs.id,
+      additional.school_id,
+      COALESCE(gas.percent_of_annual_heating, storage_heaters.percent_of_annual_heating) AS percent_of_annual_heating,
+      COALESCE(gas.warm_weather_heating_days_all_days_kwh, storage_heaters.warm_weather_heating_days_all_days_kwh) AS warm_weather_heating_days_all_days_kwh,
+      COALESCE(gas.warm_weather_heating_days_all_days_co2, storage_heaters.warm_weather_heating_days_all_days_co2) AS warm_weather_heating_days_all_days_co2,
+      COALESCE(gas.warm_weather_heating_days_all_days_gbpcurrent, storage_heaters.warm_weather_heating_days_all_days_gbpcurrent) AS warm_weather_heating_days_all_days_gbpcurrent,
+      COALESCE(gas.warm_weather_heating_days_all_days_days, storage_heaters.warm_weather_heating_days_all_days_days) AS warm_weather_heating_days_all_days_days
+     FROM (((latest_runs
+       JOIN additional ON ((latest_runs.id = additional.alert_generation_run_id)))
+       LEFT JOIN gas ON ((latest_runs.id = gas.alert_generation_run_id)))
+       LEFT JOIN storage_heaters ON ((latest_runs.id = storage_heaters.alert_generation_run_id)));
+  SQL
   create_view "holiday_usage_last_years", sql_definition: <<-SQL
       SELECT latest_runs.id,
       data.alert_generation_run_id,
@@ -3404,44 +3191,361 @@ ActiveRecord::Schema.define(version: 2024_03_25_112425) do
             ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
     WHERE (data.alert_generation_run_id = latest_runs.id);
   SQL
-  create_view "annual_change_in_electricity_out_of_hours_uses", sql_definition: <<-SQL
+  create_view "hot_water_efficiencies", sql_definition: <<-SQL
       SELECT latest_runs.id,
-      usage.alert_generation_run_id,
-      usage.school_id,
-      usage.out_of_hours_kwh,
-      usage.out_of_hours_co2,
-      usage.out_of_hours_gbpcurrent,
-      usage_previous_year.previous_out_of_hours_kwh,
-      usage_previous_year.previous_out_of_hours_co2,
-      usage_previous_year.previous_out_of_hours_gbpcurrent,
-      additional.economic_tariff_changed_this_year
+      data.alert_generation_run_id,
+      data.school_id,
+      data.avg_gas_per_pupil_gbp,
+      data.benchmark_existing_gas_efficiency,
+      data.benchmark_gas_better_control_saving_gbp,
+      data.benchmark_point_of_use_electric_saving_gbp
      FROM ( SELECT alerts.alert_generation_run_id,
               alerts.school_id,
-              json.out_of_hours_kwh,
-              json.out_of_hours_co2,
-              json.out_of_hours_gbpcurrent
+              data_1.avg_gas_per_pupil_gbp,
+              data_1.benchmark_existing_gas_efficiency,
+              data_1.benchmark_gas_better_control_saving_gbp,
+              data_1.benchmark_point_of_use_electric_saving_gbp
              FROM alerts,
               alert_types,
-              LATERAL jsonb_to_record(alerts.variables) json(out_of_hours_kwh double precision, out_of_hours_co2 double precision, out_of_hours_gbpcurrent double precision)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertOutOfHoursElectricityUsage'::text))) usage,
-      ( SELECT alerts.alert_generation_run_id,
+              LATERAL jsonb_to_record(alerts.variables) data_1(avg_gas_per_pupil_gbp double precision, benchmark_existing_gas_efficiency double precision, benchmark_gas_better_control_saving_gbp double precision, benchmark_point_of_use_electric_saving_gbp double precision)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertHotWaterEfficiency'::text))) data,
+      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
+             FROM alert_generation_runs
+            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
+    WHERE (data.alert_generation_run_id = latest_runs.id);
+  SQL
+  create_view "recent_change_in_baseloads", sql_definition: <<-SQL
+      SELECT latest_runs.id,
+      data.alert_generation_run_id,
+      data.school_id,
+      data.predicted_percent_increase_in_usage,
+      data.average_baseload_last_year_kw,
+      data.average_baseload_last_week_kw,
+      data.change_in_baseload_kw,
+      data.next_year_change_in_baseload_gbpcurrent,
+      additional.electricity_economic_tariff_changed_this_year
+     FROM ( SELECT alerts.alert_generation_run_id,
               alerts.school_id,
-              json.out_of_hours_kwh AS previous_out_of_hours_kwh,
-              json.out_of_hours_co2 AS previous_out_of_hours_co2,
-              json.out_of_hours_gbpcurrent AS previous_out_of_hours_gbpcurrent
+              data_1.predicted_percent_increase_in_usage,
+              data_1.average_baseload_last_year_kw,
+              data_1.average_baseload_last_week_kw,
+              data_1.change_in_baseload_kw,
+              data_1.next_year_change_in_baseload_gbpcurrent
              FROM alerts,
               alert_types,
-              LATERAL jsonb_to_record(alerts.variables) json(out_of_hours_kwh double precision, out_of_hours_co2 double precision, out_of_hours_gbpcurrent double precision)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertOutOfHoursElectricityUsagePreviousYear'::text))) usage_previous_year,
+              LATERAL jsonb_to_record(alerts.variables) data_1(predicted_percent_increase_in_usage double precision, average_baseload_last_year_kw double precision, average_baseload_last_week_kw double precision, change_in_baseload_kw double precision, next_year_change_in_baseload_gbpcurrent double precision)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertChangeInElectricityBaseloadShortTerm'::text))) data,
       ( SELECT alerts.alert_generation_run_id,
-              json.electricity_economic_tariff_changed_this_year AS economic_tariff_changed_this_year
+              data_1.electricity_economic_tariff_changed_this_year
              FROM alerts,
               alert_types,
-              LATERAL jsonb_to_record(alerts.variables) json(electricity_economic_tariff_changed_this_year boolean)
+              LATERAL jsonb_to_record(alerts.variables) data_1(electricity_economic_tariff_changed_this_year boolean)
             WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertAdditionalPrioritisationData'::text))) additional,
       ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
              FROM alert_generation_runs
             ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
-    WHERE ((usage.alert_generation_run_id = latest_runs.id) AND (usage_previous_year.alert_generation_run_id = latest_runs.id) AND (additional.alert_generation_run_id = latest_runs.id));
+    WHERE ((data.alert_generation_run_id = latest_runs.id) AND (additional.alert_generation_run_id = latest_runs.id));
+  SQL
+  create_view "seasonal_baseload_variations", sql_definition: <<-SQL
+      SELECT latest_runs.id,
+      additional.school_id,
+      data.alert_generation_run_id,
+      data.percent_seasonal_variation,
+      data.summer_kw,
+      data.winter_kw,
+      data.annual_cost_gbpcurrent,
+      additional.electricity_economic_tariff_changed_this_year
+     FROM ( SELECT alerts.alert_generation_run_id,
+              data_1.percent_seasonal_variation,
+              data_1.summer_kw,
+              data_1.winter_kw,
+              data_1.annual_cost_gbpcurrent
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) data_1(percent_seasonal_variation double precision, summer_kw double precision, winter_kw double precision, annual_cost_gbpcurrent double precision)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertSeasonalBaseloadVariation'::text))) data,
+      ( SELECT alerts.alert_generation_run_id,
+              alerts.school_id,
+              data_1.electricity_economic_tariff_changed_this_year
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) data_1(electricity_economic_tariff_changed_this_year boolean)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertAdditionalPrioritisationData'::text))) additional,
+      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
+             FROM alert_generation_runs
+            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
+    WHERE ((data.alert_generation_run_id = latest_runs.id) AND (additional.alert_generation_run_id = latest_runs.id));
+  SQL
+  create_view "solar_generation_summaries", sql_definition: <<-SQL
+      SELECT latest_runs.id,
+      solar_generation.alert_generation_run_id,
+      solar_generation.school_id,
+      solar_generation.annual_electricity_kwh,
+      solar_generation.annual_mains_consumed_kwh,
+      solar_generation.annual_solar_pv_kwh,
+      solar_generation.annual_exported_solar_pv_kwh,
+      solar_generation.annual_solar_pv_consumed_onsite_kwh
+     FROM ( SELECT alerts.alert_generation_run_id,
+              alerts.school_id,
+              data.annual_electricity_kwh,
+              data.annual_mains_consumed_kwh,
+              data.annual_solar_pv_kwh,
+              data.annual_exported_solar_pv_kwh,
+              data.annual_solar_pv_consumed_onsite_kwh
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) data(annual_electricity_kwh double precision, annual_mains_consumed_kwh double precision, annual_solar_pv_kwh double precision, annual_exported_solar_pv_kwh double precision, annual_solar_pv_consumed_onsite_kwh double precision)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertSolarGeneration'::text))) solar_generation,
+      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
+             FROM alert_generation_runs
+            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
+    WHERE (solar_generation.alert_generation_run_id = latest_runs.id);
+  SQL
+  create_view "solar_pv_benefit_estimates", sql_definition: <<-SQL
+      SELECT latest_runs.id,
+      additional.school_id,
+      benefit_estimate.alert_generation_run_id,
+      benefit_estimate.optimum_kwp,
+      benefit_estimate.optimum_payback_years,
+      benefit_estimate.optimum_mains_reduction_percent,
+      benefit_estimate.one_year_saving_gbpcurrent,
+      additional.electricity_economic_tariff_changed_this_year
+     FROM ( SELECT alerts.alert_generation_run_id,
+              data.optimum_kwp,
+              data.optimum_payback_years,
+              data.optimum_mains_reduction_percent,
+              data.one_year_saving_gbpcurrent
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) data(optimum_kwp double precision, optimum_payback_years double precision, optimum_mains_reduction_percent double precision, one_year_saving_gbpcurrent double precision)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertSolarPVBenefitEstimator'::text))) benefit_estimate,
+      ( SELECT alerts.alert_generation_run_id,
+              alerts.school_id,
+              data.electricity_economic_tariff_changed_this_year
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) data(electricity_economic_tariff_changed_this_year boolean)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertAdditionalPrioritisationData'::text))) additional,
+      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
+             FROM alert_generation_runs
+            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
+    WHERE ((benefit_estimate.alert_generation_run_id = latest_runs.id) AND (additional.alert_generation_run_id = latest_runs.id));
+  SQL
+  create_view "storage_heater_consumption_during_holidays", sql_definition: <<-SQL
+      SELECT latest_runs.id,
+      data.alert_generation_run_id,
+      data.school_id,
+      data.holiday_projected_usage_gbp,
+      data.holiday_usage_to_date_gbp,
+      data.holiday_type,
+      data.holiday_start_date,
+      data.holiday_end_date
+     FROM ( SELECT alerts.alert_generation_run_id,
+              alerts.school_id,
+              data_1.holiday_projected_usage_gbp,
+              data_1.holiday_usage_to_date_gbp,
+              data_1.holiday_type,
+              data_1.holiday_start_date,
+              data_1.holiday_end_date
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) data_1(holiday_projected_usage_gbp double precision, holiday_usage_to_date_gbp double precision, holiday_type text, holiday_start_date date, holiday_end_date date)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertStorageHeaterHeatingOnDuringHoliday'::text))) data,
+      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
+             FROM alert_generation_runs
+            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
+    WHERE (data.alert_generation_run_id = latest_runs.id);
+  SQL
+  create_view "thermostat_sensitivities", sql_definition: <<-SQL
+      SELECT latest_runs.id,
+      data.alert_generation_run_id,
+      data.school_id,
+      data."annual_saving_1_C_change_gbp"
+     FROM ( SELECT alerts.alert_generation_run_id,
+              alerts.school_id,
+              data_1."annual_saving_1_C_change_gbp"
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) data_1("annual_saving_1_C_change_gbp" double precision)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertHeatingSensitivityAdvice'::text))) data,
+      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
+             FROM alert_generation_runs
+            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
+    WHERE (data.alert_generation_run_id = latest_runs.id);
+  SQL
+  create_view "thermostatic_controls", sql_definition: <<-SQL
+      WITH gas AS (
+           SELECT alerts.alert_generation_run_id,
+              data.r2,
+              data.potential_saving_gbp
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) data(r2 double precision, potential_saving_gbp double precision)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertThermostaticControl'::text))
+          ), storage_heaters AS (
+           SELECT alerts.alert_generation_run_id,
+              data.r2,
+              data.potential_saving_gbp
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) data(r2 double precision, potential_saving_gbp double precision)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertStorageHeaterThermostatic'::text))
+          ), additional AS (
+           SELECT alerts.alert_generation_run_id,
+              alerts.school_id
+             FROM alerts,
+              alert_types
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertAdditionalPrioritisationData'::text))
+          ), latest_runs AS (
+           SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
+             FROM alert_generation_runs
+            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC
+          )
+   SELECT latest_runs.id,
+      additional.school_id,
+      COALESCE(gas.r2, storage_heaters.r2) AS r2,
+      NULLIF((COALESCE(gas.potential_saving_gbp, (0)::double precision) + COALESCE(storage_heaters.potential_saving_gbp, (0)::double precision)), (0)::double precision) AS potential_saving_gbp
+     FROM (((latest_runs
+       JOIN additional ON ((latest_runs.id = additional.alert_generation_run_id)))
+       LEFT JOIN gas ON ((latest_runs.id = gas.alert_generation_run_id)))
+       LEFT JOIN storage_heaters ON ((latest_runs.id = storage_heaters.alert_generation_run_id)));
+  SQL
+  create_view "weekday_baseload_variations", sql_definition: <<-SQL
+      SELECT latest_runs.id,
+      additional.school_id,
+      data.alert_generation_run_id,
+      data.percent_intraday_variation,
+      data.min_day_kw,
+      data.max_day_kw,
+      data.min_day,
+      data.max_day,
+      data.annual_cost_gbpcurrent,
+      additional.electricity_economic_tariff_changed_this_year
+     FROM ( SELECT alerts.alert_generation_run_id,
+              data_1.percent_intraday_variation,
+              data_1.min_day_kw,
+              data_1.max_day_kw,
+              data_1.min_day,
+              data_1.max_day,
+              data_1.annual_cost_gbpcurrent
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) data_1(percent_intraday_variation double precision, min_day_kw double precision, max_day_kw double precision, min_day integer, max_day integer, annual_cost_gbpcurrent double precision)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertIntraweekBaseloadVariation'::text))) data,
+      ( SELECT alerts.alert_generation_run_id,
+              alerts.school_id,
+              data_1.electricity_economic_tariff_changed_this_year
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) data_1(electricity_economic_tariff_changed_this_year boolean)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertAdditionalPrioritisationData'::text))) additional,
+      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
+             FROM alert_generation_runs
+            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
+    WHERE ((data.alert_generation_run_id = latest_runs.id) AND (additional.alert_generation_run_id = latest_runs.id));
+  SQL
+  create_view "heat_saver_march_2024s", sql_definition: <<-SQL
+      WITH electricity AS (
+           SELECT alerts.alert_generation_run_id,
+              json.current_period_kwh,
+              json.previous_period_kwh,
+              json.current_period_co2,
+              json.previous_period_co2,
+              json.current_period_gbp,
+              json.previous_period_gbp,
+              json.tariff_has_changed,
+              json.pupils_changed,
+              json.floor_area_changed
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) json(current_period_kwh double precision, previous_period_kwh double precision, current_period_co2 double precision, previous_period_co2 double precision, current_period_gbp double precision, previous_period_gbp double precision, tariff_has_changed boolean, pupils_changed boolean, floor_area_changed boolean)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertHeatSaver2024ElectricityComparison'::text))
+          ), gas AS (
+           SELECT alerts.alert_generation_run_id,
+              json.current_period_kwh,
+              json.previous_period_kwh,
+              json.current_period_co2,
+              json.previous_period_co2,
+              json.current_period_gbp,
+              json.previous_period_gbp,
+              json.previous_period_kwh_unadjusted,
+              json.tariff_has_changed,
+              json.pupils_changed,
+              json.floor_area_changed
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) json(current_period_kwh double precision, previous_period_kwh double precision, current_period_co2 double precision, previous_period_co2 double precision, current_period_gbp double precision, previous_period_gbp double precision, previous_period_kwh_unadjusted double precision, tariff_has_changed boolean, pupils_changed boolean, floor_area_changed boolean)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertHeatSaver2024GasComparison'::text))
+          ), storage_heater AS (
+           SELECT alerts.alert_generation_run_id,
+              json.current_period_kwh,
+              json.previous_period_kwh,
+              json.current_period_co2,
+              json.previous_period_co2,
+              json.current_period_gbp,
+              json.previous_period_gbp,
+              json.previous_period_kwh_unadjusted,
+              json.tariff_has_changed,
+              json.pupils_changed,
+              json.floor_area_changed
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) json(current_period_kwh double precision, previous_period_kwh double precision, current_period_co2 double precision, previous_period_co2 double precision, current_period_gbp double precision, previous_period_gbp double precision, previous_period_kwh_unadjusted double precision, tariff_has_changed boolean, pupils_changed boolean, floor_area_changed boolean)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertHeatSaver2024StorageHeaterComparison'::text))
+          ), enba AS (
+           SELECT alerts.alert_generation_run_id,
+              data.solar_type
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) data(solar_type text)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertEnergyAnnualVersusBenchmark'::text))
+          ), additional AS (
+           SELECT alerts.alert_generation_run_id,
+              alerts.school_id,
+              data.activation_date
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) data(activation_date date)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertAdditionalPrioritisationData'::text))
+          ), latest_runs AS (
+           SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
+             FROM alert_generation_runs
+            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC
+          )
+   SELECT latest_runs.id,
+      additional.school_id,
+      additional.activation_date,
+      (electricity.pupils_changed OR gas.pupils_changed OR storage_heater.pupils_changed) AS pupils_changed,
+      (electricity.floor_area_changed OR gas.floor_area_changed OR storage_heater.floor_area_changed) AS floor_area_changed,
+      enba.solar_type,
+      electricity.current_period_kwh AS electricity_current_period_kwh,
+      electricity.previous_period_kwh AS electricity_previous_period_kwh,
+      electricity.current_period_co2 AS electricity_current_period_co2,
+      electricity.previous_period_co2 AS electricity_previous_period_co2,
+      electricity.current_period_gbp AS electricity_current_period_gbp,
+      electricity.previous_period_gbp AS electricity_previous_period_gbp,
+      electricity.tariff_has_changed AS electricity_tariff_has_changed,
+      gas.current_period_kwh AS gas_current_period_kwh,
+      gas.previous_period_kwh AS gas_previous_period_kwh,
+      gas.current_period_co2 AS gas_current_period_co2,
+      gas.previous_period_co2 AS gas_previous_period_co2,
+      gas.current_period_gbp AS gas_current_period_gbp,
+      gas.previous_period_gbp AS gas_previous_period_gbp,
+      gas.previous_period_kwh_unadjusted AS gas_previous_period_kwh_unadjusted,
+      gas.tariff_has_changed AS gas_tariff_has_changed,
+      storage_heater.current_period_kwh AS storage_heater_current_period_kwh,
+      storage_heater.previous_period_kwh AS storage_heater_previous_period_kwh,
+      storage_heater.current_period_co2 AS storage_heater_current_period_co2,
+      storage_heater.previous_period_co2 AS storage_heater_previous_period_co2,
+      storage_heater.current_period_gbp AS storage_heater_current_period_gbp,
+      storage_heater.previous_period_gbp AS storage_heater_previous_period_gbp,
+      storage_heater.previous_period_kwh_unadjusted AS storage_heater_previous_period_kwh_unadjusted,
+      storage_heater.tariff_has_changed AS storage_heater_tariff_has_changed
+     FROM (((((latest_runs
+       JOIN additional ON ((latest_runs.id = additional.alert_generation_run_id)))
+       LEFT JOIN electricity ON ((latest_runs.id = electricity.alert_generation_run_id)))
+       LEFT JOIN gas ON ((latest_runs.id = gas.alert_generation_run_id)))
+       LEFT JOIN storage_heater ON ((latest_runs.id = storage_heater.alert_generation_run_id)))
+       LEFT JOIN enba ON ((latest_runs.id = enba.alert_generation_run_id)));
   SQL
 end

--- a/db/views/heat_saver_march_2024s_v01.sql
+++ b/db/views/heat_saver_march_2024s_v01.sql
@@ -1,0 +1,96 @@
+WITH electricity AS (
+  SELECT alert_generation_run_id, json.*
+  FROM alerts, alert_types, jsonb_to_record(variables) AS json(
+    current_period_kwh float,
+    previous_period_kwh float,
+    current_period_co2 float,
+    previous_period_co2 float,
+    current_period_gbp float,
+    previous_period_gbp float,
+    tariff_has_changed boolean,
+    pupils_changed boolean,
+    floor_area_changed boolean
+  )
+  WHERE alerts.alert_type_id = alert_types.id and alert_types.class_name='AlertHeatSaver2024ElectricityComparison'
+), gas AS (
+  SELECT alert_generation_run_id, json.*
+  FROM alerts, alert_types, jsonb_to_record(variables) AS json(
+    current_period_kwh float,
+    previous_period_kwh float,
+    current_period_co2 float,
+    previous_period_co2 float,
+    current_period_gbp float,
+    previous_period_gbp float,
+    previous_period_kwh_unadjusted float,
+    tariff_has_changed boolean,
+    pupils_changed boolean,
+    floor_area_changed boolean
+  )
+  WHERE alerts.alert_type_id = alert_types.id and alert_types.class_name='AlertHeatSaver2024GasComparison'
+), storage_heater AS (
+  SELECT alert_generation_run_id, json.*
+  FROM alerts, alert_types, jsonb_to_record(variables) AS json(
+    current_period_kwh float,
+    previous_period_kwh float,
+    current_period_co2 float,
+    previous_period_co2 float,
+    current_period_gbp float,
+    previous_period_gbp float,
+    previous_period_kwh_unadjusted float,
+    tariff_has_changed boolean,
+    pupils_changed boolean,
+    floor_area_changed boolean
+  )
+  WHERE alerts.alert_type_id = alert_types.id and alert_types.class_name='AlertHeatSaver2024StorageHeaterComparison'
+), enba AS (
+    SELECT alert_generation_run_id, data.*
+    FROM alerts, alert_types, jsonb_to_record(variables) AS data(
+      solar_type text
+    )
+    WHERE alerts.alert_type_id = alert_types.id and alert_types.class_name='AlertEnergyAnnualVersusBenchmark'
+), additional AS (
+  SELECT alert_generation_run_id, school_id, data.*
+  FROM alerts, alert_types, jsonb_to_record(variables) AS data(
+    activation_date date
+    )
+  WHERE alerts.alert_type_id = alert_types.id and alert_types.class_name='AlertAdditionalPrioritisationData'
+), latest_runs AS (
+  SELECT DISTINCT ON (school_id) id
+  FROM alert_generation_runs
+  ORDER BY school_id, created_at DESC
+)
+SELECT latest_runs.id,
+       additional.school_id,
+       additional.activation_date,
+       (electricity.pupils_changed OR gas.pupils_changed OR storage_heater.pupils_changed) AS pupils_changed,
+       (electricity.floor_area_changed OR gas.floor_area_changed OR storage_heater.floor_area_changed) AS floor_area_changed,
+       enba.solar_type AS solar_type,
+       electricity.current_period_kwh AS electricity_current_period_kwh,
+       electricity.previous_period_kwh AS electricity_previous_period_kwh,
+       electricity.current_period_co2 AS electricity_current_period_co2,
+       electricity.previous_period_co2 AS electricity_previous_period_co2,
+       electricity.current_period_gbp AS electricity_current_period_gbp,
+       electricity.previous_period_gbp AS electricity_previous_period_gbp,
+       electricity.tariff_has_changed AS electricity_tariff_has_changed,
+       gas.current_period_kwh AS gas_current_period_kwh,
+       gas.previous_period_kwh AS gas_previous_period_kwh,
+       gas.current_period_co2 AS gas_current_period_co2,
+       gas.previous_period_co2 AS gas_previous_period_co2,
+       gas.current_period_gbp AS gas_current_period_gbp,
+       gas.previous_period_gbp AS gas_previous_period_gbp,
+       gas.previous_period_kwh_unadjusted as gas_previous_period_kwh_unadjusted,
+       gas.tariff_has_changed AS gas_tariff_has_changed,
+       storage_heater.current_period_kwh AS storage_heater_current_period_kwh,
+       storage_heater.previous_period_kwh AS storage_heater_previous_period_kwh,
+       storage_heater.current_period_co2 AS storage_heater_current_period_co2,
+       storage_heater.previous_period_co2 AS storage_heater_previous_period_co2,
+       storage_heater.current_period_gbp AS storage_heater_current_period_gbp,
+       storage_heater.previous_period_gbp AS storage_heater_previous_period_gbp,
+       storage_heater.previous_period_kwh_unadjusted AS storage_heater_previous_period_kwh_unadjusted,
+       storage_heater.tariff_has_changed AS storage_heater_tariff_has_changed
+FROM latest_runs
+JOIN additional ON latest_runs.id = additional.alert_generation_run_id
+LEFT JOIN electricity ON latest_runs.id = electricity.alert_generation_run_id
+LEFT JOIN gas ON latest_runs.id = gas.alert_generation_run_id
+LEFT JOIN storage_heater ON latest_runs.id = storage_heater.alert_generation_run_id
+LEFT JOIN enba ON latest_runs.id = enba.alert_generation_run_id

--- a/lib/energy_sparks/calculator.rb
+++ b/lib/energy_sparks/calculator.rb
@@ -1,0 +1,46 @@
+module EnergySparks
+  class Calculator
+    # Calculate percentage change across two values or sum of values in two arrays
+    def self.percent_change(base, new_val, to_nil_if_sum_zero = false)
+      return nil if to_nil_if_sum_zero && sum_data(base) == 0.0
+      return 0.0 if sum_data(base) == 0.0
+
+      change = (sum_data(new_val) - sum_data(base)) / sum_data(base)
+      to_nil_if_sum_zero && change == 0.0 ? nil : change
+    end
+
+    def self.sum_data(data, to_nil_if_sum_zero = false)
+      data = Array(data)
+      data.map! { |value| value || 0.0 } # create array 1st to avoid statsample map/sum bug
+      val = data.sum
+      to_nil_if_sum_zero && val == 0.0 ? nil : val
+    end
+
+    # Accepts 2 arrays of kwh, co2 or £ values.
+    # Expects first 2 values of each array to be the electricity and gas values
+    # Remainder of array can be storage heater and/or solar
+    #
+    # Only sums +previous_year_values+ if:
+    #
+    # - there are values for both electricity and gas in both years
+    # - electricity (or gas) is missing in both years
+    #
+    # Returns nil if there's no values for gas/electricity in previous year, but there are
+    # for the current year. As this indicates that the data coverage is incomplete and
+    # summing the values would produce a misleading figure.
+    #
+    # Storage heater values are not checked because these are based on
+    # electricity data and will be missing if the electricity is missing.
+    #
+    # Solar is not checked as panels may not have been installed until this year.
+    #
+    def self.sum_if_complete(previous_year_values, current_year_values)
+      eg_prev = previous_year_values[0..1].map(&:nil?)
+      eg_curr = current_year_values[0..1].map(&:nil?)
+
+      return nil if eg_prev != eg_curr
+
+      sum_data(previous_year_values)
+    end
+  end
+end

--- a/lib/tasks/deployment/20240417100759_heat_saver_march2024_config.rake
+++ b/lib/tasks/deployment/20240417100759_heat_saver_march2024_config.rake
@@ -1,0 +1,50 @@
+namespace :after_party do
+  desc 'Deployment task: Heat Saver March 2024 alerts'
+  task heat_saver_march2024_config: :environment do
+    puts "Running deploy task 'heat_saver_march2024_alerts'"
+
+    AlertType.create!(
+      frequency: :weekly,
+      fuel_type: :electricity,
+      sub_category: :electricity_use,
+      title: "Heat Saver March 2024 Electricity Comparison",
+      class_name: 'AlertHeatSaver2024ElectricityComparison',
+      source: :analytics,
+      has_ratings: true,
+      benchmark: true
+    ) unless AlertType.find_by_class_name('AlertHeatSaver2024ElectricityComparison')
+
+    AlertType.create!(
+      frequency: :weekly,
+      fuel_type: :gas,
+      sub_category: :heating,
+      title: "Heat Saver March 2024 Gas Comparison",
+      class_name: 'AlertHeatSaver2024GasComparison',
+      source: :analytics,
+      has_ratings: true,
+      benchmark: true
+    ) unless AlertType.find_by_class_name('AlertHeatSaver2024GasComparison')
+
+    AlertType.create!(
+      frequency: :weekly,
+      fuel_type: :storage_heater,
+      sub_category: :storage_heaters,
+      title: "Heat Saver March 2024 Storage heater Comparison",
+      class_name: 'AlertHeatSaver2024StorageHeaterComparison',
+      source: :analytics,
+      has_ratings: true,
+      benchmark: true
+    ) unless AlertType.find_by_class_name('AlertHeatSaver2024StorageHeaterComparison')
+
+    Comparison::Report.create!(
+      key: :heat_saver_march_2024,
+      title: 'Heat Saver March 2024',
+      public: false
+    ) unless Comparison::Report.find_by_id(:heat_saver_march_2024)
+
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord
+      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+  end
+end

--- a/spec/models/concerns/multiple_fuel_comparison_view_spec.rb
+++ b/spec/models/concerns/multiple_fuel_comparison_view_spec.rb
@@ -1,0 +1,82 @@
+require 'rails_helper'
+
+class DummyMultipleFuelComparisonView < OpenStruct
+  include MultipleFuelComparisonView
+end
+
+describe MultipleFuelComparisonView do
+  subject(:model) do
+    DummyMultipleFuelComparisonView.new(
+      electricity_previous_period_kwh: 1.0,
+      electricity_current_period_kwh: 2.0,
+      electricity_previous_period_co2: 2.5,
+      electricity_current_period_co2: 5.0,
+      electricity_previous_period_gbp: 3.0,
+      electricity_current_period_gbp: 6.0,
+      gas_previous_period_kwh: 10.0,
+      gas_current_period_kwh: 20.0,
+      gas_previous_period_co2: 25.0,
+      gas_current_period_co2: 50.0,
+      gas_previous_period_gbp: 30.0,
+      gas_current_period_gbp: 60.0,
+      storage_heater_previous_period_kwh: 100.0,
+      storage_heater_current_period_kwh: 200.0,
+      storage_heater_previous_period_co2: 250.0,
+      storage_heater_current_period_co2: 500.0,
+      storage_heater_previous_period_gbp: 300.0,
+      storage_heater_current_period_gbp: 600.0
+    )
+  end
+
+  describe '#field_names' do
+    it 'returns all expected attributes' do
+      expect(model.field_names(period: :previous_period)).to match_array([:electricity_previous_period_kwh, :gas_previous_period_kwh, :storage_heater_previous_period_kwh])
+      expect(model.field_names(period: :current_period)).to match_array([:electricity_current_period_kwh, :gas_current_period_kwh, :storage_heater_current_period_kwh])
+      expect(model.field_names(period: :current_period, unit: :co2)).to match_array([:electricity_current_period_co2, :gas_current_period_co2, :storage_heater_current_period_co2])
+      expect(model.field_names(period: :current_period, unit: :£)).to match_array([:electricity_current_period_gbp, :gas_current_period_gbp, :storage_heater_current_period_gbp])
+    end
+
+    describe 'with customised_fuel_types' do
+      subject(:model) do
+        DummyMultipleFuelComparisonView.new(
+          electricity_previous_period_kwh: 1.0,
+          electricity_current_period_kwh: 2.0,
+          electricity_previous_period_co2: 2.5,
+          electricity_current_period_co2: 5.0,
+          electricity_previous_period_gbp: 3.0,
+          electricity_current_period_gbp: 6.0,
+          gas_previous_period_kwh: 10.0,
+          gas_current_period_kwh: 20.0,
+          gas_previous_period_co2: 25.0,
+          gas_current_period_co2: 50.0,
+          gas_previous_period_gbp: 30.0,
+          gas_current_period_gbp: 60.0,
+          fuel_types: [:electricity, :gas]
+        )
+      end
+
+      it 'returns all expected attributes' do
+        expect(model.field_names(period: :previous_period)).to match_array([:electricity_previous_period_kwh, :gas_previous_period_kwh])
+        expect(model.field_names(period: :current_period)).to match_array([:electricity_current_period_kwh, :gas_current_period_kwh])
+        expect(model.field_names(period: :current_period, unit: :co2)).to match_array([:electricity_current_period_co2, :gas_current_period_co2])
+        expect(model.field_names(period: :current_period, unit: :£)).to match_array([:electricity_current_period_gbp, :gas_current_period_gbp])
+      end
+    end
+  end
+
+  describe '#total_current_period' do
+    it 'returns expected values' do
+      expect(model.total_current_period).to eq(222.0)
+      expect(model.total_current_period(unit: :co2)).to eq(555.0)
+      expect(model.total_current_period(unit: :£)).to eq(666.0)
+    end
+  end
+
+  describe '#all_previous_period' do
+    it 'returns expected values' do
+      expect(model.all_previous_period).to match_array([1.0, 10.0, 100.0])
+      expect(model.all_previous_period(unit: :co2)).to match_array([2.5, 25.0, 250.0])
+      expect(model.all_previous_period(unit: :£)).to match_array([3.0, 30.0, 300.0])
+    end
+  end
+end

--- a/spec/system/comparisons/heat_saver_march_2024_spec.rb
+++ b/spec/system/comparisons/heat_saver_march_2024_spec.rb
@@ -20,6 +20,21 @@ describe 'heat_saver_march_2024' do
     }
   end
 
+  let(:heating_usage_variables) do
+    {
+      current_period_kwh: 1000.0,
+      previous_period_kwh: 2000.0,
+      previous_period_kwh_unadjusted: 1800.0,
+      current_period_co2: 100.0,
+      previous_period_co2: 200.0,
+      current_period_gbp: 2000.0,
+      previous_period_gbp: 4000.0,
+      tariff_has_changed: true,
+      pupils_changed: true,
+      floor_area_changed: true
+    }
+  end
+
   let!(:report) { create(:report, key: key) }
 
   include_context 'with comparison report footnotes' do
@@ -32,7 +47,7 @@ describe 'heat_saver_march_2024' do
 
     create(:alert, school: school, alert_generation_run: alert_run,
                    alert_type: create(:alert_type, class_name: 'AlertAdditionalPrioritisationData'),
-                   variables: { activation_date: Time.zone.today })
+                   variables: { activation_date: Date.new(2023, 1, 1) })
 
     create(:alert, school: school, alert_generation_run: alert_run,
                    alert_type: create(:alert_type, class_name: 'AlertEnergyAnnualVersusBenchmark'),
@@ -44,11 +59,11 @@ describe 'heat_saver_march_2024' do
 
     create(:alert, school: school, alert_generation_run: alert_run,
                    alert_type: create(:alert_type, class_name: 'AlertHeatSaver2024GasComparison'),
-                   variables: usage_variables)
+                   variables: heating_usage_variables)
 
     create(:alert, school: school, alert_generation_run: alert_run,
                    alert_type: create(:alert_type, class_name: 'AlertHeatSaver2024StorageHeaterComparison'),
-                   variables: usage_variables)
+                   variables: heating_usage_variables)
   end
 
   context 'when viewing report' do
@@ -58,36 +73,253 @@ describe 'heat_saver_march_2024' do
       let(:expected_report) { report }
     end
 
-    it_behaves_like 'a school comparison report with a table' do
-      let(:expected_report) { report }
-      let(:expected_school) { school }
-      let(:advice_page_path) { polymorphic_path([:insights, expected_school, :advice, advice_page_key]) }
+    context 'with a total table' do
+      it_behaves_like 'a school comparison report with a table' do
+        let(:expected_report) { report }
+        let(:expected_school) { school }
+        let(:advice_page_path) { polymorphic_path([:insights, expected_school, :advice, advice_page_key]) }
+        let(:table_name) { :total }
 
-      let(:headers) do
-        ['School',
-         'Last year electricity £/pupil',
-         'Last year electricity £',
-         'Saving if matched exemplar school (using latest tariff)']
+        let(:colgroups) do
+          [
+            '',
+            I18n.t('analytics.benchmarking.configuration.column_groups.kwh'),
+            I18n.t('analytics.benchmarking.configuration.column_groups.co2_kg'),
+            I18n.t('analytics.benchmarking.configuration.column_groups.gbp')
+          ]
+        end
+        let(:headers) do
+          [
+            I18n.t('analytics.benchmarking.configuration.column_headings.school'),
+            I18n.t('analytics.benchmarking.configuration.column_headings.fuel'),
+            I18n.t('activerecord.attributes.school.activation_date'),
+            I18n.t('comparisons.column_headings.previous_period'),
+            I18n.t('comparisons.column_headings.current_period'),
+            I18n.t('analytics.benchmarking.configuration.column_headings.change_pct'),
+            I18n.t('comparisons.column_headings.previous_period'),
+            I18n.t('comparisons.column_headings.current_period'),
+            I18n.t('analytics.benchmarking.configuration.column_headings.change_pct'),
+            I18n.t('comparisons.column_headings.previous_period'),
+            I18n.t('comparisons.column_headings.current_period'),
+            I18n.t('analytics.benchmarking.configuration.column_headings.change_pct')
+          ]
+        end
+
+        let(:expected_table) do
+          [colgroups,
+           headers,
+           ["#{school.name} [#{tariff_changed_last_year[:label]}] [#{electricity_change_rows[:label]}] [#{gas_change_rows[:label]}]",
+            '',
+            'Jan 2023',
+            '6,000',
+            '3,000',
+            '-50&percnt;',
+            '600',
+            '300',
+            '-50&percnt;',
+            '£12,000',
+            '£6,000',
+            '-50&percnt;'
+           ],
+           ["Notes\n[1] the comparison has been adjusted because the floor area has changed between the two periods for some schools. [1] the comparison has been adjusted because the number of pupils have changed between the two periods. [5] The tariff has changed during the last year for this school. Savings are calculated using the latest tariff but other £ values are calculated using the relevant tariff at the time"]
+]
+        end
+
+        let(:expected_csv) do
+          [headers,
+           [school.name,
+            '195',
+            '235,000',
+            '155,000']
+          ]
+        end
       end
+    end
 
-      let(:expected_table) do
-        [headers,
-         [school.name,
-          '£195',
-          '£235,000',
-          '£155,000',
-         ],
-         ["Notes\nIn school comparisons 'last year' is defined as this year to date."]
-        ]
+    context 'with an electricity table' do
+      it_behaves_like 'a school comparison report with a table' do
+        let(:expected_report) { report }
+        let(:expected_school) { school }
+        let(:advice_page_path) { polymorphic_path([:insights, expected_school, :advice, advice_page_key]) }
+        let(:table_name) { :electricity }
+
+        let(:colgroups) do
+          [
+            '',
+            I18n.t('analytics.benchmarking.configuration.column_groups.kwh'),
+            I18n.t('analytics.benchmarking.configuration.column_groups.co2_kg'),
+            I18n.t('analytics.benchmarking.configuration.column_groups.gbp')
+          ]
+        end
+        let(:headers) do
+          [
+            I18n.t('analytics.benchmarking.configuration.column_headings.school'),
+            I18n.t('activerecord.attributes.school.activation_date'),
+            I18n.t('comparisons.column_headings.previous_period'),
+            I18n.t('comparisons.column_headings.current_period'),
+            I18n.t('analytics.benchmarking.configuration.column_headings.change_pct'),
+            I18n.t('comparisons.column_headings.previous_period'),
+            I18n.t('comparisons.column_headings.current_period'),
+            I18n.t('analytics.benchmarking.configuration.column_headings.change_pct'),
+            I18n.t('comparisons.column_headings.previous_period'),
+            I18n.t('comparisons.column_headings.current_period'),
+            I18n.t('analytics.benchmarking.configuration.column_headings.change_pct')
+          ]
+        end
+
+        let(:expected_table) do
+          [colgroups,
+           headers,
+           ["#{school.name} [#{tariff_changed_last_year[:label]}] [#{electricity_change_rows[:label]}]",
+            'Jan 2023',
+            '2,000',
+            '1,000',
+            '-50&percnt;',
+            '200',
+            '100',
+            '-50&percnt;',
+            '£4,000',
+            '£2,000',
+            '-50&percnt;'
+           ],
+           ["Notes\n[1] the comparison has been adjusted because the number of pupils have changed between the two periods. [5] The tariff has changed during the last year for this school. Savings are calculated using the latest tariff but other £ values are calculated using the relevant tariff at the time"]
+]
+        end
+
+        let(:expected_csv) do
+          [headers,
+           [school.name,
+            '195',
+            '235,000',
+            '155,000']
+          ]
+        end
       end
+    end
 
-      let(:expected_csv) do
-        [headers,
-         [school.name,
-          '195',
-          '235,000',
-          '155,000']
-        ]
+    context 'with a gas table' do
+      it_behaves_like 'a school comparison report with a table' do
+        let(:expected_report) { report }
+        let(:expected_school) { school }
+        let(:advice_page_path) { polymorphic_path([:insights, expected_school, :advice, advice_page_key]) }
+        let(:table_name) { :gas }
+
+        let(:colgroups) do
+          [
+            '',
+            I18n.t('analytics.benchmarking.configuration.column_groups.kwh'),
+            I18n.t('analytics.benchmarking.configuration.column_groups.co2_kg'),
+            I18n.t('analytics.benchmarking.configuration.column_groups.gbp')
+          ]
+        end
+        let(:headers) do
+          [
+            I18n.t('analytics.benchmarking.configuration.column_headings.school'),
+            I18n.t('activerecord.attributes.school.activation_date'),
+            I18n.t('comparisons.column_headings.previous_period_unadjusted'),
+            I18n.t('comparisons.column_headings.previous_period'),
+            I18n.t('comparisons.column_headings.current_period'),
+            I18n.t('analytics.benchmarking.configuration.column_headings.change_pct'),
+            I18n.t('comparisons.column_headings.previous_period'),
+            I18n.t('comparisons.column_headings.current_period'),
+            I18n.t('analytics.benchmarking.configuration.column_headings.change_pct'),
+            I18n.t('comparisons.column_headings.previous_period'),
+            I18n.t('comparisons.column_headings.current_period'),
+            I18n.t('analytics.benchmarking.configuration.column_headings.change_pct')
+          ]
+        end
+
+        let(:expected_table) do
+          [colgroups,
+           headers,
+           ["#{school.name} [#{tariff_changed_last_year[:label]}] [#{electricity_change_rows[:label]}]",
+            'Jan 2023',
+            '1,800',
+            '2,000',
+            '1,000',
+            '-50&percnt;',
+            '200',
+            '100',
+            '-50&percnt;',
+            '£4,000',
+            '£2,000',
+            '-50&percnt;'
+           ],
+           ["Notes\n[1] the comparison has been adjusted because the floor area has changed between the two periods for some schools. [5] The tariff has changed during the last year for this school. Savings are calculated using the latest tariff but other £ values are calculated using the relevant tariff at the time"]
+]
+        end
+
+        let(:expected_csv) do
+          [headers,
+           [school.name,
+            '195',
+            '235,000',
+            '155,000']
+          ]
+        end
+      end
+    end
+
+    context 'with a storage heater table' do
+      it_behaves_like 'a school comparison report with a table' do
+        let(:expected_report) { report }
+        let(:expected_school) { school }
+        let(:advice_page_path) { polymorphic_path([:insights, expected_school, :advice, advice_page_key]) }
+        let(:table_name) { :storage_heater }
+
+        let(:colgroups) do
+          [
+            '',
+            I18n.t('analytics.benchmarking.configuration.column_groups.kwh'),
+            I18n.t('analytics.benchmarking.configuration.column_groups.co2_kg'),
+            I18n.t('analytics.benchmarking.configuration.column_groups.gbp')
+          ]
+        end
+        let(:headers) do
+          [
+            I18n.t('analytics.benchmarking.configuration.column_headings.school'),
+            I18n.t('activerecord.attributes.school.activation_date'),
+            I18n.t('comparisons.column_headings.previous_period_unadjusted'),
+            I18n.t('comparisons.column_headings.previous_period'),
+            I18n.t('comparisons.column_headings.current_period'),
+            I18n.t('analytics.benchmarking.configuration.column_headings.change_pct'),
+            I18n.t('comparisons.column_headings.previous_period'),
+            I18n.t('comparisons.column_headings.current_period'),
+            I18n.t('analytics.benchmarking.configuration.column_headings.change_pct'),
+            I18n.t('comparisons.column_headings.previous_period'),
+            I18n.t('comparisons.column_headings.current_period'),
+            I18n.t('analytics.benchmarking.configuration.column_headings.change_pct')
+          ]
+        end
+
+        let(:expected_table) do
+          [colgroups,
+           headers,
+           ["#{school.name} [#{tariff_changed_last_year[:label]}] [#{electricity_change_rows[:label]}]",
+            'Jan 2023',
+            '1,800',
+            '2,000',
+            '1,000',
+            '-50&percnt;',
+            '200',
+            '100',
+            '-50&percnt;',
+            '£4,000',
+            '£2,000',
+            '-50&percnt;'
+           ],
+           ["Notes\n[1] the comparison has been adjusted because the number of pupils have changed between the two periods. [5] The tariff has changed during the last year for this school. Savings are calculated using the latest tariff but other £ values are calculated using the relevant tariff at the time"]
+]
+        end
+
+        let(:expected_csv) do
+          [headers,
+           [school.name,
+            '195',
+            '235,000',
+            '155,000']
+          ]
+        end
       end
     end
 

--- a/spec/system/comparisons/heat_saver_march_2024_spec.rb
+++ b/spec/system/comparisons/heat_saver_march_2024_spec.rb
@@ -3,33 +3,52 @@ require 'rails_helper'
 describe 'heat_saver_march_2024' do
   let!(:school) { create(:school) }
   let(:key) { :heat_saver_march_2024 }
-  let(:advice_page_key) { :your_advice_page_key }
+  let(:advice_page_key) { :total_energy_use }
 
   # change to your variables
-  let(:variables) do
+  let(:usage_variables) do
     {
-      current_year_percent_of_target_relative: +0.18699995372972533,
-      current_year_unscaled_percent_of_target_relative: -0.4799985149375391,
-      current_year_kwh: 1284.7,
-      current_year_target_kwh: 2281.8825833333326,
-      unscaled_target_kwh_to_date: 2401.9816666666666,
-      tracking_start_date: '2024-01-01'
+      current_period_kwh: 1000.0,
+      previous_period_kwh: 2000.0,
+      current_period_co2: 100.0,
+      previous_period_co2: 200.0,
+      current_period_gbp: 2000.0,
+      previous_period_gbp: 4000.0,
+      tariff_has_changed: true,
+      pupils_changed: true,
+      floor_area_changed: true
     }
   end
 
-  # change to your alert type (there may be more than one!)
-  let(:alert_type) { create(:alert_type, class_name: 'AlertElectricityTargetAnnual') }
-  let(:alert_run) { create(:alert_generation_run, school: school) }
   let!(:report) { create(:report, key: key) }
+
+  include_context 'with comparison report footnotes' do
+    let(:footnotes) { [electricity_change_rows, gas_change_rows, tariff_changed_last_year] }
+  end
 
   before do
     create(:advice_page, key: advice_page_key)
-    create(:alert, school: school, alert_generation_run: alert_run, alert_type: alert_type, variables: variables)
-    # the following alert is often only required for the tariff changed footnote
-    # delete or amend as appropriate:
+    alert_run = create(:alert_generation_run, school: school)
+
     create(:alert, school: school, alert_generation_run: alert_run,
                    alert_type: create(:alert_type, class_name: 'AlertAdditionalPrioritisationData'),
-                   variables: { electricity_economic_tariff_changed_this_year: true })
+                   variables: { activation_date: Time.zone.today })
+
+    create(:alert, school: school, alert_generation_run: alert_run,
+                   alert_type: create(:alert_type, class_name: 'AlertEnergyAnnualVersusBenchmark'),
+                   variables: { solar_type: 'metered' })
+
+    create(:alert, school: school, alert_generation_run: alert_run,
+                   alert_type: create(:alert_type, class_name: 'AlertHeatSaver2024ElectricityComparison'),
+                   variables: usage_variables)
+
+    create(:alert, school: school, alert_generation_run: alert_run,
+                   alert_type: create(:alert_type, class_name: 'AlertHeatSaver2024GasComparison'),
+                   variables: usage_variables)
+
+    create(:alert, school: school, alert_generation_run: alert_run,
+                   alert_type: create(:alert_type, class_name: 'AlertHeatSaver2024StorageHeaterComparison'),
+                   variables: usage_variables)
   end
 
   context 'when viewing report' do

--- a/spec/system/comparisons/heat_saver_march_2024_spec.rb
+++ b/spec/system/comparisons/heat_saver_march_2024_spec.rb
@@ -132,7 +132,7 @@ describe 'heat_saver_march_2024' do
             headers,
             [
               school.name,
-              '',
+              'Electricity;Gas;Storage heaters',
               '2023-01-01',
               '6,000',
               '3,000',

--- a/spec/system/comparisons/heat_saver_march_2024_spec.rb
+++ b/spec/system/comparisons/heat_saver_march_2024_spec.rb
@@ -106,31 +106,44 @@ describe 'heat_saver_march_2024' do
         end
 
         let(:expected_table) do
-          [colgroups,
-           headers,
-           ["#{school.name} [#{tariff_changed_last_year[:label]}] [#{electricity_change_rows[:label]}] [#{gas_change_rows[:label]}]",
-            '',
-            'Jan 2023',
-            '6,000',
-            '3,000',
-            '-50&percnt;',
-            '600',
-            '300',
-            '-50&percnt;',
-            '£12,000',
-            '£6,000',
-            '-50&percnt;'
-           ],
-           ["Notes\n[1] the comparison has been adjusted because the floor area has changed between the two periods for some schools. [1] the comparison has been adjusted because the number of pupils have changed between the two periods. [5] The tariff has changed during the last year for this school. Savings are calculated using the latest tariff but other £ values are calculated using the relevant tariff at the time"]
-]
+          [
+            colgroups,
+            headers,
+            ["#{school.name} [#{tariff_changed_last_year[:label]}] [#{electricity_change_rows[:label]}] [#{gas_change_rows[:label]}]",
+             '',
+             'Jan 2023',
+             '6,000',
+             '3,000',
+             '-50&percnt;',
+             '600',
+             '300',
+             '-50&percnt;',
+             '£12,000',
+             '£6,000',
+             '-50&percnt;'
+            ],
+            ["Notes\n[1] the comparison has been adjusted because the floor area has changed between the two periods for some schools. [1] the comparison has been adjusted because the number of pupils have changed between the two periods. [5] The tariff has changed during the last year for this school. Savings are calculated using the latest tariff but other £ values are calculated using the relevant tariff at the time"]
+          ]
         end
 
         let(:expected_csv) do
-          [headers,
-           [school.name,
-            '195',
-            '235,000',
-            '155,000']
+          [
+            ['', '', '', 'kWh', '', '', 'CO2 (kg)', '', '', '£', '', ''],
+            headers,
+            [
+              school.name,
+              '',
+              '2023-01-01',
+              '6,000',
+              '3,000',
+              '-50',
+              '600',
+              '300',
+              '-50',
+              '12,000',
+              '6,000',
+              '-50'
+            ]
           ]
         end
       end
@@ -168,30 +181,41 @@ describe 'heat_saver_march_2024' do
         end
 
         let(:expected_table) do
-          [colgroups,
-           headers,
-           ["#{school.name} [#{tariff_changed_last_year[:label]}] [#{electricity_change_rows[:label]}]",
-            'Jan 2023',
-            '2,000',
-            '1,000',
-            '-50&percnt;',
-            '200',
-            '100',
-            '-50&percnt;',
-            '£4,000',
-            '£2,000',
-            '-50&percnt;'
-           ],
-           ["Notes\n[1] the comparison has been adjusted because the number of pupils have changed between the two periods. [5] The tariff has changed during the last year for this school. Savings are calculated using the latest tariff but other £ values are calculated using the relevant tariff at the time"]
-]
+          [
+            colgroups,
+            headers,
+            ["#{school.name} [#{tariff_changed_last_year[:label]}] [#{electricity_change_rows[:label]}]",
+             'Jan 2023',
+             '2,000',
+             '1,000',
+             '-50&percnt;',
+             '200',
+             '100',
+             '-50&percnt;',
+             '£4,000',
+             '£2,000',
+             '-50&percnt;'
+            ],
+            ["Notes\n[1] the comparison has been adjusted because the number of pupils have changed between the two periods. [5] The tariff has changed during the last year for this school. Savings are calculated using the latest tariff but other £ values are calculated using the relevant tariff at the time"]
+          ]
         end
 
         let(:expected_csv) do
-          [headers,
-           [school.name,
-            '195',
-            '235,000',
-            '155,000']
+          [
+            ['', '', 'kWh', '', '', 'CO2 (kg)', '', '', '£', '', ''],
+            headers,
+            [school.name,
+             '2023-01-01',
+             '2,000',
+             '1,000',
+             '-50',
+             '200',
+             '100',
+             '-50',
+             '4,000',
+             '2,000',
+             '-50'
+            ]
           ]
         end
       end
@@ -230,31 +254,43 @@ describe 'heat_saver_march_2024' do
         end
 
         let(:expected_table) do
-          [colgroups,
-           headers,
-           ["#{school.name} [#{tariff_changed_last_year[:label]}] [#{electricity_change_rows[:label]}]",
-            'Jan 2023',
-            '1,800',
-            '2,000',
-            '1,000',
-            '-50&percnt;',
-            '200',
-            '100',
-            '-50&percnt;',
-            '£4,000',
-            '£2,000',
-            '-50&percnt;'
-           ],
-           ["Notes\n[1] the comparison has been adjusted because the floor area has changed between the two periods for some schools. [5] The tariff has changed during the last year for this school. Savings are calculated using the latest tariff but other £ values are calculated using the relevant tariff at the time"]
-]
+          [
+            colgroups,
+            headers,
+            ["#{school.name} [#{tariff_changed_last_year[:label]}] [#{electricity_change_rows[:label]}]",
+             'Jan 2023',
+             '1,800',
+             '2,000',
+             '1,000',
+             '-50&percnt;',
+             '200',
+             '100',
+             '-50&percnt;',
+             '£4,000',
+             '£2,000',
+             '-50&percnt;'
+            ],
+            ["Notes\n[1] the comparison has been adjusted because the floor area has changed between the two periods for some schools. [5] The tariff has changed during the last year for this school. Savings are calculated using the latest tariff but other £ values are calculated using the relevant tariff at the time"]
+          ]
         end
 
         let(:expected_csv) do
-          [headers,
-           [school.name,
-            '195',
-            '235,000',
-            '155,000']
+          [
+            ['', '', 'kWh', '', '', '', 'CO2 (kg)', '', '', '£', '', ''],
+            headers,
+            [school.name,
+             '2023-01-01',
+             '1,800',
+             '2,000',
+             '1,000',
+             '-50',
+             '200',
+             '100',
+             '-50',
+             '4,000',
+             '2,000',
+             '-50'
+            ]
           ]
         end
       end
@@ -293,31 +329,43 @@ describe 'heat_saver_march_2024' do
         end
 
         let(:expected_table) do
-          [colgroups,
-           headers,
-           ["#{school.name} [#{tariff_changed_last_year[:label]}] [#{electricity_change_rows[:label]}]",
-            'Jan 2023',
-            '1,800',
-            '2,000',
-            '1,000',
-            '-50&percnt;',
-            '200',
-            '100',
-            '-50&percnt;',
-            '£4,000',
-            '£2,000',
-            '-50&percnt;'
-           ],
-           ["Notes\n[1] the comparison has been adjusted because the number of pupils have changed between the two periods. [5] The tariff has changed during the last year for this school. Savings are calculated using the latest tariff but other £ values are calculated using the relevant tariff at the time"]
-]
+          [
+            colgroups,
+            headers,
+            ["#{school.name} [#{tariff_changed_last_year[:label]}] [#{electricity_change_rows[:label]}]",
+             'Jan 2023',
+             '1,800',
+             '2,000',
+             '1,000',
+             '-50&percnt;',
+             '200',
+             '100',
+             '-50&percnt;',
+             '£4,000',
+             '£2,000',
+             '-50&percnt;'
+            ],
+            ["Notes\n[1] the comparison has been adjusted because the number of pupils have changed between the two periods. [5] The tariff has changed during the last year for this school. Savings are calculated using the latest tariff but other £ values are calculated using the relevant tariff at the time"]
+          ]
         end
 
         let(:expected_csv) do
-          [headers,
-           [school.name,
-            '195',
-            '235,000',
-            '155,000']
+          [
+            ['', '', 'kWh', '', '', '', 'CO2 (kg)', '', '', '£', '', ''],
+            headers,
+            [school.name,
+             '2023-01-01',
+             '1,800',
+             '2,000',
+             '1,000',
+             '-50',
+             '200',
+             '100',
+             '-50',
+             '4,000',
+             '2,000',
+             '-50'
+            ]
           ]
         end
       end

--- a/spec/system/comparisons/heat_saver_march_2024_spec.rb
+++ b/spec/system/comparisons/heat_saver_march_2024_spec.rb
@@ -1,0 +1,77 @@
+require 'rails_helper'
+
+describe 'heat_saver_march_2024' do
+  let!(:school) { create(:school) }
+  let(:key) { :heat_saver_march_2024 }
+  let(:advice_page_key) { :your_advice_page_key }
+
+  # change to your variables
+  let(:variables) do
+    {
+      current_year_percent_of_target_relative: +0.18699995372972533,
+      current_year_unscaled_percent_of_target_relative: -0.4799985149375391,
+      current_year_kwh: 1284.7,
+      current_year_target_kwh: 2281.8825833333326,
+      unscaled_target_kwh_to_date: 2401.9816666666666,
+      tracking_start_date: '2024-01-01'
+    }
+  end
+
+  # change to your alert type (there may be more than one!)
+  let(:alert_type) { create(:alert_type, class_name: 'AlertElectricityTargetAnnual') }
+  let(:alert_run) { create(:alert_generation_run, school: school) }
+  let!(:report) { create(:report, key: key) }
+
+  before do
+    create(:advice_page, key: advice_page_key)
+    create(:alert, school: school, alert_generation_run: alert_run, alert_type: alert_type, variables: variables)
+    # the following alert is often only required for the tariff changed footnote
+    # delete or amend as appropriate:
+    create(:alert, school: school, alert_generation_run: alert_run,
+                   alert_type: create(:alert_type, class_name: 'AlertAdditionalPrioritisationData'),
+                   variables: { electricity_economic_tariff_changed_this_year: true })
+  end
+
+  context 'when viewing report' do
+    before { visit "/comparisons/#{key}" }
+
+    it_behaves_like 'a school comparison report' do
+      let(:expected_report) { report }
+    end
+
+    it_behaves_like 'a school comparison report with a table' do
+      let(:expected_report) { report }
+      let(:expected_school) { school }
+      let(:advice_page_path) { polymorphic_path([:insights, expected_school, :advice, advice_page_key]) }
+
+      let(:headers) do
+        ['School',
+         'Last year electricity £/pupil',
+         'Last year electricity £',
+         'Saving if matched exemplar school (using latest tariff)']
+      end
+
+      let(:expected_table) do
+        [headers,
+         [school.name,
+          '£195',
+          '£235,000',
+          '£155,000',
+         ],
+         ["Notes\nIn school comparisons 'last year' is defined as this year to date."]
+        ]
+      end
+
+      let(:expected_csv) do
+        [headers,
+         [school.name,
+          '195',
+          '235,000',
+          '155,000']
+        ]
+      end
+    end
+
+    it_behaves_like 'a school comparison report with a chart'
+  end
+end


### PR DESCRIPTION
Implements a new report for the Winter Heat Saver competition.

The report uses some new period comparison alerts so the PR bumps the analytics and includes the database changes to register those and the new report.

The report consists of 4 tables (a total and one each for electricity, gas and storage heaters) and a chart.

The views can eventually be repurposed to become the basis for the new configurable period reports so I've spent a bit of time ensuring they have a sensible table structure and footnotes, although there's more that could be tidied.

I've also included a new concern `MultipleFuelComparisonView` which can be mixed into views that have columns for the three fuel types across multiple periods. The concern adds some helper methods for calculating totals and percentage changes. Some of the final set of Total Energy Use reports we have to implement will also use this.

I've also extracted some of the simple calculation functions into a separate `Calculator` class. These functions are mostly used by the existing benchmarking code. We're using some of them via helpers but as I wanted to use them in a model I've extracted into a separate class. 