### PR TITLE
Change series used on targets report

### DIFF
--- a/app/controllers/schools/school_targets/progress_controller.rb
+++ b/app/controllers/schools/school_targets/progress_controller.rb
@@ -91,7 +91,7 @@ module Schools
       def latest_progress
         if @school_target.expired?
           final_month = @school_target.target_date.prev_month.beginning_of_month
-          @progress.cumulative_performance_versus_synthetic_last_year[final_month]
+          @progress.cumulative_performance[final_month]
         else
           @progress.current_cumulative_performance_versus_synthetic_last_year
         end

--- a/app/views/schools/school_targets/progress/current.html.erb
+++ b/app/views/schools/school_targets/progress/current.html.erb
@@ -81,7 +81,7 @@
                       data: @progress.monthly_usage_kwh, keys: @reporting_months,
                       partial_months: @progress.partial_months, percentage_synthetic: {}, units: :kwh, final_row: false %>
     <%= render 'row', title: t('schools.school_targets.progress.current.overall_change_since_last_year'),
-                      progress: @progress, data: @progress.monthly_performance_versus_synthetic_last_year,
+                      progress: @progress, data: @progress.monthly_performance,
                       keys: @reporting_months, partial_months: @progress.partial_months,
                       percentage_synthetic: {}, units: :relative_percent, final_row: true %>
     </tbody>
@@ -110,7 +110,7 @@
                       data: @progress.cumulative_usage_kwh, keys: @reporting_months,
                       partial_months: @progress.partial_months, percentage_synthetic: {}, units: :kwh, final_row: false %>
     <%= render 'row', title: t('schools.school_targets.progress.current.overall_performance_since_last_year'),
-                      data: @progress.cumulative_performance_versus_synthetic_last_year, keys: @reporting_months,
+                      data: @progress.cumulative_performance, keys: @reporting_months,
                       partial_months: @progress.partial_months, percentage_synthetic: {}, units: :relative_percent,
                       final_row: true %>
     </tbody>

--- a/app/views/schools/school_targets/progress/expired.html.erb
+++ b/app/views/schools/school_targets/progress/expired.html.erb
@@ -65,7 +65,7 @@
                       units: :kwh, final_row: false %>
     <%= render 'row', title: t('schools.school_targets.progress.expired.overall_change_since_last_year'),
                       progress: @progress,
-                      data: @progress.monthly_performance_versus_synthetic_last_year,
+                      data: @progress.monthly_performance,
                       keys: @reporting_months, partial_months: @progress.partial_months, percentage_synthetic: {},
                       units: :relative_percent, final_row: true %>
     </tbody>
@@ -96,7 +96,7 @@
                       partial_months: @progress.partial_months, percentage_synthetic: {},
                       units: :kwh, final_row: false %>
     <%= render 'row', title: t('schools.school_targets.progress.expired.overall_performance_since_last_year'),
-                      data: @progress.cumulative_performance_versus_synthetic_last_year, keys: @reporting_months,
+                      data: @progress.cumulative_performance, keys: @reporting_months,
                       partial_months: @progress.partial_months, percentage_synthetic: {},
                       units: :relative_percent, final_row: true %>
     </tbody>


### PR DESCRIPTION
The school target analysis produces several difference performance metrics. 

One is a % comparison of actual usage vs their usage last year. So a simple % comparison.

The other compares their actual usage vs how much we estimate they would use in a similar month to last year. I believe this was originally done to make allowances for differences in temperature, number of school/holiday dates, etc. 

But this leads to some inconsistencies when its presented alongside the actual and target figures. So we've decided to switch to using the former as its clear to usage what is going on. 

This PR just switches which series is added as the final row in the progress report and to calculate the cumulative progress.