### PR TITLE
Use new fonts

### DIFF
--- a/app/assets/javascripts/common_chart_options.js.erb
+++ b/app/assets/javascripts/common_chart_options.js.erb
@@ -5,7 +5,7 @@ Highcharts.setOptions({
   },
   chart: {
     style: {
-      fontFamily: 'Quicksand'
+      fontFamily: 'Inter'
     }
   }
 });

--- a/app/assets/stylesheets/activities.scss
+++ b/app/assets/stylesheets/activities.scss
@@ -53,7 +53,7 @@ trix-toolbar .button_groups {
 }
 
 .select2-container {
-    width: 100% !important;
+  width: 100% !important;
 }
 
 .select2-selection--multiple:after{

--- a/app/assets/stylesheets/activities.scss
+++ b/app/assets/stylesheets/activities.scss
@@ -49,7 +49,7 @@ trix-toolbar .button_groups {
 
 .select2-container--bootstrap .select2-results__group {
   color: $text;
-  font-size: $f3;
+  font-size: $f4;
 }
 
 .select2-container {

--- a/app/assets/stylesheets/advice_page.scss
+++ b/app/assets/stylesheets/advice_page.scss
@@ -44,23 +44,6 @@
   }
 }
 
-.advice-priority-table {
-  margin-top: 10px !important;
-
-  td h4 {
-    padding-top: 0px;
-    padding-bottom: 0px;
-  }
-
-  td h4 div.trix-content div {
-    font-size: inherit;
-  }
-
-  td h4 a div.trix-content div {
-    font-size: inherit;
-  }
-}
-
 .text-positive {
   color: $green;
 }

--- a/app/assets/stylesheets/analysis.scss
+++ b/app/assets/stylesheets/analysis.scss
@@ -39,7 +39,7 @@ div.analysis-chart, div.usage-chart {
   text-align: center;
   color: $dark-grey;
   line-height: 700px;
-  font-size: $f6;
+  font-size: $f7;
   margin: 0 auto;
   padding-bottom: 25px;
   padding-top: 10px;

--- a/app/assets/stylesheets/analysis.scss
+++ b/app/assets/stylesheets/analysis.scss
@@ -168,5 +168,5 @@ div.popover {
 }
 
 .highcharts-subtitle {
-  font-size: $f5;
+  font-size: $default-font-size;
 }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -35,6 +35,7 @@
 @import "datepickers";
 
 @import "actiontext";
+@import "trix_content";
 
 @import "observations";
 @import "carousels";

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -6,6 +6,7 @@
 @import "bootstrap-xl";
 @import "font-awesome";
 
+@import "fonts";
 @import "colours";
 @import "base";
 @import "links";
@@ -34,7 +35,6 @@
 @import "datepickers";
 
 @import "actiontext";
-@import "trix_content";
 
 @import "observations";
 @import "carousels";

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -5,9 +5,9 @@
 @import "bootstrap";
 @import "bootstrap-xl";
 @import "font-awesome";
-
 @import "fonts";
 @import "colours";
+
 @import "base";
 @import "links";
 @import "headers";

--- a/app/assets/stylesheets/application_mailer.scss
+++ b/app/assets/stylesheets/application_mailer.scss
@@ -1,3 +1,4 @@
-@import url(//fonts.googleapis.com/css?family=Quicksand:500,700&display=swap);
+@import url(//fonts.googleapis.com/css?family=Inter:500,700|Quicksand:500,700&display=swap);
 @import "colours";
+@import "fonts";
 @import "base";

--- a/app/assets/stylesheets/base.scss
+++ b/app/assets/stylesheets/base.scss
@@ -45,10 +45,6 @@ p.small {
   white-space: nowrap;
 }
 
-footer li {
-  @include font(f7);
-}
-
 nav li {
   @include font(f7);
 }

--- a/app/assets/stylesheets/base.scss
+++ b/app/assets/stylesheets/base.scss
@@ -1,5 +1,5 @@
 body {
-  @include font(f4);
+  @include font(f5);
   font-family: $default-font-family;
   overflow-x: hidden;
 }

--- a/app/assets/stylesheets/base.scss
+++ b/app/assets/stylesheets/base.scss
@@ -34,7 +34,7 @@ body p {
   @include font(f6);
 }
 
-p.small {
+.small {
   @include font(f7);
 }
 

--- a/app/assets/stylesheets/base.scss
+++ b/app/assets/stylesheets/base.scss
@@ -1,5 +1,5 @@
 body {
-  @include font(f5);
+  @include font(f6);
   font-family: $default-font-family;
   font-weight: $default-font-weight;
   overflow-x: hidden;
@@ -31,15 +31,15 @@ address {
 }
 
 body p {
-  @include font(f5);
-}
-
-p.small {
   @include font(f6);
 }
 
-.very-small {
+p.small {
   @include font(f7);
+}
+
+.very-small {
+  @include font(f8);
 }
 
 .nowrap {
@@ -47,7 +47,7 @@ p.small {
 }
 
 nav li {
-  @include font(f7);
+  @include font(f8);
 }
 
 .bg-positive {

--- a/app/assets/stylesheets/base.scss
+++ b/app/assets/stylesheets/base.scss
@@ -1,6 +1,7 @@
 body {
   @include font(f5);
   font-family: $default-font-family;
+  font-weight: $default-font-weight;
   overflow-x: hidden;
 }
 

--- a/app/assets/stylesheets/base.scss
+++ b/app/assets/stylesheets/base.scss
@@ -1,32 +1,6 @@
-/* Font sizes */
-/* Other font definitions also found in common_chart_options.js.erb & live_data.js.erb */
-
-$f-super-big: 60px;
-$f0: 50px;
-$f1: 37.3px;
-$f2: 31.1px;
-$f3: 25.9px;
-$f4: 21.6px;
-$f5: 18px;
-$f6: 15px;
-$f7: 12.5px;
-$f8: 10px;
-
-$default-font-family: 'Quicksand', sans-serif;
-$default-font-size: $f5;
-
-.f1 { font-size: $f1; }
-.f2 { font-size: $f2; }
-.f3 { font-size: $f3; }
-.f4 { font-size: $f4; }
-.f5 { font-size: $f5; }
-.f6 { font-size: $f6; }
-.f7 { font-size: $f7; }
-
 body {
+  @include font(f4);
   font-family: $default-font-family;
-  font-weight: 500;
-  font-size: $default-font-size;
   overflow-x: hidden;
 }
 
@@ -56,11 +30,11 @@ address {
 }
 
 p.small {
-  font-size: $f6;
+  @include font(f6);
 }
 
 .very-small {
-  font-size: $f7;
+  @include font(f7);
 }
 
 .nowrap {
@@ -68,11 +42,11 @@ p.small {
 }
 
 footer li {
-  font-size: $f6;
+  @include font(f6);
 }
 
 nav li {
-  font-size: $f6;
+  @include font(f6);
 }
 
 .bg-positive {

--- a/app/assets/stylesheets/base.scss
+++ b/app/assets/stylesheets/base.scss
@@ -29,6 +29,10 @@ address {
   font-size: initial;
 }
 
+body p {
+  @include font(f5);
+}
+
 p.small {
   @include font(f6);
 }

--- a/app/assets/stylesheets/base.scss
+++ b/app/assets/stylesheets/base.scss
@@ -42,11 +42,11 @@ p.small {
 }
 
 footer li {
-  @include font(f6);
+  @include font(f7);
 }
 
 nav li {
-  @include font(f6);
+  @include font(f7);
 }
 
 .bg-positive {

--- a/app/assets/stylesheets/dashboards.scss
+++ b/app/assets/stylesheets/dashboards.scss
@@ -151,36 +151,36 @@ table.management-priorities {
 
   @media (min-width: 576px) and (max-width: 991.98px) {
     td {
-      font-size: $f7;
-      .btn {
-        font-size: $f7;
-        width: 80px;
-      }
-      .trix-content div {
-        font-size: $f7;
-      }
-    }
-    th {
-      font-size: $f5;
-    }
-    .h2 {
-      font-size: $f5;
-    }
-  }
-
-  @media (min-width: 300px) and (max-width: 575.99px) {
-    td {
       font-size: $f8;
       .btn {
         font-size: $f8;
         width: 80px;
       }
+      .trix-content div {
+        font-size: $f8;
+      }
     }
     th {
-      font-size: $f8;
+      font-size: $f6;
     }
     .h2 {
-      font-size: $f8;
+      font-size: $f6;
+    }
+  }
+
+  @media (min-width: 300px) and (max-width: 575.99px) {
+    td {
+      font-size: $f9;
+      .btn {
+        font-size: $f9;
+        width: 80px;
+      }
+    }
+    th {
+      font-size: $f9;
+    }
+    .h2 {
+      font-size: $f9;
     }
   }
 

--- a/app/assets/stylesheets/fonts.scss
+++ b/app/assets/stylesheets/fonts.scss
@@ -56,7 +56,6 @@ $fonts: (
     line-height: 34px,
   ),
 
-
   f5: (
     font-size: $f5, // 18
     line-height: 30px,
@@ -68,7 +67,6 @@ $fonts: (
   f7: (
     font-size: $f7, // 14
     line-height: 24px,
-    font-weight: $default-font-weight,
   ),
   f8: (
     font-size: $f8, // 12

--- a/app/assets/stylesheets/fonts.scss
+++ b/app/assets/stylesheets/fonts.scss
@@ -34,11 +34,6 @@ $f8: 10px;
 */
 
 $fonts: (
-  f-xl: (
-    font-size: $f-xl, // 60
-    line-height: 70px,
-  ),
-
   f1: (
     font-size: $f1, // 48
     line-height: 58px,

--- a/app/assets/stylesheets/fonts.scss
+++ b/app/assets/stylesheets/fonts.scss
@@ -55,7 +55,6 @@ $fonts: (
     font-size: $f4, // 24
     line-height: 34px,
   ),
-
   f5: (
     font-size: $f5, // 18
     line-height: 30px,

--- a/app/assets/stylesheets/fonts.scss
+++ b/app/assets/stylesheets/fonts.scss
@@ -3,15 +3,20 @@
 
 $f-xl: 60px;
 $f0: 48px;
-
 $f1: 36px;
 $f2: 30px;
 $f3: 24px;
-$f4: 18px;
-$f5: 16px; // default
-$f6: 14px;
-$f7: 12px;
-$f8: 10px;
+$f4: 20px; // found under 'components -> text styles' in Sketch (not in New Typography page)
+$f5: 18px; // needs to be the default
+$f6: 16px;
+$f7: 14px;
+$f8: 12px;
+$f9: 10px; // not in 'components -> text styles' in Sketch (but in New Typography page)
+
+$default-font-family: 'Inter';
+$default-font-size: $f5;
+$default-font-weight: 400; // regular. medium is 500
+$header-font-family: 'Quicksand';
 
 // old
 /*
@@ -29,44 +34,59 @@ $f8: 10px;
 
 $fonts: (
   f-xl: (
-    font-size: $f-xl,
-    line-height: 70px
+    font-size: $f-xl, // 60
+    line-height: 70px,
+    font-weight: 600,
   ),
   f0: (
-    font-size: $f0,
-    line-height: 58px
+    font-size: $f0, // 48
+    line-height: 58px,
+    font-weight: 600,
   ),
   f1: (
-    font-size: $f1,
-    line-height: 46px
+    font-size: $f1, // 36
+    line-height: 46px,
+    font-weight: 600,
   ),
   f2: (
-    font-size: $f2,
-    line-height: 40px
+    font-size: $f2, // 30
+    line-height: 40px,
+    font-weight: 700,
   ),
   f3: (
-    font-size: $f3,
-    line-height: 34px
+    font-size: $f3, // 24
+    line-height: 34px,
+    font-weight: 700,
   ),
   f4: (
-    font-size: $f4,
-    line-height: 30px
+    font-size: $f4, // 20
+    line-height: 30px,
+    font-weight: 600,
   ),
   f5: (
-    font-size: $f5,
-    line-height: 26px
+    font-size: $f5, // 18
+    line-height: 30px,
+    font-weight: $default-font-weight,
   ),
   f6: (
-    font-size: $f6,
-    line-height: 24px
+    font-size: $f6, // 16
+    line-height: 26px,
+    font-weight: $default-font-weight,
   ),
   f7: (
-    font-size: $f7,
-    line-height: 22px // spec says 24
+    font-size: $f7, // 14
+    line-height: 24px,
+    font-weight: $default-font-weight,
   ),
   f8: (
-    font-size: $f8,
-    line-height: 20px // made up as no value given for this
+    font-size: $f8, // 12
+    line-height: 22px,
+    font-weight: $default-font-weight,
+  ),
+  f9: (
+    font-size: $f9, // 10
+    line-height: 20px,
+    font-weight: $default-font-weight,
   )
 );
 
@@ -82,9 +102,3 @@ $fonts: (
   }
 }
 
-$default-font-family: 'Inter';
-$default-font-size: $f5;
-$default-font-weight: 400; // regular. medium is 500
-
-$header-font-family: 'Quicksand';
-$header-font-weight: 700;

--- a/app/assets/stylesheets/fonts.scss
+++ b/app/assets/stylesheets/fonts.scss
@@ -12,13 +12,12 @@ $f5: 18px; // default - same as old f5
 $f6: 16px; // 1px bigger than old f6
 $f7: 14px; // slightly smaller than old f6
 $f8: 12px; // old f7 ish
-$f9: 10px; // old f8. not in new design but required for responsive layout
 
 $default-font-family: 'Inter';
 $default-font-size: $f5;
 $default-font-weight: 400; // regular. medium is 500
 $header-font-family: 'Quicksand';
-$header-font-weight: 700; // regular. medium is 500
+$header-font-weight: 600;
 
 /* old
 $f-super-big: 60px;
@@ -73,10 +72,6 @@ $fonts: (
   f8: (
     font-size: $f8, // 12
     line-height: 24px,
-  ),
-  f9: (
-    font-size: $f9, // 10
-    line-height: 22px,
   )
 );
 

--- a/app/assets/stylesheets/fonts.scss
+++ b/app/assets/stylesheets/fonts.scss
@@ -12,6 +12,7 @@ $f5: 18px; // default - same as old f5
 $f6: 16px; // 1px bigger than old f6
 $f7: 14px; // slightly smaller than old f6
 $f8: 12px; // old f7 ish
+$f9: 10px; // old f8 - kept for responsive layout
 
 $default-font-family: 'Inter';
 $default-font-size: $f5;
@@ -72,7 +73,12 @@ $fonts: (
   f8: (
     font-size: $f8, // 12
     line-height: 24px,
+  ),
+  f9: (
+    font-size: $f9, // 10
+    line-height: 22px,
   )
+
 );
 
 @mixin font($name) {

--- a/app/assets/stylesheets/fonts.scss
+++ b/app/assets/stylesheets/fonts.scss
@@ -7,7 +7,7 @@ $f1: 36px;
 $f2: 30px;
 $f3: 24px;
 $f4: 20px; // found under 'components -> text styles' in Sketch (not in New Typography page)
-$f5: 18px; // needs to be the default
+$f5: 18px; // default
 $f6: 16px;
 $f7: 14px;
 $f8: 12px;

--- a/app/assets/stylesheets/fonts.scss
+++ b/app/assets/stylesheets/fonts.scss
@@ -2,22 +2,23 @@
 /* Other font definitions also found in common_chart_options.js.erb & live_data.js.erb */
 
 $f-xl: 60px;
-$f0: 48px;
-$f1: 36px;
-$f2: 30px;
-$f3: 24px;
-$f4: 20px; // found under 'components -> text styles' in Sketch (not in New Typography page)
 
-$f5: 18px; // default
-$f6: 16px; // almost an extra
-$f7: 14px; // more like old f6
+$f1: 48px; // over 10px bigger than old f1 - was 37.3
+$f2: 36px; // approx 5px bigger than old f2 - was 31.1
+$f3: 30px; // approx 4px bigger than old f3 - was 25.9
+$f4: 24px; // approx 3px bigger than old f4 - was 21.6
+
+$f5: 18px; // default - same as old f5
+$f6: 16px; // 1px bigger than old f6
+$f7: 14px; // slightly smaller than old f6
 $f8: 12px; // old f7 ish
-$f9: 10px; // old f8. not in 'components -> text styles' in Sketch (but in New Typography page)
+$f9: 10px; // old f8. not in new design but required for responsive layout
 
 $default-font-family: 'Inter';
 $default-font-size: $f5;
 $default-font-weight: 400; // regular. medium is 500
 $header-font-family: 'Quicksand';
+$header-font-weight: 700; // regular. medium is 500
 
 /* old
 $f-super-big: 60px;
@@ -36,42 +37,33 @@ $fonts: (
   f-xl: (
     font-size: $f-xl, // 60
     line-height: 70px,
-    font-weight: 600, // font weights of headers are either 600 or 700. Not sure if this is intentional
   ),
-  f0: (
-    font-size: $f0, // 48
-    line-height: 58px,
-    font-weight: 600,
-  ),
+
   f1: (
-    font-size: $f1, // 36
-    line-height: 46px,
-    font-weight: 600,
+    font-size: $f1, // 48
+    line-height: 58px,
   ),
   f2: (
-    font-size: $f2, // 30
-    line-height: 40px,
-    font-weight: 700,
+    font-size: $f2, // 36
+    line-height: 46px,
   ),
   f3: (
-    font-size: $f3, // 24
-    line-height: 34px,
-    font-weight: 700,
+    font-size: $f3, // 30
+    line-height: 40px,
   ),
   f4: (
-    font-size: $f4, // 20
-    line-height: 30px,
-    font-weight: 600,
+    font-size: $f4, // 24
+    line-height: 34px,
   ),
+
+
   f5: (
     font-size: $f5, // 18
     line-height: 30px,
-    font-weight: $default-font-weight,
   ),
   f6: (
     font-size: $f6, // 16
     line-height: 26px,
-    font-weight: $default-font-weight,
   ),
   f7: (
     font-size: $f7, // 14
@@ -80,13 +72,11 @@ $fonts: (
   ),
   f8: (
     font-size: $f8, // 12
-    line-height: 22px,
-    font-weight: $default-font-weight,
+    line-height: 24px,
   ),
   f9: (
     font-size: $f9, // 10
-    line-height: 20px,
-    font-weight: $default-font-weight,
+    line-height: 22px,
   )
 );
 

--- a/app/assets/stylesheets/fonts.scss
+++ b/app/assets/stylesheets/fonts.scss
@@ -7,12 +7,12 @@ $f1: 48px; // over 10px bigger than old f1 - was 37.3
 $f2: 36px; // approx 5px bigger than old f2 - was 31.1
 $f3: 30px; // approx 4px bigger than old f3 - was 25.9
 $f4: 24px; // approx 3px bigger than old f4 - was 21.6
-
-$f5: 18px; // default - same as old f5
-$f6: 16px; // 1px bigger than old f6
-$f7: 14px; // slightly smaller than old f6
-$f8: 12px; // old f7 ish
-$f9: 10px; // old f8 - kept for responsive layout
+$f5: 20px; // 2px bigger than old f5 - was 18
+$f6: 18px; // default - same as old f5
+$f7: 16px; // 1px bigger than old f6
+$f8: 14px; // slightly smaller than old f6
+$f9: 12px; // old f7 ish
+$f10: 10px; // old f8 - kept for responsive layout
 
 $default-font-family: 'Inter';
 $default-font-size: $f5;
@@ -56,23 +56,27 @@ $fonts: (
     line-height: 34px,
   ),
   f5: (
-    font-size: $f5, // 18
+    font-size: $f5, // 20
     line-height: 30px,
   ),
   f6: (
-    font-size: $f6, // 16
-    line-height: 26px,
+    font-size: $f6, // 18
+    line-height: 30px,
   ),
   f7: (
-    font-size: $f7, // 14
-    line-height: 24px,
+    font-size: $f7, // 16
+    line-height: 26px,
   ),
   f8: (
-    font-size: $f8, // 12
+    font-size: $f8, // 14
     line-height: 24px,
   ),
   f9: (
-    font-size: $f9, // 10
+    font-size: $f9, // 12
+    line-height: 24px,
+  ),
+  f10: (
+    font-size: $f10, // 10
     line-height: 22px,
   )
 

--- a/app/assets/stylesheets/fonts.scss
+++ b/app/assets/stylesheets/fonts.scss
@@ -7,19 +7,19 @@ $f1: 36px;
 $f2: 30px;
 $f3: 24px;
 $f4: 20px; // found under 'components -> text styles' in Sketch (not in New Typography page)
+
 $f5: 18px; // default
-$f6: 16px;
-$f7: 14px;
-$f8: 12px;
-$f9: 10px; // not in 'components -> text styles' in Sketch (but in New Typography page)
+$f6: 16px; // almost an extra
+$f7: 14px; // more like old f6
+$f8: 12px; // old f7 ish
+$f9: 10px; // old f8. not in 'components -> text styles' in Sketch (but in New Typography page)
 
 $default-font-family: 'Inter';
 $default-font-size: $f5;
 $default-font-weight: 400; // regular. medium is 500
 $header-font-family: 'Quicksand';
 
-// old
-/*
+/* old
 $f-super-big: 60px;
 $f0: 50px;
 $f1: 37.3px;
@@ -36,7 +36,7 @@ $fonts: (
   f-xl: (
     font-size: $f-xl, // 60
     line-height: 70px,
-    font-weight: 600,
+    font-weight: 600, // font weights of headers are either 600 or 700. Not sure if this is intentional
   ),
   f0: (
     font-size: $f0, // 48

--- a/app/assets/stylesheets/fonts.scss
+++ b/app/assets/stylesheets/fonts.scss
@@ -1,0 +1,90 @@
+/* Font size definitions */
+/* Other font definitions also found in common_chart_options.js.erb & live_data.js.erb */
+
+$f-xl: 60px;
+$f0: 48px;
+
+$f1: 36px;
+$f2: 30px;
+$f3: 24px;
+$f4: 18px;
+$f5: 16px; // default
+$f6: 14px;
+$f7: 12px;
+$f8: 10px;
+
+// old
+/*
+$f-super-big: 60px;
+$f0: 50px;
+$f1: 37.3px;
+$f2: 31.1px;
+$f3: 25.9px;
+$f4: 21.6px;
+$f5: 18px; // default
+$f6: 15px;
+$f7: 12.5px;
+$f8: 10px;
+*/
+
+$fonts: (
+  f-xl: (
+    font-size: $f-xl,
+    line-height: 70px
+  ),
+  f0: (
+    font-size: $f0,
+    line-height: 58px
+  ),
+  f1: (
+    font-size: $f1,
+    line-height: 46px
+  ),
+  f2: (
+    font-size: $f2,
+    line-height: 40px
+  ),
+  f3: (
+    font-size: $f3,
+    line-height: 34px
+  ),
+  f4: (
+    font-size: $f4,
+    line-height: 30px
+  ),
+  f5: (
+    font-size: $f5,
+    line-height: 26px
+  ),
+  f6: (
+    font-size: $f6,
+    line-height: 24px
+  ),
+  f7: (
+    font-size: $f7,
+    line-height: 22px // spec says 24
+  ),
+  f8: (
+    font-size: $f8,
+    line-height: 20px // made up as no value given for this
+  )
+);
+
+@mixin font($name) {
+  @each $property, $value in map-get($fonts, $name) {
+    #{$property}: #{$value};
+  }
+}
+
+@each $name, $font in $fonts {
+  .#{$name} {
+    @include font($name);
+  }
+}
+
+$default-font-family: 'Inter';
+$default-font-size: $f5;
+$default-font-weight: 400; // regular. medium is 500
+
+$header-font-family: 'Quicksand';
+$header-font-weight: 700;

--- a/app/assets/stylesheets/fonts.scss
+++ b/app/assets/stylesheets/fonts.scss
@@ -15,7 +15,7 @@ $f9: 12px; // old f7 ish
 $f10: 10px; // old f8 - kept for responsive layout
 
 $default-font-family: 'Inter';
-$default-font-size: $f5;
+$default-font-size: $f6;
 $default-font-weight: 400; // regular. medium is 500
 $header-font-family: 'Quicksand';
 $header-font-weight: 600;

--- a/app/assets/stylesheets/fonts.scss
+++ b/app/assets/stylesheets/fonts.scss
@@ -74,7 +74,6 @@ $fonts: (
     font-size: $f10, // 10
     line-height: 22px,
   )
-
 );
 
 @mixin font($name) {

--- a/app/assets/stylesheets/footer.scss
+++ b/app/assets/stylesheets/footer.scss
@@ -7,7 +7,12 @@ footer {
 }
 
 footer p {
+  @include font(f7);
   margin-right: 5px;
+}
+
+footer li {
+  @include font(f7);
 }
 
 .btn-outline {

--- a/app/assets/stylesheets/footer.scss
+++ b/app/assets/stylesheets/footer.scss
@@ -7,12 +7,12 @@ footer {
 }
 
 footer p {
-  @include font(f7);
+  @include font(f8);
   margin-right: 5px;
 }
 
 footer li {
-  @include font(f7);
+  @include font(f8);
 }
 
 .btn-outline {

--- a/app/assets/stylesheets/headers.scss
+++ b/app/assets/stylesheets/headers.scss
@@ -1,38 +1,43 @@
-h1 {
+h1, .trix-content h1 {
   @include font(f1);
 }
 
-h2 {
+h2, .trix-content h2 {
   @include font(f2);
 }
 
-h3 {
+h3, .trix-content h3 {
   @include font(f3);
 }
 
-h4 {
+h4, .trix-content h4 {
   @include font(f4);
 }
 
-h5 {
+h5, .trix-content h5 {
   @include font(f5);
 }
 
-h6 {
+h6, .trix-content h6 {
   @include font(f6);
 }
 
-h1 {
+h1, .trix-content h1 {
   padding-top: 20px;
   padding-bottom: 20px;
 }
 
-h2, h3 {
+h2, h3,
+.trix-content h2,
+.trix-content h3 {
   padding-top: 10px;
   padding-bottom: 20px;
 }
 
-h4, h5, h6 {
+h4, h5, h6,
+.trix-content h4,
+.trix-content h5,
+.trix-content h6 {
  padding-top: 10px;
  padding-bottom: 10px;
 }
@@ -52,7 +57,7 @@ h1, h2, h3, h4, h5, h6 {
 
 // Extra small devices (portrait phones, less than 576px)
 @media (max-width: 575.98px) {
-  h1 {
+  h1, .trix-content h1 {
     @include font(f6);
     padding-top: 5px;
     padding-bottom: 5px;
@@ -69,7 +74,7 @@ h1, h2, h3, h4, h5, h6 {
 
 // Small devices (landscape phones, 576px and up)
 @media (min-width: 576px) and (max-width: 767.98px) {
-  h1 {
+  h1, .trix-content h1 {
     @include font(f5);
     padding-top: 10px;
     padding-bottom: 10px;
@@ -86,7 +91,7 @@ h1, h2, h3, h4, h5, h6 {
 
 // Medium devices (tablets, 768px and up) // max-width: 991.98px
 @media (min-width: 768px) and (max-width: 991.98px) {
-  h1 {
+  h1, .trix-content h1 {
     @include font(f4);
     padding-top: 10px;
     padding-bottom: 10px;
@@ -102,7 +107,7 @@ h1, h2, h3, h4, h5, h6 {
 }
 
 @media (min-width: 992px) and (max-width: 1199.98px) {
-  h1 {
+  h1, .trix-content h1 {
     @include font(f3);
     padding-top: 10px;
     padding-bottom: 10px;
@@ -122,7 +127,7 @@ h1, h2, h3, h4, h5, h6 {
 
 // Extra large devices (large desktops, 1200px and up)
 @media (min-width: 1200px) {
-  h1 {
+  h1, .trix-content h1 {
     @include font(f1);
     padding-top: 20px;
     padding-bottom: 20px;

--- a/app/assets/stylesheets/headers.scss
+++ b/app/assets/stylesheets/headers.scss
@@ -22,6 +22,21 @@ h6 {
   @include font(f6);
 }
 
+h1 {
+  padding-top: 20px;
+  padding-bottom: 20px;
+}
+
+h2, h3 {
+  padding-top: 10px;
+  padding-bottom: 20px;
+}
+
+h4, h5, h6 {
+ padding-top: 10px;
+ padding-bottom: 10px;
+}
+
 h1, h2, h3, h4, h5, h6 {
   color: $dark-blue;
   font-family: $header-font-family;

--- a/app/assets/stylesheets/headers.scss
+++ b/app/assets/stylesheets/headers.scss
@@ -118,7 +118,7 @@ h1, h2, h3, h4, h5, h6 {
     @include font(f5);
   }
 
-  h2 {
+  h3 {
     @include font(f6);
   }
 

--- a/app/assets/stylesheets/headers.scss
+++ b/app/assets/stylesheets/headers.scss
@@ -68,6 +68,14 @@ h1, h2, h3, h4, h5, h6 {
     @include font(f7);
   }
 
+  h3 {
+    @include font(f8);
+  }
+
+  h4 {
+    @include font(f9);
+  }
+
   .trix-content div {
     @include font(f7);
   }
@@ -83,6 +91,14 @@ h1, h2, h3, h4, h5, h6 {
 
   h2 {
     @include font(f6);
+  }
+
+  h3 {
+    @include font(f7);
+  }
+
+  h4 {
+    @include font(f8);
   }
 
   .trix-content div {
@@ -102,6 +118,14 @@ h1, h2, h3, h4, h5, h6 {
     @include font(f5);
   }
 
+  h2 {
+    @include font(f6);
+  }
+
+  h4 {
+    @include font(f7);
+  }
+
   .trix-content div {
     @include font(f5);
   }
@@ -116,6 +140,14 @@ h1, h2, h3, h4, h5, h6 {
 
   h2 {
     @include font(f4);
+  }
+
+  h3 {
+    @include font(f5);
+  }
+
+  h4 {
+    @include font(f6);
   }
 
   .trix-content div {

--- a/app/assets/stylesheets/headers.scss
+++ b/app/assets/stylesheets/headers.scss
@@ -83,7 +83,7 @@ h1, h2, h3, h4, h5, h6 {
     @include font(f8);
   }
 
-  .trix-content div, p {
+  .trix-content div {
     @include font(f8);
   }
 }
@@ -112,7 +112,7 @@ h1, h2, h3, h4, h5, h6 {
     @include font(f7);
   }
 
-  .trix-content div, p {
+  .trix-content div {
     @include font(f7);
   }
 }
@@ -137,7 +137,11 @@ h1, h2, h3, h4, h5, h6 {
     @include font(f5);
   }
 
-  .trix-content div, p {
+  h5 {
+    @include font(f5);
+  }
+
+  .trix-content div {
     @include font(f6);
   }
 }
@@ -162,8 +166,11 @@ h1, h2, h3, h4, h5, h6 {
     @include font(f5);
   }
 
-  .trix-content div, p {
+  h5 {
+    @include font(f5);
+  }
+
+  .trix-content div {
     @include font(f6);
   }
 }
-

--- a/app/assets/stylesheets/headers.scss
+++ b/app/assets/stylesheets/headers.scss
@@ -56,7 +56,7 @@ h1, h2, h3, h4, h5, h6 {
 }
 
 .trix-content div {
-  @include font(f5);
+  @include font(f6);
 }
 
 // Extra small devices (portrait phones, less than 576px)
@@ -77,6 +77,10 @@ h1, h2, h3, h4, h5, h6 {
 
   h4 {
     @include font(f7);
+  }
+
+  h5 {
+    @include font(f8);
   }
 
   .trix-content div {
@@ -102,6 +106,10 @@ h1, h2, h3, h4, h5, h6 {
 
   h4 {
     @include font(f6);
+  }
+
+  h5 {
+    @include font(f7);
   }
 
   .trix-content div {
@@ -130,7 +138,7 @@ h1, h2, h3, h4, h5, h6 {
   }
 
   .trix-content div {
-    @include font(f5);
+    @include font(f6);
   }
 }
 
@@ -155,7 +163,7 @@ h1, h2, h3, h4, h5, h6 {
   }
 
   .trix-content div {
-    @include font(f5);
+    @include font(f6);
   }
 }
 

--- a/app/assets/stylesheets/headers.scss
+++ b/app/assets/stylesheets/headers.scss
@@ -55,83 +55,37 @@ h1, h2, h3, h4, h5, h6 {
   font-weight: $header-font-weight;
 }
 
+.trix-content div {
+  @include font(f5);
+}
 
 // Extra small devices (portrait phones, less than 576px)
 @media (max-width: 575.98px) {
   h1, .trix-content h1 {
-    @include font(f6);
+    @include font(f4);
     padding-top: 5px;
     padding-bottom: 5px;
   }
 
   h2 {
-    @include font(f7);
+    @include font(f5);
   }
 
   h3 {
-    @include font(f8);
+    @include font(f6);
   }
 
   h4 {
-    @include font(f9);
+    @include font(f7);
   }
 
   .trix-content div {
-    @include font(f7);
+    @include font(f8);
   }
 }
 
 // Small devices (landscape phones, 576px and up)
 @media (min-width: 576px) and (max-width: 767.98px) {
-  h1, .trix-content h1 {
-    @include font(f5);
-    padding-top: 10px;
-    padding-bottom: 10px;
-  }
-
-  h2 {
-    @include font(f6);
-  }
-
-  h3 {
-    @include font(f7);
-  }
-
-  h4 {
-    @include font(f8);
-  }
-
-  .trix-content div {
-    @include font(f6);
-  }
-}
-
-// Medium devices (tablets, 768px and up) // max-width: 991.98px
-@media (min-width: 768px) and (max-width: 991.98px) {
-  h1, .trix-content h1 {
-    @include font(f4);
-    padding-top: 10px;
-    padding-bottom: 10px;
-  }
-
-  h2 {
-    @include font(f5);
-  }
-
-  h3 {
-    @include font(f6);
-  }
-
-  h4 {
-    @include font(f7);
-  }
-
-  .trix-content div {
-    @include font(f5);
-  }
-}
-
-@media (min-width: 992px) and (max-width: 1199.98px) {
   h1, .trix-content h1 {
     @include font(f3);
     padding-top: 10px;
@@ -151,22 +105,57 @@ h1, h2, h3, h4, h5, h6 {
   }
 
   .trix-content div {
-    @include font(f5);
+    @include font(f7);
   }
 }
 
-// Large devices (desktops, 992px and up)
-// @media (min-width: 992px) and (max-width: 1199.98px) { ... }
-
-// Extra large devices (large desktops, 1200px and up)
-@media (min-width: 1200px) {
+// Medium devices (tablets, 768px and up) // max-width: 991.98px
+@media (min-width: 768px) and (max-width: 991.98px) {
   h1, .trix-content h1 {
-    @include font(f1);
-    padding-top: 20px;
-    padding-bottom: 20px;
+    @include font(f2);
+    padding-top: 10px;
+    padding-bottom: 10px;
+  }
+
+  h2 {
+    @include font(f3);
+  }
+
+  h3 {
+    @include font(f4);
+  }
+
+  h4 {
+    @include font(f5);
   }
 
   .trix-content div {
     @include font(f5);
   }
 }
+
+// Large devices (desktops, 992px and up)
+@media (min-width: 992px) and (max-width: 1199.98px) {
+  h1, .trix-content h1 {
+    @include font(f2);
+    padding-top: 10px;
+    padding-bottom: 10px;
+  }
+
+  h2 {
+    @include font(f3);
+  }
+
+  h3 {
+    @include font(f4);
+  }
+
+  h4 {
+    @include font(f5);
+  }
+
+  .trix-content div {
+    @include font(f5);
+  }
+}
+

--- a/app/assets/stylesheets/headers.scss
+++ b/app/assets/stylesheets/headers.scss
@@ -83,7 +83,7 @@ h1, h2, h3, h4, h5, h6 {
     @include font(f8);
   }
 
-  .trix-content div {
+  .trix-content div, p {
     @include font(f8);
   }
 }
@@ -112,7 +112,7 @@ h1, h2, h3, h4, h5, h6 {
     @include font(f7);
   }
 
-  .trix-content div {
+  .trix-content div, p {
     @include font(f7);
   }
 }
@@ -137,7 +137,7 @@ h1, h2, h3, h4, h5, h6 {
     @include font(f5);
   }
 
-  .trix-content div {
+  .trix-content div, p {
     @include font(f6);
   }
 }
@@ -162,7 +162,7 @@ h1, h2, h3, h4, h5, h6 {
     @include font(f5);
   }
 
-  .trix-content div {
+  .trix-content div, p {
     @include font(f6);
   }
 }

--- a/app/assets/stylesheets/headers.scss
+++ b/app/assets/stylesheets/headers.scss
@@ -27,14 +27,14 @@ h1, .trix-content h1 {
   padding-bottom: 20px;
 }
 
-h2, h3,
-.trix-content h2,
-.trix-content h3 {
+h2,
+.trix-content h2 {
   padding-top: 10px;
   padding-bottom: 20px;
 }
 
-h4, h5, h6,
+h3, h4, h5, h6,
+.trix-content h3,
 .trix-content h4,
 .trix-content h5,
 .trix-content h6 {

--- a/app/assets/stylesheets/headers.scss
+++ b/app/assets/stylesheets/headers.scss
@@ -1,39 +1,36 @@
-h1, .trix-content h1 {
-  font-size: $f1;
+h1 {
+  @include font(f1);
   padding-top: 20px;
   padding-bottom: 20px;
 }
 
-h2, .trix-content h2 {
-  font-size: $f2;
+h2 {
+  @include font(f2);
 }
 
-h3, .trix-content h3 {
-  font-size: $f3;
+h3 {
+  @include font(f3);
 }
 
-h4, .trix-content h4 {
-  font-size: $f4;
-}
-
-h5, .trix-content h5 {
-  font-size: $f5;
-}
-
-h2,
-h3,
-.trix-content h2,
-.trix-content h3 {
+h2, h3
+ {
   padding-top: 10px;
   padding-bottom: 20px;
 }
 
-h4,
-h5,
-h6,
-.trix-content h4,
-.trix-content h5,
-.trix-content h6 {
+h4 {
+  @include font(f4);
+}
+
+h5 {
+  @include font(f5);
+}
+
+h6 {
+  @include font(f6);
+}
+
+h4, h5, h6 {
  padding-top: 10px;
  padding-bottom: 10px;
 }
@@ -45,71 +42,60 @@ h6,
   margin: 0px;
 }
 
+h1, h2, h3, h4, h5, h6 {
+  font-family: $header-font-family;
+  font-weight: $header-font-weight;
+  color: $dark-blue;
+}
+
 // Extra small devices (portrait phones, less than 576px)
 @media (max-width: 575.98px) {
-  h1, .trix-content h1 {
-    font-size: $f6;
+  h1 {
+    @include font(f6);
     padding-top: 5px;
     padding-bottom: 5px;
   }
 
   h2 {
-    font-size: $f7;
-  }
-
-  .trix-content div {
-    font-size: $f7;
+    @include font(f7);
   }
 }
 
 // Small devices (landscape phones, 576px and up)
 @media (min-width: 576px) and (max-width: 767.98px) {
-  h1, .trix-content h1 {
-    font-size: $f5;
+  h1 {
+    @include font(f5);
     padding-top: 10px;
     padding-bottom: 10px;
   }
 
   h2 {
-    font-size: $f6;
-  }
-
-  .trix-content div {
-    font-size: $f6;
+    @include font(f6);
   }
 }
 
 // Medium devices (tablets, 768px and up) // max-width: 991.98px
 @media (min-width: 768px) and (max-width: 991.98px) {
-  h1, .trix-content h1 {
-    font-size: $f4;
+  h1 {
+    @include font(f4);
     padding-top: 10px;
     padding-bottom: 10px;
   }
 
   h2 {
-    font-size: $f5;
-  }
-
-
-  .trix-content div {
-    font-size: $f5;
+    @include font(f5);
   }
 }
 
 @media (min-width: 992px) and (max-width: 1199.98px) {
-  h1, .trix-content h1 {
-    font-size: $f3;
+  h1 {
+    @include font(f3);
     padding-top: 10px;
     padding-bottom: 10px;
   }
 
   h2 {
-    font-size: $f4;
-  }
-
-  .trix-content div {
-    font-size: $f5;
+    @include font(f4);
   }
 }
 
@@ -118,14 +104,9 @@ h6,
 
 // Extra large devices (large desktops, 1200px and up)
 @media (min-width: 1200px) {
-  h1, .trix-content h1 {
-    font-size: $f1;
+  h1 {
+    @include font(f1);
     padding-top: 20px;
     padding-bottom: 20px;
   }
-
-  .trix-content div {
-    font-size: $f5;
-  }
 }
-

--- a/app/assets/stylesheets/headers.scss
+++ b/app/assets/stylesheets/headers.scss
@@ -37,10 +37,18 @@ h4, h5, h6 {
  padding-bottom: 10px;
 }
 
+.sub-navbar h3,
+.sub-navbar h4 {
+  padding-top: 11px;
+  padding-bottom: 11px;
+  margin: 0px;
+}
+
 h1, h2, h3, h4, h5, h6 {
   color: $dark-blue;
   font-family: $header-font-family;
 }
+
 
 // Extra small devices (portrait phones, less than 576px)
 @media (max-width: 575.98px) {
@@ -51,6 +59,10 @@ h1, h2, h3, h4, h5, h6 {
   }
 
   h2 {
+    @include font(f7);
+  }
+
+  .trix-content div {
     @include font(f7);
   }
 }
@@ -66,6 +78,10 @@ h1, h2, h3, h4, h5, h6 {
   h2 {
     @include font(f6);
   }
+
+  .trix-content div {
+    @include font(f6);
+  }
 }
 
 // Medium devices (tablets, 768px and up) // max-width: 991.98px
@@ -77,6 +93,10 @@ h1, h2, h3, h4, h5, h6 {
   }
 
   h2 {
+    @include font(f5);
+  }
+
+  .trix-content div {
     @include font(f5);
   }
 }
@@ -91,6 +111,10 @@ h1, h2, h3, h4, h5, h6 {
   h2 {
     @include font(f4);
   }
+
+  .trix-content div {
+    @include font(f4);
+  }
 }
 
 // Large devices (desktops, 992px and up)
@@ -102,5 +126,9 @@ h1, h2, h3, h4, h5, h6 {
     @include font(f1);
     padding-top: 20px;
     padding-bottom: 20px;
+  }
+
+  .trix-content div {
+    @include font(f5);
   }
 }

--- a/app/assets/stylesheets/headers.scss
+++ b/app/assets/stylesheets/headers.scss
@@ -52,6 +52,7 @@ h3, h4, h5, h6,
 h1, h2, h3, h4, h5, h6 {
   color: $dark-blue;
   font-family: $header-font-family;
+  font-weight: $header-font-weight;
 }
 
 

--- a/app/assets/stylesheets/headers.scss
+++ b/app/assets/stylesheets/headers.scss
@@ -151,7 +151,7 @@ h1, h2, h3, h4, h5, h6 {
   }
 
   .trix-content div {
-    @include font(f4);
+    @include font(f5);
   }
 }
 

--- a/app/assets/stylesheets/headers.scss
+++ b/app/assets/stylesheets/headers.scss
@@ -1,7 +1,5 @@
 h1 {
   @include font(f1);
-  padding-top: 20px;
-  padding-bottom: 20px;
 }
 
 h2 {
@@ -10,12 +8,6 @@ h2 {
 
 h3 {
   @include font(f3);
-}
-
-h2, h3
- {
-  padding-top: 10px;
-  padding-bottom: 20px;
 }
 
 h4 {
@@ -30,22 +22,9 @@ h6 {
   @include font(f6);
 }
 
-h4, h5, h6 {
- padding-top: 10px;
- padding-bottom: 10px;
-}
-
-.sub-navbar h3,
-.sub-navbar h4 {
-  padding-top: 11px;
-  padding-bottom: 11px;
-  margin: 0px;
-}
-
 h1, h2, h3, h4, h5, h6 {
-  font-family: $header-font-family;
-  font-weight: $header-font-weight;
   color: $dark-blue;
+  font-family: $header-font-family;
 }
 
 // Extra small devices (portrait phones, less than 576px)

--- a/app/assets/stylesheets/home.scss
+++ b/app/assets/stylesheets/home.scss
@@ -27,6 +27,12 @@ header img {
   border-radius: 25px;
 }
 
+.carousel-item {
+  h1 {
+    @include font(f2);
+  }
+}
+
 // Extra small devices (portrait phones, less than 576px)
 @media (max-width: 575.98px) {
   .masthead-content {

--- a/app/assets/stylesheets/home.scss
+++ b/app/assets/stylesheets/home.scss
@@ -16,23 +16,19 @@ header img {
 .masthead {
   background-image: image-url('background-image.jpg');
   padding: 0 10px 0 0;
+  background-color: $dark-blue;
   color: $white;
+  @include font(f2);
+  font: $header-font-family;
   background-position: center;
   background-repeat: no-repeat;
   background-size: cover;
   height: 650px;
 }
 
-.masthead-content {
-  background-color: $dark-blue;
-}
-
-.masthead-content .display-4 {
+.masthead-content h1 {
   color: $white;
-}
-
-.masthead-content h3 {
-  color: $white;
+  font: $header-font-family;
   font-weight: 400;
 }
 
@@ -99,20 +95,10 @@ header img {
   }
 }
 
-.headline-text {
-  font-family: $header-font-family;
-  font-weight: 500 !important;
-}
-
-.headline-sub-text {
-  font-family: $default-font-family;
-  font-weight: 400 !important;
-}
-
 // Medium devices (tablets, 768px and up) // max-width: 991.98px
 @media (min-width: 768px) and (max-width: 1199.98px) {
   .headline-text {
-    @include font(f2);
+    @include font(f3);
   }
 
   .headline-sub-text {
@@ -155,7 +141,7 @@ header img {
 // Extra large devices (large desktops, 1200px and up)
 @media (min-width: 1140px) {
   .headline-text {
-    @include font(f1);
+    @include font(f2);
   }
   .headline-sub-text {
     @include font(f3);

--- a/app/assets/stylesheets/home.scss
+++ b/app/assets/stylesheets/home.scss
@@ -55,11 +55,11 @@ header img {
   }
 
   blockquote {
-    @include font(f7);
+    @include font(f8);
   }
 
   .quote-by {
-    @include font(f7);
+    @include font(f8);
   }
 }
 

--- a/app/assets/stylesheets/home.scss
+++ b/app/assets/stylesheets/home.scss
@@ -45,10 +45,6 @@ header img {
     }
   }
 
-  p.display-3 {
-    @include font(f3);
-  }
-
   blockquote {
     @include font(f7);
   }
@@ -80,10 +76,6 @@ header img {
       line-height: 80px;
       margin-right: 20px;
     }
-  }
-
-  p.display-3 {
-    @include font(f2);
   }
 }
 

--- a/app/assets/stylesheets/home.scss
+++ b/app/assets/stylesheets/home.scss
@@ -14,6 +14,7 @@ header img {
 }
 
 .masthead {
+  background-color: $dark-blue;
   background-image: image-url('background-image.jpg');
   padding: 0 10px 0 0;
   color: $white;
@@ -124,12 +125,12 @@ header img {
 // Extra large devices (large desktops, 1200px and up)
 @media (min-width: 1140px) {
   .masthead .btn {
-    @include font(f3);
+    @include font(f4);
     padding: 20px;
   }
 
   .cta .btn {
-    @include font(f3);
+    @include font(f4);
     padding: 20px;
   }
 

--- a/app/assets/stylesheets/home.scss
+++ b/app/assets/stylesheets/home.scss
@@ -14,7 +14,6 @@ header img {
 }
 
 .masthead {
-  background-color: $dark-blue;
   background-image: image-url('background-image.jpg');
   padding: 0 10px 0 0;
   color: $white;
@@ -30,6 +29,10 @@ header img {
 
 // Extra small devices (portrait phones, less than 576px)
 @media (max-width: 575.98px) {
+  .masthead-content {
+    background-color: $dark-blue;
+  }
+
   .home-page .carousel-item {
     h2 {
       @include font(f5);
@@ -63,6 +66,10 @@ header img {
 
 // Small devices (landscape phones, 576px and up)
 @media (min-width: 576px) and (max-width: 767.98px) {
+  .masthead-content {
+    background-color: $dark-blue;
+  }
+
   .home-page .carousel-item {
     h2 {
       @include font(f5);

--- a/app/assets/stylesheets/home.scss
+++ b/app/assets/stylesheets/home.scss
@@ -31,11 +31,11 @@ header img {
 @media (max-width: 575.98px) {
   .home-page .carousel-item {
     h2 {
-      font-size: $f5;
+      @include font(f5);
     }
 
     i {
-      font-size: $f2;
+      @include font(f2);
     }
 
     .col-1 {
@@ -49,35 +49,35 @@ header img {
   }
 
   p.display-3 {
-    font-size: $f3;
+    @include font(f3);
   }
 
   blockquote {
-    font-size: $f7;
+    @include font(f7);
   }
 
   .quote-by {
-    font-size: $f7;
+    @include font(f7);
   }
 
 }
 
 .cta .btn {
-  font-size: $f5;
-  padding: 10px;
   font-family: $default-font-family;
-  line-height: 20px;
+  @include font(f5);
+  padding: 10px;
+//  line-height: 20px; // check this
 }
 
 // Small devices (landscape phones, 576px and up)
 @media (min-width: 576px) and (max-width: 767.98px) {
   .home-page .carousel-item {
     h2 {
-      font-size: $f5;
+      @include font(f5);
     }
 
     i {
-      font-size: $f1;
+      @include font(f1);
     }
 
     .col-1 {
@@ -91,39 +91,46 @@ header img {
   }
 
   p.display-3 {
-    font-size: $f2;
+    @include font(f2);
   }
 
 }
 
+.headline-text {
+  font-family: $header-font-family;
+}
+
+.headline-sub-text {
+  font-family: $default-font-family;
+}
 
 // Medium devices (tablets, 768px and up) // max-width: 991.98px
 @media (min-width: 768px) and (max-width: 1199.98px) {
   .headline-text {
-    font-size: $f2;
+    @include font(f2);
   }
 
   .headline-sub-text {
-    font-size: $f5;
+    @include font(f5);
   }
 
   .masthead .btn {
-    font-size: $f4;
+    @include font(f4);
     padding: 10px;
   }
 
   .cta .btn {
-    font-size: $f4;
+    @include font(f4);
     padding: 10px;
   }
 
   .home-page .carousel-item {
     h2 {
-      font-size: $f3;
+      @include font(f3);
     }
 
     i {
-      font-size: $f0;
+      @include font(f0);
     }
 
     .col-1 {
@@ -143,29 +150,29 @@ header img {
 // Extra large devices (large desktops, 1200px and up)
 @media (min-width: 1140px) {
   .headline-text {
-    font-size: $f1;
+    @include font(f1);
   }
   .headline-sub-text {
-    font-size: $f3;
+    @include font(f3);
   }
 
   .masthead .btn {
-    font-size: $f3;
+    @include font(f3);
     padding: 20px;
   }
 
   .cta .btn {
-    font-size: $f3;
+    @include font(f3);
     padding: 20px;
   }
 
   .home-page .carousel-item {
     h2 {
-      font-size: $f1;
+      @include font(f1);
     }
 
     i {
-      font-size: $f-super-big;
+      @include font(f-xl);
     }
 
     .col-1 {

--- a/app/assets/stylesheets/home.scss
+++ b/app/assets/stylesheets/home.scss
@@ -145,7 +145,7 @@ header img {
     }
 
     i {
-      @include font(f-xl);
+      font-size: $f-xl;
     }
 
     .col-1 {

--- a/app/assets/stylesheets/home.scss
+++ b/app/assets/stylesheets/home.scss
@@ -23,6 +23,19 @@ header img {
   height: 650px;
 }
 
+.masthead-content {
+  background-color: $dark-blue;
+}
+
+.masthead-content .display-4 {
+  color: $white;
+}
+
+.masthead-content h3 {
+  color: $white;
+  font-weight: 400;
+}
+
 .rounded-25 {
   border-radius: 25px;
 }
@@ -44,10 +57,6 @@ header img {
     }
   }
 
-  .masthead-content {
-    background-color: $dark-blue;
-  }
-
   p.display-3 {
     @include font(f3);
   }
@@ -59,14 +68,13 @@ header img {
   .quote-by {
     @include font(f7);
   }
-
 }
 
 .cta .btn {
   font-family: $default-font-family;
-  @include font(f5);
+  font-size: $f5;
   padding: 10px;
-//  line-height: 20px; // check this
+  line-height: 20px;
 }
 
 // Small devices (landscape phones, 576px and up)
@@ -86,22 +94,19 @@ header img {
     }
   }
 
-  .masthead-content {
-    background-color: $dark-blue;
-  }
-
   p.display-3 {
     @include font(f2);
   }
-
 }
 
 .headline-text {
   font-family: $header-font-family;
+  font-weight: 500 !important;
 }
 
 .headline-sub-text {
   font-family: $default-font-family;
+  font-weight: 400 !important;
 }
 
 // Medium devices (tablets, 768px and up) // max-width: 991.98px

--- a/app/assets/stylesheets/home.scss
+++ b/app/assets/stylesheets/home.scss
@@ -135,7 +135,7 @@ header img {
     }
 
     i {
-      @include font(f0);
+      @include font(f1);
     }
 
     .col-1 {
@@ -232,7 +232,7 @@ header img {
   vertical-align: top;
   height: 30px;
   line-height: 28px;
-  font-size: $f0;
+  font-size: $f1;
 }
 
 .quotes:before {

--- a/app/assets/stylesheets/home.scss
+++ b/app/assets/stylesheets/home.scss
@@ -16,20 +16,11 @@ header img {
 .masthead {
   background-image: image-url('background-image.jpg');
   padding: 0 10px 0 0;
-  background-color: $dark-blue;
   color: $white;
-  @include font(f2);
-  font: $header-font-family;
   background-position: center;
   background-repeat: no-repeat;
   background-size: cover;
   height: 650px;
-}
-
-.masthead-content h1 {
-  color: $white;
-  font: $header-font-family;
-  font-weight: 400;
 }
 
 .rounded-25 {
@@ -97,14 +88,6 @@ header img {
 
 // Medium devices (tablets, 768px and up) // max-width: 991.98px
 @media (min-width: 768px) and (max-width: 1199.98px) {
-  .headline-text {
-    @include font(f3);
-  }
-
-  .headline-sub-text {
-    @include font(f5);
-  }
-
   .masthead .btn {
     @include font(f4);
     padding: 10px;
@@ -140,13 +123,6 @@ header img {
 
 // Extra large devices (large desktops, 1200px and up)
 @media (min-width: 1140px) {
-  .headline-text {
-    @include font(f2);
-  }
-  .headline-sub-text {
-    @include font(f3);
-  }
-
   .masthead .btn {
     @include font(f3);
     padding: 20px;

--- a/app/assets/stylesheets/links.scss
+++ b/app/assets/stylesheets/links.scss
@@ -41,7 +41,7 @@ a.badge.outline {
   color: $dark;
   background-image: linear-gradient($white, $light-grey);
   border-color: $grey;
-  font-weight: 700 !important;
+  font-weight: 600 !important;
   border-radius: 50rem !important;
 }
 

--- a/app/assets/stylesheets/links.scss
+++ b/app/assets/stylesheets/links.scss
@@ -79,7 +79,7 @@ a.badge.outline {
 
 .btn-group-xs > .btn, .btn-xs {
   padding: 1px 5px;
-  font-size: $f7;
+  font-size: $f8;
   line-height: 1.5;
   border-radius: 3px;
 }
@@ -190,7 +190,7 @@ section.highlight {
   .btn:focus,
   .btn:active,
   .btn.active {
-    font-size: $f7;
+    @include font(f8);
   }
 }
 
@@ -201,6 +201,6 @@ section.highlight {
   .btn:focus,
   .btn:active,
   .btn.active {
-    font-size: $f7;
+    @include font(f8);
   }
 }

--- a/app/assets/stylesheets/links.scss
+++ b/app/assets/stylesheets/links.scss
@@ -79,7 +79,7 @@ a.badge.outline {
 
 .btn-group-xs > .btn, .btn-xs {
   padding: 1px 5px;
-  font-size: $f8;
+  font-size: $f9;
   line-height: 1.5;
   border-radius: 3px;
 }
@@ -190,7 +190,7 @@ section.highlight {
   .btn:focus,
   .btn:active,
   .btn.active {
-    @include font(f8);
+    @include font(f9);
   }
 }
 
@@ -201,6 +201,6 @@ section.highlight {
   .btn:focus,
   .btn:active,
   .btn.active {
-    @include font(f8);
+    @include font(f9);
   }
 }

--- a/app/assets/stylesheets/live_data.scss
+++ b/app/assets/stylesheets/live_data.scss
@@ -1,5 +1,5 @@
 .live-data-subtitle {
   margin-top: 120px;
-  font-size: $f5;
+  font-size: $default-font-size;
   font-weight: lighter;
 }

--- a/app/assets/stylesheets/nav.scss
+++ b/app/assets/stylesheets/nav.scss
@@ -83,6 +83,12 @@
   }
 }
 
+.nav-tabs {
+  .nav-link.active {
+    font-weight: 600;
+  }
+}
+
 .tab-content.locales {
   padding: 10px;
   margin-bottom: 10px;

--- a/app/assets/stylesheets/nav.scss
+++ b/app/assets/stylesheets/nav.scss
@@ -16,7 +16,7 @@
   .navbar-brand:active,
   .navbar-brand.active {
     color: $white;
-    font-size: $f5;
+    font-size: $f6;
   }
 
   .navbar-nav {
@@ -25,7 +25,7 @@
 
   .navbar-toggle {
     color: $white;
-    font-size: $f9;
+    font-size: $f10;
     border-color: $white;
   }
 
@@ -91,7 +91,7 @@
 
 @media (min-width: 992px) {
   .navbar-brand {
-    font-size: $f4;
+    font-size: $f5;
   }
 }
 

--- a/app/assets/stylesheets/nav.scss
+++ b/app/assets/stylesheets/nav.scss
@@ -84,8 +84,8 @@
 }
 
 .nav-tabs {
-  .nav-link.active {
-    font-weight: 600;
+  .nav-link {
+    font-weight: 500;
   }
 }
 

--- a/app/assets/stylesheets/nav.scss
+++ b/app/assets/stylesheets/nav.scss
@@ -25,7 +25,7 @@
 
   .navbar-toggle {
     color: $white;
-    font-size: $f8;
+    font-size: $f9;
     border-color: $white;
   }
 

--- a/app/assets/stylesheets/nav.scss
+++ b/app/assets/stylesheets/nav.scss
@@ -74,18 +74,20 @@
   }
 }
 
+.nav-tabs {
+  .nav-item {
+    .nav-link.active {
+      font-weight: 600;
+    }
+  }
+}
+
 .nav-tabs.locales {
   .nav-item {
     .nav-link.active {
       background: $light-grey;
       border-color: $light-grey;
     }
-  }
-}
-
-.nav-tabs {
-  .nav-link {
-    font-weight: 500;
   }
 }
 

--- a/app/assets/stylesheets/trix_content.scss
+++ b/app/assets/stylesheets/trix_content.scss
@@ -1,0 +1,3 @@
+.trix-content {
+  @extend p;
+}

--- a/app/assets/stylesheets/trix_content.scss
+++ b/app/assets/stylesheets/trix_content.scss
@@ -1,3 +1,0 @@
-.trix-content {
-  @extend p;
-}

--- a/app/components/footnote_modal_component/footnote_modal_component.html.erb
+++ b/app/components/footnote_modal_component/footnote_modal_component.html.erb
@@ -2,8 +2,8 @@
   <div class="modal fade" id="<%= @modal_id %>" tabindex="-1" role="dialog" aria-labelledby="#<%= @modal_id %>-title" aria-hidden="true">
     <div class="modal-dialog <%= @modal_dialog_classes %>" role="document">
       <div class="modal-content">
-        <div class="footnote-modal-header modal-header" >
-          <h2 class="modal-title" id="<%= @modal_id %>-title"><%= @title %></h2>
+        <div class="footnote-modal-header modal-header">
+          <h3 class="modal-title" id="<%= @modal_id %>-title"><%= @title %></h3>
           <button type="button" class="close" data-dismiss="modal" aria-label="<%= t('common.labels.close') %>">
             <span class="footnote-modal-close-button" aria-hidden="true">&times;</span>
           </button>

--- a/app/components/footnote_modal_component/footnote_modal_component.scss
+++ b/app/components/footnote_modal_component/footnote_modal_component.scss
@@ -1,5 +1,8 @@
 .footnote-modal-header {
-  background: #232b49 !important;
+  background: $dark-blue !important;
+}
+
+.footnote-modal-header h3 {
   color: $white;
 }
 

--- a/app/components/info_bar_component/info_bar_component.html.erb
+++ b/app/components/info_bar_component/info_bar_component.html.erb
@@ -11,12 +11,12 @@
       </div>
       <% buttons.each do |title, path| %>
         <div class="col-md-2 d-flex justify-content-end">
-          <%= link_to sanitize(title), path, class: "btn btn-light btn rounded-pill font-weight-bold", style: 'height: fit-content;' %>
+          <%= link_to sanitize(title), path, class: 'btn btn-light btn rounded-pill', style: 'height: fit-content;' %>
         </div>
       <% end %>
     <% else %>
       <div class="col-md-<%= base_columns %>">
-        <h5><%= title %></h5>
+        <%= title %>
       </div>
     <% end %>
   </div>

--- a/app/components/observation_component/observation_base.html.erb
+++ b/app/components/observation_component/observation_base.html.erb
@@ -1,29 +1,41 @@
 <% if compact %>
   <div class="row pb-1">
     <div class="col-1"><%= icon %></div>
-    <div class="col-11"><%= I18n.t(:compact_message_html, scope: i18n_scope, school: school.name, school_path: school_path(school), target: target, message: message, count: observation.points || 0, compact_path: compact_path).html_safe %></div>
+    <div class="col-11">
+      <%= I18n.t(:compact_message_html, scope: i18n_scope,
+                                        school: school.name,
+                                        school_path: school_path(school),
+                                        target: target,
+                                        message: message,
+                                        count: observation.points || 0,
+                                        compact_path: compact_path).html_safe %>
+    </div>
   </div>
 <% else %>
   <td class="p-3 text-center">
     <%= icon %>
   </td>
   <td>
-    <h3 class="pt-1">
-      <strong>
-        <% if target %>
-          <%= message %><%= ": #{link_to(target, show_path)}".html_safe if linkable? %>
-        <% else %>
-          <%= link_to message, show_path if linkable? %>
-        <% end %>
-      </strong>
-    </h3>
+    <strong>
+      <% if target %>
+        <%= message %><%= ": #{link_to(target, show_path)}".html_safe if linkable? %>
+      <% else %>
+        <%= link_to message, show_path if linkable? %>
+      <% end %>
+    </strong>
     <span class="text-muted"><%= nice_dates(observation.at) %></span>
   </td>
   <% if show_buttons? %>
     <td class="text-right">
       <div class="btn-group">
-        <%= link_to t('common.labels.edit'), edit_path, class: 'btn btn-warning' if editable? %>
-        <%= link_to t('common.labels.delete'), delete_path, method: :delete, data: { confirm: t('common.confirm') }, class: 'btn btn-danger' %>
+        <%= if editable?
+              link_to t('common.labels.edit'),
+                      edit_path, class: 'btn btn-warning'
+            end %>
+        <%= link_to t('common.labels.delete'),
+                    delete_path, method: :delete,
+                                 data: { confirm: t('common.confirm') },
+                                 class: 'btn btn-danger' %>
       </div>
     </td>
   <% end %>

--- a/app/components/observation_component/observation_base.html.erb
+++ b/app/components/observation_component/observation_base.html.erb
@@ -16,13 +16,15 @@
     <%= icon %>
   </td>
   <td>
-    <strong>
-      <% if target %>
-        <%= message %><%= ": #{link_to(target, show_path)}".html_safe if linkable? %>
-      <% else %>
-        <%= link_to message, show_path if linkable? %>
-      <% end %>
-    </strong>
+    <h4 class='pt-1'>
+      <strong>
+        <% if target %>
+          <%= message %><%= ": #{link_to(target, show_path)}".html_safe if linkable? %>
+        <% else %>
+          <%= link_to message, show_path if linkable? %>
+        <% end %>
+      </strong>
+    </h4>
     <span class="text-muted"><%= nice_dates(observation.at) %></span>
   </td>
   <% if show_buttons? %>

--- a/app/components/panel_switcher_component/panel_switcher_component.html.erb
+++ b/app/components/panel_switcher_component/panel_switcher_component.html.erb
@@ -1,6 +1,6 @@
 <div<%= " id=#{id}" if id %> class="panel-switcher-component<%= " #{classes}" if classes %>">
   <% if title %>
-    <h4><%= title %></h4>
+    <h3><%= title %></h3>
   <% end %>
   <% if description %>
     <p><%= description %></p>

--- a/app/components/panel_switcher_component/panel_switcher_component.html.erb
+++ b/app/components/panel_switcher_component/panel_switcher_component.html.erb
@@ -1,6 +1,6 @@
 <div<%= " id=#{id}" if id %> class="panel-switcher-component<%= " #{classes}" if classes %>">
   <% if title %>
-    <h3><%= title %></h3>
+    <h4><%= title %></h4>
   <% end %>
   <% if description %>
     <p><%= description %></p>

--- a/app/components/panel_switcher_component/panel_switcher_component.html.erb
+++ b/app/components/panel_switcher_component/panel_switcher_component.html.erb
@@ -1,6 +1,6 @@
 <div<%= " id=#{id}" if id %> class="panel-switcher-component<%= " #{classes}" if classes %>">
   <% if title %>
-    <h3><%= title %></h3>
+    <h4><%= title %></h4>
   <% end %>
   <% if description %>
     <p><%= description %></p>
@@ -11,7 +11,9 @@
       <div class="form-check form-check-inline">
         <%= radio_button_tag name, panel.name, panel.name == selected, class: 'form-check-input' %>
         <%= label_tag "#{name}_#{panel.name}", panel.label,
-                      title: t('components.panel_switcher.change_to', name: panel.label), 'data-toggle': 'tooltip', class: 'form-check-label' %>
+                      title: t('components.panel_switcher.change_to',
+                               name: panel.label), 'data-toggle': 'tooltip',
+                      class: 'form-check-label' %>
       </div>
     <% end %>
   </div>

--- a/app/components/panel_switcher_component/panel_switcher_component.html.erb
+++ b/app/components/panel_switcher_component/panel_switcher_component.html.erb
@@ -1,6 +1,6 @@
 <div<%= " id=#{id}" if id %> class="panel-switcher-component<%= " #{classes}" if classes %>">
   <% if title %>
-    <h4><strong><%= title %></strong></h4>
+    <h3><%= title %></h3>
   <% end %>
   <% if description %>
     <p><%= description %></p>
@@ -10,7 +10,8 @@
     <% panels.each do |panel| %>
       <div class="form-check form-check-inline">
         <%= radio_button_tag name, panel.name, panel.name == selected, class: 'form-check-input' %>
-        <%= label_tag  "#{name}_#{panel.name}", panel.label, title: t('components.panel_switcher.change_to', name: panel.label), 'data-toggle': 'tooltip', class: "form-check-label" %>
+        <%= label_tag "#{name}_#{panel.name}", panel.label,
+                      title: t('components.panel_switcher.change_to', name: panel.label), 'data-toggle': 'tooltip', class: 'form-check-label' %>
       </div>
     <% end %>
   </div>

--- a/app/components/podium_component/podium_component.html.erb
+++ b/app/components/podium_component/podium_component.html.erb
@@ -21,20 +21,18 @@
     <div class="row align-items-end border-bottom grey">
       <% podium.low_to_high.each do |position| %>
         <div class="col-4 text-center">
-          <h5>
-            <% if podium.current_school?(position) %>
-              <% if podium.school_has_points? %>
-                <%= fa_icon('crown fa-2x') %>
-                <p class='h2'><%= position.ordinal %></p>
-              <% end %>
-            <% else %>
-              <p><%= position.ordinal %></p>
-              <% if (position.normalised_points * 149).to_i < 70 %>
-                <p class="mb-1"><strong><%= position.points %></strong></p>
-                <p class="text-uppercase"><%= t('components.podium.points') %></p>
-              <% end %>
+          <% if podium.current_school?(position) %>
+            <% if podium.school_has_points? %>
+              <%= fa_icon('crown fa-2x') %>
+              <p class='f2'><%= position.ordinal %></p>
             <% end %>
-          </h5>
+          <% else %>
+            <p><%= position.ordinal %></p>
+            <% if (position.normalised_points * 149).to_i < 70 %>
+              <p class="mb-1"><strong><%= position.points %></strong></p>
+              <p class="text-uppercase"><%= t('components.podium.points') %></p>
+            <% end %>
+          <% end %>
 
           <div class="bar <%= 'bar-current' if podium.current_school?(position) %>">
             <div class="bar-arrow"></div>
@@ -50,7 +48,7 @@
     </div>
     <div class="row border-top grey">
       <% podium.low_to_high.each do |position| %>
-        <div class="col-4 text-center px-3">
+        <div class="col-4 text-center px-3 small">
           <% if podium.current_school?(position) %>
             <%= position.school.name %>
           <% else %>

--- a/app/components/podium_component/podium_component.html.erb
+++ b/app/components/podium_component/podium_component.html.erb
@@ -50,14 +50,12 @@
     </div>
     <div class="row border-top grey">
       <% podium.low_to_high.each do |position| %>
-        <div class="col-4 text-center">
-          <h6>
-            <% if podium.current_school?(position) %>
-              <%= position.school.name %>
-            <% else %>
-              <%= link_to position.school.name, pupils_school_path(position.school) %>
-            <% end %>
-          </h6>
+        <div class="col-4 text-center px-3">
+          <% if podium.current_school?(position) %>
+            <%= position.school.name %>
+          <% else %>
+            <%= link_to position.school.name, pupils_school_path(position.school) %>
+          <% end %>
         </div>
       <% end %>
     </div>

--- a/app/components/recommendations_component/recommendations_component.html.erb
+++ b/app/components/recommendations_component/recommendations_component.html.erb
@@ -1,6 +1,6 @@
 <div <%= "id=#{id}" if id %> class="recommendations-component<%= classes %>">
   <% if title %>
-    <h3><%= title %></h3>
+    <h4><%= title %></h4>
   <% end %>
   <% if description %>
     <p><%= description %></p>

--- a/app/components/recommendations_component/recommendations_component.html.erb
+++ b/app/components/recommendations_component/recommendations_component.html.erb
@@ -1,6 +1,6 @@
 <div <%= "id=#{id}" if id %> class="recommendations-component<%= classes %>">
   <% if title %>
-    <h4><%= title %></h4>
+    <h3><%= title %></h3>
   <% end %>
   <% if description %>
     <p><%= description %></p>

--- a/app/components/recommendations_component/recommendations_component.html.erb
+++ b/app/components/recommendations_component/recommendations_component.html.erb
@@ -1,6 +1,6 @@
 <div <%= "id=#{id}" if id %> class="recommendations-component<%= classes %>">
   <% if title %>
-    <h4><strong><%= title %></strong></h4>
+    <h3><%= title %></h3>
   <% end %>
   <% if description %>
     <p><%= description %></p>

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -531,6 +531,6 @@ module ApplicationHelper
   end
 
   def admin_button(path, to: 'Edit', tag: nil, classes: nil)
-    admin_only(path, to: to, tag: tag, classes: classes || 'btn btn-xs align-text-top')
+    admin_only(path, to: to, tag: tag, classes: classes || 'btn btn-xs')
   end
 end

--- a/app/views/activity_categories/index.html.erb
+++ b/app/views/activity_categories/index.html.erb
@@ -32,7 +32,7 @@
     <div class="row mt-3 bg-light">
       <div class="col">
         <div class="d-flex justify-content-between align-items-center">
-          <h3><%= t('activity_categories.pupil.title') %></h3>
+          <h4><%= t('activity_categories.pupil.title') %></h4>
         </div>
         <p><%= t('activity_categories.pupil.introduction') %></p>
       </div>
@@ -44,7 +44,7 @@
     <div class="row mt-3 bg-light">
       <div class="col">
         <div class="d-flex justify-content-between align-items-center">
-          <h3><%= t('activity_categories.our_programmes.title') %></h3>
+          <h4><%= t('activity_categories.our_programmes.title') %></h4>
           <div>
             <%= link_to t('activity_categories.view_all_programmes'), programme_types_path,
                         class: 'btn btn-outline-dark rounded-pill font-weight-bold' %>
@@ -60,7 +60,7 @@
     <div class="row mt-3">
       <div class="col">
         <div class="d-flex justify-content-between align-items-center">
-          <h3><%= activity_category.name %></h3>
+          <h4><%= activity_category.name %></h4>
           <div>
             <%= link_to t('activity_categories.view_all',
                           count: activity_category.activity_types.active.count),

--- a/app/views/activity_categories/index.html.erb
+++ b/app/views/activity_categories/index.html.erb
@@ -3,7 +3,7 @@
 <div class="row mt-2">
   <div class="col">
     <div class="d-flex justify-content-between align-items-center">
-      <p class="display-3"><strong><%= t('activity_categories.title') %></strong></p>
+      <h1 class="f-xl"><%= t('activity_categories.title') %></h1>
       <%= link_to t('activity_categories.search'), search_activity_types_path,
                   class: 'btn btn-outline-dark rounded-pill font-weight-bold' %>
     </div>
@@ -32,7 +32,7 @@
     <div class="row mt-3 bg-light">
       <div class="col">
         <div class="d-flex justify-content-between align-items-center">
-          <h4><strong><%= t('activity_categories.pupil.title') %></strong></h4>
+          <h3><%= t('activity_categories.pupil.title') %></h3>
         </div>
         <p><%= t('activity_categories.pupil.introduction') %></p>
       </div>
@@ -44,7 +44,7 @@
     <div class="row mt-3 bg-light">
       <div class="col">
         <div class="d-flex justify-content-between align-items-center">
-          <h4><strong><%= t('activity_categories.our_programmes.title') %></strong></h4>
+          <h3><%= t('activity_categories.our_programmes.title') %></h3>
           <div>
             <%= link_to t('activity_categories.view_all_programmes'), programme_types_path,
                         class: 'btn btn-outline-dark rounded-pill font-weight-bold' %>
@@ -60,7 +60,7 @@
     <div class="row mt-3">
       <div class="col">
         <div class="d-flex justify-content-between align-items-center">
-          <h4><strong><%= activity_category.name %></strong></h4>
+          <h3><%= activity_category.name %></h3>
           <div>
             <%= link_to t('activity_categories.view_all',
                           count: activity_category.activity_types.active.count),

--- a/app/views/activity_categories/index.html.erb
+++ b/app/views/activity_categories/index.html.erb
@@ -3,7 +3,7 @@
 <div class="row mt-2">
   <div class="col">
     <div class="d-flex justify-content-between align-items-center">
-      <h1 class="f-xl"><%= t('activity_categories.title') %></h1>
+      <h1><%= t('activity_categories.title') %></h1>
       <%= link_to t('activity_categories.search'), search_activity_types_path,
                   class: 'btn btn-outline-dark rounded-pill font-weight-bold' %>
     </div>

--- a/app/views/activity_categories/index.html.erb
+++ b/app/views/activity_categories/index.html.erb
@@ -32,7 +32,7 @@
     <div class="row mt-3 bg-light">
       <div class="col">
         <div class="d-flex justify-content-between align-items-center">
-          <h4><%= t('activity_categories.pupil.title') %></h4>
+          <h3><%= t('activity_categories.pupil.title') %></h3>
         </div>
         <p><%= t('activity_categories.pupil.introduction') %></p>
       </div>
@@ -44,7 +44,7 @@
     <div class="row mt-3 bg-light">
       <div class="col">
         <div class="d-flex justify-content-between align-items-center">
-          <h4><%= t('activity_categories.our_programmes.title') %></h4>
+          <h3><%= t('activity_categories.our_programmes.title') %></h3>
           <div>
             <%= link_to t('activity_categories.view_all_programmes'), programme_types_path,
                         class: 'btn btn-outline-dark rounded-pill font-weight-bold' %>
@@ -60,7 +60,7 @@
     <div class="row mt-3">
       <div class="col">
         <div class="d-flex justify-content-between align-items-center">
-          <h4><%= activity_category.name %></h4>
+          <h3><%= activity_category.name %></h3>
           <div>
             <%= link_to t('activity_categories.view_all',
                           count: activity_category.activity_types.active.count),

--- a/app/views/compare/benchmarks.html.erb
+++ b/app/views/compare/benchmarks.html.erb
@@ -10,13 +10,16 @@
   <% Comparison::ReportGroup.by_position.each do |report_group| %>
     <div class="compare card mb-4">
       <div class="card-header">
-        <%= report_group.title %>
-        <%= admin_button edit_admin_comparisons_report_group_path(report_group) %>
+        <h5 class='p-0 m-0'>
+          <%= report_group.title %>
+          <%= admin_button edit_admin_comparisons_report_group_path(report_group) %>
+        </h5>
       </div>
       <div class="card-body pb-0">
         <div class="card-subtitle text-muted">
           <%= report_group.description %>
-          <%= admin_button edit_admin_comparisons_report_group_path(report_group) %>
+          <%= admin_button edit_admin_comparisons_report_group_path(report_group),
+                           classes: 'btn btn-xs align-text-top' %>
         </div>
         <ul class="fa-ul card-columns">
           <% report_group.reports.where(disabled: false).by_title.each do |report| %>

--- a/app/views/compare/index.html.erb
+++ b/app/views/compare/index.html.erb
@@ -1,14 +1,10 @@
 <% content_for :page_title, t('compare.index.title') %>
 
-<div class="row mt-2">
-  <div class="col">
-    <p class="display-3"><strong><%= t('compare.index.title') %></strong></p>
-  </div>
-</div>
+<h1 class='f-xl'><%= t('compare.index.title') %></h1>
 <div class="row">
   <div class="col-sm-6">
-    <p><%= t("compare.index.intro") %></p>
-    <p><%= t("compare.index.options_html", school_count: School.data_visible.count, benchmark_count: @benchmark_count) %></p>
+    <p><%= t('compare.index.intro') %></p>
+    <p><%= t('compare.index.options_html', school_count: School.data_visible.count, benchmark_count: @benchmark_count) %></p>
   </div>
   <div class="col-sm-6">
     <ul class="fa-ul">

--- a/app/views/compare/index.html.erb
+++ b/app/views/compare/index.html.erb
@@ -1,6 +1,6 @@
 <% content_for :page_title, t('compare.index.title') %>
 
-<h1 class='f-xl'><%= t('compare.index.title') %></h1>
+<h1><%= t('compare.index.title') %></h1>
 <div class="row">
   <div class="col-sm-6">
     <p><%= t('compare.index.intro') %></p>

--- a/app/views/home/contact.html.erb
+++ b/app/views/home/contact.html.erb
@@ -1,13 +1,7 @@
 <% content_for :page_title, 'Contact us' %>
 
 <div class="application container">
-  <div class="row">
-    <div class="col-md-6">
-      <h1><%= t('contact.title') %></h1>
-    </div>
-    <div class="col-md-6">
-    </div>
-  </div>
+  <h1><%= t('contact.title') %></h1>
   <div class="row">
     <div class="col-md-3 callout-text">
       <p><strong><%= t('contact.questions.title') %></strong></p><p>
@@ -18,7 +12,7 @@
       <p><%= t('contact.questions.content_2') %></p>
     </div>
     <div class="col-3">
-      <%= image_tag("actions/radiator-thermostat.png", class: "img-fluid") %>
+      <%= image_tag('actions/radiator-thermostat.png', class: 'img-fluid') %>
     </div>
   </div>
   <div class="row">

--- a/app/views/home/education_workshops.html.erb
+++ b/app/views/home/education_workshops.html.erb
@@ -1,7 +1,7 @@
 <% content_for :page_title, t('education_workshops.title') %>
 
 <div class="application container">
-  <h1 class="f-xl"><%= t('education_workshops.title') %></h1>
+  <h1><%= t('education_workshops.title') %></h1>
 
   <%= render 'two_column_image_deck',
              column_one: 'for-schools/workshop-class.png',

--- a/app/views/home/education_workshops.html.erb
+++ b/app/views/home/education_workshops.html.erb
@@ -1,13 +1,7 @@
 <% content_for :page_title, t('education_workshops.title') %>
 
 <div class="application container">
-  <div class="row">
-    <div class="col">
-      <div class="d-flex justify-content-between align-items-center">
-        <p class="display-3"><strong><%= t('education_workshops.title') %></strong></p>
-      </div>
-    </div>
-  </div>
+  <h1 class="f-xl"><strong><%= t('education_workshops.title') %></strong></h1>
 
   <%= render 'two_column_image_deck', column_one: 'for-schools/workshop-class.png', column_two: 'for-schools/workshop-activity.png' %>
 

--- a/app/views/home/education_workshops.html.erb
+++ b/app/views/home/education_workshops.html.erb
@@ -1,9 +1,11 @@
 <% content_for :page_title, t('education_workshops.title') %>
 
 <div class="application container">
-  <h1 class="f-xl"><strong><%= t('education_workshops.title') %></strong></h1>
+  <h1 class="f-xl"><%= t('education_workshops.title') %></h1>
 
-  <%= render 'two_column_image_deck', column_one: 'for-schools/workshop-class.png', column_two: 'for-schools/workshop-activity.png' %>
+  <%= render 'two_column_image_deck',
+             column_one: 'for-schools/workshop-class.png',
+             column_two: 'for-schools/workshop-activity.png' %>
 
   <div class="row">
     <div class="col-md-12">

--- a/app/views/home/energy_audits.html.erb
+++ b/app/views/home/energy_audits.html.erb
@@ -1,19 +1,11 @@
 <% content_for :page_title, t('energy_audits.title') %>
 
 <div class="application container">
-  <div class="row mt-2">
-    <div class="col">
-      <div class="d-flex justify-content-between align-items-center">
-        <p class="display-3"><strong><%= t('energy_audits.title') %></strong></p>
-      </div>
-    </div>
-  </div>
+  <h1 class="f-xl"><strong><%= t('energy_audits.title') %></strong></h1>
 
   <div class="row">
     <div class="col-md-12">
-      <p>
-        <%= t('energy_audits.availability') %>
-      </p>
+      <%= t('energy_audits.availability') %>
     </div>
   </div>
 

--- a/app/views/home/energy_audits.html.erb
+++ b/app/views/home/energy_audits.html.erb
@@ -1,7 +1,7 @@
 <% content_for :page_title, t('energy_audits.title') %>
 
 <div class="application container">
-  <h1 class="f-xl"><strong><%= t('energy_audits.title') %></strong></h1>
+  <h1 class="f-xl"><%= t('energy_audits.title') %></h1>
 
   <div class="row">
     <div class="col-md-12">

--- a/app/views/home/energy_audits.html.erb
+++ b/app/views/home/energy_audits.html.erb
@@ -1,7 +1,7 @@
 <% content_for :page_title, t('energy_audits.title') %>
 
 <div class="application container">
-  <h1 class="f-xl"><%= t('energy_audits.title') %></h1>
+  <h1><%= t('energy_audits.title') %></h1>
 
   <div class="row">
     <div class="col-md-12">

--- a/app/views/home/enrol_our_school.html.erb
+++ b/app/views/home/enrol_our_school.html.erb
@@ -1,13 +1,7 @@
 <% content_for :page_title, t('enrol_our_school.title') %>
 
 <div class="application container">
-  <div class="row mt-2">
-    <div class="col">
-      <div class="d-flex justify-content-between align-items-center">
-        <p class="display-3"><strong><%= t('enrol_our_school.title') %></strong></p>
-      </div>
-    </div>
-  </div>
+  <h1 class='f-xl'><%= t('enrol_our_school.title') %></h1>
 
   <div class="row mt-3">
     <div class="col-md-12">

--- a/app/views/home/enrol_our_school.html.erb
+++ b/app/views/home/enrol_our_school.html.erb
@@ -1,7 +1,7 @@
 <% content_for :page_title, t('enrol_our_school.title') %>
 
 <div class="application container">
-  <h1 class='f-xl'><%= t('enrol_our_school.title') %></h1>
+  <h1><%= t('enrol_our_school.title') %></h1>
 
   <div class="row mt-3">
     <div class="col-md-12">
@@ -18,7 +18,9 @@
   <div class="row mt-4">
     <div class="col-md-12">
       <div class="d-flex justify-content-center">
-        <a href="https://forms.gle/9seTjC4HaaGJCL3CA" class="btn btn-lg bg-positive" target="_blank"><%= t('enrol_our_school.enrol_now') %></a>
+        <a href="https://forms.gle/9seTjC4HaaGJCL3CA" class="btn btn-lg bg-positive" target="_blank">
+          <%= t('enrol_our_school.enrol_now') %>
+        </a>
       </div>
     </div>
   </div>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -8,12 +8,12 @@
     <div class="col-5 masthead-content">
       <div class="row pt-5">
         <div class="col">
-          <p class='headline-text'><%= t('home.title') %></p>
+          <h2 class='text-white'><%= t('home.title') %></h2>
         </div>
       </div>
       <div class="row">
         <div class="col pr-5">
-          <p class='headline-sub-text'><%= t('home.sub_title') %></p>
+          <h4 class='text-white'><%= t('home.sub_title') %></h4>
         </div>
       </div>
       <div class="row">

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -18,7 +18,7 @@
       </div>
       <div class="row">
         <div class="col-md-8 offset-md-3 pt-5">
-        <%= link_to t('home.enrol_your_school'), find_out_more_campaigns_path, class: 'btn bg-positive' %>
+          <%= link_to t('home.enrol_your_school'), find_out_more_campaigns_path, class: 'btn bg-positive' %>
         </div>
       </div>
     </div>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -8,12 +8,12 @@
     <div class="col-5 masthead-content">
       <div class="row pt-5">
         <div class="col">
-        <p class="headline-text"><%= t('home.title') %></p>
-      </div>
+          <p class='headline-text'><%= t('home.title') %></p>
+        </div>
       </div>
       <div class="row">
         <div class="col pr-5">
-        <p class="headline-sub-text"><%= t('home.sub_title') %></p>
+          <p class='headline-sub-text'><%= t('home.sub_title') %></p>
         </div>
       </div>
       <div class="row">

--- a/app/views/home/pricing.html.erb
+++ b/app/views/home/pricing.html.erb
@@ -1,7 +1,7 @@
 <% content_for :page_title, t('marketing.pricing.title') %>
 
 <div class="application container header-fix">
-  <h1 class="f-xl"><%= t('marketing.pricing.title') %></h1>
+  <h1><%= t('marketing.pricing.title') %></h1>
 
   <div class="row mb-4">
       <div class="col-md-4">

--- a/app/views/home/pricing.html.erb
+++ b/app/views/home/pricing.html.erb
@@ -1,13 +1,7 @@
 <% content_for :page_title, t('marketing.pricing.title') %>
 
 <div class="application container header-fix">
-  <div class="row mt-2">
-    <div class="col">
-      <div class="d-flex justify-content-between align-items-center">
-        <h1 class="display-4"><strong><%= t('marketing.pricing.title') %></strong></h1>
-      </div>
-    </div>
-  </div>
+  <h1 class="f-xl"><%= t('marketing.pricing.title') %></h1>
 
   <div class="row mb-4">
       <div class="col-md-4">

--- a/app/views/home/training.html.erb
+++ b/app/views/home/training.html.erb
@@ -2,7 +2,7 @@
 <div class="application container">
   <div class="row">
     <div class="col">
-      <h1 id="intro"><%= t('training.title') %></h1>
+      <h1 class='f-xl' id="intro"><%= t('training.title') %></h1>
       <p><%= t('training.intro') %></p>
     </div>
   </div>
@@ -10,7 +10,7 @@
   <div class="row justify-content-md-center">
     <div class="col col-md-10">
       <table class="table timeline">
-        <% @events.group_by{|evt| [evt.date.strftime("%Y"), evt.date.strftime("%-m")]}.each do |(year, month), grouped_events|%>
+        <% @events.group_by { |evt| [evt.date.strftime('%Y'), evt.date.strftime('%-m')] }.each do |(year, month), grouped_events| %>
         <thead>
           <tr>
             <th colspan="4">
@@ -26,13 +26,13 @@
               <td class="timeline-border-left"></td>
               <td class="p-3 text-center">
                 <% if event.sold_out? %>
-                  <%= fa_icon("calendar-times fa-2x") %>
+                  <%= fa_icon('calendar-times fa-2x') %>
                 <% else %>
-                  <%= fa_icon("calendar-check fa-2x") %>
+                  <%= fa_icon('calendar-check fa-2x') %>
                 <% end %>
               </td>
               <td>
-                <h3 class="pt-1"><strong><%= link_to event.name, event.url, target: "_blank" %></strong></h3>
+                <h3 class="pt-1"><strong><%= link_to event.name, event.url, target: '_blank', rel: 'noopener' %></strong></h3>
                 <span class="text-muted">
                   <%= nice_date_times(event.date) %> |
                   <%= event.sold_out? ? t('training.sold_out') : t('training.spaces_available') %>

--- a/app/views/home/training.html.erb
+++ b/app/views/home/training.html.erb
@@ -2,7 +2,7 @@
 <div class="application container">
   <div class="row">
     <div class="col">
-      <h1 class='f-xl' id="intro"><%= t('training.title') %></h1>
+      <h1 id="intro"><%= t('training.title') %></h1>
       <p><%= t('training.intro') %></p>
     </div>
   </div>

--- a/app/views/intervention_type_groups/index.html.erb
+++ b/app/views/intervention_type_groups/index.html.erb
@@ -3,7 +3,7 @@
 <div class="row mt-2">
   <div class="col">
     <div class="d-flex justify-content-between align-items-center">
-      <p class="display-3"><strong><%= t('intervention_type_groups.index.explore_energy_saving_actions') %></strong></p>
+      <h1 class="f-xl"><%= t('intervention_type_groups.index.explore_energy_saving_actions') %></h1>
       <% if EnergySparks::FeatureFlags.active?(:intervention_type_search) %>
         <%= link_to t('intervention_type_groups.index.search'),
                     search_intervention_types_path,
@@ -27,7 +27,7 @@
   <div class="row mt-3">
     <div class="col">
       <div class="d-flex justify-content-between align-items-center">
-        <h4><strong><%= intervention_type_group.name %></strong></h4>
+        <h3><%= intervention_type_group.name %></h3>
         <div>
           <%= link_to t('intervention_type_groups.index.view_all_actions',
                         count: intervention_type_group.intervention_types.active.count),

--- a/app/views/intervention_type_groups/index.html.erb
+++ b/app/views/intervention_type_groups/index.html.erb
@@ -27,7 +27,7 @@
   <div class="row mt-3">
     <div class="col">
       <div class="d-flex justify-content-between align-items-center">
-        <h3><%= intervention_type_group.name %></h3>
+        <h4><%= intervention_type_group.name %></h4>
         <div>
           <%= link_to t('intervention_type_groups.index.view_all_actions',
                         count: intervention_type_group.intervention_types.active.count),

--- a/app/views/intervention_type_groups/index.html.erb
+++ b/app/views/intervention_type_groups/index.html.erb
@@ -3,7 +3,7 @@
 <div class="row mt-2">
   <div class="col">
     <div class="d-flex justify-content-between align-items-center">
-      <h1 class="f-xl"><%= t('intervention_type_groups.index.explore_energy_saving_actions') %></h1>
+      <h1><%= t('intervention_type_groups.index.explore_energy_saving_actions') %></h1>
       <% if EnergySparks::FeatureFlags.active?(:intervention_type_search) %>
         <%= link_to t('intervention_type_groups.index.search'),
                     search_intervention_types_path,

--- a/app/views/landing_pages/find_out_more.html.erb
+++ b/app/views/landing_pages/find_out_more.html.erb
@@ -2,17 +2,17 @@
 
 <header>
   <div class="row masthead" style="height: 600px;">
-    <div class="col-md-7">
+    <div class="col-7">
     </div>
-    <div class="col-md-5 masthead-content">
+    <div class="col-5 masthead-content">
       <div class="row pt-5">
-        <div class="col-md-12">
-          <h2 class='text-white'><%= t('campaigns.find_out_more.title') %></h2>
+        <div class="col">
+          <h1 class='text-white'><%= t('campaigns.find_out_more.title') %></h1>
         </div>
       </div>
       <div class="row">
-        <div class="col-md-12 pr-5">
-          <h4 class='text-white'><%= t('campaigns.find_out_more.sub_title') %></h4>
+        <div class="col pr-5">
+          <h3 class='text-white'><%= t('campaigns.find_out_more.sub_title') %></h3>
         </div>
       </div>
     </div>

--- a/app/views/landing_pages/find_out_more.html.erb
+++ b/app/views/landing_pages/find_out_more.html.erb
@@ -7,7 +7,7 @@
     <div class="col-md-5 masthead-content">
       <div class="row pt-5">
         <div class="col-md-12">
-          <h1 class="f-xl text-white"><%= t('campaigns.find_out_more.title') %></h1>
+          <h1 class="display-4 text-white"><strong><%= t('campaigns.find_out_more.title') %></strong></h1>
       </div>
       </div>
       <div class="row">

--- a/app/views/landing_pages/find_out_more.html.erb
+++ b/app/views/landing_pages/find_out_more.html.erb
@@ -7,7 +7,7 @@
     <div class="col-md-5 masthead-content">
       <div class="row pt-5">
         <div class="col-md-12">
-          <h1 class='text-white'><%= t('campaigns.find_out_more.title') %></h2>
+          <h2 class='text-white'><%= t('campaigns.find_out_more.title') %></h2>
       </div>
       </div>
       <div class="row">

--- a/app/views/landing_pages/find_out_more.html.erb
+++ b/app/views/landing_pages/find_out_more.html.erb
@@ -7,12 +7,12 @@
     <div class="col-md-5 masthead-content">
       <div class="row pt-5">
         <div class="col-md-12">
-          <h1 class="display-4 text-white"><strong><%= t('campaigns.find_out_more.title') %></strong></h1>
+          <h1 class="display-4"><%= t('campaigns.find_out_more.title') %></h1>
       </div>
       </div>
       <div class="row">
         <div class="col-md-12 pr-5">
-          <h3 class='text-white'><%= t('campaigns.find_out_more.sub_title') %></h3>
+          <h3 class=''><%= t('campaigns.find_out_more.sub_title') %></h3>
         </div>
       </div>
     </div>

--- a/app/views/landing_pages/find_out_more.html.erb
+++ b/app/views/landing_pages/find_out_more.html.erb
@@ -7,12 +7,12 @@
     <div class="col-md-5 masthead-content">
       <div class="row pt-5">
         <div class="col-md-12">
-          <h1><%= t('campaigns.find_out_more.title') %></h1>
+          <h1 class='text-white'><%= t('campaigns.find_out_more.title') %></h2>
       </div>
       </div>
       <div class="row">
         <div class="col-md-12 pr-5">
-          <div class='f4'><%= t('campaigns.find_out_more.sub_title') %></div>
+          <h4 class='text-white'><%= t('campaigns.find_out_more.sub_title') %></h4>
         </div>
       </div>
     </div>

--- a/app/views/landing_pages/find_out_more.html.erb
+++ b/app/views/landing_pages/find_out_more.html.erb
@@ -7,12 +7,12 @@
     <div class="col-md-5 masthead-content">
       <div class="row pt-5">
         <div class="col-md-12">
-          <h1 class="display-4"><strong><%= t('campaigns.find_out_more.title') %></strong></h1>
+          <h1 class="f-xl text-white"><%= t('campaigns.find_out_more.title') %></h1>
       </div>
       </div>
       <div class="row">
         <div class="col-md-12 pr-5">
-          <h3><%= t('campaigns.find_out_more.sub_title') %></h3>
+          <h3 class='text-white'><%= t('campaigns.find_out_more.sub_title') %></h3>
         </div>
       </div>
     </div>

--- a/app/views/landing_pages/find_out_more.html.erb
+++ b/app/views/landing_pages/find_out_more.html.erb
@@ -7,12 +7,12 @@
     <div class="col-md-5 masthead-content">
       <div class="row pt-5">
         <div class="col-md-12">
-          <h1 class="display-4"><%= t('campaigns.find_out_more.title') %></h1>
+          <h1><%= t('campaigns.find_out_more.title') %></h1>
       </div>
       </div>
       <div class="row">
         <div class="col-md-12 pr-5">
-          <h3 class=''><%= t('campaigns.find_out_more.sub_title') %></h3>
+          <div class='f4'><%= t('campaigns.find_out_more.sub_title') %></div>
         </div>
       </div>
     </div>
@@ -24,17 +24,17 @@
     <div class="col-md-7">
       <div class="row">
         <div class="col-md-12">
-          <h1 class="text-dark-blue"><%= t('campaigns.find_out_more.benefits.costs') %></h1>
+          <h2><%= t('campaigns.find_out_more.benefits.costs') %></h2>
         </div>
       </div>
       <div class="row">
         <div class="col-md-12">
-          <h1 class="text-dark-blue"><%= t('campaigns.find_out_more.benefits.emissions') %></h1>
+          <h2><%= t('campaigns.find_out_more.benefits.emissions') %></h2>
         </div>
       </div>
       <div class="row">
         <div class="col-md-12">
-          <h1 class="text-dark-blue"><%= t('campaigns.find_out_more.benefits.pupils') %></h1>
+          <h2><%= t('campaigns.find_out_more.benefits.pupils') %></h2>
         </div>
       </div>
       <div class="row">
@@ -59,11 +59,11 @@
     <div class="application container home-block">
       <div class="row">
         <div class="col-md-12 text-center">
-          <h1 class='text-white'>
+          <h2 class='text-white'>
             <%= t('campaigns.find_out_more.learn_why.title',
                   school_count: marketing_school_count,
                   mat_count: marketing_mat_count) %>
-          </h1>
+          </h2>
         </div>
       </div>
     </div>
@@ -75,17 +75,17 @@
     <div class="col-md-5">
       <div class="row">
         <div class="col-md-12">
-          <h1><%= t('campaigns.find_out_more.costs.title') %></h1>
+          <h2><%= t('campaigns.find_out_more.costs.title') %></h2>
         </div>
       </div>
       <div class="row">
         <div class="col-md-12">
-          <h4><%= t('campaigns.find_out_more.costs.sub_title') %></h4>
+          <h5><%= t('campaigns.find_out_more.costs.sub_title') %></h5>
         </div>
       </div>
       <div class="row">
         <div class="col-md-12">
-          <h4><%= t('campaigns.find_out_more.costs.bullets').html_safe %></h4>
+          <h5><%= t('campaigns.find_out_more.costs.bullets').html_safe %></h5>
         </div>
       </div>
       <div class="row">
@@ -121,17 +121,17 @@
     <div class="col-md-6">
       <div class="row">
         <div class="col-md-12">
-          <h1><%= t('campaigns.find_out_more.tool.title') %></h1>
+          <h2><%= t('campaigns.find_out_more.tool.title') %></h2>
         </div>
       </div>
       <div class="row">
         <div class="col-md-12">
-          <h4><%= t('campaigns.find_out_more.tool.sub_title_1') %></h4>
+          <h5><%= t('campaigns.find_out_more.tool.sub_title_1') %></h5>
         </div>
       </div>
       <div class="row">
         <div class="col-md-12">
-          <h4><%= t('campaigns.find_out_more.tool.sub_title_2') %></h4>
+          <h5><%= t('campaigns.find_out_more.tool.sub_title_2') %></h5>
         </div>
       </div>
       <div class="row">
@@ -148,17 +148,17 @@
     <div class="col-md-5">
       <div class="row">
         <div class="col-md-12">
-          <h1><%= t('campaigns.find_out_more.pupils.title') %></h1>
+          <h2><%= t('campaigns.find_out_more.pupils.title') %></h2>
         </div>
       </div>
       <div class="row">
         <div class="col-md-12">
-          <h4><%= t('campaigns.find_out_more.pupils.sub_title_1', activities_count: marketing_activity_count) %></h4>
+          <h5><%= t('campaigns.find_out_more.pupils.sub_title_1', activities_count: marketing_activity_count) %></h5>
         </div>
       </div>
       <div class="row">
         <div class="col-md-12">
-          <h4><%= t('campaigns.find_out_more.pupils.sub_title_2') %></h4>
+          <h5><%= t('campaigns.find_out_more.pupils.sub_title_2') %></h5>
         </div>
       </div>
       <div class="row">
@@ -199,14 +199,14 @@
       </div>
       <div class="row">
         <div class="col-md-12">
-          <h4><%= t('campaigns.find_out_more.emissions.sub_title_1') %></h4>
+          <h5><%= t('campaigns.find_out_more.emissions.sub_title_1') %></h5>
         </div>
       </div>
       <div class="row">
         <div class="col-md-12">
-          <h4>
+          <h5>
             <%= t('campaigns.find_out_more.emissions.sub_title_2') %>
-          </h4>
+          </h5>
         </div>
       </div>
       <div class="row">
@@ -244,12 +244,12 @@
     <div class="col-md-7">
       <div class="row">
         <div class="col-md-12">
-          <h1 class='text-dark-blue'><%= t('campaigns.find_out_more.final_prompt.question') %></h1>
+          <h2><%= t('campaigns.find_out_more.final_prompt.question') %></h2>
         </div>
       </div>
       <div class="row">
         <div class="col-md-12">
-          <h1 class='text-dark-blue'><%= t('campaigns.find_out_more.final_prompt.booking') %></h1>
+          <h2><%= t('campaigns.find_out_more.final_prompt.booking') %></h2>
         </div>
       </div>
       <div class="row">

--- a/app/views/landing_pages/find_out_more.html.erb
+++ b/app/views/landing_pages/find_out_more.html.erb
@@ -8,7 +8,7 @@
       <div class="row pt-5">
         <div class="col-md-12">
           <h2 class='text-white'><%= t('campaigns.find_out_more.title') %></h2>
-      </div>
+        </div>
       </div>
       <div class="row">
         <div class="col-md-12 pr-5">

--- a/app/views/school_groups/current_scores.html.erb
+++ b/app/views/school_groups/current_scores.html.erb
@@ -5,15 +5,21 @@
 
     <p>
       <% if @academic_year == @current_year %>
-        <%= t('school_groups.current_scores.introduction') %> <%= link_to t('scoreboard.previous_scoreboard'), current_scores_school_group_path(@school_group, previous_year: true) %>.
+        <%= t('school_groups.current_scores.introduction') %>
+        <%= link_to t('scoreboard.previous_scoreboard'),
+                    current_scores_school_group_path(@school_group, previous_year: true) %>.
       <% else %>
-        <%= t('scoreboard.previous_scores') %>. <strong><%= link_to t('school_groups.current_scores.view_current_scores'), current_scores_school_group_path(@school_group) %></strong>.
+        <%= t('scoreboard.previous_scores') %>.
+        <strong>
+          <%= link_to t('school_groups.current_scores.view_current_scores'),
+                      current_scores_school_group_path(@school_group) %>
+        </strong>.
       <% end %>
     </p>
     <% if @school_group.default_scoreboard.present? %>
       <p>
         <%= t('school_groups.current_scores.regional_scoreboard_html',
-          scoreboard: scoreboard_path(@school_group.default_scoreboard)) %>
+              scoreboard: scoreboard_path(@school_group.default_scoreboard)) %>
       </p>
     <% end %>
   </div>
@@ -21,7 +27,9 @@
 
 <div class='text-right pt-3'>
   <% previous_year = @academic_year == @current_year ? nil : true %>
-  <%= link_to t('school_groups.download_as_csv'), current_scores_school_group_path(@school_group, previous_year: previous_year, format: :csv), class: 'btn btn-sm btn-outline-dark rounded-pill font-weight-bold' %>
+  <%= link_to t('school_groups.download_as_csv'),
+              current_scores_school_group_path(@school_group, previous_year: previous_year, format: :csv),
+              class: 'btn btn-sm btn-outline-dark rounded-pill font-weight-bold' %>
 </div>
 
 <table width="100%" class="mt-3 table advice-table">
@@ -40,24 +48,19 @@
       <% schools.each do |school| %>
         <tr>
           <td>
-            <h4><span class="badge badge-primary"><%= '=' if schools.size > 1 %><%= position %></span></h4>
+            <span class="badge badge-primary"><%= '=' if schools.size > 1 %><%= position %></span>
           </td>
-          <td>
-            <h3><%= link_to school.name, school_path(school) %></h3>
-          </td>
+          <td><%= link_to school.name, school_path(school) %></td>
           <% if can?(:update_settings, @school_group) %>
-            <td>
-              <h4><%= school.school_group_cluster_name %></h4>
-            </td>
+            <td><%= school.school_group_cluster_name %></td>
           <% end %>
           <td>
-            <h4>
-            <%= link_to school.sum_points, school_timeline_path(school, academic_year: @academic_year), class: 'badge badge-success' %>
+            <%= link_to school.sum_points, school_timeline_path(school, academic_year: @academic_year),
+                        class: 'badge badge-success' %>
             &nbsp;
             <% if school.recent_points&.positive? %>
               <i class="fa fa-arrow-up" data-toggle="tooltip" title="<%= t('scoreboard.score_tooltip') %>"></i>
             <% end %>
-            </h4>
           </td>
         </tr>
       <% end %>

--- a/app/views/schools/_adult_dashboard_buttons.html.erb
+++ b/app/views/schools/_adult_dashboard_buttons.html.erb
@@ -1,15 +1,17 @@
 <% if show_data_enabled_features %>
   <% if school.school_group && can?(:compare, school.school_group) %>
-    <%= link_to t('schools.schools.compare_schools'), compare_index_path(school_group_ids: [school.school_group.id]) + '#groups', class: 'btn btn-outline-dark rounded-pill font-weight-bold' %>
+    <%= link_to t('schools.schools.compare_schools'),
+                "#{compare_index_path(school_group_ids: [school.school_group.id])}#groups", class: 'btn btn-outline-dark rounded-pill' %>
   <% end %>
   <% if school.configuration %>
-    <%= link_to public ? t('pupils.analysis.review_energy_analysis') : t('schools.schools.review_energy_analysis'), school_advice_path(school), class: 'btn btn-outline-dark rounded-pill font-weight-bold' %>
+    <%= link_to public ? t('pupils.analysis.review_energy_analysis') : t('schools.schools.review_energy_analysis'),
+                school_advice_path(school), class: 'btn btn-outline-dark rounded-pill' %>
   <% end %>
 <% end %>
 <% if show_admin_page_switch?(school) %>
   <% if params[:no_data] %>
-    <%= link_to 'Admin view', school_path(school), class: 'btn btn-outline-dark bg-warning rounded-pill font-weight-bold' %>
+    <%= link_to 'Admin view', school_path(school), class: 'btn btn-outline-dark bg-warning rounded-pill' %>
   <% else %>
-    <%= link_to 'User view', school_path(school, no_data: true), class: 'btn btn-outline-dark bg-warning rounded-pill font-weight-bold' %>
+    <%= link_to 'User view', school_path(school, no_data: true), class: 'btn btn-outline-dark bg-warning rounded-pill' %>
   <% end %>
 <% end %>

--- a/app/views/schools/advice/index/_priority_table.html.erb
+++ b/app/views/schools/advice/index/_priority_table.html.erb
@@ -21,32 +21,24 @@
           </span>
         </td>
         <td>
-          <h4>
-            <% if priority.alert.advice_page.present? %>
-              <%= link_to priority.management_priorities_title,
-                          advice_page_path(school,
-                                           priority.alert.advice_page,
-                                           priority.alert.alert_type.advice_page_tab_for_link_to,
-                                           anchor: priority.alert.alert_type.link_to_section) %>
-            <% else %>
-              <%= priority.management_priorities_title %>
-            <% end %>
-          </h4>
+          <% if priority.alert.advice_page.present? %>
+            <%= link_to priority.management_priorities_title,
+                        advice_page_path(school,
+                                         priority.alert.advice_page,
+                                         priority.alert.alert_type.advice_page_tab_for_link_to,
+                                         anchor: priority.alert.alert_type.link_to_section) %>
+          <% else %>
+            <%= priority.management_priorities_title %>
+          <% end %>
         </td>
         <td data-order="<%= formatted_unit_to_num(priority.template_variables[:one_year_saving_kwh]) %>">
-          <h4>
-            <%= format_unit(formatted_unit_to_num(priority.template_variables[:one_year_saving_kwh]), :kwh) %>
-          </h4>
+          <%= format_unit(formatted_unit_to_num(priority.template_variables[:one_year_saving_kwh]), :kwh) %>
         </td>
         <td>
-          <h4>
-            <%= priority.template_variables[:average_one_year_saving_gbp] %>
-          </h4>
+          <%= priority.template_variables[:average_one_year_saving_gbp] %>
         </td>
         <td data-order="<%= formatted_unit_to_num(priority.template_variables[:one_year_saving_co2]) %>">
-          <h4>
-            <%= format_unit(formatted_unit_to_num(priority.template_variables[:one_year_saving_co2]), :co2) %>
-          </h4>
+          <%= format_unit(formatted_unit_to_num(priority.template_variables[:one_year_saving_co2]), :co2) %>
         </td>
       </tr>
     <% end %>

--- a/app/views/schools/index.html.erb
+++ b/app/views/schools/index.html.erb
@@ -1,7 +1,7 @@
 <% content_for :page_title, t('schools.index.page_title') %>
 
 <div class="row">
-  <div class="col-md-8">
+  <div class="col-md-12">
     <h1><%= t('schools.index.title') %></h1>
   </div>
 </div>
@@ -15,42 +15,44 @@
   <p><%= t('schools.index.introduction_3') %>.</p>
   <p><%= t('schools.index.introduction_4') %>.</p>
 
-  <br/>
+  <br>
 
   <h2><%= t('schools.index.view_energy_sparks_schools_by_group') %></h2>
   <div class="row">
-    <% school_groups_left, school_groups_right = @school_groups.partition.with_index{|_,v| v.even?} %>
+    <% school_groups_left, school_groups_right = @school_groups.partition.with_index { |_, v| v.even? } %>
     <div class="col-lg-6">
       <% school_groups_left.each do |school_group| %>
         <%= render 'school_group', school_group: school_group %>
       <% end %>
     </div>
     <div class="col-lg-6">
-      <% school_groups_right.each do |school_group|  %>
+      <% school_groups_right.each do |school_group| %>
         <%= render 'school_group', school_group: school_group %>
       <% end %>
     </div>
   </div>
 
-  <br/>
-  <br/>
+  <br>
+  <br>
 
   <div class="all-schools">
     <h2><%= t('schools.index.view_all_energy_sparks_schools') %></h2>
     <div class="row">
       <div class="col-lg-12">
-        <%= render 'schools', schools: @schools, title: t('schools.index.a_to_z_of_all_energy_sparks_schools'), label: 'allSchools' %>
+        <%= render 'schools', schools: @schools, title: t('schools.index.a_to_z_of_all_energy_sparks_schools'),
+                              label: 'allSchools' %>
       </div>
     </div>
   </div>
 
-  <% if @schools_not_visible.any? && can?(:read_invisible_schools, School)%>
-    <br/>
-    <br/>
+  <% if @schools_not_visible.any? && can?(:read_invisible_schools, School) %>
+    <br>
+    <br>
     <h2><%= t('schools.index.not_visible_schools') %></h2>
     <div class="row">
       <div class="col-lg-12">
-        <%= render 'schools', schools: @schools_not_visible, title: t('schools.index.not_visible_schools'), label: 'invisibleSchools' %>
+        <%= render 'schools', schools: @schools_not_visible, title: t('schools.index.not_visible_schools'),
+                              label: 'invisibleSchools' %>
       </div>
     </div>
   <% end %>

--- a/app/views/schools/transport_surveys/_option.html.erb
+++ b/app/views/schools/transport_surveys/_option.html.erb
@@ -1,11 +1,15 @@
 <div class="col-6 col-sm-6 col-md-4 col-lg-3 col-xl-2 mb-3">
   <div class="card bg-light text-dark h-100" id="<%= identifier %>">
-    <input type="hidden" class="option" value="<%= identifier %>" />
+    <input type="hidden" class="option" value="<%= identifier %>">
     <div class="card-body p-1">
-      <div class="text-center option-content" style="font-size: 300%;"><a href="#" class="stretched-link text-decoration-none <%= action %>"><%= content %></a></div>
+      <div class="text-center option-content" style="font-size: 300%; line-height: 150%;">
+        <a href="#" class="stretched-link text-decoration-none <%= action %>"><%= content %></a>
+      </div>
     </div>
     <% unless label.blank? %>
-      <div class="card-footer text-muted text-center p-1 small option-label"><%= label %></div>
+      <div class="card-footer text-muted text-center p-1 small option-label">
+        <%= label %>
+      </div>
     <% end %>
   </div>
 </div>

--- a/app/views/schools/transport_surveys/edit.html.erb
+++ b/app/views/schools/transport_surveys/edit.html.erb
@@ -87,7 +87,7 @@
               <%= hidden_field_tag :passengers, '', class: 'selected' %>
               <h2 class="pb-0"><%= t('schools.transport_surveys.edit.steps.sharing_html',
                                      transport: '<span id="transport_type_name"></span>'.html_safe) %></h2>
-              <h2><small class="pb-4"><%= t('schools.transport_surveys.edit.steps.sharing_note') %></small></h2>
+              <p class="f4 pb-4"><%= t('schools.transport_surveys.edit.steps.sharing_note') %></p>
               <div class="container">
                 <div class="row">
                   <% TransportSurvey::Response.passengers_options.each do |passengers| %>

--- a/app/views/scoreboards/index.html.erb
+++ b/app/views/scoreboards/index.html.erb
@@ -2,10 +2,10 @@
 
 <div class="row padded-row">
   <div class="col-lg-3">
-    <%= image_tag("actions/podium.png", class: "img-fluid ") %>
+    <%= image_tag('actions/podium.png', class: 'img-fluid ') %>
   </div>
   <div class="col-lg-9">
-    <h1 class="display-3"><strong><%= t('scoreboards.page_title') %></strong></h1>
+    <h1 class='f-xl'><%= t('scoreboards.page_title') %></h1>
     <p>
       <%= t('scoreboards.intro_para_1') %>
     </p>

--- a/app/views/scoreboards/index.html.erb
+++ b/app/views/scoreboards/index.html.erb
@@ -5,7 +5,7 @@
     <%= image_tag('actions/podium.png', class: 'img-fluid ') %>
   </div>
   <div class="col-lg-9">
-    <h1 class='f-xl'><%= t('scoreboards.page_title') %></h1>
+    <h1><%= t('scoreboards.page_title') %></h1>
     <p>
       <%= t('scoreboards.intro_para_1') %>
     </p>

--- a/app/views/scoreboards/show.html.erb
+++ b/app/views/scoreboards/show.html.erb
@@ -5,7 +5,7 @@
     <%= image_tag('actions/podium.png', class: 'img-fluid ') %>
   </div>
   <div class="col-lg-9">
-    <h1 class="display-3"><strong><%= @scoreboard.name %></strong></h1>
+    <h1 class="f-xl"><strong><%= @scoreboard.name %></strong></h1>
     <p>
       <%= t('scoreboards.intro_para_1') %>
     </p>

--- a/app/views/scoreboards/show.html.erb
+++ b/app/views/scoreboards/show.html.erb
@@ -5,7 +5,7 @@
     <%= image_tag('actions/podium.png', class: 'img-fluid ') %>
   </div>
   <div class="col-lg-9">
-    <h1 class="f-xl"><strong><%= @scoreboard.name %></strong></h1>
+    <h1><strong><%= @scoreboard.name %></strong></h1>
     <p>
       <%= t('scoreboards.intro_para_1') %>
     </p>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,7 +1,7 @@
 <!-- Footer -->
 <footer>
   <div class="footer-above">
-    <div class="container very-small">
+    <div class="container">
       <div class="row">
         <div class="col-4">
           <p>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,10 +1,10 @@
 <!-- Footer -->
 <footer>
   <div class="footer-above">
-    <div class="container">
+    <div class="container very-small">
       <div class="row">
         <div class="col-4">
-          <p class="small">
+          <p>
             <%= t('footer.registered_charity_notice') %>.
           </p>
           <div class="row">
@@ -12,15 +12,15 @@
               <%= fab_icon('creative-commons fa-2x') %>
             </div>
             <div class="col-10">
-              <p class="small">
+              <p>
                 <%= t('footer.cc_licence_notice_html') %>.
               </p>
             </div>
            </div>
         </div>
         <div class="col-5">
-          <p class="small">
-          <%= t('footer.more_information') %>
+          <p>
+            <%= t('footer.more_information') %>
           </p>
           <div class="row">
             <div class="col">
@@ -35,7 +35,7 @@
         </div>
 
         <div class="col-3">
-          <p class='small'><%= t('footer.follow_energy_sparks') %></p>
+          <p><%= t('footer.follow_energy_sparks') %></p>
           <ul class="list-inline">
             <li class="list-inline-item p-2">
               <a href="//twitter.com/EnergySparks" class=""><%= fab_icon('twitter fa-2x') %></a>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -19,7 +19,9 @@
            </div>
         </div>
         <div class="col-5">
-          <h6><%= t('footer.more_information') %></h6>
+          <p class="small">
+          <%= t('footer.more_information') %>
+          </p>
           <div class="row">
             <div class="col">
               <ul class="list-unstyled">
@@ -33,7 +35,7 @@
         </div>
 
         <div class="col-3">
-          <h6><%= t('footer.follow_energy_sparks') %></h6>
+          <p class='small'><%= t('footer.follow_energy_sparks') %></p>
           <ul class="list-inline">
             <li class="list-inline-item p-2">
               <a href="//twitter.com/EnergySparks" class=""><%= fab_icon('twitter fa-2x') %></a>

--- a/app/views/shared/_head.html.erb
+++ b/app/views/shared/_head.html.erb
@@ -21,7 +21,7 @@
 <%= stylesheet_link_tag 'https://cdn.jsdelivr.net/npm/select2@4.0.13/dist/css/select2.min.css' %>
 <%= stylesheet_link_tag \
       'https://cdnjs.cloudflare.com/ajax/libs/select2-bootstrap-theme/0.1.0-beta.10/select2-bootstrap.min.css' %>
-<%= stylesheet_link_tag 'https://fonts.googleapis.com/css?family=Inter:500,700|Quicksand:300,500,700&display=swap' %>
+<%= stylesheet_link_tag 'https://fonts.googleapis.com/css?family=Inter:500,700|Quicksand:600,700&display=swap' %>
 <%= stylesheet_link_tag 'https://cdn.datatables.net/2.0.2/css/dataTables.bootstrap4.min.css' %>
 <%= stylesheet_link_tag 'application', media: 'all' %>
 

--- a/app/views/shared/_head.html.erb
+++ b/app/views/shared/_head.html.erb
@@ -21,7 +21,7 @@
 <%= stylesheet_link_tag 'https://cdn.jsdelivr.net/npm/select2@4.0.13/dist/css/select2.min.css' %>
 <%= stylesheet_link_tag \
       'https://cdnjs.cloudflare.com/ajax/libs/select2-bootstrap-theme/0.1.0-beta.10/select2-bootstrap.min.css' %>
-<%= stylesheet_link_tag 'https://fonts.googleapis.com/css?family=Quicksand:300,500,700&display=swap' %>
+<%= stylesheet_link_tag 'https://fonts.googleapis.com/css?family=Inter:500,700|Quicksand:300,500,700&display=swap' %>
 <%= stylesheet_link_tag 'https://cdn.datatables.net/2.0.2/css/dataTables.bootstrap4.min.css' %>
 <%= stylesheet_link_tag 'application', media: 'all' %>
 

--- a/app/views/shared/_head.html.erb
+++ b/app/views/shared/_head.html.erb
@@ -21,7 +21,7 @@
 <%= stylesheet_link_tag 'https://cdn.jsdelivr.net/npm/select2@4.0.13/dist/css/select2.min.css' %>
 <%= stylesheet_link_tag \
       'https://cdnjs.cloudflare.com/ajax/libs/select2-bootstrap-theme/0.1.0-beta.10/select2-bootstrap.min.css' %>
-<%= stylesheet_link_tag 'https://fonts.googleapis.com/css?family=Inter:500,700|Quicksand:600,700&display=swap' %>
+<%= stylesheet_link_tag 'https://fonts.googleapis.com/css?family=Inter:400,500,600,700|Quicksand:600,700&display=swap' %>
 <%= stylesheet_link_tag 'https://cdn.datatables.net/2.0.2/css/dataTables.bootstrap4.min.css' %>
 <%= stylesheet_link_tag 'application', media: 'all' %>
 

--- a/spec/components/panel_switcher_component_spec.rb
+++ b/spec/components/panel_switcher_component_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe PanelSwitcherComponent, type: :component, include_url_helpers: tr
   context 'with all params' do
     let(:params) { all_params }
 
-    it { expect(html).to have_selector('h4', text: 'Title text') }
+    it { expect(html).to have_selector('h3', text: 'Title text') }
     it { expect(html).to have_selector('div.panel-switcher-component>p', text: 'Description text') }
 
     it 'adds specified classes' do

--- a/spec/components/panel_switcher_component_spec.rb
+++ b/spec/components/panel_switcher_component_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe PanelSwitcherComponent, type: :component, include_url_helpers: tr
   context 'with all params' do
     let(:params) { all_params }
 
-    it { expect(html).to have_selector('h4 strong', text: 'Title text') }
+    it { expect(html).to have_selector('h4', text: 'Title text') }
     it { expect(html).to have_selector('div.panel-switcher-component>p', text: 'Description text') }
 
     it 'adds specified classes' do

--- a/spec/components/panel_switcher_component_spec.rb
+++ b/spec/components/panel_switcher_component_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe PanelSwitcherComponent, type: :component, include_url_helpers: tr
   context 'with all params' do
     let(:params) { all_params }
 
-    it { expect(html).to have_selector('h3', text: 'Title text') }
+    it { expect(html).to have_selector('h4', text: 'Title text') }
     it { expect(html).to have_selector('div.panel-switcher-component>p', text: 'Description text') }
 
     it 'adds specified classes' do

--- a/spec/components/podium_component_spec.rb
+++ b/spec/components/podium_component_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe PodiumComponent, type: :component, include_url_helpers: true do
     it { expect(html).to have_css('i.fa-crown') }
 
     it 'shows ordinal' do
-      expect(html).to have_css('p.h2', text: ordinal)
+      expect(html).to have_css('p.f2', text: ordinal)
     end
   end
 
@@ -41,7 +41,7 @@ RSpec.describe PodiumComponent, type: :component, include_url_helpers: true do
     it { expect(html).not_to have_css('i.fa-crown') }
 
     it "doesn't show ordinal" do
-      expect(html).not_to have_css('p.h2', text: ordinal)
+      expect(html).not_to have_css('p.f2', text: ordinal)
     end
   end
 

--- a/spec/components/recommendations_component_spec.rb
+++ b/spec/components/recommendations_component_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe RecommendationsComponent, type: :component, include_url_helpers: 
   context 'with all params' do
     let(:params) { all_params }
 
-    it { expect(html).to have_selector('h3', text: 'Title text') }
+    it { expect(html).to have_selector('h4', text: 'Title text') }
     it { expect(html).to have_selector('div.recommendations-component>p', text: 'Description text') }
 
     it 'adds specified classes' do

--- a/spec/components/recommendations_component_spec.rb
+++ b/spec/components/recommendations_component_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe RecommendationsComponent, type: :component, include_url_helpers: 
   context 'with all params' do
     let(:params) { all_params }
 
-    it { expect(html).to have_selector('h4', text: 'Title text') }
+    it { expect(html).to have_selector('h3', text: 'Title text') }
     it { expect(html).to have_selector('div.recommendations-component>p', text: 'Description text') }
 
     it 'adds specified classes' do

--- a/spec/components/recommendations_component_spec.rb
+++ b/spec/components/recommendations_component_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe RecommendationsComponent, type: :component, include_url_helpers: 
   context 'with all params' do
     let(:params) { all_params }
 
-    it { expect(html).to have_selector('h4 strong', text: 'Title text') }
+    it { expect(html).to have_selector('h4', text: 'Title text') }
     it { expect(html).to have_selector('div.recommendations-component>p', text: 'Description text') }
 
     it 'adds specified classes' do


### PR DESCRIPTION
* Updated fonts to the latest version of the Storm design.
* Changes the headers to dark blue. Does not change the main text colour as per the new design - firstly because I didn't see this had been changed until the latest design and also because it might be best changed when we switch the site colours for the new ones.
* Has required quite a bit of tidying to allow the changes to be made consistently across the site. This has mostly been to the headers to make them all use h tags where possible.
* Found some places (i.e. some notices, but not all, on the dashboard) where h tags were being used for normal text, where we wouldn't have noticed the inconsistencies before as the fonts were the same (note to Deb to check I have all these!).
* Because the headers are now bigger sizes than previous, some text does look a bit oversized, especially where h tags were used inline rather than as headers. I've mostly tried to rectify this with exception of the scoreboard pages - wanted to see what you thought first @ldodds. The front page and the find out more pages still don't look ideal to me but compared to the original, they do look similar :-)
* I've kept the super big font on the pages that had it (now with a class of f-xl) but it would be good to go to just plain h1 if we could consistently for all headers. 