### PR TITLE
Display unlisted schools in comparison reports

### DIFF
--- a/app/components/comparison_table_component.rb
+++ b/app/components/comparison_table_component.rb
@@ -227,8 +227,12 @@ class ComparisonTableComponent < ViewComponent::Base
       @note = note
     end
 
+    def note
+      @note || content || ''
+    end
+
     def call
-      (@note || content).html_safe
+      note.html_safe
     end
   end
 end

--- a/app/components/comparison_table_component.rb
+++ b/app/components/comparison_table_component.rb
@@ -75,12 +75,7 @@ class ComparisonTableComponent < ViewComponent::Base
 
     # First column, showing school name and a link
     renders_one :school, ->(school:) do
-      path = if @advice_page.present?
-               helpers.advice_page_path(school, @advice_page, @advice_page_tab)
-             else
-               school_advice_path(school)
-             end
-      link_to school.name, path
+      link_to school.name, helpers.advice_page_path(school, @advice_page, @advice_page_tab)
     end
 
     # Footnote references

--- a/app/components/comparison_table_component.rb
+++ b/app/components/comparison_table_component.rb
@@ -38,7 +38,12 @@ class ComparisonTableComponent < ViewComponent::Base
   end
 
   renders_many :footnotes, 'ComparisonTableComponent::FootnoteComponent'
-  renders_many :notes, 'ComparisonTableComponent::NoteComponent'
+
+  renders_many :notes, ->(**kwargs) do
+    if kwargs.key?(:if) ? kwargs.delete(:if) : true
+      NoteComponent.new(**kwargs)
+    end
+  end
 
   def fetch(key)
     @footnote_cache[key] ||= Comparison::Footnote.fetch(key)
@@ -218,12 +223,12 @@ class ComparisonTableComponent < ViewComponent::Base
   end
 
   class NoteComponent < ViewComponent::Base
-    def initialize(note = nil)
+    def initialize(note: nil)
       @note = note
     end
 
     def call
-      @note || content
+      (@note || content).html_safe
     end
   end
 end

--- a/app/components/footnote_modal_component.rb
+++ b/app/components/footnote_modal_component.rb
@@ -10,9 +10,9 @@ class FootnoteModalComponent < ViewComponent::Base
   end
 
   class Link < ViewComponent::Base
-    attr_reader :modal_id
+    attr_reader :modal_id, :href, :title, :remote
 
-    def initialize(modal_id:, href: '', remote: false, title: 'Schools')
+    def initialize(modal_id:, href: '', remote: false, title: '')
       @modal_id = modal_id
       @href = href
       @title = title
@@ -20,9 +20,9 @@ class FootnoteModalComponent < ViewComponent::Base
     end
 
     def call
-      args = { title: @title, 'data-toggle': 'modal', 'data-target': "##{modal_id}", 'data-remote': @remote.to_s }
+      args = { title: title, 'data-toggle': 'modal', 'data-target': "##{modal_id}", 'data-remote': remote.to_s }
 
-      link_to(content, @href, args)
+      link_to(content, href, args)
     end
   end
 end

--- a/app/components/footnote_modal_component.rb
+++ b/app/components/footnote_modal_component.rb
@@ -8,4 +8,21 @@ class FootnoteModalComponent < ViewComponent::Base
     @modal_id = modal_id
     @modal_dialog_classes = modal_dialog_classes
   end
+
+  class Link < ViewComponent::Base
+    attr_reader :modal_id
+
+    def initialize(modal_id:, href: '', remote: false, title: 'Schools')
+      @modal_id = modal_id
+      @href = href
+      @title = title
+      @remote = remote
+    end
+
+    def call
+      args = { title: @title, 'data-toggle': 'modal', 'data-target': "##{modal_id}", 'data-remote': @remote.to_s }
+
+      link_to(content, @href, args)
+    end
+  end
 end

--- a/app/components/footnote_modal_component.rb
+++ b/app/components/footnote_modal_component.rb
@@ -12,7 +12,7 @@ class FootnoteModalComponent < ViewComponent::Base
   class Link < ViewComponent::Base
     attr_reader :modal_id, :href, :title, :remote
 
-    def initialize(modal_id:, href: '', remote: false, title: '')
+    def initialize(modal_id:, href: '#', remote: false, title: '')
       @modal_id = modal_id
       @href = href
       @title = title

--- a/app/components/school_group_comparison_component.rb
+++ b/app/components/school_group_comparison_component.rb
@@ -4,6 +4,8 @@ class SchoolGroupComparisonComponent < ViewComponent::Base
   renders_one :footer
   renders_one :csv_download_link
 
+  include ApplicationHelper
+
   CATEGORIES = [:exemplar_school, :benchmark_school, :other_school].freeze
 
   def initialize(id:, comparison:, advice_page_key:, include_cluster: false)

--- a/app/components/school_group_comparison_component/school_group_comparison_component.html.erb
+++ b/app/components/school_group_comparison_component/school_group_comparison_component.html.erb
@@ -8,16 +8,16 @@
       class="school-group-comparison-component-callout-row row mt-4">
       <% categories.each do |category| %>
         <% count = count_for(category) %>
-        <div class="col-md-4 justify-content-center <%=category%> d-flex">
+        <div class="col-md-4 justify-content-center <%= category %> d-flex">
             <div class="school-group-comparison-component-callout-box">
               <div class="body m-2">
                 <% label = t('school_count', count: count).split(' ') %>
                 <div class="body m-2">
                   <h2>
                     <% if count.positive? %>
-                      <a href='#' data-toggle="modal" data-target="#<%= @advice_page_key.to_s.camelize + category.to_s.camelize %>ModalCenter">
+                      <%= component 'footnote_modal/link', modal_id: modal_id_for(category) do %>
                         <%= label.first %>
-                      </a>
+                      <% end %>
                     <% else %>
                       <%= label.first %>
                     <% end %>
@@ -27,10 +27,14 @@
                   <small><%= label.last.capitalize %></small>
                 </div>
                 <% if count.positive? %>
-                  <%= render(FootnoteModalComponent.new(title: tag.small(modal_title_for(category)), modal_id: modal_id_for(category))) do |component| %>
+                  <%= component 'footnote_modal',
+                                title: tag.small(modal_title_for(category)),
+                                modal_id: modal_id_for(category) do |component| %>
                     <% component.with_body_content do %>
                       <div class="text-left">
-                        <%= t('school_groups.comparisons.modal_subtitle_html', category_id: category, category: t("advice_pages.benchmarks.#{category}")) %>
+                        <%= t('school_groups.comparisons.modal_subtitle_html',
+                              category_id: category,
+                              category: t("advice_pages.benchmarks.#{category}")) %>
                       </div>
                       <% if csv_download_link %>
                         <div class='text-right pt-3'>
@@ -50,11 +54,13 @@
                         <tbody>
                           <% @comparison[category]&.each do |school| %>
                             <tr>
-                              <td class='text-left'><%= link_to school['school_name'], school_path(id: school['school_slug']) %></td>
+                              <td class='text-left'><%= link_to school['school_name'],
+                                                                school_path(id: school['school_slug']) %></td>
                               <% if include_cluster? %>
                                 <td class='text-right'><%= school['cluster_name'] || t('common.labels.not_set') %></td>
                               <% end %>
-                              <td class='text-right'><%= link_to t('school_groups.priority_actions.view_analysis'), advice_page_path_for(school['school_slug']) %></td>
+                              <td class='text-right'><%= link_to t('school_groups.priority_actions.view_analysis'),
+                                                                 advice_page_path_for(school['school_slug']) %></td>
                             </tr>
                           <% end %>
                         </tbody>

--- a/app/controllers/comparisons/base_controller.rb
+++ b/app/controllers/comparisons/base_controller.rb
@@ -7,6 +7,8 @@ module Comparisons
 
     before_action :filter
     before_action :set_schools
+    before_action :set_results, only: [:index]
+    before_action :set_unlisted_schools_count, only: [:index]
     helper_method :index_params
     helper_method :footnote_cache
     before_action :set_advice_page
@@ -14,7 +16,6 @@ module Comparisons
     before_action :set_headers
 
     def index
-      @results = load_data
       respond_to do |format|
         format.html do
           @charts = create_charts(@results)
@@ -27,6 +28,11 @@ module Comparisons
           render partial: filter[:table_name].to_s
         end
       end
+    end
+
+    def unlisted
+      @unlisted = School.where(id: (@schools - load_data.pluck(:school_id))).order(:name)
+      respond_to(&:js)
     end
 
     # Used to store footnotes loaded by the comparison table component across multiple calls in one page
@@ -51,6 +57,14 @@ module Comparisons
 
     def set_report
       @report = Comparison::Report.find_by!(key: key) if key
+    end
+
+    def set_results
+      @results = load_data
+    end
+
+    def set_unlisted_schools_count
+      @unlisted_schools_count = @schools.count - @results.count
     end
 
     def set_advice_page

--- a/app/controllers/comparisons/base_controller.rb
+++ b/app/controllers/comparisons/base_controller.rb
@@ -64,7 +64,7 @@ module Comparisons
     end
 
     def set_unlisted_schools_count
-      @unlisted_schools_count = @schools.count - @results.count
+      @unlisted_schools_count = @schools.length - @results.length
     end
 
     def set_advice_page

--- a/app/controllers/comparisons/base_controller.rb
+++ b/app/controllers/comparisons/base_controller.rb
@@ -7,12 +7,13 @@ module Comparisons
 
     before_action :filter
     before_action :set_schools
+    before_action :set_advice_page
+    before_action :set_report
     before_action :set_results, only: [:index]
     before_action :set_unlisted_schools_count, only: [:index]
     helper_method :index_params
+    helper_method :key
     helper_method :footnote_cache
-    before_action :set_advice_page
-    before_action :set_report
     before_action :set_headers
 
     def index

--- a/app/controllers/comparisons/base_controller.rb
+++ b/app/controllers/comparisons/base_controller.rb
@@ -12,7 +12,6 @@ module Comparisons
     before_action :set_results, only: [:index]
     before_action :set_unlisted_schools_count, only: [:index]
     helper_method :index_params
-    helper_method :key
     helper_method :footnote_cache
     before_action :set_headers
 

--- a/app/helpers/advice_page_helper.rb
+++ b/app/helpers/advice_page_helper.rb
@@ -1,7 +1,11 @@
 # rubocop:disable Naming/AsciiIdentifiers
 module AdvicePageHelper
-  def advice_page_path(school, advice_page, tab = :insights, params: {}, anchor: nil)
-    polymorphic_path([tab, school, :advice, advice_page.key.to_sym], params: params, anchor: anchor)
+  def advice_page_path(school, advice_page = nil, tab = :insights, params: {}, anchor: nil)
+    if advice_page.present?
+      polymorphic_path([tab, school, :advice, advice_page.key.to_sym], params: params, anchor: anchor)
+    else
+      school_advice_path(school)
+    end
   end
 
   def sort_by_label(advice_pages)

--- a/app/views/comparisons/base/_unlisted.html.erb
+++ b/app/views/comparisons/base/_unlisted.html.erb
@@ -1,0 +1,19 @@
+<p><%= @unlisted.count %> schools could not be shown in this report as they do not have enough data to be analysed.</p>
+
+<table class="table table-borderless table-sorted advice-table">
+  <thead>
+    <tr>
+      <th class="text-left"><%= t('common.school') %></th>
+      <th class="no-sort"></th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @unlisted&.each do |school| %>
+      <tr>
+        <td class='text-left'><%= link_to school.name, school_path(school) %></td>
+        <td class='text-right'><%= link_to t('school_groups.priority_actions.view_analysis'),
+                                           advice_page_path(school, @advice_page, :insights) %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/comparisons/base/_unlisted.html.erb
+++ b/app/views/comparisons/base/_unlisted.html.erb
@@ -4,17 +4,12 @@
   <thead>
     <tr>
       <th class="text-left"><%= t('common.school') %></th>
-      <th class="no-sort"></th>
     </tr>
   </thead>
   <tbody>
     <% @unlisted&.each do |school| %>
       <tr>
         <td class='text-left'><%= link_to school.name, school_path(school) %></td>
-        <td class='text-right'>
-          <%= link_to t('school_groups.priority_actions.view_analysis'),
-                      advice_page_path(school, @advice_page, @advice_page_tab) %>
-         </td>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/comparisons/base/_unlisted.html.erb
+++ b/app/views/comparisons/base/_unlisted.html.erb
@@ -1,4 +1,4 @@
-<p><%= @unlisted.count %> schools could not be shown in this report as they do not have enough data to be analysed.</p>
+<p><%= t('comparisons.unlisted.message', count: @unlisted.count) %>.</p>
 
 <table class="table table-borderless table-sorted advice-table">
   <thead>

--- a/app/views/comparisons/base/_unlisted.html.erb
+++ b/app/views/comparisons/base/_unlisted.html.erb
@@ -11,8 +11,10 @@
     <% @unlisted&.each do |school| %>
       <tr>
         <td class='text-left'><%= link_to school.name, school_path(school) %></td>
-        <td class='text-right'><%= link_to t('school_groups.priority_actions.view_analysis'),
-                                           advice_page_path(school, @advice_page, :insights) %></td>
+        <td class='text-right'>
+          <%= link_to t('school_groups.priority_actions.view_analysis'),
+                      advice_page_path(school, @advice_page, @advice_page_tab) %>
+         </td>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/comparisons/base/_unlisted.html.erb
+++ b/app/views/comparisons/base/_unlisted.html.erb
@@ -1,4 +1,4 @@
-<p><%= t('comparisons.unlisted.message', count: @unlisted.count) %>.</p>
+<p><%= t('comparisons.unlisted.message', count: @unlisted.length) %>.</p>
 
 <table class="table table-borderless table-sorted advice-table">
   <thead>

--- a/app/views/comparisons/base/_unlisted_schools.html.erb
+++ b/app/views/comparisons/base/_unlisted_schools.html.erb
@@ -1,17 +1,18 @@
 <% if unlisted_schools_count > 0 %>
   <div class="alert alert-secondary">
-  <%= unlisted_schools_count %> schools could not be shown in this report as they do not have enough data to be analysed.
+  <%= t('comparisons.unlisted.message', count: unlisted_schools_count) %>.
   <%= component 'footnote_modal/link', modal_id: 'unlisted-schools',
                                        href: polymorphic_path(
                                          [:unlisted, :comparisons, controller_name.to_sym, :index]
                                        ),
                                        title: 'Title', remote: true do
-        'View list of schools'
+        t('comparisons.unlisted.link')
       end %>
   </div>
   <%= component 'footnote_modal', title: 'Schools excluded from report', modal_id: 'unlisted-schools' do |c| %>
     <% c.with_body_content do %>
-        <%= unlisted_schools_count %> schools could not be shown in this report as they do not have enough data to be analysed. Loading schools <div class="spinner-border"></div>
+      <%= t('comparisons.unlisted.message', count: unlisted_schools_count) %>
+         <%= t('comparisons.unlisted.loading') %> <div class="spinner-border"></div>
 
     <% end %>
   <% end %>

--- a/app/views/comparisons/base/_unlisted_schools.html.erb
+++ b/app/views/comparisons/base/_unlisted_schools.html.erb
@@ -6,14 +6,13 @@
                                          [:unlisted, :comparisons, controller_name.to_sym, :index]
                                        ),
                                        title: 'Title', remote: true do
-        t('comparisons.unlisted.link')
+        t('comparisons.unlisted.link', count: unlisted_schools_count)
       end %>
   </div>
   <%= component 'footnote_modal', title: 'Schools excluded from report', modal_id: 'unlisted-schools' do |c| %>
     <% c.with_body_content do %>
-      <%= t('comparisons.unlisted.message', count: unlisted_schools_count) %>
-         <%= t('comparisons.unlisted.loading') %> <div class="spinner-border"></div>
-
+      <%= t('comparisons.unlisted.message', count: unlisted_schools_count) %>.
+      <%= t('comparisons.unlisted.loading') %> <div class="spinner-border"></div>
     <% end %>
   <% end %>
 <% end %>

--- a/app/views/comparisons/base/_unlisted_schools.html.erb
+++ b/app/views/comparisons/base/_unlisted_schools.html.erb
@@ -1,0 +1,17 @@
+<% if unlisted_schools_count > 0 %>
+  <div class="alert alert-secondary">
+  <strong><%= unlisted_schools_count %> schools</strong> could not be shown in this report as they do not have enough data to be analysed.
+  <%= component 'footnote_modal/link', modal_id: 'unlisted-schools',
+                                       href: polymorphic_path(
+                                         [:unlisted, :comparisons, controller_name.to_sym, :index]
+                                       ),
+                                       title: 'Title', remote: true do
+        'View list of schools'
+      end %>
+  </div>
+  <%= component 'footnote_modal', title: 'Schools not displayed in report', modal_id: 'unlisted-schools' do |c| %>
+    <% c.with_body_content do %>
+      <div class="spinner-border"></div>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/comparisons/base/_unlisted_schools.html.erb
+++ b/app/views/comparisons/base/_unlisted_schools.html.erb
@@ -1,6 +1,6 @@
 <% if unlisted_schools_count > 0 %>
   <div class="alert alert-secondary">
-  <strong><%= unlisted_schools_count %> schools</strong> could not be shown in this report as they do not have enough data to be analysed.
+  <%= unlisted_schools_count %> schools could not be shown in this report as they do not have enough data to be analysed.
   <%= component 'footnote_modal/link', modal_id: 'unlisted-schools',
                                        href: polymorphic_path(
                                          [:unlisted, :comparisons, controller_name.to_sym, :index]
@@ -11,7 +11,8 @@
   </div>
   <%= component 'footnote_modal', title: 'Schools excluded from report', modal_id: 'unlisted-schools' do |c| %>
     <% c.with_body_content do %>
-      <div class="spinner-border"></div>
+        <%= unlisted_schools_count %> schools could not be shown in this report as they do not have enough data to be analysed. Loading schools <div class="spinner-border"></div>
+
     <% end %>
   <% end %>
 <% end %>

--- a/app/views/comparisons/base/_unlisted_schools.html.erb
+++ b/app/views/comparisons/base/_unlisted_schools.html.erb
@@ -9,7 +9,7 @@
         'View list of schools'
       end %>
   </div>
-  <%= component 'footnote_modal', title: 'Schools not displayed in report', modal_id: 'unlisted-schools' do |c| %>
+  <%= component 'footnote_modal', title: 'Schools excluded from report', modal_id: 'unlisted-schools' do |c| %>
     <% c.with_body_content do %>
       <div class="spinner-border"></div>
     <% end %>

--- a/app/views/comparisons/base/_unlisted_schools.html.erb
+++ b/app/views/comparisons/base/_unlisted_schools.html.erb
@@ -2,9 +2,9 @@
   <div class="alert alert-secondary">
   <%= t('comparisons.unlisted.message', count: unlisted_schools_count) %>.
   <%= component 'footnote_modal/link', modal_id: 'unlisted-schools',
-                                       href: polymorphic_path(
-                                         [:unlisted, :comparisons, controller_name.to_sym, :index]
-                                       ),
+                                       href:
+                                        url_for({ controller: "/comparisons/#{controller_name.to_sym}",
+                                                  action: 'unlisted' }.merge(index_params)),
                                        title: 'Title', remote: true do
         t('comparisons.unlisted.link', count: unlisted_schools_count)
       end %>

--- a/app/views/comparisons/base/index.html.erb
+++ b/app/views/comparisons/base/index.html.erb
@@ -25,6 +25,7 @@
       <div class="col-sm-12">
         <%= render 'tables', results: @results, advice_page: @advice_page, report: @report,
                              headers: @headers, colgroups: @colgroups, advice_page_tab: @advice_page_tab %>
+        <%= render 'unlisted_schools', unlisted_schools_count: @unlisted_schools_count %>
       </div>
     </div>
   </div>

--- a/app/views/comparisons/base/unlisted.js.erb
+++ b/app/views/comparisons/base/unlisted.js.erb
@@ -1,0 +1,2 @@
+$("#unlisted-schools").find(".modal-body").html("<%= j (render 'unlisted') %>");
+$("#unlisted-schools").modal();

--- a/app/views/comparisons/shared/arbitrary_period/_total.html.erb
+++ b/app/views/comparisons/shared/arbitrary_period/_total.html.erb
@@ -40,13 +40,12 @@
       <% %i[kwh co2 £].each do |unit| %>
         <%= r.with_var val: result.total_previous_period(unit: unit),
                        unit: unit %>
-         <%= r.with_var val: result.total_current_period(unit: unit),
-                        unit: unit %>
-         <%= r.with_var val: result.total_percentage_change(unit: unit),
-                        change: true,
-                        unit: :relative_percent_0dp %>
-     <% end %>
-
+        <%= r.with_var val: result.total_current_period(unit: unit),
+                       unit: unit %>
+        <%= r.with_var val: result.total_percentage_change(unit: unit),
+                       change: true,
+                       unit: :relative_percent_0dp %>
+      <% end %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/views/school_groups/priority_actions.html.erb
+++ b/app/views/school_groups/priority_actions.html.erb
@@ -9,7 +9,10 @@
 <div class="row">
   <div class="col-md-12">
     <div class='text-right'>
-      <%= link_to t('school_groups.download_as_csv'), priority_actions_school_group_path(@school_group, format: :csv), class: 'btn btn-sm btn-outline-dark rounded-pill font-weight-bold', id: 'download-priority-actions-school-group-csv' %>
+      <%= link_to t('school_groups.download_as_csv'),
+                  priority_actions_school_group_path(@school_group, format: :csv),
+                  class: 'btn btn-sm btn-outline-dark rounded-pill font-weight-bold',
+                  id: 'download-priority-actions-school-group-csv' %>
     </div>
 
     <table class="table table-borderless table-sorted advice-table advice-priority-table">
@@ -31,27 +34,30 @@
         <% @total_savings.each do |alert_type_rating, savings| %>
           <tr>
             <td data-order="<%= alert_type_rating.alert_type.fuel_type %>">
-              <span class="<%=fuel_type_class(alert_type_rating.alert_type.fuel_type)%>">
-                <%= fa_icon alert_type_icon(alert_type_rating.alert_type,'fa-2x') %>
+              <span class="<%= fuel_type_class(alert_type_rating.alert_type.fuel_type) %>">
+                <%= fa_icon alert_type_icon(alert_type_rating.alert_type, 'fa-2x') %>
               </span>
             </td>
             <td>
-                <a href="" data-toggle="modal" data-target="#action-<%= alert_type_rating.id %>">
-                  <%= alert_type_rating.current_content.management_priorities_title %>
-                </a>
-              <%= component 'footnote_modal', title: alert_type_rating.current_content.management_priorities_title.to_plain_text, modal_id: "action-#{alert_type_rating.id}", modal_dialog_classes: 'modal-xl modal-dialog-centered' do |component| %>
+              <%= component 'footnote_modal/link', modal_id: "action-#{alert_type_rating.id}" do %>
+                <%= alert_type_rating.current_content.management_priorities_title %>
+              <% end %>
+              <%= component 'footnote_modal',
+                            title: alert_type_rating.current_content.management_priorities_title.to_plain_text,
+                            modal_id: "action-#{alert_type_rating.id}",
+                            modal_dialog_classes: 'modal-xl modal-dialog-centered' do |component| %>
                 <% component.with_body_content do %>
                   <%= render 'priority_action_modal',
-                    alert_type_rating: alert_type_rating,
-                    savings: savings,
-                    priority_actions: @priority_actions %>
+                             alert_type_rating: alert_type_rating,
+                             savings: savings,
+                             priority_actions: @priority_actions %>
                 <% end %>
               <% end %>
             </td>
             <td class="text-right">
                 <%= savings.schools.length %>
             </td>
-            <td  class="text-right" data-order="<%= savings.one_year_saving_kwh %>">
+            <td class="text-right" data-order="<%= savings.one_year_saving_kwh %>">
                 <%= format_unit(savings.one_year_saving_kwh, :kwh) %>
             </td>
             <td class="text-right" data-order="<%= savings.average_one_year_saving_gbp %>">

--- a/app/views/schools/advice/_how_have_we_analysed_your_data_table_caption.html.erb
+++ b/app/views/schools/advice/_how_have_we_analysed_your_data_table_caption.html.erb
@@ -1,7 +1,7 @@
 <div class="text-right advice-table-caption">
   <%= @additional_notice_text %>
-  <a href="" data-toggle="modal" data-target="#<%= data_target %>">
+  <%= component 'footnote_modal/link', modal_id: data_target do %>
     <%= t('advice_pages.how_have_we_analysed_your_data.link_title') %>
     <span class="advice-question-icon"><%= fa_icon('question-circle') %></span>
-  </a>
+  <% end %>
 </div>

--- a/app/views/schools/advice/advice_base/insights.html.erb
+++ b/app/views/schools/advice/advice_base/insights.html.erb
@@ -1,4 +1,5 @@
-<%= render 'schools/advice/advice_page', school: @school, advice_pages: @advice_pages, advice_page: @advice_page, tab: @tab, data_warning: @data_warning do %>
+<%= render 'schools/advice/advice_page', school: @school, advice_pages: @advice_pages, advice_page: @advice_page,
+                                         tab: @tab, data_warning: @data_warning do %>
 
   <% if @advice_page_subtitle.present? %>
     <h2><%= @advice_page_subtitle %></h2>
@@ -6,17 +7,22 @@
 
   <%= render 'insights' %>
 
-  <%= render 'schools/advice/section_title', section_id: 'recommendations', section_title: t('advice_pages.insights.recommendations.title') %>
+  <%= render 'schools/advice/section_title', section_id: 'recommendations',
+                                             section_title: t('advice_pages.insights.recommendations.title') %>
 
   <% if @advice_page_insights_next_steps.present? %>
     <p><%= @advice_page_insights_next_steps %></p>
   <% end %>
 
-  <%= component 'recommendations', recommendations: @activity_types, title: t("advice_pages.insights.recommendations.activities_title"), classes: 'pb-4' %>
+  <%= component 'recommendations', recommendations: @activity_types,
+                                   title: t('advice_pages.insights.recommendations.activities_title'), classes: 'pb-4' %>
 
-  <%= component 'recommendations', recommendations: @intervention_types, title: t("advice_pages.insights.recommendations.actions_title"), classes: 'pb-4' %>
+  <%= component 'recommendations', recommendations: @intervention_types,
+                                   title: t('advice_pages.insights.recommendations.actions_title'), classes: 'pb-4' %>
 
-  <%= render(FootnoteModalComponent.new(title: t('advice_pages.how_have_we_analysed_your_data.page_title'), modal_id: 'how-have-we-analysed-your-data-footnotes')) do |component| %>
+  <%= component 'footnote_modal',
+                title: t('advice_pages.how_have_we_analysed_your_data.page_title'),
+                modal_id: 'how-have-we-analysed-your-data-footnotes' do |component| %>
     <% component.with_body_content do %>
       <%= render 'schools/advice/how_have_we_analysed_your_data' %>
     <% end %>

--- a/config/locales/views/comparisons/comparisons.yml
+++ b/config/locales/views/comparisons/comparisons.yml
@@ -23,5 +23,5 @@ en:
       link: View list of schools
       loading: Loading schools
       message:
-        many: "%{count} schools could not be shown in this report as they do not have enough data to be analysed"
+        one: "%{count} schools could not be shown in this report as they do not have enough data to be analysed"
         other: "%{count} school could not be shown in this report as it does not have enough data to be analysed"

--- a/config/locales/views/comparisons/comparisons.yml
+++ b/config/locales/views/comparisons/comparisons.yml
@@ -20,8 +20,10 @@ en:
       table_title: 'Table %{table_number}: %{table_title}'
       total_usage: Total energy usage comparison
     unlisted:
-      link: View list of schools
+      link:
+        one: View school
+        other: View list of schools
       loading: Loading schools
       message:
-        one: "%{count} schools could not be shown in this report as they do not have enough data to be analysed"
-        other: "%{count} school could not be shown in this report as it does not have enough data to be analysed"
+        one: "%{count} school could not be shown in this report as it does not have enough data to be analysed"
+        other: "%{count} schools could not be shown in this report as they do not have enough data to be analysed"

--- a/config/locales/views/comparisons/comparisons.yml
+++ b/config/locales/views/comparisons/comparisons.yml
@@ -19,3 +19,9 @@ en:
       storage_heater_usage: Storage heater usage comparison
       table_title: 'Table %{table_number}: %{table_title}'
       total_usage: Total energy usage comparison
+    unlisted:
+      link: View list of schools
+      loading: Loading schools
+      message:
+        many: "%{count} schools could not be shown in this report as they do not have enough data to be analysed"
+        other: "%{count} school could not be shown in this report as it does not have enough data to be analysed"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -128,6 +128,7 @@ Rails.application.routes.draw do
     resources :thermostatic_control, only: [:index], concerns: :unlisted
     resources :weekday_baseload_variation, only: [:index], concerns: :unlisted
 
+    get '*key/unlisted', to: 'configurable_period#unlisted'
     get '*key', to: 'configurable_period#index', as: :configurable_period
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -81,49 +81,53 @@ Rails.application.routes.draw do
     end
   end
 
-  namespace :comparisons do
-    resources :annual_change_in_electricity_out_of_hours_use, only: [:index]
-    resources :annual_change_in_gas_out_of_hours_use, only: [:index]
-    resources :annual_change_in_storage_heater_out_of_hours_use, only: [:index]
-    resources :annual_electricity_costs_per_pupil, only: [:index]
-    resources :annual_electricity_out_of_hours_use, only: [:index]
-    resources :annual_energy_costs_per_floor_area, only: [:index]
-    resources :annual_energy_costs_per_pupil, only: [:index]
-    resources :annual_energy_costs, only: [:index]
-    resources :annual_gas_out_of_hours_use, only: [:index]
-    resources :annual_heating_costs_per_floor_area, only: [:index]
-    resources :annual_storage_heater_out_of_hours_use, only: [:index]
-    resources :baseload_per_pupil, only: [:index]
-    resources :change_in_electricity_consumption_recent_school_weeks, only: [:index]
-    resources :change_in_electricity_holiday_consumption_previous_holiday, only: [:index]
-    resources :change_in_electricity_holiday_consumption_previous_years_holiday, only: [:index]
-    resources :change_in_electricity_since_last_year, only: [:index]
-    resources :change_in_energy_since_last_year, only: [:index]
-    resources :change_in_gas_consumption_recent_school_weeks, only: [:index]
-    resources :change_in_gas_holiday_consumption_previous_holiday, only: [:index]
-    resources :change_in_gas_holiday_consumption_previous_years_holiday, only: [:index]
-    resources :change_in_gas_since_last_year, only: [:index]
-    resources :change_in_solar_pv_since_last_year, only: [:index]
-    resources :change_in_storage_heaters_since_last_year, only: [:index]
-    resources :electricity_consumption_during_holiday, only: [:index]
-    resources :electricity_peak_kw_per_pupil, only: [:index]
-    resources :electricity_targets, only: [:index]
-    resources :gas_consumption_during_holiday, only: [:index]
-    resources :gas_targets, only: [:index]
-    resources :heat_saver_march_2024, only: [:index]
-    resources :heating_coming_on_too_early, only: [:index]
-    resources :heating_in_warm_weather, only: [:index]
-    resources :holiday_usage_last_year, only: [:index]
-    resources :hot_water_efficiency, only: [:index]
-    resources :recent_change_in_baseload, only: [:index]
-    resources :seasonal_baseload_variation, only: [:index]
-    resources :solar_generation_summary, only: [:index]
-    resources :solar_pv_benefit_estimate, only: [:index]
-    resources :storage_heater_consumption_during_holiday, only: [:index]
-    resources :thermostat_sensitivity, only: [:index]
-    resources :thermostatic_control, only: [:index]
-    resources :weekday_baseload_variation, only: [:index]
+  concern :unlisted do
+    get :unlisted, on: :collection
+  end
 
+  namespace :comparisons do
+    resources :annual_change_in_electricity_out_of_hours_use, only: [:index], concerns: :unlisted
+    resources :annual_change_in_gas_out_of_hours_use, only: [:index], concerns: :unlisted
+    resources :annual_change_in_storage_heater_out_of_hours_use, only: [:index], concerns: :unlisted
+    resources :annual_electricity_costs_per_pupil, only: [:index], concerns: :unlisted
+    resources :annual_electricity_out_of_hours_use, only: [:index], concerns: :unlisted
+    resources :annual_energy_costs_per_floor_area, only: [:index], concerns: :unlisted
+    resources :annual_energy_costs_per_pupil, only: [:index], concerns: :unlisted
+    resources :annual_energy_costs, only: [:index], concerns: :unlisted
+    resources :annual_gas_out_of_hours_use, only: [:index], concerns: :unlisted
+    resources :annual_heating_costs_per_floor_area, only: [:index], concerns: :unlisted
+    resources :annual_storage_heater_out_of_hours_use, only: [:index], concerns: :unlisted
+    resources :baseload_per_pupil, only: [:index], concerns: :unlisted
+    resources :change_in_electricity_consumption_recent_school_weeks, only: [:index], concerns: :unlisted
+    resources :change_in_electricity_holiday_consumption_previous_holiday, only: [:index], concerns: :unlisted
+    resources :change_in_electricity_holiday_consumption_previous_years_holiday, only: [:index], concerns: :unlisted
+    resources :change_in_electricity_since_last_year, only: [:index], concerns: :unlisted
+    resources :change_in_energy_since_last_year, only: [:index], concerns: :unlisted
+    resources :change_in_gas_consumption_recent_school_weeks, only: [:index], concerns: :unlisted
+    resources :change_in_gas_holiday_consumption_previous_holiday, only: [:index], concerns: :unlisted
+    resources :change_in_gas_holiday_consumption_previous_years_holiday, only: [:index], concerns: :unlisted
+    resources :change_in_gas_since_last_year, only: [:index], concerns: :unlisted
+    resources :change_in_solar_pv_since_last_year, only: [:index], concerns: :unlisted
+    resources :change_in_storage_heaters_since_last_year, only: [:index], concerns: :unlisted
+    resources :electricity_consumption_during_holiday, only: [:index], concerns: :unlisted
+    resources :electricity_peak_kw_per_pupil, only: [:index], concerns: :unlisted
+    resources :electricity_targets, only: [:index], concerns: :unlisted
+    resources :gas_consumption_during_holiday, only: [:index], concerns: :unlisted
+    resources :gas_targets, only: [:index], concerns: :unlisted
+    resources :heat_saver_march_2024, only: [:index], concerns: :unlisted
+    resources :heating_coming_on_too_early, only: [:index], concerns: :unlisted
+    resources :heating_in_warm_weather, only: [:index], concerns: :unlisted
+    resources :holiday_usage_last_year, only: [:index], concerns: :unlisted
+    resources :hot_water_efficiency, only: [:index], concerns: :unlisted
+    resources :recent_change_in_baseload, only: [:index], concerns: :unlisted
+    resources :seasonal_baseload_variation, only: [:index], concerns: :unlisted
+    resources :solar_generation_summary, only: [:index], concerns: :unlisted
+    resources :solar_pv_benefit_estimate, only: [:index], concerns: :unlisted
+    resources :storage_heater_consumption_during_holiday, only: [:index], concerns: :unlisted
+    resources :thermostat_sensitivity, only: [:index], concerns: :unlisted
+    resources :thermostatic_control, only: [:index], concerns: :unlisted
+    resources :weekday_baseload_variation, only: [:index], concerns: :unlisted
+    
     get '*key', to: 'configurable_period#index', as: :configurable_period
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -127,7 +127,7 @@ Rails.application.routes.draw do
     resources :thermostat_sensitivity, only: [:index], concerns: :unlisted
     resources :thermostatic_control, only: [:index], concerns: :unlisted
     resources :weekday_baseload_variation, only: [:index], concerns: :unlisted
-    
+
     get '*key', to: 'configurable_period#index', as: :configurable_period
   end
 

--- a/lib/generators/comparison_report/comparison_report_generator.rb
+++ b/lib/generators/comparison_report/comparison_report_generator.rb
@@ -32,6 +32,6 @@ class ComparisonReportGenerator < Rails::Generators::NamedBase
   end
 
   def add_route
-    route "resources :#{file_name}, only: [:index]", namespace: :comparisons
+    route "resources :#{file_name}, only: [:index], concerns: :unlisted", namespace: :comparisons
   end
 end

--- a/spec/components/comparison_table_component_spec.rb
+++ b/spec/components/comparison_table_component_spec.rb
@@ -57,12 +57,17 @@ RSpec.describe ComparisonTableComponent, type: :component, include_url_helpers: 
   context 'with notes' do
     let(:note_1) { 'This is note 1' }
     let(:note_2) { 'This is note 2' }
+    let(:note_3) { 'This is note 3' }
+    let(:condition) { true }
 
     subject(:html) do
       render_inline(described_class.new(**params)) do |c|
-        c.with_note note_1
+        c.with_note note: note_1
         c.with_note do
           note_2
+        end
+        c.with_note if: condition do
+          note_3
         end
       end
     end
@@ -71,6 +76,15 @@ RSpec.describe ComparisonTableComponent, type: :component, include_url_helpers: 
       within('table tfoot') do
         expect(html).to have_content(note_1)
         expect(html).to have_content(note_2)
+        expect(html).to have_content(note_3)
+      end
+    end
+
+    context 'when conditon is false' do
+      let(:condition) { false }
+
+      it 'does not add note' do
+        expect(html).not_to have_content(note_3)
       end
     end
   end

--- a/spec/components/footnote_modal_component_spec.rb
+++ b/spec/components/footnote_modal_component_spec.rb
@@ -49,4 +49,40 @@ RSpec.describe FootnoteModalComponent, type: :component do
 
     it { expect(html).to have_text(body_content) }
   end
+
+  describe 'FootnoteModalComponent::Link', type: :component do
+    shared_examples 'a footnote modal link' do |modal_id:, title:, remote:, href:, content:|
+      it 'links to modal' do
+        expect(html).to have_selector(
+          'a' \
+          "[title='#{title}']" \
+          "[data-toggle='modal']" \
+          "[data-target='##{modal_id}']" \
+          "[data-remote='#{remote}']" \
+          "[href='#{href}']" \
+          )
+        expect(html).to have_link(content)
+      end
+    end
+
+    let(:link_params) { { modal_id: 'mymodal', href: 'http://href', remote: true, title: 'Another title', content: 'Link text' } }
+
+    let(:html) do
+      render_inline(FootnoteModalComponent::Link.new(**params.except(:content))) do
+        params[:content]
+      end
+    end
+
+    context 'with all params' do
+      let(:params) { link_params }
+
+      it_behaves_like 'a footnote modal link', title: 'Another title', remote: true, href: 'http://href', modal_id: 'mymodal', content: 'Link text'
+    end
+
+    context 'with default params' do
+      let(:params) { link_params.except(:title, :remote, :title, :href) }
+
+      it_behaves_like 'a footnote modal link', title: '', remote: false, href: '', modal_id: 'mymodal', content: ''
+    end
+  end
 end

--- a/spec/components/footnote_modal_component_spec.rb
+++ b/spec/components/footnote_modal_component_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe FootnoteModalComponent, type: :component do
     context 'with default params' do
       let(:params) { link_params.except(:title, :remote, :title, :href) }
 
-      it_behaves_like 'a footnote modal link', title: '', remote: false, href: '', modal_id: 'mymodal', content: ''
+      it_behaves_like 'a footnote modal link', title: '', remote: false, href: '#', modal_id: 'mymodal', content: ''
     end
   end
 end

--- a/spec/helpers/advice_page_helper_spec.rb
+++ b/spec/helpers/advice_page_helper_spec.rb
@@ -88,6 +88,10 @@ describe AdvicePageHelper do
         helper.advice_page_path(school, advice_page, :blah)
       end.to raise_error(NoMethodError)
     end
+
+    it 'returns advice root if advice page not specified' do
+      expect(helper.advice_page_path(school)).to end_with("/schools/#{school.slug}/advice")
+    end
   end
 
   describe '.sort_by_label' do

--- a/spec/system/compare_spec.rb
+++ b/spec/system/compare_spec.rb
@@ -111,14 +111,6 @@ describe 'compare pages', :compare, type: :system do
         end
       end
     end
-
-    it 'links to advice pages' do
-      within '.modal-body' do
-        unlisted_schools.each do |school|
-          expect(page).to have_link 'View analysis', href: insights_school_advice_baseload_path(school)
-        end
-      end
-    end
   end
 
   shared_examples 'a results page with unlisted schools' do |unlisted_count: 0|


### PR DESCRIPTION
Currently looks like this:

![image](https://github.com/Energy-Sparks/energy-sparks/assets/6051/58ae40b1-8a2b-4395-aaf9-c49f2ae32e0c)

![image](https://github.com/Energy-Sparks/energy-sparks/assets/6051/2ba54495-d24a-4918-8631-242c168fb638)

It derives the count of unlisted schools by subtracting the count of the result set from the original list of schools. 

Clicking on the list of schools runs the original queries again, subtracts the schools returned in the query from the filtered schools. It possibly could be made quicker to load by passing a list of unlisted schools extracted from the original query, but this would likely add processing time to the original page.

The modal links to the analysis page for each school - as well as the school. Not sure about the analysis link as it quite often is a link to a page where it shows no data... See what you think.

This PR also adds a Link component to the FootnoteModal component, so have added this in other parts of the codebase where for links where FootnoteModal is in use.