### PR TITLE
Dont load tariffs for some n3rgy meters

### DIFF
--- a/app/controllers/admin/data_sources_controller.rb
+++ b/app/controllers/admin/data_sources_controller.rb
@@ -35,7 +35,7 @@ module Admin
     private
 
     def data_source_params
-      params.require(:data_source).permit(:name, :organisation_type, :contact_name, :contact_email, :loa_contact_details, :data_prerequisites, :data_feed_type, :new_area_data_feed, :add_existing_data_feed, :data_issues_contact_details, :historic_data, :loa_expiry_procedure, :comments)
+      params.require(:data_source).permit(:name, :organisation_type, :contact_name, :contact_email, :loa_contact_details, :data_prerequisites, :data_feed_type, :new_area_data_feed, :add_existing_data_feed, :data_issues_contact_details, :historic_data, :loa_expiry_procedure, :comments, :load_tariffs)
     end
   end
 end

--- a/app/models/data_source.rb
+++ b/app/models/data_source.rb
@@ -15,6 +15,7 @@
 #  import_warning_days         :integer
 #  loa_contact_details         :text
 #  loa_expiry_procedure        :text
+#  load_tariffs                :boolean          default(TRUE), not null
 #  name                        :string           not null
 #  new_area_data_feed          :text
 #  organisation_type           :integer

--- a/app/services/amr/n3rgy_energy_tariff_loader.rb
+++ b/app/services/amr/n3rgy_energy_tariff_loader.rb
@@ -5,6 +5,8 @@ module Amr
     end
 
     def perform
+      return unless @meter.data_source.nil? || @meter.data_source.load_tariffs
+
       todays_tariff = N3rgyTariffDownloader.new(meter: @meter).current_tariff
 
       N3rgyTariffManager.new(meter: @meter,

--- a/app/views/admin/data_sources/_form.html.erb
+++ b/app/views/admin/data_sources/_form.html.erb
@@ -5,19 +5,20 @@
     <% end %>
     <%= simple_form_for [:admin, data_source] do |f| %>
       <%= redirect_back_tag params %>
-      <%= f.input :name, label: "Organisation name" %>
-      <%= f.input :organisation_type, collection: DataSource.organisation_types.keys, label_method: lambda {|k| k.humanize} %>
+      <%= f.input :name, label: 'Organisation name' %>
+      <%= f.input :organisation_type, collection: DataSource.organisation_types.keys, label_method: :humanize %>
       <%= f.input :contact_name %>
       <%= f.input :contact_email %>
-      <%= f.input :loa_contact_details, label: "Who to send LOA to" %>
+      <%= f.input :loa_contact_details, label: 'Who to send LOA to' %>
       <%= f.input :data_prerequisites %>
-      <%= f.input :data_feed_type, label: "Type of data feed" %>
-      <%= f.input :new_area_data_feed, label: "How to setup data feed for a new area" %>
-      <%= f.input :add_existing_data_feed, label: "How to add to an existing data feed" %>
-      <%= f.input :data_issues_contact_details, label: "Who to contact about data issues" %>
+      <%= f.input :data_feed_type, label: 'Type of data feed' %>
+      <%= f.input :new_area_data_feed, label: 'How to setup data feed for a new area' %>
+      <%= f.input :add_existing_data_feed, label: 'How to add to an existing data feed' %>
+      <%= f.input :data_issues_contact_details, label: 'Who to contact about data issues' %>
       <%= f.input :historic_data %>
-      <%= f.input :loa_expiry_procedure, label: "What to do when LOA is about expire" %>
+      <%= f.input :loa_expiry_procedure, label: 'What to do when LOA is about expire' %>
       <%= f.input :comments %>
+      <%= f.input :load_tariffs, label: 'Load tariffs for SMETS meters' %>
       <%= f.submit 'Save', class: 'btn btn-primary' %>
     <% end %>
   </div>

--- a/db/migrate/20240530103709_add_load_tariffs_to_data_source.rb
+++ b/db/migrate/20240530103709_add_load_tariffs_to_data_source.rb
@@ -1,0 +1,5 @@
+class AddLoadTariffsToDataSource < ActiveRecord::Migration[6.1]
+  def change
+    add_column :data_sources, :load_tariffs, :boolean, null: false, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_05_22_155559) do
+ActiveRecord::Schema.define(version: 2024_05_30_103709) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
@@ -825,6 +825,7 @@ ActiveRecord::Schema.define(version: 2024_05_22_155559) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.integer "import_warning_days"
+    t.boolean "load_tariffs", default: true, null: false
   end
 
   create_table "emails", force: :cascade do |t|

--- a/lib/tasks/deployment/20240530110935_disable_tgp_energy_tariffs.rake
+++ b/lib/tasks/deployment/20240530110935_disable_tgp_energy_tariffs.rake
@@ -1,0 +1,17 @@
+namespace :after_party do
+  desc 'Deployment task: disable_tgp_energy_tariffs'
+  task disable_tgp_energy_tariffs: :environment do
+    puts "Running deploy task 'disable_tgp_energy_tariffs'"
+
+    # TGP n3rgy (SMS)
+    data_source = DataSource.find_by_id(52)
+    if data_source
+      data_source.update(load_tariffs: false)
+    end
+
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord
+      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+  end
+end

--- a/lib/tasks/deployment/20240530110935_disable_tgp_energy_tariffs.rake
+++ b/lib/tasks/deployment/20240530110935_disable_tgp_energy_tariffs.rake
@@ -4,10 +4,7 @@ namespace :after_party do
     puts "Running deploy task 'disable_tgp_energy_tariffs'"
 
     # TGP n3rgy (SMS)
-    data_source = DataSource.find_by_id(52)
-    if data_source
-      data_source.update(load_tariffs: false)
-    end
+    data_source = DataSource.find_by_id(52)&.update!(load_tariffs: false)
 
     # Update task as completed.  If you remove the line below, the task will
     # run with every deploy (or every time you call after_party:run).

--- a/spec/services/amr/n3rgy_energy_tariff_loader_spec.rb
+++ b/spec/services/amr/n3rgy_energy_tariff_loader_spec.rb
@@ -1,0 +1,46 @@
+require 'rails_helper'
+
+describe Amr::N3rgyEnergyTariffLoader do
+  subject(:service) do
+    described_class.new(meter: meter)
+  end
+
+  describe '#perform' do
+    let(:downloader) { instance_double(Amr::N3rgyTariffDownloader) }
+    let(:manager) { instance_double(Amr::N3rgyTariffManager) }
+
+    context 'when tariff loading is disabled' do
+      let(:meter) { create(:electricity_meter, dcc_meter: true, consent_granted: true, data_source: create(:data_source, load_tariffs: false))}
+
+      it 'does not load tariffs' do
+        expect { service.perform }.not_to change(TariffImportLog, :count)
+      end
+    end
+
+    context 'when tariff loading is enabled' do
+      context 'with data source setting' do
+        let(:meter) { create(:electricity_meter, dcc_meter: true, consent_granted: true, data_source: create(:data_source, load_tariffs: true))}
+
+        it 'loads tariffs' do
+          allow(Amr::N3rgyTariffDownloader).to receive(:new).and_return(downloader)
+          expect(downloader).to receive(:current_tariff)
+          allow(Amr::N3rgyTariffManager).to receive(:new).and_return(manager)
+          expect(manager).to receive(:perform)
+          service.perform
+        end
+      end
+
+      context 'with no data source configured' do
+        let(:meter) { create(:electricity_meter, dcc_meter: true, consent_granted: true, data_source: nil)}
+
+        it 'loads tariffs' do
+          allow(Amr::N3rgyTariffDownloader).to receive(:new).and_return(downloader)
+          expect(downloader).to receive(:current_tariff)
+          allow(Amr::N3rgyTariffManager).to receive(:new).and_return(manager)
+          expect(manager).to receive(:perform)
+          service.perform
+        end
+      end
+    end
+  end
+end

--- a/spec/system/admin/data_sources_spec.rb
+++ b/spec/system/admin/data_sources_spec.rb
@@ -12,6 +12,8 @@ end
 shared_examples_for 'a data source form' do
   it 'shows prefilled form' do
     expect(page).to have_select('Organisation type', selected: data_source.organisation_type.try(:humanize).presence || [])
+    expect(page).to have_field('Load tariffs for SMETS meters')
+
     text_attributes.each do |text_field, label|
       if data_source[text_field]
         expect(page).to have_field(label, with: data_source[text_field])
@@ -139,6 +141,7 @@ RSpec.describe 'Data Sources admin', :school_groups, type: :system, include_appl
 
               before do
                 select new_data_source.organisation_type.humanize, from: 'Organisation type'
+                check 'Load tariffs for SMETS meters'
                 text_attributes.each do |text_field, label|
                   fill_in label, with: new_data_source[text_field]
                 end


### PR DESCRIPTION
We are now using the n3rgy API to load data for:

- real SMETS-2 meters
- some AMR meters which are provided by their API

The first set have tariffs the second do not. Currently we expect both to be available so get errors in Rollbar when trying to load tariffs for the AMR meters.

This PR disables loading of tariffs from the n3rgy API using a flag on the DataSource associated with a Meter. 

All of the AMR meters have associated with a specific DataSource and the changes include a database update to switch off the new flag for that.

This seemed best option as there's no reliable way to distinguish the meters via the n3rgy API.