### PR TITLE
Change GoodJobs priority scores to disable deprecated warning

### DIFF
--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,2 +1,5 @@
 class ApplicationJob < ActiveJob::Base
+  def priority
+    10
+  end
 end

--- a/app/jobs/campaign_contact_handler_job.rb
+++ b/app/jobs/campaign_contact_handler_job.rb
@@ -1,10 +1,6 @@
 class CampaignContactHandlerJob < ApplicationJob
   queue_as :default
 
-  def priority
-    5
-  end
-
   def perform(request_type, contact)
     Campaigns::ContactHandlerService.new(request_type, contact).perform
   rescue => e

--- a/app/jobs/daily_regeneration_job.rb
+++ b/app/jobs/daily_regeneration_job.rb
@@ -2,7 +2,7 @@ class DailyRegenerationJob < ApplicationJob
   queue_as :regeneration
 
   def priority
-    10
+    5
   end
 
   def perform(school:)

--- a/app/jobs/dcc_checker_job.rb
+++ b/app/jobs/dcc_checker_job.rb
@@ -1,10 +1,6 @@
 class DccCheckerJob < ApplicationJob
   queue_as :default
 
-  def priority
-    5
-  end
-
   def perform(meter)
     Meters::DccChecker.new([meter]).perform
   end

--- a/app/jobs/dcc_grant_trusted_consents_job.rb
+++ b/app/jobs/dcc_grant_trusted_consents_job.rb
@@ -1,10 +1,6 @@
 class DccGrantTrustedConsentsJob < ApplicationJob
   queue_as :default
 
-  def priority
-    5
-  end
-
   def perform(meters)
     Meters::DccGrantTrustedConsents.new(meters).perform
   end

--- a/app/jobs/funder_allocation_report_job.rb
+++ b/app/jobs/funder_allocation_report_job.rb
@@ -2,7 +2,7 @@ class FunderAllocationReportJob < ApplicationJob
   queue_as :default
 
   def priority
-    10
+    5
   end
 
   def perform(to:)

--- a/app/jobs/generate_subscriptions_job.rb
+++ b/app/jobs/generate_subscriptions_job.rb
@@ -1,10 +1,6 @@
 class GenerateSubscriptionsJob < ApplicationJob
   queue_as :regeneration
 
-  def priority
-    5
-  end
-
   def perform(school_id:)
     school = School.find(school_id)
     Alerts::GenerateSubscriptions.new(school).perform(subscription_frequency: school.subscription_frequency)

--- a/app/jobs/manual_data_load_run_job.rb
+++ b/app/jobs/manual_data_load_run_job.rb
@@ -2,7 +2,7 @@ class ManualDataLoadRunJob < ApplicationJob
   queue_as :default
 
   def priority
-    10
+    5
   end
 
   def perform(manual_data_load_run)

--- a/app/jobs/school_batch_run_job.rb
+++ b/app/jobs/school_batch_run_job.rb
@@ -2,7 +2,7 @@ class SchoolBatchRunJob < ApplicationJob
   queue_as :default
 
   def priority
-    10
+    5
   end
 
   def perform(school_batch_run)

--- a/app/jobs/school_group_meter_report_job.rb
+++ b/app/jobs/school_group_meter_report_job.rb
@@ -2,7 +2,7 @@ class SchoolGroupMeterReportJob < ApplicationJob
   queue_as :default
 
   def priority
-    10
+    5
   end
 
   def perform(to:, school_group:, all_meters: false)

--- a/app/jobs/send_data_source_report_job.rb
+++ b/app/jobs/send_data_source_report_job.rb
@@ -2,7 +2,7 @@ class SendDataSourceReportJob < ApplicationJob
   queue_as :default
 
   def priority
-    10
+    5
   end
 
   def perform(to:, data_source_id:)

--- a/app/jobs/send_procurement_route_report_job.rb
+++ b/app/jobs/send_procurement_route_report_job.rb
@@ -2,7 +2,7 @@ class SendProcurementRouteReportJob < ApplicationJob
   queue_as :default
 
   def priority
-    10
+    5
   end
 
   def perform(to:, procurement_route_id:)

--- a/app/jobs/send_review_group_tariffs_reminder_job.rb
+++ b/app/jobs/send_review_group_tariffs_reminder_job.rb
@@ -2,7 +2,7 @@ class SendReviewGroupTariffsReminderJob < ApplicationJob
   queue_as :default
 
   def priority
-    10
+    5
   end
 
   def perform

--- a/app/jobs/send_review_school_tariffs_reminder_job.rb
+++ b/app/jobs/send_review_school_tariffs_reminder_job.rb
@@ -2,7 +2,7 @@ class SendReviewSchoolTariffsReminderJob < ApplicationJob
   queue_as :default
 
   def priority
-    10
+    5
   end
 
   def perform

--- a/app/jobs/solar/base_solar_loader_job.rb
+++ b/app/jobs/solar/base_solar_loader_job.rb
@@ -5,10 +5,6 @@ module Solar
 
     queue_as :default
 
-    def priority
-      5
-    end
-
     def perform(installation:, notify_email:, start_date: nil, end_date: nil)
       @installation = installation
       @upserter = upserter(start_date, end_date)

--- a/app/jobs/solar_area_loader_job.rb
+++ b/app/jobs/solar_area_loader_job.rb
@@ -1,10 +1,6 @@
 class SolarAreaLoaderJob < ApplicationJob
   queue_as :default
 
-  def priority
-    5
-  end
-
   def perform(area)
     start_date = Date.yesterday - 2.years
     DataFeeds::SolarPvTuosLoader.new(start_date).import_area(area)

--- a/config/application.rb
+++ b/config/application.rb
@@ -69,6 +69,7 @@ module EnergySparks
     config.good_job.enable_cron = false
     config.good_job.cleanup_preserved_jobs_before_seconds_ago = 30.days.to_i
     config.good_job.logger = Logger.new(File.join(Rails.root, 'log', 'good_job.log'))
+    config.good_job.smaller_number_is_higher_priority = true
 
     config.i18n.available_locales = [:en, :cy]
     config.i18n.default_locale = :en

--- a/spec/jobs/daily_regeneration_job_spec.rb
+++ b/spec/jobs/daily_regeneration_job_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+describe DailyRegenerationJob do
+  subject(:job) { described_class.new }
+
+  describe '#priority' do
+    it_behaves_like 'a high priority job'
+
+    it 'is higher priority than sending weekly alert emails' do
+      expect(job.priority).to be < GenerateSubscriptionsJob.new.priority
+    end
+  end
+end

--- a/spec/jobs/manual_data_load_run_job_spec.rb
+++ b/spec/jobs/manual_data_load_run_job_spec.rb
@@ -15,6 +15,10 @@ describe ManualDataLoadRunJob, ts: false do
     allow_any_instance_of(AmrDataFeedImportLog).to receive(:records_updated).and_return(updated)
   end
 
+  describe '#priority' do
+    it_behaves_like 'a high priority job'
+  end
+
   context 'with a valid file' do
     before do
       expect(run.status).to eq 'pending'

--- a/spec/jobs/school_batch_run_job_spec.rb
+++ b/spec/jobs/school_batch_run_job_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+describe SchoolBatchRunJob do
+  subject(:job) { described_class.new }
+
+  describe '#priority' do
+    it_behaves_like 'a high priority job'
+  end
+end

--- a/spec/jobs/send_review_group_tariffs_reminder_job_spec.rb
+++ b/spec/jobs/send_review_group_tariffs_reminder_job_spec.rb
@@ -1,9 +1,14 @@
 require 'rails_helper'
 
 describe SendReviewGroupTariffsReminderJob do
+  subject(:job) { SendReviewGroupTariffsReminderJob.new }
+
   let!(:school_group) { create(:school_group) }
   let!(:school_group_admin) { create(:group_admin, school_group: school_group) }
-  let(:job) { SendReviewGroupTariffsReminderJob.new }
+
+  describe '#priority' do
+    it_behaves_like 'a high priority job'
+  end
 
   describe '#perform' do
     it 'sends an email to school admins to remind them to keep their tariff updated on a valid day of the year' do

--- a/spec/jobs/send_review_school_tariffs_reminder_job_spec.rb
+++ b/spec/jobs/send_review_school_tariffs_reminder_job_spec.rb
@@ -1,13 +1,17 @@
 require 'rails_helper'
 
 describe SendReviewSchoolTariffsReminderJob do
+  subject(:job) { SendReviewSchoolTariffsReminderJob.new }
+
   let(:school) { create(:school) }
   let!(:school_admin) { create(:school_admin, school: school) }
   let!(:admin) { create(:admin) }
   let!(:staff) { create(:staff, school: school) }
   let!(:pupil) { create(:pupil, school: school) }
 
-  let(:job) { SendReviewSchoolTariffsReminderJob.new }
+  describe '#priority' do
+    it_behaves_like 'a high priority job'
+  end
 
   describe '#perform' do
     it 'sends an email to school admins to remind them to keep their tariff updated on a valid day of the year' do

--- a/spec/jobs/solar_area_loader_job_spec.rb
+++ b/spec/jobs/solar_area_loader_job_spec.rb
@@ -1,12 +1,16 @@
 require 'rails_helper'
 
 describe SolarAreaLoaderJob do
+  subject(:job) { SolarAreaLoaderJob.new }
+
   let(:area)          { create(:solar_pv_tuos_area) }
   let(:start_date)    { Date.yesterday - 2.years }
   let(:result)        { 'Imported xx records, Updated xx records' }
   let(:loader)        { double(DataFeeds::SolarPvTuosLoader, import_area: result) }
 
-  let(:job)           { SolarAreaLoaderJob.new }
+  describe '#priority' do
+    it_behaves_like 'a low priority job'
+  end
 
   describe '#perfom' do
     it 'requests 2 years data' do

--- a/spec/support/shared_contexts/jobs.rb
+++ b/spec/support/shared_contexts/jobs.rb
@@ -1,0 +1,11 @@
+RSpec.shared_examples 'a high priority job' do
+  it 'has a high priority' do
+    expect(job.priority).to eq(5)
+  end
+end
+
+RSpec.shared_examples 'a low priority job' do
+  it 'has a low priority' do
+    expect(job.priority).to eq(10)
+  end
+end


### PR DESCRIPTION
Warning from GoodJobs:

> DEPRECATION WARNING: The next major version of GoodJob (v4.0) will change job priority to give smaller numbers higher priority (default: 0), in accordance with Active Job's definition of priority.
> To opt-in to this behavior now, set config.good_job.smaller_number_is_higher_priority = true in your GoodJob initializer or application.rb.
> To not opt-in yet, but silence this deprecation warning, set config.good_job.smaller_number_is_higher_priority = false.

Currently we set a priority of 5 for low priority jobs and 10 for high priority.

High priority jobs are:

* Requests for reports from admins
* Manual data loads or regenerations
* Daily school regenerations

Lower priorities are:

* Sending out alert emails. These need to be lower priority that the daily regeneration.
* other background checks

This PR sets:

```
config.good_job.smaller_number_is_higher_priority = true
```

And then:

- adds a default priority of 10 in ApplicationJob. This is the new default lower priority. Most jobs now just defer to the base class method instead of setting a low priority
- switches the jobs that currently have a priority of 10 to have a priority of 5 by overriding the base class method.

The numbers are a bit arbitrary but allow some spacing to adjust as needed.

Added some basic specs, mostly importantly to ensure that the daily regeneration jobs are higher priority than the emails. We want all the regeneration jobs to be done before we start sending out the emails.