### PR TITLE
Change id for chart axis controls

### DIFF
--- a/app/components/chart_component/chart_component.html.erb
+++ b/app/components/chart_component/chart_component.html.erb
@@ -12,9 +12,14 @@
 
     <%= header %>
 
-    <%= render 'shared/analysis_controls', chart_type: chart_type, axis_controls: axis_controls, analysis_controls: analysis_controls %>
+    <%= render 'shared/analysis_controls',
+               chart_id: chart_id,
+               axis_controls: axis_controls,
+               analysis_controls: analysis_controls %>
 
-    <div id="<%= chart_id %>" class="<%= html_class %>" data-autoload-chart="<%= autoload_chart %>" data-chart-config="<%= chart_config_json %>">
+    <div id="<%= chart_id %>" class="<%= html_class %>"
+         data-autoload-chart="<%= autoload_chart %>"
+         data-chart-config="<%= chart_config_json %>">
     </div>
     <div id='chart-error' class='d-none'><%= I18n.t('chart_data_values.standard_error_message') %></div>
 

--- a/app/views/shared/_analysis_controls.html.erb
+++ b/app/views/shared/_analysis_controls.html.erb
@@ -6,8 +6,16 @@
         <span class="text-align-center mr-1"><%= t('analysis_controls.change_units') %> </span>
         <% possible_y1_axis_choices.each do |axis| %>
           <div class="custom-control custom-radio custom-control-inline">
-            <input type="radio" name="<%= chart_type %>-y1-axis-choices" id="<%= chart_type %>-y1-axis-choices-<%=axis%>" data-unit="<%= axis %>" class="custom-control-input axis-choice" disabled>
-            <label class="custom-control-label" for="<%= chart_type %>-y1-axis-choices-<%=axis%>" data-toggle="tooltip" data-placement="top" title="Change chart y-axis to <%= axis %>"><%= t(axis) %></label>
+            <input type="radio"
+                   name="<%= chart_id %>-y1-axis-choices"
+                   id="<%= chart_id %>-y1-axis-choices-<%= axis %>"
+                   data-unit="<%= axis %>"
+                   class="custom-control-input axis-choice" disabled>
+            <label class="custom-control-label"
+                   for="<%= chart_id %>-y1-axis-choices-<%= axis %>"
+                   data-toggle="tooltip"
+                   data-placement="top"
+                   title="Change chart y-axis to <%= axis %>"><%= t(axis) %></label>
           </div>
         <% end %>
       <% end %>
@@ -20,17 +28,20 @@
         <span class="mr-2 align-bottom"><%= t('analysis_controls.explore') %></span>
         <div>
           <button class="btn btn-sm btn-outline-dark rounded-pill explore-button move_back" disabled>
-            <%= fa_icon('backward') %> <%= t('analysis_controls.back_one') %> <span class='period'><%= t('analysis_controls.period') %></span>
+            <%= fa_icon('backward') %> <%= t('analysis_controls.back_one') %>
+            <span class='period'><%= t('analysis_controls.period') %></span>
           </button>
         </div>
         <div>
           <button class="btn btn-sm btn-outline-dark rounded-pill explore-button drillup" disabled>
-            <%= fa_icon('eject') %> <%= t('analysis_controls.up_to') %> <span class='period'><%= t('analysis_controls.period') %></span> <%= t('analysis_controls.view') %>
+            <%= fa_icon('eject') %> <%= t('analysis_controls.up_to') %>
+            <span class='period'><%= t('analysis_controls.period') %></span> <%= t('analysis_controls.view') %>
           </button>
         </div>
         <div>
           <button class="btn btn-sm btn-outline-dark rounded-pill explore-button move_forward" disabled>
-            <%= t('analysis_controls.forward_one') %> <span class='period'><%= t('analysis_controls.period') %></span> <%= fa_icon('forward') %>
+            <%= t('analysis_controls.forward_one') %>
+            <span class='period'><%= t('analysis_controls.period') %></span> <%= fa_icon('forward') %>
           </button>
         </div>
       </div>


### PR DESCRIPTION
Currently the axis controls for the charts are named after the chart type, e.g. `chart_gas_heating_season_intraday_up_to_1_year`. But if we have more than one chart of the same type on the page then the controls don't have unique names. Trying to change the axis of the second chart updates the first.

This is noticeable on the heating control analysis when a school has multiple gas meters. We show the `gas_heating_season_intraday_up_to_1_year` chart for the school then a separate section with options to view charts for each meter.

The charts are already named uniquely to avoid problems with loading data. So this PR just changes the controls to use the chart id as the basis for their names, rather than the type.

Tested manually but chart switching still works fine and resolves the problem on the heating control page.