### PR TITLE
Reporting period quick fix

### DIFF
--- a/app/services/alerts/adapters/analytics_adapter.rb
+++ b/app/services/alerts/adapters/analytics_adapter.rb
@@ -64,8 +64,11 @@ module Alerts
           table_data: analysis_object.front_end_template_table_data,
           priority_data: analysis_object.priority_template_data,
           variables: rename_variables(convert_for_storage(analysis_object.variables_for_reporting)),
-          reporting_period: analysis_object.try(:reporting_period)
         }
+
+        if defined? analysis_object.reporting_period
+          variable_data[:reporting_period] = analysis_object.reporting_period
+        end
 
         I18n.with_locale(:cy) do
           variable_data[:template_data_cy] = analysis_object.front_end_template_data

--- a/app/services/alerts/adapters/analytics_adapter.rb
+++ b/app/services/alerts/adapters/analytics_adapter.rb
@@ -64,7 +64,7 @@ module Alerts
           table_data: analysis_object.front_end_template_table_data,
           priority_data: analysis_object.priority_template_data,
           variables: rename_variables(convert_for_storage(analysis_object.variables_for_reporting)),
-          reporting_period: analysis_object.reporting_period
+          reporting_period: analysis_object.try(:reporting_period)
         }
 
         I18n.with_locale(:cy) do

--- a/spec/services/alerts/adapters/analytics_adapter_spec.rb
+++ b/spec/services/alerts/adapters/analytics_adapter_spec.rb
@@ -287,5 +287,23 @@ module Alerts
         )
       end
     end
+
+    context 'when reporting_period is undefined' do
+      class DummyAlertWithMissingMethod < DummyAnalyticsAlertClass
+        undef_method :reporting_period
+
+        def self.alert_type
+          FactoryBot.create :alert_type,
+            class_name: 'Alerts::DummyAlertWithMissingMethod',
+            source: :analytics
+        end
+      end
+
+      subject(:normalised_report) { Adapters::AnalyticsAdapter.new(alert_type: DummyAlertWithMissingMethod.alert_type, school: school, analysis_date: analysis_date, aggregate_school: aggregate_school).report }
+
+      it 'returns nil' do
+        expect(normalised_report.reporting_period).to eq(nil)
+      end
+    end
   end
 end


### PR DESCRIPTION
A quick fix to the issue reported by Leigh: https://app.rollbar.com/a/energysparks/fix/item/EnergySparksProduction/3411#detail

This is more of a sticking plaster fix, I think there is a better fix.

Quick investigation shows that reporting_period is not defined in all analysis_object objects, just those that inherit from AlertAnalysisBase, this is why the error is occurring when reporting_period is called on non-alert analysis objects. Other methods used in the same method (such as  front_end_template_data) are defined in ContentBase. 

So perhaps we need to check that the object is an alert before we call reporting_period on it. Or define reporting_period in ContentBase and have it returning nil - although I'm not sure that would be the right solution.