### PR TITLE
Add comparison report groups

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -112,6 +112,10 @@ gem 'roo-xls'
 # Used to handle mail processing for the admin mailer
 gem 'premailer-rails'
 
+# Feature flags
+gem "flipper-ui", "~> 1.3"
+gem "flipper-active_record", "~> 1.3"
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'bullet', require: false # use bullet to optimise queries

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -270,6 +270,18 @@ GEM
     fasterer (0.11.0)
       ruby_parser (>= 3.19.1)
     ffi (1.16.3)
+    flipper (1.3.0)
+      concurrent-ruby (< 2)
+    flipper-active_record (1.3.0)
+      activerecord (>= 4.2, < 8)
+      flipper (~> 1.3.0)
+    flipper-ui (1.3.0)
+      erubi (>= 1.0.0, < 2.0.0)
+      flipper (~> 1.3.0)
+      rack (>= 1.4, < 4)
+      rack-protection (>= 1.5.3, < 5.0.0)
+      rack-session (>= 1.0.2, < 3.0.0)
+      sanitize (< 7)
     font-awesome-sass (6.5.2)
       sassc (~> 2.0)
     foreman (0.88.1)
@@ -475,8 +487,13 @@ GEM
     rack-canonical-host (1.3.0)
       addressable (> 0, < 3)
       rack (>= 1.6, < 4)
+    rack-protection (3.2.0)
+      base64 (>= 0.1.0)
+      rack (~> 2.2, >= 2.2.4)
     rack-proxy (0.7.7)
       rack
+    rack-session (1.0.2)
+      rack (< 3)
     rack-test (2.1.0)
       rack (>= 1.3)
     rails (6.1.7.7)
@@ -612,6 +629,9 @@ GEM
       sexp_processor (~> 4.16)
     rubyvis (0.6.1)
     rubyzip (2.3.2)
+    sanitize (6.1.0)
+      crass (~> 1.0.2)
+      nokogiri (>= 1.12.0)
     sass-rails (6.0.0)
       sassc-rails (~> 2.1, >= 2.1.1)
     sassc (2.4.0)
@@ -757,6 +777,8 @@ DEPENDENCIES
   faraday
   faraday-follow_redirects
   fasterer
+  flipper-active_record (~> 1.3)
+  flipper-ui (~> 1.3)
   font-awesome-sass
   foreman
   friendly_id

--- a/app/controllers/admin/comparisons/reports_controller.rb
+++ b/app/controllers/admin/comparisons/reports_controller.rb
@@ -46,6 +46,7 @@ module Admin
           translated_params,
           :key,
           :reporting_period,
+          :report_group_id,
           :title,
           :introduction,
           :notes,

--- a/app/controllers/compare_controller.rb
+++ b/app/controllers/compare_controller.rb
@@ -12,7 +12,7 @@ class CompareController < ApplicationController
   # filters
   def index
     # Count is of all available benchmarks for guest users only
-    if EnergySparks::FeatureFlags.active?(:comparison_reports) || current_user&.admin?
+    if Flipper.enabled?(:comparison_reports, current_user)
       @benchmark_count = Comparison::Report.where(public: true).count
     else
       @benchmark_count = Benchmarking::BenchmarkManager.structured_pages(user_type: user_type_hash_guest).inject(0) { |count, group| count + group[:benchmarks].count }
@@ -60,7 +60,9 @@ class CompareController < ApplicationController
   end
 
   def benchmark_groups
-    @benchmark_groups ||= content_manager.structured_pages(user_type: user_type_hash)
+    unless Flipper.enabled?(:comparison_reports, current_user)
+      @benchmark_groups ||= content_manager.structured_pages(user_type: user_type_hash)
+    end
   end
 
   def set_included_schools

--- a/app/models/comparison/report.rb
+++ b/app/models/comparison/report.rb
@@ -2,21 +2,24 @@
 #
 # Table name: comparison_reports
 #
-#  created_at       :datetime         not null
-#  custom_period_id :bigint(8)
-#  id               :bigint(8)        not null, primary key
-#  key              :string           not null
-#  public           :boolean          default(FALSE)
-#  reporting_period :integer
-#  updated_at       :datetime         not null
+#  comparison_report_groups_id :bigint(8)
+#  created_at                  :datetime         not null
+#  custom_period_id            :bigint(8)
+#  id                          :bigint(8)        not null, primary key
+#  key                         :string           not null
+#  public                      :boolean          default(FALSE)
+#  reporting_period            :integer
+#  updated_at                  :datetime         not null
 #
 # Indexes
 #
-#  index_comparison_reports_on_custom_period_id  (custom_period_id)
-#  index_comparison_reports_on_key               (key) UNIQUE
+#  index_comparison_reports_on_comparison_report_groups_id  (comparison_report_groups_id)
+#  index_comparison_reports_on_custom_period_id             (custom_period_id)
+#  index_comparison_reports_on_key                          (key) UNIQUE
 #
 # Foreign Keys
 #
+#  fk_rails_...  (comparison_report_groups_id => comparison_report_groups.id)
 #  fk_rails_...  (custom_period_id => comparison_custom_periods.id)
 #
 class Comparison::Report < ApplicationRecord
@@ -31,6 +34,8 @@ class Comparison::Report < ApplicationRecord
   translates :notes, backend: :action_text
 
   belongs_to :custom_period, class_name: 'Comparison::CustomPeriod', optional: true, autosave: true, dependent: :destroy
+  belongs_to :report_group, class_name: 'Comparison::ReportGroup'
+
   accepts_nested_attributes_for :custom_period, update_only: true, reject_if: :not_custom?
 
   before_validation -> { custom_period.try(:mark_for_destruction) if not_custom? }

--- a/app/models/comparison/report.rb
+++ b/app/models/comparison/report.rb
@@ -2,25 +2,25 @@
 #
 # Table name: comparison_reports
 #
-#  comparison_report_groups_id :bigint(8)
-#  created_at                  :datetime         not null
-#  custom_period_id            :bigint(8)
-#  id                          :bigint(8)        not null, primary key
-#  key                         :string           not null
-#  public                      :boolean          default(FALSE)
-#  reporting_period            :integer
-#  updated_at                  :datetime         not null
+#  created_at       :datetime         not null
+#  custom_period_id :bigint(8)
+#  id               :bigint(8)        not null, primary key
+#  key              :string           not null
+#  public           :boolean          default(FALSE)
+#  report_group_id  :bigint(8)
+#  reporting_period :integer
+#  updated_at       :datetime         not null
 #
 # Indexes
 #
-#  index_comparison_reports_on_comparison_report_groups_id  (comparison_report_groups_id)
-#  index_comparison_reports_on_custom_period_id             (custom_period_id)
-#  index_comparison_reports_on_key                          (key) UNIQUE
+#  index_comparison_reports_on_custom_period_id  (custom_period_id)
+#  index_comparison_reports_on_key               (key) UNIQUE
+#  index_comparison_reports_on_report_group_id   (report_group_id)
 #
 # Foreign Keys
 #
-#  fk_rails_...  (comparison_report_groups_id => comparison_report_groups.id)
 #  fk_rails_...  (custom_period_id => comparison_custom_periods.id)
+#  fk_rails_...  (report_group_id => comparison_report_groups.id)
 #
 class Comparison::Report < ApplicationRecord
   self.table_name = 'comparison_reports'

--- a/app/models/comparison/report.rb
+++ b/app/models/comparison/report.rb
@@ -57,6 +57,10 @@ class Comparison::Report < ApplicationRecord
       previous_period: custom_period.previous_start_date..custom_period.previous_end_date }
   end
 
+  def self.fetch(key)
+    find_by(key: key)
+  end
+
   private
 
   def not_custom?

--- a/app/models/comparison/report.rb
+++ b/app/models/comparison/report.rb
@@ -7,7 +7,6 @@
 #  id               :bigint(8)        not null, primary key
 #  key              :string           not null
 #  public           :boolean          default(FALSE)
-#  report_group_id  :bigint(8)
 #  reporting_period :integer
 #  updated_at       :datetime         not null
 #
@@ -15,12 +14,10 @@
 #
 #  index_comparison_reports_on_custom_period_id  (custom_period_id)
 #  index_comparison_reports_on_key               (key) UNIQUE
-#  index_comparison_reports_on_report_group_id   (report_group_id)
 #
 # Foreign Keys
 #
 #  fk_rails_...  (custom_period_id => comparison_custom_periods.id)
-#  fk_rails_...  (report_group_id => comparison_report_groups.id)
 #
 class Comparison::Report < ApplicationRecord
   self.table_name = 'comparison_reports'
@@ -34,7 +31,7 @@ class Comparison::Report < ApplicationRecord
   translates :notes, backend: :action_text
 
   belongs_to :custom_period, class_name: 'Comparison::CustomPeriod', optional: true, autosave: true, dependent: :destroy
-  belongs_to :report_group, class_name: 'Comparison::ReportGroup'
+  belongs_to :report_group, class_name: 'Comparison::ReportGroup', optional: true
 
   accepts_nested_attributes_for :custom_period, update_only: true, reject_if: :not_custom?
 

--- a/app/models/comparison/report.rb
+++ b/app/models/comparison/report.rb
@@ -7,6 +7,7 @@
 #  id               :bigint(8)        not null, primary key
 #  key              :string           not null
 #  public           :boolean          default(FALSE)
+#  report_group_id  :bigint(8)
 #  reporting_period :integer
 #  updated_at       :datetime         not null
 #
@@ -14,10 +15,12 @@
 #
 #  index_comparison_reports_on_custom_period_id  (custom_period_id)
 #  index_comparison_reports_on_key               (key) UNIQUE
+#  index_comparison_reports_on_report_group_id   (report_group_id)
 #
 # Foreign Keys
 #
 #  fk_rails_...  (custom_period_id => comparison_custom_periods.id)
+#  fk_rails_...  (report_group_id => comparison_report_groups.id)
 #
 class Comparison::Report < ApplicationRecord
   self.table_name = 'comparison_reports'

--- a/app/models/comparison/report.rb
+++ b/app/models/comparison/report.rb
@@ -34,7 +34,7 @@ class Comparison::Report < ApplicationRecord
   translates :notes, backend: :action_text
 
   belongs_to :custom_period, class_name: 'Comparison::CustomPeriod', optional: true, autosave: true, dependent: :destroy
-  belongs_to :report_group, class_name: 'Comparison::ReportGroup', optional: true
+  belongs_to :report_group, class_name: 'Comparison::ReportGroup'
 
   scope :by_title, ->(order = :asc) { i18n.order(title: order) }
 

--- a/app/models/comparison/report.rb
+++ b/app/models/comparison/report.rb
@@ -36,6 +36,8 @@ class Comparison::Report < ApplicationRecord
   belongs_to :custom_period, class_name: 'Comparison::CustomPeriod', optional: true, autosave: true, dependent: :destroy
   belongs_to :report_group, class_name: 'Comparison::ReportGroup', optional: true
 
+  scope :by_title, ->(order = :asc) { i18n.order(title: order) }
+
   accepts_nested_attributes_for :custom_period, update_only: true, reject_if: :not_custom?
 
   before_validation -> { custom_period.try(:mark_for_destruction) if not_custom? }

--- a/app/models/comparison/report_group.rb
+++ b/app/models/comparison/report_group.rb
@@ -1,0 +1,23 @@
+# == Schema Information
+#
+# Table name: comparison_report_groups
+#
+#  created_at :datetime         not null
+#  id         :bigint(8)        not null, primary key
+#  position   :integer          default(0), not null
+#  updated_at :datetime         not null
+#
+class Comparison::ReportGroup < ApplicationRecord
+  self.table_name = 'comparison_report_groups'
+
+  extend Mobility
+  include TransifexSerialisable
+
+  has_many :reports, class_name: 'Comparison::Report'
+
+  translates :title, type: :string, fallbacks: { cy: :en }
+  translates :description, backend: :action_text
+
+  validates :title, presence: true
+  validates :position, numericality: true, presence: true
+end

--- a/app/models/comparison/report_group.rb
+++ b/app/models/comparison/report_group.rb
@@ -15,8 +15,10 @@ class Comparison::ReportGroup < ApplicationRecord
 
   has_many :reports, class_name: 'Comparison::Report'
 
+  scope :by_position, ->(order = :asc) { order(position: order) }
+
   translates :title, type: :string, fallbacks: { cy: :en }
-  translates :description, backend: :action_text
+  translates :description, type: :string, fallbacks: { cy: :en }
 
   validates :title, presence: true
   validates :position, numericality: true, presence: true

--- a/app/services/transifex/loader.rb
+++ b/app/services/transifex/loader.rb
@@ -35,6 +35,8 @@ module Transifex
         synchronise_resources(transifex_load, Comparison::Report.tx_resources)
         log('Synchronising Comparison Footnotes')
         synchronise_resources(transifex_load, Comparison::Footnote.tx_resources)
+        log('Synchronising Comparison Report Groups')
+        synchronise_resources(transifex_load, Comparison::ReportGroup.tx_resources)
 
         if EnergySparks::FeatureFlags.active?(:sync_advice_page_translations)
           log('Synchronising Advice Pages')

--- a/app/views/admin/comparisons/reports/_form.html.erb
+++ b/app/views/admin/comparisons/reports/_form.html.erb
@@ -8,6 +8,7 @@
       <%= render 'admin/shared/locale_tabs', f: f, field: :title do |locale| %>
         <%= f.input t_field(:title, locale), as: :string %>
       <% end %>
+      <%= f.association :report_group, label_method: :title, value_method: :id, include_blank: false %>
       <%= f.input :reporting_period,
                   collection: Comparison::Report.reporting_periods.keys,
                   label_method: ->(k) { k.humanize } %>

--- a/app/views/admin/comparisons/reports/index.html.erb
+++ b/app/views/admin/comparisons/reports/index.html.erb
@@ -5,6 +5,7 @@
     <tr>
       <th>Key</th>
       <th>Title</th>
+      <th>Group</th>
       <th>Reporting period</th>
       <th>Public</th>
       <th>Actions</th>
@@ -16,6 +17,7 @@
       <tr>
         <td><span class="badge badge-secondary"><%= report.key %></span></td>
         <td><%= report.title %></td>
+        <td><%= report.report_group.title %></td>
         <td>
           <%= report.reporting_period.try(:humanize) %>
           <%= "(#{report.custom_period})" if report.custom_period %>

--- a/app/views/admin/index.html.erb
+++ b/app/views/admin/index.html.erb
@@ -69,6 +69,7 @@
       <li><%= link_to 'Transport Types', admin_transport_types_path %></li>
       <li><%= link_to 'Videos', admin_videos_path %></li>
       <li><%= link_to 'Background Jobs', admin_good_job_path %></li>
+      <li><%= link_to 'Feature Flags', admin_flipper_path %></li>
       <li><%= link_to 'Admin meter statuses', admin_meter_statuses_path %></li>
       <li><%= link_to 'Funders', admin_funders_path %></li>
       <li><%= link_to 'Email previews', admin_mailer_previews_path %></li>

--- a/app/views/compare/benchmarks.html.erb
+++ b/app/views/compare/benchmarks.html.erb
@@ -6,35 +6,45 @@
 
 <h4><%= t('compare.benchmarks.description') %></h4>
 
-<% @benchmark_groups.each do |benchmark_group| %>
-  <div class="compare card mb-4">
-    <div class="card-header"><%= benchmark_group[:name] %></div>
-    <div class="card-body pb-0">
-      <div class="card-subtitle text-muted"><%= benchmark_group[:description] %></div>
-      <ul class="fa-ul card-columns">
-        <% if EnergySparks::FeatureFlags.active?(:comparison_reports) || current_user&.admin? %>
-          <% benchmark_group[:benchmarks].each do |key, title| %>
+<% if Flipper.enabled?(:comparison_reports, current_user) %>
+  <% Comparison::ReportGroup.by_position.each do |report_group| %>
+    <div class="compare card mb-4">
+      <div class="card-header"><%= report_group.title %></div>
+      <div class="card-body pb-0">
+        <div class="card-subtitle text-muted"><%= report_group.description %></div>
+        <ul class="fa-ul card-columns">
+          <% report_group.reports.by_title.each do |report| %>
             <li class="pt-1">
               <i class="fa-li fas fa-check"></i>
-                <% if comparison_page_exists?(key) %>
-                  <%= link_to Comparison::Report.find_by(key: key).try(:title),
-                              { controller: "/comparisons/#{key}" }.merge(@filter) %>
-                <% else %>
-                  <%= Comparison::Report.find_by(key: key).try(:title) %>
-                <% end %>
-                <% if EnergySparks::FeatureFlags.active?(:comparison_reports_link_to_old) || current_user&.admin? %>
-                  <%= link_to 'current', compare_path(key, @filter), class: 'badge badge-light' %>
-                <% end %>
-            </li>
+              <% if comparison_page_exists?(report.key) %>
+                <%= link_to report.title,
+                            { controller: "/comparisons/#{report.key}" }.merge(@filter) %>
+              <% else %>
+                <%= report.title %>
+              <% end %>
+              <% if Flipper.enabled?(:comparison_reports_link_to_old, current_user) %>
+                <%= link_to 'current', compare_path(report.key, @filter), class: 'badge badge-light' %>
+              <% end %>
+           </li>
           <% end %>
-        <% else %>
+        </ul>
+      </div>
+    </div>
+  <% end %>
+<% else %>
+  <% @benchmark_groups.each do |benchmark_group| %>
+    <div class="compare card mb-4">
+      <div class="card-header"><%= benchmark_group[:name] %></div>
+      <div class="card-body pb-0">
+        <div class="card-subtitle text-muted"><%= benchmark_group[:description] %></div>
+        <ul class="fa-ul card-columns">
           <% benchmark_group[:benchmarks].each do |key, title| %>
             <li class="pt-1"><i class="fa-li fas fa-check"></i>
               <%= link_to title, compare_path(key, @filter) %>
             </li>
           <% end %>
-        <% end %>
-      </ul>
+        </ul>
+      </div>
     </div>
-  </div>
+  <% end %>
 <% end %>

--- a/config/initializers/flipper.rb
+++ b/config/initializers/flipper.rb
@@ -1,0 +1,3 @@
+Flipper.register(:admins) do |actor, context|
+  actor.respond_to?(:admin?) && actor.admin?
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -710,6 +710,7 @@ Rails.application.routes.draw do
 
     authenticate :user, ->(user) { user.admin? } do
       mount GoodJob::Engine => 'good_job'
+      mount Flipper::UI.app(Flipper) => 'flipper', as: :flipper
     end
   end # Admin name space
 

--- a/db/migrate/20240501145002_create_comparison_report_groups.rb
+++ b/db/migrate/20240501145002_create_comparison_report_groups.rb
@@ -1,0 +1,10 @@
+class CreateComparisonReportGroups < ActiveRecord::Migration[6.1]
+  def change
+    create_table :comparison_report_groups do |t|
+      t.integer :position, default: 0, null: false
+      t.timestamps
+    end
+
+    add_reference :comparison_reports, :comparison_report_groups, foreign_key: :report_group_id, foreign_key: true
+  end
+end

--- a/db/migrate/20240501145002_create_comparison_report_groups.rb
+++ b/db/migrate/20240501145002_create_comparison_report_groups.rb
@@ -5,6 +5,6 @@ class CreateComparisonReportGroups < ActiveRecord::Migration[6.1]
       t.timestamps
     end
 
-    add_reference :comparison_reports, :comparison_report_groups, foreign_key: :report_group_id, foreign_key: true
+    add_reference :comparison_reports, :report_group, foreign_key: { to_table: :comparison_report_groups }
   end
 end

--- a/db/migrate/20240501145002_create_comparison_report_groups.rb
+++ b/db/migrate/20240501145002_create_comparison_report_groups.rb
@@ -5,6 +5,6 @@ class CreateComparisonReportGroups < ActiveRecord::Migration[6.1]
       t.timestamps
     end
 
-    add_reference :comparison_reports, :report_group, foreign_key: { to_table: :comparison_report_groups }
+    add_reference :comparison_reports, :report_group, null: true, foreign_key: { to_table: :comparison_report_groups }
   end
 end

--- a/db/migrate/20240507101407_create_flipper_tables.rb
+++ b/db/migrate/20240507101407_create_flipper_tables.rb
@@ -1,0 +1,22 @@
+class CreateFlipperTables < ActiveRecord::Migration[6.1]
+  def up
+    create_table :flipper_features do |t|
+      t.string :key, null: false
+      t.timestamps null: false
+    end
+    add_index :flipper_features, :key, unique: true
+
+    create_table :flipper_gates do |t|
+      t.string :feature_key, null: false
+      t.string :key, null: false
+      t.text :value
+      t.timestamps null: false
+    end
+    add_index :flipper_gates, [:feature_key, :key, :value], unique: true, length: { value: 255 }
+  end
+
+  def down
+    drop_table :flipper_gates
+    drop_table :flipper_features
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -692,10 +692,10 @@ ActiveRecord::Schema.define(version: 2024_05_01_145002) do
     t.bigint "custom_period_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.bigint "comparison_report_groups_id"
-    t.index ["comparison_report_groups_id"], name: "index_comparison_reports_on_comparison_report_groups_id"
+    t.bigint "report_group_id"
     t.index ["custom_period_id"], name: "index_comparison_reports_on_custom_period_id"
     t.index ["key"], name: "index_comparison_reports_on_key", unique: true
+    t.index ["report_group_id"], name: "index_comparison_reports_on_report_group_id"
   end
 
   create_table "configurations", force: :cascade do |t|
@@ -2018,7 +2018,7 @@ ActiveRecord::Schema.define(version: 2024_05_01_145002) do
   add_foreign_key "cluster_schools_users", "schools", on_delete: :cascade
   add_foreign_key "cluster_schools_users", "users", on_delete: :cascade
   add_foreign_key "comparison_reports", "comparison_custom_periods", column: "custom_period_id"
-  add_foreign_key "comparison_reports", "comparison_report_groups", column: "comparison_report_groups_id"
+  add_foreign_key "comparison_reports", "comparison_report_groups", column: "report_group_id"
   add_foreign_key "configurations", "schools", on_delete: :cascade
   add_foreign_key "consent_grants", "consent_statements"
   add_foreign_key "consent_grants", "schools"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_04_29_144652) do
+ActiveRecord::Schema.define(version: 2024_05_01_145002) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
@@ -679,6 +679,12 @@ ActiveRecord::Schema.define(version: 2024_04_29_144652) do
     t.index ["key"], name: "index_comparison_footnotes_on_key", unique: true
   end
 
+  create_table "comparison_report_groups", force: :cascade do |t|
+    t.integer "position", default: 0, null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
   create_table "comparison_reports", force: :cascade do |t|
     t.string "key", null: false
     t.boolean "public", default: false
@@ -686,6 +692,8 @@ ActiveRecord::Schema.define(version: 2024_04_29_144652) do
     t.bigint "custom_period_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.bigint "comparison_report_groups_id"
+    t.index ["comparison_report_groups_id"], name: "index_comparison_reports_on_comparison_report_groups_id"
     t.index ["custom_period_id"], name: "index_comparison_reports_on_custom_period_id"
     t.index ["key"], name: "index_comparison_reports_on_key", unique: true
   end
@@ -2010,6 +2018,7 @@ ActiveRecord::Schema.define(version: 2024_04_29_144652) do
   add_foreign_key "cluster_schools_users", "schools", on_delete: :cascade
   add_foreign_key "cluster_schools_users", "users", on_delete: :cascade
   add_foreign_key "comparison_reports", "comparison_custom_periods", column: "custom_period_id"
+  add_foreign_key "comparison_reports", "comparison_report_groups", column: "comparison_report_groups_id"
   add_foreign_key "configurations", "schools", on_delete: :cascade
   add_foreign_key "consent_grants", "consent_statements"
   add_foreign_key "consent_grants", "schools"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_04_29_144652) do
+ActiveRecord::Schema.define(version: 2024_05_01_145002) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
@@ -679,6 +679,12 @@ ActiveRecord::Schema.define(version: 2024_04_29_144652) do
     t.index ["key"], name: "index_comparison_footnotes_on_key", unique: true
   end
 
+  create_table "comparison_report_groups", force: :cascade do |t|
+    t.integer "position", default: 0, null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
   create_table "comparison_reports", force: :cascade do |t|
     t.string "key", null: false
     t.boolean "public", default: false
@@ -686,8 +692,10 @@ ActiveRecord::Schema.define(version: 2024_04_29_144652) do
     t.bigint "custom_period_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.bigint "report_group_id"
     t.index ["custom_period_id"], name: "index_comparison_reports_on_custom_period_id"
     t.index ["key"], name: "index_comparison_reports_on_key", unique: true
+    t.index ["report_group_id"], name: "index_comparison_reports_on_report_group_id"
   end
 
   create_table "configurations", force: :cascade do |t|
@@ -2010,6 +2018,7 @@ ActiveRecord::Schema.define(version: 2024_04_29_144652) do
   add_foreign_key "cluster_schools_users", "schools", on_delete: :cascade
   add_foreign_key "cluster_schools_users", "users", on_delete: :cascade
   add_foreign_key "comparison_reports", "comparison_custom_periods", column: "custom_period_id"
+  add_foreign_key "comparison_reports", "comparison_report_groups", column: "report_group_id"
   add_foreign_key "configurations", "schools", on_delete: :cascade
   add_foreign_key "consent_grants", "consent_statements"
   add_foreign_key "consent_grants", "schools"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_05_01_145002) do
+ActiveRecord::Schema.define(version: 2024_04_29_144652) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
@@ -679,12 +679,6 @@ ActiveRecord::Schema.define(version: 2024_05_01_145002) do
     t.index ["key"], name: "index_comparison_footnotes_on_key", unique: true
   end
 
-  create_table "comparison_report_groups", force: :cascade do |t|
-    t.integer "position", default: 0, null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-  end
-
   create_table "comparison_reports", force: :cascade do |t|
     t.string "key", null: false
     t.boolean "public", default: false
@@ -692,10 +686,8 @@ ActiveRecord::Schema.define(version: 2024_05_01_145002) do
     t.bigint "custom_period_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.bigint "report_group_id"
     t.index ["custom_period_id"], name: "index_comparison_reports_on_custom_period_id"
     t.index ["key"], name: "index_comparison_reports_on_key", unique: true
-    t.index ["report_group_id"], name: "index_comparison_reports_on_report_group_id"
   end
 
   create_table "configurations", force: :cascade do |t|
@@ -2018,7 +2010,6 @@ ActiveRecord::Schema.define(version: 2024_05_01_145002) do
   add_foreign_key "cluster_schools_users", "schools", on_delete: :cascade
   add_foreign_key "cluster_schools_users", "users", on_delete: :cascade
   add_foreign_key "comparison_reports", "comparison_custom_periods", column: "custom_period_id"
-  add_foreign_key "comparison_reports", "comparison_report_groups", column: "report_group_id"
   add_foreign_key "configurations", "schools", on_delete: :cascade
   add_foreign_key "consent_grants", "consent_statements"
   add_foreign_key "consent_grants", "schools"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_05_01_145002) do
+ActiveRecord::Schema.define(version: 2024_05_07_101407) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
@@ -935,6 +935,22 @@ ActiveRecord::Schema.define(version: 2024_05_01_145002) do
     t.index ["alert_id"], name: "index_find_out_mores_on_alert_id"
     t.index ["alert_type_rating_content_version_id"], name: "fom_fom_content_v_id"
     t.index ["content_generation_run_id"], name: "index_find_out_mores_on_content_generation_run_id"
+  end
+
+  create_table "flipper_features", force: :cascade do |t|
+    t.string "key", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["key"], name: "index_flipper_features_on_key", unique: true
+  end
+
+  create_table "flipper_gates", force: :cascade do |t|
+    t.string "feature_key", null: false
+    t.string "key", null: false
+    t.text "value"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["feature_key", "key", "value"], name: "index_flipper_gates_on_feature_key_and_key_and_value", unique: true
   end
 
   create_table "friendly_id_slugs", force: :cascade do |t|

--- a/lib/tasks/deployment/20240502154836_migrate_benchmark_groups.rake
+++ b/lib/tasks/deployment/20240502154836_migrate_benchmark_groups.rake
@@ -1,0 +1,33 @@
+namespace :after_party do
+  desc 'Deployment task: migrate_benchmark_groups'
+  task migrate_benchmark_groups: :environment do
+    puts "Running deploy task 'migrate_benchmark_groups'"
+
+    position = 0
+    Benchmarking::BenchmarkManager::CHART_TABLE_GROUPING.each do |key, benchmarks|
+      i18n_scope = "analytics.benchmarking.chart_table_grouping.#{key}"
+
+      title_en = I18n.t(:title, scope: i18n_scope, locale: :en)
+
+      report_group = Comparison::ReportGroup.i18n.find_or_initialize_by(title: title_en)
+      report_group.description_en = I18n.t(:description, scope: i18n_scope, locale: :en)
+
+      report_group.title_cy = I18n.t(:title, scope: i18n_scope, locale: :cy)
+      report_group.description_cy = I18n.t(:description, scope: i18n_scope, locale: :cy)
+      report_group.position = position
+      position+=1
+
+      benchmarks.each do |benchmark|
+        report = Comparison::Report.fetch(benchmark)
+        report_group.reports << report unless report_group.reports.include?(report)
+      end
+
+      report_group.save!
+    end
+
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord
+      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+  end
+end

--- a/lib/tasks/deployment/20240502154836_migrate_benchmark_groups.rake
+++ b/lib/tasks/deployment/20240502154836_migrate_benchmark_groups.rake
@@ -19,7 +19,8 @@ namespace :after_party do
 
       benchmarks.each do |benchmark|
         report = Comparison::Report.fetch(benchmark)
-        report_group.reports << report unless report_group.reports.include?(report)
+        report.report_group = report_group
+        report.save!
       end
 
       report_group.save!

--- a/lib/tasks/deployment/20240507103733_enable_comparison_reports_for_admins_feature_flag.rake
+++ b/lib/tasks/deployment/20240507103733_enable_comparison_reports_for_admins_feature_flag.rake
@@ -1,0 +1,14 @@
+namespace :after_party do
+  desc 'Deployment task: enable_comparison_reports_for_admins_feature_flag'
+  task enable_comparison_reports_for_admins_feature_flag: :environment do
+    puts "Running deploy task 'enable_comparison_reports_for_admins_feature_flag'"
+
+    Flipper.enable_group(:comparison_reports, :admins)
+    Flipper.enable_group(:comparison_reports_link_to_old, :admins)
+
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord
+      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+  end
+end

--- a/spec/factories/comparisons/report_groups.rb
+++ b/spec/factories/comparisons/report_groups.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :report_group, class: 'Comparison::ReportGroup' do
+    sequence(:title) {|n| "Title #{n}"}
+    sequence(:description) {|n| "Description #{n}"}
+    position { 0 }
+  end
+end

--- a/spec/factories/comparisons/reports.rb
+++ b/spec/factories/comparisons/reports.rb
@@ -7,6 +7,8 @@ FactoryBot.define do
     sequence(:introduction) {|n| "Introduction #{n}"}
     sequence(:notes) {|n| "Notes #{n}"}
     public { true }
+
+    initialize_with { Comparison::Report.find_or_create_by(key: key) }
   end
 
   trait :with_custom_period do

--- a/spec/factories/comparisons/reports.rb
+++ b/spec/factories/comparisons/reports.rb
@@ -1,6 +1,7 @@
 FactoryBot.define do
   factory :report, class: 'Comparison::Report' do
     reporting_period { :last_12_months }
+    report_group
     sequence(:key) {|n| "key#{n}"}
     sequence(:title) {|n| "Title #{n}"}
     sequence(:introduction) {|n| "Introduction #{n}"}

--- a/spec/models/comparison/report_group_spec.rb
+++ b/spec/models/comparison/report_group_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe Comparison::ReportGroup, type: :model do
+  describe 'validations' do
+    context 'with standard validations' do
+      subject(:report_group) { create :report_group }
+
+      it { expect(report_group).to be_valid }
+      it { expect(report_group).to validate_presence_of(:title) }
+      it { expect(report_group).to validate_presence_of(:position) }
+      it { expect(report_group).to validate_numericality_of(:position) }
+    end
+
+    context 'with relationships' do
+      subject(:report_group) { create :report_group }
+
+      it { expect(report_group).to have_many(:reports) }
+    end
+  end
+end

--- a/spec/models/comparison/report_spec.rb
+++ b/spec/models/comparison/report_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Comparison::Report, type: :model do
     context 'with relationships' do
       subject(:report) { create :report }
 
-      it { expect(report).to belong_to(:report_group) }
+      it { expect(report).to belong_to(:report_group).optional(true) }
     end
   end
 

--- a/spec/models/comparison/report_spec.rb
+++ b/spec/models/comparison/report_spec.rb
@@ -13,6 +13,12 @@ RSpec.describe Comparison::Report, type: :model do
       it { expect(report).not_to validate_presence_of(:notes) }
       it { expect(report).not_to validate_presence_of(:reporting_period) }
     end
+
+    context 'with relationships' do
+      subject(:report) { create :report }
+
+      it { expect(report).to belong_to(:report_group) }
+    end
   end
 
   it_behaves_like 'an enum reporting period', model: :report

--- a/spec/models/comparison/report_spec.rb
+++ b/spec/models/comparison/report_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Comparison::Report, type: :model do
     context 'with relationships' do
       subject(:report) { create :report }
 
-      it { expect(report).to belong_to(:report_group).optional(true) }
+      it { expect(report).to belong_to(:report_group).optional(false) }
     end
   end
 

--- a/spec/services/transifex/loader_spec.rb
+++ b/spec/services/transifex/loader_spec.rb
@@ -67,9 +67,9 @@ describe Transifex::Loader, type: :service do
     let!(:programme_type2)          { create(:programme_type, active: false) }
     let!(:transport_type)           { create(:transport_type) }
     let!(:consent_statement)        { create(:consent_statement) }
-    let!(:comparison_report)        { create(:report) }
-    let!(:comparison_footnote)      { create(:footnote) }
     let!(:comparison_report_group)  { create(:report_group) }
+    let!(:comparison_report)        { create(:report, report_group: comparison_report_group) }
+    let!(:comparison_footnote)      { create(:footnote) }
     let!(:advice_page)              { create(:advice_page, learn_more: advice_page_text) }
 
     before do

--- a/spec/services/transifex/loader_spec.rb
+++ b/spec/services/transifex/loader_spec.rb
@@ -69,6 +69,7 @@ describe Transifex::Loader, type: :service do
     let!(:consent_statement)        { create(:consent_statement) }
     let!(:comparison_report)        { create(:report) }
     let!(:comparison_footnote)      { create(:footnote) }
+    let!(:comparison_report_group)  { create(:report_group) }
     let!(:advice_page)              { create(:advice_page, learn_more: advice_page_text) }
 
     before do
@@ -78,11 +79,11 @@ describe Transifex::Loader, type: :service do
     end
 
     it 'updates the pull count' do
-      expect(TransifexLoad.first.pulled).to eq 11
+      expect(TransifexLoad.first.pulled).to eq 12
     end
 
     it 'updates the push count' do
-      expect(TransifexLoad.first.pushed).to eq 11
+      expect(TransifexLoad.first.pushed).to eq 12
     end
 
     context 'when advice page syncing is enabled' do
@@ -93,22 +94,22 @@ describe Transifex::Loader, type: :service do
       end
 
       it 'updates the pull count' do
-        expect(TransifexLoad.first.pulled).to eq 12
+        expect(TransifexLoad.first.pulled).to eq 13
       end
 
       it 'updates the push count' do
-        expect(TransifexLoad.first.pushed).to eq 12
+        expect(TransifexLoad.first.pushed).to eq 13
       end
 
       context 'when a record has no contents' do
         let!(:advice_page_text) { '' }
 
         it 'skips the pull' do
-          expect(TransifexLoad.first.pulled).to eq 11
+          expect(TransifexLoad.first.pulled).to eq 12
         end
 
         it 'skips the push' do
-          expect(TransifexLoad.first.pushed).to eq 11
+          expect(TransifexLoad.first.pushed).to eq 12
         end
       end
     end

--- a/spec/system/admin/comparisons/reports_spec.rb
+++ b/spec/system/admin/comparisons/reports_spec.rb
@@ -5,6 +5,7 @@ require 'rails_helper'
 shared_examples 'a report page with valid attributes' do |action:|
   before do
     fill_in 'Key', with: 'New key'
+    select 'Electricity', from: 'Report group'
     fill_in 'Title en', with: 'New title'
 
     select 'Custom', from: 'Reporting period'
@@ -28,6 +29,7 @@ shared_examples 'a report page with valid attributes' do |action:|
   it do
     expect(page).to have_selector(:table_row, { 'Key' => 'New key',
                                                 'Title' => 'New title',
+                                                'Group' => 'Electricity',
                                                 'Reporting period' =>
                                                   'Custom (comparing Current label to Previous label',
                                                 'Public' => '' })
@@ -59,7 +61,8 @@ end
 
 describe 'admin comparisons reports', :include_application_helper do
   let!(:admin)  { create(:admin) }
-  let!(:report) { create(:report) }
+  let!(:report_group) { create(:report_group, title: 'Electricity') }
+  let!(:report) { create(:report, report_group: report_group) }
 
   describe 'when not logged in' do
     context 'when viewing the index' do
@@ -98,6 +101,7 @@ describe 'admin comparisons reports', :include_application_helper do
           expect(page).to have_selector(:table_row,
                                         { 'Key' => report.key,
                                           'Reporting period' => report.reporting_period.humanize,
+                                          'Group' => report.report_group.title,
                                           'Title' => report.title,
                                           'Public' => '' })
         end

--- a/spec/system/admin/flipper_spec.rb
+++ b/spec/system/admin/flipper_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+RSpec.describe 'flipper', type: :system do
+  let(:admin) { create(:admin) }
+  let(:user) { create(:user) }
+
+  context 'when viewing the admin flipper web page' do
+    it 'is visible by an admin' do
+      sign_in(admin)
+      visit admin_flipper_path
+      expect(page).to have_content('Flipper')
+    end
+
+    it 'is not visible by a non-admin' do
+      (User.roles.keys - ['admin']).each do |role|
+        user.update(role: role)
+        sign_in(user)
+        expect { visit admin_flipper_path }.to raise_error(ActionController::RoutingError)
+      end
+    end
+  end
+end

--- a/spec/system/compare_spec.rb
+++ b/spec/system/compare_spec.rb
@@ -221,7 +221,7 @@ describe 'compare pages', :compare, type: :system do
   shared_context 'index page context' do |display_new_comparison_pages: false|
     before do
       if display_new_comparison_pages
-        Comparison::Report.find_or_create_by(key: 'baseload_per_pupil').update(title: 'Baseload per pupil', introduction: 'intro html', public: true)
+        create(:report, key: 'baseload_per_pupil', title: 'Baseload per pupil', introduction: 'intro html', public: true)
       else
         expect(Benchmarking::BenchmarkManager).to receive(:structured_pages).at_least(:once).and_return(benchmark_groups)
       end

--- a/spec/system/compare_spec.rb
+++ b/spec/system/compare_spec.rb
@@ -38,13 +38,13 @@ describe 'compare pages', :compare, type: :system do
     it { expect(page).to have_selector('h1', text: 'Baseload per pupil') }
     it { expect(page).to have_content('intro html') }
 
-    it 'allows report introduction to be edited', if: edit do
+    it 'allows report introduction to be edited', if: display_new_comparison_pages && edit do
       within('#intro') do
         expect(page).to have_link('Edit')
       end
     end
 
-    it 'does not allow report introduction to be edited', unless: edit do
+    it 'does not allow report introduction to be edited', unless: display_new_comparison_pages && edit do
       within('#intro') do
         expect(page).not_to have_link('Edit')
       end
@@ -229,12 +229,15 @@ describe 'compare pages', :compare, type: :system do
   end
 
   shared_context 'benchmarks page context' do |display_new_comparison_pages: false|
-    ### Ready for if we switch the benchmark group info over to the frontend
-    if display_new_comparison_pages || !display_new_comparison_pages
-      let(:content_manager)   { double(:content_manager) }
-      let!(:benchmark_run)    { BenchmarkResultSchoolGenerationRun.create(school: school, benchmark_result_generation_run: BenchmarkResultGenerationRun.create!) }
+    if display_new_comparison_pages
+      before do
+        create(:report_group, title: 'Benchmark group name', description: 'Benchmark description')
+      end
+    else
+      let!(:content_manager) { double(:content_manager) }
 
       before do
+        BenchmarkResultSchoolGenerationRun.create!(school: school, benchmark_result_generation_run: BenchmarkResultGenerationRun.create!)
         expect(Benchmarking::BenchmarkContentManager).to receive(:new).at_least(:once).and_return(content_manager)
         expect(content_manager).to receive(:structured_pages).at_least(:once).and_return(benchmark_groups)
       end
@@ -292,9 +295,8 @@ describe 'compare pages', :compare, type: :system do
 
   ## tests start here ##
 
-
   [true, false].each do |feature_flag|
-    context "when comparison report feature flag is set to #{feature_flag}" do
+    context "when comparison report feature flag is #{feature_flag}" do
       let(:user) {}
       let(:all_school_types) { School.school_types.keys }
       let!(:funder)          { create(:funder, name: 'Grant Funder') }
@@ -308,44 +310,53 @@ describe 'compare pages', :compare, type: :system do
       let(:benchmark_groups) { [{ name: 'Benchmark group name', description: 'Benchmark description', benchmarks: { baseload_per_pupil: 'Baseload per pupil' } }] }
 
       before do
+        feature_flag ? Flipper.enable(:comparison_reports) : Flipper.disable(:comparison_reports)
         sign_in(user) if user
       end
 
-      around do |example|
-        ClimateControl.modify FEATURE_FLAG_COMPARISON_REPORTS: feature_flag.to_s do
-          example.run
-        end
-      end
+      include_context 'index page context', display_new_comparison_pages: feature_flag
 
-      context 'when user is non-admin' do
-        include_context 'index page context', display_new_comparison_pages: feature_flag
+      before { visit compare_index_path }
 
-        before { visit compare_index_path }
+      context 'when user is logged in user with school group' do
+        let(:user) { create(:user, school_group: school_group) }
 
-        context 'when user is logged in user with school group' do
-          let(:user) { create(:user, school_group: school_group) }
+        it_behaves_like 'an index page', tab: 'Your group'
+
+        context "'Your group' filter tab" do
+          before { click_on 'Your group' }
 
           it_behaves_like 'an index page', tab: 'Your group'
 
-          context "'Your group' filter tab" do
-            before { click_on 'Your group' }
+          it { expect(page).to have_content "Compare all schools within #{user.school_group_name}" }
+          it_behaves_like 'a form filter', id: '#group', school_types_excluding: [] # show all
 
-            it_behaves_like 'an index page', tab: 'Your group'
+          context 'Benchmark page' do
+            include_context 'benchmarks page context', display_new_comparison_pages: feature_flag
 
-            it { expect(page).to have_content "Compare all schools within #{user.school_group_name}" }
-            it_behaves_like 'a form filter', id: '#group', school_types_excluding: [] # show all
-
-            context 'Benchmark page' do
-              include_context 'benchmarks page context', display_new_comparison_pages: feature_flag
-
-              before do
-                within '#group' do
-                  uncheck 'Junior'
-                  click_on 'Compare schools'
-                end
+            before do
+              within '#group' do
+                uncheck 'Junior'
+                click_on 'Compare schools'
               end
+            end
 
-              it_behaves_like 'a benchmark list page'
+            it_behaves_like 'a benchmark list page'
+            it_behaves_like 'a filter summary', school_types_excluding: ['junior']
+
+            context 'Changing options' do
+              before { click_on 'Change options' }
+
+              it_behaves_like 'an index page', tab: 'Your group'
+              it_behaves_like 'a form filter', id: '#group', school_types_excluding: ['junior']
+            end
+
+            context 'results page' do
+              include_context 'results page context', display_new_comparison_pages: feature_flag
+
+              before { click_on 'Baseload per pupil' }
+
+              it_behaves_like 'a results page', display_new_comparison_pages: feature_flag
               it_behaves_like 'a filter summary', school_types_excluding: ['junior']
 
               context 'Changing options' do
@@ -354,45 +365,45 @@ describe 'compare pages', :compare, type: :system do
                 it_behaves_like 'an index page', tab: 'Your group'
                 it_behaves_like 'a form filter', id: '#group', school_types_excluding: ['junior']
               end
-
-              context 'results page' do
-                include_context 'results page context', display_new_comparison_pages: feature_flag
-
-                before { click_on 'Baseload per pupil' }
-
-                it_behaves_like 'a results page', display_new_comparison_pages: feature_flag
-                it_behaves_like 'a filter summary', school_types_excluding: ['junior']
-
-                context 'Changing options' do
-                  before { click_on 'Change options' }
-
-                  it_behaves_like 'an index page', tab: 'Your group'
-                  it_behaves_like 'a form filter', id: '#group', school_types_excluding: ['junior']
-                end
-              end
             end
           end
+        end
 
-          context "'Country' filter tab" do
-            before { click_on 'Choose country' }
+        context "'Country' filter tab" do
+          before { click_on 'Choose country' }
 
-            it_behaves_like 'an index page', tab: 'Choose country'
-            it { expect(page).to have_content 'Compare schools by country' }
+          it_behaves_like 'an index page', tab: 'Choose country'
+          it { expect(page).to have_content 'Compare schools by country' }
 
-            it_behaves_like 'a form filter', id: '#country', country: 'All countries'
+          it_behaves_like 'a form filter', id: '#country', country: 'All countries'
 
-            context 'Benchmark page' do
-              include_context 'benchmarks page context', display_new_comparison_pages: feature_flag
+          context 'Benchmark page' do
+            include_context 'benchmarks page context', display_new_comparison_pages: feature_flag
 
-              before do
-                within '#country' do
-                  choose 'Scotland'
-                  uncheck 'Middle'
-                  click_on 'Compare schools'
-                end
+            before do
+              within '#country' do
+                choose 'Scotland'
+                uncheck 'Middle'
+                click_on 'Compare schools'
               end
+            end
 
-              it_behaves_like 'a benchmark list page'
+            it_behaves_like 'a benchmark list page'
+            it_behaves_like 'a filter summary', country: 'Scotland', school_types_excluding: ['middle']
+
+            context 'Changing options' do
+              before { click_on 'Change options' }
+
+              it_behaves_like 'an index page', tab: 'Choose country'
+              it_behaves_like 'a form filter', id: '#country', country: 'scotland', school_types_excluding: ['middle']
+            end
+
+            context 'results page' do
+              include_context 'results page context', display_new_comparison_pages: feature_flag
+
+              before { click_on 'Baseload per pupil' }
+
+              it_behaves_like 'a results page', display_new_comparison_pages: feature_flag
               it_behaves_like 'a filter summary', country: 'Scotland', school_types_excluding: ['middle']
 
               context 'Changing options' do
@@ -401,45 +412,45 @@ describe 'compare pages', :compare, type: :system do
                 it_behaves_like 'an index page', tab: 'Choose country'
                 it_behaves_like 'a form filter', id: '#country', country: 'scotland', school_types_excluding: ['middle']
               end
-
-              context 'results page' do
-                include_context 'results page context', display_new_comparison_pages: feature_flag
-
-                before { click_on 'Baseload per pupil' }
-
-                it_behaves_like 'a results page', display_new_comparison_pages: feature_flag
-                it_behaves_like 'a filter summary', country: 'Scotland', school_types_excluding: ['middle']
-
-                context 'Changing options' do
-                  before { click_on 'Change options' }
-
-                  it_behaves_like 'an index page', tab: 'Choose country'
-                  it_behaves_like 'a form filter', id: '#country', country: 'scotland', school_types_excluding: ['middle']
-                end
-              end
             end
           end
+        end
 
-          context "'Type' filter tab" do
-            before { click_on 'Choose type' }
+        context "'Type' filter tab" do
+          before { click_on 'Choose type' }
 
-            it_behaves_like 'an index page', tab: 'Choose type'
-            it { expect(page).to have_content 'Compare schools by type' }
+          it_behaves_like 'an index page', tab: 'Choose type'
+          it { expect(page).to have_content 'Compare schools by type' }
 
-            it_behaves_like 'a form filter', id: '#type', school_type: []
+          it_behaves_like 'a form filter', id: '#type', school_type: []
 
-            context 'Benchmark page' do
-              include_context 'benchmarks page context', display_new_comparison_pages: feature_flag
+          context 'Benchmark page' do
+            include_context 'benchmarks page context', display_new_comparison_pages: feature_flag
 
-              before do
-                within '#type' do
-                  select 'Primary'
-                  click_on 'Compare schools'
-                end
+            before do
+              within '#type' do
+                select 'Primary'
+                click_on 'Compare schools'
               end
+            end
 
+            it_behaves_like 'a filter summary', school_types: ['primary']
+            it_behaves_like 'a benchmark list page'
+
+            context 'Changing options' do
+              before { click_on 'Change options' }
+
+              it_behaves_like 'an index page', tab: 'Choose type'
+              it_behaves_like 'a form filter', id: '#type', school_type: 'Primary'
+            end
+
+            context 'results page' do
+              include_context 'results page context', display_new_comparison_pages: feature_flag
+
+              before { click_on 'Baseload per pupil' }
+
+              it_behaves_like 'a results page', display_new_comparison_pages: feature_flag
               it_behaves_like 'a filter summary', school_types: ['primary']
-              it_behaves_like 'a benchmark list page'
 
               context 'Changing options' do
                 before { click_on 'Change options' }
@@ -447,100 +458,80 @@ describe 'compare pages', :compare, type: :system do
                 it_behaves_like 'an index page', tab: 'Choose type'
                 it_behaves_like 'a form filter', id: '#type', school_type: 'Primary'
               end
-
-              context 'results page' do
-                include_context 'results page context', display_new_comparison_pages: feature_flag
-
-                before { click_on 'Baseload per pupil' }
-
-                it_behaves_like 'a results page', display_new_comparison_pages: feature_flag
-                it_behaves_like 'a filter summary', school_types: ['primary']
-
-                context 'Changing options' do
-                  before { click_on 'Change options' }
-
-                  it_behaves_like 'an index page', tab: 'Choose type'
-                  it_behaves_like 'a form filter', id: '#type', school_type: 'Primary'
-                end
-              end
             end
           end
+        end
 
-          context "'Groups' filter tab" do
-            before { click_on 'Choose groups' }
+        context "'Groups' filter tab" do
+          before { click_on 'Choose groups' }
 
-            it_behaves_like 'an index page', tab: 'Choose groups'
-            it { expect(page).to have_content 'Compare schools in groups' }
-            it_behaves_like 'a form filter', id: '#groups', school_group_list: ['Group 1', 'Group 2'], school_groups: [], school_types_excluding: [] # show all
+          it_behaves_like 'an index page', tab: 'Choose groups'
+          it { expect(page).to have_content 'Compare schools in groups' }
+          it_behaves_like 'a form filter', id: '#groups', school_group_list: ['Group 1', 'Group 2'], school_groups: [], school_types_excluding: [] # show all
 
-            context 'Benchmark page' do
-              include_context 'benchmarks page context', display_new_comparison_pages: feature_flag
+          context 'Benchmark page' do
+            include_context 'benchmarks page context', display_new_comparison_pages: feature_flag
 
+            before do
+              within '#groups' do
+                select 'Group 1'
+                select 'Group 2'
+                uncheck 'Infant'
+                click_on 'Compare schools'
+              end
+            end
+
+            it_behaves_like 'a benchmark list page'
+            it_behaves_like 'a filter summary', school_types_excluding: ['infant'], school_groups: ['Group 1', 'Group 2']
+
+            context 'Changing options' do
+              before { click_on 'Change options' }
+
+              it_behaves_like 'an index page', tab: 'Choose groups'
+              it_behaves_like 'a form filter', id: '#groups', school_group_list: ['Group 1', 'Group 2'], school_groups: ['Group 1', 'Group 2'], school_types_excluding: ['infant']
+            end
+
+            context 'Filtering all schools' do
               before do
+                click_on 'Change options'
                 within '#groups' do
-                  select 'Group 1'
-                  select 'Group 2'
-                  uncheck 'Infant'
+                  uncheck 'Primary'
                   click_on 'Compare schools'
                 end
               end
 
-              it_behaves_like 'a benchmark list page'
+              it_behaves_like 'a filter summary', school_types_excluding: ['infant'], school_groups: ['Group 1', 'Group 2']
+              it_behaves_like 'an empty filter notice'
+            end
+
+            context 'results page' do
+              include_context 'results page context', display_new_comparison_pages: feature_flag
+
+              before { click_on 'Baseload per pupil' }
+
+              it_behaves_like 'a results page', display_new_comparison_pages: feature_flag
               it_behaves_like 'a filter summary', school_types_excluding: ['infant'], school_groups: ['Group 1', 'Group 2']
 
               context 'Changing options' do
                 before { click_on 'Change options' }
 
                 it_behaves_like 'an index page', tab: 'Choose groups'
-                it_behaves_like 'a form filter', id: '#groups', school_group_list: ['Group 1', 'Group 2'], school_groups: ['Group 1', 'Group 2'], school_types_excluding: ['infant']
-              end
-
-              context 'Filtering all schools' do
-                before do
-                  click_on 'Change options'
-                  within '#groups' do
-                    uncheck 'Primary'
-                    click_on 'Compare schools'
-                  end
-                end
-
-                it_behaves_like 'a filter summary', school_types_excluding: ['infant'], school_groups: ['Group 1', 'Group 2']
-                it_behaves_like 'an empty filter notice'
-              end
-
-              context 'results page' do
-                include_context 'results page context', display_new_comparison_pages: feature_flag
-
-                before { click_on 'Baseload per pupil' }
-
-                it_behaves_like 'a results page', display_new_comparison_pages: feature_flag
-                it_behaves_like 'a filter summary', school_types_excluding: ['infant'], school_groups: ['Group 1', 'Group 2']
-
-                context 'Changing options' do
-                  before { click_on 'Change options' }
-
-                  it_behaves_like 'an index page', tab: 'Choose groups'
-                  it_behaves_like 'a form filter', id: '#groups', school_groups: ['Group 1', 'Group 2'], school_types_excluding: ['infant']
-                end
+                it_behaves_like 'a form filter', id: '#groups', school_groups: ['Group 1', 'Group 2'], school_types_excluding: ['infant']
               end
             end
           end
         end
-
-        context 'when user is logged out' do
-          let(:user) {}
-
-          it_behaves_like 'an index page', tab: 'Choose country', show_your_group_tab: false
-          it_behaves_like 'a form filter', id: '#groups', school_group_list: ['Group 1', 'Group 2']
-        end
       end
 
-      context 'when user is an admin' do
+      context 'when user is logged out' do
+        let(:user) {}
+
+        it_behaves_like 'an index page', tab: 'Choose country', show_your_group_tab: false
+        it_behaves_like 'a form filter', id: '#groups', school_group_list: ['Group 1', 'Group 2']
+      end
+
+      context 'When user is admin' do
         let(:user) { create(:admin) }
-
-        include_context 'index page context', display_new_comparison_pages: true
-
-        before { visit compare_index_path }
 
         context "'Country' filter tab" do
           before { click_on 'Choose country' }
@@ -553,7 +544,7 @@ describe 'compare pages', :compare, type: :system do
           it_behaves_like 'a form filter', id: '#groups', school_group_list: ['Group 1', 'Group 2', 'Not Public']
 
           context 'Benchmark page' do
-            include_context 'benchmarks page context', display_new_comparison_pages: true
+            include_context 'benchmarks page context', display_new_comparison_pages: feature_flag
 
             before do
               within '#country' do
@@ -581,11 +572,11 @@ describe 'compare pages', :compare, type: :system do
             end
 
             context 'results page' do
-              include_context 'results page context', display_new_comparison_pages: true
+              include_context 'results page context', display_new_comparison_pages: feature_flag
 
               before { click_on 'Baseload per pupil' }
 
-              it_behaves_like 'a results page', display_new_comparison_pages: true, edit: true
+              it_behaves_like 'a results page', display_new_comparison_pages: feature_flag, edit: true
               it_behaves_like 'a filter summary', country: 'Scotland', school_types_excluding: ['middle']
               it_behaves_like 'a filter summary', funder: 'Grant Funder'
 
@@ -603,10 +594,8 @@ describe 'compare pages', :compare, type: :system do
   end
 
   context 'when comparison report feature is switched on' do
-    around do |example|
-      ClimateControl.modify FEATURE_FLAG_COMPARISON_REPORTS: 'true' do
-        example.run
-      end
+    before do
+      Flipper.enable :comparison_reports
     end
 
     describe 'displaying unlisted schools on the results page' do


### PR DESCRIPTION
**Adds flipper**

- [x] Add a Comparison Report Group model. It will have a title, description (as currently shown on the list) and an order (numeric). It may have many Comparison Reports
- [x] The Report Group title and description should be synched with Transifex
- [x] We migrate the existing report group title, description from the YAML and order from the existing configuration
- [x] We generate the comparison report index from the report groups and reports. The groups are ordered by their order.
- [x] Within a group the reports are ordered by name.
- [x] We update Comparison::Report so that is belong to a report group, updating the forms to allow the report group to be picked by an admin. A Report must have a group

Doing the next tasks as a new branch
- Create admin interface for report groups and add inline edit buttons. Don't allow those attached to a report to be deleted. 
- Add Comparison admin menu to all comparison admin pages
