### PR TITLE
Change how chart failures are displayed 

### DIFF
--- a/app/assets/javascripts/analysis.js
+++ b/app/assets/javascripts/analysis.js
@@ -25,18 +25,19 @@ function updateDatesInSubtitles(subTitleElement, chartData) {
   }
 }
 
-function chartFailure(chart, title) {
-  var $standardErrorMessage = document.getElementById('chart-error').textContent
+function chartFailure(chart) {
+  // the chart
   var $chartDiv = $(chart.renderTo);
+  // the chart wrapper containing the titles, header, various controls
+
   var $chartWrapper = $chartDiv.parents('.chart-wrapper');
+  // disable specific controls if chart fails
+  $chartWrapper.find('.chart-controls .axis-controls :input').attr("disabled", true);
+  $chartWrapper.find('.chart-controls .analysis-controls :input').attr("disabled", true);
 
-  $chartWrapper.addClass('alert alert-warning');
-
-  if (title) {
-    $chartWrapper.html(`<h3>${title}</h3>`)
-  } else {
-    $chartWrapper.html(`<h3>${$standardErrorMessage}</h3>`)
-  }
+  // display standard error message
+  var $standardErrorMessage = document.getElementById('chart-error').textContent
+  $chartDiv.html(`<div class='alert alert-warning'><h3>${$standardErrorMessage}</h3></div>`)
 }
 
 function chartSuccess(chartConfig, chartData, chart) {
@@ -177,15 +178,15 @@ function processAnalysisChartAjax(chartId, chartConfig, highchartsChart) {
     success: function (returnedData) {
       var thisChartData = returnedData;
       if (thisChartData == undefined || thisChartData.length == 0) {
-        chartFailure(highchartsChart, "");
+        chartFailure(highchartsChart);
       } else if (thisChartData.series_data == null) {
-        chartFailure(highchartsChart, thisChartData.title);
+        chartFailure(highchartsChart);
       } else {
         chartSuccess(chartConfig, thisChartData, highchartsChart);
       }
     },
     error: function(broken) {
-      chartFailure(highchartsChart, "");
+      chartFailure(highchartsChart);
     }
   });
 }

--- a/app/assets/javascripts/analysis.js
+++ b/app/assets/javascripts/analysis.js
@@ -37,7 +37,7 @@ function chartFailure(chart) {
 
   // display standard error message
   var $standardErrorMessage = document.getElementById('chart-error').textContent
-  $chartDiv.html(`<div class='alert alert-warning'><h3>${$standardErrorMessage}</h3></div>`)
+  $chartDiv.html(`<div class='alert alert-warning align-middle'><h3 style="padding-bottom: 10px;">${$standardErrorMessage}</h3></div>`)
 }
 
 function chartSuccess(chartConfig, chartData, chart) {


### PR DESCRIPTION
Currently if we get an error trying to display a chart we replace the entire `chart-wrapper` div with an error message. That means the title and controls are removed.

This isn't ideal for the meter breakdown charts where the chart wrapper also includes a select box allowing users to switch between meters. This means an error with one meter removes the ability for the user to look at other meters.

This can happen on the heating control pages where we should a breakdown of gas usage by meter. If we have limited data for a meter, or issues creating heating model the user can't switch to another meter.

This PR changes the standard `chartFailure` function in our javascript to:

- no longer display the chart id to users. This is internal and not necessary
- replace the div containing the Highchart chart, not the entire wrapper. This leaves the title, subtitle and other controls available
- disables the controls for switching the y-axis and navigating forwards and background, but leaves the meter selection box (if available) still active

This means a failed chart, if inserted into the page without a chart component (only used on some admin pages):

![Screenshot from 2024-05-29 17-07-10](https://github.com/Energy-Sparks/energy-sparks/assets/109082/bf0526ab-7ade-461b-b44d-1f7ddb3b5bf6)

If inserted via chart component (which is majority of charts now) then failed chart looks like:

![Screenshot from 2024-05-29 17-11-58](https://github.com/Energy-Sparks/energy-sparks/assets/109082/811e48c3-1f8f-4d2f-9091-5773ec4169bd)

And finally for a meter breakdown chart:

![Screenshot from 2024-05-29 17-06-43](https://github.com/Energy-Sparks/energy-sparks/assets/109082/a1d013f2-6ace-4c46-83b0-c166f8499c67)

The axis and explore controls are disabled, but the meter selection box is still available. 

Tested in development with `forest-school` gas meters `3262342507` and `44543802` which both have issues.