### PR TITLE
Hot water efficiency - filter out 0 cost per pupil

### DIFF
--- a/app/models/comparison/hot_water_efficiency.rb
+++ b/app/models/comparison/hot_water_efficiency.rb
@@ -11,6 +11,6 @@
 #  school_id                                  :bigint(8)
 #
 class Comparison::HotWaterEfficiency < Comparison::View
-  scope :with_data, -> { where.not(avg_gas_per_pupil_gbp: nil) }
+  scope :with_data, -> { where.not(avg_gas_per_pupil_gbp: [nil, 0.0]) }
   scope :sort_default, -> { order(avg_gas_per_pupil_gbp: :desc) }
 end


### PR DESCRIPTION
Looking at the advice page there are additional relevance checks at https://github.com/Energy-Sparks/energy-sparks/blob/51fa420b14454b3f441b2e6ef5e65fbb8185e7d1/app/controllers/schools/advice/hot_water_controller.rb#L30 that  cause it to not show the analysis

Looks like for the efficiency to be infinite this estimate is coming out at zero
https://github.com/Energy-Sparks/energy-sparks_analytics/blob/53d0dfab07e93e972774429c2b84a10246f7f6d6/lib/dashboard/modelling/heating/hot_water_investment_analysis.rb#L61
