### PR TITLE
Fix ordering issues in comparison report specs

### DIFF
--- a/spec/factories/activity_types_factory.rb
+++ b/spec/factories/activity_types_factory.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :activity_type do
     activity_category
-    sequence(:name)                         {|n| "test activity_type name #{n}"}
+    sequence(:name, 'Test Activity Type AAAA1')
     score                                   { 25 }
     active                                  { true }
     sequence(:description)                  {|n| "generic description #{n}"}

--- a/spec/factories/intervention_types_factory.rb
+++ b/spec/factories/intervention_types_factory.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :intervention_type do
-    sequence(:name) {|n| "Intervention type #{n}"}
+    sequence(:name, 'Intervention Type AAAA1')
     intervention_type_group
     score { 30 }
     sequence(:summary)                  {|n| "Intervention type summary #{n}"}

--- a/spec/factories/schools_factory.rb
+++ b/spec/factories/schools_factory.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :school do
     sequence(:urn)
     sequence(:number_of_pupils)
-    sequence(:name) { |n| "test #{n} school" }
+    sequence(:name, 'School AAAAA1')
     school_type     { :primary }
     funding_status  { :state_school }
     visible         { true }

--- a/spec/models/alert_spec.rb
+++ b/spec/models/alert_spec.rb
@@ -10,7 +10,7 @@ describe 'Alert' do
     alert_1 = create(:alert, school: school, alert_type: gas_fuel_alert_type, created_at: Time.zone.today)
     alert_2 = create(:alert, school: school, alert_type: electricity_fuel_alert_type, created_at: Time.zone.today)
 
-    expect(Alert.without_exclusions).to eq([alert_1, alert_2])
+    expect(Alert.without_exclusions).to match_array([alert_1, alert_2])
 
     SchoolAlertTypeExclusion.create(school: school, alert_type: gas_fuel_alert_type)
     expect(Alert.without_exclusions).to eq([alert_2])


### PR DESCRIPTION
We have been getting some flaky tests in the comparison reports. Some of these, e.g. the heating coming on too early, involve sorting schools by name. And then asserting the order.

However the existing School factory creates names like: `test school #{n}`. 

When we get to around 100 schools then the specs can fail because we might have schools: "test school 98", "test school 99" and "test school 100". When sorted by name, they will be returned in the reverse order.

This PR updates the sequence of school name to be: `sequence(:name, 'School AAAAA1')` which produces names using [succ](https://apidock.com/ruby/String/succ). This should produce sensible sorts.

Also:

- fixes a flake in the Alert model spec. Spec asserts a fixed order in the array but the SQL doesn't impose an order
- updates the activity type and intervention type factories to also use the above style of sequence naming. This might sort out some of the other occasional test flakes we get, e.g. with search.
 