### PR TITLE
Fix issue with partially configured solar meters

### DIFF
--- a/app/services/schools/advice/baseload_service.rb
+++ b/app/services/schools/advice/baseload_service.rb
@@ -169,7 +169,7 @@ module Schools
       end
 
       def electricity_meters
-        @electricity_meters ||= @meter_collection.electricity_meters
+        @electricity_meters ||= @meter_collection.electricity_meters.select { |meter| meter.fuel_type == :electricity }
       end
 
       def aggregate_meter

--- a/spec/services/schools/advice/baseload_service_spec.rb
+++ b/spec/services/schools/advice/baseload_service_spec.rb
@@ -219,6 +219,16 @@ RSpec.describe Schools::Advice::BaseloadService, type: :service do
         expect(result['meter1'].to_h.keys).to match_array([:meter, :enough_data?, :data_available_from])
       end
     end
+
+    context 'when there is a solar meter that hasnt been configured' do
+      let(:solar_meter) { double(mpan_mprn: 'solar_meter', amr_data: double(end_date: Date.parse('20200101')), fuel_type: :solar_pv, aggregate_meter?: false) }
+      let(:electricity_meters) { [electricity_meter_1, electricity_meter_2, solar_meter] }
+
+      it 'returns variation for the actual electricity meters only' do
+        result = service.seasonal_variation_by_meter
+        expect(result.keys).to match_array(%w[meter1 meter2])
+      end
+    end
   end
 
   describe '#intraweek_variation' do
@@ -269,8 +279,8 @@ RSpec.describe Schools::Advice::BaseloadService, type: :service do
   end
 
   describe '#date_ranges_by_meter' do
-    let(:electricity_meter_1) { double(mpan_mprn: 'meter1', amr_data: double(start_date: Date.parse('20190101'), end_date: Date.parse('20200101'))) }
-    let(:electricity_meter_2) { double(mpan_mprn: 'meter2', amr_data: double(start_date: Date.parse('20180101'), end_date: Date.parse('20210101'))) }
+    let(:electricity_meter_1) { double(mpan_mprn: 'meter1', fuel_type: :electricity, amr_data: double(start_date: Date.parse('20190101'), end_date: Date.parse('20200101'))) }
+    let(:electricity_meter_2) { double(mpan_mprn: 'meter2', fuel_type: :electricity, amr_data: double(start_date: Date.parse('20180101'), end_date: Date.parse('20210101'))) }
     let(:electricity_meters) { [electricity_meter_1, electricity_meter_2] }
 
     it 'returns date ranges' do


### PR DESCRIPTION
The BaseloadService currently attempts to generation seasonal (and intraday) variations for all electricity meters:

```
@electricity_meters ||= @meter_collection.electricity_meters
```

When a MeterCollection is setup by the application it initially includes all types of electricity meters, including solar generation and export meters. During the aggregation process the list of electricity meters is updated so that it only contains mains meters.

It turns out there's a subtle bug which can occur when there's an incompletely configured solar setup:

- an admin has added a solar_pv meter
- data has been loaded for the solar_pv meter, e.g. by backfilling from a CSV file
- the meter attributes configuring the solar panels have not been added
- a user visits the baseload analysis page

In the above scenario the solar pv meter will remain in the list of electricity meters which causes errors when attempting to calculate the seasonal variation as we don't support doing that for solar_pv or export meters.

The PR fixes this by ensuring that we only fetch the electricity meters from the list.

Likely to only happen during the process of configuring a school.