### PR TITLE
Fix attribute in AlertError

### DIFF
--- a/app/services/alerts/generate_and_save_alerts_and_benchmarks.rb
+++ b/app/services/alerts/generate_and_save_alerts_and_benchmarks.rb
@@ -102,7 +102,7 @@ module Alerts
 
       alert_type_run_result.error_messages.each do |error_message|
         AlertError.create!(alert_generation_run: @alert_generation_run, asof_date: asof_date,
-                           information: error_message, alert_type: alert_type, report: report)
+                           information: error_message, alert_type: alert_type, comparison_report: report)
       end
 
       alert_type_run_result.reports.each do |alert_report|


### PR DESCRIPTION
Incorrectly named attribute referenced in alert code. Need to get this fixed as possibly masking underlying errors in alerts.