### PR TITLE
Annual energy use report

### DIFF
--- a/app/controllers/comparisons/annual_energy_use_controller.rb
+++ b/app/controllers/comparisons/annual_energy_use_controller.rb
@@ -1,0 +1,54 @@
+module Comparisons
+  class AnnualEnergyUseController < BaseController
+    private
+
+    def colgroups
+      [
+        { label: '', colspan: 2 },
+        { label: t('analytics.benchmarking.configuration.column_groups.electricity_consumption'), colspan: 3 },
+        { label: t('analytics.benchmarking.configuration.column_groups.gas_consumption'), colspan: 3 },
+        { label: t('analytics.benchmarking.configuration.column_groups.storage_heater_consumption'), colspan: 3 },
+        { label: '', colspan: 3 }
+      ]
+    end
+
+    def headers
+      [
+        t('analytics.benchmarking.configuration.column_headings.school'),
+        t('comparisons.column_headings.recent_data'),
+        t('kwh'),
+        t('£'),
+        t('co2'),
+        t('kwh'),
+        t('£'),
+        t('co2'),
+        t('kwh'),
+        t('£'),
+        t('co2'),
+        t('analytics.benchmarking.configuration.column_headings.type'),
+        t('analytics.benchmarking.configuration.column_headings.pupils'),
+        t('analytics.benchmarking.configuration.column_headings.floor_area')
+      ]
+    end
+
+    def key
+      :annual_energy_use
+    end
+
+    def advice_page_key
+      :total_energy_use
+    end
+
+    def load_data
+      Comparison::AnnualEnergyUse.for_schools(@schools).with_data.sort_default
+    end
+
+    def create_charts(results)
+      create_multi_chart(results, {
+        electricity_last_year_kwh: :electricity,
+        gas_last_year_kwh: :gas,
+        storage_heaters_last_year_kwh: :storage_heaters,
+        }, nil, :kwh)
+    end
+  end
+end

--- a/app/models/comparison/annual_energy_use.rb
+++ b/app/models/comparison/annual_energy_use.rb
@@ -1,0 +1,42 @@
+# == Schema Information
+#
+# Table name: annual_energy_uses
+#
+#  alert_generation_run_id        :bigint(8)
+#  electricity_last_year_co2      :float
+#  electricity_last_year_gbp      :float
+#  electricity_last_year_kwh      :float
+#  electricity_tariff_has_changed :boolean
+#  floor_area                     :float
+#  gas_last_year_co2              :float
+#  gas_last_year_gbp              :float
+#  gas_last_year_kwh              :float
+#  gas_tariff_has_changed         :boolean
+#  id                             :bigint(8)
+#  pupils                         :float
+#  school_id                      :bigint(8)
+#  school_type_name               :text
+#  storage_heaters_last_year_co2  :float
+#  storage_heaters_last_year_gbp  :float
+#  storage_heaters_last_year_kwh  :float
+#
+class Comparison::AnnualEnergyUse < Comparison::View
+  self.table_name = 'annual_energy_uses'
+
+  scope :with_data, -> { where('electricity_last_year_kwh IS NOT NULL OR gas_last_year_kwh IS NOT NULL OR storage_heaters_last_year_kwh IS NOT NULL')}
+  scope :sort_default, -> { joins(:school).order('schools.name') }
+
+  def any_tariff_changed?
+    electricity_tariff_has_changed || gas_tariff_has_changed
+  end
+
+  # For CSV export
+  def fuel_type_names
+    codes = []
+    codes << I18n.t('common.electricity') if electricity_previous_period_kwh
+    codes << I18n.t('common.gas') if gas_previous_period_kwh
+    codes << I18n.t('common.storage_heaters') if storage_heater_previous_period_kwh
+    codes << I18n.t('common.solar_pv') if solar_type.present?
+    codes.join(';')
+  end
+end

--- a/app/views/comparisons/annual_energy_use/_table.csv.ruby
+++ b/app/views/comparisons/annual_energy_use/_table.csv.ruby
@@ -18,7 +18,6 @@ CSV.generate do |csv|
 
   csv << @headers
   @results.each do |result|
-
     recent = (gas_or_electricity_data_stale?(result) ? I18n.t('common.labels.no_label') : I18n.t('common.labels.yes_label'))
 
     csv << [

--- a/app/views/comparisons/annual_energy_use/_table.csv.ruby
+++ b/app/views/comparisons/annual_energy_use/_table.csv.ruby
@@ -1,0 +1,41 @@
+CSV.generate do |csv|
+  csv << [
+    "",
+    "",
+    I18n.t('analytics.benchmarking.configuration.column_groups.electricity_consumption'),
+    "",
+    "",
+    I18n.t('analytics.benchmarking.configuration.column_groups.gas_consumption'),
+    "",
+    "",
+    I18n.t('analytics.benchmarking.configuration.column_groups.storage_heater_consumption'),
+    "",
+    "",
+    "",
+    "",
+    ""
+  ]
+
+  csv << @headers
+  @results.each do |result|
+
+    recent = (gas_or_electricity_data_stale?(result) ? I18n.t('common.labels.no_label') : I18n.t('common.labels.yes_label'))
+
+    csv << [
+      result.school.name,
+      recent,
+      format_unit(result.electricity_last_year_kwh, Float, true, :benchmark),
+      format_unit(result.electricity_last_year_gbp, Float, true, :benchmark),
+      format_unit(result.electricity_last_year_co2, Float, true, :benchmark),
+      format_unit(result.gas_last_year_kwh, Float, true, :benchmark),
+      format_unit(result.gas_last_year_gbp, Float, true, :benchmark),
+      format_unit(result.gas_last_year_co2, Float, true, :benchmark),
+      format_unit(result.storage_heaters_last_year_kwh, Float, true, :benchmark),
+      format_unit(result.storage_heaters_last_year_gbp, Float, true, :benchmark),
+      format_unit(result.storage_heaters_last_year_co2, Float, true, :benchmark),
+      result.school_type_name,
+      format_unit(result.pupils, :pupils, true, :benchmark),
+      format_unit(result.floor_area, Float, true, :benchmark)
+    ]
+  end
+end.html_safe

--- a/app/views/comparisons/annual_energy_use/_table.html.erb
+++ b/app/views/comparisons/annual_energy_use/_table.html.erb
@@ -1,0 +1,31 @@
+<%= component 'comparison_table',
+              report: report, advice_page: advice_page, table_name: table_name, index_params: index_params,
+              headers: headers, colgroups: colgroups, advice_page_tab: advice_page_tab do |c| %>
+  <% @results.each do |result| %>
+    <% c.with_row classes: (gas_or_electricity_data_stale?(result) ? 'old-data' : '') do |r| %>
+      <% r.with_school school: result.school %>
+      <% r.with_reference key: 'tariff_changed_last_year',
+                          if: result.any_tariff_changed? %>
+
+      <% r.with_var do
+           gas_or_electricity_data_stale?(result) ? t('common.labels.no_label') : t('common.labels.yes_label')
+         end %>
+
+      <%= r.with_var val: result.electricity_last_year_kwh, unit: :kwh %>
+      <%= r.with_var val: result.electricity_last_year_gbp, unit: :£ %>
+      <%= r.with_var val: result.electricity_last_year_co2, unit: :co2 %>
+
+      <%= r.with_var val: result.gas_last_year_kwh, unit: :kwh %>
+      <%= r.with_var val: result.gas_last_year_gbp, unit: :£ %>
+      <%= r.with_var val: result.gas_last_year_co2, unit: :co2 %>
+
+      <%= r.with_var val: result.storage_heaters_last_year_kwh, unit: :kwh %>
+      <%= r.with_var val: result.storage_heaters_last_year_gbp, unit: :£ %>
+      <%= r.with_var val: result.storage_heaters_last_year_co2, unit: :co2 %>
+
+      <% r.with_var { result.school_type_name } %>
+      <% r.with_var val: result.pupils, unit: :pupils %>
+      <% r.with_var val: result.floor_area, unit: :m2 %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -86,6 +86,7 @@ Rails.application.routes.draw do
   end
 
   namespace :comparisons do
+    resources :annual_energy_use, only: [:index], concerns: :unlisted
     resources :annual_change_in_electricity_out_of_hours_use, only: [:index], concerns: :unlisted
     resources :annual_change_in_gas_out_of_hours_use, only: [:index], concerns: :unlisted
     resources :annual_change_in_storage_heater_out_of_hours_use, only: [:index], concerns: :unlisted

--- a/db/migrate/20240521110411_create_annual_energy_uses.rb
+++ b/db/migrate/20240521110411_create_annual_energy_uses.rb
@@ -1,0 +1,5 @@
+class CreateAnnualEnergyUses < ActiveRecord::Migration[6.1]
+  def change
+    create_view :annual_energy_uses
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_05_20_132318) do
+ActiveRecord::Schema.define(version: 2024_05_21_110411) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
@@ -2159,225 +2159,125 @@ ActiveRecord::Schema.define(version: 2024_05_20_132318) do
   add_foreign_key "users", "staff_roles", on_delete: :restrict
   add_foreign_key "weather_observations", "weather_stations", on_delete: :cascade
 
-  create_view "baseload_per_pupils", sql_definition: <<-SQL
+  create_view "annual_change_in_electricity_out_of_hours_uses", sql_definition: <<-SQL
       SELECT latest_runs.id,
-      additional.school_id,
-      baseload.alert_generation_run_id,
-      baseload.average_baseload_last_year_kw,
-      baseload.average_baseload_last_year_gbp,
-      baseload.one_year_baseload_per_pupil_kw,
-      baseload.annual_baseload_percent,
-      baseload.one_year_saving_versus_exemplar_gbp,
-      additional.electricity_economic_tariff_changed_this_year
+      usage.alert_generation_run_id,
+      usage.school_id,
+      usage.out_of_hours_kwh,
+      usage.out_of_hours_co2,
+      usage.out_of_hours_gbpcurrent,
+      usage_previous_year.previous_out_of_hours_kwh,
+      usage_previous_year.previous_out_of_hours_co2,
+      usage_previous_year.previous_out_of_hours_gbpcurrent,
+      additional.economic_tariff_changed_this_year
      FROM ( SELECT alerts.alert_generation_run_id,
-              data.average_baseload_last_year_kw,
-              data.average_baseload_last_year_gbp,
-              data.one_year_baseload_per_pupil_kw,
-              data.annual_baseload_percent,
-              data.one_year_saving_versus_exemplar_gbp
+              alerts.school_id,
+              json.out_of_hours_kwh,
+              json.out_of_hours_co2,
+              json.out_of_hours_gbpcurrent
              FROM alerts,
               alert_types,
-              LATERAL jsonb_to_record(alerts.variables) data(average_baseload_last_year_kw double precision, average_baseload_last_year_gbp double precision, one_year_baseload_per_pupil_kw double precision, annual_baseload_percent double precision, one_year_saving_versus_exemplar_gbp double precision)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertElectricityBaseloadVersusBenchmark'::text))) baseload,
+              LATERAL jsonb_to_record(alerts.variables) json(out_of_hours_kwh double precision, out_of_hours_co2 double precision, out_of_hours_gbpcurrent double precision)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertOutOfHoursElectricityUsage'::text))) usage,
       ( SELECT alerts.alert_generation_run_id,
               alerts.school_id,
-              data.electricity_economic_tariff_changed_this_year
+              json.out_of_hours_kwh AS previous_out_of_hours_kwh,
+              json.out_of_hours_co2 AS previous_out_of_hours_co2,
+              json.out_of_hours_gbpcurrent AS previous_out_of_hours_gbpcurrent
              FROM alerts,
               alert_types,
-              LATERAL jsonb_to_record(alerts.variables) data(electricity_economic_tariff_changed_this_year boolean)
+              LATERAL jsonb_to_record(alerts.variables) json(out_of_hours_kwh double precision, out_of_hours_co2 double precision, out_of_hours_gbpcurrent double precision)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertOutOfHoursElectricityUsagePreviousYear'::text))) usage_previous_year,
+      ( SELECT alerts.alert_generation_run_id,
+              json.electricity_economic_tariff_changed_this_year AS economic_tariff_changed_this_year
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) json(electricity_economic_tariff_changed_this_year boolean)
             WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertAdditionalPrioritisationData'::text))) additional,
       ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
              FROM alert_generation_runs
             ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
-    WHERE ((baseload.alert_generation_run_id = latest_runs.id) AND (additional.alert_generation_run_id = latest_runs.id));
+    WHERE ((usage.alert_generation_run_id = latest_runs.id) AND (usage_previous_year.alert_generation_run_id = latest_runs.id) AND (additional.alert_generation_run_id = latest_runs.id));
   SQL
-  create_view "change_in_electricity_since_last_years", sql_definition: <<-SQL
+  create_view "annual_change_in_gas_out_of_hours_uses", sql_definition: <<-SQL
       SELECT latest_runs.id,
-      enba.school_id,
-      enba.previous_year_electricity_kwh,
-      enba.current_year_electricity_kwh,
-      enba.previous_year_electricity_co2,
-      enba.current_year_electricity_co2,
-      enba.previous_year_electricity_gbp,
-      enba.current_year_electricity_gbp,
-      enba.solar_type
+      usage.alert_generation_run_id,
+      usage.school_id,
+      usage.out_of_hours_kwh,
+      usage.out_of_hours_co2,
+      usage.out_of_hours_gbpcurrent,
+      usage_previous_year.previous_out_of_hours_kwh,
+      usage_previous_year.previous_out_of_hours_co2,
+      usage_previous_year.previous_out_of_hours_gbpcurrent,
+      additional.economic_tariff_changed_this_year
      FROM ( SELECT alerts.alert_generation_run_id,
               alerts.school_id,
-              data.previous_year_electricity_kwh,
-              data.current_year_electricity_kwh,
-              data.previous_year_electricity_co2,
-              data.current_year_electricity_co2,
-              data.previous_year_electricity_gbp,
-              data.current_year_electricity_gbp,
-              data.solar_type
+              json.out_of_hours_kwh,
+              json.out_of_hours_co2,
+              json.out_of_hours_gbpcurrent
              FROM alerts,
               alert_types,
-              LATERAL jsonb_to_record(alerts.variables) data(previous_year_electricity_kwh double precision, current_year_electricity_kwh double precision, previous_year_electricity_co2 double precision, current_year_electricity_co2 double precision, previous_year_electricity_gbp double precision, current_year_electricity_gbp double precision, solar_type text)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertEnergyAnnualVersusBenchmark'::text))) enba,
-      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
-             FROM alert_generation_runs
-            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
-    WHERE (enba.alert_generation_run_id = latest_runs.id);
-  SQL
-  create_view "electricity_peak_kw_per_pupils", sql_definition: <<-SQL
-      SELECT latest_runs.id,
-      data.alert_generation_run_id,
-      data.school_id,
-      data.average_school_day_last_year_kw_per_floor_area,
-      data.average_school_day_last_year_kw,
-      data.exemplar_kw,
-      data.one_year_saving_versus_exemplar_gbp,
-      additional.electricity_economic_tariff_changed_this_year
-     FROM ( SELECT alerts.alert_generation_run_id,
-              alerts.school_id,
-              data_1.average_school_day_last_year_kw_per_floor_area,
-              data_1.average_school_day_last_year_kw,
-              data_1.exemplar_kw,
-              data_1.one_year_saving_versus_exemplar_gbp
-             FROM alerts,
-              alert_types,
-              LATERAL jsonb_to_record(alerts.variables) data_1(average_school_day_last_year_kw_per_floor_area double precision, average_school_day_last_year_kw double precision, exemplar_kw double precision, one_year_saving_versus_exemplar_gbp double precision)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertElectricityPeakKWVersusBenchmark'::text))) data,
+              LATERAL jsonb_to_record(alerts.variables) json(out_of_hours_kwh double precision, out_of_hours_co2 double precision, out_of_hours_gbpcurrent double precision)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertOutOfHoursGasUsage'::text))) usage,
       ( SELECT alerts.alert_generation_run_id,
-              data_1.electricity_economic_tariff_changed_this_year
+              alerts.school_id,
+              json.out_of_hours_kwh AS previous_out_of_hours_kwh,
+              json.out_of_hours_co2 AS previous_out_of_hours_co2,
+              json.out_of_hours_gbpcurrent AS previous_out_of_hours_gbpcurrent
              FROM alerts,
               alert_types,
-              LATERAL jsonb_to_record(alerts.variables) data_1(electricity_economic_tariff_changed_this_year boolean)
+              LATERAL jsonb_to_record(alerts.variables) json(out_of_hours_kwh double precision, out_of_hours_co2 double precision, out_of_hours_gbpcurrent double precision)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertOutOfHoursGasUsagePreviousYear'::text))) usage_previous_year,
+      ( SELECT alerts.alert_generation_run_id,
+              json.gas_economic_tariff_changed_this_year AS economic_tariff_changed_this_year
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) json(gas_economic_tariff_changed_this_year boolean)
             WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertAdditionalPrioritisationData'::text))) additional,
       ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
              FROM alert_generation_runs
             ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
-    WHERE ((data.alert_generation_run_id = latest_runs.id) AND (additional.alert_generation_run_id = latest_runs.id));
+    WHERE ((usage.alert_generation_run_id = latest_runs.id) AND (usage_previous_year.alert_generation_run_id = latest_runs.id) AND (additional.alert_generation_run_id = latest_runs.id));
   SQL
-  create_view "electricity_targets", sql_definition: <<-SQL
+  create_view "annual_change_in_storage_heater_out_of_hours_uses", sql_definition: <<-SQL
       SELECT latest_runs.id,
-      data.alert_generation_run_id,
-      data.school_id,
-      data.current_year_percent_of_target_relative,
-      data.current_year_unscaled_percent_of_target_relative,
-      data.current_year_kwh,
-      data.current_year_target_kwh,
-      data.unscaled_target_kwh_to_date,
-      data.tracking_start_date
+      usage.alert_generation_run_id,
+      usage.school_id,
+      usage.out_of_hours_kwh,
+      usage.out_of_hours_co2,
+      usage.out_of_hours_gbpcurrent,
+      usage_previous_year.previous_out_of_hours_kwh,
+      usage_previous_year.previous_out_of_hours_co2,
+      usage_previous_year.previous_out_of_hours_gbpcurrent,
+      additional.economic_tariff_changed_this_year
      FROM ( SELECT alerts.alert_generation_run_id,
               alerts.school_id,
-              data_1.current_year_percent_of_target_relative,
-              data_1.current_year_unscaled_percent_of_target_relative,
-              data_1.current_year_kwh,
-              data_1.current_year_target_kwh,
-              data_1.unscaled_target_kwh_to_date,
-              data_1.tracking_start_date
+              json.out_of_hours_kwh,
+              json.out_of_hours_co2,
+              json.out_of_hours_gbpcurrent
              FROM alerts,
               alert_types,
-              LATERAL jsonb_to_record(alerts.variables) data_1(current_year_percent_of_target_relative double precision, current_year_unscaled_percent_of_target_relative double precision, current_year_kwh double precision, current_year_target_kwh double precision, unscaled_target_kwh_to_date double precision, tracking_start_date date)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertElectricityTargetAnnual'::text))) data,
+              LATERAL jsonb_to_record(alerts.variables) json(out_of_hours_kwh double precision, out_of_hours_co2 double precision, out_of_hours_gbpcurrent double precision)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertStorageHeaterOutOfHours'::text))) usage,
+      ( SELECT alerts.alert_generation_run_id,
+              alerts.school_id,
+              json.out_of_hours_kwh AS previous_out_of_hours_kwh,
+              json.out_of_hours_co2 AS previous_out_of_hours_co2,
+              json.out_of_hours_gbpcurrent AS previous_out_of_hours_gbpcurrent
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) json(out_of_hours_kwh double precision, out_of_hours_co2 double precision, out_of_hours_gbpcurrent double precision)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertOutOfHoursStorageHeaterUsagePreviousYear'::text))) usage_previous_year,
+      ( SELECT alerts.alert_generation_run_id,
+              json.electricity_economic_tariff_changed_this_year AS economic_tariff_changed_this_year
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) json(electricity_economic_tariff_changed_this_year boolean)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertAdditionalPrioritisationData'::text))) additional,
       ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
              FROM alert_generation_runs
             ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
-    WHERE (data.alert_generation_run_id = latest_runs.id);
-  SQL
-  create_view "change_in_electricity_holiday_consumption_previous_years_holida", sql_definition: <<-SQL
-      SELECT latest_runs.id,
-      data.alert_generation_run_id,
-      data.school_id,
-      data.current_period_type,
-      data.current_period_start_date,
-      data.current_period_end_date,
-      data.difference_gbpcurrent,
-      data.difference_kwh,
-      data.difference_percent,
-      data.previous_period_type,
-      data.previous_period_start_date,
-      data.previous_period_end_date,
-      data.pupils_changed,
-      data.tariff_has_changed,
-      data.truncated_current_period
-     FROM ( SELECT alerts.alert_generation_run_id,
-              alerts.school_id,
-              data_1.current_period_type,
-              data_1.current_period_start_date,
-              data_1.current_period_end_date,
-              data_1.difference_gbpcurrent,
-              data_1.difference_kwh,
-              data_1.difference_percent,
-              data_1.previous_period_type,
-              data_1.previous_period_start_date,
-              data_1.previous_period_end_date,
-              data_1.pupils_changed,
-              data_1.tariff_has_changed,
-              data_1.truncated_current_period
-             FROM alerts,
-              alert_types,
-              LATERAL jsonb_to_record(alerts.variables) data_1(current_period_type text, current_period_start_date date, current_period_end_date date, difference_gbpcurrent double precision, difference_kwh double precision, difference_percent double precision, previous_period_type text, previous_period_start_date date, previous_period_end_date date, pupils_changed boolean, tariff_has_changed boolean, truncated_current_period boolean)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertPreviousYearHolidayComparisonElectricity'::text))) data,
-      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
-             FROM alert_generation_runs
-            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
-    WHERE (data.alert_generation_run_id = latest_runs.id);
-  SQL
-  create_view "change_in_electricity_holiday_consumption_previous_holidays", sql_definition: <<-SQL
-      SELECT latest_runs.id,
-      data.alert_generation_run_id,
-      data.school_id,
-      data.difference_percent,
-      data.difference_gbpcurrent,
-      data.difference_kwh,
-      data.current_period_type,
-      data.current_period_start_date,
-      data.current_period_end_date,
-      data.truncated_current_period,
-      data.previous_period_type,
-      data.previous_period_start_date,
-      data.previous_period_end_date,
-      data.pupils_changed,
-      data.tariff_has_changed
-     FROM ( SELECT alerts.alert_generation_run_id,
-              alerts.school_id,
-              data_1.difference_percent,
-              data_1.difference_gbpcurrent,
-              data_1.difference_kwh,
-              data_1.current_period_type,
-              data_1.current_period_start_date,
-              data_1.current_period_end_date,
-              data_1.truncated_current_period,
-              data_1.previous_period_type,
-              data_1.previous_period_start_date,
-              data_1.previous_period_end_date,
-              data_1.pupils_changed,
-              data_1.tariff_has_changed
-             FROM alerts,
-              alert_types,
-              LATERAL jsonb_to_record(alerts.variables) data_1(difference_percent double precision, difference_gbpcurrent double precision, difference_kwh double precision, current_period_type text, current_period_start_date date, current_period_end_date date, truncated_current_period boolean, previous_period_type text, previous_period_start_date date, previous_period_end_date date, pupils_changed boolean, tariff_has_changed boolean)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertPreviousHolidayComparisonElectricity'::text))) data,
-      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
-             FROM alert_generation_runs
-            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
-    WHERE (data.alert_generation_run_id = latest_runs.id);
-  SQL
-  create_view "change_in_electricity_consumption_recent_school_weeks", sql_definition: <<-SQL
-      SELECT latest_runs.id,
-      data.alert_generation_run_id,
-      data.school_id,
-      data.difference_percent,
-      data.difference_gbpcurrent,
-      data.difference_kwh,
-      data.pupils_changed,
-      data.tariff_has_changed
-     FROM ( SELECT alerts.alert_generation_run_id,
-              alerts.school_id,
-              data_1.difference_percent,
-              data_1.difference_gbpcurrent,
-              data_1.difference_kwh,
-              data_1.pupils_changed,
-              data_1.tariff_has_changed
-             FROM alerts,
-              alert_types,
-              LATERAL jsonb_to_record(alerts.variables) data_1(difference_percent double precision, difference_gbpcurrent double precision, difference_kwh double precision, pupils_changed boolean, tariff_has_changed boolean)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertSchoolWeekComparisonElectricity'::text))) data,
-      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
-             FROM alert_generation_runs
-            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
-    WHERE (data.alert_generation_run_id = latest_runs.id);
+    WHERE ((usage.alert_generation_run_id = latest_runs.id) AND (usage_previous_year.alert_generation_run_id = latest_runs.id) AND (additional.alert_generation_run_id = latest_runs.id));
   SQL
   create_view "annual_electricity_costs_per_pupils", sql_definition: <<-SQL
       SELECT latest_runs.id,
@@ -2438,389 +2338,47 @@ ActiveRecord::Schema.define(version: 2024_05_20_132318) do
             ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
     WHERE ((data.alert_generation_run_id = latest_runs.id) AND (additional.alert_generation_run_id = latest_runs.id));
   SQL
-  create_view "weekday_baseload_variations", sql_definition: <<-SQL
-      SELECT latest_runs.id,
-      additional.school_id,
-      data.alert_generation_run_id,
-      data.percent_intraday_variation,
-      data.min_day_kw,
-      data.max_day_kw,
-      data.min_day,
-      data.max_day,
-      data.annual_cost_gbpcurrent,
-      additional.electricity_economic_tariff_changed_this_year
-     FROM ( SELECT alerts.alert_generation_run_id,
-              data_1.percent_intraday_variation,
-              data_1.min_day_kw,
-              data_1.max_day_kw,
-              data_1.min_day,
-              data_1.max_day,
-              data_1.annual_cost_gbpcurrent
-             FROM alerts,
-              alert_types,
-              LATERAL jsonb_to_record(alerts.variables) data_1(percent_intraday_variation double precision, min_day_kw double precision, max_day_kw double precision, min_day integer, max_day integer, annual_cost_gbpcurrent double precision)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertIntraweekBaseloadVariation'::text))) data,
-      ( SELECT alerts.alert_generation_run_id,
-              alerts.school_id,
-              data_1.electricity_economic_tariff_changed_this_year
-             FROM alerts,
-              alert_types,
-              LATERAL jsonb_to_record(alerts.variables) data_1(electricity_economic_tariff_changed_this_year boolean)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertAdditionalPrioritisationData'::text))) additional,
-      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
-             FROM alert_generation_runs
-            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
-    WHERE ((data.alert_generation_run_id = latest_runs.id) AND (additional.alert_generation_run_id = latest_runs.id));
-  SQL
-  create_view "solar_generation_summaries", sql_definition: <<-SQL
-      SELECT latest_runs.id,
-      solar_generation.alert_generation_run_id,
-      solar_generation.school_id,
-      solar_generation.annual_electricity_kwh,
-      solar_generation.annual_mains_consumed_kwh,
-      solar_generation.annual_solar_pv_kwh,
-      solar_generation.annual_exported_solar_pv_kwh,
-      solar_generation.annual_solar_pv_consumed_onsite_kwh
-     FROM ( SELECT alerts.alert_generation_run_id,
-              alerts.school_id,
-              data.annual_electricity_kwh,
-              data.annual_mains_consumed_kwh,
-              data.annual_solar_pv_kwh,
-              data.annual_exported_solar_pv_kwh,
-              data.annual_solar_pv_consumed_onsite_kwh
-             FROM alerts,
-              alert_types,
-              LATERAL jsonb_to_record(alerts.variables) data(annual_electricity_kwh double precision, annual_mains_consumed_kwh double precision, annual_solar_pv_kwh double precision, annual_exported_solar_pv_kwh double precision, annual_solar_pv_consumed_onsite_kwh double precision)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertSolarGeneration'::text))) solar_generation,
-      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
-             FROM alert_generation_runs
-            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
-    WHERE (solar_generation.alert_generation_run_id = latest_runs.id);
-  SQL
-  create_view "solar_pv_benefit_estimates", sql_definition: <<-SQL
-      SELECT latest_runs.id,
-      additional.school_id,
-      benefit_estimate.alert_generation_run_id,
-      benefit_estimate.optimum_kwp,
-      benefit_estimate.optimum_payback_years,
-      benefit_estimate.optimum_mains_reduction_percent,
-      benefit_estimate.one_year_saving_gbpcurrent,
-      additional.electricity_economic_tariff_changed_this_year
-     FROM ( SELECT alerts.alert_generation_run_id,
-              data.optimum_kwp,
-              data.optimum_payback_years,
-              data.optimum_mains_reduction_percent,
-              data.one_year_saving_gbpcurrent
-             FROM alerts,
-              alert_types,
-              LATERAL jsonb_to_record(alerts.variables) data(optimum_kwp double precision, optimum_payback_years double precision, optimum_mains_reduction_percent double precision, one_year_saving_gbpcurrent double precision)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertSolarPVBenefitEstimator'::text))) benefit_estimate,
-      ( SELECT alerts.alert_generation_run_id,
-              alerts.school_id,
-              data.electricity_economic_tariff_changed_this_year
-             FROM alerts,
-              alert_types,
-              LATERAL jsonb_to_record(alerts.variables) data(electricity_economic_tariff_changed_this_year boolean)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertAdditionalPrioritisationData'::text))) additional,
-      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
-             FROM alert_generation_runs
-            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
-    WHERE ((benefit_estimate.alert_generation_run_id = latest_runs.id) AND (additional.alert_generation_run_id = latest_runs.id));
-  SQL
-  create_view "recent_change_in_baseloads", sql_definition: <<-SQL
-      SELECT latest_runs.id,
-      data.alert_generation_run_id,
-      data.school_id,
-      data.predicted_percent_increase_in_usage,
-      data.average_baseload_last_year_kw,
-      data.average_baseload_last_week_kw,
-      data.change_in_baseload_kw,
-      data.next_year_change_in_baseload_gbpcurrent,
-      additional.electricity_economic_tariff_changed_this_year
-     FROM ( SELECT alerts.alert_generation_run_id,
-              alerts.school_id,
-              data_1.predicted_percent_increase_in_usage,
-              data_1.average_baseload_last_year_kw,
-              data_1.average_baseload_last_week_kw,
-              data_1.change_in_baseload_kw,
-              data_1.next_year_change_in_baseload_gbpcurrent
-             FROM alerts,
-              alert_types,
-              LATERAL jsonb_to_record(alerts.variables) data_1(predicted_percent_increase_in_usage double precision, average_baseload_last_year_kw double precision, average_baseload_last_week_kw double precision, change_in_baseload_kw double precision, next_year_change_in_baseload_gbpcurrent double precision)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertChangeInElectricityBaseloadShortTerm'::text))) data,
-      ( SELECT alerts.alert_generation_run_id,
-              data_1.electricity_economic_tariff_changed_this_year
-             FROM alerts,
-              alert_types,
-              LATERAL jsonb_to_record(alerts.variables) data_1(electricity_economic_tariff_changed_this_year boolean)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertAdditionalPrioritisationData'::text))) additional,
-      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
-             FROM alert_generation_runs
-            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
-    WHERE ((data.alert_generation_run_id = latest_runs.id) AND (additional.alert_generation_run_id = latest_runs.id));
-  SQL
-  create_view "change_in_solar_pv_since_last_years", sql_definition: <<-SQL
-      SELECT latest_runs.id,
-      versus_benchmark.school_id,
-      versus_benchmark.previous_year_solar_pv_kwh,
-      versus_benchmark.current_year_solar_pv_kwh,
-      versus_benchmark.previous_year_solar_pv_co2,
-      versus_benchmark.current_year_solar_pv_co2,
-      versus_benchmark.solar_type
-     FROM ( SELECT alerts.alert_generation_run_id,
-              alerts.school_id,
-              data.previous_year_solar_pv_kwh,
-              data.current_year_solar_pv_kwh,
-              data.previous_year_solar_pv_co2,
-              data.current_year_solar_pv_co2,
-              data.solar_type
-             FROM alerts,
-              alert_types,
-              LATERAL jsonb_to_record(alerts.variables) data(previous_year_solar_pv_kwh double precision, current_year_solar_pv_kwh double precision, previous_year_solar_pv_co2 double precision, current_year_solar_pv_co2 double precision, solar_type text)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertEnergyAnnualVersusBenchmark'::text))) versus_benchmark,
-      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
-             FROM alert_generation_runs
-            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
-    WHERE (versus_benchmark.alert_generation_run_id = latest_runs.id);
-  SQL
-  create_view "seasonal_baseload_variations", sql_definition: <<-SQL
-      SELECT latest_runs.id,
-      additional.school_id,
-      data.alert_generation_run_id,
-      data.percent_seasonal_variation,
-      data.summer_kw,
-      data.winter_kw,
-      data.annual_cost_gbpcurrent,
-      additional.electricity_economic_tariff_changed_this_year
-     FROM ( SELECT alerts.alert_generation_run_id,
-              data_1.percent_seasonal_variation,
-              data_1.summer_kw,
-              data_1.winter_kw,
-              data_1.annual_cost_gbpcurrent
-             FROM alerts,
-              alert_types,
-              LATERAL jsonb_to_record(alerts.variables) data_1(percent_seasonal_variation double precision, summer_kw double precision, winter_kw double precision, annual_cost_gbpcurrent double precision)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertSeasonalBaseloadVariation'::text))) data,
-      ( SELECT alerts.alert_generation_run_id,
-              alerts.school_id,
-              data_1.electricity_economic_tariff_changed_this_year
-             FROM alerts,
-              alert_types,
-              LATERAL jsonb_to_record(alerts.variables) data_1(electricity_economic_tariff_changed_this_year boolean)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertAdditionalPrioritisationData'::text))) additional,
-      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
-             FROM alert_generation_runs
-            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
-    WHERE ((data.alert_generation_run_id = latest_runs.id) AND (additional.alert_generation_run_id = latest_runs.id));
-  SQL
-  create_view "change_in_gas_holiday_consumption_previous_holidays", sql_definition: <<-SQL
-      SELECT latest_runs.id,
-      data.alert_generation_run_id,
-      data.school_id,
-      data.difference_percent,
-      data.difference_gbpcurrent,
-      data.difference_kwh,
-      data.current_period_type,
-      data.current_period_start_date,
-      data.current_period_end_date,
-      data.truncated_current_period,
-      data.previous_period_type,
-      data.previous_period_start_date,
-      data.previous_period_end_date,
-      data.pupils_changed,
-      data.tariff_has_changed
-     FROM ( SELECT alerts.alert_generation_run_id,
-              alerts.school_id,
-              data_1.difference_percent,
-              data_1.difference_gbpcurrent,
-              data_1.difference_kwh,
-              data_1.current_period_type,
-              data_1.current_period_start_date,
-              data_1.current_period_end_date,
-              data_1.truncated_current_period,
-              data_1.previous_period_type,
-              data_1.previous_period_start_date,
-              data_1.previous_period_end_date,
-              data_1.pupils_changed,
-              data_1.tariff_has_changed
-             FROM alerts,
-              alert_types,
-              LATERAL jsonb_to_record(alerts.variables) data_1(difference_percent double precision, difference_gbpcurrent double precision, difference_kwh double precision, current_period_type text, current_period_start_date date, current_period_end_date date, truncated_current_period boolean, previous_period_type text, previous_period_start_date date, previous_period_end_date date, pupils_changed boolean, tariff_has_changed boolean)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertPreviousHolidayComparisonGas'::text))) data,
-      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
-             FROM alert_generation_runs
-            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
-    WHERE (data.alert_generation_run_id = latest_runs.id);
-  SQL
-  create_view "change_in_gas_holiday_consumption_previous_years_holidays", sql_definition: <<-SQL
-      SELECT latest_runs.id,
-      data.alert_generation_run_id,
-      data.school_id,
-      data.difference_percent,
-      data.difference_gbpcurrent,
-      data.difference_kwh,
-      data.current_period_type,
-      data.current_period_start_date,
-      data.current_period_end_date,
-      data.truncated_current_period,
-      data.previous_period_type,
-      data.previous_period_start_date,
-      data.previous_period_end_date,
-      data.pupils_changed,
-      data.tariff_has_changed
-     FROM ( SELECT alerts.alert_generation_run_id,
-              alerts.school_id,
-              data_1.difference_percent,
-              data_1.difference_gbpcurrent,
-              data_1.difference_kwh,
-              data_1.current_period_type,
-              data_1.current_period_start_date,
-              data_1.current_period_end_date,
-              data_1.truncated_current_period,
-              data_1.previous_period_type,
-              data_1.previous_period_start_date,
-              data_1.previous_period_end_date,
-              data_1.pupils_changed,
-              data_1.tariff_has_changed
-             FROM alerts,
-              alert_types,
-              LATERAL jsonb_to_record(alerts.variables) data_1(difference_percent double precision, difference_gbpcurrent double precision, difference_kwh double precision, current_period_type text, current_period_start_date date, current_period_end_date date, truncated_current_period boolean, previous_period_type text, previous_period_start_date date, previous_period_end_date date, pupils_changed boolean, tariff_has_changed boolean)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertPreviousYearHolidayComparisonGas'::text))) data,
-      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
-             FROM alert_generation_runs
-            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
-    WHERE (data.alert_generation_run_id = latest_runs.id);
-  SQL
-  create_view "change_in_gas_consumption_recent_school_weeks", sql_definition: <<-SQL
-      SELECT latest_runs.id,
-      data.alert_generation_run_id,
-      data.school_id,
-      data.difference_percent,
-      data.difference_gbpcurrent,
-      data.difference_kwh,
-      data.pupils_changed,
-      data.tariff_has_changed
-     FROM ( SELECT alerts.alert_generation_run_id,
-              alerts.school_id,
-              data_1.difference_percent,
-              data_1.difference_gbpcurrent,
-              data_1.difference_kwh,
-              data_1.pupils_changed,
-              data_1.tariff_has_changed
-             FROM alerts,
-              alert_types,
-              LATERAL jsonb_to_record(alerts.variables) data_1(difference_percent double precision, difference_gbpcurrent double precision, difference_kwh double precision, pupils_changed boolean, tariff_has_changed boolean)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertSchoolWeekComparisonGas'::text))) data,
-      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
-             FROM alert_generation_runs
-            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
-    WHERE (data.alert_generation_run_id = latest_runs.id);
-  SQL
-  create_view "storage_heater_consumption_during_holidays", sql_definition: <<-SQL
-      SELECT latest_runs.id,
-      data.alert_generation_run_id,
-      data.school_id,
-      data.holiday_projected_usage_gbp,
-      data.holiday_usage_to_date_gbp,
-      data.holiday_type,
-      data.holiday_start_date,
-      data.holiday_end_date
-     FROM ( SELECT alerts.alert_generation_run_id,
-              alerts.school_id,
-              data_1.holiday_projected_usage_gbp,
-              data_1.holiday_usage_to_date_gbp,
-              data_1.holiday_type,
-              data_1.holiday_start_date,
-              data_1.holiday_end_date
-             FROM alerts,
-              alert_types,
-              LATERAL jsonb_to_record(alerts.variables) data_1(holiday_projected_usage_gbp double precision, holiday_usage_to_date_gbp double precision, holiday_type text, holiday_start_date date, holiday_end_date date)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertStorageHeaterHeatingOnDuringHoliday'::text))) data,
-      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
-             FROM alert_generation_runs
-            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
-    WHERE (data.alert_generation_run_id = latest_runs.id);
-  SQL
-  create_view "electricity_consumption_during_holidays", sql_definition: <<-SQL
-      SELECT latest_runs.id,
-      data.alert_generation_run_id,
-      data.school_id,
-      data.holiday_projected_usage_gbp,
-      data.holiday_usage_to_date_gbp,
-      data.holiday_type,
-      data.holiday_start_date,
-      data.holiday_end_date
-     FROM ( SELECT alerts.alert_generation_run_id,
-              alerts.school_id,
-              data_1.holiday_projected_usage_gbp,
-              data_1.holiday_usage_to_date_gbp,
-              data_1.holiday_type,
-              data_1.holiday_start_date,
-              data_1.holiday_end_date
-             FROM alerts,
-              alert_types,
-              LATERAL jsonb_to_record(alerts.variables) data_1(holiday_projected_usage_gbp double precision, holiday_usage_to_date_gbp double precision, holiday_type text, holiday_start_date date, holiday_end_date date)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertElectricityUsageDuringCurrentHoliday'::text))) data,
-      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
-             FROM alert_generation_runs
-            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
-    WHERE (data.alert_generation_run_id = latest_runs.id);
-  SQL
-  create_view "gas_consumption_during_holidays", sql_definition: <<-SQL
-      SELECT latest_runs.id,
-      data.alert_generation_run_id,
-      data.school_id,
-      data.holiday_projected_usage_gbp,
-      data.holiday_usage_to_date_gbp,
-      data.holiday_type,
-      data.holiday_start_date,
-      data.holiday_end_date
-     FROM ( SELECT alerts.alert_generation_run_id,
-              alerts.school_id,
-              data_1.holiday_projected_usage_gbp,
-              data_1.holiday_usage_to_date_gbp,
-              data_1.holiday_type,
-              data_1.holiday_start_date,
-              data_1.holiday_end_date
-             FROM alerts,
-              alert_types,
-              LATERAL jsonb_to_record(alerts.variables) data_1(holiday_projected_usage_gbp double precision, holiday_usage_to_date_gbp double precision, holiday_type text, holiday_start_date date, holiday_end_date date)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertGasHeatingHotWaterOnDuringHoliday'::text))) data,
-      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
-             FROM alert_generation_runs
-            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
-    WHERE (data.alert_generation_run_id = latest_runs.id);
-  SQL
-  create_view "annual_heating_costs_per_floor_areas", sql_definition: <<-SQL
-      WITH gas AS (
+  create_view "annual_energy_costs", sql_definition: <<-SQL
+      WITH electricity AS (
            SELECT alerts.alert_generation_run_id,
-              data.one_year_gas_per_floor_area_normalised_gbp,
-              data.last_year_gbp,
-              data.one_year_saving_versus_exemplar_gbpcurrent,
-              data.last_year_kwh,
-              data.last_year_co2
+              data.last_year_gbp
              FROM alerts,
               alert_types,
-              LATERAL jsonb_to_record(alerts.variables) data(one_year_gas_per_floor_area_normalised_gbp double precision, last_year_gbp double precision, one_year_saving_versus_exemplar_gbpcurrent double precision, last_year_kwh double precision, last_year_co2 double precision)
+              LATERAL jsonb_to_record(alerts.variables) data(last_year_gbp double precision)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertElectricityAnnualVersusBenchmark'::text))
+          ), gas AS (
+           SELECT alerts.alert_generation_run_id,
+              data.last_year_gbp
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) data(last_year_gbp double precision)
             WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertGasAnnualVersusBenchmark'::text))
           ), storage_heaters AS (
            SELECT alerts.alert_generation_run_id,
-              data.one_year_gas_per_floor_area_normalised_gbp,
-              data.last_year_gbp,
-              data.one_year_saving_versus_exemplar_gbpcurrent,
-              data.last_year_kwh,
-              data.last_year_co2
+              data.last_year_gbp
              FROM alerts,
               alert_types,
-              LATERAL jsonb_to_record(alerts.variables) data(one_year_gas_per_floor_area_normalised_gbp double precision, last_year_gbp double precision, one_year_saving_versus_exemplar_gbpcurrent double precision, last_year_kwh double precision, last_year_co2 double precision)
+              LATERAL jsonb_to_record(alerts.variables) data(last_year_gbp double precision)
             WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertStorageHeaterAnnualVersusBenchmark'::text))
+          ), energy AS (
+           SELECT alerts.alert_generation_run_id,
+              data.last_year_gbp,
+              data.one_year_energy_per_pupil_gbp,
+              data.last_year_co2_tonnes,
+              data.last_year_kwh
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) data(last_year_gbp double precision, one_year_energy_per_pupil_gbp double precision, last_year_co2_tonnes double precision, last_year_kwh double precision)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertEnergyAnnualVersusBenchmark'::text))
           ), additional AS (
            SELECT alerts.alert_generation_run_id,
               alerts.school_id,
-              data.gas_economic_tariff_changed_this_year
+              data.school_type_name,
+              data.pupils,
+              data.floor_area
              FROM alerts,
               alert_types,
-              LATERAL jsonb_to_record(alerts.variables) data(gas_economic_tariff_changed_this_year boolean)
+              LATERAL jsonb_to_record(alerts.variables) data(school_type_name text, pupils double precision, floor_area double precision)
             WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertAdditionalPrioritisationData'::text))
           ), latest_runs AS (
            SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
@@ -2828,83 +2386,24 @@ ActiveRecord::Schema.define(version: 2024_05_20_132318) do
             ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC
           )
    SELECT latest_runs.id,
+      electricity.last_year_gbp AS last_year_electricity,
+      gas.last_year_gbp AS last_year_gas,
+      storage_heaters.last_year_gbp AS last_year_storage_heaters,
+      energy.last_year_gbp,
+      energy.one_year_energy_per_pupil_gbp,
+      energy.last_year_co2_tonnes,
+      energy.last_year_kwh,
+      additional.alert_generation_run_id,
       additional.school_id,
-      (COALESCE(gas.one_year_gas_per_floor_area_normalised_gbp, (0)::double precision) + COALESCE(storage_heaters.one_year_gas_per_floor_area_normalised_gbp, (0)::double precision)) AS one_year_gas_per_floor_area_normalised_gbp,
-      (COALESCE(gas.last_year_gbp, (0)::double precision) + COALESCE(storage_heaters.last_year_gbp, (0)::double precision)) AS last_year_gbp,
-      (COALESCE(gas.one_year_saving_versus_exemplar_gbpcurrent, (0)::double precision) + COALESCE(storage_heaters.one_year_saving_versus_exemplar_gbpcurrent, (0)::double precision)) AS one_year_saving_versus_exemplar_gbpcurrent,
-      (COALESCE(gas.last_year_kwh, (0)::double precision) + COALESCE(storage_heaters.last_year_kwh, (0)::double precision)) AS last_year_kwh,
-      (COALESCE(gas.last_year_co2, (0)::double precision) + COALESCE(storage_heaters.last_year_co2, (0)::double precision)) AS last_year_co2,
-      gas.last_year_co2 AS gas_last_year_co2,
-      additional.gas_economic_tariff_changed_this_year
-     FROM (((latest_runs
+      additional.school_type_name,
+      additional.pupils,
+      additional.floor_area
+     FROM (((((latest_runs
        JOIN additional ON ((latest_runs.id = additional.alert_generation_run_id)))
+       LEFT JOIN electricity ON ((latest_runs.id = electricity.alert_generation_run_id)))
        LEFT JOIN gas ON ((latest_runs.id = gas.alert_generation_run_id)))
-       LEFT JOIN storage_heaters ON ((latest_runs.id = storage_heaters.alert_generation_run_id)));
-  SQL
-  create_view "annual_gas_out_of_hours_uses", sql_definition: <<-SQL
-      SELECT latest_runs.id,
-      data.alert_generation_run_id,
-      data.school_id,
-      data.schoolday_open_percent,
-      data.schoolday_closed_percent,
-      data.holidays_percent,
-      data.weekends_percent,
-      data.community_percent,
-      data.community_gbp,
-      data.out_of_hours_gbp,
-      data.potential_saving_gbp,
-      additional.gas_economic_tariff_changed_this_year
-     FROM ( SELECT alerts.alert_generation_run_id,
-              alerts.school_id,
-              data_1.schoolday_open_percent,
-              data_1.schoolday_closed_percent,
-              data_1.holidays_percent,
-              data_1.weekends_percent,
-              data_1.community_percent,
-              data_1.community_gbp,
-              data_1.out_of_hours_gbp,
-              data_1.potential_saving_gbp
-             FROM alerts,
-              alert_types,
-              LATERAL jsonb_to_record(alerts.variables) data_1(schoolday_open_percent double precision, schoolday_closed_percent double precision, holidays_percent double precision, weekends_percent double precision, community_percent double precision, community_gbp double precision, out_of_hours_gbp double precision, potential_saving_gbp double precision)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertOutOfHoursGasUsage'::text))) data,
-      ( SELECT alerts.alert_generation_run_id,
-              data_1.gas_economic_tariff_changed_this_year
-             FROM alerts,
-              alert_types,
-              LATERAL jsonb_to_record(alerts.variables) data_1(gas_economic_tariff_changed_this_year boolean)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertAdditionalPrioritisationData'::text))) additional,
-      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
-             FROM alert_generation_runs
-            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
-    WHERE ((data.alert_generation_run_id = latest_runs.id) AND (additional.alert_generation_run_id = latest_runs.id));
-  SQL
-  create_view "annual_storage_heater_out_of_hours_uses", sql_definition: <<-SQL
-      SELECT latest_runs.id,
-      data.alert_generation_run_id,
-      data.school_id,
-      data.schoolday_open_percent,
-      data.schoolday_closed_percent,
-      data.holidays_percent,
-      data.weekends_percent,
-      data.holidays_gbp,
-      data.weekends_gbp
-     FROM ( SELECT alerts.alert_generation_run_id,
-              alerts.school_id,
-              data_1.schoolday_open_percent,
-              data_1.schoolday_closed_percent,
-              data_1.holidays_percent,
-              data_1.weekends_percent,
-              data_1.holidays_gbp,
-              data_1.weekends_gbp
-             FROM alerts,
-              alert_types,
-              LATERAL jsonb_to_record(alerts.variables) data_1(schoolday_open_percent double precision, schoolday_closed_percent double precision, holidays_percent double precision, weekends_percent double precision, holidays_gbp double precision, weekends_gbp double precision)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertStorageHeaterOutOfHours'::text))) data,
-      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
-             FROM alert_generation_runs
-            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
-    WHERE (data.alert_generation_run_id = latest_runs.id);
+       LEFT JOIN storage_heaters ON ((latest_runs.id = storage_heaters.alert_generation_run_id)))
+       LEFT JOIN energy ON ((latest_runs.id = energy.alert_generation_run_id)));
   SQL
   create_view "annual_energy_costs_per_units", sql_definition: <<-SQL
       WITH electricity AS (
@@ -2989,197 +2488,74 @@ ActiveRecord::Schema.define(version: 2024_05_20_132318) do
        LEFT JOIN gas ON ((latest_runs.id = gas.alert_generation_run_id)))
        LEFT JOIN storage_heaters ON ((latest_runs.id = storage_heaters.alert_generation_run_id)));
   SQL
-  create_view "thermostat_sensitivities", sql_definition: <<-SQL
+  create_view "annual_gas_out_of_hours_uses", sql_definition: <<-SQL
       SELECT latest_runs.id,
       data.alert_generation_run_id,
       data.school_id,
-      data."annual_saving_1_C_change_gbp"
+      data.schoolday_open_percent,
+      data.schoolday_closed_percent,
+      data.holidays_percent,
+      data.weekends_percent,
+      data.community_percent,
+      data.community_gbp,
+      data.out_of_hours_gbp,
+      data.potential_saving_gbp,
+      additional.gas_economic_tariff_changed_this_year
      FROM ( SELECT alerts.alert_generation_run_id,
               alerts.school_id,
-              data_1."annual_saving_1_C_change_gbp"
+              data_1.schoolday_open_percent,
+              data_1.schoolday_closed_percent,
+              data_1.holidays_percent,
+              data_1.weekends_percent,
+              data_1.community_percent,
+              data_1.community_gbp,
+              data_1.out_of_hours_gbp,
+              data_1.potential_saving_gbp
              FROM alerts,
               alert_types,
-              LATERAL jsonb_to_record(alerts.variables) data_1("annual_saving_1_C_change_gbp" double precision)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertHeatingSensitivityAdvice'::text))) data,
+              LATERAL jsonb_to_record(alerts.variables) data_1(schoolday_open_percent double precision, schoolday_closed_percent double precision, holidays_percent double precision, weekends_percent double precision, community_percent double precision, community_gbp double precision, out_of_hours_gbp double precision, potential_saving_gbp double precision)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertOutOfHoursGasUsage'::text))) data,
+      ( SELECT alerts.alert_generation_run_id,
+              data_1.gas_economic_tariff_changed_this_year
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) data_1(gas_economic_tariff_changed_this_year boolean)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertAdditionalPrioritisationData'::text))) additional,
       ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
              FROM alert_generation_runs
             ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
-    WHERE (data.alert_generation_run_id = latest_runs.id);
+    WHERE ((data.alert_generation_run_id = latest_runs.id) AND (additional.alert_generation_run_id = latest_runs.id));
   SQL
-  create_view "heating_in_warm_weathers", sql_definition: <<-SQL
+  create_view "annual_heating_costs_per_floor_areas", sql_definition: <<-SQL
       WITH gas AS (
            SELECT alerts.alert_generation_run_id,
-              data.percent_of_annual_heating,
-              data.warm_weather_heating_days_all_days_kwh,
-              data.warm_weather_heating_days_all_days_co2,
-              data.warm_weather_heating_days_all_days_gbpcurrent,
-              data.warm_weather_heating_days_all_days_days
+              data.one_year_gas_per_floor_area_normalised_gbp,
+              data.last_year_gbp,
+              data.one_year_saving_versus_exemplar_gbpcurrent,
+              data.last_year_kwh,
+              data.last_year_co2
              FROM alerts,
               alert_types,
-              LATERAL jsonb_to_record(alerts.variables) data(percent_of_annual_heating double precision, warm_weather_heating_days_all_days_kwh double precision, warm_weather_heating_days_all_days_co2 double precision, warm_weather_heating_days_all_days_gbpcurrent double precision, warm_weather_heating_days_all_days_days double precision)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertSeasonalHeatingSchoolDays'::text))
-          ), storage_heaters AS (
-           SELECT alerts.alert_generation_run_id,
-              data.percent_of_annual_heating,
-              data.warm_weather_heating_days_all_days_kwh,
-              data.warm_weather_heating_days_all_days_co2,
-              data.warm_weather_heating_days_all_days_gbpcurrent,
-              data.warm_weather_heating_days_all_days_days
-             FROM alerts,
-              alert_types,
-              LATERAL jsonb_to_record(alerts.variables) data(percent_of_annual_heating double precision, warm_weather_heating_days_all_days_kwh double precision, warm_weather_heating_days_all_days_co2 double precision, warm_weather_heating_days_all_days_gbpcurrent double precision, warm_weather_heating_days_all_days_days double precision)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertSeasonalHeatingSchoolDaysStorageHeaters'::text))
-          ), additional AS (
-           SELECT alerts.alert_generation_run_id,
-              alerts.school_id
-             FROM alerts,
-              alert_types
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertAdditionalPrioritisationData'::text))
-          ), latest_runs AS (
-           SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
-             FROM alert_generation_runs
-            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC
-          )
-   SELECT latest_runs.id,
-      additional.school_id,
-      COALESCE(gas.percent_of_annual_heating, storage_heaters.percent_of_annual_heating) AS percent_of_annual_heating,
-      COALESCE(gas.warm_weather_heating_days_all_days_kwh, storage_heaters.warm_weather_heating_days_all_days_kwh) AS warm_weather_heating_days_all_days_kwh,
-      COALESCE(gas.warm_weather_heating_days_all_days_co2, storage_heaters.warm_weather_heating_days_all_days_co2) AS warm_weather_heating_days_all_days_co2,
-      COALESCE(gas.warm_weather_heating_days_all_days_gbpcurrent, storage_heaters.warm_weather_heating_days_all_days_gbpcurrent) AS warm_weather_heating_days_all_days_gbpcurrent,
-      COALESCE(gas.warm_weather_heating_days_all_days_days, storage_heaters.warm_weather_heating_days_all_days_days) AS warm_weather_heating_days_all_days_days
-     FROM (((latest_runs
-       JOIN additional ON ((latest_runs.id = additional.alert_generation_run_id)))
-       LEFT JOIN gas ON ((latest_runs.id = gas.alert_generation_run_id)))
-       LEFT JOIN storage_heaters ON ((latest_runs.id = storage_heaters.alert_generation_run_id)));
-  SQL
-  create_view "thermostatic_controls", sql_definition: <<-SQL
-      WITH gas AS (
-           SELECT alerts.alert_generation_run_id,
-              data.r2,
-              data.potential_saving_gbp
-             FROM alerts,
-              alert_types,
-              LATERAL jsonb_to_record(alerts.variables) data(r2 double precision, potential_saving_gbp double precision)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertThermostaticControl'::text))
-          ), storage_heaters AS (
-           SELECT alerts.alert_generation_run_id,
-              data.r2,
-              data.potential_saving_gbp
-             FROM alerts,
-              alert_types,
-              LATERAL jsonb_to_record(alerts.variables) data(r2 double precision, potential_saving_gbp double precision)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertStorageHeaterThermostatic'::text))
-          ), additional AS (
-           SELECT alerts.alert_generation_run_id,
-              alerts.school_id
-             FROM alerts,
-              alert_types
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertAdditionalPrioritisationData'::text))
-          ), latest_runs AS (
-           SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
-             FROM alert_generation_runs
-            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC
-          )
-   SELECT latest_runs.id,
-      additional.school_id,
-      COALESCE(gas.r2, storage_heaters.r2) AS r2,
-      NULLIF((COALESCE(gas.potential_saving_gbp, (0)::double precision) + COALESCE(storage_heaters.potential_saving_gbp, (0)::double precision)), (0)::double precision) AS potential_saving_gbp
-     FROM (((latest_runs
-       JOIN additional ON ((latest_runs.id = additional.alert_generation_run_id)))
-       LEFT JOIN gas ON ((latest_runs.id = gas.alert_generation_run_id)))
-       LEFT JOIN storage_heaters ON ((latest_runs.id = storage_heaters.alert_generation_run_id)));
-  SQL
-  create_view "hot_water_efficiencies", sql_definition: <<-SQL
-      SELECT latest_runs.id,
-      data.alert_generation_run_id,
-      data.school_id,
-      data.avg_gas_per_pupil_gbp,
-      data.benchmark_existing_gas_efficiency,
-      data.benchmark_gas_better_control_saving_gbp,
-      data.benchmark_point_of_use_electric_saving_gbp
-     FROM ( SELECT alerts.alert_generation_run_id,
-              alerts.school_id,
-              data_1.avg_gas_per_pupil_gbp,
-              data_1.benchmark_existing_gas_efficiency,
-              data_1.benchmark_gas_better_control_saving_gbp,
-              data_1.benchmark_point_of_use_electric_saving_gbp
-             FROM alerts,
-              alert_types,
-              LATERAL jsonb_to_record(alerts.variables) data_1(avg_gas_per_pupil_gbp double precision, benchmark_existing_gas_efficiency double precision, benchmark_gas_better_control_saving_gbp double precision, benchmark_point_of_use_electric_saving_gbp double precision)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertHotWaterEfficiency'::text))) data,
-      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
-             FROM alert_generation_runs
-            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
-    WHERE (data.alert_generation_run_id = latest_runs.id);
-  SQL
-  create_view "gas_targets", sql_definition: <<-SQL
-      SELECT latest_runs.id,
-      data.alert_generation_run_id,
-      data.school_id,
-      data.current_year_percent_of_target_relative,
-      data.current_year_unscaled_percent_of_target_relative,
-      data.current_year_kwh,
-      data.current_year_target_kwh,
-      data.unscaled_target_kwh_to_date,
-      data.tracking_start_date
-     FROM ( SELECT alerts.alert_generation_run_id,
-              alerts.school_id,
-              data_1.current_year_percent_of_target_relative,
-              data_1.current_year_unscaled_percent_of_target_relative,
-              data_1.current_year_kwh,
-              data_1.current_year_target_kwh,
-              data_1.unscaled_target_kwh_to_date,
-              data_1.tracking_start_date
-             FROM alerts,
-              alert_types,
-              LATERAL jsonb_to_record(alerts.variables) data_1(current_year_percent_of_target_relative double precision, current_year_unscaled_percent_of_target_relative double precision, current_year_kwh double precision, current_year_target_kwh double precision, unscaled_target_kwh_to_date double precision, tracking_start_date date)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertGasTargetAnnual'::text))) data,
-      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
-             FROM alert_generation_runs
-            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
-    WHERE (data.alert_generation_run_id = latest_runs.id);
-  SQL
-  create_view "annual_energy_costs", sql_definition: <<-SQL
-      WITH electricity AS (
-           SELECT alerts.alert_generation_run_id,
-              data.last_year_gbp
-             FROM alerts,
-              alert_types,
-              LATERAL jsonb_to_record(alerts.variables) data(last_year_gbp double precision)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertElectricityAnnualVersusBenchmark'::text))
-          ), gas AS (
-           SELECT alerts.alert_generation_run_id,
-              data.last_year_gbp
-             FROM alerts,
-              alert_types,
-              LATERAL jsonb_to_record(alerts.variables) data(last_year_gbp double precision)
+              LATERAL jsonb_to_record(alerts.variables) data(one_year_gas_per_floor_area_normalised_gbp double precision, last_year_gbp double precision, one_year_saving_versus_exemplar_gbpcurrent double precision, last_year_kwh double precision, last_year_co2 double precision)
             WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertGasAnnualVersusBenchmark'::text))
           ), storage_heaters AS (
            SELECT alerts.alert_generation_run_id,
-              data.last_year_gbp
-             FROM alerts,
-              alert_types,
-              LATERAL jsonb_to_record(alerts.variables) data(last_year_gbp double precision)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertStorageHeaterAnnualVersusBenchmark'::text))
-          ), energy AS (
-           SELECT alerts.alert_generation_run_id,
+              data.one_year_gas_per_floor_area_normalised_gbp,
               data.last_year_gbp,
-              data.one_year_energy_per_pupil_gbp,
-              data.last_year_co2_tonnes,
-              data.last_year_kwh
+              data.one_year_saving_versus_exemplar_gbpcurrent,
+              data.last_year_kwh,
+              data.last_year_co2
              FROM alerts,
               alert_types,
-              LATERAL jsonb_to_record(alerts.variables) data(last_year_gbp double precision, one_year_energy_per_pupil_gbp double precision, last_year_co2_tonnes double precision, last_year_kwh double precision)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertEnergyAnnualVersusBenchmark'::text))
+              LATERAL jsonb_to_record(alerts.variables) data(one_year_gas_per_floor_area_normalised_gbp double precision, last_year_gbp double precision, one_year_saving_versus_exemplar_gbpcurrent double precision, last_year_kwh double precision, last_year_co2 double precision)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertStorageHeaterAnnualVersusBenchmark'::text))
           ), additional AS (
            SELECT alerts.alert_generation_run_id,
               alerts.school_id,
-              data.school_type_name,
-              data.pupils,
-              data.floor_area
+              data.gas_economic_tariff_changed_this_year
              FROM alerts,
               alert_types,
-              LATERAL jsonb_to_record(alerts.variables) data(school_type_name text, pupils double precision, floor_area double precision)
+              LATERAL jsonb_to_record(alerts.variables) data(gas_economic_tariff_changed_this_year boolean)
             WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertAdditionalPrioritisationData'::text))
           ), latest_runs AS (
            SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
@@ -3187,24 +2563,311 @@ ActiveRecord::Schema.define(version: 2024_05_20_132318) do
             ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC
           )
    SELECT latest_runs.id,
-      electricity.last_year_gbp AS last_year_electricity,
-      gas.last_year_gbp AS last_year_gas,
-      storage_heaters.last_year_gbp AS last_year_storage_heaters,
-      energy.last_year_gbp,
-      energy.one_year_energy_per_pupil_gbp,
-      energy.last_year_co2_tonnes,
-      energy.last_year_kwh,
-      additional.alert_generation_run_id,
       additional.school_id,
-      additional.school_type_name,
-      additional.pupils,
-      additional.floor_area
-     FROM (((((latest_runs
+      (COALESCE(gas.one_year_gas_per_floor_area_normalised_gbp, (0)::double precision) + COALESCE(storage_heaters.one_year_gas_per_floor_area_normalised_gbp, (0)::double precision)) AS one_year_gas_per_floor_area_normalised_gbp,
+      (COALESCE(gas.last_year_gbp, (0)::double precision) + COALESCE(storage_heaters.last_year_gbp, (0)::double precision)) AS last_year_gbp,
+      (COALESCE(gas.one_year_saving_versus_exemplar_gbpcurrent, (0)::double precision) + COALESCE(storage_heaters.one_year_saving_versus_exemplar_gbpcurrent, (0)::double precision)) AS one_year_saving_versus_exemplar_gbpcurrent,
+      (COALESCE(gas.last_year_kwh, (0)::double precision) + COALESCE(storage_heaters.last_year_kwh, (0)::double precision)) AS last_year_kwh,
+      (COALESCE(gas.last_year_co2, (0)::double precision) + COALESCE(storage_heaters.last_year_co2, (0)::double precision)) AS last_year_co2,
+      gas.last_year_co2 AS gas_last_year_co2,
+      additional.gas_economic_tariff_changed_this_year
+     FROM (((latest_runs
        JOIN additional ON ((latest_runs.id = additional.alert_generation_run_id)))
-       LEFT JOIN electricity ON ((latest_runs.id = electricity.alert_generation_run_id)))
        LEFT JOIN gas ON ((latest_runs.id = gas.alert_generation_run_id)))
-       LEFT JOIN storage_heaters ON ((latest_runs.id = storage_heaters.alert_generation_run_id)))
-       LEFT JOIN energy ON ((latest_runs.id = energy.alert_generation_run_id)));
+       LEFT JOIN storage_heaters ON ((latest_runs.id = storage_heaters.alert_generation_run_id)));
+  SQL
+  create_view "annual_storage_heater_out_of_hours_uses", sql_definition: <<-SQL
+      SELECT latest_runs.id,
+      data.alert_generation_run_id,
+      data.school_id,
+      data.schoolday_open_percent,
+      data.schoolday_closed_percent,
+      data.holidays_percent,
+      data.weekends_percent,
+      data.holidays_gbp,
+      data.weekends_gbp
+     FROM ( SELECT alerts.alert_generation_run_id,
+              alerts.school_id,
+              data_1.schoolday_open_percent,
+              data_1.schoolday_closed_percent,
+              data_1.holidays_percent,
+              data_1.weekends_percent,
+              data_1.holidays_gbp,
+              data_1.weekends_gbp
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) data_1(schoolday_open_percent double precision, schoolday_closed_percent double precision, holidays_percent double precision, weekends_percent double precision, holidays_gbp double precision, weekends_gbp double precision)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertStorageHeaterOutOfHours'::text))) data,
+      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
+             FROM alert_generation_runs
+            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
+    WHERE (data.alert_generation_run_id = latest_runs.id);
+  SQL
+  create_view "baseload_per_pupils", sql_definition: <<-SQL
+      SELECT latest_runs.id,
+      additional.school_id,
+      baseload.alert_generation_run_id,
+      baseload.average_baseload_last_year_kw,
+      baseload.average_baseload_last_year_gbp,
+      baseload.one_year_baseload_per_pupil_kw,
+      baseload.annual_baseload_percent,
+      baseload.one_year_saving_versus_exemplar_gbp,
+      additional.electricity_economic_tariff_changed_this_year
+     FROM ( SELECT alerts.alert_generation_run_id,
+              data.average_baseload_last_year_kw,
+              data.average_baseload_last_year_gbp,
+              data.one_year_baseload_per_pupil_kw,
+              data.annual_baseload_percent,
+              data.one_year_saving_versus_exemplar_gbp
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) data(average_baseload_last_year_kw double precision, average_baseload_last_year_gbp double precision, one_year_baseload_per_pupil_kw double precision, annual_baseload_percent double precision, one_year_saving_versus_exemplar_gbp double precision)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertElectricityBaseloadVersusBenchmark'::text))) baseload,
+      ( SELECT alerts.alert_generation_run_id,
+              alerts.school_id,
+              data.electricity_economic_tariff_changed_this_year
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) data(electricity_economic_tariff_changed_this_year boolean)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertAdditionalPrioritisationData'::text))) additional,
+      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
+             FROM alert_generation_runs
+            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
+    WHERE ((baseload.alert_generation_run_id = latest_runs.id) AND (additional.alert_generation_run_id = latest_runs.id));
+  SQL
+  create_view "change_in_electricity_consumption_recent_school_weeks", sql_definition: <<-SQL
+      SELECT latest_runs.id,
+      data.alert_generation_run_id,
+      data.school_id,
+      data.difference_percent,
+      data.difference_gbpcurrent,
+      data.difference_kwh,
+      data.pupils_changed,
+      data.tariff_has_changed
+     FROM ( SELECT alerts.alert_generation_run_id,
+              alerts.school_id,
+              data_1.difference_percent,
+              data_1.difference_gbpcurrent,
+              data_1.difference_kwh,
+              data_1.pupils_changed,
+              data_1.tariff_has_changed
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) data_1(difference_percent double precision, difference_gbpcurrent double precision, difference_kwh double precision, pupils_changed boolean, tariff_has_changed boolean)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertSchoolWeekComparisonElectricity'::text))) data,
+      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
+             FROM alert_generation_runs
+            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
+    WHERE (data.alert_generation_run_id = latest_runs.id);
+  SQL
+  create_view "change_in_electricity_holiday_consumption_previous_holidays", sql_definition: <<-SQL
+      SELECT latest_runs.id,
+      data.alert_generation_run_id,
+      data.school_id,
+      data.difference_percent,
+      data.difference_gbpcurrent,
+      data.difference_kwh,
+      data.current_period_type,
+      data.current_period_start_date,
+      data.current_period_end_date,
+      data.truncated_current_period,
+      data.previous_period_type,
+      data.previous_period_start_date,
+      data.previous_period_end_date,
+      data.pupils_changed,
+      data.tariff_has_changed
+     FROM ( SELECT alerts.alert_generation_run_id,
+              alerts.school_id,
+              data_1.difference_percent,
+              data_1.difference_gbpcurrent,
+              data_1.difference_kwh,
+              data_1.current_period_type,
+              data_1.current_period_start_date,
+              data_1.current_period_end_date,
+              data_1.truncated_current_period,
+              data_1.previous_period_type,
+              data_1.previous_period_start_date,
+              data_1.previous_period_end_date,
+              data_1.pupils_changed,
+              data_1.tariff_has_changed
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) data_1(difference_percent double precision, difference_gbpcurrent double precision, difference_kwh double precision, current_period_type text, current_period_start_date date, current_period_end_date date, truncated_current_period boolean, previous_period_type text, previous_period_start_date date, previous_period_end_date date, pupils_changed boolean, tariff_has_changed boolean)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertPreviousHolidayComparisonElectricity'::text))) data,
+      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
+             FROM alert_generation_runs
+            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
+    WHERE (data.alert_generation_run_id = latest_runs.id);
+  SQL
+  create_view "change_in_electricity_holiday_consumption_previous_years_holida", sql_definition: <<-SQL
+      SELECT latest_runs.id,
+      data.alert_generation_run_id,
+      data.school_id,
+      data.current_period_type,
+      data.current_period_start_date,
+      data.current_period_end_date,
+      data.difference_gbpcurrent,
+      data.difference_kwh,
+      data.difference_percent,
+      data.previous_period_type,
+      data.previous_period_start_date,
+      data.previous_period_end_date,
+      data.pupils_changed,
+      data.tariff_has_changed,
+      data.truncated_current_period
+     FROM ( SELECT alerts.alert_generation_run_id,
+              alerts.school_id,
+              data_1.current_period_type,
+              data_1.current_period_start_date,
+              data_1.current_period_end_date,
+              data_1.difference_gbpcurrent,
+              data_1.difference_kwh,
+              data_1.difference_percent,
+              data_1.previous_period_type,
+              data_1.previous_period_start_date,
+              data_1.previous_period_end_date,
+              data_1.pupils_changed,
+              data_1.tariff_has_changed,
+              data_1.truncated_current_period
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) data_1(current_period_type text, current_period_start_date date, current_period_end_date date, difference_gbpcurrent double precision, difference_kwh double precision, difference_percent double precision, previous_period_type text, previous_period_start_date date, previous_period_end_date date, pupils_changed boolean, tariff_has_changed boolean, truncated_current_period boolean)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertPreviousYearHolidayComparisonElectricity'::text))) data,
+      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
+             FROM alert_generation_runs
+            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
+    WHERE (data.alert_generation_run_id = latest_runs.id);
+  SQL
+  create_view "change_in_electricity_since_last_years", sql_definition: <<-SQL
+      SELECT latest_runs.id,
+      enba.school_id,
+      enba.previous_year_electricity_kwh,
+      enba.current_year_electricity_kwh,
+      enba.previous_year_electricity_co2,
+      enba.current_year_electricity_co2,
+      enba.previous_year_electricity_gbp,
+      enba.current_year_electricity_gbp,
+      enba.solar_type
+     FROM ( SELECT alerts.alert_generation_run_id,
+              alerts.school_id,
+              data.previous_year_electricity_kwh,
+              data.current_year_electricity_kwh,
+              data.previous_year_electricity_co2,
+              data.current_year_electricity_co2,
+              data.previous_year_electricity_gbp,
+              data.current_year_electricity_gbp,
+              data.solar_type
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) data(previous_year_electricity_kwh double precision, current_year_electricity_kwh double precision, previous_year_electricity_co2 double precision, current_year_electricity_co2 double precision, previous_year_electricity_gbp double precision, current_year_electricity_gbp double precision, solar_type text)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertEnergyAnnualVersusBenchmark'::text))) enba,
+      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
+             FROM alert_generation_runs
+            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
+    WHERE (enba.alert_generation_run_id = latest_runs.id);
+  SQL
+  create_view "change_in_gas_consumption_recent_school_weeks", sql_definition: <<-SQL
+      SELECT latest_runs.id,
+      data.alert_generation_run_id,
+      data.school_id,
+      data.difference_percent,
+      data.difference_gbpcurrent,
+      data.difference_kwh,
+      data.pupils_changed,
+      data.tariff_has_changed
+     FROM ( SELECT alerts.alert_generation_run_id,
+              alerts.school_id,
+              data_1.difference_percent,
+              data_1.difference_gbpcurrent,
+              data_1.difference_kwh,
+              data_1.pupils_changed,
+              data_1.tariff_has_changed
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) data_1(difference_percent double precision, difference_gbpcurrent double precision, difference_kwh double precision, pupils_changed boolean, tariff_has_changed boolean)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertSchoolWeekComparisonGas'::text))) data,
+      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
+             FROM alert_generation_runs
+            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
+    WHERE (data.alert_generation_run_id = latest_runs.id);
+  SQL
+  create_view "change_in_gas_holiday_consumption_previous_holidays", sql_definition: <<-SQL
+      SELECT latest_runs.id,
+      data.alert_generation_run_id,
+      data.school_id,
+      data.difference_percent,
+      data.difference_gbpcurrent,
+      data.difference_kwh,
+      data.current_period_type,
+      data.current_period_start_date,
+      data.current_period_end_date,
+      data.truncated_current_period,
+      data.previous_period_type,
+      data.previous_period_start_date,
+      data.previous_period_end_date,
+      data.pupils_changed,
+      data.tariff_has_changed
+     FROM ( SELECT alerts.alert_generation_run_id,
+              alerts.school_id,
+              data_1.difference_percent,
+              data_1.difference_gbpcurrent,
+              data_1.difference_kwh,
+              data_1.current_period_type,
+              data_1.current_period_start_date,
+              data_1.current_period_end_date,
+              data_1.truncated_current_period,
+              data_1.previous_period_type,
+              data_1.previous_period_start_date,
+              data_1.previous_period_end_date,
+              data_1.pupils_changed,
+              data_1.tariff_has_changed
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) data_1(difference_percent double precision, difference_gbpcurrent double precision, difference_kwh double precision, current_period_type text, current_period_start_date date, current_period_end_date date, truncated_current_period boolean, previous_period_type text, previous_period_start_date date, previous_period_end_date date, pupils_changed boolean, tariff_has_changed boolean)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertPreviousHolidayComparisonGas'::text))) data,
+      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
+             FROM alert_generation_runs
+            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
+    WHERE (data.alert_generation_run_id = latest_runs.id);
+  SQL
+  create_view "change_in_gas_holiday_consumption_previous_years_holidays", sql_definition: <<-SQL
+      SELECT latest_runs.id,
+      data.alert_generation_run_id,
+      data.school_id,
+      data.difference_percent,
+      data.difference_gbpcurrent,
+      data.difference_kwh,
+      data.current_period_type,
+      data.current_period_start_date,
+      data.current_period_end_date,
+      data.truncated_current_period,
+      data.previous_period_type,
+      data.previous_period_start_date,
+      data.previous_period_end_date,
+      data.pupils_changed,
+      data.tariff_has_changed
+     FROM ( SELECT alerts.alert_generation_run_id,
+              alerts.school_id,
+              data_1.difference_percent,
+              data_1.difference_gbpcurrent,
+              data_1.difference_kwh,
+              data_1.current_period_type,
+              data_1.current_period_start_date,
+              data_1.current_period_end_date,
+              data_1.truncated_current_period,
+              data_1.previous_period_type,
+              data_1.previous_period_start_date,
+              data_1.previous_period_end_date,
+              data_1.pupils_changed,
+              data_1.tariff_has_changed
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) data_1(difference_percent double precision, difference_gbpcurrent double precision, difference_kwh double precision, current_period_type text, current_period_start_date date, current_period_end_date date, truncated_current_period boolean, previous_period_type text, previous_period_start_date date, previous_period_end_date date, pupils_changed boolean, tariff_has_changed boolean)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertPreviousYearHolidayComparisonGas'::text))) data,
+      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
+             FROM alert_generation_runs
+            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
+    WHERE (data.alert_generation_run_id = latest_runs.id);
   SQL
   create_view "change_in_gas_since_last_years", sql_definition: <<-SQL
       SELECT latest_runs.id,
@@ -3243,6 +2906,30 @@ ActiveRecord::Schema.define(version: 2024_05_20_132318) do
             ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
     WHERE ((energy.alert_generation_run_id = latest_runs.id) AND (gas.alert_generation_run_id = latest_runs.id));
   SQL
+  create_view "change_in_solar_pv_since_last_years", sql_definition: <<-SQL
+      SELECT latest_runs.id,
+      versus_benchmark.school_id,
+      versus_benchmark.previous_year_solar_pv_kwh,
+      versus_benchmark.current_year_solar_pv_kwh,
+      versus_benchmark.previous_year_solar_pv_co2,
+      versus_benchmark.current_year_solar_pv_co2,
+      versus_benchmark.solar_type
+     FROM ( SELECT alerts.alert_generation_run_id,
+              alerts.school_id,
+              data.previous_year_solar_pv_kwh,
+              data.current_year_solar_pv_kwh,
+              data.previous_year_solar_pv_co2,
+              data.current_year_solar_pv_co2,
+              data.solar_type
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) data(previous_year_solar_pv_kwh double precision, current_year_solar_pv_kwh double precision, previous_year_solar_pv_co2 double precision, current_year_solar_pv_co2 double precision, solar_type text)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertEnergyAnnualVersusBenchmark'::text))) versus_benchmark,
+      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
+             FROM alert_generation_runs
+            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
+    WHERE (versus_benchmark.alert_generation_run_id = latest_runs.id);
+  SQL
   create_view "change_in_storage_heaters_since_last_years", sql_definition: <<-SQL
       SELECT latest_runs.id,
       energy.alert_generation_run_id,
@@ -3280,245 +2967,139 @@ ActiveRecord::Schema.define(version: 2024_05_20_132318) do
             ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
     WHERE ((energy.alert_generation_run_id = latest_runs.id) AND (storage.alert_generation_run_id = latest_runs.id));
   SQL
-  create_view "annual_change_in_gas_out_of_hours_uses", sql_definition: <<-SQL
+  create_view "electricity_consumption_during_holidays", sql_definition: <<-SQL
       SELECT latest_runs.id,
-      usage.alert_generation_run_id,
-      usage.school_id,
-      usage.out_of_hours_kwh,
-      usage.out_of_hours_co2,
-      usage.out_of_hours_gbpcurrent,
-      usage_previous_year.previous_out_of_hours_kwh,
-      usage_previous_year.previous_out_of_hours_co2,
-      usage_previous_year.previous_out_of_hours_gbpcurrent,
-      additional.economic_tariff_changed_this_year
+      data.alert_generation_run_id,
+      data.school_id,
+      data.holiday_projected_usage_gbp,
+      data.holiday_usage_to_date_gbp,
+      data.holiday_type,
+      data.holiday_start_date,
+      data.holiday_end_date
      FROM ( SELECT alerts.alert_generation_run_id,
               alerts.school_id,
-              json.out_of_hours_kwh,
-              json.out_of_hours_co2,
-              json.out_of_hours_gbpcurrent
+              data_1.holiday_projected_usage_gbp,
+              data_1.holiday_usage_to_date_gbp,
+              data_1.holiday_type,
+              data_1.holiday_start_date,
+              data_1.holiday_end_date
              FROM alerts,
               alert_types,
-              LATERAL jsonb_to_record(alerts.variables) json(out_of_hours_kwh double precision, out_of_hours_co2 double precision, out_of_hours_gbpcurrent double precision)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertOutOfHoursGasUsage'::text))) usage,
-      ( SELECT alerts.alert_generation_run_id,
+              LATERAL jsonb_to_record(alerts.variables) data_1(holiday_projected_usage_gbp double precision, holiday_usage_to_date_gbp double precision, holiday_type text, holiday_start_date date, holiday_end_date date)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertElectricityUsageDuringCurrentHoliday'::text))) data,
+      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
+             FROM alert_generation_runs
+            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
+    WHERE (data.alert_generation_run_id = latest_runs.id);
+  SQL
+  create_view "electricity_peak_kw_per_pupils", sql_definition: <<-SQL
+      SELECT latest_runs.id,
+      data.alert_generation_run_id,
+      data.school_id,
+      data.average_school_day_last_year_kw_per_floor_area,
+      data.average_school_day_last_year_kw,
+      data.exemplar_kw,
+      data.one_year_saving_versus_exemplar_gbp,
+      additional.electricity_economic_tariff_changed_this_year
+     FROM ( SELECT alerts.alert_generation_run_id,
               alerts.school_id,
-              json.out_of_hours_kwh AS previous_out_of_hours_kwh,
-              json.out_of_hours_co2 AS previous_out_of_hours_co2,
-              json.out_of_hours_gbpcurrent AS previous_out_of_hours_gbpcurrent
+              data_1.average_school_day_last_year_kw_per_floor_area,
+              data_1.average_school_day_last_year_kw,
+              data_1.exemplar_kw,
+              data_1.one_year_saving_versus_exemplar_gbp
              FROM alerts,
               alert_types,
-              LATERAL jsonb_to_record(alerts.variables) json(out_of_hours_kwh double precision, out_of_hours_co2 double precision, out_of_hours_gbpcurrent double precision)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertOutOfHoursGasUsagePreviousYear'::text))) usage_previous_year,
+              LATERAL jsonb_to_record(alerts.variables) data_1(average_school_day_last_year_kw_per_floor_area double precision, average_school_day_last_year_kw double precision, exemplar_kw double precision, one_year_saving_versus_exemplar_gbp double precision)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertElectricityPeakKWVersusBenchmark'::text))) data,
       ( SELECT alerts.alert_generation_run_id,
-              json.gas_economic_tariff_changed_this_year AS economic_tariff_changed_this_year
+              data_1.electricity_economic_tariff_changed_this_year
              FROM alerts,
               alert_types,
-              LATERAL jsonb_to_record(alerts.variables) json(gas_economic_tariff_changed_this_year boolean)
+              LATERAL jsonb_to_record(alerts.variables) data_1(electricity_economic_tariff_changed_this_year boolean)
             WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertAdditionalPrioritisationData'::text))) additional,
       ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
              FROM alert_generation_runs
             ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
-    WHERE ((usage.alert_generation_run_id = latest_runs.id) AND (usage_previous_year.alert_generation_run_id = latest_runs.id) AND (additional.alert_generation_run_id = latest_runs.id));
+    WHERE ((data.alert_generation_run_id = latest_runs.id) AND (additional.alert_generation_run_id = latest_runs.id));
   SQL
-  create_view "annual_change_in_storage_heater_out_of_hours_uses", sql_definition: <<-SQL
+  create_view "electricity_targets", sql_definition: <<-SQL
       SELECT latest_runs.id,
-      usage.alert_generation_run_id,
-      usage.school_id,
-      usage.out_of_hours_kwh,
-      usage.out_of_hours_co2,
-      usage.out_of_hours_gbpcurrent,
-      usage_previous_year.previous_out_of_hours_kwh,
-      usage_previous_year.previous_out_of_hours_co2,
-      usage_previous_year.previous_out_of_hours_gbpcurrent,
-      additional.economic_tariff_changed_this_year
+      data.alert_generation_run_id,
+      data.school_id,
+      data.current_year_percent_of_target_relative,
+      data.current_year_unscaled_percent_of_target_relative,
+      data.current_year_kwh,
+      data.current_year_target_kwh,
+      data.unscaled_target_kwh_to_date,
+      data.tracking_start_date
      FROM ( SELECT alerts.alert_generation_run_id,
               alerts.school_id,
-              json.out_of_hours_kwh,
-              json.out_of_hours_co2,
-              json.out_of_hours_gbpcurrent
+              data_1.current_year_percent_of_target_relative,
+              data_1.current_year_unscaled_percent_of_target_relative,
+              data_1.current_year_kwh,
+              data_1.current_year_target_kwh,
+              data_1.unscaled_target_kwh_to_date,
+              data_1.tracking_start_date
              FROM alerts,
               alert_types,
-              LATERAL jsonb_to_record(alerts.variables) json(out_of_hours_kwh double precision, out_of_hours_co2 double precision, out_of_hours_gbpcurrent double precision)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertStorageHeaterOutOfHours'::text))) usage,
-      ( SELECT alerts.alert_generation_run_id,
-              alerts.school_id,
-              json.out_of_hours_kwh AS previous_out_of_hours_kwh,
-              json.out_of_hours_co2 AS previous_out_of_hours_co2,
-              json.out_of_hours_gbpcurrent AS previous_out_of_hours_gbpcurrent
-             FROM alerts,
-              alert_types,
-              LATERAL jsonb_to_record(alerts.variables) json(out_of_hours_kwh double precision, out_of_hours_co2 double precision, out_of_hours_gbpcurrent double precision)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertOutOfHoursStorageHeaterUsagePreviousYear'::text))) usage_previous_year,
-      ( SELECT alerts.alert_generation_run_id,
-              json.electricity_economic_tariff_changed_this_year AS economic_tariff_changed_this_year
-             FROM alerts,
-              alert_types,
-              LATERAL jsonb_to_record(alerts.variables) json(electricity_economic_tariff_changed_this_year boolean)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertAdditionalPrioritisationData'::text))) additional,
+              LATERAL jsonb_to_record(alerts.variables) data_1(current_year_percent_of_target_relative double precision, current_year_unscaled_percent_of_target_relative double precision, current_year_kwh double precision, current_year_target_kwh double precision, unscaled_target_kwh_to_date double precision, tracking_start_date date)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertElectricityTargetAnnual'::text))) data,
       ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
              FROM alert_generation_runs
             ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
-    WHERE ((usage.alert_generation_run_id = latest_runs.id) AND (usage_previous_year.alert_generation_run_id = latest_runs.id) AND (additional.alert_generation_run_id = latest_runs.id));
+    WHERE (data.alert_generation_run_id = latest_runs.id);
   SQL
-  create_view "heating_coming_on_too_early", sql_definition: <<-SQL
-      WITH early AS (
-           SELECT alerts.alert_generation_run_id,
-              json.avg_week_start_time,
-              json.one_year_optimum_start_saving_gbpcurrent
-             FROM alerts,
-              alert_types,
-              LATERAL jsonb_to_record(alerts.variables) json(avg_week_start_time time without time zone, one_year_optimum_start_saving_gbpcurrent double precision)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertHeatingComingOnTooEarly'::text))
-          ), optimum AS (
-           SELECT alerts.alert_generation_run_id,
-              json.average_start_time_hh_mm,
-              json.start_time_standard_devation,
-              json.rating,
-              json.regression_start_time,
-              json.optimum_start_sensitivity,
-              json.regression_r2
-             FROM alerts,
-              alert_types,
-              LATERAL jsonb_to_record(alerts.variables) json(average_start_time_hh_mm time without time zone, start_time_standard_devation double precision, rating double precision, regression_start_time double precision, optimum_start_sensitivity double precision, regression_r2 double precision)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertOptimumStartAnalysis'::text))
-          ), additional AS (
-           SELECT alerts.alert_generation_run_id,
-              alerts.school_id,
-              json.gas_economic_tariff_changed_this_year
-             FROM alerts,
-              alert_types,
-              LATERAL jsonb_to_record(alerts.variables) json(gas_economic_tariff_changed_this_year boolean)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertAdditionalPrioritisationData'::text))
-          ), latest_runs AS (
-           SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
-             FROM alert_generation_runs
-            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC
-          )
-   SELECT latest_runs.id,
-      additional.alert_generation_run_id,
-      additional.school_id,
-      additional.gas_economic_tariff_changed_this_year,
-      early.avg_week_start_time,
-      early.one_year_optimum_start_saving_gbpcurrent,
-      optimum.average_start_time_hh_mm,
-      optimum.start_time_standard_devation,
-      optimum.rating,
-      optimum.regression_start_time,
-      optimum.optimum_start_sensitivity,
-      optimum.regression_r2
-     FROM (((latest_runs
-       JOIN additional ON ((latest_runs.id = additional.alert_generation_run_id)))
-       LEFT JOIN early ON ((latest_runs.id = early.alert_generation_run_id)))
-       LEFT JOIN optimum ON ((latest_runs.id = optimum.alert_generation_run_id)));
-  SQL
-  create_view "annual_change_in_electricity_out_of_hours_uses", sql_definition: <<-SQL
+  create_view "gas_consumption_during_holidays", sql_definition: <<-SQL
       SELECT latest_runs.id,
-      usage.alert_generation_run_id,
-      usage.school_id,
-      usage.out_of_hours_kwh,
-      usage.out_of_hours_co2,
-      usage.out_of_hours_gbpcurrent,
-      usage_previous_year.previous_out_of_hours_kwh,
-      usage_previous_year.previous_out_of_hours_co2,
-      usage_previous_year.previous_out_of_hours_gbpcurrent,
-      additional.economic_tariff_changed_this_year
+      data.alert_generation_run_id,
+      data.school_id,
+      data.holiday_projected_usage_gbp,
+      data.holiday_usage_to_date_gbp,
+      data.holiday_type,
+      data.holiday_start_date,
+      data.holiday_end_date
      FROM ( SELECT alerts.alert_generation_run_id,
               alerts.school_id,
-              json.out_of_hours_kwh,
-              json.out_of_hours_co2,
-              json.out_of_hours_gbpcurrent
+              data_1.holiday_projected_usage_gbp,
+              data_1.holiday_usage_to_date_gbp,
+              data_1.holiday_type,
+              data_1.holiday_start_date,
+              data_1.holiday_end_date
              FROM alerts,
               alert_types,
-              LATERAL jsonb_to_record(alerts.variables) json(out_of_hours_kwh double precision, out_of_hours_co2 double precision, out_of_hours_gbpcurrent double precision)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertOutOfHoursElectricityUsage'::text))) usage,
-      ( SELECT alerts.alert_generation_run_id,
-              alerts.school_id,
-              json.out_of_hours_kwh AS previous_out_of_hours_kwh,
-              json.out_of_hours_co2 AS previous_out_of_hours_co2,
-              json.out_of_hours_gbpcurrent AS previous_out_of_hours_gbpcurrent
-             FROM alerts,
-              alert_types,
-              LATERAL jsonb_to_record(alerts.variables) json(out_of_hours_kwh double precision, out_of_hours_co2 double precision, out_of_hours_gbpcurrent double precision)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertOutOfHoursElectricityUsagePreviousYear'::text))) usage_previous_year,
-      ( SELECT alerts.alert_generation_run_id,
-              json.electricity_economic_tariff_changed_this_year AS economic_tariff_changed_this_year
-             FROM alerts,
-              alert_types,
-              LATERAL jsonb_to_record(alerts.variables) json(electricity_economic_tariff_changed_this_year boolean)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertAdditionalPrioritisationData'::text))) additional,
+              LATERAL jsonb_to_record(alerts.variables) data_1(holiday_projected_usage_gbp double precision, holiday_usage_to_date_gbp double precision, holiday_type text, holiday_start_date date, holiday_end_date date)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertGasHeatingHotWaterOnDuringHoliday'::text))) data,
       ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
              FROM alert_generation_runs
             ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
-    WHERE ((usage.alert_generation_run_id = latest_runs.id) AND (usage_previous_year.alert_generation_run_id = latest_runs.id) AND (additional.alert_generation_run_id = latest_runs.id));
+    WHERE (data.alert_generation_run_id = latest_runs.id);
   SQL
-  create_view "change_in_energy_since_last_years", sql_definition: <<-SQL
+  create_view "gas_targets", sql_definition: <<-SQL
       SELECT latest_runs.id,
-      energy.school_id,
-      energy.current_year_electricity_kwh AS electricity_current_period_kwh,
-      energy.previous_year_electricity_kwh AS electricity_previous_period_kwh,
-      energy.current_year_electricity_co2 AS electricity_current_period_co2,
-      energy.previous_year_electricity_co2 AS electricity_previous_period_co2,
-      energy.current_year_electricity_gbp AS electricity_current_period_gbp,
-      energy.previous_year_electricity_gbp AS electricity_previous_period_gbp,
-      energy.current_year_gas_kwh AS gas_current_period_kwh,
-      energy.previous_year_gas_kwh AS gas_previous_period_kwh,
-      energy.current_year_gas_co2 AS gas_current_period_co2,
-      energy.previous_year_gas_co2 AS gas_previous_period_co2,
-      energy.current_year_gas_gbp AS gas_current_period_gbp,
-      energy.previous_year_gas_gbp AS gas_previous_period_gbp,
-      energy.current_year_storage_heaters_kwh AS storage_heater_current_period_kwh,
-      energy.previous_year_storage_heaters_kwh AS storage_heater_previous_period_kwh,
-      energy.current_year_storage_heaters_co2 AS storage_heater_current_period_co2,
-      energy.previous_year_storage_heaters_co2 AS storage_heater_previous_period_co2,
-      energy.current_year_storage_heaters_gbp AS storage_heater_current_period_gbp,
-      energy.previous_year_storage_heaters_gbp AS storage_heater_previous_period_gbp,
-      energy.current_year_solar_pv_kwh AS solar_pv_current_period_kwh,
-      energy.previous_year_solar_pv_kwh AS solar_pv_previous_period_kwh,
-      energy.current_year_solar_pv_co2 AS solar_pv_current_period_co2,
-      energy.previous_year_solar_pv_co2 AS solar_pv_previous_period_co2,
-      additional.electricity_economic_tariff_changed_this_year AS electricity_tariff_has_changed,
-      additional.gas_economic_tariff_changed_this_year AS gas_tariff_has_changed,
-      energy.solar_type
+      data.alert_generation_run_id,
+      data.school_id,
+      data.current_year_percent_of_target_relative,
+      data.current_year_unscaled_percent_of_target_relative,
+      data.current_year_kwh,
+      data.current_year_target_kwh,
+      data.unscaled_target_kwh_to_date,
+      data.tracking_start_date
      FROM ( SELECT alerts.alert_generation_run_id,
               alerts.school_id,
-              data.previous_year_electricity_kwh,
-              data.current_year_electricity_kwh,
-              data.previous_year_electricity_co2,
-              data.current_year_electricity_co2,
-              data.previous_year_electricity_gbp,
-              data.current_year_electricity_gbp,
-              data.previous_year_gas_kwh,
-              data.current_year_gas_kwh,
-              data.previous_year_gas_co2,
-              data.current_year_gas_co2,
-              data.previous_year_gas_gbp,
-              data.current_year_gas_gbp,
-              data.previous_year_storage_heaters_kwh,
-              data.current_year_storage_heaters_kwh,
-              data.previous_year_storage_heaters_co2,
-              data.current_year_storage_heaters_co2,
-              data.previous_year_storage_heaters_gbp,
-              data.current_year_storage_heaters_gbp,
-              data.previous_year_solar_pv_kwh,
-              data.current_year_solar_pv_kwh,
-              data.previous_year_solar_pv_co2,
-              data.current_year_solar_pv_co2,
-              data.solar_type
+              data_1.current_year_percent_of_target_relative,
+              data_1.current_year_unscaled_percent_of_target_relative,
+              data_1.current_year_kwh,
+              data_1.current_year_target_kwh,
+              data_1.unscaled_target_kwh_to_date,
+              data_1.tracking_start_date
              FROM alerts,
               alert_types,
-              LATERAL jsonb_to_record(alerts.variables) data(previous_year_electricity_kwh double precision, current_year_electricity_kwh double precision, previous_year_electricity_co2 double precision, current_year_electricity_co2 double precision, previous_year_electricity_gbp double precision, current_year_electricity_gbp double precision, previous_year_gas_kwh double precision, current_year_gas_kwh double precision, previous_year_gas_co2 double precision, current_year_gas_co2 double precision, previous_year_gas_gbp double precision, current_year_gas_gbp double precision, previous_year_storage_heaters_kwh double precision, current_year_storage_heaters_kwh double precision, previous_year_storage_heaters_co2 double precision, current_year_storage_heaters_co2 double precision, previous_year_storage_heaters_gbp double precision, current_year_storage_heaters_gbp double precision, previous_year_solar_pv_kwh double precision, current_year_solar_pv_kwh double precision, previous_year_solar_pv_co2 double precision, current_year_solar_pv_co2 double precision, solar_type text)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertEnergyAnnualVersusBenchmark'::text))) energy,
-      ( SELECT alerts.alert_generation_run_id,
-              data.electricity_economic_tariff_changed_this_year,
-              data.gas_economic_tariff_changed_this_year
-             FROM alerts,
-              alert_types,
-              LATERAL jsonb_to_record(alerts.variables) data(electricity_economic_tariff_changed_this_year boolean, gas_economic_tariff_changed_this_year boolean)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertAdditionalPrioritisationData'::text))) additional,
+              LATERAL jsonb_to_record(alerts.variables) data_1(current_year_percent_of_target_relative double precision, current_year_unscaled_percent_of_target_relative double precision, current_year_kwh double precision, current_year_target_kwh double precision, unscaled_target_kwh_to_date double precision, tracking_start_date date)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertGasTargetAnnual'::text))) data,
       ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
              FROM alert_generation_runs
             ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
-    WHERE ((energy.alert_generation_run_id = latest_runs.id) AND (additional.alert_generation_run_id = latest_runs.id));
+    WHERE (data.alert_generation_run_id = latest_runs.id);
   SQL
   create_view "heat_saver_march_2024s", sql_definition: <<-SQL
       WITH electricity AS (
@@ -3623,6 +3204,356 @@ ActiveRecord::Schema.define(version: 2024_05_20_132318) do
        LEFT JOIN gas ON ((latest_runs.id = gas.alert_generation_run_id)))
        LEFT JOIN storage_heater ON ((latest_runs.id = storage_heater.alert_generation_run_id)))
        LEFT JOIN enba ON ((latest_runs.id = enba.alert_generation_run_id)));
+  SQL
+  create_view "heating_coming_on_too_early", sql_definition: <<-SQL
+      WITH early AS (
+           SELECT alerts.alert_generation_run_id,
+              json.avg_week_start_time,
+              json.one_year_optimum_start_saving_gbpcurrent
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) json(avg_week_start_time time without time zone, one_year_optimum_start_saving_gbpcurrent double precision)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertHeatingComingOnTooEarly'::text))
+          ), optimum AS (
+           SELECT alerts.alert_generation_run_id,
+              json.average_start_time_hh_mm,
+              json.start_time_standard_devation,
+              json.rating,
+              json.regression_start_time,
+              json.optimum_start_sensitivity,
+              json.regression_r2
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) json(average_start_time_hh_mm time without time zone, start_time_standard_devation double precision, rating double precision, regression_start_time double precision, optimum_start_sensitivity double precision, regression_r2 double precision)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertOptimumStartAnalysis'::text))
+          ), additional AS (
+           SELECT alerts.alert_generation_run_id,
+              alerts.school_id,
+              json.gas_economic_tariff_changed_this_year
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) json(gas_economic_tariff_changed_this_year boolean)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertAdditionalPrioritisationData'::text))
+          ), latest_runs AS (
+           SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
+             FROM alert_generation_runs
+            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC
+          )
+   SELECT latest_runs.id,
+      additional.alert_generation_run_id,
+      additional.school_id,
+      additional.gas_economic_tariff_changed_this_year,
+      early.avg_week_start_time,
+      early.one_year_optimum_start_saving_gbpcurrent,
+      optimum.average_start_time_hh_mm,
+      optimum.start_time_standard_devation,
+      optimum.rating,
+      optimum.regression_start_time,
+      optimum.optimum_start_sensitivity,
+      optimum.regression_r2
+     FROM (((latest_runs
+       JOIN additional ON ((latest_runs.id = additional.alert_generation_run_id)))
+       LEFT JOIN early ON ((latest_runs.id = early.alert_generation_run_id)))
+       LEFT JOIN optimum ON ((latest_runs.id = optimum.alert_generation_run_id)));
+  SQL
+  create_view "heating_in_warm_weathers", sql_definition: <<-SQL
+      WITH gas AS (
+           SELECT alerts.alert_generation_run_id,
+              data.percent_of_annual_heating,
+              data.warm_weather_heating_days_all_days_kwh,
+              data.warm_weather_heating_days_all_days_co2,
+              data.warm_weather_heating_days_all_days_gbpcurrent,
+              data.warm_weather_heating_days_all_days_days
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) data(percent_of_annual_heating double precision, warm_weather_heating_days_all_days_kwh double precision, warm_weather_heating_days_all_days_co2 double precision, warm_weather_heating_days_all_days_gbpcurrent double precision, warm_weather_heating_days_all_days_days double precision)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertSeasonalHeatingSchoolDays'::text))
+          ), storage_heaters AS (
+           SELECT alerts.alert_generation_run_id,
+              data.percent_of_annual_heating,
+              data.warm_weather_heating_days_all_days_kwh,
+              data.warm_weather_heating_days_all_days_co2,
+              data.warm_weather_heating_days_all_days_gbpcurrent,
+              data.warm_weather_heating_days_all_days_days
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) data(percent_of_annual_heating double precision, warm_weather_heating_days_all_days_kwh double precision, warm_weather_heating_days_all_days_co2 double precision, warm_weather_heating_days_all_days_gbpcurrent double precision, warm_weather_heating_days_all_days_days double precision)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertSeasonalHeatingSchoolDaysStorageHeaters'::text))
+          ), additional AS (
+           SELECT alerts.alert_generation_run_id,
+              alerts.school_id
+             FROM alerts,
+              alert_types
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertAdditionalPrioritisationData'::text))
+          ), latest_runs AS (
+           SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
+             FROM alert_generation_runs
+            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC
+          )
+   SELECT latest_runs.id,
+      additional.school_id,
+      COALESCE(gas.percent_of_annual_heating, storage_heaters.percent_of_annual_heating) AS percent_of_annual_heating,
+      COALESCE(gas.warm_weather_heating_days_all_days_kwh, storage_heaters.warm_weather_heating_days_all_days_kwh) AS warm_weather_heating_days_all_days_kwh,
+      COALESCE(gas.warm_weather_heating_days_all_days_co2, storage_heaters.warm_weather_heating_days_all_days_co2) AS warm_weather_heating_days_all_days_co2,
+      COALESCE(gas.warm_weather_heating_days_all_days_gbpcurrent, storage_heaters.warm_weather_heating_days_all_days_gbpcurrent) AS warm_weather_heating_days_all_days_gbpcurrent,
+      COALESCE(gas.warm_weather_heating_days_all_days_days, storage_heaters.warm_weather_heating_days_all_days_days) AS warm_weather_heating_days_all_days_days
+     FROM (((latest_runs
+       JOIN additional ON ((latest_runs.id = additional.alert_generation_run_id)))
+       LEFT JOIN gas ON ((latest_runs.id = gas.alert_generation_run_id)))
+       LEFT JOIN storage_heaters ON ((latest_runs.id = storage_heaters.alert_generation_run_id)));
+  SQL
+  create_view "hot_water_efficiencies", sql_definition: <<-SQL
+      SELECT latest_runs.id,
+      data.alert_generation_run_id,
+      data.school_id,
+      data.avg_gas_per_pupil_gbp,
+      data.benchmark_existing_gas_efficiency,
+      data.benchmark_gas_better_control_saving_gbp,
+      data.benchmark_point_of_use_electric_saving_gbp
+     FROM ( SELECT alerts.alert_generation_run_id,
+              alerts.school_id,
+              data_1.avg_gas_per_pupil_gbp,
+              data_1.benchmark_existing_gas_efficiency,
+              data_1.benchmark_gas_better_control_saving_gbp,
+              data_1.benchmark_point_of_use_electric_saving_gbp
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) data_1(avg_gas_per_pupil_gbp double precision, benchmark_existing_gas_efficiency double precision, benchmark_gas_better_control_saving_gbp double precision, benchmark_point_of_use_electric_saving_gbp double precision)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertHotWaterEfficiency'::text))) data,
+      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
+             FROM alert_generation_runs
+            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
+    WHERE (data.alert_generation_run_id = latest_runs.id);
+  SQL
+  create_view "recent_change_in_baseloads", sql_definition: <<-SQL
+      SELECT latest_runs.id,
+      data.alert_generation_run_id,
+      data.school_id,
+      data.predicted_percent_increase_in_usage,
+      data.average_baseload_last_year_kw,
+      data.average_baseload_last_week_kw,
+      data.change_in_baseload_kw,
+      data.next_year_change_in_baseload_gbpcurrent,
+      additional.electricity_economic_tariff_changed_this_year
+     FROM ( SELECT alerts.alert_generation_run_id,
+              alerts.school_id,
+              data_1.predicted_percent_increase_in_usage,
+              data_1.average_baseload_last_year_kw,
+              data_1.average_baseload_last_week_kw,
+              data_1.change_in_baseload_kw,
+              data_1.next_year_change_in_baseload_gbpcurrent
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) data_1(predicted_percent_increase_in_usage double precision, average_baseload_last_year_kw double precision, average_baseload_last_week_kw double precision, change_in_baseload_kw double precision, next_year_change_in_baseload_gbpcurrent double precision)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertChangeInElectricityBaseloadShortTerm'::text))) data,
+      ( SELECT alerts.alert_generation_run_id,
+              data_1.electricity_economic_tariff_changed_this_year
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) data_1(electricity_economic_tariff_changed_this_year boolean)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertAdditionalPrioritisationData'::text))) additional,
+      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
+             FROM alert_generation_runs
+            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
+    WHERE ((data.alert_generation_run_id = latest_runs.id) AND (additional.alert_generation_run_id = latest_runs.id));
+  SQL
+  create_view "seasonal_baseload_variations", sql_definition: <<-SQL
+      SELECT latest_runs.id,
+      additional.school_id,
+      data.alert_generation_run_id,
+      data.percent_seasonal_variation,
+      data.summer_kw,
+      data.winter_kw,
+      data.annual_cost_gbpcurrent,
+      additional.electricity_economic_tariff_changed_this_year
+     FROM ( SELECT alerts.alert_generation_run_id,
+              data_1.percent_seasonal_variation,
+              data_1.summer_kw,
+              data_1.winter_kw,
+              data_1.annual_cost_gbpcurrent
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) data_1(percent_seasonal_variation double precision, summer_kw double precision, winter_kw double precision, annual_cost_gbpcurrent double precision)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertSeasonalBaseloadVariation'::text))) data,
+      ( SELECT alerts.alert_generation_run_id,
+              alerts.school_id,
+              data_1.electricity_economic_tariff_changed_this_year
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) data_1(electricity_economic_tariff_changed_this_year boolean)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertAdditionalPrioritisationData'::text))) additional,
+      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
+             FROM alert_generation_runs
+            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
+    WHERE ((data.alert_generation_run_id = latest_runs.id) AND (additional.alert_generation_run_id = latest_runs.id));
+  SQL
+  create_view "solar_generation_summaries", sql_definition: <<-SQL
+      SELECT latest_runs.id,
+      solar_generation.alert_generation_run_id,
+      solar_generation.school_id,
+      solar_generation.annual_electricity_kwh,
+      solar_generation.annual_mains_consumed_kwh,
+      solar_generation.annual_solar_pv_kwh,
+      solar_generation.annual_exported_solar_pv_kwh,
+      solar_generation.annual_solar_pv_consumed_onsite_kwh
+     FROM ( SELECT alerts.alert_generation_run_id,
+              alerts.school_id,
+              data.annual_electricity_kwh,
+              data.annual_mains_consumed_kwh,
+              data.annual_solar_pv_kwh,
+              data.annual_exported_solar_pv_kwh,
+              data.annual_solar_pv_consumed_onsite_kwh
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) data(annual_electricity_kwh double precision, annual_mains_consumed_kwh double precision, annual_solar_pv_kwh double precision, annual_exported_solar_pv_kwh double precision, annual_solar_pv_consumed_onsite_kwh double precision)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertSolarGeneration'::text))) solar_generation,
+      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
+             FROM alert_generation_runs
+            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
+    WHERE (solar_generation.alert_generation_run_id = latest_runs.id);
+  SQL
+  create_view "solar_pv_benefit_estimates", sql_definition: <<-SQL
+      SELECT latest_runs.id,
+      additional.school_id,
+      benefit_estimate.alert_generation_run_id,
+      benefit_estimate.optimum_kwp,
+      benefit_estimate.optimum_payback_years,
+      benefit_estimate.optimum_mains_reduction_percent,
+      benefit_estimate.one_year_saving_gbpcurrent,
+      additional.electricity_economic_tariff_changed_this_year
+     FROM ( SELECT alerts.alert_generation_run_id,
+              data.optimum_kwp,
+              data.optimum_payback_years,
+              data.optimum_mains_reduction_percent,
+              data.one_year_saving_gbpcurrent
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) data(optimum_kwp double precision, optimum_payback_years double precision, optimum_mains_reduction_percent double precision, one_year_saving_gbpcurrent double precision)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertSolarPVBenefitEstimator'::text))) benefit_estimate,
+      ( SELECT alerts.alert_generation_run_id,
+              alerts.school_id,
+              data.electricity_economic_tariff_changed_this_year
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) data(electricity_economic_tariff_changed_this_year boolean)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertAdditionalPrioritisationData'::text))) additional,
+      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
+             FROM alert_generation_runs
+            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
+    WHERE ((benefit_estimate.alert_generation_run_id = latest_runs.id) AND (additional.alert_generation_run_id = latest_runs.id));
+  SQL
+  create_view "storage_heater_consumption_during_holidays", sql_definition: <<-SQL
+      SELECT latest_runs.id,
+      data.alert_generation_run_id,
+      data.school_id,
+      data.holiday_projected_usage_gbp,
+      data.holiday_usage_to_date_gbp,
+      data.holiday_type,
+      data.holiday_start_date,
+      data.holiday_end_date
+     FROM ( SELECT alerts.alert_generation_run_id,
+              alerts.school_id,
+              data_1.holiday_projected_usage_gbp,
+              data_1.holiday_usage_to_date_gbp,
+              data_1.holiday_type,
+              data_1.holiday_start_date,
+              data_1.holiday_end_date
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) data_1(holiday_projected_usage_gbp double precision, holiday_usage_to_date_gbp double precision, holiday_type text, holiday_start_date date, holiday_end_date date)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertStorageHeaterHeatingOnDuringHoliday'::text))) data,
+      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
+             FROM alert_generation_runs
+            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
+    WHERE (data.alert_generation_run_id = latest_runs.id);
+  SQL
+  create_view "thermostat_sensitivities", sql_definition: <<-SQL
+      SELECT latest_runs.id,
+      data.alert_generation_run_id,
+      data.school_id,
+      data."annual_saving_1_C_change_gbp"
+     FROM ( SELECT alerts.alert_generation_run_id,
+              alerts.school_id,
+              data_1."annual_saving_1_C_change_gbp"
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) data_1("annual_saving_1_C_change_gbp" double precision)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertHeatingSensitivityAdvice'::text))) data,
+      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
+             FROM alert_generation_runs
+            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
+    WHERE (data.alert_generation_run_id = latest_runs.id);
+  SQL
+  create_view "thermostatic_controls", sql_definition: <<-SQL
+      WITH gas AS (
+           SELECT alerts.alert_generation_run_id,
+              data.r2,
+              data.potential_saving_gbp
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) data(r2 double precision, potential_saving_gbp double precision)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertThermostaticControl'::text))
+          ), storage_heaters AS (
+           SELECT alerts.alert_generation_run_id,
+              data.r2,
+              data.potential_saving_gbp
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) data(r2 double precision, potential_saving_gbp double precision)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertStorageHeaterThermostatic'::text))
+          ), additional AS (
+           SELECT alerts.alert_generation_run_id,
+              alerts.school_id
+             FROM alerts,
+              alert_types
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertAdditionalPrioritisationData'::text))
+          ), latest_runs AS (
+           SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
+             FROM alert_generation_runs
+            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC
+          )
+   SELECT latest_runs.id,
+      additional.school_id,
+      COALESCE(gas.r2, storage_heaters.r2) AS r2,
+      NULLIF((COALESCE(gas.potential_saving_gbp, (0)::double precision) + COALESCE(storage_heaters.potential_saving_gbp, (0)::double precision)), (0)::double precision) AS potential_saving_gbp
+     FROM (((latest_runs
+       JOIN additional ON ((latest_runs.id = additional.alert_generation_run_id)))
+       LEFT JOIN gas ON ((latest_runs.id = gas.alert_generation_run_id)))
+       LEFT JOIN storage_heaters ON ((latest_runs.id = storage_heaters.alert_generation_run_id)));
+  SQL
+  create_view "weekday_baseload_variations", sql_definition: <<-SQL
+      SELECT latest_runs.id,
+      additional.school_id,
+      data.alert_generation_run_id,
+      data.percent_intraday_variation,
+      data.min_day_kw,
+      data.max_day_kw,
+      data.min_day,
+      data.max_day,
+      data.annual_cost_gbpcurrent,
+      additional.electricity_economic_tariff_changed_this_year
+     FROM ( SELECT alerts.alert_generation_run_id,
+              data_1.percent_intraday_variation,
+              data_1.min_day_kw,
+              data_1.max_day_kw,
+              data_1.min_day,
+              data_1.max_day,
+              data_1.annual_cost_gbpcurrent
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) data_1(percent_intraday_variation double precision, min_day_kw double precision, max_day_kw double precision, min_day integer, max_day integer, annual_cost_gbpcurrent double precision)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertIntraweekBaseloadVariation'::text))) data,
+      ( SELECT alerts.alert_generation_run_id,
+              alerts.school_id,
+              data_1.electricity_economic_tariff_changed_this_year
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) data_1(electricity_economic_tariff_changed_this_year boolean)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertAdditionalPrioritisationData'::text))) additional,
+      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
+             FROM alert_generation_runs
+            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
+    WHERE ((data.alert_generation_run_id = latest_runs.id) AND (additional.alert_generation_run_id = latest_runs.id));
   SQL
   create_view "configurable_periods", sql_definition: <<-SQL
       WITH electricity AS (
@@ -3736,6 +3667,75 @@ ActiveRecord::Schema.define(version: 2024_05_20_132318) do
        LEFT JOIN benchmark ON ((latest_runs.id = benchmark.alert_generation_run_id)))
     WHERE (((electricity.custom_period_id = gas.custom_period_id) AND (gas.custom_period_id = storage_heater.custom_period_id)) OR ((electricity.custom_period_id IS NULL) AND (gas.custom_period_id = storage_heater.custom_period_id)) OR ((gas.custom_period_id IS NULL) AND (electricity.custom_period_id = storage_heater.custom_period_id)) OR ((storage_heater.custom_period_id IS NULL) AND (electricity.custom_period_id = gas.custom_period_id)) OR ((electricity.custom_period_id IS NOT NULL) AND (COALESCE(gas.custom_period_id, storage_heater.custom_period_id) IS NULL)) OR ((gas.custom_period_id IS NOT NULL) AND (COALESCE(electricity.custom_period_id, storage_heater.custom_period_id) IS NULL)) OR ((storage_heater.custom_period_id IS NOT NULL) AND (COALESCE(electricity.custom_period_id, gas.custom_period_id) IS NULL)));
   SQL
+  create_view "change_in_energy_since_last_years", sql_definition: <<-SQL
+      SELECT latest_runs.id,
+      energy.school_id,
+      energy.current_year_electricity_kwh AS electricity_current_period_kwh,
+      energy.previous_year_electricity_kwh AS electricity_previous_period_kwh,
+      energy.current_year_electricity_co2 AS electricity_current_period_co2,
+      energy.previous_year_electricity_co2 AS electricity_previous_period_co2,
+      energy.current_year_electricity_gbp AS electricity_current_period_gbp,
+      energy.previous_year_electricity_gbp AS electricity_previous_period_gbp,
+      energy.current_year_gas_kwh AS gas_current_period_kwh,
+      energy.previous_year_gas_kwh AS gas_previous_period_kwh,
+      energy.current_year_gas_co2 AS gas_current_period_co2,
+      energy.previous_year_gas_co2 AS gas_previous_period_co2,
+      energy.current_year_gas_gbp AS gas_current_period_gbp,
+      energy.previous_year_gas_gbp AS gas_previous_period_gbp,
+      energy.current_year_storage_heaters_kwh AS storage_heater_current_period_kwh,
+      energy.previous_year_storage_heaters_kwh AS storage_heater_previous_period_kwh,
+      energy.current_year_storage_heaters_co2 AS storage_heater_current_period_co2,
+      energy.previous_year_storage_heaters_co2 AS storage_heater_previous_period_co2,
+      energy.current_year_storage_heaters_gbp AS storage_heater_current_period_gbp,
+      energy.previous_year_storage_heaters_gbp AS storage_heater_previous_period_gbp,
+      energy.current_year_solar_pv_kwh AS solar_pv_current_period_kwh,
+      energy.previous_year_solar_pv_kwh AS solar_pv_previous_period_kwh,
+      energy.current_year_solar_pv_co2 AS solar_pv_current_period_co2,
+      energy.previous_year_solar_pv_co2 AS solar_pv_previous_period_co2,
+      additional.electricity_economic_tariff_changed_this_year AS electricity_tariff_has_changed,
+      additional.gas_economic_tariff_changed_this_year AS gas_tariff_has_changed,
+      energy.solar_type
+     FROM ( SELECT alerts.alert_generation_run_id,
+              alerts.school_id,
+              data.previous_year_electricity_kwh,
+              data.current_year_electricity_kwh,
+              data.previous_year_electricity_co2,
+              data.current_year_electricity_co2,
+              data.previous_year_electricity_gbp,
+              data.current_year_electricity_gbp,
+              data.previous_year_gas_kwh,
+              data.current_year_gas_kwh,
+              data.previous_year_gas_co2,
+              data.current_year_gas_co2,
+              data.previous_year_gas_gbp,
+              data.current_year_gas_gbp,
+              data.previous_year_storage_heaters_kwh,
+              data.current_year_storage_heaters_kwh,
+              data.previous_year_storage_heaters_co2,
+              data.current_year_storage_heaters_co2,
+              data.previous_year_storage_heaters_gbp,
+              data.current_year_storage_heaters_gbp,
+              data.previous_year_solar_pv_kwh,
+              data.current_year_solar_pv_kwh,
+              data.previous_year_solar_pv_co2,
+              data.current_year_solar_pv_co2,
+              data.solar_type
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) data(previous_year_electricity_kwh double precision, current_year_electricity_kwh double precision, previous_year_electricity_co2 double precision, current_year_electricity_co2 double precision, previous_year_electricity_gbp double precision, current_year_electricity_gbp double precision, previous_year_gas_kwh double precision, current_year_gas_kwh double precision, previous_year_gas_co2 double precision, current_year_gas_co2 double precision, previous_year_gas_gbp double precision, current_year_gas_gbp double precision, previous_year_storage_heaters_kwh double precision, current_year_storage_heaters_kwh double precision, previous_year_storage_heaters_co2 double precision, current_year_storage_heaters_co2 double precision, previous_year_storage_heaters_gbp double precision, current_year_storage_heaters_gbp double precision, previous_year_solar_pv_kwh double precision, current_year_solar_pv_kwh double precision, previous_year_solar_pv_co2 double precision, current_year_solar_pv_co2 double precision, solar_type text)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertEnergyAnnualVersusBenchmark'::text))) energy,
+      ( SELECT alerts.alert_generation_run_id,
+              data.electricity_economic_tariff_changed_this_year,
+              data.gas_economic_tariff_changed_this_year
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) data(electricity_economic_tariff_changed_this_year boolean, gas_economic_tariff_changed_this_year boolean)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertAdditionalPrioritisationData'::text))) additional,
+      ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
+             FROM alert_generation_runs
+            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
+    WHERE ((energy.alert_generation_run_id = latest_runs.id) AND (additional.alert_generation_run_id = latest_runs.id));
+  SQL
   create_view "change_in_energy_use_since_joined_energy_sparks", sql_definition: <<-SQL
       SELECT latest_runs.id,
       energy.school_id,
@@ -3835,5 +3835,73 @@ ActiveRecord::Schema.define(version: 2024_05_20_132318) do
              FROM alert_generation_runs
             ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
     WHERE (data.alert_generation_run_id = latest_runs.id);
+  SQL
+  create_view "annual_energy_uses", sql_definition: <<-SQL
+      WITH electricity AS (
+           SELECT alerts.alert_generation_run_id,
+              data.last_year_kwh,
+              data.last_year_co2,
+              data.last_year_gbp
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) data(last_year_kwh double precision, last_year_co2 double precision, last_year_gbp double precision)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertElectricityAnnualVersusBenchmark'::text))
+          ), gas AS (
+           SELECT alerts.alert_generation_run_id,
+              data.last_year_kwh,
+              data.last_year_co2,
+              data.last_year_gbp
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) data(last_year_kwh double precision, last_year_co2 double precision, last_year_gbp double precision)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertGasAnnualVersusBenchmark'::text))
+          ), storage_heaters AS (
+           SELECT alerts.alert_generation_run_id,
+              data.last_year_kwh,
+              data.last_year_co2,
+              data.last_year_gbp
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) data(last_year_kwh double precision, last_year_co2 double precision, last_year_gbp double precision)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertStorageHeaterAnnualVersusBenchmark'::text))
+          ), additional AS (
+           SELECT alerts.alert_generation_run_id,
+              alerts.school_id,
+              data.electricity_economic_tariff_changed_this_year,
+              data.gas_economic_tariff_changed_this_year,
+              data.school_type_name,
+              data.pupils,
+              data.floor_area
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) data(electricity_economic_tariff_changed_this_year boolean, gas_economic_tariff_changed_this_year boolean, school_type_name text, pupils double precision, floor_area double precision)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertAdditionalPrioritisationData'::text))
+          ), latest_runs AS (
+           SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
+             FROM alert_generation_runs
+            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC
+          )
+   SELECT latest_runs.id,
+      electricity.last_year_kwh AS electricity_last_year_kwh,
+      electricity.last_year_gbp AS electricity_last_year_gbp,
+      electricity.last_year_co2 AS electricity_last_year_co2,
+      gas.last_year_kwh AS gas_last_year_kwh,
+      gas.last_year_gbp AS gas_last_year_gbp,
+      gas.last_year_co2 AS gas_last_year_co2,
+      storage_heaters.last_year_kwh AS storage_heaters_last_year_kwh,
+      storage_heaters.last_year_gbp AS storage_heaters_last_year_gbp,
+      storage_heaters.last_year_co2 AS storage_heaters_last_year_co2,
+      additional.electricity_economic_tariff_changed_this_year AS electricity_tariff_has_changed,
+      additional.gas_economic_tariff_changed_this_year AS gas_tariff_has_changed,
+      additional.school_type_name,
+      additional.pupils,
+      additional.floor_area,
+      additional.school_id,
+      additional.alert_generation_run_id
+     FROM ((((latest_runs
+       JOIN additional ON ((latest_runs.id = additional.alert_generation_run_id)))
+       LEFT JOIN electricity ON ((latest_runs.id = electricity.alert_generation_run_id)))
+       LEFT JOIN gas ON ((latest_runs.id = gas.alert_generation_run_id)))
+       LEFT JOIN storage_heaters ON ((latest_runs.id = storage_heaters.alert_generation_run_id)));
   SQL
 end

--- a/db/views/annual_energy_uses_v01.sql
+++ b/db/views/annual_energy_uses_v01.sql
@@ -1,0 +1,61 @@
+WITH electricity AS (
+  SELECT alert_generation_run_id, data.*
+  FROM alerts, alert_types, jsonb_to_record(variables) AS data(
+    last_year_kwh float,
+    last_year_co2 float,
+    last_year_gbp float
+  )
+  WHERE alerts.alert_type_id = alert_types.id and alert_types.class_name='AlertElectricityAnnualVersusBenchmark'
+), gas AS (
+  SELECT alert_generation_run_id, data.*
+  FROM alerts, alert_types, jsonb_to_record(variables) AS data(
+    last_year_kwh float,
+    last_year_co2 float,
+    last_year_gbp float
+  )
+  WHERE alerts.alert_type_id = alert_types.id and alert_types.class_name='AlertGasAnnualVersusBenchmark'
+), storage_heaters AS (
+  SELECT alert_generation_run_id, data.*
+  FROM alerts, alert_types, jsonb_to_record(variables) AS data(
+    last_year_kwh float,
+    last_year_co2 float,
+    last_year_gbp float
+  )
+    WHERE alerts.alert_type_id = alert_types.id and alert_types.class_name='AlertStorageHeaterAnnualVersusBenchmark'
+), additional AS (
+  SELECT alert_generation_run_id, school_id, data.*
+  FROM alerts, alert_types, jsonb_to_record(variables) AS data(
+    electricity_economic_tariff_changed_this_year boolean,
+    gas_economic_tariff_changed_this_year boolean,
+    school_type_name text,
+    pupils float,
+    floor_area float
+  )
+  WHERE alerts.alert_type_id = alert_types.id and alert_types.class_name='AlertAdditionalPrioritisationData'
+), latest_runs AS (
+    SELECT DISTINCT ON (school_id) id
+    FROM alert_generation_runs
+    ORDER BY school_id, created_at DESC
+)
+SELECT latest_runs.id,
+  electricity.last_year_kwh as electricity_last_year_kwh,
+  electricity.last_year_gbp as electricity_last_year_gbp,
+  electricity.last_year_co2 as electricity_last_year_co2,
+  gas.last_year_kwh as gas_last_year_kwh,
+  gas.last_year_gbp as gas_last_year_gbp,
+  gas.last_year_co2 as gas_last_year_co2,
+  storage_heaters.last_year_kwh as storage_heaters_last_year_kwh,
+  storage_heaters.last_year_gbp as storage_heaters_last_year_gbp,
+  storage_heaters.last_year_co2 as storage_heaters_last_year_co2,
+  additional.electricity_economic_tariff_changed_this_year as electricity_tariff_has_changed,
+  additional.gas_economic_tariff_changed_this_year as gas_tariff_has_changed,
+  additional.school_type_name,
+  additional.pupils,
+  additional.floor_area,
+  additional.school_id,
+  additional.alert_generation_run_id
+FROM latest_runs
+JOIN additional ON latest_runs.id = additional.alert_generation_run_id
+LEFT JOIN electricity ON latest_runs.id = electricity.alert_generation_run_id
+LEFT JOIN gas ON latest_runs.id = gas.alert_generation_run_id
+LEFT JOIN storage_heaters ON latest_runs.id = storage_heaters.alert_generation_run_id;

--- a/lib/tasks/deployment/20240521113016_create_annual_energy_use_report.rake
+++ b/lib/tasks/deployment/20240521113016_create_annual_energy_use_report.rake
@@ -1,0 +1,19 @@
+namespace :after_party do
+  desc 'Deployment task: create_annual_energy_use_report'
+  task create_annual_energy_use_report: :environment do
+    puts "Running deploy task 'create_annual_energy_use_report'"
+
+    Comparison::Report.create!(
+      key: :annual_energy_use,
+      reporting_period: :last_12_months,
+      title: "Annual Energy Use",
+      report_group_id: 1,
+      public: false
+    )
+
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord
+      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+  end
+end

--- a/spec/system/comparisons/annual_energy_use_spec.rb
+++ b/spec/system/comparisons/annual_energy_use_spec.rb
@@ -1,0 +1,77 @@
+require 'rails_helper'
+
+describe 'annual_energy_use' do
+  let!(:school) { create(:school) }
+  let(:key) { :annual_energy_use }
+  let(:advice_page_key) { :total_energy_use }
+
+  # change to your variables
+  let(:variables) do
+    {
+      current_year_percent_of_target_relative: +0.18699995372972533,
+      current_year_unscaled_percent_of_target_relative: -0.4799985149375391,
+      current_year_kwh: 1284.7,
+      current_year_target_kwh: 2281.8825833333326,
+      unscaled_target_kwh_to_date: 2401.9816666666666,
+      tracking_start_date: '2024-01-01'
+    }
+  end
+
+  # change to your alert type (there may be more than one!)
+  let(:alert_type) { create(:alert_type, class_name: 'AlertElectricityTargetAnnual') }
+  let(:alert_run) { create(:alert_generation_run, school: school) }
+  let!(:report) { create(:report, key: key) }
+
+  before do
+    create(:advice_page, key: advice_page_key)
+    create(:alert, school: school, alert_generation_run: alert_run, alert_type: alert_type, variables: variables)
+    # the following alert is often only required for the tariff changed footnote
+    # delete or amend as appropriate:
+    create(:alert, school: school, alert_generation_run: alert_run,
+                   alert_type: create(:alert_type, class_name: 'AlertAdditionalPrioritisationData'),
+                   variables: { electricity_economic_tariff_changed_this_year: true })
+  end
+
+  context 'when viewing report' do
+    before { visit "/comparisons/#{key}" }
+
+    it_behaves_like 'a school comparison report' do
+      let(:expected_report) { report }
+    end
+
+    it_behaves_like 'a school comparison report with a table' do
+      let(:expected_report) { report }
+      let(:expected_school) { school }
+      let(:advice_page_path) { polymorphic_path([:insights, expected_school, :advice, advice_page_key]) }
+
+      let(:headers) do
+        ['School',
+         'Last year electricity £/pupil',
+         'Last year electricity £',
+         'Saving if matched exemplar school (using latest tariff)']
+      end
+
+      let(:expected_table) do
+        [headers,
+         [school.name,
+          '£195',
+          '£235,000',
+          '£155,000',
+         ],
+         ["Notes\nIn school comparisons 'last year' is defined as this year to date."]
+        ]
+      end
+
+      let(:expected_csv) do
+        [headers,
+         [school.name,
+          '195',
+          '235,000',
+          '155,000']
+        ]
+      end
+    end
+
+    it_behaves_like 'a school comparison report with a chart'
+  end
+end


### PR DESCRIPTION
A new report, intended to replace the "annual change in cost" report.

Shows the kwh, £ and co2 for each fuel type for the last 12 months. Includes metadata to indicate if school data is up to date, school type, number of pupils and floor area.