### PR TITLE
Fix links on long term advice pages

### DIFF
--- a/app/views/schools/advice/long_term/_comparison.html.erb
+++ b/app/views/schools/advice/long_term/_comparison.html.erb
@@ -27,6 +27,6 @@
 <% if school.school_group.present? %>
   <p>
     <%= t("advice_pages.#{fuel_type}_long_term.insights.comparison.more_detail_html",
-          link: compare_for_school_group_path("annual_#{fuel_type}_costs_per_pupil", school)) %>
+          link: compare_for_school_group_path(compare_benchmark_key_for(@advice_page.key.to_sym), school)) %>
   </p>
 <% end %>

--- a/spec/system/schools/advice_pages/electricity_long_term_spec.rb
+++ b/spec/system/schools/advice_pages/electricity_long_term_spec.rb
@@ -87,6 +87,7 @@ RSpec.describe 'electricity long term advice page', :aggregate_failures do
 
         it 'includes the comparison' do
           expect(page).to have_css('#electricity-comparison')
+          expect(page).to have_link('compare with other schools in your group', href: compare_path(benchmark: :annual_electricity_costs_per_pupil, school_group_ids: [school.school_group.id]))
         end
       end
     end

--- a/spec/system/schools/advice_pages/gas_long_term_spec.rb
+++ b/spec/system/schools/advice_pages/gas_long_term_spec.rb
@@ -81,6 +81,7 @@ RSpec.describe 'gas long term advice page', :aggregate_failures do
 
         it 'includes the comparison' do
           expect(page).to have_css('#gas-comparison')
+          expect(page).to have_link('compare with other schools in your group', href: compare_path(benchmark: :annual_heating_costs_per_floor_area, school_group_ids: [school.school_group.id]))
         end
       end
     end


### PR DESCRIPTION
The shared template used to build the links to the comparison pages is creating the wrong key for the gas analysis.

Updates the template to lookup the correct key using a helper that already exists for the school group pages.

Adds a spec to check the links on the two pages.