### PR TITLE
Remove additional ordering in heating_coming_on_too_early report

### DIFF
--- a/app/views/comparisons/heating_coming_on_too_early/_optimum_start_analysis.csv.ruby
+++ b/app/views/comparisons/heating_coming_on_too_early/_optimum_start_analysis.csv.ruby
@@ -2,7 +2,7 @@
 
 CSV.generate do |csv|
   csv << @headers_optimum_start_analysis
-  @results.order(average_start_time_hh_mm: :desc).each do |result|
+  @results.each do |result|
     csv << [
       result.school.name,
       result.average_start_time_hh_mm_to_time_of_day,

--- a/app/views/comparisons/heating_coming_on_too_early/_optimum_start_analysis.html.erb
+++ b/app/views/comparisons/heating_coming_on_too_early/_optimum_start_analysis.html.erb
@@ -6,7 +6,7 @@
               table_name: table_name,
               index_params: index_params,
               headers: @headers_optimum_start_analysis do |c| %>
-  <% @results.order(average_start_time_hh_mm: :desc).each do |result| %>
+  <% @results.each do |result| %>
     <% c.with_row do |row| %>
       <% row.with_school school: result.school %>
       <% row.with_var { result.average_start_time_hh_mm_to_time_of_day.to_s } %>

--- a/app/views/comparisons/heating_coming_on_too_early/_table.csv.ruby
+++ b/app/views/comparisons/heating_coming_on_too_early/_table.csv.ruby
@@ -2,7 +2,7 @@
 
 CSV.generate do |csv|
   csv << @headers
-  @results.order(avg_week_start_time: :desc).each do |result|
+  @results.each do |result|
     csv << [
       result.school.name,
       result.avg_week_start_time_to_time_of_day,

--- a/app/views/comparisons/heating_coming_on_too_early/_table.html.erb
+++ b/app/views/comparisons/heating_coming_on_too_early/_table.html.erb
@@ -1,7 +1,7 @@
 <%= component 'comparison_table',
               report: report, advice_page: advice_page, table_name: table_name, index_params: index_params,
               headers: headers, colgroups: colgroups, advice_page_tab: advice_page_tab do |c| %>
-  <% @results.order(avg_week_start_time: :desc).each do |result| %>
+  <% @results.each do |result| %>
     <% c.with_row do |row| %>
       <% row.with_school school: result.school %>
       <% row.with_reference key: 'tariff_changed_last_year',


### PR DESCRIPTION
I recently changed the heating_coming_on_too_early comparison to order by school name.

Just noticed that there are additional calls to `.order` in the individual tables. These seem to be ignored as the spec is checking for sorting by name already.

However they do trigger ActiveRecord to run the query more than once. This can be slow when there is a lot of schools, so removing it optimises the report generation.