### PR TITLE
Exclude schools with poor thermostatic control from 1C saving report

### DIFF
--- a/app/models/comparison/thermostat_sensitivity.rb
+++ b/app/models/comparison/thermostat_sensitivity.rb
@@ -8,6 +8,6 @@
 #  school_id                    :bigint(8)
 #
 class Comparison::ThermostatSensitivity < Comparison::View
-  scope :with_data, -> { where.not(annual_saving_1_C_change_gbp: nil) }
+  scope :with_data, -> { where('"annual_saving_1_C_change_gbp" IS NOT NULL and "annual_saving_1_C_change_gbp" > 0.0') }
   scope :sort_default, -> { order(annual_saving_1_C_change_gbp: :desc) }
 end


### PR DESCRIPTION
If a school has very poor thermostatic control then our heating modelling cannot produce sensible savings from a 1C change in thermostat.

The current report just includes these schools with a note to explain negative values. For the new report we will filter these out.