### PR TITLE
Passiv Solar Data Format

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -118,7 +118,6 @@ RSpec/ContextWording:
     - 'spec/services/alerts/system/missing_gas_data_spec.rb'
     - 'spec/services/alerts/system/upcoming_holiday_spec.rb'
     - 'spec/services/amr/csv_parser_and_upserter_spec.rb'
-    - 'spec/services/amr/data_feed_translator_spec.rb'
     - 'spec/services/amr/data_file_parser_spec.rb'
     - 'spec/services/amr/n3rgy_readings_upserter_spec.rb'
     - 'spec/services/amr/single_read_converter_spec.rb'

--- a/app/models/amr_data_feed_config.rb
+++ b/app/models/amr_data_feed_config.rb
@@ -7,6 +7,7 @@
 #  convert_to_kwh          :boolean          default(FALSE)
 #  created_at              :datetime         not null
 #  date_format             :text             not null
+#  delayed_reading         :boolean          default(FALSE), not null
 #  description             :text             not null
 #  enabled                 :boolean          default(TRUE), not null
 #  expected_units          :string

--- a/app/services/amr/data_feed_translator.rb
+++ b/app/services/amr/data_feed_translator.rb
@@ -17,7 +17,7 @@ module Amr
     def translate_row_to_hash(row)
       data_feed_reading_hash = meter_details_from_row(row)
       data_feed_reading_hash[:amr_data_feed_config_id] = @config.id
-      data_feed_reading_hash[:reading_date] = fetch_from_row(:reading_date_index, row)
+      data_feed_reading_hash[:reading_date] = reading_date(row)
       data_feed_reading_hash[:reading_time] = fetch_from_row(:reading_time_index, row)
       data_feed_reading_hash[:postcode] = fetch_from_row(:postcode_index, row)
       data_feed_reading_hash[:units] = fetch_from_row(:units_index, row)
@@ -43,6 +43,19 @@ module Amr
         meter_serial_number: meter_serial_number,
         mpan_mprn: mpan_mprn
       }
+    end
+
+    def reading_date(row)
+      date_string = fetch_from_row(:reading_date_index, row)
+      return date_string unless @config.delayed_reading
+
+      begin
+        date = DateTime.strptime(date_string, @config.date_format)
+        date = date - 1.day
+        date.strftime(@config.date_format)
+      rescue ArgumentError
+        nil
+      end
     end
 
     def fetch_from_row(index_symbol, row)

--- a/app/services/amr/data_feed_translator.rb
+++ b/app/services/amr/data_feed_translator.rb
@@ -49,11 +49,16 @@ module Amr
       date_string = fetch_from_row(:reading_date_index, row)
       return date_string unless @config.delayed_reading
 
+      # a delayed reading config means the date/date-time column is when the readings
+      # where collected, rather than the date the energy was consumed. For now
+      # this only appears in one config where the readings are collected a day later
       begin
         date = DateTime.strptime(date_string, @config.date_format)
         date = date - 1.day
         date.strftime(@config.date_format)
       rescue ArgumentError
+        # return nil here and we should end up rejecting the data
+        # better to do this than load with incorrect date
         nil
       end
     end

--- a/app/views/admin/amr_uploaded_readings/new.html.erb
+++ b/app/views/admin/amr_uploaded_readings/new.html.erb
@@ -100,6 +100,12 @@
         <li>Dates formatted like this <b><%= DateTime.now.strftime(@amr_data_feed_config.date_format) %></b>
           (<code><%= @amr_data_feed_config.date_format %></code>)</li>
 
+        <% if @amr_data_feed_config.delayed_reading %>
+          <li><strong>Important:</strong> this configuration will adjust the dates in the uploaded file backwards by 1 day. This matches what the supplier provides.
+            But use caution if you are manually preparing data.
+          </li>
+        <% end %>
+
         <% if @amr_data_feed_config.row_per_reading %>
           <li>A reading field column labelled  <b><%= @amr_data_feed_config.reading_fields.first %></b></li>
           <% if @amr_data_feed_config.positional_index && @amr_data_feed_config.period_field %>

--- a/bin/importmap
+++ b/bin/importmap
@@ -1,4 +1,4 @@
 #!/usr/bin/env ruby
 
-require_relative "../config/application"
-require "importmap/commands"
+require_relative '../config/application'
+require 'importmap/commands'

--- a/bin/importmap
+++ b/bin/importmap
@@ -1,4 +1,4 @@
 #!/usr/bin/env ruby
 
-require_relative '../config/application'
-require 'importmap/commands'
+require_relative "../config/application"
+require "importmap/commands"

--- a/db/migrate/20240619153937_add_delayed_reading_to_amr_data_feed_config.rb
+++ b/db/migrate/20240619153937_add_delayed_reading_to_amr_data_feed_config.rb
@@ -1,0 +1,5 @@
+class AddDelayedReadingToAmrDataFeedConfig < ActiveRecord::Migration[7.0]
+  def change
+    add_column :amr_data_feed_configs, :delayed_reading, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -3892,4 +3892,132 @@ ActiveRecord::Schema[7.0].define(version: 2024_06_19_153937) do
             ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
     WHERE ((data.alert_generation_run_id = latest_runs.id) AND (additional.alert_generation_run_id = latest_runs.id));
   SQL
+  create_view "holiday_and_terms", sql_definition: <<-SQL
+      WITH electricity AS (
+           SELECT alerts.alert_generation_run_id,
+              json.current_period_kwh,
+              json.previous_period_kwh,
+              json.current_period_co2,
+              json.previous_period_co2,
+              json.current_period_gbp,
+              json.previous_period_gbp,
+              json.tariff_has_changed,
+              json.pupils_changed,
+              json.floor_area_changed,
+              json.current_period_type,
+              json.current_period_start_date,
+              json.current_period_end_date,
+              json.truncated_current_period
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) json(current_period_kwh double precision, previous_period_kwh double precision, current_period_co2 double precision, previous_period_co2 double precision, current_period_gbp double precision, previous_period_gbp double precision, tariff_has_changed boolean, pupils_changed boolean, floor_area_changed boolean, current_period_type text, current_period_start_date date, current_period_end_date date, truncated_current_period boolean)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertHolidayAndTermElectricityComparison'::text))
+          ), gas AS (
+           SELECT alerts.alert_generation_run_id,
+              json.current_period_kwh,
+              json.previous_period_kwh,
+              json.current_period_co2,
+              json.previous_period_co2,
+              json.current_period_gbp,
+              json.previous_period_gbp,
+              json.previous_period_kwh_unadjusted,
+              json.tariff_has_changed,
+              json.pupils_changed,
+              json.floor_area_changed,
+              json.current_period_type,
+              json.current_period_start_date,
+              json.current_period_end_date,
+              json.truncated_current_period
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) json(current_period_kwh double precision, previous_period_kwh double precision, current_period_co2 double precision, previous_period_co2 double precision, current_period_gbp double precision, previous_period_gbp double precision, previous_period_kwh_unadjusted double precision, tariff_has_changed boolean, pupils_changed boolean, floor_area_changed boolean, current_period_type text, current_period_start_date date, current_period_end_date date, truncated_current_period boolean)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertHolidayAndTermGasComparison'::text))
+          ), storage_heater AS (
+           SELECT alerts.alert_generation_run_id,
+              json.current_period_kwh,
+              json.previous_period_kwh,
+              json.current_period_co2,
+              json.previous_period_co2,
+              json.current_period_gbp,
+              json.previous_period_gbp,
+              json.previous_period_kwh_unadjusted,
+              json.tariff_has_changed,
+              json.pupils_changed,
+              json.floor_area_changed,
+              json.current_period_type,
+              json.current_period_start_date,
+              json.current_period_end_date,
+              json.truncated_current_period
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) json(current_period_kwh double precision, previous_period_kwh double precision, current_period_co2 double precision, previous_period_co2 double precision, current_period_gbp double precision, previous_period_gbp double precision, previous_period_kwh_unadjusted double precision, tariff_has_changed boolean, pupils_changed boolean, floor_area_changed boolean, current_period_type text, current_period_start_date date, current_period_end_date date, truncated_current_period boolean)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertHolidayAndTermStorageHeaterComparison'::text))
+          ), enba AS (
+           SELECT alerts.alert_generation_run_id,
+              data.solar_type
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) data(solar_type text)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertEnergyAnnualVersusBenchmark'::text))
+          ), additional AS (
+           SELECT alerts.alert_generation_run_id,
+              alerts.school_id,
+              data.activation_date
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) data(activation_date date)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertAdditionalPrioritisationData'::text))
+          ), latest_runs AS (
+           SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
+             FROM alert_generation_runs
+            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC
+          )
+   SELECT latest_runs.id,
+      additional.school_id,
+      additional.activation_date,
+      (electricity.pupils_changed OR gas.pupils_changed OR storage_heater.pupils_changed) AS pupils_changed,
+      (electricity.floor_area_changed OR gas.floor_area_changed OR storage_heater.floor_area_changed) AS floor_area_changed,
+      enba.solar_type,
+      electricity.current_period_kwh AS electricity_current_period_kwh,
+      electricity.previous_period_kwh AS electricity_previous_period_kwh,
+      electricity.current_period_co2 AS electricity_current_period_co2,
+      electricity.previous_period_co2 AS electricity_previous_period_co2,
+      electricity.current_period_gbp AS electricity_current_period_gbp,
+      electricity.previous_period_gbp AS electricity_previous_period_gbp,
+      electricity.tariff_has_changed AS electricity_tariff_has_changed,
+      electricity.current_period_type AS electricity_current_period_type,
+      electricity.current_period_start_date AS electricity_current_period_start_date,
+      electricity.current_period_end_date AS electricity_current_period_end_date,
+      electricity.truncated_current_period AS electricity_truncated_current_period,
+      gas.current_period_kwh AS gas_current_period_kwh,
+      gas.previous_period_kwh AS gas_previous_period_kwh,
+      gas.current_period_co2 AS gas_current_period_co2,
+      gas.previous_period_co2 AS gas_previous_period_co2,
+      gas.current_period_gbp AS gas_current_period_gbp,
+      gas.previous_period_gbp AS gas_previous_period_gbp,
+      gas.previous_period_kwh_unadjusted AS gas_previous_period_kwh_unadjusted,
+      gas.tariff_has_changed AS gas_tariff_has_changed,
+      gas.current_period_type AS gas_current_period_type,
+      gas.current_period_start_date AS gas_current_period_start_date,
+      gas.current_period_end_date AS gas_current_period_end_date,
+      gas.truncated_current_period AS gas_truncated_current_period,
+      storage_heater.current_period_kwh AS storage_heater_current_period_kwh,
+      storage_heater.previous_period_kwh AS storage_heater_previous_period_kwh,
+      storage_heater.current_period_co2 AS storage_heater_current_period_co2,
+      storage_heater.previous_period_co2 AS storage_heater_previous_period_co2,
+      storage_heater.current_period_gbp AS storage_heater_current_period_gbp,
+      storage_heater.previous_period_gbp AS storage_heater_previous_period_gbp,
+      storage_heater.previous_period_kwh_unadjusted AS storage_heater_previous_period_kwh_unadjusted,
+      storage_heater.tariff_has_changed AS storage_heater_tariff_has_changed,
+      storage_heater.current_period_type AS storage_heater_current_period_type,
+      storage_heater.current_period_start_date AS storage_heater_current_period_start_date,
+      storage_heater.current_period_end_date AS storage_heater_current_period_end_date,
+      storage_heater.truncated_current_period AS storage_heater_truncated_current_period
+     FROM (((((latest_runs
+       JOIN additional ON ((latest_runs.id = additional.alert_generation_run_id)))
+       LEFT JOIN electricity ON ((latest_runs.id = electricity.alert_generation_run_id)))
+       LEFT JOIN gas ON ((latest_runs.id = gas.alert_generation_run_id)))
+       LEFT JOIN storage_heater ON ((latest_runs.id = storage_heater.alert_generation_run_id)))
+       LEFT JOIN enba ON ((latest_runs.id = enba.alert_generation_run_id)));
+  SQL
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_06_05_154636) do
+ActiveRecord::Schema[7.0].define(version: 2024_06_19_153937) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pgcrypto"
@@ -411,6 +411,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_06_05_154636) do
     t.boolean "enabled", default: true, null: false
     t.text "reading_time_field"
     t.boolean "convert_to_kwh", default: false
+    t.boolean "delayed_reading", default: false, null: false
     t.index ["description"], name: "index_amr_data_feed_configs_on_description", unique: true
     t.index ["identifier"], name: "index_amr_data_feed_configs_on_identifier", unique: true
   end
@@ -1013,17 +1014,13 @@ ActiveRecord::Schema[7.0].define(version: 2024_06_05_154636) do
     t.datetime "finished_at", precision: nil
     t.text "error"
     t.integer "error_event", limit: 2
-    t.text "error_backtrace", array: true
-    t.uuid "process_id"
     t.index ["active_job_id", "created_at"], name: "index_good_job_executions_on_active_job_id_and_created_at"
-    t.index ["process_id", "created_at"], name: "index_good_job_executions_on_process_id_and_created_at"
   end
 
   create_table "good_job_processes", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.jsonb "state"
-    t.integer "lock_type", limit: 2
   end
 
   create_table "good_job_settings", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
@@ -1056,8 +1053,6 @@ ActiveRecord::Schema[7.0].define(version: 2024_06_05_154636) do
     t.text "job_class"
     t.integer "error_event", limit: 2
     t.text "labels", array: true
-    t.uuid "locked_by_id"
-    t.datetime "locked_at", precision: nil
     t.index ["active_job_id", "created_at"], name: "index_good_jobs_on_active_job_id_and_created_at"
     t.index ["batch_callback_id"], name: "index_good_jobs_on_batch_callback_id", where: "(batch_callback_id IS NOT NULL)"
     t.index ["batch_id"], name: "index_good_jobs_on_batch_id", where: "(batch_id IS NOT NULL)"
@@ -1066,10 +1061,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_06_05_154636) do
     t.index ["cron_key", "cron_at"], name: "index_good_jobs_on_cron_key_and_cron_at_cond", unique: true, where: "(cron_key IS NOT NULL)"
     t.index ["finished_at"], name: "index_good_jobs_jobs_on_finished_at", where: "((retried_good_job_id IS NULL) AND (finished_at IS NOT NULL))"
     t.index ["labels"], name: "index_good_jobs_on_labels", where: "(labels IS NOT NULL)", using: :gin
-    t.index ["locked_by_id"], name: "index_good_jobs_on_locked_by_id", where: "(locked_by_id IS NOT NULL)"
-    t.index ["priority", "created_at"], name: "index_good_job_jobs_for_candidate_lookup", where: "(finished_at IS NULL)"
     t.index ["priority", "created_at"], name: "index_good_jobs_jobs_on_priority_created_at_when_unfinished", order: { priority: "DESC NULLS LAST" }, where: "(finished_at IS NULL)"
-    t.index ["priority", "scheduled_at"], name: "index_good_jobs_on_priority_scheduled_at_unfinished_unlocked", where: "((finished_at IS NULL) AND (locked_by_id IS NULL))"
     t.index ["queue_name", "scheduled_at"], name: "index_good_jobs_on_queue_name_and_scheduled_at", where: "(finished_at IS NULL)"
     t.index ["scheduled_at"], name: "index_good_jobs_on_scheduled_at", where: "(finished_at IS NULL)"
   end
@@ -3582,6 +3574,36 @@ ActiveRecord::Schema[7.0].define(version: 2024_06_05_154636) do
        LEFT JOIN gas ON ((latest_runs.id = gas.alert_generation_run_id)))
        LEFT JOIN storage_heaters ON ((latest_runs.id = storage_heaters.alert_generation_run_id)));
   SQL
+  create_view "heating_vs_hot_waters", sql_definition: <<-SQL
+      WITH gas AS (
+           SELECT alerts.alert_generation_run_id,
+              alerts.school_id,
+              data.last_year_kwh
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) data(last_year_kwh double precision)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertGasAnnualVersusBenchmark'::text))
+          ), hot_water AS (
+           SELECT alerts.alert_generation_run_id,
+              data.existing_gas_annual_kwh
+             FROM alerts,
+              alert_types,
+              LATERAL jsonb_to_record(alerts.variables) data(existing_gas_annual_kwh double precision)
+            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertHotWaterEfficiency'::text))
+          ), latest_runs AS (
+           SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
+             FROM alert_generation_runs
+            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC
+          )
+   SELECT latest_runs.id,
+      gas.school_id,
+      gas.last_year_kwh AS last_year_gas_kwh,
+      hot_water.existing_gas_annual_kwh AS estimated_hot_water_gas_kwh,
+      (hot_water.existing_gas_annual_kwh / gas.last_year_kwh) AS estimated_hot_water_percentage
+     FROM ((latest_runs
+       LEFT JOIN gas ON ((latest_runs.id = gas.alert_generation_run_id)))
+       LEFT JOIN hot_water ON ((latest_runs.id = hot_water.alert_generation_run_id)));
+  SQL
   create_view "holiday_usage_last_years", sql_definition: <<-SQL
       SELECT latest_runs.id,
       data.alert_generation_run_id,
@@ -3869,35 +3891,5 @@ ActiveRecord::Schema[7.0].define(version: 2024_06_05_154636) do
              FROM alert_generation_runs
             ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC) latest_runs
     WHERE ((data.alert_generation_run_id = latest_runs.id) AND (additional.alert_generation_run_id = latest_runs.id));
-  SQL
-  create_view "heating_vs_hot_waters", sql_definition: <<-SQL
-      WITH gas AS (
-           SELECT alerts.alert_generation_run_id,
-              alerts.school_id,
-              data.last_year_kwh
-             FROM alerts,
-              alert_types,
-              LATERAL jsonb_to_record(alerts.variables) data(last_year_kwh double precision)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertGasAnnualVersusBenchmark'::text))
-          ), hot_water AS (
-           SELECT alerts.alert_generation_run_id,
-              data.existing_gas_annual_kwh
-             FROM alerts,
-              alert_types,
-              LATERAL jsonb_to_record(alerts.variables) data(existing_gas_annual_kwh double precision)
-            WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertHotWaterEfficiency'::text))
-          ), latest_runs AS (
-           SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
-             FROM alert_generation_runs
-            ORDER BY alert_generation_runs.school_id, alert_generation_runs.created_at DESC
-          )
-   SELECT latest_runs.id,
-      gas.school_id,
-      gas.last_year_kwh AS last_year_gas_kwh,
-      hot_water.existing_gas_annual_kwh AS estimated_hot_water_gas_kwh,
-      (hot_water.existing_gas_annual_kwh / gas.last_year_kwh) AS estimated_hot_water_percentage
-     FROM ((latest_runs
-       LEFT JOIN gas ON ((latest_runs.id = gas.alert_generation_run_id)))
-       LEFT JOIN hot_water ON ((latest_runs.id = hot_water.alert_generation_run_id)));
   SQL
 end

--- a/lib/tasks/deployment/20240619171210_create_passiv_solar_format.rake
+++ b/lib/tasks/deployment/20240619171210_create_passiv_solar_format.rake
@@ -1,0 +1,32 @@
+namespace :after_party do
+  desc 'Deployment task: create_passiv_solar_format'
+  task create_passiv_solar_format: :environment do
+    puts "Running deploy task 'create_passiv_solar_format'"
+
+    identifier = 'passiv-solar'
+    AmrDataFeedConfig.create!({
+      identifier: identifier,
+      description: 'Passiv Solar Data',
+      notes: 'Format for Passiv Solar Data. Note: this data config expects the dates to be the day AFTER the energy is consumed',
+      delayed_reading: true,
+      mpan_mprn_field: '', # must not be null, but wont be used
+      lookup_by_serial_number: true,
+      msn_field: 'Generation MSN',
+      reading_date_field: 'Date/Time Stamp',
+      date_format: '%Y-%m-%dT%H:%M:%SZ',
+      header_example: 'Meter Type,Generation MSN,Latest Generation Meter Reading (kWh),Date/Time Stamp,00:00 - 00:30,00:30 - 01:00,01:00 - 01:30,01:30 - 02:00,02:00 - 02:30,02:30 - 03:00,03:00 - 03:30,03:30 - 04:0
+0,04:00 - 04:30,04:30 - 05:00,05:00 - 05:30,05:30 - 06:00,06:00 - 06:30,06:30 - 07:00,07:00 - 07:30,07:30 - 08:00,08:00 - 08:30,08:30 - 09:00,09:00 - 09:30,09:30 - 10:00,10:00 - 10:30,10:30
+- 11:00,11:00 - 11:30,11:30 - 12:00,12:00 - 12:30,12:30 - 13:00,13:00 - 13:30,13:30 - 14:00,14:00 - 14:30,14:30 - 15:00,15:00 - 15:30,15:30 - 16:00,16:00 - 16:30,16:30 - 17:00,17:00 - 17:30,
+17:30 - 18:00,18:00 - 18:30,18:30 - 19:00,19:00 - 19:30,19:30 - 20:00,20:00 - 20:30,20:30 - 21:00,21:00 - 21:30,21:30 - 22:00,22:00 - 22:30,22:30 - 23:00,23:00 - 23:30,23:30 - 00:00',
+      reading_fields: '00:00 - 00:30,00:30 - 01:00,01:00 - 01:30,01:30 - 02:00,02:00 - 02:30,02:30 - 03:00,03:00 - 03:30,03:30 - 04:0
+0,04:00 - 04:30,04:30 - 05:00,05:00 - 05:30,05:30 - 06:00,06:00 - 06:30,06:30 - 07:00,07:00 - 07:30,07:30 - 08:00,08:00 - 08:30,08:30 - 09:00,09:00 - 09:30,09:30 - 10:00,10:00 - 10:30,10:30
+- 11:00,11:00 - 11:30,11:30 - 12:00,12:00 - 12:30,12:30 - 13:00,13:00 - 13:30,13:30 - 14:00,14:00 - 14:30,14:30 - 15:00,15:00 - 15:30,15:30 - 16:00,16:00 - 16:30,16:30 - 17:00,17:00 - 17:30,
+17:30 - 18:00,18:00 - 18:30,18:30 - 19:00,19:00 - 19:30,19:30 - 20:00,20:00 - 20:30,20:30 - 21:00,21:00 - 21:30,21:30 - 22:00,22:00 - 22:30,22:30 - 23:00,23:00 - 23:30,23:30 - 00:00'.split(",")
+    }) unless AmrDataFeedConfig.find_by_identifier(identifier)
+
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord
+      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+  end
+end

--- a/spec/services/amr/data_feed_translator_spec.rb
+++ b/spec/services/amr/data_feed_translator_spec.rb
@@ -249,7 +249,35 @@ describe Amr::DataFeedTranslator do
     end
 
     context 'when the config indicates there are delayed readings' do
-      it 'reformats the dates'
+      before do
+        config.delayed_reading = true
+      end
+
+      it 'reformats the dates' do
+        expect(results.first[:reading_date]).to eq('30/12/2019')
+      end
+
+      context 'with a date time format' do
+        let(:reading) do
+          ['MEERSBROOK PRIMARY - M1', '2333300681718', '2023-09-12T01:05:02Z', '1', 'kwh',
+           '1.20800000', '1.16100000', '1.19500000', '1.21000000', '1.16600000', '1.20100000',
+           '1.17800000', '1.30000000', '1.30100000', '1.26600000', '1.27300000', '1.28000000',
+           '2.10900000', '2.03700000', '1.29100000', '1.24600000', '1.67800000', '1.24500000',
+           '1.12800000', '1.11300000', '1.35000000', '1.11700000', '1.14200000', '1.40600000',
+           '1.10100000', '1.12300000', '1.16400000', '1.42700000', '1.12900000', '1.10400000',
+           '1.11900000', '1.46600000', '1.18400000', '1.14600000', '1.22600000', '1.20800000',
+           '1.25500000', '1.20000000', '1.23600000', '1.16300000', '1.12400000', '1.19800000',
+           '1.12800000', '1.15500000', '1.13000000', '1.18200000', '1.14500000', '1.17700000'] + ([''] * 48)
+        end
+
+        before do
+          config.date_format = '%Y-%m-%dT%H:%M:%SZ'
+        end
+
+        it 'reformats the dates' do
+          expect(results.first[:reading_date]).to eq('2023-09-11T01:05:02Z')
+        end
+      end
     end
   end
 end

--- a/spec/services/amr/data_feed_translator_spec.rb
+++ b/spec/services/amr/data_feed_translator_spec.rb
@@ -76,7 +76,7 @@ describe Amr::DataFeedTranslator do
 
       let(:readings) do
         half_hours = (0..23).map { |hour| [format('%02d:00', hour), format('%02d:30', hour)] }.flatten
-        readings = ['01/06/2023', '02/06/2023'].flat_map do |date|
+        ['01/06/2023', '02/06/2023'].flat_map do |date|
           half_hours.map.with_index do |time, i|
             # ['Read date', 'Time', 'Site Name', ' Actual (KWH)']
             [date, time, '10070831', "0.#{format('%03d', (i + 1))}"]

--- a/spec/services/amr/data_feed_translator_spec.rb
+++ b/spec/services/amr/data_feed_translator_spec.rb
@@ -4,9 +4,8 @@ require 'rails_helper'
 
 describe Amr::DataFeedTranslator do
   let(:reading_fields) { (1..48).map { |i| "kWh_#{i}" } }
-  let(:sheffield_config) do
+  let(:config) do
     build(:amr_data_feed_config,
-          description: 'Sheffield',
           date_format: '%d/%m/%Y',
           mpan_mprn_field: 'MPAN',
           units_field: 'units',
@@ -29,346 +28,229 @@ describe Amr::DataFeedTranslator do
      '1.12800000', '1.15500000', '1.13000000', '1.18200000', '1.14500000', '1.17700000'] + ([''] * 48)
   end
 
-  it 'converts array rows to a keyed hash' do
-    result = described_class.new(sheffield_config, [reading]).perform.first
-
-    expect(result[:mpan_mprn]).to eq('2333300681718')
-    expect(result[:reading_date]).to eq('31/12/2019')
-    expect(result[:description]).to eq('MEERSBROOK PRIMARY - M1')
-    expect(result[:readings].first).to eq('1.20800000')
-    expect(result[:readings].last).to eq('1.17700000')
-    expect(result[:units]).to eq('kwh')
-  end
-
-  it 'adds period for positionally indexed files' do
-    sheffield_config.positional_index = true
-    result = described_class.new(sheffield_config, [reading]).perform.first
-    expect(result[:period]).to eq('1')
-  end
-
-  context 'when checking units' do
-    it 'removes rows that do not match the expected_units' do
-      sheffield_config.expected_units = 'kwh'
-      readings = [reading, reading.dup.tap { |r| r[4] = 'LEAD' }]
-      results = described_class.new(sheffield_config, readings).perform
-      expect(results.size).to eq(1)
-      expect(results.first[:readings].first).to eq('1.20800000')
-    end
-  end
-
-  it 'handles trailing whitespace on the MPAN' do
-    reading[1] = "#{reading[1]} "
-    result = described_class.new(sheffield_config, [reading]).perform.first
-    expect(result[:mpan_mprn]).to eq('2333300681718')
-  end
-
-  context 'when converting rows' do
-    before do
-      sheffield_config.convert_to_kwh = true
+  describe '#perform' do
+    it 'converts array rows to a keyed hash' do
+      result = described_class.new(config, [reading]).perform.first
+      expect(result[:mpan_mprn]).to eq('2333300681718')
+      expect(result[:reading_date]).to eq('31/12/2019')
+      expect(result[:description]).to eq('MEERSBROOK PRIMARY - M1')
+      expect(result[:readings].first).to eq('1.20800000')
+      expect(result[:readings].last).to eq('1.17700000')
+      expect(result[:units]).to eq('kwh')
     end
 
-    context 'when no units field is specified for each row' do
-      before do
-        sheffield_config.units_field = nil
-        sheffield_config.expected_units = nil
+    it 'removes trailing whitespace from the MPAN' do
+      reading[1] = "#{reading[1]} "
+      result = described_class.new(config, [reading]).perform.first
+      expect(result[:mpan_mprn]).to eq('2333300681718')
+    end
+
+    context 'when the config has a positional index' do
+      it 'adds period to hash' do
+        config.positional_index = true
+        result = described_class.new(config, [reading]).perform.first
+        expect(result[:period]).to eq('1')
+      end
+    end
+
+    context 'when the config is a row per reading format with a separate reading time' do
+      let(:config) do
+        build(:amr_data_feed_config,
+              date_format: '%d/%m/%Y',
+              mpan_mprn_field: 'Site Name',
+              reading_date_field: 'Read date',
+              reading_time_field: 'Time',
+              reading_fields: [' Actual (KWH)'],
+              header_example: 'Read date,Time,Site Name, Actual (KWH)',
+              row_per_reading: true,
+              positional_index: true)
       end
 
-      it 'converts all rows to kwh' do
-        readings = [reading]
-        results = described_class.new(sheffield_config, readings).perform
+      let!(:meter_1) { create(:solar_pv_meter, meter_serial_number: '10070831') }
+      let!(:meter_2) { create(:solar_pv_meter, meter_serial_number: '10070839') }
+
+      it 'parses into a hash with date, time and single readings' do
+        half_hours = (0..23).map { |hour| [format('%02d:00', hour), format('%02d:30', hour)] }.flatten
+        readings = ['01/06/2023', '02/06/2023'].flat_map do |date|
+          half_hours.map.with_index do |time, i|
+            # ['Read date', 'Time', 'Site Name', ' Actual (KWH)']
+            [date, time, '10070831', "0.#{format('%03d', (i + 1))}"]
+          end
+        end
+
+        results = described_class.new(config, readings).perform
+
+        expect(results.size).to eq(readings.size)
+
+        expect(results.first[:mpan_mprn]).to eq('10070831')
+        expect(results.first[:reading_date]).to eq('01/06/2023')
+        expect(results.first[:reading_time]).to eq('00:00')
+        expect(results.first[:readings]).to eq(['0.001'])
+
+        expect(results.last[:mpan_mprn]).to eq('10070831')
+        expect(results.last[:reading_date]).to eq('02/06/2023')
+        expect(results.last[:reading_time]).to eq('23:30')
+        expect(results.last[:readings]).to eq(['0.048'])
+      end
+    end
+
+    context 'when the config defines expected units' do
+      it 'removes rows that do not match the expected_units' do
+        config.expected_units = 'kwh'
+        readings = [reading, reading.dup.tap { |r| r[4] = 'LEAD' }]
+        results = described_class.new(config, readings).perform
         expect(results.size).to eq(1)
-        expect(results.first[:readings].first).to eq(1.20800000 * 11.1)
+        expect(results.first[:readings].first).to eq('1.20800000')
       end
     end
 
-    context 'when there are different units per row' do
-      it 'converts only specific m3 rows to kwh' do
-        # one row kwh, one row m3
-        readings = [reading, reading.dup.tap { |r| r[4] = 'm3' }]
-        results = described_class.new(sheffield_config, readings).perform
+    context 'when the config uses serial numbers' do
+      let(:config) do
+        build(:amr_data_feed_config,
+              date_format: '%H:%M:%S %a %d/%m/%Y',
+              mpan_mprn_field: '',
+              units_field: 'units',
+              reading_date_field: 'DateTime',
+              reading_fields: reading_fields,
+              meter_description_field: 'Description',
+              header_example: "Description,SerialNumber,DateTime,import_total,export_total,#{reading_fields.join(',_,')}",
+              expected_units: '',
+              msn_field: 'SerialNumber',
+              lookup_by_serial_number: true)
+      end
+      let!(:meters) do
+        [create(:solar_pv_meter, meter_serial_number: '10070831'),
+         create(:solar_pv_meter, meter_serial_number: '10070839')]
+      end
+      let(:readings) do
+        [
+          ['10070831', '10070831', '00:13:07 Thu 07/04/2022', '83294159.417', '0',
+           '0.000000', '0.000000', '0.000000', '0.000000', '0.000000', '0.000000', '0.000000', '0.000000',
+           '0.000000', '0.000000', '0.000000', '0.000000', '0.000000', '0.000000', '0.000000', '0.000000',
+           '0.000000', '0.000000', '0.000000', '0.000000', '0.000000', '0.000000', '0.000000', '0.000000',
+           '0.121895', '0.000000', '0.399635', '0.000000', '0.756100', '0.000000', '1.137950', '0.000000',
+           '1.524650', '0.000000', '1.825500', '0.000000', '1.618100', '0.000000', '1.478200', '0.000000',
+           '2.088200', '0.000000', '2.045800', '0.000000', '2.190850', '0.000000', '2.860450', '0.000000',
+           '2.912200', '0.000000', '1.213350', '0.000000', '1.885650', '0.000000', '2.116800', '0.000000',
+           '1.517650', '0.000000', '1.855550', '0.000000', '1.435450', '0.000000', '1.340200', '0.000000',
+           '0.933100', '0.000000', '0.760450', '0.000000', '0.548250', '0.000000', '0.110745', '0.000000',
+           '0.035366', '0.000000', '0.000000', '0.000000', '0.000000', '0.000000', '0.000000', '0.000000',
+           '0.000000', '0.000000', '0.000000', '0.000000', '0.000000', '0.000000', '0.000000', '0.000000',
+           '0.000000', '0.000000', '0.000000', '0.000000', '0.000000', '0.000000', '0.000000', '0.000000'],
+          ['10070839', '10070839', '00:10:58 Thu 07/04/2022', '84079387.609', '0',
+           '0.000000', '0.000000', '0.000000', '0.000000', '0.000000', '0.000000', '0.000000', '0.000000',
+           '0.000000', '0.000000', '0.000000', '0.000000', '0.000000', '0.000000', '0.000000', '0.000000',
+           '0.000000', '0.000000', '0.000000', '0.000000', '0.000000', '0.000000', '0.066830', '0.000000',
+           '0.036760', '0.000000', '0.741800', '0.000000', '0.703950', '0.000000', '1.255700', '0.000000',
+           '2.213050', '0.000000', '2.983500', '0.000000', '2.985250', '0.000000', '3.140100', '0.000000',
+           '3.415300', '0.000000', '3.449850', '0.000000', '3.144750', '0.000000', '2.859600', '0.000000',
+           '2.685850', '0.000000', '3.200550', '0.000000', '2.425800', '0.000000', '2.163900', '0.000000',
+           '1.110500', '0.000000', '0.995000', '0.000000', '0.985400', '0.000000', '0.696800', '0.000000',
+           '0.343965', '0.000000', '0.430185', '0.000000', '0.340685', '0.000000', '0.215565', '0.000000',
+           '0.091900', '0.000000', '0.004118', '0.000000', '0.000000', '0.000000', '0.000000', '0.000000',
+           '0.000000', '0.000000', '0.000000', '0.000000', '0.000000', '0.000000', '0.000000', '0.000000',
+           '0.000000', '0.000000', '0.000000', '0.000000', '0.000000', '0.000000', '0.000000', '0.000000']
+        ]
+      end
+
+      it 'parses into a hash with serial number' do
+        results = described_class.new(config, readings).perform
+
+        expect(results.size).to eq(2)
+        expect(results.first[:readings].count).to eq(48)
+        expect(results.first[:meter_serial_number]).to eq('10070831')
+        expect(results.first[:readings][12]).to eq('0.121895')
+        expect(results.first[:readings][13]).to eq('0.399635')
+        expect(results.first[:readings][14]).to eq('0.756100')
+        expect(results.second[:readings].count).to eq(48)
+        expect(results.second[:meter_serial_number]).to eq('10070839')
+        expect(results.second[:readings][11]).to eq('0.066830')
+        expect(results.second[:readings][12]).to eq('0.036760')
+        expect(results.second[:readings][13]).to eq('0.741800')
+      end
+
+      it 'finds correct meter id and mpan from serial number' do
+        results = described_class.new(config, readings).perform
+
         expect(results.size).to eq(2)
 
-        expect(results.first[:units]).to eq('kwh')
-        expect(results.first[:readings].first).to eq('1.20800000')
+        expect(results.first[:meter_id]).to eq(meters[0].id)
+        expect(results.first[:mpan_mprn]).to eq(meters[0].mpan_mprn.to_s)
+        expect(results.first[:meter_serial_number]).to eq('10070831')
 
-        expect(results.last[:units]).to eq('kwh')
-        expect(results.last[:readings].first).to eq(1.20800000 * 11.1)
+        expect(results.second[:meter_id]).to eq(meters[1].id)
+        expect(results.second[:mpan_mprn]).to eq(meters[1].mpan_mprn.to_s)
+        expect(results.second[:meter_serial_number]).to eq('10070839')
+      end
+
+      it 'handles missing meter serial numbers' do
+        readings[0][0] = readings[0][1] = '1234'
+        readings[1][0] = readings[1][1] = '5678'
+
+        results = described_class.new(config, readings).perform
+
+        expect(results.size).to eq(2)
+
+        expect(results.first[:meter_id]).to be_nil
+        expect(results.first[:mpan_mprn]).to be_nil
+        expect(results.first[:meter_serial_number]).to eq('1234')
+
+        expect(results.second[:meter_id]).to be_nil
+        expect(results.second[:mpan_mprn]).to be_nil
+        expect(results.second[:meter_serial_number]).to eq('5678')
+      end
+
+      it 'raises error if duplicate serial numbers found' do
+        create(:solar_pv_meter, meter_serial_number: meters[0].meter_serial_number)
+        expect do
+          described_class.new(config, [readings.first]).perform
+        end.to raise_error(Amr::DataFeedException)
+      end
+
+      it 'handles trailing whitespace on the meter serial' do
+        readings[0][1] = "#{readings[0][1]} "
+        results = described_class.new(config, readings).perform
+        expect(results.first[:meter_serial_number]).to eq('10070831')
       end
     end
-  end
 
-  context 'for Opus gas feed' do
-    let(:opus_gas_config) do
-      build(:amr_data_feed_config,
-            description: 'Opus gas',
-            date_format: '%d/%m/%Y',
-            mpan_mprn_field: 'MPAN',
-            reading_date_field: 'ReadingDate',
-            reading_time_field: 'ReadTime',
-            reading_fields: ['MeterConsumption'],
-            header_example: 'MPAN,ReadingDate,ReadTime,MeterConsumption',
-            row_per_reading: true,
-            positional_index: true)
-    end
+    context 'when converting rows to kwh' do
+      before do
+        config.convert_to_kwh = true
+      end
 
-    let!(:meter_1) { create(:solar_pv_meter, meter_serial_number: '10070831') }
-    let!(:meter_2) { create(:solar_pv_meter, meter_serial_number: '10070839') }
+      context 'when no units field is specified for each row' do
+        before do
+          config.units_field = nil
+          config.expected_units = nil
+        end
 
-    it 'picks imports only, from every other column' do
-      readings = [
-        # ['MPAN,ReadingDate,ReadTime,MeterConsumption'],
-        ['10070831', '01/05/2023', '530', '0.001'],
-        ['10070831', '01/05/2023', '600', '0'],
-        ['10070831', '01/05/2023', '630', '0'],
-        ['10070831', '01/05/2023', '700', '0'],
-        ['10070831', '01/05/2023', '730', '11.1922'],
-        ['10070831', '01/05/2023', '800', '0'],
-        ['10070831', '01/05/2023', '830', '0'],
-        ['10070831', '01/05/2023', '900', '0'],
-        ['10070831', '01/05/2023', '930', '0'],
-        ['10070831', '01/05/2023', '1000', '0'],
-        ['10070831', '01/05/2023', '1030', '11.1922'],
-        ['10070831', '01/05/2023', '1100', '0'],
-        ['10070831', '01/05/2023', '1130', '0'],
-        ['10070831', '01/05/2023', '1200', '0'],
-        ['10070831', '01/05/2023', '1230', '0'],
-        ['10070831', '01/05/2023', '1300', '0'],
-        ['10070831', '01/05/2023', '1330', '0'],
-        ['10070831', '01/05/2023', '1400', '11.1922'],
-        ['10070831', '01/05/2023', '1430', '0'],
-        ['10070831', '01/05/2023', '1500', '0'],
-        ['10070831', '01/05/2023', '1530', '0'],
-        ['10070831', '01/05/2023', '1600', '0'],
-        ['10070831', '01/05/2023', '1630', '0'],
-        ['10070831', '01/05/2023', '1700', '11.1922'],
-        ['10070831', '01/05/2023', '1730', '0'],
-        ['10070831', '01/05/2023', '1800', '0'],
-        ['10070831', '01/05/2023', '1830', '0'],
-        ['10070831', '01/05/2023', '1900', '0'],
-        ['10070831', '01/05/2023', '1930', '0'],
-        ['10070831', '01/05/2023', '2000', '0'],
-        ['10070831', '01/05/2023', '2030', '11.1922'],
-        ['10070831', '01/05/2023', '2100', '0'],
-        ['10070831', '01/05/2023', '2130', '0'],
-        ['10070831', '01/05/2023', '2200', '0'],
-        ['10070831', '01/05/2023', '2230', '0'],
-        ['10070831', '01/05/2023', '2300', '11.1922'],
-        ['10070831', '01/05/2023', '2330', '0'],
-        ['10070831', '02/05/2023', '0', '0'],
-        ['10070831', '02/05/2023', '30', '0'],
-        ['10070831', '02/05/2023', '100', '0'],
-        ['10070831', '02/05/2023', '130', '0'],
-        ['10070831', '02/05/2023', '200', '0'],
-        ['10070831', '02/05/2023', '230', '0'],
-        ['10070831', '02/05/2023', '300', '11.1922'],
-        ['10070831', '02/05/2023', '330', '0'],
-        ['10070831', '02/05/2023', '400', '0'],
-        ['10070831', '02/05/2023', '430', '0'],
-        ['10070831', '02/05/2023', '500', '0'],
-        ['10070831', '02/05/2023', '530', '67.1534'],
-        ['10070831', '02/05/2023', '600', '190.268'],
-        ['10070831', '02/05/2023', '630', '179.076'],
-        ['10070831', '02/05/2023', '700', '123.114'],
-        ['10070831', '02/05/2023', '730', '111.922'],
-        ['10070831', '02/05/2023', '800', '111.922'],
-        ['10070831', '02/05/2023', '830', '111.922'],
-        ['10070831', '02/05/2023', '900', '100.73'],
-        ['10070831', '02/05/2023', '930', '111.922'],
-        ['10070831', '02/05/2023', '1000', '100.73'],
-        ['10070831', '02/05/2023', '1030', '111.922'],
-        ['10070831', '02/05/2023', '1100', '100.73'],
-        ['10070831', '02/05/2023', '1130', '100.73'],
-        ['10070831', '02/05/2023', '1200', '11.1922'],
-        ['10070831', '02/05/2023', '1230', '0'],
-        ['10070831', '02/05/2023', '1300', '0'],
-        ['10070831', '02/05/2023', '1330', '11.1922'],
-        ['10070831', '02/05/2023', '1400', '0'],
-        ['10070831', '02/05/2023', '1430', '0'],
-        ['10070831', '02/05/2023', '1500', '0'],
-        ['10070831', '02/05/2023', '1530', '0'],
-        ['10070831', '02/05/2023', '1600', '11.1922'],
-        ['10070831', '02/05/2023', '1630', '0'],
-        ['10070831', '02/05/2023', '1700', '0'],
-        ['10070831', '02/05/2023', '1730', '0'],
-        ['10070831', '02/05/2023', '1800', '0'],
-        ['10070831', '02/05/2023', '1830', '0'],
-        ['10070831', '02/05/2023', '1900', '0'],
-        ['10070831', '02/05/2023', '1930', '0'],
-        ['10070831', '02/05/2023', '2000', '11.1922'],
-        ['10070831', '02/05/2023', '2030', '0'],
-        ['10070831', '02/05/2023', '2100', '0'],
-        ['10070831', '02/05/2023', '2130', '0'],
-        ['10070831', '02/05/2023', '2200', '0'],
-        ['10070831', '02/05/2023', '2230', '0'],
-        ['10070831', '02/05/2023', '2300', '0'],
-        ['10070831', '02/05/2023', '2330', '11.1922']
-      ]
-      results = described_class.new(opus_gas_config, readings).perform
-
-      expect(results.size).to eq(85)
-
-      expect(results.first[:mpan_mprn]).to eq('10070831')
-      expect(results.first[:reading_date]).to eq('01/05/2023')
-      expect(results.first[:reading_time]).to eq('530')
-      expect(results.first[:readings]).to eq(['0.001'])
-
-      expect(results.last[:mpan_mprn]).to eq('10070831')
-      expect(results.last[:reading_date]).to eq('02/05/2023')
-      expect(results.last[:reading_time]).to eq('2330')
-      expect(results.last[:readings]).to eq(['11.1922'])
-    end
-  end
-
-  context 'for MyCorona feed' do
-    let(:mycorona_config) do
-      build(:amr_data_feed_config,
-            description: 'MyCorona portal',
-            date_format: '%d/%m/%Y',
-            mpan_mprn_field: 'Site Name',
-            reading_date_field: 'Read date',
-            reading_time_field: 'Time',
-            reading_fields: [' Actual (KWH)'],
-            header_example: 'Read date,Time,Site Name, Actual (KWH)',
-            row_per_reading: true,
-            positional_index: true)
-    end
-
-    let!(:meter_1) { create(:solar_pv_meter, meter_serial_number: '10070831') }
-    let!(:meter_2) { create(:solar_pv_meter, meter_serial_number: '10070839') }
-
-    it 'picks imports only, from every other column' do
-      half_hours = (0..23).map { |hour| [format('%02d:00', hour), format('%02d:30', hour)] }.flatten
-      readings = ['01/06/2023', '02/06/2023'].flat_map do |date|
-        half_hours.map.with_index do |time, i|
-          # ['Read date', 'Time', 'Site Name', ' Actual (KWH)']
-          [date, time, '10070831', "0.#{format('%03d', (i + 1))}"]
+        it 'converts all rows to kwh' do
+          readings = [reading]
+          results = described_class.new(config, readings).perform
+          expect(results.size).to eq(1)
+          expect(results.first[:readings].first).to eq(1.20800000 * 11.1)
         end
       end
 
-      results = described_class.new(mycorona_config, readings).perform
+      context 'when there are different units per row' do
+        it 'converts only specific m3 rows to kwh' do
+          # one row kwh, one row m3
+          readings = [reading, reading.dup.tap { |r| r[4] = 'm3' }]
+          results = described_class.new(config, readings).perform
+          expect(results.size).to eq(2)
 
-      expect(results.size).to eq(96)
+          expect(results.first[:units]).to eq('kwh')
+          expect(results.first[:readings].first).to eq('1.20800000')
 
-      expect(results.first[:mpan_mprn]).to eq('10070831')
-      expect(results.first[:reading_date]).to eq('01/06/2023')
-      expect(results.first[:reading_time]).to eq('00:00')
-      expect(results.first[:readings]).to eq(['0.001'])
-
-      expect(results.last[:mpan_mprn]).to eq('10070831')
-      expect(results.last[:reading_date]).to eq('02/06/2023')
-      expect(results.last[:reading_time]).to eq('23:30')
-      expect(results.last[:readings]).to eq(['0.048'])
-    end
-  end
-
-  context 'for EfT solar feed' do
-    let(:eft_config) do
-      build(:amr_data_feed_config,
-            description: 'EfT',
-            date_format: '%H:%M:%S %a %d/%m/%Y',
-            mpan_mprn_field: '',
-            units_field: 'units',
-            reading_date_field: 'DateTime',
-            reading_fields: reading_fields,
-            meter_description_field: 'Description',
-            header_example: "Description,SerialNumber,DateTime,import_total,export_total,#{reading_fields.join(',_,')}",
-            expected_units: '',
-            msn_field: 'SerialNumber',
-            lookup_by_serial_number: true)
-    end
-    let!(:meters) do
-      [create(:solar_pv_meter, meter_serial_number: '10070831'),
-       create(:solar_pv_meter, meter_serial_number: '10070839')]
-    end
-    let(:readings) do
-      [
-        ['10070831', '10070831', '00:13:07 Thu 07/04/2022', '83294159.417', '0',
-         '0.000000', '0.000000', '0.000000', '0.000000', '0.000000', '0.000000', '0.000000', '0.000000',
-         '0.000000', '0.000000', '0.000000', '0.000000', '0.000000', '0.000000', '0.000000', '0.000000',
-         '0.000000', '0.000000', '0.000000', '0.000000', '0.000000', '0.000000', '0.000000', '0.000000',
-         '0.121895', '0.000000', '0.399635', '0.000000', '0.756100', '0.000000', '1.137950', '0.000000',
-         '1.524650', '0.000000', '1.825500', '0.000000', '1.618100', '0.000000', '1.478200', '0.000000',
-         '2.088200', '0.000000', '2.045800', '0.000000', '2.190850', '0.000000', '2.860450', '0.000000',
-         '2.912200', '0.000000', '1.213350', '0.000000', '1.885650', '0.000000', '2.116800', '0.000000',
-         '1.517650', '0.000000', '1.855550', '0.000000', '1.435450', '0.000000', '1.340200', '0.000000',
-         '0.933100', '0.000000', '0.760450', '0.000000', '0.548250', '0.000000', '0.110745', '0.000000',
-         '0.035366', '0.000000', '0.000000', '0.000000', '0.000000', '0.000000', '0.000000', '0.000000',
-         '0.000000', '0.000000', '0.000000', '0.000000', '0.000000', '0.000000', '0.000000', '0.000000',
-         '0.000000', '0.000000', '0.000000', '0.000000', '0.000000', '0.000000', '0.000000', '0.000000'],
-        ['10070839', '10070839', '00:10:58 Thu 07/04/2022', '84079387.609', '0',
-         '0.000000', '0.000000', '0.000000', '0.000000', '0.000000', '0.000000', '0.000000', '0.000000',
-         '0.000000', '0.000000', '0.000000', '0.000000', '0.000000', '0.000000', '0.000000', '0.000000',
-         '0.000000', '0.000000', '0.000000', '0.000000', '0.000000', '0.000000', '0.066830', '0.000000',
-         '0.036760', '0.000000', '0.741800', '0.000000', '0.703950', '0.000000', '1.255700', '0.000000',
-         '2.213050', '0.000000', '2.983500', '0.000000', '2.985250', '0.000000', '3.140100', '0.000000',
-         '3.415300', '0.000000', '3.449850', '0.000000', '3.144750', '0.000000', '2.859600', '0.000000',
-         '2.685850', '0.000000', '3.200550', '0.000000', '2.425800', '0.000000', '2.163900', '0.000000',
-         '1.110500', '0.000000', '0.995000', '0.000000', '0.985400', '0.000000', '0.696800', '0.000000',
-         '0.343965', '0.000000', '0.430185', '0.000000', '0.340685', '0.000000', '0.215565', '0.000000',
-         '0.091900', '0.000000', '0.004118', '0.000000', '0.000000', '0.000000', '0.000000', '0.000000',
-         '0.000000', '0.000000', '0.000000', '0.000000', '0.000000', '0.000000', '0.000000', '0.000000',
-         '0.000000', '0.000000', '0.000000', '0.000000', '0.000000', '0.000000', '0.000000', '0.000000']
-      ]
+          expect(results.last[:units]).to eq('kwh')
+          expect(results.last[:readings].first).to eq(1.20800000 * 11.1)
+        end
+      end
     end
 
-    it 'picks imports only, from every other column' do
-      results = described_class.new(eft_config, readings).perform
-
-      expect(results.size).to eq(2)
-      expect(results.first[:readings].count).to eq(48)
-      expect(results.first[:meter_serial_number]).to eq('10070831')
-      expect(results.first[:readings][12]).to eq('0.121895')
-      expect(results.first[:readings][13]).to eq('0.399635')
-      expect(results.first[:readings][14]).to eq('0.756100')
-      expect(results.second[:readings].count).to eq(48)
-      expect(results.second[:meter_serial_number]).to eq('10070839')
-      expect(results.second[:readings][11]).to eq('0.066830')
-      expect(results.second[:readings][12]).to eq('0.036760')
-      expect(results.second[:readings][13]).to eq('0.741800')
-    end
-
-    it 'finds correct meter id and mpan from serial number' do
-      results = described_class.new(eft_config, readings).perform
-
-      expect(results.size).to eq(2)
-
-      expect(results.first[:meter_id]).to eq(meters[0].id)
-      expect(results.first[:mpan_mprn]).to eq(meters[0].mpan_mprn.to_s)
-      expect(results.first[:meter_serial_number]).to eq('10070831')
-
-      expect(results.second[:meter_id]).to eq(meters[1].id)
-      expect(results.second[:mpan_mprn]).to eq(meters[1].mpan_mprn.to_s)
-      expect(results.second[:meter_serial_number]).to eq('10070839')
-    end
-
-    it 'handles missing meter' do
-      readings[0][0] = readings[0][1] = '1234'
-      readings[1][0] = readings[1][1] = '5678'
-
-      results = described_class.new(eft_config, readings).perform
-
-      expect(results.size).to eq(2)
-
-      expect(results.first[:meter_id]).to be_nil
-      expect(results.first[:mpan_mprn]).to be_nil
-      expect(results.first[:meter_serial_number]).to eq('1234')
-
-      expect(results.second[:meter_id]).to be_nil
-      expect(results.second[:mpan_mprn]).to be_nil
-      expect(results.second[:meter_serial_number]).to eq('5678')
-    end
-
-    it 'raises error if duplicate serial numbers found' do
-      create(:solar_pv_meter, meter_serial_number: meters[0].meter_serial_number)
-      expect do
-        described_class.new(eft_config, [readings.first]).perform
-      end.to raise_error(Amr::DataFeedException)
-    end
-
-    it 'handles trailing whitespace on the meter serial' do
-      readings[0][1] = "#{readings[0][1]} "
-      results = described_class.new(eft_config, readings).perform
-      expect(results.first[:meter_serial_number]).to eq('10070831')
+    context 'when the config delayed readings' do
+      it 'reformats the dates'
     end
   end
 end

--- a/spec/system/admin/amr_uploaded_readings_spec.rb
+++ b/spec/system/admin/amr_uploaded_readings_spec.rb
@@ -91,6 +91,14 @@ describe AmrUploadedReading, type: :system do
         end
       end
     end
+
+    context 'with delayed reading config' do
+      let!(:config) { create(:amr_data_feed_config, delayed_reading: true, number_of_header_rows: 1) }
+
+      it 'explains this to user' do
+        expect(page).to have_content('this configuration will adjust the dates in the uploaded file backwards by 1 day')
+      end
+    end
   end
 
   describe 'normal file format' do


### PR DESCRIPTION
The passiv system for collecting solar data is only able to produce CSV files that contain a timestamp for the day the readings were _collected_ rather than when the energy was consumed. So the timestamps are always a day behind.

As they are unable to change this, this PR:

* Adds a new option to our data feed configs to flag that there are "delayed readings"
* Refactors the existing data feed translator spec to clarify what is currently being tested and just tidy up. The test names didn't really reflect what was being asserts in many cases
* Changes the data feed translator to reformat the dates to a day earlier so we end up with the correct dates in the database
* Adds a configuration for the Passiv format, which uses this setting
* Adds a warning on the upload page for admins about the odd date behaviour