### PR TITLE
Fix transport js

### DIFF
--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -2,4 +2,5 @@
 //= link application.js
 //= link application.css
 //= link application_mailer.css
-
+//= link_tree ../javascripts/transport_surveys .js
+//= link transport_surveys.js

--- a/app/assets/javascripts/transport_surveys/storage.js
+++ b/app/assets/javascripts/transport_surveys/storage.js
@@ -29,7 +29,11 @@ export const storage = ( function() {
 
   function getResponses(date) {
     let responses = getAllResponses();
-    responses[date] ||= []
+    // changed to bypass an issue with uglifier
+    // responses[date] ||= [];
+    if (!responses[date]) {
+      responses[date] = [];
+    }
     return responses[date];
   }
 
@@ -41,7 +45,11 @@ export const storage = ( function() {
 
   function addResponse(date, response) {
     let responses = getAllResponses();
-    responses[date] ||= [];
+    // changed to bypass an issue with uglifier
+    // responses[date] ||= [];
+    if (!responses[date]) {
+      responses[date] = [];
+    }
     responses[date].push(response);
     localStorage.setItem(local.key, JSON.stringify( responses ));
   }

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -14,5 +14,6 @@ Rails.application.config.assets.precompile += %w( application_mailer.scss )
 # application.js, application.css, and all non-JS/CSS in the app/assets
 # folder are already added.
 # Rails.application.config.assets.precompile += %w( admin.js admin.css )
-# A note about sprockets v4 and using manifest.js:
+
+# A note about sprockets v4 and using manifest.js for assets instead:
 # https://github.com/rails/sprockets/blob/main/UPGRADING.md#manifestjs

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -13,5 +13,4 @@ Rails.application.config.assets.precompile += %w( application_mailer.scss )
 # Precompile additional assets.
 # application.js, application.css, and all non-JS/CSS in the app/assets
 # folder are already added.
-
-Rails.application.config.assets.precompile += %w( transport_surveys transport_surveys/charts.js )
+Rails.application.config.assets.precompile += %w( transport_surveys.js transport_surveys/carbon.js transport_surveys/charts.js transport_surveys/handlebars_helpers.js transport_surveys/helpers.js transport_surveys/notifier.js transport_surveys/storage.js )

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -13,4 +13,6 @@ Rails.application.config.assets.precompile += %w( application_mailer.scss )
 # Precompile additional assets.
 # application.js, application.css, and all non-JS/CSS in the app/assets
 # folder are already added.
-Rails.application.config.assets.precompile += %w( transport_surveys.js transport_surveys/carbon.js transport_surveys/charts.js transport_surveys/handlebars_helpers.js transport_surveys/helpers.js transport_surveys/notifier.js transport_surveys/storage.js )
+# Rails.application.config.assets.precompile += %w( admin.js admin.css )
+# A note about sprockets v4 and using manifest.js:
+# https://github.com/rails/sprockets/blob/main/UPGRADING.md#manifestjs


### PR DESCRIPTION
The changes discussed earlier did indeed allow the code to be deployed, however, the transport app loaded, but still didn't work properly - erroring with the following files missing:
<img width="636" alt="Screenshot 2024-05-21 at 23 02 23" src="https://github.com/Energy-Sparks/energy-sparks/assets/6051/0063a1a0-7b50-41ca-8494-9b6c3ef45a1d">

Which I think would make sense, as they are not listed in the precompile config line in assets.rb
(worked locally though, that's why I didn't add them)

I have now added them to this branch - which bought up a couple of similar uglifier issues using ||= operator in storage.js. Have also fixed those in this branch.

Ended up having to list all the individual assets, as transport_surveys/* glob doesn't appear to work

`rake assets:clobber assets:precompile` shows all assets compiling now.