### PR TITLE
Add additional school features to edit school details & school estates page + issues search

### DIFF
--- a/app/controllers/admin/issues_controller.rb
+++ b/app/controllers/admin/issues_controller.rb
@@ -14,6 +14,7 @@ module Admin
       @issues = @issues.for_issue_types(params[:issue_types])
       @issues = @issues.for_statuses(params[:statuses])
       @issues = @issues.for_owned_by(params[:user]) if params[:user].present?
+      @issues = @issues.search(params[:search]) if params[:search].present?
 
       respond_to do |format|
         format.html do

--- a/app/controllers/schools/your_school_estates_controller.rb
+++ b/app/controllers/schools/your_school_estates_controller.rb
@@ -1,7 +1,6 @@
 module Schools
   class YourSchoolEstatesController < ApplicationController
     load_and_authorize_resource :school
-    before_action :return_to_school_unless_feature_enabled
     before_action :set_breadcrumbs
 
     def edit
@@ -23,10 +22,6 @@ module Schools
       @breadcrumbs = [{ name: I18n.t('manage_school_menu.your_school_estate') }]
     end
 
-    def return_to_school_unless_feature_enabled
-      redirect_to school_path(@school) and return unless EnergySparks::FeatureFlags.active?(:your_school_estates)
-    end
-
     def school_params
       params.require(:school).permit(
         :indicated_has_solar_panels,
@@ -36,14 +31,20 @@ module Schools
         :alternative_heating_lpg,
         :alternative_heating_biomass,
         :alternative_heating_district_heating,
+        :alternative_heating_ground_source_heat_pump,
+        :alternative_heating_air_source_heat_pump,
         :alternative_heating_oil_percent,
         :alternative_heating_lpg_percent,
         :alternative_heating_biomass_percent,
         :alternative_heating_district_heating_percent,
+        :alternative_heating_ground_source_heat_pump_percent,
+        :alternative_heating_air_source_heat_pump_percent,
         :alternative_heating_oil_notes,
         :alternative_heating_lpg_notes,
         :alternative_heating_biomass_notes,
-        :alternative_heating_district_heating_notes
+        :alternative_heating_district_heating_notes,
+        :alternative_heating_ground_source_heat_pump_notes,
+        :alternative_heating_air_source_heat_pump_notes
       )
     end
   end

--- a/app/controllers/schools_controller.rb
+++ b/app/controllers/schools_controller.rb
@@ -209,6 +209,8 @@ private
       :alternative_heating_lpg,
       :alternative_heating_biomass,
       :alternative_heating_district_heating,
+      :alternative_heating_ground_source_heat_pump,
+      :alternative_heating_air_source_heat_pump,
       :enable_targets_feature,
       :public,
       :chart_preference,

--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -52,10 +52,7 @@ class Issue < ApplicationRecord
   scope :for_issue_types, ->(issue_types) { where(issue_type: issue_types) }
   scope :for_owned_by, ->(owned_by) { where(owned_by: owned_by) }
   scope :for_statuses, ->(statuses) { where(status: statuses) }
-
-  scope :title, ->(search) { where('title ~* ?', search) }
-  scope :description, ->(search) { joins(:rich_text_description).where('action_text_rich_texts.body ~* ?', search) }
-  scope :search, ->(search) { title(search).or(description(search)) }
+  scope :search, ->(search) { joins(:rich_text_description).where('title ~* ? or action_text_rich_texts.body ~* ?', search, search) }
 
   scope :by_pinned, -> { order(pinned: :desc) }
   scope :by_status, -> { order(status: :asc) }

--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -31,7 +31,6 @@
 #
 class Issue < ApplicationRecord
   include CsvExportable
-
   delegated_type :issueable, types: %w[School SchoolGroup DataSource]
   delegate :name, to: :issueable
 
@@ -53,6 +52,10 @@ class Issue < ApplicationRecord
   scope :for_issue_types, ->(issue_types) { where(issue_type: issue_types) }
   scope :for_owned_by, ->(owned_by) { where(owned_by: owned_by) }
   scope :for_statuses, ->(statuses) { where(status: statuses) }
+
+  scope :title, ->(search) { where('title ~* ?', search) }
+  scope :description, ->(search) { joins(:rich_text_description).where('action_text_rich_texts.body ~* ?', search) }
+  scope :search, ->(search) { title(search).or(description(search)) }
 
   scope :by_pinned, -> { order(pinned: :desc) }
   scope :by_status, -> { order(status: :asc) }

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -2,68 +2,74 @@
 #
 # Table name: schools
 #
-#  activation_date                              :date
-#  active                                       :boolean          default(TRUE)
-#  address                                      :text
-#  alternative_heating_biomass                  :boolean          default(FALSE), not null
-#  alternative_heating_biomass_notes            :text
-#  alternative_heating_biomass_percent          :integer          default(0)
-#  alternative_heating_district_heating         :boolean          default(FALSE), not null
-#  alternative_heating_district_heating_notes   :text
-#  alternative_heating_district_heating_percent :integer          default(0)
-#  alternative_heating_lpg                      :boolean          default(FALSE), not null
-#  alternative_heating_lpg_notes                :text
-#  alternative_heating_lpg_percent              :integer          default(0)
-#  alternative_heating_oil                      :boolean          default(FALSE), not null
-#  alternative_heating_oil_notes                :text
-#  alternative_heating_oil_percent              :integer          default(0)
-#  bill_requested                               :boolean          default(FALSE)
-#  bill_requested_at                            :datetime
-#  calendar_id                                  :bigint(8)
-#  chart_preference                             :integer          default("default"), not null
-#  cooks_dinners_for_other_schools              :boolean          default(FALSE), not null
-#  cooks_dinners_for_other_schools_count        :integer
-#  cooks_dinners_onsite                         :boolean          default(FALSE), not null
-#  country                                      :integer          default("england"), not null
-#  created_at                                   :datetime         not null
-#  dark_sky_area_id                             :bigint(8)
-#  data_enabled                                 :boolean          default(FALSE)
-#  enable_targets_feature                       :boolean          default(TRUE)
-#  floor_area                                   :decimal(, )
-#  funder_id                                    :bigint(8)
-#  funding_status                               :integer          default("state_school"), not null
-#  has_swimming_pool                            :boolean          default(FALSE), not null
-#  id                                           :bigint(8)        not null, primary key
-#  indicated_has_solar_panels                   :boolean          default(FALSE), not null
-#  indicated_has_storage_heaters                :boolean          default(FALSE)
-#  latitude                                     :decimal(10, 6)
-#  level                                        :integer          default(0)
-#  local_authority_area_id                      :bigint(8)
-#  longitude                                    :decimal(10, 6)
-#  met_office_area_id                           :bigint(8)
-#  name                                         :string
-#  number_of_pupils                             :integer
-#  percentage_free_school_meals                 :integer
-#  postcode                                     :string
-#  process_data                                 :boolean          default(FALSE)
-#  public                                       :boolean          default(TRUE)
-#  region                                       :integer
-#  removal_date                                 :date
-#  school_group_cluster_id                      :bigint(8)
-#  school_group_id                              :bigint(8)
-#  school_type                                  :integer          not null
-#  scoreboard_id                                :bigint(8)
-#  serves_dinners                               :boolean          default(FALSE), not null
-#  slug                                         :string
-#  solar_pv_tuos_area_id                        :bigint(8)
-#  temperature_area_id                          :bigint(8)
-#  template_calendar_id                         :integer
-#  updated_at                                   :datetime         not null
-#  urn                                          :integer          not null
-#  validation_cache_key                         :string           default("initial")
-#  visible                                      :boolean          default(FALSE)
-#  weather_station_id                           :bigint(8)
-#  website                                      :string
+#  activation_date                                     :date
+#  active                                              :boolean          default(TRUE)
+#  address                                             :text
+#  alternative_heating_air_source_heat_pump            :boolean          default(FALSE), not null
+#  alternative_heating_air_source_heat_pump_notes      :text
+#  alternative_heating_air_source_heat_pump_percent    :integer          default(0)
+#  alternative_heating_biomass                         :boolean          default(FALSE), not null
+#  alternative_heating_biomass_notes                   :text
+#  alternative_heating_biomass_percent                 :integer          default(0)
+#  alternative_heating_district_heating                :boolean          default(FALSE), not null
+#  alternative_heating_district_heating_notes          :text
+#  alternative_heating_district_heating_percent        :integer          default(0)
+#  alternative_heating_ground_source_heat_pump         :boolean          default(FALSE), not null
+#  alternative_heating_ground_source_heat_pump_notes   :text
+#  alternative_heating_ground_source_heat_pump_percent :integer          default(0)
+#  alternative_heating_lpg                             :boolean          default(FALSE), not null
+#  alternative_heating_lpg_notes                       :text
+#  alternative_heating_lpg_percent                     :integer          default(0)
+#  alternative_heating_oil                             :boolean          default(FALSE), not null
+#  alternative_heating_oil_notes                       :text
+#  alternative_heating_oil_percent                     :integer          default(0)
+#  bill_requested                                      :boolean          default(FALSE)
+#  bill_requested_at                                   :datetime
+#  calendar_id                                         :bigint(8)
+#  chart_preference                                    :integer          default("default"), not null
+#  cooks_dinners_for_other_schools                     :boolean          default(FALSE), not null
+#  cooks_dinners_for_other_schools_count               :integer
+#  cooks_dinners_onsite                                :boolean          default(FALSE), not null
+#  country                                             :integer          default("england"), not null
+#  created_at                                          :datetime         not null
+#  dark_sky_area_id                                    :bigint(8)
+#  data_enabled                                        :boolean          default(FALSE)
+#  enable_targets_feature                              :boolean          default(TRUE)
+#  floor_area                                          :decimal(, )
+#  funder_id                                           :bigint(8)
+#  funding_status                                      :integer          default("state_school"), not null
+#  has_swimming_pool                                   :boolean          default(FALSE), not null
+#  id                                                  :bigint(8)        not null, primary key
+#  indicated_has_solar_panels                          :boolean          default(FALSE), not null
+#  indicated_has_storage_heaters                       :boolean          default(FALSE)
+#  latitude                                            :decimal(10, 6)
+#  level                                               :integer          default(0)
+#  local_authority_area_id                             :bigint(8)
+#  longitude                                           :decimal(10, 6)
+#  met_office_area_id                                  :bigint(8)
+#  name                                                :string
+#  number_of_pupils                                    :integer
+#  percentage_free_school_meals                        :integer
+#  postcode                                            :string
+#  process_data                                        :boolean          default(FALSE)
+#  public                                              :boolean          default(TRUE)
+#  region                                              :integer
+#  removal_date                                        :date
+#  school_group_cluster_id                             :bigint(8)
+#  school_group_id                                     :bigint(8)
+#  school_type                                         :integer          not null
+#  scoreboard_id                                       :bigint(8)
+#  serves_dinners                                      :boolean          default(FALSE), not null
+#  slug                                                :string
+#  solar_pv_tuos_area_id                               :bigint(8)
+#  temperature_area_id                                 :bigint(8)
+#  template_calendar_id                                :integer
+#  updated_at                                          :datetime         not null
+#  urn                                                 :integer          not null
+#  validation_cache_key                                :string           default("initial")
+#  visible                                             :boolean          default(FALSE)
+#  weather_station_id                                  :bigint(8)
+#  website                                             :string
 #
 # Indexes
 #

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -248,7 +248,13 @@ class School < ApplicationRecord
 
   validates_associated :school_times, on: :school_time_update
 
-  validates :alternative_heating_oil_percent, :alternative_heating_lpg_percent, :alternative_heating_biomass_percent, :alternative_heating_district_heating_percent, numericality: { greater_than_or_equal_to: 0, less_than_or_equal_to: 100, allow_blank: true }
+  validates :alternative_heating_oil_percent,
+            :alternative_heating_lpg_percent,
+            :alternative_heating_biomass_percent,
+            :alternative_heating_district_heating_percent,
+            :alternative_heating_ground_source_heat_pump_percent,
+            :alternative_heating_air_source_heat_pump_percent,
+            numericality: { greater_than_or_equal_to: 0, less_than_or_equal_to: 100, allow_blank: true }
 
   validates :weather_station, presence: true
 

--- a/app/views/admin/issues/index.html.erb
+++ b/app/views/admin/issues/index.html.erb
@@ -1,4 +1,4 @@
-<%= render 'header', title: "Issues & Notes" do %>
+<%= render 'header', title: 'Issues & Notes' do %>
   <% if @issueable.try(:school_group) %>
     <%= header_nav_link "#{@issueable.school_group.name} school group", admin_school_group_path(@issueable.school_group) %>
   <% elsif @issueable %>
@@ -7,7 +7,9 @@
 <% end %>
 <% if @issueable %>
   <div class="clearfix">
-    <%= link_to "Issues & Notes", admin_issues_path %> > <%= @issueable.model_name.human.capitalize %> > <%= @issueable.try(:name) %>
+    <%= link_to 'Issues & Notes', admin_issues_path %> >
+    <%= @issueable.model_name.human.capitalize %> >
+    <%= @issueable.try(:name) %>
     <span class="float-right"><%= render 'new_issues_links', issueable: @issueable %></span>
   </div>
 <% end %>
@@ -15,20 +17,34 @@
   <%= form_tag polymorphic_path(@issueable ? [:admin, @issueable, Issue] : [:admin, Issue]), method: :get do %>
     <span class="nowrap">
       <%= label_tag :user, nil, class: 'small' %>
-      <%= select_tag :user, options_from_collection_for_select(User.admin,:id, :display_name, params[:user]), include_blank: "Any Admin User", class: "form-control-sm" %>
+      <%= select_tag :user,
+                     options_from_collection_for_select(User.admin, :id, :display_name, params[:user]),
+                     include_blank: 'Any Admin User',
+                     class: 'form-control-sm' %>
+    </span>
+    <span class="ml-4 nowrap">
+      <%= label_tag :search, nil, class: 'small' %>
+      <%= text_field_tag :search, params[:search], autocomplete: 'off' %>
     </span>
     <span class="ml-4 nowrap ensure-one-checked">
       <%= label_tag :issue_type, nil, class: 'small' %>
       <% Issue.issue_types.keys.each do |issue_type, issue_type_id| %>
-        <%= check_box_tag('issue_types[]', issue_type, (params[:issue_types] ||= []).include?(issue_type), id: issue_type, class: "badge-toggle-#{Issue.issue_type_classes[issue_type.to_sym]}") %>
-        <%= label_tag issue_type, issue_type.capitalize, data: {toggle: "tooltip", placement: "bottom", delay: { "show": 500, "hide": 100 }}, title: "Select at least one" %>
+        <%= check_box_tag('issue_types[]', issue_type, (params[:issue_types] ||= []).include?(issue_type),
+                          id: issue_type, class: "badge-toggle-#{Issue.issue_type_classes[issue_type.to_sym]}") %>
+        <%= label_tag issue_type, issue_type.capitalize,
+                      data: { toggle: 'tooltip', placement: 'bottom', delay: { "show": 500, "hide": 100 } },
+                      title: 'Select at least one' %>
       <% end %>
     </span>
     <span class="ml-4 nowrap ensure-one-checked">
       <%= label_tag :status, nil, class: 'small' %>
       <% Issue.statuses.keys.each do |status, status_id| %>
-        <%= check_box_tag('statuses[]', status, (params[:statuses] ||= []).include?(status), id: status, class: "badge badge-pill-toggle-#{Issue.status_classes[status.to_sym]}") %>
-        <%= label_tag status, status.capitalize, data: {toggle: "tooltip", placement: "bottom", delay: { "show": 500, "hide": 100 }}, title: "Select at least one" %>
+        <%= check_box_tag('statuses[]', status, (params[:statuses] ||= []).include?(status),
+                          id: status,
+                          class: "badge badge-pill-toggle-#{Issue.status_classes[status.to_sym]}") %>
+        <%= label_tag status, status.capitalize,
+                      data: { toggle: 'tooltip', placement: 'bottom', delay: { "show": 500, "hide": 100 } },
+                      title: 'Select at least one' %>
       <% end %>
     </span>
     <span class="float-right">
@@ -47,8 +63,7 @@
   <% else %>
     <%= render 'issues_list', issues: @issues %>
   <% end %>
-  <%= render "shared/pagy_footer" %>
+  <%= render 'shared/pagy_footer' %>
 <% else %>
   <p>No issues or notes to display.</p>
 <% end %>
-

--- a/app/views/schools/_details_form.html.erb
+++ b/app/views/schools/_details_form.html.erb
@@ -8,17 +8,25 @@
 
 <div class="form-group">
   <%= f.label :funding_status %>
-  <%= f.select :funding_status, options_for_select(School.funding_statuses.map {|key, value| [t("schools.funding_status.#{key}"), key]}, f.object.funding_status), {include_blank: false}, { class: 'form-control' } %>
+  <%= f.select :funding_status,
+               options_for_select(
+                 School.funding_statuses.map { |key, _value| [t("schools.funding_status.#{key}"), key] },
+                 f.object.funding_status
+               ),
+               { include_blank: false },
+               { class: 'form-control' } %>
 </div>
 
 <% if current_user.admin? %>
   <div class="bg-light">
     <strong><%= t('schools.school_details.admin_options') %></strong>
-    <%= f.input :activation_date, as: :tempus_dominus_date, default_date: nil, hint: t('schools.school_details.activation_date_hint') %>
+    <%= f.input :activation_date, as: :tempus_dominus_date, default_date: nil,
+                                  hint: t('schools.school_details.activation_date_hint') %>
     <%= f.input :enable_targets_feature %>
     <%= f.input :public %>
     <%= f.label :funder %>
-    <%= f.select :funder_id, options_for_select(Funder.all.order(name: :asc).pluck(:name, :id), school.funder_id), { include_blank: true }, { class: 'form-control' } %>
+    <%= f.select :funder_id, options_for_select(Funder.all.order(name: :asc).pluck(:name, :id), school.funder_id),
+                 { include_blank: true }, { class: 'form-control' } %>
   </div>
 <% end %>
 
@@ -31,7 +39,13 @@
   <h2><%= t('schools.school_details.location') %></h2>
   <div class="form-group">
     <%= f.label :country %>
-    <%= f.select :country, options_for_select(School.countries.map {|key, value| [t('school_statistics.' + key), key]}, f.object.country), {include_blank: false}, { class: 'form-control' } %>
+    <%= f.select :country,
+                 options_for_select(
+                   School.countries.map { |key, _value| [t("school_statistics.#{key}"), key] },
+                   f.object.country
+                 ),
+                 { include_blank: false },
+                 { class: 'form-control' } %>
   </div>
   <p><%= t('schools.school_details.geocode_message') %></p>
   <div class="form-group">
@@ -41,7 +55,10 @@
 
   <% if f.object.latitude && f.object.longitude %>
     <p>
-      <%= link_to t('schools.school_details.view_on_map'), "https://www.openstreetmap.org/?mlat=#{f.object.latitude}&mlon=#{f.object.longitude}", target: "_blank" %>
+      <%= link_to t('schools.school_details.view_on_map'),
+                  "https://www.openstreetmap.org/?mlat=#{f.object.latitude}&mlon=#{f.object.longitude}",
+                  target: '_blank',
+                  rel: 'noopener' %>
     </p>
   <% end %>
 <% end %>
@@ -52,8 +69,9 @@
 
   <% School.school_types.keys.each do |school_type| %>
     <div class="form-check form-check-inline">
-      <%= f.radio_button :school_type, school_type, class: "form-check-input" %>
-      <%= f.label "school_type_#{school_type.to_sym}", t("common.school_types.#{school_type}", default: school_type.humanize),  class: "form-check-label" %>
+      <%= f.radio_button :school_type, school_type, class: 'form-check-input' %>
+      <%= f.label "school_type_#{school_type.to_sym}",
+                  t("common.school_types.#{school_type}", default: school_type.humanize), class: 'form-check-label' %>
     </div>
   <% end %>
 </div>
@@ -63,8 +81,8 @@
 
   <%= f.collection_check_boxes(:key_stage_ids, key_stages, :id, :name) do |b| %>
     <div class="custom-control custom-checkbox custom-control-inline">
-      <%= b.check_box(class: "custom-control-input") %>
-      <%= b.label(class: "custom-control-label") do %>
+      <%= b.check_box(class: 'custom-control-input') %>
+      <%= b.label(class: 'custom-control-label') do %>
         <%= t(b.object.i18n_key) %>
       <% end %>
     </div>
@@ -90,27 +108,33 @@
 <%= f.input :indicated_has_solar_panels %>
 <%= f.input :indicated_has_storage_heaters %>
 <%= f.input :has_swimming_pool %>
-<%= f.input :serves_dinners, input_html: {data: {reveals: '.school_cooks_dinners_onsite'}}%>
-<%= f.input :cooks_dinners_onsite, input_html: {data: {reveals: '.school_cooks_dinners_for_other_schools'}}, wrapper_html: {data: {revealed_by: '.school_serves_dinners'}} %>
-<%= f.input :cooks_dinners_for_other_schools, input_html: {data: {reveals: '.school_cooks_dinners_for_other_schools_count'}}, wrapper_html: {data: {revealed_by: '.school_cooks_dinners_on_site'}} %>
-<%= f.input :cooks_dinners_for_other_schools_count, wrapper_html: {data: {revealed_by: '.school_cooks_dinners_for_other_schools'}}%>
+<%= f.input :serves_dinners, input_html: { data: { reveals: '.school_cooks_dinners_onsite' } } %>
+<%= f.input :cooks_dinners_onsite, input_html: { data: { reveals: '.school_cooks_dinners_for_other_schools' } },
+                                   wrapper_html: { data: { revealed_by: '.school_serves_dinners' } } %>
+<%= f.input :cooks_dinners_for_other_schools,
+            input_html: { data: { reveals: '.school_cooks_dinners_for_other_schools_count' } },
+            wrapper_html: { data: { revealed_by: '.school_cooks_dinners_on_site' } } %>
+<%= f.input :cooks_dinners_for_other_schools_count,
+            wrapper_html: { data: { revealed_by: '.school_cooks_dinners_for_other_schools' } } %>
 
-<% if EnergySparks::FeatureFlags.active?(:your_school_estates) %>
-  <%= f.input :alternative_heating_oil %>
-  <%= f.input :alternative_heating_lpg %>
-  <%= f.input :alternative_heating_biomass %>
-  <%= f.input :alternative_heating_district_heating %>
-<% end %>
+<%= f.input :alternative_heating_oil %>
+<%= f.input :alternative_heating_lpg %>
+<%= f.input :alternative_heating_biomass %>
+<%= f.input :alternative_heating_district_heating %>
+<%= f.input :alternative_heating_ground_source_heat_pump %>
+<%= f.input :alternative_heating_air_source_heat_pump %>
 
 <h2 id="preferences"><%= t('schools.school_details.analysis_preferences') %></h2>
 
 <div class="form-group">
-  <label><%= t("schools.chart_preference.form_group") %></label>
-  <p class="small"><%= t("schools.chart_preference.explanation") %></p>
+  <label><%= t('schools.chart_preference.form_group') %></label>
+  <p class="small"><%= t('schools.chart_preference.explanation') %></p>
   <% School.chart_preferences.keys.each do |preference| %>
     <div class="form-check">
-      <%= f.radio_button :chart_preference, preference, checked: @school.chart_preference == preference, class: "form-check-input" %>
-      <%= f.label "chart_preference_#{preference.to_sym}", t("schools.chart_preference.#{preference}", default: preference.humanize),  class: "form-check-label" %>
+      <%= f.radio_button :chart_preference, preference, checked: @school.chart_preference == preference,
+                                                        class: 'form-check-input' %>
+      <%= f.label "chart_preference_#{preference.to_sym}",
+                  t("schools.chart_preference.#{preference}", default: preference.humanize), class: 'form-check-label' %>
     </div>
   <% end %>
 </div>

--- a/app/views/schools/your_school_estates/edit.html.erb
+++ b/app/views/schools/your_school_estates/edit.html.erb
@@ -21,28 +21,64 @@
       <p><%= t('schools.your_school_estates.edit.alternative_heating_sources.description_1') %>.</p>
       <p><%= t('schools.your_school_estates.edit.alternative_heating_sources.description_2') %>.</p>
 
-      <%= f.input :alternative_heating_oil, label: t('schools.your_school_estates.edit.alternative_heating_sources.oil.label'), input_html: {data: {reveals: '.school_alternative_heating_oil_fields' }} %>
+      <%= f.input :alternative_heating_oil,
+                  label: t('.alternative_heating_sources.oil.label'),
+                  input_html: { data: { reveals: '.school_alternative_heating_oil_fields' } } %>
       <div class='school_alternative_heating_oil_fields' data-revealed-by=".school_alternative_heating_oil">
-        <%= f.input :alternative_heating_oil_percent, label: t('schools.your_school_estates.edit.alternative_heating_sources.oil.percentage') %>
-        <%= f.input :alternative_heating_oil_notes, label: t('schools.your_school_estates.edit.alternative_heating_sources.notes') %>
+        <%= f.input :alternative_heating_oil_percent,
+                    label: t('.alternative_heating_sources.oil.percentage') %>
+        <%= f.input :alternative_heating_oil_notes,
+                    label: t('.alternative_heating_sources.notes') %>
       </div>
 
-      <%= f.input :alternative_heating_lpg, label: t('schools.your_school_estates.edit.alternative_heating_sources.lpg.label'), input_html: {data: {reveals: '.school_alternative_lpg_fields' }} %>
+      <%= f.input :alternative_heating_lpg,
+                  label: t('.alternative_heating_sources.lpg.label'),
+                  input_html: { data: { reveals: '.school_alternative_lpg_fields' } } %>
       <div class='school_alternative_lpg_fields' data-revealed-by=".school_alternative_heating_lpg">
-        <%= f.input :alternative_heating_lpg_percent, label: t('schools.your_school_estates.edit.alternative_heating_sources.lpg.percentage') %>
-        <%= f.input :alternative_heating_lpg_notes, label: t('schools.your_school_estates.edit.alternative_heating_sources.notes') %>
+        <%= f.input :alternative_heating_lpg_percent,
+                    label: t('.alternative_heating_sources.lpg.percentage') %>
+        <%= f.input :alternative_heating_lpg_notes,
+                    label: t('.alternative_heating_sources.notes') %>
       </div>
 
-      <%= f.input :alternative_heating_biomass, label: t('schools.your_school_estates.edit.alternative_heating_sources.biomass.label'), input_html: {data: {reveals: '.school_alternative_biomass_fields' }} %>
+      <%= f.input :alternative_heating_biomass,
+                  label: t('.alternative_heating_sources.biomass.label'),
+                  input_html: { data: { reveals: '.school_alternative_biomass_fields' } } %>
       <div class='school_alternative_biomass_fields' data-revealed-by=".school_alternative_heating_biomass">
-        <%= f.input :alternative_heating_biomass_percent, label: t('schools.your_school_estates.edit.alternative_heating_sources.biomass.percentage') %>
-        <%= f.input :alternative_heating_biomass_notes, label: t('schools.your_school_estates.edit.alternative_heating_sources.notes') %>
+        <%= f.input :alternative_heating_biomass_percent,
+                    label: t('.alternative_heating_sources.biomass.percentage') %>
+        <%= f.input :alternative_heating_biomass_notes,
+                    label: t('.alternative_heating_sources.notes') %>
       </div>
 
-      <%= f.input :alternative_heating_district_heating, label: t('schools.your_school_estates.edit.alternative_heating_sources.district_heating.label'), input_html: {data: {reveals: '.school_alternative_district_heating_fields' }} %>
+      <%= f.input :alternative_heating_district_heating,
+                  label: t('.alternative_heating_sources.district_heating.label'),
+                  input_html: { data: { reveals: '.school_alternative_district_heating_fields' } } %>
       <div class='school_alternative_district_heating_fields' data-revealed-by=".school_alternative_heating_district_heating">
-        <%= f.input :alternative_heating_district_heating_percent, label: t('schools.your_school_estates.edit.alternative_heating_sources.district_heating.percentage') %>
-        <%= f.input :alternative_heating_district_heating_notes, label: t('schools.your_school_estates.edit.alternative_heating_sources.notes') %>
+        <%= f.input :alternative_heating_district_heating_percent,
+                    label: t('.alternative_heating_sources.district_heating.percentage') %>
+        <%= f.input :alternative_heating_district_heating_notes,
+                    label: t('.alternative_heating_sources.notes') %>
+      </div>
+
+      <%= f.input :alternative_heating_ground_source_heat_pump,
+                  label: t('.alternative_heating_sources.ground_source_heat_pump.label'),
+                  input_html: { data: { reveals: '.school_alternative_ground_source_heat_pump_fields' } } %>
+      <div class='school_alternative_ground_source_heat_pump_fields' data-revealed-by=".school_alternative_heating_ground_source_heat_pump">
+        <%= f.input :alternative_heating_ground_source_heat_pump_percent,
+                    label: t('.alternative_heating_sources.ground_source_heat_pump.percentage') %>
+        <%= f.input :alternative_heating_ground_source_heat_pump_notes,
+                    label: t('.alternative_heating_sources.notes') %>
+      </div>
+
+      <%= f.input :alternative_heating_air_source_heat_pump,
+                  label: t('.alternative_heating_sources.air_source_heat_pump.label'),
+                  input_html: { data: { reveals: '.school_alternative_air_source_heat_pump_fields' } } %>
+      <div class='school_alternative_air_source_heat_pump_fields' data-revealed-by=".school_alternative_heating_air_source_heat_pump">
+        <%= f.input :alternative_heating_air_source_heat_pump_percent,
+                    label: t('.alternative_heating_sources.air_source_heat_pump.percentage') %>
+        <%= f.input :alternative_heating_air_source_heat_pump_notes,
+                    label: t('.alternative_heating_sources.notes') %>
       </div>
 
       <%= f.submit t('common.labels.save'), class: 'btn btn-primary pt-6' %>

--- a/app/views/shared/_manage_school.html.erb
+++ b/app/views/shared/_manage_school.html.erb
@@ -6,10 +6,8 @@
     <%= if can? :manage_school_times, school
           link_to t('manage_school_menu.edit_school_times'), edit_school_times_path(school), class: 'dropdown-item'
         end %>
-    <%= if EnergySparks::FeatureFlags.active?(:your_school_estates)
-          link_to t('manage_school_menu.your_school_estate'), edit_school_your_school_estate_path(school),
-                  class: 'dropdown-item'
-        end %>
+    <%= link_to t('manage_school_menu.your_school_estate'), edit_school_your_school_estate_path(school),
+                class: 'dropdown-item' %>
     <%= if school.calendar && can?(:show, school.calendar)
           link_to t('manage_school_menu.school_calendar'), calendar_path(school.calendar), class: 'dropdown-item'
         end %>

--- a/config/locales/activerecord.yml
+++ b/config/locales/activerecord.yml
@@ -21,11 +21,11 @@ en:
         activation_date: Activation date
         address: Address
         alternative_heating_air_source_heat_pump: Our school has an air source heat pump
-        alternative_heating_biomass: Our school has a Biomass boiler
-        alternative_heating_district_heating: Our school has District Heating
+        alternative_heating_biomass: Our school has a biomass boiler
+        alternative_heating_district_heating: Our school has district heating
         alternative_heating_ground_source_heat_pump: Our school has a ground source heat pump
         alternative_heating_lpg: Our school is using LPG for heating
-        alternative_heating_oil: Our school uses Oil for heating
+        alternative_heating_oil: Our school uses oil for heating
         cooks_dinners_for_other_schools: The kitchen cooks dinners for other schools
         cooks_dinners_for_other_schools_count: How many schools does your school cook dinners for?
         cooks_dinners_onsite: Dinners are cooked on site

--- a/config/locales/activerecord.yml
+++ b/config/locales/activerecord.yml
@@ -20,8 +20,10 @@ en:
       school:
         activation_date: Activation date
         address: Address
+        alternative_heating_air_source_heat_pump: Our school has an air source heat pump
         alternative_heating_biomass: Our school has a Biomass boiler
         alternative_heating_district_heating: Our school has District Heating
+        alternative_heating_ground_source_heat_pump: Our school has a ground source heat pump
         alternative_heating_lpg: Our school is using LPG for heating
         alternative_heating_oil: Our school uses Oil for heating
         cooks_dinners_for_other_schools: The kitchen cooks dinners for other schools

--- a/config/locales/views/schools/schools.yml
+++ b/config/locales/views/schools/schools.yml
@@ -691,26 +691,26 @@ en:
         alternative_heating_sources:
           air_source_heat_pump:
             label: Our school has an air source heat pump
-            percentage: What percentage of the school using the air source heat pump for heating?
+            percentage: What percentage of the school is using the air source heat pump for heating?
           biomass:
-            label: Our school has a Biomass boiler
-            percentage: What percentage of the school using a Biomass boiler for heating?
+            label: Our school has a biomass boiler
+            percentage: What percentage of the school is using a biomass boiler for heating?
           description_1: Tell us about any alternative sources of heating that you use in your school
           description_2: At the moment we only analyse your gas data. But by letting us know about other sources, we can qualify any potential cost savings or recommendations
           district_heating:
-            label: Our school has District Heating
-            percentage: What percentage of the school using District Heating for heating?
+            label: Our school has district heating
+            percentage: What percentage of the school is using district heating for heating?
           ground_source_heat_pump:
             label: Our school has a ground source heat pump
-            percentage: What percentage of the school using the ground source heat pump for heating?
+            percentage: What percentage of the school is using the ground source heat pump for heating?
           header: Alternative heating sources
           lpg:
             label: Our school is using LPG for heating
             percentage: What percentage of the school using LPG for heating?
           notes: Is there anything else we should know?
           oil:
-            label: Our school uses Oil for heating
-            percentage: What percentage of the school is heated by Oil Heating?
+            label: Our school uses oil for heating
+            percentage: What percentage of the school is heated by oil heating?
         description: EnergySparks uses a variety of data about your school to tailor our analysis and advice. By telling us a bit more about your school estate we can improve the support we offer you
         school_was_successfully_updated: School was successfully updated
         solar_panels: Solar panels

--- a/config/locales/views/schools/schools.yml
+++ b/config/locales/views/schools/schools.yml
@@ -689,6 +689,9 @@ en:
     your_school_estates:
       edit:
         alternative_heating_sources:
+          air_source_heat_pump:
+            label: Our school has an air source heat pump
+            percentage: What percentage of the school using the air source heat pump for heating?
           biomass:
             label: Our school has a Biomass boiler
             percentage: What percentage of the school using a Biomass boiler for heating?
@@ -697,6 +700,9 @@ en:
           district_heating:
             label: Our school has District Heating
             percentage: What percentage of the school using District Heating for heating?
+          ground_source_heat_pump:
+            label: Our school has a ground source heat pump
+            percentage: What percentage of the school using the ground source heat pump for heating?
           header: Alternative heating sources
           lpg:
             label: Our school is using LPG for heating

--- a/db/migrate/20240419090546_add_heat_pump_fields_to_schools.rb
+++ b/db/migrate/20240419090546_add_heat_pump_fields_to_schools.rb
@@ -1,0 +1,11 @@
+class AddHeatPumpFieldsToSchools < ActiveRecord::Migration[6.1]
+  def change
+    add_column :schools, :alternative_heating_ground_source_heat_pump, :boolean, default: false, null: false
+    add_column :schools, :alternative_heating_ground_source_heat_pump_percent, :integer, default: 0
+    add_column :schools, :alternative_heating_ground_source_heat_pump_notes, :text
+
+    add_column :schools, :alternative_heating_air_source_heat_pump, :boolean, default: false, null: false
+    add_column :schools, :alternative_heating_air_source_heat_pump_percent, :integer, default: 0
+    add_column :schools, :alternative_heating_air_source_heat_pump_notes, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_04_17_104449) do
+ActiveRecord::Schema.define(version: 2024_04_19_090546) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
@@ -1668,6 +1668,12 @@ ActiveRecord::Schema.define(version: 2024_04_17_104449) do
     t.datetime "bill_requested_at"
     t.bigint "school_group_cluster_id"
     t.bigint "funder_id"
+    t.boolean "alternative_heating_ground_source_heat_pump", default: false, null: false
+    t.integer "alternative_heating_ground_source_heat_pump_percent", default: 0
+    t.text "alternative_heating_ground_source_heat_pump_notes"
+    t.boolean "alternative_heating_air_source_heat_pump", default: false, null: false
+    t.integer "alternative_heating_air_source_heat_pump_percent", default: 0
+    t.text "alternative_heating_air_source_heat_pump_notes"
     t.index ["calendar_id"], name: "index_schools_on_calendar_id"
     t.index ["latitude", "longitude"], name: "index_schools_on_latitude_and_longitude"
     t.index ["local_authority_area_id"], name: "index_schools_on_local_authority_area_id"
@@ -2119,125 +2125,225 @@ ActiveRecord::Schema.define(version: 2024_04_17_104449) do
   add_foreign_key "users", "staff_roles", on_delete: :restrict
   add_foreign_key "weather_observations", "weather_stations", on_delete: :cascade
 
-  create_view "annual_change_in_electricity_out_of_hours_uses", sql_definition: <<-SQL
+  create_view "baseload_per_pupils", sql_definition: <<-SQL
       SELECT latest_runs.id,
-      usage.alert_generation_run_id,
-      usage.school_id,
-      usage.out_of_hours_kwh,
-      usage.out_of_hours_co2,
-      usage.out_of_hours_gbpcurrent,
-      usage_previous_year.previous_out_of_hours_kwh,
-      usage_previous_year.previous_out_of_hours_co2,
-      usage_previous_year.previous_out_of_hours_gbpcurrent,
-      additional.economic_tariff_changed_this_year
+      additional.school_id,
+      baseload.alert_generation_run_id,
+      baseload.average_baseload_last_year_kw,
+      baseload.average_baseload_last_year_gbp,
+      baseload.one_year_baseload_per_pupil_kw,
+      baseload.annual_baseload_percent,
+      baseload.one_year_saving_versus_exemplar_gbp,
+      additional.electricity_economic_tariff_changed_this_year
      FROM ( SELECT alerts.alert_generation_run_id,
-              alerts.school_id,
-              json.out_of_hours_kwh,
-              json.out_of_hours_co2,
-              json.out_of_hours_gbpcurrent
+              data.average_baseload_last_year_kw,
+              data.average_baseload_last_year_gbp,
+              data.one_year_baseload_per_pupil_kw,
+              data.annual_baseload_percent,
+              data.one_year_saving_versus_exemplar_gbp
              FROM alerts,
               alert_types,
-              LATERAL jsonb_to_record(alerts.variables) json(out_of_hours_kwh double precision, out_of_hours_co2 double precision, out_of_hours_gbpcurrent double precision)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertOutOfHoursElectricityUsage'::text))) usage,
+              LATERAL jsonb_to_record(alerts.variables) data(average_baseload_last_year_kw double precision, average_baseload_last_year_gbp double precision, one_year_baseload_per_pupil_kw double precision, annual_baseload_percent double precision, one_year_saving_versus_exemplar_gbp double precision)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertElectricityBaseloadVersusBenchmark'::text))) baseload,
       ( SELECT alerts.alert_generation_run_id,
               alerts.school_id,
-              json.out_of_hours_kwh AS previous_out_of_hours_kwh,
-              json.out_of_hours_co2 AS previous_out_of_hours_co2,
-              json.out_of_hours_gbpcurrent AS previous_out_of_hours_gbpcurrent
+              data.electricity_economic_tariff_changed_this_year
              FROM alerts,
               alert_types,
-              LATERAL jsonb_to_record(alerts.variables) json(out_of_hours_kwh double precision, out_of_hours_co2 double precision, out_of_hours_gbpcurrent double precision)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertOutOfHoursElectricityUsagePreviousYear'::text))) usage_previous_year,
-      ( SELECT alerts.alert_generation_run_id,
-              json.electricity_economic_tariff_changed_this_year AS economic_tariff_changed_this_year
-             FROM alerts,
-              alert_types,
-              LATERAL jsonb_to_record(alerts.variables) json(electricity_economic_tariff_changed_this_year boolean)
+              LATERAL jsonb_to_record(alerts.variables) data(electricity_economic_tariff_changed_this_year boolean)
             WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertAdditionalPrioritisationData'::text))) additional,
       ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
              FROM alert_generation_runs
             ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
-    WHERE ((usage.alert_generation_run_id = latest_runs.id) AND (usage_previous_year.alert_generation_run_id = latest_runs.id) AND (additional.alert_generation_run_id = latest_runs.id));
+    WHERE ((baseload.alert_generation_run_id = latest_runs.id) AND (additional.alert_generation_run_id = latest_runs.id));
   SQL
-  create_view "annual_change_in_gas_out_of_hours_uses", sql_definition: <<-SQL
+  create_view "change_in_electricity_since_last_years", sql_definition: <<-SQL
       SELECT latest_runs.id,
-      usage.alert_generation_run_id,
-      usage.school_id,
-      usage.out_of_hours_kwh,
-      usage.out_of_hours_co2,
-      usage.out_of_hours_gbpcurrent,
-      usage_previous_year.previous_out_of_hours_kwh,
-      usage_previous_year.previous_out_of_hours_co2,
-      usage_previous_year.previous_out_of_hours_gbpcurrent,
-      additional.economic_tariff_changed_this_year
+      enba.school_id,
+      enba.previous_year_electricity_kwh,
+      enba.current_year_electricity_kwh,
+      enba.previous_year_electricity_co2,
+      enba.current_year_electricity_co2,
+      enba.previous_year_electricity_gbp,
+      enba.current_year_electricity_gbp,
+      enba.solar_type
      FROM ( SELECT alerts.alert_generation_run_id,
               alerts.school_id,
-              json.out_of_hours_kwh,
-              json.out_of_hours_co2,
-              json.out_of_hours_gbpcurrent
+              data.previous_year_electricity_kwh,
+              data.current_year_electricity_kwh,
+              data.previous_year_electricity_co2,
+              data.current_year_electricity_co2,
+              data.previous_year_electricity_gbp,
+              data.current_year_electricity_gbp,
+              data.solar_type
              FROM alerts,
               alert_types,
-              LATERAL jsonb_to_record(alerts.variables) json(out_of_hours_kwh double precision, out_of_hours_co2 double precision, out_of_hours_gbpcurrent double precision)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertOutOfHoursGasUsage'::text))) usage,
-      ( SELECT alerts.alert_generation_run_id,
-              alerts.school_id,
-              json.out_of_hours_kwh AS previous_out_of_hours_kwh,
-              json.out_of_hours_co2 AS previous_out_of_hours_co2,
-              json.out_of_hours_gbpcurrent AS previous_out_of_hours_gbpcurrent
-             FROM alerts,
-              alert_types,
-              LATERAL jsonb_to_record(alerts.variables) json(out_of_hours_kwh double precision, out_of_hours_co2 double precision, out_of_hours_gbpcurrent double precision)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertOutOfHoursGasUsagePreviousYear'::text))) usage_previous_year,
-      ( SELECT alerts.alert_generation_run_id,
-              json.gas_economic_tariff_changed_this_year AS economic_tariff_changed_this_year
-             FROM alerts,
-              alert_types,
-              LATERAL jsonb_to_record(alerts.variables) json(gas_economic_tariff_changed_this_year boolean)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertAdditionalPrioritisationData'::text))) additional,
+              LATERAL jsonb_to_record(alerts.variables) data(previous_year_electricity_kwh double precision, current_year_electricity_kwh double precision, previous_year_electricity_co2 double precision, current_year_electricity_co2 double precision, previous_year_electricity_gbp double precision, current_year_electricity_gbp double precision, solar_type text)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertEnergyAnnualVersusBenchmark'::text))) enba,
       ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
              FROM alert_generation_runs
             ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
-    WHERE ((usage.alert_generation_run_id = latest_runs.id) AND (usage_previous_year.alert_generation_run_id = latest_runs.id) AND (additional.alert_generation_run_id = latest_runs.id));
+    WHERE (enba.alert_generation_run_id = latest_runs.id);
   SQL
-  create_view "annual_change_in_storage_heater_out_of_hours_uses", sql_definition: <<-SQL
+  create_view "electricity_peak_kw_per_pupils", sql_definition: <<-SQL
       SELECT latest_runs.id,
-      usage.alert_generation_run_id,
-      usage.school_id,
-      usage.out_of_hours_kwh,
-      usage.out_of_hours_co2,
-      usage.out_of_hours_gbpcurrent,
-      usage_previous_year.previous_out_of_hours_kwh,
-      usage_previous_year.previous_out_of_hours_co2,
-      usage_previous_year.previous_out_of_hours_gbpcurrent,
-      additional.economic_tariff_changed_this_year
+      data.alert_generation_run_id,
+      data.school_id,
+      data.average_school_day_last_year_kw_per_floor_area,
+      data.average_school_day_last_year_kw,
+      data.exemplar_kw,
+      data.one_year_saving_versus_exemplar_gbp,
+      additional.electricity_economic_tariff_changed_this_year
      FROM ( SELECT alerts.alert_generation_run_id,
               alerts.school_id,
-              json.out_of_hours_kwh,
-              json.out_of_hours_co2,
-              json.out_of_hours_gbpcurrent
+              data_1.average_school_day_last_year_kw_per_floor_area,
+              data_1.average_school_day_last_year_kw,
+              data_1.exemplar_kw,
+              data_1.one_year_saving_versus_exemplar_gbp
              FROM alerts,
               alert_types,
-              LATERAL jsonb_to_record(alerts.variables) json(out_of_hours_kwh double precision, out_of_hours_co2 double precision, out_of_hours_gbpcurrent double precision)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertStorageHeaterOutOfHours'::text))) usage,
+              LATERAL jsonb_to_record(alerts.variables) data_1(average_school_day_last_year_kw_per_floor_area double precision, average_school_day_last_year_kw double precision, exemplar_kw double precision, one_year_saving_versus_exemplar_gbp double precision)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertElectricityPeakKWVersusBenchmark'::text))) data,
       ( SELECT alerts.alert_generation_run_id,
-              alerts.school_id,
-              json.out_of_hours_kwh AS previous_out_of_hours_kwh,
-              json.out_of_hours_co2 AS previous_out_of_hours_co2,
-              json.out_of_hours_gbpcurrent AS previous_out_of_hours_gbpcurrent
+              data_1.electricity_economic_tariff_changed_this_year
              FROM alerts,
               alert_types,
-              LATERAL jsonb_to_record(alerts.variables) json(out_of_hours_kwh double precision, out_of_hours_co2 double precision, out_of_hours_gbpcurrent double precision)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertOutOfHoursStorageHeaterUsagePreviousYear'::text))) usage_previous_year,
-      ( SELECT alerts.alert_generation_run_id,
-              json.electricity_economic_tariff_changed_this_year AS economic_tariff_changed_this_year
-             FROM alerts,
-              alert_types,
-              LATERAL jsonb_to_record(alerts.variables) json(electricity_economic_tariff_changed_this_year boolean)
+              LATERAL jsonb_to_record(alerts.variables) data_1(electricity_economic_tariff_changed_this_year boolean)
             WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertAdditionalPrioritisationData'::text))) additional,
       ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
              FROM alert_generation_runs
             ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
-    WHERE ((usage.alert_generation_run_id = latest_runs.id) AND (usage_previous_year.alert_generation_run_id = latest_runs.id) AND (additional.alert_generation_run_id = latest_runs.id));
+    WHERE ((data.alert_generation_run_id = latest_runs.id) AND (additional.alert_generation_run_id = latest_runs.id));
+  SQL
+  create_view "change_in_electricity_holiday_consumption_previous_years_holida", sql_definition: <<-SQL
+      SELECT latest_runs.id,
+      data.alert_generation_run_id,
+      data.school_id,
+      data.current_period_type,
+      data.current_period_start_date,
+      data.current_period_end_date,
+      data.difference_gbpcurrent,
+      data.difference_kwh,
+      data.difference_percent,
+      data.previous_period_type,
+      data.previous_period_start_date,
+      data.previous_period_end_date,
+      data.pupils_changed,
+      data.tariff_has_changed,
+      data.truncated_current_period
+     FROM ( SELECT alerts.alert_generation_run_id,
+              alerts.school_id,
+              data_1.current_period_type,
+              data_1.current_period_start_date,
+              data_1.current_period_end_date,
+              data_1.difference_gbpcurrent,
+              data_1.difference_kwh,
+              data_1.difference_percent,
+              data_1.previous_period_type,
+              data_1.previous_period_start_date,
+              data_1.previous_period_end_date,
+              data_1.pupils_changed,
+              data_1.tariff_has_changed,
+              data_1.truncated_current_period
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) data_1(current_period_type text, current_period_start_date date, current_period_end_date date, difference_gbpcurrent double precision, difference_kwh double precision, difference_percent double precision, previous_period_type text, previous_period_start_date date, previous_period_end_date date, pupils_changed boolean, tariff_has_changed boolean, truncated_current_period boolean)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertPreviousYearHolidayComparisonElectricity'::text))) data,
+      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
+             FROM alert_generation_runs
+            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
+    WHERE (data.alert_generation_run_id = latest_runs.id);
+  SQL
+  create_view "electricity_targets", sql_definition: <<-SQL
+      SELECT latest_runs.id,
+      data.alert_generation_run_id,
+      data.school_id,
+      data.current_year_percent_of_target_relative,
+      data.current_year_unscaled_percent_of_target_relative,
+      data.current_year_kwh,
+      data.current_year_target_kwh,
+      data.unscaled_target_kwh_to_date,
+      data.tracking_start_date
+     FROM ( SELECT alerts.alert_generation_run_id,
+              alerts.school_id,
+              data_1.current_year_percent_of_target_relative,
+              data_1.current_year_unscaled_percent_of_target_relative,
+              data_1.current_year_kwh,
+              data_1.current_year_target_kwh,
+              data_1.unscaled_target_kwh_to_date,
+              data_1.tracking_start_date
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) data_1(current_year_percent_of_target_relative double precision, current_year_unscaled_percent_of_target_relative double precision, current_year_kwh double precision, current_year_target_kwh double precision, unscaled_target_kwh_to_date double precision, tracking_start_date date)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertElectricityTargetAnnual'::text))) data,
+      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
+             FROM alert_generation_runs
+            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
+    WHERE (data.alert_generation_run_id = latest_runs.id);
+  SQL
+  create_view "change_in_electricity_holiday_consumption_previous_holidays", sql_definition: <<-SQL
+      SELECT latest_runs.id,
+      data.alert_generation_run_id,
+      data.school_id,
+      data.difference_percent,
+      data.difference_gbpcurrent,
+      data.difference_kwh,
+      data.current_period_type,
+      data.current_period_start_date,
+      data.current_period_end_date,
+      data.truncated_current_period,
+      data.previous_period_type,
+      data.previous_period_start_date,
+      data.previous_period_end_date,
+      data.pupils_changed,
+      data.tariff_has_changed
+     FROM ( SELECT alerts.alert_generation_run_id,
+              alerts.school_id,
+              data_1.difference_percent,
+              data_1.difference_gbpcurrent,
+              data_1.difference_kwh,
+              data_1.current_period_type,
+              data_1.current_period_start_date,
+              data_1.current_period_end_date,
+              data_1.truncated_current_period,
+              data_1.previous_period_type,
+              data_1.previous_period_start_date,
+              data_1.previous_period_end_date,
+              data_1.pupils_changed,
+              data_1.tariff_has_changed
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) data_1(difference_percent double precision, difference_gbpcurrent double precision, difference_kwh double precision, current_period_type text, current_period_start_date date, current_period_end_date date, truncated_current_period boolean, previous_period_type text, previous_period_start_date date, previous_period_end_date date, pupils_changed boolean, tariff_has_changed boolean)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertPreviousHolidayComparisonElectricity'::text))) data,
+      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
+             FROM alert_generation_runs
+            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
+    WHERE (data.alert_generation_run_id = latest_runs.id);
+  SQL
+  create_view "change_in_electricity_consumption_recent_school_weeks", sql_definition: <<-SQL
+      SELECT latest_runs.id,
+      data.alert_generation_run_id,
+      data.school_id,
+      data.difference_percent,
+      data.difference_gbpcurrent,
+      data.difference_kwh,
+      data.pupils_changed,
+      data.tariff_has_changed
+     FROM ( SELECT alerts.alert_generation_run_id,
+              alerts.school_id,
+              data_1.difference_percent,
+              data_1.difference_gbpcurrent,
+              data_1.difference_kwh,
+              data_1.pupils_changed,
+              data_1.tariff_has_changed
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) data_1(difference_percent double precision, difference_gbpcurrent double precision, difference_kwh double precision, pupils_changed boolean, tariff_has_changed boolean)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertSchoolWeekComparisonElectricity'::text))) data,
+      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
+             FROM alert_generation_runs
+            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
+    WHERE (data.alert_generation_run_id = latest_runs.id);
   SQL
   create_view "annual_electricity_costs_per_pupils", sql_definition: <<-SQL
       SELECT latest_runs.id,
@@ -2298,72 +2404,358 @@ ActiveRecord::Schema.define(version: 2024_04_17_104449) do
             ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
     WHERE ((data.alert_generation_run_id = latest_runs.id) AND (additional.alert_generation_run_id = latest_runs.id));
   SQL
-  create_view "annual_energy_costs", sql_definition: <<-SQL
-      WITH electricity AS (
-           SELECT alerts.alert_generation_run_id,
-              data.last_year_gbp
-             FROM alerts,
-              alert_types,
-              LATERAL jsonb_to_record(alerts.variables) data(last_year_gbp double precision)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertElectricityAnnualVersusBenchmark'::text))
-          ), gas AS (
-           SELECT alerts.alert_generation_run_id,
-              data.last_year_gbp
-             FROM alerts,
-              alert_types,
-              LATERAL jsonb_to_record(alerts.variables) data(last_year_gbp double precision)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertGasAnnualVersusBenchmark'::text))
-          ), storage_heaters AS (
-           SELECT alerts.alert_generation_run_id,
-              data.last_year_gbp
-             FROM alerts,
-              alert_types,
-              LATERAL jsonb_to_record(alerts.variables) data(last_year_gbp double precision)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertStorageHeaterAnnualVersusBenchmark'::text))
-          ), energy AS (
-           SELECT alerts.alert_generation_run_id,
-              data.last_year_gbp,
-              data.one_year_energy_per_pupil_gbp,
-              data.last_year_co2_tonnes,
-              data.last_year_kwh
-             FROM alerts,
-              alert_types,
-              LATERAL jsonb_to_record(alerts.variables) data(last_year_gbp double precision, one_year_energy_per_pupil_gbp double precision, last_year_co2_tonnes double precision, last_year_kwh double precision)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertEnergyAnnualVersusBenchmark'::text))
-          ), additional AS (
-           SELECT alerts.alert_generation_run_id,
-              alerts.school_id,
-              data.school_type_name,
-              data.pupils,
-              data.floor_area
-             FROM alerts,
-              alert_types,
-              LATERAL jsonb_to_record(alerts.variables) data(school_type_name text, pupils double precision, floor_area double precision)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertAdditionalPrioritisationData'::text))
-          ), latest_runs AS (
-           SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
-             FROM alert_generation_runs
-            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC
-          )
-   SELECT latest_runs.id,
-      electricity.last_year_gbp AS last_year_electricity,
-      gas.last_year_gbp AS last_year_gas,
-      storage_heaters.last_year_gbp AS last_year_storage_heaters,
-      energy.last_year_gbp,
-      energy.one_year_energy_per_pupil_gbp,
-      energy.last_year_co2_tonnes,
-      energy.last_year_kwh,
-      additional.alert_generation_run_id,
+  create_view "weekday_baseload_variations", sql_definition: <<-SQL
+      SELECT latest_runs.id,
       additional.school_id,
-      additional.school_type_name,
-      additional.pupils,
-      additional.floor_area
-     FROM (((((latest_runs
-       JOIN additional ON ((latest_runs.id = additional.alert_generation_run_id)))
-       LEFT JOIN electricity ON ((latest_runs.id = electricity.alert_generation_run_id)))
-       LEFT JOIN gas ON ((latest_runs.id = gas.alert_generation_run_id)))
-       LEFT JOIN storage_heaters ON ((latest_runs.id = storage_heaters.alert_generation_run_id)))
-       LEFT JOIN energy ON ((latest_runs.id = energy.alert_generation_run_id)));
+      data.alert_generation_run_id,
+      data.percent_intraday_variation,
+      data.min_day_kw,
+      data.max_day_kw,
+      data.min_day,
+      data.max_day,
+      data.annual_cost_gbpcurrent,
+      additional.electricity_economic_tariff_changed_this_year
+     FROM ( SELECT alerts.alert_generation_run_id,
+              data_1.percent_intraday_variation,
+              data_1.min_day_kw,
+              data_1.max_day_kw,
+              data_1.min_day,
+              data_1.max_day,
+              data_1.annual_cost_gbpcurrent
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) data_1(percent_intraday_variation double precision, min_day_kw double precision, max_day_kw double precision, min_day integer, max_day integer, annual_cost_gbpcurrent double precision)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertIntraweekBaseloadVariation'::text))) data,
+      ( SELECT alerts.alert_generation_run_id,
+              alerts.school_id,
+              data_1.electricity_economic_tariff_changed_this_year
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) data_1(electricity_economic_tariff_changed_this_year boolean)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertAdditionalPrioritisationData'::text))) additional,
+      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
+             FROM alert_generation_runs
+            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
+    WHERE ((data.alert_generation_run_id = latest_runs.id) AND (additional.alert_generation_run_id = latest_runs.id));
+  SQL
+  create_view "solar_generation_summaries", sql_definition: <<-SQL
+      SELECT latest_runs.id,
+      solar_generation.alert_generation_run_id,
+      solar_generation.school_id,
+      solar_generation.annual_electricity_kwh,
+      solar_generation.annual_mains_consumed_kwh,
+      solar_generation.annual_solar_pv_kwh,
+      solar_generation.annual_exported_solar_pv_kwh,
+      solar_generation.annual_solar_pv_consumed_onsite_kwh
+     FROM ( SELECT alerts.alert_generation_run_id,
+              alerts.school_id,
+              data.annual_electricity_kwh,
+              data.annual_mains_consumed_kwh,
+              data.annual_solar_pv_kwh,
+              data.annual_exported_solar_pv_kwh,
+              data.annual_solar_pv_consumed_onsite_kwh
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) data(annual_electricity_kwh double precision, annual_mains_consumed_kwh double precision, annual_solar_pv_kwh double precision, annual_exported_solar_pv_kwh double precision, annual_solar_pv_consumed_onsite_kwh double precision)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertSolarGeneration'::text))) solar_generation,
+      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
+             FROM alert_generation_runs
+            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
+    WHERE (solar_generation.alert_generation_run_id = latest_runs.id);
+  SQL
+  create_view "solar_pv_benefit_estimates", sql_definition: <<-SQL
+      SELECT latest_runs.id,
+      additional.school_id,
+      benefit_estimate.alert_generation_run_id,
+      benefit_estimate.optimum_kwp,
+      benefit_estimate.optimum_payback_years,
+      benefit_estimate.optimum_mains_reduction_percent,
+      benefit_estimate.one_year_saving_gbpcurrent,
+      additional.electricity_economic_tariff_changed_this_year
+     FROM ( SELECT alerts.alert_generation_run_id,
+              data.optimum_kwp,
+              data.optimum_payback_years,
+              data.optimum_mains_reduction_percent,
+              data.one_year_saving_gbpcurrent
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) data(optimum_kwp double precision, optimum_payback_years double precision, optimum_mains_reduction_percent double precision, one_year_saving_gbpcurrent double precision)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertSolarPVBenefitEstimator'::text))) benefit_estimate,
+      ( SELECT alerts.alert_generation_run_id,
+              alerts.school_id,
+              data.electricity_economic_tariff_changed_this_year
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) data(electricity_economic_tariff_changed_this_year boolean)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertAdditionalPrioritisationData'::text))) additional,
+      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
+             FROM alert_generation_runs
+            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
+    WHERE ((benefit_estimate.alert_generation_run_id = latest_runs.id) AND (additional.alert_generation_run_id = latest_runs.id));
+  SQL
+  create_view "seasonal_baseload_variations", sql_definition: <<-SQL
+      SELECT latest_runs.id,
+      additional.school_id,
+      data.alert_generation_run_id,
+      data.percent_seasonal_variation,
+      data.summer_kw,
+      data.winter_kw,
+      data.annual_cost_gbpcurrent,
+      additional.electricity_economic_tariff_changed_this_year
+     FROM ( SELECT alerts.alert_generation_run_id,
+              data_1.percent_seasonal_variation,
+              data_1.summer_kw,
+              data_1.winter_kw,
+              data_1.annual_cost_gbpcurrent
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) data_1(percent_seasonal_variation double precision, summer_kw double precision, winter_kw double precision, annual_cost_gbpcurrent double precision)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertSeasonalBaseloadVariation'::text))) data,
+      ( SELECT alerts.alert_generation_run_id,
+              alerts.school_id,
+              data_1.electricity_economic_tariff_changed_this_year
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) data_1(electricity_economic_tariff_changed_this_year boolean)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertAdditionalPrioritisationData'::text))) additional,
+      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
+             FROM alert_generation_runs
+            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
+    WHERE ((data.alert_generation_run_id = latest_runs.id) AND (additional.alert_generation_run_id = latest_runs.id));
+  SQL
+  create_view "recent_change_in_baseloads", sql_definition: <<-SQL
+      SELECT latest_runs.id,
+      data.alert_generation_run_id,
+      data.school_id,
+      data.predicted_percent_increase_in_usage,
+      data.average_baseload_last_year_kw,
+      data.average_baseload_last_week_kw,
+      data.change_in_baseload_kw,
+      data.next_year_change_in_baseload_gbpcurrent,
+      additional.electricity_economic_tariff_changed_this_year
+     FROM ( SELECT alerts.alert_generation_run_id,
+              alerts.school_id,
+              data_1.predicted_percent_increase_in_usage,
+              data_1.average_baseload_last_year_kw,
+              data_1.average_baseload_last_week_kw,
+              data_1.change_in_baseload_kw,
+              data_1.next_year_change_in_baseload_gbpcurrent
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) data_1(predicted_percent_increase_in_usage double precision, average_baseload_last_year_kw double precision, average_baseload_last_week_kw double precision, change_in_baseload_kw double precision, next_year_change_in_baseload_gbpcurrent double precision)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertChangeInElectricityBaseloadShortTerm'::text))) data,
+      ( SELECT alerts.alert_generation_run_id,
+              data_1.electricity_economic_tariff_changed_this_year
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) data_1(electricity_economic_tariff_changed_this_year boolean)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertAdditionalPrioritisationData'::text))) additional,
+      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
+             FROM alert_generation_runs
+            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
+    WHERE ((data.alert_generation_run_id = latest_runs.id) AND (additional.alert_generation_run_id = latest_runs.id));
+  SQL
+  create_view "change_in_solar_pv_since_last_years", sql_definition: <<-SQL
+      SELECT latest_runs.id,
+      versus_benchmark.school_id,
+      versus_benchmark.previous_year_solar_pv_kwh,
+      versus_benchmark.current_year_solar_pv_kwh,
+      versus_benchmark.previous_year_solar_pv_co2,
+      versus_benchmark.current_year_solar_pv_co2,
+      versus_benchmark.solar_type
+     FROM ( SELECT alerts.alert_generation_run_id,
+              alerts.school_id,
+              data.previous_year_solar_pv_kwh,
+              data.current_year_solar_pv_kwh,
+              data.previous_year_solar_pv_co2,
+              data.current_year_solar_pv_co2,
+              data.solar_type
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) data(previous_year_solar_pv_kwh double precision, current_year_solar_pv_kwh double precision, previous_year_solar_pv_co2 double precision, current_year_solar_pv_co2 double precision, solar_type text)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertEnergyAnnualVersusBenchmark'::text))) versus_benchmark,
+      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
+             FROM alert_generation_runs
+            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
+    WHERE (versus_benchmark.alert_generation_run_id = latest_runs.id);
+  SQL
+  create_view "change_in_gas_holiday_consumption_previous_holidays", sql_definition: <<-SQL
+      SELECT latest_runs.id,
+      data.alert_generation_run_id,
+      data.school_id,
+      data.difference_percent,
+      data.difference_gbpcurrent,
+      data.difference_kwh,
+      data.current_period_type,
+      data.current_period_start_date,
+      data.current_period_end_date,
+      data.truncated_current_period,
+      data.previous_period_type,
+      data.previous_period_start_date,
+      data.previous_period_end_date,
+      data.pupils_changed,
+      data.tariff_has_changed
+     FROM ( SELECT alerts.alert_generation_run_id,
+              alerts.school_id,
+              data_1.difference_percent,
+              data_1.difference_gbpcurrent,
+              data_1.difference_kwh,
+              data_1.current_period_type,
+              data_1.current_period_start_date,
+              data_1.current_period_end_date,
+              data_1.truncated_current_period,
+              data_1.previous_period_type,
+              data_1.previous_period_start_date,
+              data_1.previous_period_end_date,
+              data_1.pupils_changed,
+              data_1.tariff_has_changed
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) data_1(difference_percent double precision, difference_gbpcurrent double precision, difference_kwh double precision, current_period_type text, current_period_start_date date, current_period_end_date date, truncated_current_period boolean, previous_period_type text, previous_period_start_date date, previous_period_end_date date, pupils_changed boolean, tariff_has_changed boolean)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertPreviousHolidayComparisonGas'::text))) data,
+      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
+             FROM alert_generation_runs
+            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
+    WHERE (data.alert_generation_run_id = latest_runs.id);
+  SQL
+  create_view "change_in_gas_holiday_consumption_previous_years_holidays", sql_definition: <<-SQL
+      SELECT latest_runs.id,
+      data.alert_generation_run_id,
+      data.school_id,
+      data.difference_percent,
+      data.difference_gbpcurrent,
+      data.difference_kwh,
+      data.current_period_type,
+      data.current_period_start_date,
+      data.current_period_end_date,
+      data.truncated_current_period,
+      data.previous_period_type,
+      data.previous_period_start_date,
+      data.previous_period_end_date,
+      data.pupils_changed,
+      data.tariff_has_changed
+     FROM ( SELECT alerts.alert_generation_run_id,
+              alerts.school_id,
+              data_1.difference_percent,
+              data_1.difference_gbpcurrent,
+              data_1.difference_kwh,
+              data_1.current_period_type,
+              data_1.current_period_start_date,
+              data_1.current_period_end_date,
+              data_1.truncated_current_period,
+              data_1.previous_period_type,
+              data_1.previous_period_start_date,
+              data_1.previous_period_end_date,
+              data_1.pupils_changed,
+              data_1.tariff_has_changed
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) data_1(difference_percent double precision, difference_gbpcurrent double precision, difference_kwh double precision, current_period_type text, current_period_start_date date, current_period_end_date date, truncated_current_period boolean, previous_period_type text, previous_period_start_date date, previous_period_end_date date, pupils_changed boolean, tariff_has_changed boolean)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertPreviousYearHolidayComparisonGas'::text))) data,
+      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
+             FROM alert_generation_runs
+            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
+    WHERE (data.alert_generation_run_id = latest_runs.id);
+  SQL
+  create_view "change_in_gas_consumption_recent_school_weeks", sql_definition: <<-SQL
+      SELECT latest_runs.id,
+      data.alert_generation_run_id,
+      data.school_id,
+      data.difference_percent,
+      data.difference_gbpcurrent,
+      data.difference_kwh,
+      data.pupils_changed,
+      data.tariff_has_changed
+     FROM ( SELECT alerts.alert_generation_run_id,
+              alerts.school_id,
+              data_1.difference_percent,
+              data_1.difference_gbpcurrent,
+              data_1.difference_kwh,
+              data_1.pupils_changed,
+              data_1.tariff_has_changed
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) data_1(difference_percent double precision, difference_gbpcurrent double precision, difference_kwh double precision, pupils_changed boolean, tariff_has_changed boolean)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertSchoolWeekComparisonGas'::text))) data,
+      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
+             FROM alert_generation_runs
+            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
+    WHERE (data.alert_generation_run_id = latest_runs.id);
+  SQL
+  create_view "storage_heater_consumption_during_holidays", sql_definition: <<-SQL
+      SELECT latest_runs.id,
+      data.alert_generation_run_id,
+      data.school_id,
+      data.holiday_projected_usage_gbp,
+      data.holiday_usage_to_date_gbp,
+      data.holiday_type,
+      data.holiday_start_date,
+      data.holiday_end_date
+     FROM ( SELECT alerts.alert_generation_run_id,
+              alerts.school_id,
+              data_1.holiday_projected_usage_gbp,
+              data_1.holiday_usage_to_date_gbp,
+              data_1.holiday_type,
+              data_1.holiday_start_date,
+              data_1.holiday_end_date
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) data_1(holiday_projected_usage_gbp double precision, holiday_usage_to_date_gbp double precision, holiday_type text, holiday_start_date date, holiday_end_date date)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertStorageHeaterHeatingOnDuringHoliday'::text))) data,
+      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
+             FROM alert_generation_runs
+            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
+    WHERE (data.alert_generation_run_id = latest_runs.id);
+  SQL
+  create_view "electricity_consumption_during_holidays", sql_definition: <<-SQL
+      SELECT latest_runs.id,
+      data.alert_generation_run_id,
+      data.school_id,
+      data.holiday_projected_usage_gbp,
+      data.holiday_usage_to_date_gbp,
+      data.holiday_type,
+      data.holiday_start_date,
+      data.holiday_end_date
+     FROM ( SELECT alerts.alert_generation_run_id,
+              alerts.school_id,
+              data_1.holiday_projected_usage_gbp,
+              data_1.holiday_usage_to_date_gbp,
+              data_1.holiday_type,
+              data_1.holiday_start_date,
+              data_1.holiday_end_date
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) data_1(holiday_projected_usage_gbp double precision, holiday_usage_to_date_gbp double precision, holiday_type text, holiday_start_date date, holiday_end_date date)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertElectricityUsageDuringCurrentHoliday'::text))) data,
+      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
+             FROM alert_generation_runs
+            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
+    WHERE (data.alert_generation_run_id = latest_runs.id);
+  SQL
+  create_view "gas_consumption_during_holidays", sql_definition: <<-SQL
+      SELECT latest_runs.id,
+      data.alert_generation_run_id,
+      data.school_id,
+      data.holiday_projected_usage_gbp,
+      data.holiday_usage_to_date_gbp,
+      data.holiday_type,
+      data.holiday_start_date,
+      data.holiday_end_date
+     FROM ( SELECT alerts.alert_generation_run_id,
+              alerts.school_id,
+              data_1.holiday_projected_usage_gbp,
+              data_1.holiday_usage_to_date_gbp,
+              data_1.holiday_type,
+              data_1.holiday_start_date,
+              data_1.holiday_end_date
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) data_1(holiday_projected_usage_gbp double precision, holiday_usage_to_date_gbp double precision, holiday_type text, holiday_start_date date, holiday_end_date date)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertGasHeatingHotWaterOnDuringHoliday'::text))) data,
+      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
+             FROM alert_generation_runs
+            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
+    WHERE (data.alert_generation_run_id = latest_runs.id);
   SQL
   create_view "annual_energy_costs_per_units", sql_definition: <<-SQL
       WITH electricity AS (
@@ -2448,43 +2840,42 @@ ActiveRecord::Schema.define(version: 2024_04_17_104449) do
        LEFT JOIN gas ON ((latest_runs.id = gas.alert_generation_run_id)))
        LEFT JOIN storage_heaters ON ((latest_runs.id = storage_heaters.alert_generation_run_id)));
   SQL
-  create_view "annual_gas_out_of_hours_uses", sql_definition: <<-SQL
+  create_view "change_in_gas_since_last_years", sql_definition: <<-SQL
       SELECT latest_runs.id,
-      data.alert_generation_run_id,
-      data.school_id,
-      data.schoolday_open_percent,
-      data.schoolday_closed_percent,
-      data.holidays_percent,
-      data.weekends_percent,
-      data.community_percent,
-      data.community_gbp,
-      data.out_of_hours_gbp,
-      data.potential_saving_gbp,
-      additional.gas_economic_tariff_changed_this_year
+      energy.alert_generation_run_id,
+      energy.school_id,
+      energy.previous_year_kwh,
+      energy.current_year_kwh,
+      energy.previous_year_co2,
+      energy.current_year_co2,
+      energy.previous_year_gbp,
+      energy.current_year_gbp,
+      gas.temperature_adjusted_previous_year_kwh,
+      gas.temperature_adjusted_percent
      FROM ( SELECT alerts.alert_generation_run_id,
               alerts.school_id,
-              data_1.schoolday_open_percent,
-              data_1.schoolday_closed_percent,
-              data_1.holidays_percent,
-              data_1.weekends_percent,
-              data_1.community_percent,
-              data_1.community_gbp,
-              data_1.out_of_hours_gbp,
-              data_1.potential_saving_gbp
+              json.previous_year_gas_kwh AS previous_year_kwh,
+              json.current_year_gas_kwh AS current_year_kwh,
+              json.previous_year_gas_co2 AS previous_year_co2,
+              json.current_year_gas_co2 AS current_year_co2,
+              json.previous_year_gas_gbp AS previous_year_gbp,
+              json.current_year_gas_gbp AS current_year_gbp
              FROM alerts,
               alert_types,
-              LATERAL jsonb_to_record(alerts.variables) data_1(schoolday_open_percent double precision, schoolday_closed_percent double precision, holidays_percent double precision, weekends_percent double precision, community_percent double precision, community_gbp double precision, out_of_hours_gbp double precision, potential_saving_gbp double precision)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertOutOfHoursGasUsage'::text))) data,
+              LATERAL jsonb_to_record(alerts.variables) json(previous_year_gas_kwh double precision, current_year_gas_kwh double precision, previous_year_gas_co2 double precision, current_year_gas_co2 double precision, previous_year_gas_gbp double precision, current_year_gas_gbp double precision)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertEnergyAnnualVersusBenchmark'::text))) energy,
       ( SELECT alerts.alert_generation_run_id,
-              data_1.gas_economic_tariff_changed_this_year
+              alerts.school_id,
+              json.temperature_adjusted_previous_year_kwh,
+              json.temperature_adjusted_percent
              FROM alerts,
               alert_types,
-              LATERAL jsonb_to_record(alerts.variables) data_1(gas_economic_tariff_changed_this_year boolean)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertAdditionalPrioritisationData'::text))) additional,
+              LATERAL jsonb_to_record(alerts.variables) json(temperature_adjusted_previous_year_kwh double precision, temperature_adjusted_percent double precision)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertGasAnnualVersusBenchmark'::text))) gas,
       ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
              FROM alert_generation_runs
             ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
-    WHERE ((data.alert_generation_run_id = latest_runs.id) AND (additional.alert_generation_run_id = latest_runs.id));
+    WHERE ((energy.alert_generation_run_id = latest_runs.id) AND (gas.alert_generation_run_id = latest_runs.id));
   SQL
   create_view "annual_heating_costs_per_floor_areas", sql_definition: <<-SQL
       WITH gas AS (
@@ -2536,360 +2927,6 @@ ActiveRecord::Schema.define(version: 2024_04_17_104449) do
        LEFT JOIN gas ON ((latest_runs.id = gas.alert_generation_run_id)))
        LEFT JOIN storage_heaters ON ((latest_runs.id = storage_heaters.alert_generation_run_id)));
   SQL
-  create_view "annual_storage_heater_out_of_hours_uses", sql_definition: <<-SQL
-      SELECT latest_runs.id,
-      data.alert_generation_run_id,
-      data.school_id,
-      data.schoolday_open_percent,
-      data.schoolday_closed_percent,
-      data.holidays_percent,
-      data.weekends_percent,
-      data.holidays_gbp,
-      data.weekends_gbp
-     FROM ( SELECT alerts.alert_generation_run_id,
-              alerts.school_id,
-              data_1.schoolday_open_percent,
-              data_1.schoolday_closed_percent,
-              data_1.holidays_percent,
-              data_1.weekends_percent,
-              data_1.holidays_gbp,
-              data_1.weekends_gbp
-             FROM alerts,
-              alert_types,
-              LATERAL jsonb_to_record(alerts.variables) data_1(schoolday_open_percent double precision, schoolday_closed_percent double precision, holidays_percent double precision, weekends_percent double precision, holidays_gbp double precision, weekends_gbp double precision)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertStorageHeaterOutOfHours'::text))) data,
-      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
-             FROM alert_generation_runs
-            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
-    WHERE (data.alert_generation_run_id = latest_runs.id);
-  SQL
-  create_view "baseload_per_pupils", sql_definition: <<-SQL
-      SELECT latest_runs.id,
-      additional.school_id,
-      baseload.alert_generation_run_id,
-      baseload.average_baseload_last_year_kw,
-      baseload.average_baseload_last_year_gbp,
-      baseload.one_year_baseload_per_pupil_kw,
-      baseload.annual_baseload_percent,
-      baseload.one_year_saving_versus_exemplar_gbp,
-      additional.electricity_economic_tariff_changed_this_year
-     FROM ( SELECT alerts.alert_generation_run_id,
-              data.average_baseload_last_year_kw,
-              data.average_baseload_last_year_gbp,
-              data.one_year_baseload_per_pupil_kw,
-              data.annual_baseload_percent,
-              data.one_year_saving_versus_exemplar_gbp
-             FROM alerts,
-              alert_types,
-              LATERAL jsonb_to_record(alerts.variables) data(average_baseload_last_year_kw double precision, average_baseload_last_year_gbp double precision, one_year_baseload_per_pupil_kw double precision, annual_baseload_percent double precision, one_year_saving_versus_exemplar_gbp double precision)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertElectricityBaseloadVersusBenchmark'::text))) baseload,
-      ( SELECT alerts.alert_generation_run_id,
-              alerts.school_id,
-              data.electricity_economic_tariff_changed_this_year
-             FROM alerts,
-              alert_types,
-              LATERAL jsonb_to_record(alerts.variables) data(electricity_economic_tariff_changed_this_year boolean)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertAdditionalPrioritisationData'::text))) additional,
-      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
-             FROM alert_generation_runs
-            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
-    WHERE ((baseload.alert_generation_run_id = latest_runs.id) AND (additional.alert_generation_run_id = latest_runs.id));
-  SQL
-  create_view "change_in_electricity_consumption_recent_school_weeks", sql_definition: <<-SQL
-      SELECT latest_runs.id,
-      data.alert_generation_run_id,
-      data.school_id,
-      data.difference_percent,
-      data.difference_gbpcurrent,
-      data.difference_kwh,
-      data.pupils_changed,
-      data.tariff_has_changed
-     FROM ( SELECT alerts.alert_generation_run_id,
-              alerts.school_id,
-              data_1.difference_percent,
-              data_1.difference_gbpcurrent,
-              data_1.difference_kwh,
-              data_1.pupils_changed,
-              data_1.tariff_has_changed
-             FROM alerts,
-              alert_types,
-              LATERAL jsonb_to_record(alerts.variables) data_1(difference_percent double precision, difference_gbpcurrent double precision, difference_kwh double precision, pupils_changed boolean, tariff_has_changed boolean)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertSchoolWeekComparisonElectricity'::text))) data,
-      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
-             FROM alert_generation_runs
-            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
-    WHERE (data.alert_generation_run_id = latest_runs.id);
-  SQL
-  create_view "change_in_electricity_holiday_consumption_previous_holidays", sql_definition: <<-SQL
-      SELECT latest_runs.id,
-      data.alert_generation_run_id,
-      data.school_id,
-      data.difference_percent,
-      data.difference_gbpcurrent,
-      data.difference_kwh,
-      data.current_period_type,
-      data.current_period_start_date,
-      data.current_period_end_date,
-      data.truncated_current_period,
-      data.previous_period_type,
-      data.previous_period_start_date,
-      data.previous_period_end_date,
-      data.pupils_changed,
-      data.tariff_has_changed
-     FROM ( SELECT alerts.alert_generation_run_id,
-              alerts.school_id,
-              data_1.difference_percent,
-              data_1.difference_gbpcurrent,
-              data_1.difference_kwh,
-              data_1.current_period_type,
-              data_1.current_period_start_date,
-              data_1.current_period_end_date,
-              data_1.truncated_current_period,
-              data_1.previous_period_type,
-              data_1.previous_period_start_date,
-              data_1.previous_period_end_date,
-              data_1.pupils_changed,
-              data_1.tariff_has_changed
-             FROM alerts,
-              alert_types,
-              LATERAL jsonb_to_record(alerts.variables) data_1(difference_percent double precision, difference_gbpcurrent double precision, difference_kwh double precision, current_period_type text, current_period_start_date date, current_period_end_date date, truncated_current_period boolean, previous_period_type text, previous_period_start_date date, previous_period_end_date date, pupils_changed boolean, tariff_has_changed boolean)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertPreviousHolidayComparisonElectricity'::text))) data,
-      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
-             FROM alert_generation_runs
-            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
-    WHERE (data.alert_generation_run_id = latest_runs.id);
-  SQL
-  create_view "change_in_electricity_holiday_consumption_previous_years_holida", sql_definition: <<-SQL
-      SELECT latest_runs.id,
-      data.alert_generation_run_id,
-      data.school_id,
-      data.current_period_type,
-      data.current_period_start_date,
-      data.current_period_end_date,
-      data.difference_gbpcurrent,
-      data.difference_kwh,
-      data.difference_percent,
-      data.previous_period_type,
-      data.previous_period_start_date,
-      data.previous_period_end_date,
-      data.pupils_changed,
-      data.tariff_has_changed,
-      data.truncated_current_period
-     FROM ( SELECT alerts.alert_generation_run_id,
-              alerts.school_id,
-              data_1.current_period_type,
-              data_1.current_period_start_date,
-              data_1.current_period_end_date,
-              data_1.difference_gbpcurrent,
-              data_1.difference_kwh,
-              data_1.difference_percent,
-              data_1.previous_period_type,
-              data_1.previous_period_start_date,
-              data_1.previous_period_end_date,
-              data_1.pupils_changed,
-              data_1.tariff_has_changed,
-              data_1.truncated_current_period
-             FROM alerts,
-              alert_types,
-              LATERAL jsonb_to_record(alerts.variables) data_1(current_period_type text, current_period_start_date date, current_period_end_date date, difference_gbpcurrent double precision, difference_kwh double precision, difference_percent double precision, previous_period_type text, previous_period_start_date date, previous_period_end_date date, pupils_changed boolean, tariff_has_changed boolean, truncated_current_period boolean)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertPreviousYearHolidayComparisonElectricity'::text))) data,
-      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
-             FROM alert_generation_runs
-            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
-    WHERE (data.alert_generation_run_id = latest_runs.id);
-  SQL
-  create_view "change_in_electricity_since_last_years", sql_definition: <<-SQL
-      SELECT latest_runs.id,
-      enba.school_id,
-      enba.previous_year_electricity_kwh,
-      enba.current_year_electricity_kwh,
-      enba.previous_year_electricity_co2,
-      enba.current_year_electricity_co2,
-      enba.previous_year_electricity_gbp,
-      enba.current_year_electricity_gbp,
-      enba.solar_type
-     FROM ( SELECT alerts.alert_generation_run_id,
-              alerts.school_id,
-              data.previous_year_electricity_kwh,
-              data.current_year_electricity_kwh,
-              data.previous_year_electricity_co2,
-              data.current_year_electricity_co2,
-              data.previous_year_electricity_gbp,
-              data.current_year_electricity_gbp,
-              data.solar_type
-             FROM alerts,
-              alert_types,
-              LATERAL jsonb_to_record(alerts.variables) data(previous_year_electricity_kwh double precision, current_year_electricity_kwh double precision, previous_year_electricity_co2 double precision, current_year_electricity_co2 double precision, previous_year_electricity_gbp double precision, current_year_electricity_gbp double precision, solar_type text)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertEnergyAnnualVersusBenchmark'::text))) enba,
-      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
-             FROM alert_generation_runs
-            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
-    WHERE (enba.alert_generation_run_id = latest_runs.id);
-  SQL
-  create_view "change_in_gas_consumption_recent_school_weeks", sql_definition: <<-SQL
-      SELECT latest_runs.id,
-      data.alert_generation_run_id,
-      data.school_id,
-      data.difference_percent,
-      data.difference_gbpcurrent,
-      data.difference_kwh,
-      data.pupils_changed,
-      data.tariff_has_changed
-     FROM ( SELECT alerts.alert_generation_run_id,
-              alerts.school_id,
-              data_1.difference_percent,
-              data_1.difference_gbpcurrent,
-              data_1.difference_kwh,
-              data_1.pupils_changed,
-              data_1.tariff_has_changed
-             FROM alerts,
-              alert_types,
-              LATERAL jsonb_to_record(alerts.variables) data_1(difference_percent double precision, difference_gbpcurrent double precision, difference_kwh double precision, pupils_changed boolean, tariff_has_changed boolean)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertSchoolWeekComparisonGas'::text))) data,
-      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
-             FROM alert_generation_runs
-            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
-    WHERE (data.alert_generation_run_id = latest_runs.id);
-  SQL
-  create_view "change_in_gas_holiday_consumption_previous_holidays", sql_definition: <<-SQL
-      SELECT latest_runs.id,
-      data.alert_generation_run_id,
-      data.school_id,
-      data.difference_percent,
-      data.difference_gbpcurrent,
-      data.difference_kwh,
-      data.current_period_type,
-      data.current_period_start_date,
-      data.current_period_end_date,
-      data.truncated_current_period,
-      data.previous_period_type,
-      data.previous_period_start_date,
-      data.previous_period_end_date,
-      data.pupils_changed,
-      data.tariff_has_changed
-     FROM ( SELECT alerts.alert_generation_run_id,
-              alerts.school_id,
-              data_1.difference_percent,
-              data_1.difference_gbpcurrent,
-              data_1.difference_kwh,
-              data_1.current_period_type,
-              data_1.current_period_start_date,
-              data_1.current_period_end_date,
-              data_1.truncated_current_period,
-              data_1.previous_period_type,
-              data_1.previous_period_start_date,
-              data_1.previous_period_end_date,
-              data_1.pupils_changed,
-              data_1.tariff_has_changed
-             FROM alerts,
-              alert_types,
-              LATERAL jsonb_to_record(alerts.variables) data_1(difference_percent double precision, difference_gbpcurrent double precision, difference_kwh double precision, current_period_type text, current_period_start_date date, current_period_end_date date, truncated_current_period boolean, previous_period_type text, previous_period_start_date date, previous_period_end_date date, pupils_changed boolean, tariff_has_changed boolean)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertPreviousHolidayComparisonGas'::text))) data,
-      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
-             FROM alert_generation_runs
-            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
-    WHERE (data.alert_generation_run_id = latest_runs.id);
-  SQL
-  create_view "change_in_gas_holiday_consumption_previous_years_holidays", sql_definition: <<-SQL
-      SELECT latest_runs.id,
-      data.alert_generation_run_id,
-      data.school_id,
-      data.difference_percent,
-      data.difference_gbpcurrent,
-      data.difference_kwh,
-      data.current_period_type,
-      data.current_period_start_date,
-      data.current_period_end_date,
-      data.truncated_current_period,
-      data.previous_period_type,
-      data.previous_period_start_date,
-      data.previous_period_end_date,
-      data.pupils_changed,
-      data.tariff_has_changed
-     FROM ( SELECT alerts.alert_generation_run_id,
-              alerts.school_id,
-              data_1.difference_percent,
-              data_1.difference_gbpcurrent,
-              data_1.difference_kwh,
-              data_1.current_period_type,
-              data_1.current_period_start_date,
-              data_1.current_period_end_date,
-              data_1.truncated_current_period,
-              data_1.previous_period_type,
-              data_1.previous_period_start_date,
-              data_1.previous_period_end_date,
-              data_1.pupils_changed,
-              data_1.tariff_has_changed
-             FROM alerts,
-              alert_types,
-              LATERAL jsonb_to_record(alerts.variables) data_1(difference_percent double precision, difference_gbpcurrent double precision, difference_kwh double precision, current_period_type text, current_period_start_date date, current_period_end_date date, truncated_current_period boolean, previous_period_type text, previous_period_start_date date, previous_period_end_date date, pupils_changed boolean, tariff_has_changed boolean)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertPreviousYearHolidayComparisonGas'::text))) data,
-      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
-             FROM alert_generation_runs
-            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
-    WHERE (data.alert_generation_run_id = latest_runs.id);
-  SQL
-  create_view "change_in_gas_since_last_years", sql_definition: <<-SQL
-      SELECT latest_runs.id,
-      energy.alert_generation_run_id,
-      energy.school_id,
-      energy.previous_year_kwh,
-      energy.current_year_kwh,
-      energy.previous_year_co2,
-      energy.current_year_co2,
-      energy.previous_year_gbp,
-      energy.current_year_gbp,
-      gas.temperature_adjusted_previous_year_kwh,
-      gas.temperature_adjusted_percent
-     FROM ( SELECT alerts.alert_generation_run_id,
-              alerts.school_id,
-              json.previous_year_gas_kwh AS previous_year_kwh,
-              json.current_year_gas_kwh AS current_year_kwh,
-              json.previous_year_gas_co2 AS previous_year_co2,
-              json.current_year_gas_co2 AS current_year_co2,
-              json.previous_year_gas_gbp AS previous_year_gbp,
-              json.current_year_gas_gbp AS current_year_gbp
-             FROM alerts,
-              alert_types,
-              LATERAL jsonb_to_record(alerts.variables) json(previous_year_gas_kwh double precision, current_year_gas_kwh double precision, previous_year_gas_co2 double precision, current_year_gas_co2 double precision, previous_year_gas_gbp double precision, current_year_gas_gbp double precision)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertEnergyAnnualVersusBenchmark'::text))) energy,
-      ( SELECT alerts.alert_generation_run_id,
-              alerts.school_id,
-              json.temperature_adjusted_previous_year_kwh,
-              json.temperature_adjusted_percent
-             FROM alerts,
-              alert_types,
-              LATERAL jsonb_to_record(alerts.variables) json(temperature_adjusted_previous_year_kwh double precision, temperature_adjusted_percent double precision)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertGasAnnualVersusBenchmark'::text))) gas,
-      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
-             FROM alert_generation_runs
-            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
-    WHERE ((energy.alert_generation_run_id = latest_runs.id) AND (gas.alert_generation_run_id = latest_runs.id));
-  SQL
-  create_view "change_in_solar_pv_since_last_years", sql_definition: <<-SQL
-      SELECT latest_runs.id,
-      versus_benchmark.school_id,
-      versus_benchmark.previous_year_solar_pv_kwh,
-      versus_benchmark.current_year_solar_pv_kwh,
-      versus_benchmark.previous_year_solar_pv_co2,
-      versus_benchmark.current_year_solar_pv_co2,
-      versus_benchmark.solar_type
-     FROM ( SELECT alerts.alert_generation_run_id,
-              alerts.school_id,
-              data.previous_year_solar_pv_kwh,
-              data.current_year_solar_pv_kwh,
-              data.previous_year_solar_pv_co2,
-              data.current_year_solar_pv_co2,
-              data.solar_type
-             FROM alerts,
-              alert_types,
-              LATERAL jsonb_to_record(alerts.variables) data(previous_year_solar_pv_kwh double precision, current_year_solar_pv_kwh double precision, previous_year_solar_pv_co2 double precision, current_year_solar_pv_co2 double precision, solar_type text)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertEnergyAnnualVersusBenchmark'::text))) versus_benchmark,
-      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
-             FROM alert_generation_runs
-            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
-    WHERE (versus_benchmark.alert_generation_run_id = latest_runs.id);
-  SQL
   create_view "change_in_storage_heaters_since_last_years", sql_definition: <<-SQL
       SELECT latest_runs.id,
       energy.alert_generation_run_id,
@@ -2927,139 +2964,213 @@ ActiveRecord::Schema.define(version: 2024_04_17_104449) do
             ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
     WHERE ((energy.alert_generation_run_id = latest_runs.id) AND (storage.alert_generation_run_id = latest_runs.id));
   SQL
-  create_view "electricity_consumption_during_holidays", sql_definition: <<-SQL
+  create_view "annual_gas_out_of_hours_uses", sql_definition: <<-SQL
       SELECT latest_runs.id,
       data.alert_generation_run_id,
       data.school_id,
-      data.holiday_projected_usage_gbp,
-      data.holiday_usage_to_date_gbp,
-      data.holiday_type,
-      data.holiday_start_date,
-      data.holiday_end_date
+      data.schoolday_open_percent,
+      data.schoolday_closed_percent,
+      data.holidays_percent,
+      data.weekends_percent,
+      data.community_percent,
+      data.community_gbp,
+      data.out_of_hours_gbp,
+      data.potential_saving_gbp,
+      additional.gas_economic_tariff_changed_this_year
      FROM ( SELECT alerts.alert_generation_run_id,
               alerts.school_id,
-              data_1.holiday_projected_usage_gbp,
-              data_1.holiday_usage_to_date_gbp,
-              data_1.holiday_type,
-              data_1.holiday_start_date,
-              data_1.holiday_end_date
+              data_1.schoolday_open_percent,
+              data_1.schoolday_closed_percent,
+              data_1.holidays_percent,
+              data_1.weekends_percent,
+              data_1.community_percent,
+              data_1.community_gbp,
+              data_1.out_of_hours_gbp,
+              data_1.potential_saving_gbp
              FROM alerts,
               alert_types,
-              LATERAL jsonb_to_record(alerts.variables) data_1(holiday_projected_usage_gbp double precision, holiday_usage_to_date_gbp double precision, holiday_type text, holiday_start_date date, holiday_end_date date)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertElectricityUsageDuringCurrentHoliday'::text))) data,
-      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
-             FROM alert_generation_runs
-            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
-    WHERE (data.alert_generation_run_id = latest_runs.id);
-  SQL
-  create_view "electricity_peak_kw_per_pupils", sql_definition: <<-SQL
-      SELECT latest_runs.id,
-      data.alert_generation_run_id,
-      data.school_id,
-      data.average_school_day_last_year_kw_per_floor_area,
-      data.average_school_day_last_year_kw,
-      data.exemplar_kw,
-      data.one_year_saving_versus_exemplar_gbp,
-      additional.electricity_economic_tariff_changed_this_year
-     FROM ( SELECT alerts.alert_generation_run_id,
-              alerts.school_id,
-              data_1.average_school_day_last_year_kw_per_floor_area,
-              data_1.average_school_day_last_year_kw,
-              data_1.exemplar_kw,
-              data_1.one_year_saving_versus_exemplar_gbp
-             FROM alerts,
-              alert_types,
-              LATERAL jsonb_to_record(alerts.variables) data_1(average_school_day_last_year_kw_per_floor_area double precision, average_school_day_last_year_kw double precision, exemplar_kw double precision, one_year_saving_versus_exemplar_gbp double precision)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertElectricityPeakKWVersusBenchmark'::text))) data,
+              LATERAL jsonb_to_record(alerts.variables) data_1(schoolday_open_percent double precision, schoolday_closed_percent double precision, holidays_percent double precision, weekends_percent double precision, community_percent double precision, community_gbp double precision, out_of_hours_gbp double precision, potential_saving_gbp double precision)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertOutOfHoursGasUsage'::text))) data,
       ( SELECT alerts.alert_generation_run_id,
-              data_1.electricity_economic_tariff_changed_this_year
+              data_1.gas_economic_tariff_changed_this_year
              FROM alerts,
               alert_types,
-              LATERAL jsonb_to_record(alerts.variables) data_1(electricity_economic_tariff_changed_this_year boolean)
+              LATERAL jsonb_to_record(alerts.variables) data_1(gas_economic_tariff_changed_this_year boolean)
             WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertAdditionalPrioritisationData'::text))) additional,
       ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
              FROM alert_generation_runs
             ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
     WHERE ((data.alert_generation_run_id = latest_runs.id) AND (additional.alert_generation_run_id = latest_runs.id));
   SQL
-  create_view "electricity_targets", sql_definition: <<-SQL
+  create_view "annual_change_in_gas_out_of_hours_uses", sql_definition: <<-SQL
+      SELECT latest_runs.id,
+      usage.alert_generation_run_id,
+      usage.school_id,
+      usage.out_of_hours_kwh,
+      usage.out_of_hours_co2,
+      usage.out_of_hours_gbpcurrent,
+      usage_previous_year.previous_out_of_hours_kwh,
+      usage_previous_year.previous_out_of_hours_co2,
+      usage_previous_year.previous_out_of_hours_gbpcurrent,
+      additional.economic_tariff_changed_this_year
+     FROM ( SELECT alerts.alert_generation_run_id,
+              alerts.school_id,
+              json.out_of_hours_kwh,
+              json.out_of_hours_co2,
+              json.out_of_hours_gbpcurrent
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) json(out_of_hours_kwh double precision, out_of_hours_co2 double precision, out_of_hours_gbpcurrent double precision)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertOutOfHoursGasUsage'::text))) usage,
+      ( SELECT alerts.alert_generation_run_id,
+              alerts.school_id,
+              json.out_of_hours_kwh AS previous_out_of_hours_kwh,
+              json.out_of_hours_co2 AS previous_out_of_hours_co2,
+              json.out_of_hours_gbpcurrent AS previous_out_of_hours_gbpcurrent
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) json(out_of_hours_kwh double precision, out_of_hours_co2 double precision, out_of_hours_gbpcurrent double precision)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertOutOfHoursGasUsagePreviousYear'::text))) usage_previous_year,
+      ( SELECT alerts.alert_generation_run_id,
+              json.gas_economic_tariff_changed_this_year AS economic_tariff_changed_this_year
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) json(gas_economic_tariff_changed_this_year boolean)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertAdditionalPrioritisationData'::text))) additional,
+      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
+             FROM alert_generation_runs
+            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
+    WHERE ((usage.alert_generation_run_id = latest_runs.id) AND (usage_previous_year.alert_generation_run_id = latest_runs.id) AND (additional.alert_generation_run_id = latest_runs.id));
+  SQL
+  create_view "annual_storage_heater_out_of_hours_uses", sql_definition: <<-SQL
       SELECT latest_runs.id,
       data.alert_generation_run_id,
       data.school_id,
-      data.current_year_percent_of_target_relative,
-      data.current_year_unscaled_percent_of_target_relative,
-      data.current_year_kwh,
-      data.current_year_target_kwh,
-      data.unscaled_target_kwh_to_date,
-      data.tracking_start_date
+      data.schoolday_open_percent,
+      data.schoolday_closed_percent,
+      data.holidays_percent,
+      data.weekends_percent,
+      data.holidays_gbp,
+      data.weekends_gbp
      FROM ( SELECT alerts.alert_generation_run_id,
               alerts.school_id,
-              data_1.current_year_percent_of_target_relative,
-              data_1.current_year_unscaled_percent_of_target_relative,
-              data_1.current_year_kwh,
-              data_1.current_year_target_kwh,
-              data_1.unscaled_target_kwh_to_date,
-              data_1.tracking_start_date
+              data_1.schoolday_open_percent,
+              data_1.schoolday_closed_percent,
+              data_1.holidays_percent,
+              data_1.weekends_percent,
+              data_1.holidays_gbp,
+              data_1.weekends_gbp
              FROM alerts,
               alert_types,
-              LATERAL jsonb_to_record(alerts.variables) data_1(current_year_percent_of_target_relative double precision, current_year_unscaled_percent_of_target_relative double precision, current_year_kwh double precision, current_year_target_kwh double precision, unscaled_target_kwh_to_date double precision, tracking_start_date date)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertElectricityTargetAnnual'::text))) data,
+              LATERAL jsonb_to_record(alerts.variables) data_1(schoolday_open_percent double precision, schoolday_closed_percent double precision, holidays_percent double precision, weekends_percent double precision, holidays_gbp double precision, weekends_gbp double precision)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertStorageHeaterOutOfHours'::text))) data,
       ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
              FROM alert_generation_runs
             ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
     WHERE (data.alert_generation_run_id = latest_runs.id);
   SQL
-  create_view "gas_consumption_during_holidays", sql_definition: <<-SQL
+  create_view "annual_change_in_storage_heater_out_of_hours_uses", sql_definition: <<-SQL
+      SELECT latest_runs.id,
+      usage.alert_generation_run_id,
+      usage.school_id,
+      usage.out_of_hours_kwh,
+      usage.out_of_hours_co2,
+      usage.out_of_hours_gbpcurrent,
+      usage_previous_year.previous_out_of_hours_kwh,
+      usage_previous_year.previous_out_of_hours_co2,
+      usage_previous_year.previous_out_of_hours_gbpcurrent,
+      additional.economic_tariff_changed_this_year
+     FROM ( SELECT alerts.alert_generation_run_id,
+              alerts.school_id,
+              json.out_of_hours_kwh,
+              json.out_of_hours_co2,
+              json.out_of_hours_gbpcurrent
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) json(out_of_hours_kwh double precision, out_of_hours_co2 double precision, out_of_hours_gbpcurrent double precision)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertStorageHeaterOutOfHours'::text))) usage,
+      ( SELECT alerts.alert_generation_run_id,
+              alerts.school_id,
+              json.out_of_hours_kwh AS previous_out_of_hours_kwh,
+              json.out_of_hours_co2 AS previous_out_of_hours_co2,
+              json.out_of_hours_gbpcurrent AS previous_out_of_hours_gbpcurrent
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) json(out_of_hours_kwh double precision, out_of_hours_co2 double precision, out_of_hours_gbpcurrent double precision)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertOutOfHoursStorageHeaterUsagePreviousYear'::text))) usage_previous_year,
+      ( SELECT alerts.alert_generation_run_id,
+              json.electricity_economic_tariff_changed_this_year AS economic_tariff_changed_this_year
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) json(electricity_economic_tariff_changed_this_year boolean)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertAdditionalPrioritisationData'::text))) additional,
+      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
+             FROM alert_generation_runs
+            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
+    WHERE ((usage.alert_generation_run_id = latest_runs.id) AND (usage_previous_year.alert_generation_run_id = latest_runs.id) AND (additional.alert_generation_run_id = latest_runs.id));
+  SQL
+  create_view "thermostat_sensitivities", sql_definition: <<-SQL
       SELECT latest_runs.id,
       data.alert_generation_run_id,
       data.school_id,
-      data.holiday_projected_usage_gbp,
-      data.holiday_usage_to_date_gbp,
-      data.holiday_type,
-      data.holiday_start_date,
-      data.holiday_end_date
+      data."annual_saving_1_C_change_gbp"
      FROM ( SELECT alerts.alert_generation_run_id,
               alerts.school_id,
-              data_1.holiday_projected_usage_gbp,
-              data_1.holiday_usage_to_date_gbp,
-              data_1.holiday_type,
-              data_1.holiday_start_date,
-              data_1.holiday_end_date
+              data_1."annual_saving_1_C_change_gbp"
              FROM alerts,
               alert_types,
-              LATERAL jsonb_to_record(alerts.variables) data_1(holiday_projected_usage_gbp double precision, holiday_usage_to_date_gbp double precision, holiday_type text, holiday_start_date date, holiday_end_date date)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertGasHeatingHotWaterOnDuringHoliday'::text))) data,
+              LATERAL jsonb_to_record(alerts.variables) data_1("annual_saving_1_C_change_gbp" double precision)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertHeatingSensitivityAdvice'::text))) data,
       ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
              FROM alert_generation_runs
             ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
     WHERE (data.alert_generation_run_id = latest_runs.id);
   SQL
-  create_view "gas_targets", sql_definition: <<-SQL
-      SELECT latest_runs.id,
-      data.alert_generation_run_id,
-      data.school_id,
-      data.current_year_percent_of_target_relative,
-      data.current_year_unscaled_percent_of_target_relative,
-      data.current_year_kwh,
-      data.current_year_target_kwh,
-      data.unscaled_target_kwh_to_date,
-      data.tracking_start_date
-     FROM ( SELECT alerts.alert_generation_run_id,
-              alerts.school_id,
-              data_1.current_year_percent_of_target_relative,
-              data_1.current_year_unscaled_percent_of_target_relative,
-              data_1.current_year_kwh,
-              data_1.current_year_target_kwh,
-              data_1.unscaled_target_kwh_to_date,
-              data_1.tracking_start_date
+  create_view "heating_in_warm_weathers", sql_definition: <<-SQL
+      WITH gas AS (
+           SELECT alerts.alert_generation_run_id,
+              data.percent_of_annual_heating,
+              data.warm_weather_heating_days_all_days_kwh,
+              data.warm_weather_heating_days_all_days_co2,
+              data.warm_weather_heating_days_all_days_gbpcurrent,
+              data.warm_weather_heating_days_all_days_days
              FROM alerts,
               alert_types,
-              LATERAL jsonb_to_record(alerts.variables) data_1(current_year_percent_of_target_relative double precision, current_year_unscaled_percent_of_target_relative double precision, current_year_kwh double precision, current_year_target_kwh double precision, unscaled_target_kwh_to_date double precision, tracking_start_date date)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertGasTargetAnnual'::text))) data,
-      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
+              LATERAL jsonb_to_record(alerts.variables) data(percent_of_annual_heating double precision, warm_weather_heating_days_all_days_kwh double precision, warm_weather_heating_days_all_days_co2 double precision, warm_weather_heating_days_all_days_gbpcurrent double precision, warm_weather_heating_days_all_days_days double precision)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertSeasonalHeatingSchoolDays'::text))
+          ), storage_heaters AS (
+           SELECT alerts.alert_generation_run_id,
+              data.percent_of_annual_heating,
+              data.warm_weather_heating_days_all_days_kwh,
+              data.warm_weather_heating_days_all_days_co2,
+              data.warm_weather_heating_days_all_days_gbpcurrent,
+              data.warm_weather_heating_days_all_days_days
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) data(percent_of_annual_heating double precision, warm_weather_heating_days_all_days_kwh double precision, warm_weather_heating_days_all_days_co2 double precision, warm_weather_heating_days_all_days_gbpcurrent double precision, warm_weather_heating_days_all_days_days double precision)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertSeasonalHeatingSchoolDaysStorageHeaters'::text))
+          ), additional AS (
+           SELECT alerts.alert_generation_run_id,
+              alerts.school_id
+             FROM alerts,
+              alert_types
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertAdditionalPrioritisationData'::text))
+          ), latest_runs AS (
+           SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
              FROM alert_generation_runs
-            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
-    WHERE (data.alert_generation_run_id = latest_runs.id);
+            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC
+          )
+   SELECT latest_runs.id,
+      additional.school_id,
+      COALESCE(gas.percent_of_annual_heating, storage_heaters.percent_of_annual_heating) AS percent_of_annual_heating,
+      COALESCE(gas.warm_weather_heating_days_all_days_kwh, storage_heaters.warm_weather_heating_days_all_days_kwh) AS warm_weather_heating_days_all_days_kwh,
+      COALESCE(gas.warm_weather_heating_days_all_days_co2, storage_heaters.warm_weather_heating_days_all_days_co2) AS warm_weather_heating_days_all_days_co2,
+      COALESCE(gas.warm_weather_heating_days_all_days_gbpcurrent, storage_heaters.warm_weather_heating_days_all_days_gbpcurrent) AS warm_weather_heating_days_all_days_gbpcurrent,
+      COALESCE(gas.warm_weather_heating_days_all_days_days, storage_heaters.warm_weather_heating_days_all_days_days) AS warm_weather_heating_days_all_days_days
+     FROM (((latest_runs
+       JOIN additional ON ((latest_runs.id = additional.alert_generation_run_id)))
+       LEFT JOIN gas ON ((latest_runs.id = gas.alert_generation_run_id)))
+       LEFT JOIN storage_heaters ON ((latest_runs.id = storage_heaters.alert_generation_run_id)));
   SQL
   create_view "heating_coming_on_too_early", sql_definition: <<-SQL
       WITH early AS (
@@ -3112,29 +3223,23 @@ ActiveRecord::Schema.define(version: 2024_04_17_104449) do
        LEFT JOIN early ON ((latest_runs.id = early.alert_generation_run_id)))
        LEFT JOIN optimum ON ((latest_runs.id = optimum.alert_generation_run_id)));
   SQL
-  create_view "heating_in_warm_weathers", sql_definition: <<-SQL
+  create_view "thermostatic_controls", sql_definition: <<-SQL
       WITH gas AS (
            SELECT alerts.alert_generation_run_id,
-              data.percent_of_annual_heating,
-              data.warm_weather_heating_days_all_days_kwh,
-              data.warm_weather_heating_days_all_days_co2,
-              data.warm_weather_heating_days_all_days_gbpcurrent,
-              data.warm_weather_heating_days_all_days_days
+              data.r2,
+              data.potential_saving_gbp
              FROM alerts,
               alert_types,
-              LATERAL jsonb_to_record(alerts.variables) data(percent_of_annual_heating double precision, warm_weather_heating_days_all_days_kwh double precision, warm_weather_heating_days_all_days_co2 double precision, warm_weather_heating_days_all_days_gbpcurrent double precision, warm_weather_heating_days_all_days_days double precision)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertSeasonalHeatingSchoolDays'::text))
+              LATERAL jsonb_to_record(alerts.variables) data(r2 double precision, potential_saving_gbp double precision)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertThermostaticControl'::text))
           ), storage_heaters AS (
            SELECT alerts.alert_generation_run_id,
-              data.percent_of_annual_heating,
-              data.warm_weather_heating_days_all_days_kwh,
-              data.warm_weather_heating_days_all_days_co2,
-              data.warm_weather_heating_days_all_days_gbpcurrent,
-              data.warm_weather_heating_days_all_days_days
+              data.r2,
+              data.potential_saving_gbp
              FROM alerts,
               alert_types,
-              LATERAL jsonb_to_record(alerts.variables) data(percent_of_annual_heating double precision, warm_weather_heating_days_all_days_kwh double precision, warm_weather_heating_days_all_days_co2 double precision, warm_weather_heating_days_all_days_gbpcurrent double precision, warm_weather_heating_days_all_days_days double precision)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertSeasonalHeatingSchoolDaysStorageHeaters'::text))
+              LATERAL jsonb_to_record(alerts.variables) data(r2 double precision, potential_saving_gbp double precision)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertStorageHeaterThermostatic'::text))
           ), additional AS (
            SELECT alerts.alert_generation_run_id,
               alerts.school_id
@@ -3148,15 +3253,129 @@ ActiveRecord::Schema.define(version: 2024_04_17_104449) do
           )
    SELECT latest_runs.id,
       additional.school_id,
-      COALESCE(gas.percent_of_annual_heating, storage_heaters.percent_of_annual_heating) AS percent_of_annual_heating,
-      COALESCE(gas.warm_weather_heating_days_all_days_kwh, storage_heaters.warm_weather_heating_days_all_days_kwh) AS warm_weather_heating_days_all_days_kwh,
-      COALESCE(gas.warm_weather_heating_days_all_days_co2, storage_heaters.warm_weather_heating_days_all_days_co2) AS warm_weather_heating_days_all_days_co2,
-      COALESCE(gas.warm_weather_heating_days_all_days_gbpcurrent, storage_heaters.warm_weather_heating_days_all_days_gbpcurrent) AS warm_weather_heating_days_all_days_gbpcurrent,
-      COALESCE(gas.warm_weather_heating_days_all_days_days, storage_heaters.warm_weather_heating_days_all_days_days) AS warm_weather_heating_days_all_days_days
+      COALESCE(gas.r2, storage_heaters.r2) AS r2,
+      NULLIF((COALESCE(gas.potential_saving_gbp, (0)::double precision) + COALESCE(storage_heaters.potential_saving_gbp, (0)::double precision)), (0)::double precision) AS potential_saving_gbp
      FROM (((latest_runs
        JOIN additional ON ((latest_runs.id = additional.alert_generation_run_id)))
        LEFT JOIN gas ON ((latest_runs.id = gas.alert_generation_run_id)))
        LEFT JOIN storage_heaters ON ((latest_runs.id = storage_heaters.alert_generation_run_id)));
+  SQL
+  create_view "hot_water_efficiencies", sql_definition: <<-SQL
+      SELECT latest_runs.id,
+      data.alert_generation_run_id,
+      data.school_id,
+      data.avg_gas_per_pupil_gbp,
+      data.benchmark_existing_gas_efficiency,
+      data.benchmark_gas_better_control_saving_gbp,
+      data.benchmark_point_of_use_electric_saving_gbp
+     FROM ( SELECT alerts.alert_generation_run_id,
+              alerts.school_id,
+              data_1.avg_gas_per_pupil_gbp,
+              data_1.benchmark_existing_gas_efficiency,
+              data_1.benchmark_gas_better_control_saving_gbp,
+              data_1.benchmark_point_of_use_electric_saving_gbp
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) data_1(avg_gas_per_pupil_gbp double precision, benchmark_existing_gas_efficiency double precision, benchmark_gas_better_control_saving_gbp double precision, benchmark_point_of_use_electric_saving_gbp double precision)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertHotWaterEfficiency'::text))) data,
+      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
+             FROM alert_generation_runs
+            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
+    WHERE (data.alert_generation_run_id = latest_runs.id);
+  SQL
+  create_view "gas_targets", sql_definition: <<-SQL
+      SELECT latest_runs.id,
+      data.alert_generation_run_id,
+      data.school_id,
+      data.current_year_percent_of_target_relative,
+      data.current_year_unscaled_percent_of_target_relative,
+      data.current_year_kwh,
+      data.current_year_target_kwh,
+      data.unscaled_target_kwh_to_date,
+      data.tracking_start_date
+     FROM ( SELECT alerts.alert_generation_run_id,
+              alerts.school_id,
+              data_1.current_year_percent_of_target_relative,
+              data_1.current_year_unscaled_percent_of_target_relative,
+              data_1.current_year_kwh,
+              data_1.current_year_target_kwh,
+              data_1.unscaled_target_kwh_to_date,
+              data_1.tracking_start_date
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) data_1(current_year_percent_of_target_relative double precision, current_year_unscaled_percent_of_target_relative double precision, current_year_kwh double precision, current_year_target_kwh double precision, unscaled_target_kwh_to_date double precision, tracking_start_date date)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertGasTargetAnnual'::text))) data,
+      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
+             FROM alert_generation_runs
+            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
+    WHERE (data.alert_generation_run_id = latest_runs.id);
+  SQL
+  create_view "annual_energy_costs", sql_definition: <<-SQL
+      WITH electricity AS (
+           SELECT alerts.alert_generation_run_id,
+              data.last_year_gbp
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) data(last_year_gbp double precision)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertElectricityAnnualVersusBenchmark'::text))
+          ), gas AS (
+           SELECT alerts.alert_generation_run_id,
+              data.last_year_gbp
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) data(last_year_gbp double precision)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertGasAnnualVersusBenchmark'::text))
+          ), storage_heaters AS (
+           SELECT alerts.alert_generation_run_id,
+              data.last_year_gbp
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) data(last_year_gbp double precision)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertStorageHeaterAnnualVersusBenchmark'::text))
+          ), energy AS (
+           SELECT alerts.alert_generation_run_id,
+              data.last_year_gbp,
+              data.one_year_energy_per_pupil_gbp,
+              data.last_year_co2_tonnes,
+              data.last_year_kwh
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) data(last_year_gbp double precision, one_year_energy_per_pupil_gbp double precision, last_year_co2_tonnes double precision, last_year_kwh double precision)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertEnergyAnnualVersusBenchmark'::text))
+          ), additional AS (
+           SELECT alerts.alert_generation_run_id,
+              alerts.school_id,
+              data.school_type_name,
+              data.pupils,
+              data.floor_area
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) data(school_type_name text, pupils double precision, floor_area double precision)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertAdditionalPrioritisationData'::text))
+          ), latest_runs AS (
+           SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
+             FROM alert_generation_runs
+            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC
+          )
+   SELECT latest_runs.id,
+      electricity.last_year_gbp AS last_year_electricity,
+      gas.last_year_gbp AS last_year_gas,
+      storage_heaters.last_year_gbp AS last_year_storage_heaters,
+      energy.last_year_gbp,
+      energy.one_year_energy_per_pupil_gbp,
+      energy.last_year_co2_tonnes,
+      energy.last_year_kwh,
+      additional.alert_generation_run_id,
+      additional.school_id,
+      additional.school_type_name,
+      additional.pupils,
+      additional.floor_area
+     FROM (((((latest_runs
+       JOIN additional ON ((latest_runs.id = additional.alert_generation_run_id)))
+       LEFT JOIN electricity ON ((latest_runs.id = electricity.alert_generation_run_id)))
+       LEFT JOIN gas ON ((latest_runs.id = gas.alert_generation_run_id)))
+       LEFT JOIN storage_heaters ON ((latest_runs.id = storage_heaters.alert_generation_run_id)))
+       LEFT JOIN energy ON ((latest_runs.id = energy.alert_generation_run_id)));
   SQL
   create_view "holiday_usage_last_years", sql_definition: <<-SQL
       SELECT latest_runs.id,

--- a/spec/models/issue_spec.rb
+++ b/spec/models/issue_spec.rb
@@ -232,19 +232,19 @@ RSpec.describe Issue, type: :model do
     let!(:issue_2) { create(:issue, title: 'Issue 2 title', description: 'I\'m hiding here') }
 
     it 'finds records with term in title' do
-      Issue.search('findme').should eq([issue_1])
+      expect(Issue.search('findme')).to eq([issue_1])
     end
 
     it 'finds records with term in description' do
-      Issue.search('hiding').should eq([issue_2])
+      expect(Issue.search('hiding')).to eq([issue_2])
     end
 
     it 'finds records with term in either' do
-      Issue.search('findme|hiding').should eq([issue_1, issue_2])
+      expect(Issue.search('findme|hiding')).to eq([issue_1, issue_2])
     end
 
     it 'returns nothing when not found' do
-      Issue.search('nothing to see here').should be_empty
+      expect(Issue.search('nothing to see here')).to be_empty
     end
   end
 end

--- a/spec/models/issue_spec.rb
+++ b/spec/models/issue_spec.rb
@@ -226,4 +226,25 @@ RSpec.describe Issue, type: :model do
       it { expect(school_group_issue.school_group).to eq(school_group) }
     end
   end
+
+  describe '.search' do
+    let!(:issue_1) { create(:issue, title: 'Issue 1 findme here', description: 'description') }
+    let!(:issue_2) { create(:issue, title: 'Issue 2 title', description: 'I\'m hiding here') }
+
+    it 'finds records with term in title' do
+      Issue.search('findme').should eq([issue_1])
+    end
+
+    it 'finds records with term in description' do
+      Issue.search('hiding').should eq([issue_2])
+    end
+
+    it 'finds records with term in either' do
+      Issue.search('findme|hiding').should eq([issue_1, issue_2])
+    end
+
+    it 'returns nothing when not found' do
+      Issue.search('nothing to see here').should be_empty
+    end
+  end
 end

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -57,18 +57,22 @@ describe School do
     end
   end
 
-  it 'validates alternative heating percents' do
-    [:alternative_heating_oil_percent, :alternative_heating_lpg_percent, :alternative_heating_biomass_percent, :alternative_heating_district_heating_percent].each do |field|
-      subject[field] = 100
-      expect(subject).to be_valid
-      subject[field] = 0
-      expect(subject).to be_valid
-      subject[field] = -1
-      expect(subject).not_to be_valid
-      subject[field] = 101
-      expect(subject).not_to be_valid
-      subject[field] = nil
-      expect(subject).to be_valid
+  context 'when validating alternative heating percent fields' do
+    let(:alternative_heating_fields) do
+      [
+        :alternative_heating_oil_percent,
+        :alternative_heating_lpg_percent,
+        :alternative_heating_biomass_percent,
+        :alternative_heating_district_heating_percent,
+        :alternative_heating_ground_source_heat_pump_percent,
+        :alternative_heating_air_source_heat_pump_percent
+      ]
+    end
+
+    it 'validates alternative heating percentages' do
+      alternative_heating_fields.each do |field|
+        expect(subject).to validate_numericality_of(field).is_greater_than_or_equal_to(0).is_less_than_or_equal_to(100).allow_nil
+      end
     end
   end
 

--- a/spec/system/admin/issues_spec.rb
+++ b/spec/system/admin/issues_spec.rb
@@ -364,8 +364,27 @@ RSpec.describe 'issues', :issues, type: :system, include_application_helper: tru
         it_behaves_like 'a displayed list issue' do
           let(:issue) { user_issue }
         end
+
         it "doesn't display issue for other user" do
           expect(page).not_to have_content other_user_issue.title
+        end
+      end
+
+      context 'and searching issues' do
+        let!(:issue_1) { create(:issue, title: 'Issue 1 findme here', description: 'description') }
+        let!(:issue_2) { create(:issue, title: 'Issue 2 title', description: 'I\'m hiding here') }
+        let(:setup_data) { [issue_1, issue_2] }
+
+        before do
+          fill_in 'Search', with: 'findme|hiding'
+          click_button 'Filter'
+        end
+
+        it_behaves_like 'a displayed list issue' do
+          let(:issue) { issue_1 }
+        end
+        it_behaves_like 'a displayed list issue' do
+          let(:issue) { issue_2 }
         end
       end
 

--- a/spec/system/admin/school_editing_spec.rb
+++ b/spec/system/admin/school_editing_spec.rb
@@ -111,16 +111,32 @@ RSpec.describe 'editing school details', type: :system do
     expect(school.enable_targets_feature?).to be false
   end
 
-  context 'when updating storage heaters' do
-    it 'and changes are saved' do
+  context 'when updating school features checkboxes - excluding dinners js fields' do
+    before do
       click_on(school_name)
       click_on('Edit school details')
+      check 'Our school has solar PV panels'
       check 'Our school has night storage heaters'
-
+      check 'Our school has its own swimming pool'
+      check 'Our school uses Oil for heating'
+      check 'Our school is using LPG for heating'
+      check 'Our school has a Biomass boiler'
+      check 'Our school has District Heating'
+      check 'Our school has a ground source heat pump'
+      check 'Our school has an air source heat pump'
       click_on('Update School')
-
       school.reload
+    end
+
+    it 'and changes are saved' do
+      expect(school.indicated_has_solar_panels).to be true
       expect(school.indicated_has_storage_heaters).to be true
+      expect(school.has_swimming_pool).to be true
+      expect(school.alternative_heating_oil).to be true
+      expect(school.alternative_heating_lpg).to be true
+      expect(school.alternative_heating_biomass).to be true
+      expect(school.alternative_heating_ground_source_heat_pump).to be true
+      expect(school.alternative_heating_air_source_heat_pump).to be true
     end
   end
 

--- a/spec/system/admin/school_editing_spec.rb
+++ b/spec/system/admin/school_editing_spec.rb
@@ -118,10 +118,10 @@ RSpec.describe 'editing school details', type: :system do
       check 'Our school has solar PV panels'
       check 'Our school has night storage heaters'
       check 'Our school has its own swimming pool'
-      check 'Our school uses Oil for heating'
+      check 'Our school uses oil for heating'
       check 'Our school is using LPG for heating'
-      check 'Our school has a Biomass boiler'
-      check 'Our school has District Heating'
+      check 'Our school has a biomass boiler'
+      check 'Our school has district Heating'
       check 'Our school has a ground source heat pump'
       check 'Our school has an air source heat pump'
       click_on('Update School')

--- a/spec/system/admin/school_editing_spec.rb
+++ b/spec/system/admin/school_editing_spec.rb
@@ -121,7 +121,7 @@ RSpec.describe 'editing school details', type: :system do
       check 'Our school uses oil for heating'
       check 'Our school is using LPG for heating'
       check 'Our school has a biomass boiler'
-      check 'Our school has district Heating'
+      check 'Our school has district heating'
       check 'Our school has a ground source heat pump'
       check 'Our school has an air source heat pump'
       click_on('Update School')


### PR DESCRIPTION
* Note search: wasn't sure if it was intended to just run an ad-hoc query to return a list of notes or to add a feature - it was as easy to add a search feature to issues/notes, so I did that. Hope that's ok. It looks in the title or description for search terms. You can do an or by typing in GSHP|ground source heat pump. 
* Added new fields - just the checkboxes to the edit school details page, but also the percent and notes fields to the school estates page (as per other similar fields)
* Removes your_school_estates feature flag, which can be removed from test/production env too once this has been deployed

Might benefit if we all had a new database dump as getting big conflicts for schema.rb ?