### PR TITLE
Correct 'school day' chart series label on electricity intraday chart

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,7 @@ gem 'pg'
 gem 'scenic'
 
 # Dashboard analytics
-gem 'energy-sparks_analytics', github: 'Energy-Sparks/energy-sparks_analytics', tag: '5.2.7'
+gem 'energy-sparks_analytics', github: 'Energy-Sparks/energy-sparks_analytics', branch: '3848-school-day-legend-needs-capitalising-on-electricity-intraday-analysis-chart'
 #gem 'energy-sparks_analytics', path: '../energy-sparks_analytics'
 
 # Using master due to it having a patch which doesn't override Enumerable#sum if it's already defined

--- a/Gemfile
+++ b/Gemfile
@@ -26,8 +26,8 @@ gem 'pg'
 gem 'scenic'
 
 # Dashboard analytics
-gem 'energy-sparks_analytics', github: 'Energy-Sparks/energy-sparks_analytics', branch: '3848-school-day-legend-needs-capitalising-on-electricity-intraday-analysis-chart'
-#gem 'energy-sparks_analytics', path: '../energy-sparks_analytics'
+gem 'energy-sparks_analytics', github: 'Energy-Sparks/energy-sparks_analytics', tag: '5.2.8'
+# gem 'energy-sparks_analytics', path: '../energy-sparks_analytics'
 
 # Using master due to it having a patch which doesn't override Enumerable#sum if it's already defined
 # Last proper release does that, causing all kinds of weird behaviour (+ not defined etc)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/Energy-Sparks/energy-sparks_analytics.git
-  revision: 077fc774b308739481fe3d0296b6ce90a8bf22f4
-  branch: 3848-school-day-legend-needs-capitalising-on-electricity-intraday-analysis-chart
+  revision: d74174e84e73259f40bb9aaadb41dce015c4641b
+  tag: 5.2.8
   specs:
     energy-sparks_analytics (1.2.1)
       activesupport (>= 6.0, < 7.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/Energy-Sparks/energy-sparks_analytics.git
-  revision: 6d6e216e563f13450524be68f4474cc840279b7e
-  tag: 5.2.7
+  revision: 077fc774b308739481fe3d0296b6ce90a8bf22f4
+  branch: 3848-school-day-legend-needs-capitalising-on-electricity-intraday-analysis-chart
   specs:
     energy-sparks_analytics (1.2.1)
       activesupport (>= 6.0, < 7.1)

--- a/config/locales/analytics/common.yml
+++ b/config/locales/analytics/common.yml
@@ -42,7 +42,7 @@ en:
       last_school_week: last school week
       pa: "%{cost}pa"
       previous_school_week: previous school week
-      school_day: school day
+      school_day: School day
       storage_heaters: storage heaters
       weekend: weekend
     holidays:

--- a/config/locales/cy/analytics/common.yml
+++ b/config/locales/cy/analytics/common.yml
@@ -41,7 +41,7 @@ cy:
       last_school_week: wythnos ysgol ddiwethaf
       pa: "%{cost}pa"
       previous_school_week: wythnos ysgol flaenorol
-      school_day: diwrnod ysgol
+      school_day: Diwrnod ysgol
       storage_heaters: stôr-wresogyddion
       weekend: penwythnos
     holidays:

--- a/config/locales/cy/views/advice_pages/electricity_intraday.yml
+++ b/config/locales/cy/views/advice_pages/electricity_intraday.yml
@@ -13,7 +13,7 @@ cy:
             <p>
               Os oes gan eich ysgol ddefnydd uchel dros nos, o gymharu <p></p>â'r ysgolion meincnod, gallai hyn ddangos bod angen i chi leihau eich llwyth sylfaenol. Os yw defnydd yn bennaf yn uchel yn ystod canol y dydd, mae hyn yn dangos bod angen i chi leihau eich defnydd trydan brig.
             </p>
-          comparison_chart_subtitle_html: Mae'r siart isod yn darparu cymhariaeth o ddefnydd cyfartalog eich ysgol yn ystod diwrnod ysgol rhwng <span class="start-date">%{start_month_year}</span> a %{end_month_year}<span class="end-date">, ac yn cynnwys cymhariaeth gydag ysgolion 'Dan reolaeth dda' ac 'Enghreifftiol'.
+          comparison_chart_subtitle_html: Mae'r siart isod yn darparu cymhariaeth o ddefnydd cyfartalog eich ysgol yn ystod diwrnod ysgol rhwng <span class="start-date">%{start_month_year}</span> a <span class="end-date">%{end_month_year}</span>, ac yn cynnwys cymhariaeth gydag ysgolion 'Dan reolaeth dda' ac 'Enghreifftiol'.
           comparison_chart_title:
             one: Eich defnydd trydan diwrnod ysgol diweddar
             two: Eich defnydd o drydan diwrnod ysgol dros y %{count} fis diwethaf

--- a/config/locales/cy/views/advice_pages/electricity_intraday.yml
+++ b/config/locales/cy/views/advice_pages/electricity_intraday.yml
@@ -48,7 +48,7 @@ cy:
         schooldays:
           title: Diwrnodau ysgol
         sections: Mae'r adrannau canlynol yn darparu mwy o gefndir a dadansoddiad ar eich llwyth sylfaenol trydan
-        summary: 'Mae''r adran hon yn rhoi dadansoddiad manylach o sut mae defnydd trydan eich ysgol yn amrywio drwy gydol y dydd. Gwneir cymhariaethau rhwng eich ysgol ac ysgolion meincnod ac ysgolion enghreifftiol yn ogystal â rhwng eleni a''r flwyddyn flaenorol ar gyfer dyddiau''r wythnos, penwythnosau a gwyliau. '
+        summary: Mae'r adran hon yn rhoi dadansoddiad manylach o sut mae defnydd trydan eich ysgol yn amrywio drwy gydol y dydd. Gwneir cymhariaethau rhwng eich ysgol ac ysgolion meincnod ac ysgolion enghreifftiol yn ogystal â rhwng eleni a'r flwyddyn flaenorol ar gyfer dyddiau'r wythnos, penwythnosau a gwyliau.
         title: Dadansoddiad
         trends:
           title: Tueddiadau diweddar

--- a/config/locales/cy/views/advice_pages/electricity_intraday.yml
+++ b/config/locales/cy/views/advice_pages/electricity_intraday.yml
@@ -5,7 +5,7 @@ cy:
         charts:
           comparison_chart_explanation_html: |-
             <p>
-              Mae'r siart hwn yn eich galluogi i weld sut mae defnydd trydan eich ysgol yn cymharu ag ysgolion eraill sy'n defnyddio ynni'n effeithlon trwy gydol y diwrnod ysgol. Mae ysgol 'meincnod' yn cynrychioli'r 30.0% gorau o ysgolion %{school_type} ac mae 'enghreifftiol' yn cynrychioli'r 17.5% o ysgolion %{school_type} orau.
+              Mae'r siart hwn yn eich galluogi i weld sut mae defnydd trydan eich ysgol yn cymharu ag ysgolion eraill sy'n defnyddio ynni'n effeithlon trwy gydol y diwrnod ysgol. Mae ysgol 'Dan reolaeth dda' yn cynrychioli'r 30.0% gorau o ysgolion %{school_type} ac mae 'Enghreifftiol' yn cynrychioli'r 17.5% o ysgolion %{school_type} orau.
             </p>
 
               Gall y siart hwn fod yn ddefnyddiol i arsylwi lle mae patrwm eich ysgol o ddefnyddio ynni yn wahanol i ysgolion eraill. Efallai y bydd anghysondebau fel neidiau mewn defnydd y tu allan i oriau ysgol na ellir eu cyfrif.
@@ -13,7 +13,7 @@ cy:
             <p>
               Os oes gan eich ysgol ddefnydd uchel dros nos, o gymharu <p></p>â'r ysgolion meincnod, gallai hyn ddangos bod angen i chi leihau eich llwyth sylfaenol. Os yw defnydd yn bennaf yn uchel yn ystod canol y dydd, mae hyn yn dangos bod angen i chi leihau eich defnydd trydan brig.
             </p>
-          comparison_chart_subtitle_html: Mae'r siart isod yn darparu cymhariaeth o ddefnydd cyfartalog eich ysgol yn ystod diwrnod ysgol rhwng <span class="start-date">%{start_month_year}</span> a %{end_month_year}<span class="end-date">, ac yn cynnwys cymhariaeth gydag ysgolion 'meincnod' ac 'enghreifftiol'.
+          comparison_chart_subtitle_html: Mae'r siart isod yn darparu cymhariaeth o ddefnydd cyfartalog eich ysgol yn ystod diwrnod ysgol rhwng <span class="start-date">%{start_month_year}</span> a %{end_month_year}<span class="end-date">, ac yn cynnwys cymhariaeth gydag ysgolion 'Dan reolaeth dda' ac 'Enghreifftiol'.
           comparison_chart_title:
             one: Eich defnydd trydan diwrnod ysgol diweddar
             two: Eich defnydd o drydan diwrnod ysgol dros y %{count} fis diwethaf

--- a/config/locales/views/advice_pages/electricity_intraday.yml
+++ b/config/locales/views/advice_pages/electricity_intraday.yml
@@ -6,7 +6,7 @@ en:
         charts:
           comparison_chart_explanation_html: |-
             <p>
-              This chart allows you to see how your school’s electricity consumption compares with other energy efficient schools throughout the school day. A 'benchmark' school represents the 30.0% best ranked %{school_type} schools and 'exemplar' the 17.5% best %{school_type} schools.
+              This chart allows you to see how your school’s electricity consumption compares with other energy efficient schools throughout the school day. A 'Well Managed' school represents the 30.0% best ranked %{school_type} schools and 'Exemplar' the 17.5% best %{school_type} schools.
             </p>
             <p>
               This chart can be useful to observe where your school’s pattern of energy use differs from other schools. There might be anomalies like jumps in usage outside school hours which can’t be accounted for.
@@ -14,7 +14,7 @@ en:
             <p>
               If your school has high consumption overnight, compared to the benchmark schools, this could indicate that you need to reduce your baseload. If consumption is mainly high during the middle of the day, this indicates you need to reduce your peak electricity use.
             </p>
-          comparison_chart_subtitle_html: The chart below provides a comparison of your school's average consumption during school days between <span class="start-date">%{start_month_year}</span> and <span class="end-date">%{end_month_year}</span>, and includes a comparison with 'benchmark' and 'exemplar' schools.
+          comparison_chart_subtitle_html: The chart below provides a comparison of your school's average consumption during school days between <span class="start-date">%{start_month_year}</span> and <span class="end-date">%{end_month_year}</span>, and includes a comparison with 'Well managed' and 'Exemplar' schools.
           comparison_chart_title:
             one: Your recent school day electricity consumption
             other: Your school day electricity consumption over the last %{count} months
@@ -47,7 +47,7 @@ en:
         schooldays:
           title: School days
         sections: The following sections provide more background and analysis on your electricity baseload
-        summary: This section gives a more detailed analysis of how your school’s electricity use varies throughout the day. Comparisons are made between your school and benchmark and exemplar schools as well as between this year and the previous year for weekdays, weekends and holidays.
+        summary: This section gives a more detailed analysis of how your school’s electricity use varies throughout the day. Comparisons are made between your school, 'Well managed' and 'Exemplar' schools as well as between this year and the previous year for weekdays, weekends and holidays.
         title: Analysis
         trends:
           title: Recent trends


### PR DESCRIPTION
* Capitalise "school day" series name. https://github.com/Energy-Sparks/energy-sparks_analytics/pull/698
* Update intraday page text to refer to Well Managed and Exemplar not benchmark and exemplar
* Fixes previously missed issue with chart sub title markup in Welsh version of electricity_intraday.yml