### PR TITLE
Set maximum frequency for scoring on activities and interventions

### DIFF
--- a/app/models/activity_type.rb
+++ b/app/models/activity_type.rb
@@ -10,6 +10,7 @@
 #  deprecated_description :text
 #  fuel_type              :string           default([]), is an Array
 #  id                     :bigint(8)        not null, primary key
+#  maximum_frequency      :integer          default(10)
 #  name                   :string
 #  score                  :integer
 #  show_on_charts         :boolean          default(TRUE)
@@ -32,6 +33,7 @@ class ActivityType < ApplicationRecord
   include Searchable
   include TranslatableAttachment
   include FuelTypeable
+  include Recordable
 
   translates :name, type: :string, fallbacks: { cy: :en }
   translates :summary, type: :string, fallbacks: { cy: :en }
@@ -132,6 +134,10 @@ class ActivityType < ApplicationRecord
 
   def self.tx_resources
     active.order(:id)
+  end
+
+  def count_existing_for_academic_year(school, academic_year)
+    school.activities.where(activity_type: self).where(happened_on: academic_year.start_date..academic_year.end_date).count
   end
 
   private

--- a/app/models/concerns/recordable.rb
+++ b/app/models/concerns/recordable.rb
@@ -1,0 +1,20 @@
+module Recordable
+  # Return the point score when a given school records this recordable on a given
+  # date
+  #
+  # Centralises the logic around deciding what points to score for an item
+  #
+  # Including classes should implement: a +score+ method or attribute
+  def score_when_recorded_at(school, date)
+    academic_year = school.academic_year_for(date)
+    return nil unless academic_year&.current?
+    return nil if count_existing_for_academic_year(school, academic_year) >= maximum_frequency
+    score
+  end
+
+  # Implement in including class. Should return number of existing recordings of this
+  # recordable in the given academic year
+  def count_existing_for_academic_year(_school, _academic_year)
+    nil
+  end
+end

--- a/app/models/intervention_type.rb
+++ b/app/models/intervention_type.rb
@@ -8,6 +8,7 @@
 #  fuel_type                  :string           default([]), is an Array
 #  id                         :bigint(8)        not null, primary key
 #  intervention_type_group_id :bigint(8)        not null
+#  maximum_frequency          :integer          default(10)
 #  name                       :string
 #  score                      :integer
 #  show_on_charts             :boolean          default(TRUE)
@@ -29,6 +30,7 @@ class InterventionType < ApplicationRecord
   include Searchable
   include TranslatableAttachment
   include FuelTypeable
+  include Recordable
 
   TX_REWRITEABLE_FIELDS = [:description_cy, :download_links_cy].freeze
 
@@ -79,6 +81,10 @@ class InterventionType < ApplicationRecord
 
   def self.tx_resources
     active.order(:id)
+  end
+
+  def count_existing_for_academic_year(school, academic_year)
+    school.observations.where(intervention_type: self).where(at: academic_year.start_date..academic_year.end_date).count
   end
 
   private

--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -111,13 +111,7 @@ class Observation < ApplicationRecord
   end
 
   def add_points_for_interventions
-    record_points_for_current_academic_year
-  end
-
-  def record_points_for_current_academic_year
-    return unless school.academic_year_for(at)&.current?
-
-    self.points = intervention_type.score
+    self.points = intervention_type.score_when_recorded_at(school, at)
   end
 
   def reject_temperature_recordings(attributes)

--- a/app/services/activity_creator.rb
+++ b/app/services/activity_creator.rb
@@ -30,10 +30,7 @@ class ActivityCreator
   end
 
   def create_activity_observation
-    academic_year = @activity.school.academic_year_for(@activity.happened_on)
-    points = if academic_year && academic_year.current?
-               @activity.activity_type.score
-             end
+    points = @activity.activity_type.score_when_recorded_at(@activity.school, @activity.happened_on)
     Observation.create!(
       school: @activity.school,
       observation_type: :activity,

--- a/db/migrate/20240429144652_add_maximum_frequency_to_recordables.rb
+++ b/db/migrate/20240429144652_add_maximum_frequency_to_recordables.rb
@@ -1,0 +1,6 @@
+class AddMaximumFrequencyToRecordables < ActiveRecord::Migration[6.1]
+  def change
+    add_column :activity_types, :maximum_frequency, :integer, default: 10
+    add_column :intervention_types, :maximum_frequency, :integer, default: 10
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -3067,6 +3067,110 @@ ActiveRecord::Schema.define(version: 2024_04_29_144652) do
             ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
     WHERE (data.alert_generation_run_id = latest_runs.id);
   SQL
+  create_view "heat_saver_march_2024s", sql_definition: <<-SQL
+      WITH electricity AS (
+           SELECT alerts.alert_generation_run_id,
+              json.current_period_kwh,
+              json.previous_period_kwh,
+              json.current_period_co2,
+              json.previous_period_co2,
+              json.current_period_gbp,
+              json.previous_period_gbp,
+              json.tariff_has_changed,
+              json.pupils_changed,
+              json.floor_area_changed
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) json(current_period_kwh double precision, previous_period_kwh double precision, current_period_co2 double precision, previous_period_co2 double precision, current_period_gbp double precision, previous_period_gbp double precision, tariff_has_changed boolean, pupils_changed boolean, floor_area_changed boolean)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertHeatSaver2024ElectricityComparison'::text))
+          ), gas AS (
+           SELECT alerts.alert_generation_run_id,
+              json.current_period_kwh,
+              json.previous_period_kwh,
+              json.current_period_co2,
+              json.previous_period_co2,
+              json.current_period_gbp,
+              json.previous_period_gbp,
+              json.previous_period_kwh_unadjusted,
+              json.tariff_has_changed,
+              json.pupils_changed,
+              json.floor_area_changed
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) json(current_period_kwh double precision, previous_period_kwh double precision, current_period_co2 double precision, previous_period_co2 double precision, current_period_gbp double precision, previous_period_gbp double precision, previous_period_kwh_unadjusted double precision, tariff_has_changed boolean, pupils_changed boolean, floor_area_changed boolean)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertHeatSaver2024GasComparison'::text))
+          ), storage_heater AS (
+           SELECT alerts.alert_generation_run_id,
+              json.current_period_kwh,
+              json.previous_period_kwh,
+              json.current_period_co2,
+              json.previous_period_co2,
+              json.current_period_gbp,
+              json.previous_period_gbp,
+              json.previous_period_kwh_unadjusted,
+              json.tariff_has_changed,
+              json.pupils_changed,
+              json.floor_area_changed
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) json(current_period_kwh double precision, previous_period_kwh double precision, current_period_co2 double precision, previous_period_co2 double precision, current_period_gbp double precision, previous_period_gbp double precision, previous_period_kwh_unadjusted double precision, tariff_has_changed boolean, pupils_changed boolean, floor_area_changed boolean)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertHeatSaver2024StorageHeaterComparison'::text))
+          ), enba AS (
+           SELECT alerts.alert_generation_run_id,
+              data.solar_type
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) data(solar_type text)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertEnergyAnnualVersusBenchmark'::text))
+          ), additional AS (
+           SELECT alerts.alert_generation_run_id,
+              alerts.school_id,
+              data.activation_date
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) data(activation_date date)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertAdditionalPrioritisationData'::text))
+          ), latest_runs AS (
+           SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
+             FROM alert_generation_runs
+            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC
+          )
+   SELECT latest_runs.id,
+      additional.school_id,
+      additional.activation_date,
+      (electricity.pupils_changed OR gas.pupils_changed OR storage_heater.pupils_changed) AS pupils_changed,
+      (electricity.floor_area_changed OR gas.floor_area_changed OR storage_heater.floor_area_changed) AS floor_area_changed,
+      enba.solar_type,
+      electricity.current_period_kwh AS electricity_current_period_kwh,
+      electricity.previous_period_kwh AS electricity_previous_period_kwh,
+      electricity.current_period_co2 AS electricity_current_period_co2,
+      electricity.previous_period_co2 AS electricity_previous_period_co2,
+      electricity.current_period_gbp AS electricity_current_period_gbp,
+      electricity.previous_period_gbp AS electricity_previous_period_gbp,
+      electricity.tariff_has_changed AS electricity_tariff_has_changed,
+      gas.current_period_kwh AS gas_current_period_kwh,
+      gas.previous_period_kwh AS gas_previous_period_kwh,
+      gas.current_period_co2 AS gas_current_period_co2,
+      gas.previous_period_co2 AS gas_previous_period_co2,
+      gas.current_period_gbp AS gas_current_period_gbp,
+      gas.previous_period_gbp AS gas_previous_period_gbp,
+      gas.previous_period_kwh_unadjusted AS gas_previous_period_kwh_unadjusted,
+      gas.tariff_has_changed AS gas_tariff_has_changed,
+      storage_heater.current_period_kwh AS storage_heater_current_period_kwh,
+      storage_heater.previous_period_kwh AS storage_heater_previous_period_kwh,
+      storage_heater.current_period_co2 AS storage_heater_current_period_co2,
+      storage_heater.previous_period_co2 AS storage_heater_previous_period_co2,
+      storage_heater.current_period_gbp AS storage_heater_current_period_gbp,
+      storage_heater.previous_period_gbp AS storage_heater_previous_period_gbp,
+      storage_heater.previous_period_kwh_unadjusted AS storage_heater_previous_period_kwh_unadjusted,
+      storage_heater.tariff_has_changed AS storage_heater_tariff_has_changed
+     FROM (((((latest_runs
+       JOIN additional ON ((latest_runs.id = additional.alert_generation_run_id)))
+       LEFT JOIN electricity ON ((latest_runs.id = electricity.alert_generation_run_id)))
+       LEFT JOIN gas ON ((latest_runs.id = gas.alert_generation_run_id)))
+       LEFT JOIN storage_heater ON ((latest_runs.id = storage_heater.alert_generation_run_id)))
+       LEFT JOIN enba ON ((latest_runs.id = enba.alert_generation_run_id)));
+  SQL
   create_view "heating_coming_on_too_early", sql_definition: <<-SQL
       WITH early AS (
            SELECT alerts.alert_generation_run_id,
@@ -3449,178 +3553,5 @@ ActiveRecord::Schema.define(version: 2024_04_29_144652) do
              FROM alert_generation_runs
             ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
     WHERE ((data.alert_generation_run_id = latest_runs.id) AND (additional.alert_generation_run_id = latest_runs.id));
-  SQL
-  create_view "change_in_energy_since_last_years", sql_definition: <<-SQL
-      SELECT latest_runs.id,
-      energy.school_id,
-      energy.current_year_electricity_kwh AS electricity_current_period_kwh,
-      energy.previous_year_electricity_kwh AS electricity_previous_period_kwh,
-      energy.current_year_electricity_co2 AS electricity_current_period_co2,
-      energy.previous_year_electricity_co2 AS electricity_previous_period_co2,
-      energy.current_year_electricity_gbp AS electricity_current_period_gbp,
-      energy.previous_year_electricity_gbp AS electricity_previous_period_gbp,
-      energy.current_year_gas_kwh AS gas_current_period_kwh,
-      energy.previous_year_gas_kwh AS gas_previous_period_kwh,
-      energy.current_year_gas_co2 AS gas_current_period_co2,
-      energy.previous_year_gas_co2 AS gas_previous_period_co2,
-      energy.current_year_gas_gbp AS gas_current_period_gbp,
-      energy.previous_year_gas_gbp AS gas_previous_period_gbp,
-      energy.current_year_storage_heaters_kwh AS storage_heater_current_period_kwh,
-      energy.previous_year_storage_heaters_kwh AS storage_heater_previous_period_kwh,
-      energy.current_year_storage_heaters_co2 AS storage_heater_current_period_co2,
-      energy.previous_year_storage_heaters_co2 AS storage_heater_previous_period_co2,
-      energy.current_year_storage_heaters_gbp AS storage_heater_current_period_gbp,
-      energy.previous_year_storage_heaters_gbp AS storage_heater_previous_period_gbp,
-      energy.current_year_solar_pv_kwh AS solar_pv_current_period_kwh,
-      energy.previous_year_solar_pv_kwh AS solar_pv_previous_period_kwh,
-      energy.current_year_solar_pv_co2 AS solar_pv_current_period_co2,
-      energy.previous_year_solar_pv_co2 AS solar_pv_previous_period_co2,
-      additional.electricity_economic_tariff_changed_this_year AS electricity_tariff_has_changed,
-      additional.gas_economic_tariff_changed_this_year AS gas_tariff_has_changed,
-      energy.solar_type
-     FROM ( SELECT alerts.alert_generation_run_id,
-              alerts.school_id,
-              data.previous_year_electricity_kwh,
-              data.current_year_electricity_kwh,
-              data.previous_year_electricity_co2,
-              data.current_year_electricity_co2,
-              data.previous_year_electricity_gbp,
-              data.current_year_electricity_gbp,
-              data.previous_year_gas_kwh,
-              data.current_year_gas_kwh,
-              data.previous_year_gas_co2,
-              data.current_year_gas_co2,
-              data.previous_year_gas_gbp,
-              data.current_year_gas_gbp,
-              data.previous_year_storage_heaters_kwh,
-              data.current_year_storage_heaters_kwh,
-              data.previous_year_storage_heaters_co2,
-              data.current_year_storage_heaters_co2,
-              data.previous_year_storage_heaters_gbp,
-              data.current_year_storage_heaters_gbp,
-              data.previous_year_solar_pv_kwh,
-              data.current_year_solar_pv_kwh,
-              data.previous_year_solar_pv_co2,
-              data.current_year_solar_pv_co2,
-              data.solar_type
-             FROM alerts,
-              alert_types,
-              LATERAL jsonb_to_record(alerts.variables) data(previous_year_electricity_kwh double precision, current_year_electricity_kwh double precision, previous_year_electricity_co2 double precision, current_year_electricity_co2 double precision, previous_year_electricity_gbp double precision, current_year_electricity_gbp double precision, previous_year_gas_kwh double precision, current_year_gas_kwh double precision, previous_year_gas_co2 double precision, current_year_gas_co2 double precision, previous_year_gas_gbp double precision, current_year_gas_gbp double precision, previous_year_storage_heaters_kwh double precision, current_year_storage_heaters_kwh double precision, previous_year_storage_heaters_co2 double precision, current_year_storage_heaters_co2 double precision, previous_year_storage_heaters_gbp double precision, current_year_storage_heaters_gbp double precision, previous_year_solar_pv_kwh double precision, current_year_solar_pv_kwh double precision, previous_year_solar_pv_co2 double precision, current_year_solar_pv_co2 double precision, solar_type text)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertEnergyAnnualVersusBenchmark'::text))) energy,
-      ( SELECT alerts.alert_generation_run_id,
-              data.electricity_economic_tariff_changed_this_year,
-              data.gas_economic_tariff_changed_this_year
-             FROM alerts,
-              alert_types,
-              LATERAL jsonb_to_record(alerts.variables) data(electricity_economic_tariff_changed_this_year boolean, gas_economic_tariff_changed_this_year boolean)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertAdditionalPrioritisationData'::text))) additional,
-      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
-             FROM alert_generation_runs
-            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
-    WHERE ((energy.alert_generation_run_id = latest_runs.id) AND (additional.alert_generation_run_id = latest_runs.id));
-  SQL
-  create_view "heat_saver_march_2024s", sql_definition: <<-SQL
-      WITH electricity AS (
-           SELECT alerts.alert_generation_run_id,
-              json.current_period_kwh,
-              json.previous_period_kwh,
-              json.current_period_co2,
-              json.previous_period_co2,
-              json.current_period_gbp,
-              json.previous_period_gbp,
-              json.tariff_has_changed,
-              json.pupils_changed,
-              json.floor_area_changed
-             FROM alerts,
-              alert_types,
-              LATERAL jsonb_to_record(alerts.variables) json(current_period_kwh double precision, previous_period_kwh double precision, current_period_co2 double precision, previous_period_co2 double precision, current_period_gbp double precision, previous_period_gbp double precision, tariff_has_changed boolean, pupils_changed boolean, floor_area_changed boolean)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertHeatSaver2024ElectricityComparison'::text))
-          ), gas AS (
-           SELECT alerts.alert_generation_run_id,
-              json.current_period_kwh,
-              json.previous_period_kwh,
-              json.current_period_co2,
-              json.previous_period_co2,
-              json.current_period_gbp,
-              json.previous_period_gbp,
-              json.previous_period_kwh_unadjusted,
-              json.tariff_has_changed,
-              json.pupils_changed,
-              json.floor_area_changed
-             FROM alerts,
-              alert_types,
-              LATERAL jsonb_to_record(alerts.variables) json(current_period_kwh double precision, previous_period_kwh double precision, current_period_co2 double precision, previous_period_co2 double precision, current_period_gbp double precision, previous_period_gbp double precision, previous_period_kwh_unadjusted double precision, tariff_has_changed boolean, pupils_changed boolean, floor_area_changed boolean)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertHeatSaver2024GasComparison'::text))
-          ), storage_heater AS (
-           SELECT alerts.alert_generation_run_id,
-              json.current_period_kwh,
-              json.previous_period_kwh,
-              json.current_period_co2,
-              json.previous_period_co2,
-              json.current_period_gbp,
-              json.previous_period_gbp,
-              json.previous_period_kwh_unadjusted,
-              json.tariff_has_changed,
-              json.pupils_changed,
-              json.floor_area_changed
-             FROM alerts,
-              alert_types,
-              LATERAL jsonb_to_record(alerts.variables) json(current_period_kwh double precision, previous_period_kwh double precision, current_period_co2 double precision, previous_period_co2 double precision, current_period_gbp double precision, previous_period_gbp double precision, previous_period_kwh_unadjusted double precision, tariff_has_changed boolean, pupils_changed boolean, floor_area_changed boolean)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertHeatSaver2024StorageHeaterComparison'::text))
-          ), enba AS (
-           SELECT alerts.alert_generation_run_id,
-              data.solar_type
-             FROM alerts,
-              alert_types,
-              LATERAL jsonb_to_record(alerts.variables) data(solar_type text)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertEnergyAnnualVersusBenchmark'::text))
-          ), additional AS (
-           SELECT alerts.alert_generation_run_id,
-              alerts.school_id,
-              data.activation_date
-             FROM alerts,
-              alert_types,
-              LATERAL jsonb_to_record(alerts.variables) data(activation_date date)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertAdditionalPrioritisationData'::text))
-          ), latest_runs AS (
-           SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
-             FROM alert_generation_runs
-            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC
-          )
-   SELECT latest_runs.id,
-      additional.school_id,
-      additional.activation_date,
-      (electricity.pupils_changed OR gas.pupils_changed OR storage_heater.pupils_changed) AS pupils_changed,
-      (electricity.floor_area_changed OR gas.floor_area_changed OR storage_heater.floor_area_changed) AS floor_area_changed,
-      enba.solar_type,
-      electricity.current_period_kwh AS electricity_current_period_kwh,
-      electricity.previous_period_kwh AS electricity_previous_period_kwh,
-      electricity.current_period_co2 AS electricity_current_period_co2,
-      electricity.previous_period_co2 AS electricity_previous_period_co2,
-      electricity.current_period_gbp AS electricity_current_period_gbp,
-      electricity.previous_period_gbp AS electricity_previous_period_gbp,
-      electricity.tariff_has_changed AS electricity_tariff_has_changed,
-      gas.current_period_kwh AS gas_current_period_kwh,
-      gas.previous_period_kwh AS gas_previous_period_kwh,
-      gas.current_period_co2 AS gas_current_period_co2,
-      gas.previous_period_co2 AS gas_previous_period_co2,
-      gas.current_period_gbp AS gas_current_period_gbp,
-      gas.previous_period_gbp AS gas_previous_period_gbp,
-      gas.previous_period_kwh_unadjusted AS gas_previous_period_kwh_unadjusted,
-      gas.tariff_has_changed AS gas_tariff_has_changed,
-      storage_heater.current_period_kwh AS storage_heater_current_period_kwh,
-      storage_heater.previous_period_kwh AS storage_heater_previous_period_kwh,
-      storage_heater.current_period_co2 AS storage_heater_current_period_co2,
-      storage_heater.previous_period_co2 AS storage_heater_previous_period_co2,
-      storage_heater.current_period_gbp AS storage_heater_current_period_gbp,
-      storage_heater.previous_period_gbp AS storage_heater_previous_period_gbp,
-      storage_heater.previous_period_kwh_unadjusted AS storage_heater_previous_period_kwh_unadjusted,
-      storage_heater.tariff_has_changed AS storage_heater_tariff_has_changed
-     FROM (((((latest_runs
-       JOIN additional ON ((latest_runs.id = additional.alert_generation_run_id)))
-       LEFT JOIN electricity ON ((latest_runs.id = electricity.alert_generation_run_id)))
-       LEFT JOIN gas ON ((latest_runs.id = gas.alert_generation_run_id)))
-       LEFT JOIN storage_heater ON ((latest_runs.id = storage_heater.alert_generation_run_id)))
-       LEFT JOIN enba ON ((latest_runs.id = enba.alert_generation_run_id)));
   SQL
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_04_24_142738) do
+ActiveRecord::Schema.define(version: 2024_04_29_144652) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
@@ -153,6 +153,7 @@ ActiveRecord::Schema.define(version: 2024_04_24_142738) do
     t.string "summary"
     t.boolean "show_on_charts", default: true
     t.string "fuel_type", default: [], array: true
+    t.integer "maximum_frequency", default: 10
     t.index ["active"], name: "index_activity_types_on_active"
     t.index ["activity_category_id"], name: "index_activity_types_on_activity_category_id"
   end
@@ -1078,6 +1079,7 @@ ActiveRecord::Schema.define(version: 2024_04_24_142738) do
     t.datetime "updated_at", precision: 6, default: -> { "now()" }, null: false
     t.boolean "show_on_charts", default: true
     t.string "fuel_type", default: [], array: true
+    t.integer "maximum_frequency", default: 10
     t.index ["intervention_type_group_id"], name: "index_intervention_types_on_intervention_type_group_id"
   end
 
@@ -3065,110 +3067,6 @@ ActiveRecord::Schema.define(version: 2024_04_24_142738) do
             ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
     WHERE (data.alert_generation_run_id = latest_runs.id);
   SQL
-  create_view "heat_saver_march_2024s", sql_definition: <<-SQL
-      WITH electricity AS (
-           SELECT alerts.alert_generation_run_id,
-              json.current_period_kwh,
-              json.previous_period_kwh,
-              json.current_period_co2,
-              json.previous_period_co2,
-              json.current_period_gbp,
-              json.previous_period_gbp,
-              json.tariff_has_changed,
-              json.pupils_changed,
-              json.floor_area_changed
-             FROM alerts,
-              alert_types,
-              LATERAL jsonb_to_record(alerts.variables) json(current_period_kwh double precision, previous_period_kwh double precision, current_period_co2 double precision, previous_period_co2 double precision, current_period_gbp double precision, previous_period_gbp double precision, tariff_has_changed boolean, pupils_changed boolean, floor_area_changed boolean)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertHeatSaver2024ElectricityComparison'::text))
-          ), gas AS (
-           SELECT alerts.alert_generation_run_id,
-              json.current_period_kwh,
-              json.previous_period_kwh,
-              json.current_period_co2,
-              json.previous_period_co2,
-              json.current_period_gbp,
-              json.previous_period_gbp,
-              json.previous_period_kwh_unadjusted,
-              json.tariff_has_changed,
-              json.pupils_changed,
-              json.floor_area_changed
-             FROM alerts,
-              alert_types,
-              LATERAL jsonb_to_record(alerts.variables) json(current_period_kwh double precision, previous_period_kwh double precision, current_period_co2 double precision, previous_period_co2 double precision, current_period_gbp double precision, previous_period_gbp double precision, previous_period_kwh_unadjusted double precision, tariff_has_changed boolean, pupils_changed boolean, floor_area_changed boolean)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertHeatSaver2024GasComparison'::text))
-          ), storage_heater AS (
-           SELECT alerts.alert_generation_run_id,
-              json.current_period_kwh,
-              json.previous_period_kwh,
-              json.current_period_co2,
-              json.previous_period_co2,
-              json.current_period_gbp,
-              json.previous_period_gbp,
-              json.previous_period_kwh_unadjusted,
-              json.tariff_has_changed,
-              json.pupils_changed,
-              json.floor_area_changed
-             FROM alerts,
-              alert_types,
-              LATERAL jsonb_to_record(alerts.variables) json(current_period_kwh double precision, previous_period_kwh double precision, current_period_co2 double precision, previous_period_co2 double precision, current_period_gbp double precision, previous_period_gbp double precision, previous_period_kwh_unadjusted double precision, tariff_has_changed boolean, pupils_changed boolean, floor_area_changed boolean)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertHeatSaver2024StorageHeaterComparison'::text))
-          ), enba AS (
-           SELECT alerts.alert_generation_run_id,
-              data.solar_type
-             FROM alerts,
-              alert_types,
-              LATERAL jsonb_to_record(alerts.variables) data(solar_type text)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertEnergyAnnualVersusBenchmark'::text))
-          ), additional AS (
-           SELECT alerts.alert_generation_run_id,
-              alerts.school_id,
-              data.activation_date
-             FROM alerts,
-              alert_types,
-              LATERAL jsonb_to_record(alerts.variables) data(activation_date date)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertAdditionalPrioritisationData'::text))
-          ), latest_runs AS (
-           SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
-             FROM alert_generation_runs
-            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC
-          )
-   SELECT latest_runs.id,
-      additional.school_id,
-      additional.activation_date,
-      (electricity.pupils_changed OR gas.pupils_changed OR storage_heater.pupils_changed) AS pupils_changed,
-      (electricity.floor_area_changed OR gas.floor_area_changed OR storage_heater.floor_area_changed) AS floor_area_changed,
-      enba.solar_type,
-      electricity.current_period_kwh AS electricity_current_period_kwh,
-      electricity.previous_period_kwh AS electricity_previous_period_kwh,
-      electricity.current_period_co2 AS electricity_current_period_co2,
-      electricity.previous_period_co2 AS electricity_previous_period_co2,
-      electricity.current_period_gbp AS electricity_current_period_gbp,
-      electricity.previous_period_gbp AS electricity_previous_period_gbp,
-      electricity.tariff_has_changed AS electricity_tariff_has_changed,
-      gas.current_period_kwh AS gas_current_period_kwh,
-      gas.previous_period_kwh AS gas_previous_period_kwh,
-      gas.current_period_co2 AS gas_current_period_co2,
-      gas.previous_period_co2 AS gas_previous_period_co2,
-      gas.current_period_gbp AS gas_current_period_gbp,
-      gas.previous_period_gbp AS gas_previous_period_gbp,
-      gas.previous_period_kwh_unadjusted AS gas_previous_period_kwh_unadjusted,
-      gas.tariff_has_changed AS gas_tariff_has_changed,
-      storage_heater.current_period_kwh AS storage_heater_current_period_kwh,
-      storage_heater.previous_period_kwh AS storage_heater_previous_period_kwh,
-      storage_heater.current_period_co2 AS storage_heater_current_period_co2,
-      storage_heater.previous_period_co2 AS storage_heater_previous_period_co2,
-      storage_heater.current_period_gbp AS storage_heater_current_period_gbp,
-      storage_heater.previous_period_gbp AS storage_heater_previous_period_gbp,
-      storage_heater.previous_period_kwh_unadjusted AS storage_heater_previous_period_kwh_unadjusted,
-      storage_heater.tariff_has_changed AS storage_heater_tariff_has_changed
-     FROM (((((latest_runs
-       JOIN additional ON ((latest_runs.id = additional.alert_generation_run_id)))
-       LEFT JOIN electricity ON ((latest_runs.id = electricity.alert_generation_run_id)))
-       LEFT JOIN gas ON ((latest_runs.id = gas.alert_generation_run_id)))
-       LEFT JOIN storage_heater ON ((latest_runs.id = storage_heater.alert_generation_run_id)))
-       LEFT JOIN enba ON ((latest_runs.id = enba.alert_generation_run_id)));
-  SQL
   create_view "heating_coming_on_too_early", sql_definition: <<-SQL
       WITH early AS (
            SELECT alerts.alert_generation_run_id,
@@ -3551,5 +3449,178 @@ ActiveRecord::Schema.define(version: 2024_04_24_142738) do
              FROM alert_generation_runs
             ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
     WHERE ((data.alert_generation_run_id = latest_runs.id) AND (additional.alert_generation_run_id = latest_runs.id));
+  SQL
+  create_view "change_in_energy_since_last_years", sql_definition: <<-SQL
+      SELECT latest_runs.id,
+      energy.school_id,
+      energy.current_year_electricity_kwh AS electricity_current_period_kwh,
+      energy.previous_year_electricity_kwh AS electricity_previous_period_kwh,
+      energy.current_year_electricity_co2 AS electricity_current_period_co2,
+      energy.previous_year_electricity_co2 AS electricity_previous_period_co2,
+      energy.current_year_electricity_gbp AS electricity_current_period_gbp,
+      energy.previous_year_electricity_gbp AS electricity_previous_period_gbp,
+      energy.current_year_gas_kwh AS gas_current_period_kwh,
+      energy.previous_year_gas_kwh AS gas_previous_period_kwh,
+      energy.current_year_gas_co2 AS gas_current_period_co2,
+      energy.previous_year_gas_co2 AS gas_previous_period_co2,
+      energy.current_year_gas_gbp AS gas_current_period_gbp,
+      energy.previous_year_gas_gbp AS gas_previous_period_gbp,
+      energy.current_year_storage_heaters_kwh AS storage_heater_current_period_kwh,
+      energy.previous_year_storage_heaters_kwh AS storage_heater_previous_period_kwh,
+      energy.current_year_storage_heaters_co2 AS storage_heater_current_period_co2,
+      energy.previous_year_storage_heaters_co2 AS storage_heater_previous_period_co2,
+      energy.current_year_storage_heaters_gbp AS storage_heater_current_period_gbp,
+      energy.previous_year_storage_heaters_gbp AS storage_heater_previous_period_gbp,
+      energy.current_year_solar_pv_kwh AS solar_pv_current_period_kwh,
+      energy.previous_year_solar_pv_kwh AS solar_pv_previous_period_kwh,
+      energy.current_year_solar_pv_co2 AS solar_pv_current_period_co2,
+      energy.previous_year_solar_pv_co2 AS solar_pv_previous_period_co2,
+      additional.electricity_economic_tariff_changed_this_year AS electricity_tariff_has_changed,
+      additional.gas_economic_tariff_changed_this_year AS gas_tariff_has_changed,
+      energy.solar_type
+     FROM ( SELECT alerts.alert_generation_run_id,
+              alerts.school_id,
+              data.previous_year_electricity_kwh,
+              data.current_year_electricity_kwh,
+              data.previous_year_electricity_co2,
+              data.current_year_electricity_co2,
+              data.previous_year_electricity_gbp,
+              data.current_year_electricity_gbp,
+              data.previous_year_gas_kwh,
+              data.current_year_gas_kwh,
+              data.previous_year_gas_co2,
+              data.current_year_gas_co2,
+              data.previous_year_gas_gbp,
+              data.current_year_gas_gbp,
+              data.previous_year_storage_heaters_kwh,
+              data.current_year_storage_heaters_kwh,
+              data.previous_year_storage_heaters_co2,
+              data.current_year_storage_heaters_co2,
+              data.previous_year_storage_heaters_gbp,
+              data.current_year_storage_heaters_gbp,
+              data.previous_year_solar_pv_kwh,
+              data.current_year_solar_pv_kwh,
+              data.previous_year_solar_pv_co2,
+              data.current_year_solar_pv_co2,
+              data.solar_type
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) data(previous_year_electricity_kwh double precision, current_year_electricity_kwh double precision, previous_year_electricity_co2 double precision, current_year_electricity_co2 double precision, previous_year_electricity_gbp double precision, current_year_electricity_gbp double precision, previous_year_gas_kwh double precision, current_year_gas_kwh double precision, previous_year_gas_co2 double precision, current_year_gas_co2 double precision, previous_year_gas_gbp double precision, current_year_gas_gbp double precision, previous_year_storage_heaters_kwh double precision, current_year_storage_heaters_kwh double precision, previous_year_storage_heaters_co2 double precision, current_year_storage_heaters_co2 double precision, previous_year_storage_heaters_gbp double precision, current_year_storage_heaters_gbp double precision, previous_year_solar_pv_kwh double precision, current_year_solar_pv_kwh double precision, previous_year_solar_pv_co2 double precision, current_year_solar_pv_co2 double precision, solar_type text)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertEnergyAnnualVersusBenchmark'::text))) energy,
+      ( SELECT alerts.alert_generation_run_id,
+              data.electricity_economic_tariff_changed_this_year,
+              data.gas_economic_tariff_changed_this_year
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) data(electricity_economic_tariff_changed_this_year boolean, gas_economic_tariff_changed_this_year boolean)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertAdditionalPrioritisationData'::text))) additional,
+      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
+             FROM alert_generation_runs
+            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
+    WHERE ((energy.alert_generation_run_id = latest_runs.id) AND (additional.alert_generation_run_id = latest_runs.id));
+  SQL
+  create_view "heat_saver_march_2024s", sql_definition: <<-SQL
+      WITH electricity AS (
+           SELECT alerts.alert_generation_run_id,
+              json.current_period_kwh,
+              json.previous_period_kwh,
+              json.current_period_co2,
+              json.previous_period_co2,
+              json.current_period_gbp,
+              json.previous_period_gbp,
+              json.tariff_has_changed,
+              json.pupils_changed,
+              json.floor_area_changed
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) json(current_period_kwh double precision, previous_period_kwh double precision, current_period_co2 double precision, previous_period_co2 double precision, current_period_gbp double precision, previous_period_gbp double precision, tariff_has_changed boolean, pupils_changed boolean, floor_area_changed boolean)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertHeatSaver2024ElectricityComparison'::text))
+          ), gas AS (
+           SELECT alerts.alert_generation_run_id,
+              json.current_period_kwh,
+              json.previous_period_kwh,
+              json.current_period_co2,
+              json.previous_period_co2,
+              json.current_period_gbp,
+              json.previous_period_gbp,
+              json.previous_period_kwh_unadjusted,
+              json.tariff_has_changed,
+              json.pupils_changed,
+              json.floor_area_changed
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) json(current_period_kwh double precision, previous_period_kwh double precision, current_period_co2 double precision, previous_period_co2 double precision, current_period_gbp double precision, previous_period_gbp double precision, previous_period_kwh_unadjusted double precision, tariff_has_changed boolean, pupils_changed boolean, floor_area_changed boolean)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertHeatSaver2024GasComparison'::text))
+          ), storage_heater AS (
+           SELECT alerts.alert_generation_run_id,
+              json.current_period_kwh,
+              json.previous_period_kwh,
+              json.current_period_co2,
+              json.previous_period_co2,
+              json.current_period_gbp,
+              json.previous_period_gbp,
+              json.previous_period_kwh_unadjusted,
+              json.tariff_has_changed,
+              json.pupils_changed,
+              json.floor_area_changed
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) json(current_period_kwh double precision, previous_period_kwh double precision, current_period_co2 double precision, previous_period_co2 double precision, current_period_gbp double precision, previous_period_gbp double precision, previous_period_kwh_unadjusted double precision, tariff_has_changed boolean, pupils_changed boolean, floor_area_changed boolean)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertHeatSaver2024StorageHeaterComparison'::text))
+          ), enba AS (
+           SELECT alerts.alert_generation_run_id,
+              data.solar_type
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) data(solar_type text)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertEnergyAnnualVersusBenchmark'::text))
+          ), additional AS (
+           SELECT alerts.alert_generation_run_id,
+              alerts.school_id,
+              data.activation_date
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) data(activation_date date)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertAdditionalPrioritisationData'::text))
+          ), latest_runs AS (
+           SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
+             FROM alert_generation_runs
+            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC
+          )
+   SELECT latest_runs.id,
+      additional.school_id,
+      additional.activation_date,
+      (electricity.pupils_changed OR gas.pupils_changed OR storage_heater.pupils_changed) AS pupils_changed,
+      (electricity.floor_area_changed OR gas.floor_area_changed OR storage_heater.floor_area_changed) AS floor_area_changed,
+      enba.solar_type,
+      electricity.current_period_kwh AS electricity_current_period_kwh,
+      electricity.previous_period_kwh AS electricity_previous_period_kwh,
+      electricity.current_period_co2 AS electricity_current_period_co2,
+      electricity.previous_period_co2 AS electricity_previous_period_co2,
+      electricity.current_period_gbp AS electricity_current_period_gbp,
+      electricity.previous_period_gbp AS electricity_previous_period_gbp,
+      electricity.tariff_has_changed AS electricity_tariff_has_changed,
+      gas.current_period_kwh AS gas_current_period_kwh,
+      gas.previous_period_kwh AS gas_previous_period_kwh,
+      gas.current_period_co2 AS gas_current_period_co2,
+      gas.previous_period_co2 AS gas_previous_period_co2,
+      gas.current_period_gbp AS gas_current_period_gbp,
+      gas.previous_period_gbp AS gas_previous_period_gbp,
+      gas.previous_period_kwh_unadjusted AS gas_previous_period_kwh_unadjusted,
+      gas.tariff_has_changed AS gas_tariff_has_changed,
+      storage_heater.current_period_kwh AS storage_heater_current_period_kwh,
+      storage_heater.previous_period_kwh AS storage_heater_previous_period_kwh,
+      storage_heater.current_period_co2 AS storage_heater_current_period_co2,
+      storage_heater.previous_period_co2 AS storage_heater_previous_period_co2,
+      storage_heater.current_period_gbp AS storage_heater_current_period_gbp,
+      storage_heater.previous_period_gbp AS storage_heater_previous_period_gbp,
+      storage_heater.previous_period_kwh_unadjusted AS storage_heater_previous_period_kwh_unadjusted,
+      storage_heater.tariff_has_changed AS storage_heater_tariff_has_changed
+     FROM (((((latest_runs
+       JOIN additional ON ((latest_runs.id = additional.alert_generation_run_id)))
+       LEFT JOIN electricity ON ((latest_runs.id = electricity.alert_generation_run_id)))
+       LEFT JOIN gas ON ((latest_runs.id = gas.alert_generation_run_id)))
+       LEFT JOIN storage_heater ON ((latest_runs.id = storage_heater.alert_generation_run_id)))
+       LEFT JOIN enba ON ((latest_runs.id = enba.alert_generation_run_id)));
   SQL
 end

--- a/spec/models/activity_type_spec.rb
+++ b/spec/models/activity_type_spec.rb
@@ -303,4 +303,13 @@ describe 'ActivityType' do
       end
     end
   end
+
+  context 'as a Recordable' do
+    it_behaves_like 'a recordable' do
+      let(:factory) {:activity_type}
+      let(:recorded_factory) {:activity}
+      let(:trait) { nil }
+      let(:recording_date_field) { :happened_on }
+    end
+  end
 end

--- a/spec/models/intervention_type_spec.rb
+++ b/spec/models/intervention_type_spec.rb
@@ -178,4 +178,13 @@ describe 'InterventionType' do
       expect(subject.download_links_cy.to_s).to eql("<div class=\"trix-content\">\n  Links for Welsh <a href=\"google.com\">Google</a>\n</div>\n")
     end
   end
+
+  context 'as a Recordable' do
+    it_behaves_like 'a recordable' do
+      let(:factory) {:intervention_type}
+      let(:recorded_factory) {:observation}
+      let(:trait) { :intervention }
+      let(:recording_date_field) { :at }
+    end
+  end
 end

--- a/spec/models/observation_spec.rb
+++ b/spec/models/observation_spec.rb
@@ -105,7 +105,7 @@ describe Observation do
         expect(observation.points).to eq(nil)
         observation = build(:observation, observation_type: :intervention, intervention_type: intervention_type, description: '<div></div>', points: 0)
         observation.save
-        expect(observation.points).to eq(0)
+        expect(observation.points).to eq(nil)
       end
 
       it 'only adds points automatically if its an intervention' do

--- a/spec/support/shared_examples/recordable.rb
+++ b/spec/support/shared_examples/recordable.rb
@@ -1,0 +1,69 @@
+RSpec.shared_examples 'a recordable' do
+  subject(:recordable) { create(factory, score: 50, maximum_frequency: 5) }
+
+  let(:school) { create(:school) }
+  let(:academic_year) { create(:academic_year)}
+
+  context 'when recording in current year' do
+    context 'with no previous recordings' do
+      it 'returns a score' do
+        allow(school).to receive(:academic_year_for).and_return(academic_year)
+        expect(recordable.score_when_recorded_at(school, Time.zone.today)).to eq(50)
+      end
+    end
+
+    context 'with previous recordings this academic year' do
+      let(:existing) { 1 }
+
+      before do
+        create_list(recorded_factory, existing, trait, {
+          school: school,
+          recording_date_field => Time.zone.today,
+          recordable.class.model_name.param_key => recordable
+        })
+      end
+
+      context 'when there are less than the threshold' do
+        it 'returns a score' do
+          allow(school).to receive(:academic_year_for).and_return(academic_year)
+          expect(recordable.score_when_recorded_at(school, Time.zone.today)).to eq(50)
+        end
+      end
+
+      context 'when there are more than the threshold' do
+        let(:existing) { 5 }
+
+        it 'returns no score' do
+          allow(school).to receive(:academic_year_for).and_return(academic_year)
+          expect(recordable.score_when_recorded_at(school, Time.zone.today)).to eq(nil)
+        end
+      end
+    end
+
+    context 'with the previous recordings are in earlier academic years' do
+      let(:existing) { 5 }
+
+      before do
+        allow(school).to receive(:academic_year_for).and_return(academic_year)
+        create_list(recorded_factory, existing, trait, {
+          school: school,
+          recording_date_field => academic_year.start_date - 1,
+          recordable.class.model_name.param_key => recordable
+        })
+      end
+
+      it 'returns a score' do
+        expect(recordable.score_when_recorded_at(school, Time.zone.today)).to eq(50)
+      end
+    end
+  end
+
+  context 'when recordings are in earlier academic years' do
+    let(:academic_year) { create(:academic_year, start_date: 12.months.ago, end_date: 6.months.ago)}
+
+    it 'returns no score' do
+      allow(school).to receive(:academic_year_for).and_return(academic_year)
+      expect(recordable.score_when_recorded_at(school, Time.zone.today)).to eq(nil)
+    end
+  end
+end


### PR DESCRIPTION
Adds a `maximum_frequency` attribute to ActivityType and InterventionType

Adds a `Reportable` concern to try and centralise the logic around when to award a point score. This is implemented by the above. 

For the specs I've added some shared examples. These are parameterised to pass in the factories used to record the Recordable objects and the instances of the things that are recorded using them. Possibly slightly unusual, but seemed better than just duplicating the tests.

Reminds me that we need to iron out more of the inconsistencies around ActivityType and InterventionType and the related recordings.