### PR TITLE
Add task to reload all n3rgy data

### DIFF
--- a/app/services/amr/n3rgy_readings_download_and_upsert.rb
+++ b/app/services/amr/n3rgy_readings_download_and_upsert.rb
@@ -4,12 +4,14 @@ module Amr
         meter:,
         config:,
         override_start_date: nil,
-        override_end_date: nil
+        override_end_date: nil,
+        reload: false
       )
       @meter = meter
       @config = config
       @override_start_date = override_start_date
       @override_end_date = override_end_date
+      @reload = reload
     end
 
     def perform
@@ -83,6 +85,9 @@ module Amr
       if start == start.at_midnight
         start = n3rgy_first_reading_of_day(start - 1)
       end
+
+      # if set to reload, then just use dates from n3rgy
+      return n3rgy_first_reading_of_day(start) if @reload
 
       # start new loading from the end of any existing readings if we have any
       current_range = current_date_range_of_readings

--- a/lib/tasks/amr_importer/import_n3rgy_readings.rake
+++ b/lib/tasks/amr_importer/import_n3rgy_readings.rake
@@ -1,8 +1,6 @@
 namespace :amr do
   desc "Import data from N3RGY/DCC"
   task :import_n3rgy_readings, [:start_date, :end_date] => :environment do |_t, args|
-    #Only expecting there to be one system-wide config
-    #its just there to refer to import logs/messages
     config = AmrDataFeedConfig.n3rgy_api.first
 
     start_date = Date.parse(args[:start_date]) if args[:start_date].present?
@@ -10,8 +8,22 @@ namespace :amr do
 
     puts "#{DateTime.now.utc} #{config.description} start"
     Meter.where(active: true, dcc_meter: true, consent_granted: true).each do |meter|
-      Amr::N3rgyReadingsDownloadAndUpsert.new(meter: meter, config: config, override_start_date: start_date, override_end_date: end_date).perform
+      Amr::N3rgyReadingsDownloadAndUpsert.new(
+        meter: meter,
+        config: config,
+        override_start_date: start_date,
+        override_end_date: end_date).perform
     end
     puts "#{DateTime.now.utc} #{config.description} end"
+  end
+
+  task reload_n3rgy_readings: :environment do
+    config = AmrDataFeedConfig.n3rgy_api.first
+
+    puts "#{DateTime.now.utc} #{config.description} reload start"
+    Meter.where(active: true, dcc_meter: true, consent_granted: true).each do |meter|
+      Amr::N3rgyReadingsDownloadAndUpsert.new(meter: meter, config: config, reload: true).perform
+    end
+    puts "#{DateTime.now.utc} #{config.description} reload end"
   end
 end

--- a/spec/services/amr/n3rgy_readings_download_and_upsert_spec.rb
+++ b/spec/services/amr/n3rgy_readings_download_and_upsert_spec.rb
@@ -145,7 +145,7 @@ module Amr
         end
       end
 
-      context 'when there is previously loaded readings' do
+      context 'when there are previously loaded readings' do
         # Note: this is a Date object as the reading date needs to be stored in the database
         # in ISO 8601 format e.g. 2023-06-29
         let(:earliest_reading) { Date.new(2024, 4, 1) }
@@ -186,6 +186,21 @@ module Amr
             )
             upserter.perform
           end
+
+          context 'when reload option is set' do
+            subject(:upserter) do
+              described_class.new(config: config, meter: meter, reload: true)
+            end
+
+            it 'reloads all the data' do
+              expect(Amr::N3rgyDownloader).to receive(:new).with(
+                meter: meter,
+                start_date: expected_start,
+                end_date: yesterday_last_reading
+              )
+              upserter.perform
+            end
+          end
         end
 
         context 'when we are up to date' do
@@ -197,6 +212,21 @@ module Amr
             expect(Amr::N3rgyDownloader).not_to receive(:new)
             expect(downloader).not_to receive(:readings)
             upserter.perform
+          end
+
+          context 'when reload option is set' do
+            subject(:upserter) do
+              described_class.new(config: config, meter: meter, reload: true)
+            end
+
+            it 'reloads all the data' do
+              expect(Amr::N3rgyDownloader).to receive(:new).with(
+                meter: meter,
+                start_date: available_data.first,
+                end_date: available_data.last
+              )
+              upserter.perform
+            end
           end
         end
 


### PR DESCRIPTION
Revises the service used to load data from n3rgy so that it can reload all available data.

Adds a rake task to run the service using this configuration, for all n3rgy meters.