### PR TITLE
Remove schools with swimming pools from hot water report

### DIFF
--- a/app/controllers/comparisons/base_controller.rb
+++ b/app/controllers/comparisons/base_controller.rb
@@ -13,7 +13,9 @@ module Comparisons
     before_action :set_unlisted_schools_count, only: [:index]
     helper_method :index_params
     helper_method :footnote_cache
+    helper_method :unlisted_message
     before_action :set_headers, only: [:index]
+
 
     def index
       respond_to do |format|
@@ -162,6 +164,10 @@ module Comparisons
       filter = SchoolFilter.new(**school_params).filter
       filter = filter.accessible_by(current_ability, :show) unless include_invisible
       filter.pluck(:id)
+    end
+
+    def unlisted_message(count)
+      I18n.t('comparisons.unlisted.message', count: count)
     end
   end
 end

--- a/app/controllers/comparisons/hot_water_efficiency_controller.rb
+++ b/app/controllers/comparisons/hot_water_efficiency_controller.rb
@@ -21,11 +21,15 @@ module Comparisons
     end
 
     def load_data
-      Comparison::HotWaterEfficiency.for_schools(@schools).with_data.sort_default
+      Comparison::HotWaterEfficiency.for_schools(@schools).with_data.without_swimming_pool.sort_default
     end
 
     def create_charts(results)
       create_single_number_chart(results, :avg_gas_per_pupil_gbp, nil, :cost_per_pupil, :£)
+    end
+
+    def unlisted_message(count)
+      I18n.t('comparisons.hot_water_efficiency.unlisted.message', count: count)
     end
   end
 end

--- a/app/models/comparison/hot_water_efficiency.rb
+++ b/app/models/comparison/hot_water_efficiency.rb
@@ -12,5 +12,6 @@
 #
 class Comparison::HotWaterEfficiency < Comparison::View
   scope :with_data, -> { where.not(avg_gas_per_pupil_gbp: [nil, 0.0]) }
+  scope :without_swimming_pool, -> { joins(:school).where({ school: { has_swimming_pool: false } }) }
   scope :sort_default, -> { order(avg_gas_per_pupil_gbp: :desc) }
 end

--- a/app/views/comparisons/base/_unlisted_schools.html.erb
+++ b/app/views/comparisons/base/_unlisted_schools.html.erb
@@ -1,15 +1,15 @@
 <% if unlisted_schools_count > 0 %>
   <div class="alert alert-secondary">
-  <%= t('comparisons.unlisted.message', count: unlisted_schools_count) %>.
+  <%= unlisted_message(@unlisted_schools_count) %>.
   <%= component 'footnote_modal/link', modal_id: 'unlisted-schools',
                                        href: url_for({ action: :unlisted }.merge(index_params)),
                                        title: 'Title', remote: true do
-        t('comparisons.unlisted.link', count: unlisted_schools_count)
+        t('comparisons.unlisted.link', count: @unlisted_schools_count)
       end %>
   </div>
   <%= component 'footnote_modal', title: 'Schools excluded from report', modal_id: 'unlisted-schools' do |c| %>
     <% c.with_body_content do %>
-      <%= t('comparisons.unlisted.message', count: unlisted_schools_count) %>.
+      <%= unlisted_message(@unlisted_schools_count) %>.
       <%= t('comparisons.unlisted.loading') %> <div class="spinner-border"></div>
     <% end %>
   <% end %>

--- a/app/views/comparisons/hot_water_efficiency/_unlisted.html.erb
+++ b/app/views/comparisons/hot_water_efficiency/_unlisted.html.erb
@@ -4,12 +4,14 @@
   <thead>
     <tr>
       <th class="text-left"><%= t('common.school') %></th>
+      <th class="text-right"><%= t('comparisons.column_headings.swimming_pool') %></th>
     </tr>
   </thead>
   <tbody>
     <% @unlisted&.each do |school| %>
       <tr>
         <td class='text-left'><%= link_to school.name, school_path(school) %></td>
+        <td class='text-right'><%= y_n(school.has_swimming_pool) %></td>
       </tr>
     <% end %>
   </tbody>

--- a/config/locales/views/comparisons/comparisons.yml
+++ b/config/locales/views/comparisons/comparisons.yml
@@ -11,6 +11,12 @@ en:
       previous_period: Previous period
       previous_period_unadjusted: Previous period (not adjusted)
       recent_data: Recent data
+      swimming_pool: Swimming pool
+    hot_water_efficiency:
+      unlisted:
+        message:
+          one: "%{count} school could not be shown in this report as it does not have enough data to be analysed, or has a swimming pool so its hot water usage cannot be accurately estimated"
+          other: "%{count} schools could not be shown in this report as they do not have enough data to be analysed, or have swimming pools so their hot water usage cannot be accurately estimated"
     period_types:
       periods: periods
     tables:

--- a/spec/system/comparisons/hot_water_efficiency_spec.rb
+++ b/spec/system/comparisons/hot_water_efficiency_spec.rb
@@ -79,5 +79,16 @@ describe 'hot_water_efficiency' do
     it 'has custom unlisted message' do
       expect(page).to have_content('1 school could not be shown in this report as it does not have enough data to be analysed, or has a swimming pool so its hot water usage cannot be accurately estimated')
     end
+
+    context 'when opening the modal', js: true do
+      before { click_on 'View school' }
+
+      it 'displays the school name and whether it has a swimming pool' do
+        within '.modal-body' do
+          expect(page).to have_link other_school.name, href: school_path(other_school)
+          expect(page).to have_content 'Yes'
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Extracts the message for unlisted schools into a helper method that can be overridden on a per-controller basis.

Adds filter to where clause

Overrides the unlisted school modal to indicate whether a school has a swimming pool in the list.
