### PR TITLE
Fix where clause for annual change in electricity use

### DIFF
--- a/app/models/comparison/change_in_electricity_since_last_year.rb
+++ b/app/models/comparison/change_in_electricity_since_last_year.rb
@@ -13,5 +13,5 @@
 #  solar_type                    :text
 #
 class Comparison::ChangeInElectricitySinceLastYear < Comparison::View
-  scope :with_data, -> { where.not(previous_year_electricity_kwh: nil, current_year_electricity_kwh: nil) }
+  scope :with_data, -> { where('previous_year_electricity_kwh IS NOT NULL AND current_year_electricity_kwh IS NOT NULL') }
 end


### PR DESCRIPTION
Where clause was only removing schools where BOTH previous and current year kwh values were not null. It should be excluding any school whether EITHER value is null.