### PR TITLE
New Solar For Schools CSV format

### DIFF
--- a/lib/tasks/deployment/20240619125347_new_solar_for_schools.rake
+++ b/lib/tasks/deployment/20240619125347_new_solar_for_schools.rake
@@ -1,0 +1,32 @@
+namespace :after_party do
+  desc 'Deployment task: new_solar_for_schools'
+  task new_solar_for_schools: :environment do
+    puts "Running deploy task 'new_solar_for_schools'"
+
+    # Create new format
+    identifier = 'solar-for-schools-new'
+    AmrDataFeedConfig.create!({
+      identifier: identifier,
+      description: 'Solar for Schools (New)',
+      notes: 'New format for Solar data supplied by Solar for Schools',
+      number_of_header_rows: 1,
+      mpan_mprn_field: '', # must not be null, but wont be used
+      lookup_by_serial_number: true,
+      msn_field: 'meter',
+      reading_date_field: 'date',
+      date_format: '%Y-%m-%d',
+      header_example: 'name,meter,date,00:00,00:30,01:00,01:30,02:00,02:30,03:00,03:30,04:00,04:30,05:00,05:30,06:00,06:30,07:00,07:30,08:00,08:30,09:00,09:30,10:00,10:30,11:00,11:30,12:00,12:30,13:00,13:30,14:00,
+  14:30,15:00,15:30,16:00,16:30,17:00,17:30,18:00,18:30,19:00,19:30,20:00,20:30,21:00,21:30,22:00,22:30,23:00,23:30',
+      reading_fields: '00:00,00:30,01:00,01:30,02:00,02:30,03:00,03:30,04:00,04:30,05:00,05:30,06:00,06:30,07:00,07:30,08:00,08:30,09:00,09:30,10:00,10:30,11:00,11:30,12:00,12:30,13:00,13:30,14:00,
+  14:30,15:00,15:30,16:00,16:30,17:00,17:30,18:00,18:30,19:00,19:30,20:00,20:30,21:00,21:30,22:00,22:30,23:00,23:30'.split(",")
+    }) unless AmrDataFeedConfig.find_by_identifier(identifier)
+
+    # Disable old format
+    AmrDataFeedConfig.find_by_identifier('solar-for-schools').update!(enabled: false)
+
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord
+      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+  end
+end


### PR DESCRIPTION
Adds a new CSV format for loading data for Solar for Schools.

Disables the old format that we were last using in 2022. 

Have confirmed format works for manually uploaded files after setting up a couple of serial numbers.