### PR TITLE
Initialise tooltips and popovers on all pages

### DIFF
--- a/app/assets/javascripts/analysis.js
+++ b/app/assets/javascripts/analysis.js
@@ -145,9 +145,6 @@ function processAnalysisCharts(){
       }
     });
   }
-
-  //activate tooltips
-  $('[data-toggle="tooltip"]').tooltip();
 }
 
 function processAnalysisChartAjax(chartId, chartConfig, highchartsChart) {
@@ -251,6 +248,7 @@ function processAnnotations(loaded_annotations, chart){
     labels: annotations
   }, true);
   if (annotations.length) {
+    // activate tooltips created in the annotations
     $('.highcharts-annotation [data-toggle="tooltip"]').tooltip()
     chart.redraw()
   }

--- a/app/assets/javascripts/analysis.js
+++ b/app/assets/javascripts/analysis.js
@@ -126,9 +126,6 @@ function chartSuccess(chartConfig, chartData, chart) {
 
   $chartDiv.attr( "maxYvalue", chart.yAxis[0].max );
 
-  // Activate any popovers
-  $('[data-toggle="popover"]').popover();
-
   chart.hideLoading();
 }
 
@@ -206,7 +203,7 @@ function processAnalysisChart(chartContainer, chartConfig){
 }
 
 //Highcharts filters attributes from HTML given as text labels, so add this
-//so we can style the annotation popovers using Bootstrap.
+//so we can style the annotation tooltips using Bootstrap.
 Highcharts.AST.allowedAttributes.push('data-toggle');
 Highcharts.AST.allowedAttributes.push('data-placement');
 

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -65,3 +65,4 @@
 //= require cocoon
 //= require loading
 //= require cookie_banner
+//= require init_bootstrap

--- a/app/assets/javascripts/init_bootstrap.js
+++ b/app/assets/javascripts/init_bootstrap.js
@@ -1,8 +1,8 @@
 "use strict"
 $(document).ready(function() {
-  //activate tooltips
+  // Activate tooltips
   $('[data-toggle="tooltip"]').tooltip();
 
-  // Activate any popovers
+  // Activate popovers
   $('[data-toggle="popover"]').popover();
 });

--- a/app/assets/javascripts/init_bootstrap.js
+++ b/app/assets/javascripts/init_bootstrap.js
@@ -1,0 +1,8 @@
+"use strict"
+$(document).ready(function() {
+  //activate tooltips
+  $('[data-toggle="tooltip"]').tooltip();
+
+  // Activate any popovers
+  $('[data-toggle="popover"]').popover();
+});


### PR DESCRIPTION
Currently Bootstrap tooltips and popovers are initialised in `analysis.js`

- all tooltips are initialised when page is ready, aftering setting up charts
- tooltips in chart annotations are initialised after the annotations have been loaded and added to the chart
- popovers are only initialised when a chart has been successfully loaded

This means that if a page doesn't have a chart then popovers don't work. Tooltips will be working everywhere though.

We also use popovers in the calendar views but these are explicitly initialised already.

I've changed things so that:

- there's a separate `init_bootstrap.js` file which initialises all tooltips and popovers. Seemed better to have that more clearly defined
- removed the call to initialise popovers in `analysis.js` as it doesn't seem to be needed there. The charts only use tooltips, not popovers, and the tooltips are already handled when chart is refreshed
- clarified some comments in the code

I've manually confirmed that:

- annotations still work on dashboards
- chart controls still work
- tooltips in advice pages work
- popovers work on comparison reports with and without charts
- calendar views work OK
