### PR TITLE
Fix query for heating meters

### DIFF
--- a/app/services/schools/advice/heating_control_service.rb
+++ b/app/services/schools/advice/heating_control_service.rb
@@ -93,12 +93,12 @@ module Schools
         @school.meters
                .active
                .gas
-               .where.not(id: MeterAttribute.where(meter_id: @school.meters.pluck(:id))
+               .where.not(id: MeterAttribute.where(meter_id: @school.meters.pluck(:id), attribute_type: :function_switch)
                                             .where(
                                               <<-SQL.squish
                                                 input_data::text IN ('"kitchen_only"', '"hotwater_only"')
                                               SQL
-                                            ).select(:meter_id)
+                                            ).active.select(:meter_id)
               )
       end
 

--- a/spec/factories/meter_attribute.rb
+++ b/spec/factories/meter_attribute.rb
@@ -3,6 +3,36 @@ FactoryBot.define do
     attribute_type { :function_switch }
     input_data { 'heating_only' }
     association :meter, factory: :gas_meter
+    replaces { nil }
+
+    trait :replaced do
+      replaced_by { create(:meter_attribute) }
+    end
+
+    trait :deleted do
+      replaced
+      deleted_by { create(:admin) }
+    end
+
+    trait :heating_only do
+      attribute_type { 'function_switch' }
+      input_data { 'heating_only' }
+    end
+
+    trait :kitchen_only do
+      attribute_type { 'function_switch' }
+      input_data { 'kitchen_only' }
+    end
+
+    trait :hotwater_only do
+      attribute_type { 'function_switch' }
+      input_data { 'hotwater_only' }
+    end
+
+    trait :aggregation_switch do
+      attribute_type { 'aggregation_switch' }
+      input_data { 'ignore_start_date' }
+    end
   end
 
   factory :storage_heaters_attribute, class: 'MeterAttribute' do

--- a/spec/services/schools/advice/heating_control_service_spec.rb
+++ b/spec/services/schools/advice/heating_control_service_spec.rb
@@ -2,20 +2,43 @@ require 'rails_helper'
 
 RSpec.describe Schools::Advice::HeatingControlService, type: :service do
   let(:school) { create(:school) }
-  let!(:electricity_meter) { create :electricity_meter, name: 'Electricity meter 1', school: school }
-  let!(:gas_meter_1) { create :gas_meter, name: 'Gas meter 1', school: school, meter_attributes: []}
-  let!(:gas_meter_2) { create :gas_meter, name: 'Gas meter 2', school: school, meter_attributes: [create(:meter_attribute)] }
-  let!(:gas_meter_3) { create :gas_meter, name: 'Gas meter 3', school: school, meter_attributes: [create(:meter_attribute, attribute_type: 'function_switch', input_data: 'heating_only')] }
-  let!(:gas_meter_4) { create :gas_meter, name: 'Gas meter 4', school: school, meter_attributes: [create(:meter_attribute, attribute_type: 'function_switch', input_data: 'kitchen_only')] }
-  let!(:gas_meter_5) { create :gas_meter, name: 'Gas meter 5', school: school, meter_attributes: [create(:meter_attribute, attribute_type: 'function_switch', input_data: 'hotwater_only')] }
-
   let(:meter_collection) { double(:meter_collection) }
 
   let(:service) { Schools::Advice::HeatingControlService.new(school, meter_collection) }
 
-  it 'returns relevent meters' do
-    expect(school.meters.count).to eq(6)
-    expect(school.meters.gas.count).to eq(5)
-    expect(service.meters.pluck(:name).sort).to eq([gas_meter_1, gas_meter_2, gas_meter_3].map(&:name).sort)
+  describe '#meters' do
+    context 'when there are gas and electricity meters' do
+      let!(:electricity_meter) { create :electricity_meter, name: 'Electricity meter 1', school: school }
+      let!(:gas_meter_1) { create :gas_meter, name: 'Gas meter 1', school: school, meter_attributes: []}
+
+      it 'returns only the gas meters' do
+        expect(service.meters).to eq([gas_meter_1])
+      end
+    end
+
+    context 'when the gas meters have function attributes' do
+      let!(:gas_meter_1) { create :gas_meter, name: 'Gas meter 1', school: school, meter_attributes: []}
+      let!(:gas_meter_2) { create :gas_meter, name: 'Gas meter 2', school: school, meter_attributes: [create(:meter_attribute, :aggregation_switch)] }
+      let!(:gas_meter_3) { create :gas_meter, name: 'Gas meter 3', school: school, meter_attributes: [create(:meter_attribute, :heating_only)] }
+      let!(:gas_meter_4) { create :gas_meter, name: 'Gas meter 4', school: school, meter_attributes: [create(:meter_attribute, :kitchen_only)] }
+      let!(:gas_meter_5) { create :gas_meter, name: 'Gas meter 5', school: school, meter_attributes: [create(:meter_attribute, :hotwater_only)] }
+
+      it 'returns only the meters used for heating' do
+        expect(service.meters).to match_array([gas_meter_1, gas_meter_2, gas_meter_3])
+      end
+
+      context 'with some old configuration' do
+        let!(:gas_meter_6) do
+          current = create(:meter_attribute, :heating_only)
+          old = create(:meter_attribute, :kitchen_only, replaced_by: current)
+          current.update!(replaces: old)
+          create :gas_meter, name: 'Gas meter 3', school: school, meter_attributes: [current, old]
+        end
+
+        it 'returns only the meters currently used for heating' do
+          expect(service.meters).to match_array([gas_meter_1, gas_meter_2, gas_meter_3, gas_meter_6])
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
The HeatingControlService returns a list of gas meters used for heating.

It ignores those meters which have been configured to indicate they are monitoring the kitchen or the hot water system. It should return any gas meter without attributes as well as those explicitly configured as heating only.

The current query has bugs:

- not checking the attribute type
- not checking for active meter attributes

The latter is causing a bug where a meter that was incorrectly configured as hotwater_only, so has an inactive meter attribute, is not being included in the meter breakdown charts on the heating control advice page.

Fixes the query, improve the specs and factories.