### PR TITLE
Fix heating coming on too early comparison

### DIFF
--- a/app/controllers/comparisons/heating_coming_on_too_early_controller.rb
+++ b/app/controllers/comparisons/heating_coming_on_too_early_controller.rb
@@ -38,7 +38,7 @@ module Comparisons
     end
 
     def load_data
-      Comparison::HeatingComingOnTooEarly.for_schools(@schools)
+      Comparison::HeatingComingOnTooEarly.for_schools(@schools).with_data.sort_default
     end
 
     def create_charts(results)

--- a/app/models/comparison/heating_coming_on_too_early.rb
+++ b/app/models/comparison/heating_coming_on_too_early.rb
@@ -18,6 +18,9 @@
 class Comparison::HeatingComingOnTooEarly < Comparison::View
   self.table_name = :heating_coming_on_too_early
 
+  scope :with_data, -> { where.not(avg_week_start_time: nil, average_start_time_hh_mm: nil) }
+  scope :sort_default, -> { joins(:school).order('schools.name') }
+
   def avg_week_start_time_to_time_of_day
     avg_week_start_time.nil? ? '' : TimeOfDay.from_time(avg_week_start_time)
   end

--- a/spec/system/comparisons/heating_coming_on_too_early_spec.rb
+++ b/spec/system/comparisons/heating_coming_on_too_early_spec.rb
@@ -88,9 +88,9 @@ describe 'heating_coming_on_too_early' do
 
       let(:expected_table) do
         [headers,
-         [schools[2].name, '', '13:03', ''],
-         [schools[1].name, '13:02', '', '£1.10'],
          ["#{schools[0].name} [5]", '13:00', '13:01', '10p'],
+         [schools[1].name, '13:02', '', '£1.10'],
+         [schools[2].name, '', '13:03', ''],
          ["Notes\n[5] The tariff has changed during the last year for this school. Savings are calculated using the " \
           "latest tariff but other £ values are calculated using the relevant tariff at the time\n" \
           "In school comparisons 'last year' is defined as this year to date."]]
@@ -98,9 +98,9 @@ describe 'heating_coming_on_too_early' do
 
       let(:expected_csv) do
         [headers,
-         [schools[2].name, '', '13:03', ''],
+         [schools[0].name, '13:00', '13:01', '0.1'],
          [schools[1].name, '13:02', '', '1.1'],
-         [schools[0].name, '13:00', '13:01', '0.1']]
+         [schools[2].name, '', '13:03', '']]
       end
     end
 
@@ -118,9 +118,9 @@ describe 'heating_coming_on_too_early' do
 
       let(:expected_table) do
         [headers,
+         [schools[0].name, '13:01', '0.2', '0.3', '0.4', '0.5', '0.6', '13:00'],
          [schools[1].name, '', '', '', '', '', '', '13:02'],
-         [schools[2].name, '13:03', '2.1', '2.2', '2.3', '2.4', '2.5', ''],
-         [schools[0].name, '13:01', '0.2', '0.3', '0.4', '0.5', '0.6', '13:00']]
+         [schools[2].name, '13:03', '2.1', '2.2', '2.3', '2.4', '2.5', '']]
       end
 
       let(:expected_csv) do


### PR DESCRIPTION
Report was including schools that didn't have any gas data, or enough gas data to analyse. Have fixed this by adding a where clauses that checks that some data is available.

Also added a sort based on school name so that there is a consistent order across both tables.
