### PR TITLE
Avoid requesting future dates in n3rgy API

### DIFF
--- a/app/services/amr/n3rgy_downloader_dates.rb
+++ b/app/services/amr/n3rgy_downloader_dates.rb
@@ -8,12 +8,13 @@ module Amr
       if current_range && current_range.first <= start
         start = current_range.last
       end
-
       start.change({ hour: 0, min: 0, sec: 0 })
     end
 
     def self.end_date(available_range)
-      available_range.present? ? available_range.last : default_end_date
+      candidate_end_date = available_range.present? ? available_range.last : default_end_date
+      # encountered a data problem at n3rgy where availableCacheRange had a future date
+      candidate_end_date >= Time.zone.today ? default_end_date : candidate_end_date
     end
 
     def self.default_start_date

--- a/spec/services/amr/n3rgy_downloader_dates_spec.rb
+++ b/spec/services/amr/n3rgy_downloader_dates_spec.rb
@@ -24,6 +24,12 @@ module Amr
           expect(Amr::N3rgyDownloaderDates.end_date(nil).to_s).to eq('2023-06-28T23:30:00+00:00') # DateTime now minus 1 day
         end
       end
+
+      it 'does not use future dates' do
+        travel_to DateTime.parse('2023-06-29T04:05:06+00:00') do
+          expect(Amr::N3rgyDownloaderDates.end_date([DateTime.parse('2023-01-01T12:00'), DateTime.parse('2023-06-30T00:00')]).to_s).to eq('2023-06-28T23:30:00+00:00')
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Encountered a problem with data not loading for a meter.

The issue is that the `availableCacheRange` from the N3rgy API is returning a future date (tomorrow) as the end of the range of data they have. This is obviously incorrect.

As we plug those dates into the API call, we then get an error as their API doesn't support requesting data for a future date.

This PR makes a small fix so that if we're given a future date then we just fall back to requesting data up until yesterday.