### PR TITLE
Change where weekend gas alert notice is shown on advice page

### DIFF
--- a/app/controllers/schools/advice/gas_recent_changes_controller.rb
+++ b/app/controllers/schools/advice/gas_recent_changes_controller.rb
@@ -1,7 +1,7 @@
 module Schools
   module Advice
     class GasRecentChangesController < AdviceBaseController
-      before_action :load_dashboard_alerts, only: [:insights]
+      before_action :load_dashboard_alerts
 
       def insights
         @analysis_dates = analysis_dates

--- a/app/helpers/advice_page_helper.rb
+++ b/app/helpers/advice_page_helper.rb
@@ -171,7 +171,8 @@ module AdvicePageHelper
   end
 
   def alert_types_for_class(class_name)
-    AlertType.where(class_name: class_name.to_s)
+    class_names = Array(class_name).map(&:to_s)
+    AlertType.where(class_name: class_names)
   end
 
   # alert type groups have a specific order here

--- a/app/views/schools/advice/gas_out_of_hours/_insights.html.erb
+++ b/app/views/schools/advice/gas_out_of_hours/_insights.html.erb
@@ -4,7 +4,7 @@
            analysis_dates: @analysis_dates,
            dashboard_alerts: @dashboard_alerts,
            annual_usage_breakdown: @annual_usage_breakdown,
-           alert_classes: [AlertOutOfHoursGasUsage, AlertWeekendGasConsumptionShortTerm],
+           alert_classes: [AlertOutOfHoursGasUsage],
            fuel_type: :gas %>
 <%= render 'schools/advice/out_of_hours/comparison',
            school: @school,

--- a/app/views/schools/advice/gas_recent_changes/_analysis.html.erb
+++ b/app/views/schools/advice/gas_recent_changes/_analysis.html.erb
@@ -10,7 +10,8 @@
 </ul>
 
 <!--  COMPARISON OF GAS USE OVER 2 RECENT WEEKS -->
-<%= render 'schools/advice/section_title', section_id: 'compare-recent-weeks', section_title: t('advice_pages.gas_recent_changes.analysis.compare_recent_weeks.title') %>
+<%= render 'schools/advice/section_title', section_id: 'compare-recent-weeks',
+                                           section_title: t('advice_pages.gas_recent_changes.analysis.compare_recent_weeks.title') %>
 
 <div class="charts">
   <%= component 'chart',
@@ -26,13 +27,15 @@
       <p><%= t('advice_pages.gas_recent_changes.analysis.charts.compare_recent_weeks_chart_explanation') %></p>
     <% end %>
     <% c.with_footer do %>
-      <%= render 'shared/usage_controls', chart_config: @chart_config, period: :weekly, supply: :gas, split_meters: false, meters: @meters %>
+      <%= render 'shared/usage_controls', chart_config: @chart_config, period: :weekly, supply: :gas,
+                                          split_meters: false, meters: @meters %>
     <% end %>
   <% end %>
 </div>
 
 <!--  COMPARISON OF GAS USE OVER 2 RECENT DAYS -->
-<%= render 'schools/advice/section_title', section_id: 'compare-recent-days', section_title: t('advice_pages.gas_recent_changes.analysis.compare_recent_days.title') %>
+<%= render 'schools/advice/section_title', section_id: 'compare-recent-days',
+                                           section_title: t('advice_pages.gas_recent_changes.analysis.compare_recent_days.title') %>
 
 <div class="charts">
   <%= component 'chart',
@@ -49,22 +52,29 @@
       <p><%= t('advice_pages.gas_recent_changes.analysis.charts.compare_recent_days_chart_explanation') %></p>
     <% end %>
     <% c.with_footer do %>
-      <%= render 'shared/usage_controls', chart_config: @chart_config, period: :daily, supply: :gas, split_meters: false, meters: @meters  %>
-      <br/>
+      <%= render 'shared/usage_controls', chart_config: @chart_config, period: :daily, supply: :gas,
+                                          split_meters: false, meters: @meters %>
+      <br>
       <p><%= t('advice_pages.gas_recent_changes.analysis.expected_usage_patterns') %></p>
       <p><%= t('advice_pages.gas_recent_changes.analysis.optimal_start_control') %></p>
     <% end %>
   <% end %>
 </div>
 
-<%= render 'schools/advice/section_title', section_id: 'compare-last-week', section_title: t('advice_pages.gas_recent_changes.analysis.compare_last_week.title') %>
+<%= render 'schools/advice/section_title', section_id: 'compare-last-week',
+                                           section_title: t('advice_pages.gas_recent_changes.analysis.compare_last_week.title') %>
+
+<%= component 'alerts', school: @school,
+                        dashboard_alerts: @dashboard_alerts,
+                        alert_types: alert_types_for_class([AlertSchoolWeekComparisonGas, AlertWeekendGasConsumptionShortTerm]),
+                        show_links: false, show_icons: false %>
 
 <%= component 'chart',
-           chart_type: :last_7_days_intraday_gas,
-           school: @school,
-           analysis_controls: true,
-           no_zoom: true,
-           axis_controls: false do |c| %>
+              chart_type: :last_7_days_intraday_gas,
+              school: @school,
+              analysis_controls: true,
+              no_zoom: true,
+              axis_controls: false do |c| %>
   <% c.with_title { t('advice_pages.gas_recent_changes.analysis.charts.compare_last_week_chart_title') } %>
   <% c.with_subtitle { t('advice_pages.gas_recent_changes.analysis.charts.compare_last_week_chart_subtitle') } %>
   <% c.with_header do %>
@@ -76,7 +86,8 @@
 <% end %>
 
 <!--  IMPACT ON GAS USE OF TEMP -->
-<%= render 'schools/advice/section_title', section_id: 'impact-of-temperature', section_title: t('advice_pages.gas_recent_changes.analysis.impact_of_temperature.title') %>
+<%= render 'schools/advice/section_title', section_id: 'impact-of-temperature',
+                                           section_title: t('advice_pages.gas_recent_changes.analysis.impact_of_temperature.title') %>
 
 <div class="xcharts">
   <%= component 'chart',
@@ -87,10 +98,15 @@
                 chart_config: @chart_config,
                 axis_controls: false do |c| %>
     <% c.with_title { t('advice_pages.gas_recent_changes.analysis.charts.impact_of_temperature_chart_title') } %>
-    <% c.with_subtitle { t('advice_pages.gas_recent_changes.analysis.charts.impact_of_temperature_chart_subtitle_html', start_date: short_dates(@chart_config[:last_reading] - 13.days), end_date: short_dates(@chart_config[:last_reading])) } %>
+    <% c.with_subtitle do
+         t('advice_pages.gas_recent_changes.analysis.charts.impact_of_temperature_chart_subtitle_html',
+           start_date: short_dates(@chart_config[:last_reading] - 13.days), end_date: short_dates(@chart_config[:last_reading]))
+       end %>
     <% c.with_footer do %>
-      <% more_detail_url = link_to(t('advice_pages.gas_recent_changes.analysis.see_more_detail'), "https://www.sustainabilityexchange.ac.uk/files/degree_days_for_energy_management_carbon_trust.pdf", target: '_blank') %>
-      <p><%= t('advice_pages.gas_recent_changes.analysis.charts.impact_of_temperature_chart_explanation_html', more_detail_url: more_detail_url) %></p>
+      <% more_detail_url = link_to(t('advice_pages.gas_recent_changes.analysis.see_more_detail'),
+                                   'https://www.sustainabilityexchange.ac.uk/files/degree_days_for_energy_management_carbon_trust.pdf', target: '_blank', rel: 'noopener') %>
+      <p><%= t('advice_pages.gas_recent_changes.analysis.charts.impact_of_temperature_chart_explanation_html',
+               more_detail_url: more_detail_url) %></p>
     <% end %>
   <% end %>
 </div>

--- a/app/views/schools/advice/gas_recent_changes/_insights.html.erb
+++ b/app/views/schools/advice/gas_recent_changes/_insights.html.erb
@@ -8,8 +8,11 @@
 <%= render 'schools/advice/section_title',
            section_id: 'your_recent_gas_use',
            section_title: t('advice_pages.gas_recent_changes.insights.your_recent_gas_use.title') %>
+
 <%= component 'alerts', school: @school,
                         dashboard_alerts: @dashboard_alerts,
-                        alert_types: alert_types_for_class(AlertSchoolWeekComparisonGas),
+                        alert_types: alert_types_for_class([AlertSchoolWeekComparisonGas,
+                                                            AlertWeekendGasConsumptionShortTerm]),
                         show_links: false, show_icons: false %>
+
 <%= render 'your_recent_gas_use_table' %>

--- a/app/views/schools/advice/out_of_hours/_current_usage.html.erb
+++ b/app/views/schools/advice/out_of_hours/_current_usage.html.erb
@@ -3,10 +3,8 @@
            section_title:
           t("advice_pages.#{fuel_type}_out_of_hours.insights.your_out_of_hours_usage_title") %>
 
-<% alert_classes.each do |alert_class| %>
-  <%= component 'alerts', school: school, dashboard_alerts: dashboard_alerts,
-                          alert_types: alert_types_for_class(alert_class), show_links: false, show_icons: false %>
-<% end %>
+<%= component 'alerts', school: school, dashboard_alerts: dashboard_alerts,
+                        alert_types: alert_types_for_class(alert_classes), show_links: false, show_icons: false %>
 
 <% if analysis_dates.one_years_data? %>
   <%= t(

--- a/lib/tasks/deployment/20240530133928_change_weekend_gas_alert_link.rake
+++ b/lib/tasks/deployment/20240530133928_change_weekend_gas_alert_link.rake
@@ -1,0 +1,15 @@
+namespace :after_party do
+  desc 'Deployment task: change_weekend_gas_alert_link'
+  task change_weekend_gas_alert_link: :environment do
+    puts "Running deploy task 'change_weekend_gas_alert_link'"
+
+    alert_type = AlertType.find_by_class_name('AlertWeekendGasConsumptionShortTerm')
+    advice_page = AdvicePage.find_by_key(:gas_recent_changes)
+    alert_type.update!(advice_page: advice_page, link_to_section: 'compare-last-week') if alert_type && advice_page
+
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord
+      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+  end
+end

--- a/spec/helpers/advice_page_helper_spec.rb
+++ b/spec/helpers/advice_page_helper_spec.rb
@@ -149,8 +149,12 @@ describe AdvicePageHelper do
     end
 
     describe '.alert_types_for_class' do
-      it 'returns alert types for class name' do
+      it 'returns alert types for class name as string' do
         expect(helper.alert_types_for_class('ChangeAlert')).to eq([alert_type_change])
+      end
+
+      it 'returns alert types for class name as array' do
+        expect(helper.alert_types_for_class(['ChangeAlert'])).to eq([alert_type_change])
       end
     end
   end

--- a/spec/support/shared_contexts/advice_pages.rb
+++ b/spec/support/shared_contexts/advice_pages.rb
@@ -144,3 +144,35 @@ RSpec.shared_context 'storage advice page' do
     allow_any_instance_of(AggregateSchoolService).to receive(:aggregate_school).and_return(meter_collection)
   end
 end
+
+RSpec.shared_context 'displayable alert content' do
+  let(:template_data) { {} }
+  let(:template_data_cy) { {} }
+  let(:alert_text) { 'Expected alert content' }
+  let(:alert_text_cy) { 'Welsh alert content' }
+
+  before do
+    alert_type_rating = create(
+      :alert_type_rating,
+      alert_type: alert_type,
+      rating_from: 0,
+      rating_to: 10,
+      management_dashboard_alert_active: true,
+    )
+    create(
+      :alert_type_rating_content_version,
+      alert_type_rating: alert_type_rating,
+      management_dashboard_title_en: alert_text,
+      management_dashboard_title_cy: alert_text_cy,
+    )
+    create(:alert, :with_run,
+      alert_type: alert_type,
+      run_on: Time.zone.today,
+      school: school,
+      rating: 5.0,
+      template_data: template_data,
+      template_data_cy: template_data_cy
+    )
+    Alerts::GenerateContent.new(school).perform
+  end
+end

--- a/spec/support/shared_examples/advice_pages.rb
+++ b/spec/support/shared_examples/advice_pages.rb
@@ -79,3 +79,17 @@ RSpec.shared_examples 'an advice page showing electricity data warning' do
     expect(page).to have_content('We have not received data for your electricity usage for over thirty days')
   end
 end
+
+RSpec.shared_examples 'an advice page with an alert notice' do |link: false|
+  it 'shows the notice' do
+    within('.alerts-component') do
+      expect(page).to have_content(expected_notice)
+    end
+  end
+
+  it 'has a link in the notice', if: link do
+    within('.alerts-component') do
+      expect(page).to have_link('View analysis')
+    end
+  end
+end

--- a/spec/system/schools/advice_pages/gas_recent_changes_spec.rb
+++ b/spec/system/schools/advice_pages/gas_recent_changes_spec.rb
@@ -6,6 +6,13 @@ RSpec.describe 'gas recent changes advice page', type: :system do
 
   include_context 'gas advice page'
 
+  let(:alert_notice) { 'Weekend gas consumption is poor' }
+
+  include_context 'displayable alert content' do
+    let(:alert_type) { create(:alert_type, class_name: AlertWeekendGasConsumptionShortTerm) }
+    let(:alert_text) { alert_notice }
+  end
+
   context 'as school admin' do
     let(:user) { create(:school_admin, school: school) }
 
@@ -26,6 +33,10 @@ RSpec.describe 'gas recent changes advice page', type: :system do
         expect(page).to have_content('Your recent gas use')
         expect(page).to have_content(12)
       end
+
+      it_behaves_like 'an advice page with an alert notice' do
+        let(:expected_notice) { alert_notice }
+      end
     end
 
     context "clicking the 'Analysis' tab" do
@@ -34,6 +45,10 @@ RSpec.describe 'gas recent changes advice page', type: :system do
       end
 
       it_behaves_like 'an advice page tab', tab: 'Analysis'
+
+      it_behaves_like 'an advice page with an alert notice' do
+        let(:expected_notice) { alert_notice }
+      end
 
       it 'shows titles' do
         expect(page).to have_content('Comparison of gas use over 2 recent weeks')


### PR DESCRIPTION
![Screenshot from 2024-05-30 14-45-06](https://github.com/Energy-Sparks/energy-sparks/assets/109082/28a83e7d-56bf-43c6-94f2-bed2887db1c0)

The above alert currently links to a section of the out of hours usage analysis page. It's also shown on the out of hours insights page.

But if a school has limited data (< 3 months) then we can still show this alert but they won't have access to that advice page.

This PR:

- moves the alert notice so that its included on the gas recent changes insights and analysis page instead
- updated the configuration of the alert type, so that the links are repointed

I've added a spec for the advice page and some shared context/examples to help with setup. The presence of these alerts wasn't being tested before so this starts to fill in a gap.

Also fixed an issue with displaying alerts for multiple types. 