### PR TITLE
Add redirects from old comparison report urls to new

### DIFF
--- a/app/controllers/compare_controller.rb
+++ b/app/controllers/compare_controller.rb
@@ -6,7 +6,7 @@ class CompareController < ApplicationController
   before_action :benchmark_groups, only: [:benchmarks]
 
   before_action :set_school_groups, only: [:index]
-  before_action :comparison_report_redirect, only: [:show]
+  before_action :comparison_reports_redirect, only: [:show]
   before_action :set_included_schools, only: [:benchmarks, :show]
   helper_method :index_params
 
@@ -103,7 +103,7 @@ class CompareController < ApplicationController
     @school_groups = ComparisonService.new(current_user).list_school_groups.select(&:has_visible_schools?)
   end
 
-  def comparison_report_redirect
+  def comparison_reports_redirect
     if Flipper.enabled?(:comparison_reports_redirect, current_user)
       redirect_to controller: "comparisons/#{filter.delete(:benchmark)}", **filter
     end

--- a/app/controllers/compare_controller.rb
+++ b/app/controllers/compare_controller.rb
@@ -6,6 +6,7 @@ class CompareController < ApplicationController
   before_action :benchmark_groups, only: [:benchmarks]
 
   before_action :set_school_groups, only: [:index]
+  before_action :comparison_report_redirect, only: [:show]
   before_action :set_included_schools, only: [:benchmarks, :show]
   helper_method :index_params
 
@@ -100,5 +101,11 @@ class CompareController < ApplicationController
   # Set list of school groups visible to this user
   def set_school_groups
     @school_groups = ComparisonService.new(current_user).list_school_groups.select(&:has_visible_schools?)
+  end
+
+  def comparison_report_redirect
+    if Flipper.enabled?(:comparison_reports_redirect, current_user)
+      redirect_to controller: "comparisons/#{filter.delete(:benchmark)}", **filter
+    end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -133,7 +133,7 @@ Rails.application.routes.draw do
     get '*key', to: 'configurable_period#index', as: :configurable_period
   end
 
-  # older version of benchmarks redirect
+  # redirect old benchmark URLs
   get '/benchmarks', to: redirect('/compare')
   get '/benchmark', to: redirect(BenchmarkRedirector.new)
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -75,10 +75,6 @@ Rails.application.routes.draw do
     end
   end
 
-  # older version of benchmarks redirect
-  get '/benchmarks', to: redirect('/compare')
-  get '/benchmark', to: redirect(BenchmarkRedirector.new)
-
   resources :compare, controller: 'compare', param: :benchmark, only: [:index, :show] do
     collection do
       get :benchmarks
@@ -136,6 +132,10 @@ Rails.application.routes.draw do
     get '*key/unlisted', to: 'configurable_period#unlisted'
     get '*key', to: 'configurable_period#index', as: :configurable_period
   end
+
+  # older version of benchmarks redirect
+  get '/benchmarks', to: redirect('/compare')
+  get '/benchmark', to: redirect(BenchmarkRedirector.new)
 
   get 'version', to: 'version#show'
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -75,6 +75,10 @@ Rails.application.routes.draw do
     end
   end
 
+  # older version of benchmarks redirect
+  get '/benchmarks', to: redirect('/compare')
+  get '/benchmark', to: redirect(BenchmarkRedirector.new)
+
   resources :compare, controller: 'compare', param: :benchmark, only: [:index, :show] do
     collection do
       get :benchmarks
@@ -132,10 +136,6 @@ Rails.application.routes.draw do
     get '*key/unlisted', to: 'configurable_period#unlisted'
     get '*key', to: 'configurable_period#index', as: :configurable_period
   end
-
-  # redirect old benchmark URLs
-  get '/benchmarks', to: redirect('/compare')
-  get '/benchmark', to: redirect(BenchmarkRedirector.new)
 
   get 'version', to: 'version#show'
 

--- a/lib/tasks/deployment/20240520102800_comparison_reports_redirect.rake
+++ b/lib/tasks/deployment/20240520102800_comparison_reports_redirect.rake
@@ -1,0 +1,15 @@
+namespace :after_party do
+  desc 'Deployment task: comparison_reports_redirect'
+  task comparison_reports_redirect: :environment do
+    puts "Running deploy task 'comparison_reports_redirect'"
+
+    Flipper.enable(:comparison_reports)
+    Flipper.enable(:comparison_reports_redirect)
+    Flipper.disable(:comparison_reports_link_to_old)
+
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord
+      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+  end
+end

--- a/spec/system/compare_spec.rb
+++ b/spec/system/compare_spec.rb
@@ -650,6 +650,36 @@ describe 'compare pages', :compare, type: :system do
     end
   end
 
+  context 'when comparison report redirect is switched on', type: :request do
+    before do
+      Flipper.enable :comparison_reports_redirect
+      get old_compare_url
+    end
+
+    context 'with school groups' do
+      let!(:school_group) { create(:school_group) }
+      let!(:school_group_2) { create(:school_group) }
+
+      let(:old_compare_url) { "/compare/baseload_per_pupil?school_group_ids%5B%5D=#{school_group.id}&school_group_ids%5B%5D=#{school_group_2.id}&school_types%5B%5D=primary&school_types%5B%5D=secondary&search=groups" }
+
+      it 'redirects to the new report' do
+        expect(response).to redirect_to("/comparisons/baseload_per_pupil?school_group_ids%5B%5D=#{school_group.id}&school_group_ids%5B%5D=#{school_group_2.id}&school_types%5B%5D=primary&school_types%5B%5D=secondary&search=groups")
+      end
+
+      it { expect(response.status).to eq(302) }
+    end
+
+    context 'without school groups' do
+      let(:old_compare_url) { '/compare/baseload_per_pupil?school_types%5B%5D=primary&school_types%5B%5D=secondary&search=groups' }
+
+      it 'redirects to the new pages' do
+        expect(response).to redirect_to('/comparisons/baseload_per_pupil?school_types%5B%5D=primary&school_types%5B%5D=secondary&search=groups')
+      end
+
+      it { expect(response.status).to eq(302) }
+    end
+  end
+
   describe 'Redirecting old benchmark routes to new compare routes', type: :request do
     before do
       get old_benchmark_url


### PR DESCRIPTION
Have put the redirect from old report urls to new behind a comparison_reports_redirect feature flag, so we can revert if need be.

This PR also:
* Switches on comparison_reports_redirects for all
* Switches on new comparison reports for all on the benchmark list page
* Switches off comparison_reports_link_to_old (the current links on the benchmark list page) as it doesn't make sense to have them now

Hopefully this is right - wasn't sure if you'd rather switch these on manually or not - can always change them.