### PR TITLE
Programme progress fix

### DIFF
--- a/app/models/programme.rb
+++ b/app/models/programme.rb
@@ -69,4 +69,12 @@ class Programme < ApplicationRecord
 
     self.observations.programme.first_or_create(at: self.ended_on, points: points_for_completion)
   end
+
+  def all_activities_complete?
+    # Completed programme if all activity types for the programme type are in the list of completed  activities
+    # (extra completed activities are ignored - activity types may have been removed from programme..)
+    programme_type_activity_ids = programme_type.activity_types.pluck(:id)
+    programme_activity_types = activity_types_completed.pluck(:id)
+    (programme_type_activity_ids - programme_activity_types).empty?
+  end
 end

--- a/app/models/programme_type.rb
+++ b/app/models/programme_type.rb
@@ -79,9 +79,9 @@ class ProgrammeType < ApplicationRecord
     end
   end
 
-  # provide a list of activity types a school has already completed this uear for this programme type
+  # provide a list of activity types a school has already completed this year for this programme type
   def activity_types_for_school(school)
-    activity_types.ids & school.activity_types_in_academic_year.pluck(:id)
+    activity_types & school.activity_types_in_academic_year
   end
 
   def self.tx_resources

--- a/app/models/programme_type.rb
+++ b/app/models/programme_type.rb
@@ -79,6 +79,7 @@ class ProgrammeType < ApplicationRecord
     end
   end
 
+  # provide a list of activity types a school has already completed this uear for this programme type
   def activity_types_for_school(school)
     activity_types.ids & school.activity_types_in_academic_year.pluck(:id)
   end

--- a/app/models/programme_type.rb
+++ b/app/models/programme_type.rb
@@ -79,6 +79,10 @@ class ProgrammeType < ApplicationRecord
     end
   end
 
+  def activity_types_for_school(school)
+    activity_types.ids & school.activity_types_in_academic_year.pluck(:id)
+  end
+
   def self.tx_resources
     active.order(:id)
   end

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -358,7 +358,7 @@ class School < ApplicationRecord
   end
 
   def suggested_programme_types
-    ProgrammeType.active.with_school_activity_count(self)
+    ProgrammeType.active.with_school_activity_type_count(self)
       .merge(activities.in_academic_year(current_academic_year))
       .not_in(programme_types)
   end

--- a/app/services/activity_creator.rb
+++ b/app/services/activity_creator.rb
@@ -21,7 +21,7 @@ class ActivityCreator
   def process_programmes
     started_active_programmes.each do |programme|
       add_programme_activity(programme)
-      programme.complete! if completed_programme?(programme)
+      programme.complete! if programme.all_activities_complete?
     end
   end
 

--- a/app/services/activity_creator.rb
+++ b/app/services/activity_creator.rb
@@ -70,12 +70,4 @@ class ActivityCreator
   def programme_activities(programme)
     programme.programme_activities.where(activity_type: @activity.activity_type)
   end
-
-  def completed_programme?(programme)
-    # Completed programme if all activity types for the programme type are in the list of completed  activities
-    # (extra completed activities are ignored - activity types may have been removed from programme..)
-    programme_type_activity_ids = programme.programme_type.activity_types.pluck(:id)
-    programme_activity_types = programme.activities.map(&:activity_type).pluck(:id)
-    (programme_type_activity_ids - programme_activity_types).empty?
-  end
 end

--- a/app/services/programmes/creator.rb
+++ b/app/services/programmes/creator.rb
@@ -24,6 +24,7 @@ module Programmes
           programme.programme_activities.create!(activity_type: programme_type_activity_type.activity_type, activity: activity)
         end
       end
+      programme.complete! if programme.all_activities_complete?
     end
 
     def latest_activity_this_academic_year(activity_type)

--- a/app/views/programme_types/_completed.html.erb
+++ b/app/views/programme_types/_completed.html.erb
@@ -1,11 +1,12 @@
 <div class="row">
-  <div class="col-md-9">
+  <div class="col-md-12">
     <div class="row alert info-bar text-dark bg-neutral" role="alert">
       <div class="col-md-1">
         <i class="fas fa-check fa-2x"></i>
       </div>
       <div class="col-md-8 align-self-center">
-        <%= t('programme_types.completed.you_completed_this_programme_on') %> <%= nice_dates(programme_type.programme_for_school(school).ended_on) %>
+        <%= t('programme_types.completed.you_completed_this_programme_on') %>
+        <%= nice_dates(programme_type.programme_for_school(school).ended_on) %>
       </div>
       <div class="col-md-3">
       </div>

--- a/app/views/programme_types/_prompt.html.erb
+++ b/app/views/programme_types/_prompt.html.erb
@@ -1,15 +1,29 @@
 <div class="row">
-  <div class="col-md-9">
+  <div class="col-md-12">
     <div class="row info-bar text-dark bg-neutral" role="alert">
       <div class="col-lg-1 d-none d-lg-block align-self-center">
         <i class="fas fa-play-circle fa-3x"></i>
       </div>
-      <div class="col-lg-7 col-sm-12 align-self-center">
-        <%= t('programme_types.prompt.you_can_enrol_your_school_in_this_programme') %>
-      </div>
-      <div class="col-lg-4 col-sm-12">
-        <%= link_to t('programme_types.prompt.start'), school_programmes_path(school, programme_type_id: programme_type), method: :post, class: 'btn btn-secondary' %>
-      </div>
+      <% if programme_type.all_activity_types_completed_for_school?(school) %>
+        <div class="col-lg-8 col-sm-12 align-self-center">
+          <%= t('programme_types.prompt.completed_message_html', count: programme_type.bonus_score) %>
+        </div>
+        <div class="col-lg-3 col-sm-12">
+          <%= link_to t('common.labels.complete'),
+                      school_programmes_path(school, programme_type_id: programme_type),
+                      method: :post, class: 'btn btn-secondary' %>
+        </div>
+      <% else %>
+        <div class="col-lg-8 col-sm-12 align-self-center">
+          <%= t('programme_types.prompt.message_html',
+                count: programme_type.activity_type_ids_for_school(school).length) %>
+        </div>
+        <div class="col-lg-3 col-sm-12">
+          <%= link_to t('common.labels.start'),
+                      school_programmes_path(school, programme_type_id: programme_type),
+                      method: :post, class: 'btn btn-secondary' %>
+        </div>
+      <% end %>
     </div>
   </div>
 </div>

--- a/app/views/programme_types/_prompt_login.html.erb
+++ b/app/views/programme_types/_prompt_login.html.erb
@@ -1,4 +1,4 @@
-<div class="col-md-9">
+<div class="col-md-12">
   <div class="row alert info-bar text-dark bg-light" role="alert">
     <div class="col-lg-1 d-none d-lg-block align-self-center">
       <i class="fas fa-play-circle fa-3x"></i>
@@ -7,7 +7,9 @@
       <%= t('programme_types.prompt_login.are_you_an_energy_sparks_user_html') %>
     </div>
     <div class="col-lg-4 col-sm-12">
-      <%= link_to t('programme_types.prompt_login.sign_in_now'), sign_in_and_redirect_path(url: programme_type_path(programme_type)), class: 'btn btn-primary' %>
+      <%= link_to t('programme_types.prompt_login.sign_in_now'),
+                  sign_in_and_redirect_path(url: programme_type_path(programme_type)),
+                  class: 'btn btn-primary' %>
     </div>
   </div>
 </div>

--- a/app/views/programme_types/_started.html.erb
+++ b/app/views/programme_types/_started.html.erb
@@ -1,11 +1,12 @@
 <div class="row">
-  <div class="col-md-9">
+  <div class="col-md-12">
     <div class="row alert info-bar text-dark bg-positive" role="alert">
       <div class="col-md-1">
         <i class="fas fa-check fa-2x"></i>
       </div>
       <div class="col-md-8 align-self-center">
-        <%= t('programme_types.started.you_started_this_programme_on') %> <%= nice_dates(programme_type.programme_for_school(school).started_on) %>
+        <%= t('programme_types.started.you_started_this_programme_on') %>
+        <%= nice_dates(programme_type.programme_for_school(school).started_on) %>
       </div>
       <div class="col-md-3">
       </div>

--- a/app/views/schools/_prompt_join_programme.html.erb
+++ b/app/views/schools/_prompt_join_programme.html.erb
@@ -1,11 +1,12 @@
 <% if school %>
   <% if programme_type = school.suggested_programme_types.first %>
     <%= component 'info_bar',
-        status: :neutral,
-        style: local_assigns[:style],
-        title: t("schools.prompts.join_programme.message_html", count: programme_type.activity_count, title: programme_type.title),
-        icon: fa_icon('tasks fa-3x'),
-        buttons: { t("common.labels.start") => programme_type_path(programme_type) }
-    %>
+                  status: :neutral,
+                  style: local_assigns[:style],
+                  title: t('schools.prompts.join_programme.message_html',
+                           count: programme_type.activity_types_for_school(school).length,
+                           title: programme_type.title),
+                  icon: fa_icon('tasks fa-3x'),
+                  buttons: { t('common.labels.start') => programme_type_path(programme_type) } %>
   <% end %>
 <% end %>

--- a/app/views/schools/_prompt_join_programme.html.erb
+++ b/app/views/schools/_prompt_join_programme.html.erb
@@ -1,12 +1,23 @@
 <% if school %>
   <% if programme_type = school.suggested_programme_types.first %>
-    <%= component 'info_bar',
-                  status: :neutral,
-                  style: local_assigns[:style],
-                  title: t('schools.prompts.join_programme.message_html',
-                           count: programme_type.activity_types_for_school(school).length,
-                           title: programme_type.title),
-                  icon: fa_icon('tasks fa-3x'),
-                  buttons: { t('common.labels.start') => programme_type_path(programme_type) } %>
+    <% if programme_type.activity_types.length == programme_type.activity_type_count %>
+      <%= component 'info_bar',
+                    status: :neutral,
+                    style: local_assigns[:style],
+                    title: t('schools.prompts.join_programme.completed_message_html',
+                             count: programme_type.bonus_score,
+                             title: programme_type.title),
+                    icon: fa_icon('tasks fa-3x'),
+                    buttons: { t('common.labels.complete') => programme_type_path(programme_type) } %>
+    <% else %>
+      <%= component 'info_bar',
+                    status: :neutral,
+                    style: local_assigns[:style],
+                    title: t('schools.prompts.join_programme.message_html',
+                             count: programme_type.activity_type_count,
+                             title: programme_type.title),
+                    icon: fa_icon('tasks fa-3x'),
+                    buttons: { t('common.labels.start') => programme_type_path(programme_type) } %>
+    <% end %>
   <% end %>
 <% end %>

--- a/config/locales/common.yml
+++ b/config/locales/common.yml
@@ -26,6 +26,7 @@ en:
       cancel: Cancel
       choose_activity: Choose activity
       close: Close
+      complete: Complete
       continue: Continue
       create: Create
       created: Created

--- a/config/locales/cy/views/programme_types/programme_types.yml
+++ b/config/locales/cy/views/programme_types/programme_types.yml
@@ -13,7 +13,6 @@ cy:
       introduction_2: Fel defnyddiwr Sbarcynni gallwch chi gofrestru ar unrhyw un o'n rhaglenni a chofnodi gweithgareddau i olrhain eich cynnydd a sgorio pwyntiau ar gyfer eich ysgol.
       page_title: Rhaglenni
       title: Ein Rhaglenni Arbed Ynni
-    prompt:
     prompt_login:
       are_you_an_energy_sparks_user_html: Ydych chi'n ddefnyddiwr Sbarcynni?<br>Mewngofnodwch a chofrestrwch eich ysgol ar y rhaglen hon, neu cofnodwch eich cynnydd diweddar
       sign_in_now: Mewngofnodi nawr

--- a/config/locales/cy/views/programme_types/programme_types.yml
+++ b/config/locales/cy/views/programme_types/programme_types.yml
@@ -14,7 +14,6 @@ cy:
       page_title: Rhaglenni
       title: Ein Rhaglenni Arbed Ynni
     prompt:
-      message_html:
     prompt_login:
       are_you_an_energy_sparks_user_html: Ydych chi'n ddefnyddiwr Sbarcynni?<br>Mewngofnodwch a chofrestrwch eich ysgol ar y rhaglen hon, neu cofnodwch eich cynnydd diweddar
       sign_in_now: Mewngofnodi nawr

--- a/config/locales/cy/views/programme_types/programme_types.yml
+++ b/config/locales/cy/views/programme_types/programme_types.yml
@@ -14,8 +14,7 @@ cy:
       page_title: Rhaglenni
       title: Ein Rhaglenni Arbed Ynni
     prompt:
-      start: Dechrau
-      you_can_enrol_your_school_in_this_programme: Gallwch chi gofrestru eich ysgol yn y rhaglen hon
+      message_html:
     prompt_login:
       are_you_an_energy_sparks_user_html: Ydych chi'n ddefnyddiwr Sbarcynni?<br>Mewngofnodwch a chofrestrwch eich ysgol ar y rhaglen hon, neu cofnodwch eich cynnydd diweddar
       sign_in_now: Mewngofnodi nawr

--- a/config/locales/views/programme_types/programme_types.yml
+++ b/config/locales/views/programme_types/programme_types.yml
@@ -15,6 +15,11 @@ en:
       page_title: Programmes
       title: Our Energy Saving Programmes
     prompt:
+      completed_message_html: You've completed all the activities in this programme. Mark it done to score <strong>%{count}</strong> bonus points?
+      message_html:
+        one: You've recently completed an activity that is part of this programme. Do you want to enroll in the programme?
+        other: You've recently completed %{count} activities that are part of this programme. Do you want to enroll in the programme?
+        zero: You can enrol your school in this programme
       start: Start
       you_can_enrol_your_school_in_this_programme: You can enrol your school in this programme
     prompt_login:

--- a/config/locales/views/programme_types/programme_types.yml
+++ b/config/locales/views/programme_types/programme_types.yml
@@ -16,6 +16,7 @@ en:
       title: Our Energy Saving Programmes
     prompt:
       completed_message_html:
+        one: You've completed all the activities in this programme. Mark it done to score <strong>%{count}</strong> bonus point?
         other: You've completed all the activities in this programme. Mark it done to score <strong>%{count}</strong> bonus points?
         zero: You've completed all the activities in this programme. Mark it as complete?
       message_html:

--- a/config/locales/views/programme_types/programme_types.yml
+++ b/config/locales/views/programme_types/programme_types.yml
@@ -20,8 +20,6 @@ en:
         one: You've recently completed an activity that is part of this programme. Do you want to enroll in the programme?
         other: You've recently completed %{count} activities that are part of this programme. Do you want to enroll in the programme?
         zero: You can enrol your school in this programme
-      start: Start
-      you_can_enrol_your_school_in_this_programme: You can enrol your school in this programme
     prompt_login:
       are_you_an_energy_sparks_user_html: Are you an Energy Sparks user?<br>Sign in and enrol your school in this programme, or record your recent progress
       sign_in_now: Sign in now

--- a/config/locales/views/programme_types/programme_types.yml
+++ b/config/locales/views/programme_types/programme_types.yml
@@ -19,8 +19,8 @@ en:
         other: You've completed all the activities in this programme. Mark it done to score <strong>%{count}</strong> bonus points?
         zero: You've completed all the activities in this programme. Mark it as complete?
       message_html:
-        one: You've recently completed an activity that is part of this programme. Do you want to enroll in the programme?
-        other: You've recently completed %{count} activities that are part of this programme. Do you want to enroll in the programme?
+        one: You've recently completed an activity that is part of this programme. Do you want to enrol in the programme?
+        other: You've recently completed %{count} activities that are part of this programme. Do you want to enrol in the programme?
         zero: You can enrol your school in this programme
     prompt_login:
       are_you_an_energy_sparks_user_html: Are you an Energy Sparks user?<br>Sign in and enrol your school in this programme, or record your recent progress

--- a/config/locales/views/programme_types/programme_types.yml
+++ b/config/locales/views/programme_types/programme_types.yml
@@ -15,7 +15,9 @@ en:
       page_title: Programmes
       title: Our Energy Saving Programmes
     prompt:
-      completed_message_html: You've completed all the activities in this programme. Mark it done to score <strong>%{count}</strong> bonus points?
+      completed_message_html:
+        other: You've completed all the activities in this programme. Mark it done to score <strong>%{count}</strong> bonus points?
+        zero: You've completed all the activities in this programme. Mark it as complete?
       message_html:
         one: You've recently completed an activity that is part of this programme. Do you want to enroll in the programme?
         other: You've recently completed %{count} activities that are part of this programme. Do you want to enroll in the programme?

--- a/config/locales/views/schools/schools.yml
+++ b/config/locales/views/schools/schools.yml
@@ -329,7 +329,9 @@ en:
           other: Well done, you've just completed the <strong>%{title}</strong> programme and have earned <strong>%{count}</strong> bonus points!
           zero: Well done, you've just completed the <strong>%{title}</strong> programme!
       join_programme:
-        completed_message_html: You've completed all the activities in the <strong>%{title}</strong> programme. Mark it done to score <strong>%{count}</strong> bonus points?
+        completed_message_html:
+          other: You've completed all the activities in the <strong>%{title}</strong> programme. Mark it done to score <strong>%{count}</strong> bonus points?
+          zero: You've completed all the activities in the <strong>%{title}</strong> programme. Mark it as commplete?
         message_html:
           one: You've recently completed an activity that is part of the <strong>%{title}</strong> programme. Do you want to enroll in the programme?
           other: You've recently completed %{count} activities that are part of the <strong>%{title}</strong> programme. Do you want to enroll in the programme?

--- a/config/locales/views/schools/schools.yml
+++ b/config/locales/views/schools/schools.yml
@@ -329,6 +329,7 @@ en:
           other: Well done, you've just completed the <strong>%{title}</strong> programme and have earned <strong>%{count}</strong> bonus points!
           zero: Well done, you've just completed the <strong>%{title}</strong> programme!
       join_programme:
+        completed_message_html: You've completed all the activities in the <strong>%{title}</strong> programme. Mark it done to score <strong>%{count}</strong> bonus points?
         message_html:
           one: You've recently completed an activity that is part of the <strong>%{title}</strong> programme. Do you want to enroll in the programme?
           other: You've recently completed %{count} activities that are part of the <strong>%{title}</strong> programme. Do you want to enroll in the programme?

--- a/config/locales/views/schools/schools.yml
+++ b/config/locales/views/schools/schools.yml
@@ -333,8 +333,8 @@ en:
           other: You've completed all the activities in the <strong>%{title}</strong> programme. Mark it done to score <strong>%{count}</strong> bonus points?
           zero: You've completed all the activities in the <strong>%{title}</strong> programme. Mark it as commplete?
         message_html:
-          one: You've recently completed an activity that is part of the <strong>%{title}</strong> programme. Do you want to enroll in the programme?
-          other: You've recently completed %{count} activities that are part of the <strong>%{title}</strong> programme. Do you want to enroll in the programme?
+          one: You've recently completed an activity that is part of the <strong>%{title}</strong> programme. Do you want to enrol in the programme?
+          other: You've recently completed %{count} activities that are part of the <strong>%{title}</strong> programme. Do you want to enrol in the programme?
       no_active_programmes:
         choose_programme: Choose programme
         message: Congratulations you've completed all your energy saving programmes! Time to choose your next programme

--- a/config/locales/views/schools/schools.yml
+++ b/config/locales/views/schools/schools.yml
@@ -331,7 +331,7 @@ en:
       join_programme:
         completed_message_html:
           other: You've completed all the activities in the <strong>%{title}</strong> programme. Mark it done to score <strong>%{count}</strong> bonus points?
-          zero: You've completed all the activities in the <strong>%{title}</strong> programme. Mark it as commplete?
+          zero: You've completed all the activities in the <strong>%{title}</strong> programme. Mark it as complete?
         message_html:
           one: You've recently completed an activity that is part of the <strong>%{title}</strong> programme. Do you want to enrol in the programme?
           other: You've recently completed %{count} activities that are part of the <strong>%{title}</strong> programme. Do you want to enrol in the programme?

--- a/config/locales/views/schools/schools.yml
+++ b/config/locales/views/schools/schools.yml
@@ -330,6 +330,7 @@ en:
           zero: Well done, you've just completed the <strong>%{title}</strong> programme!
       join_programme:
         completed_message_html:
+          one: You've completed all the activities in the <strong>%{title}</strong> programme. Mark it done to score <strong>%{count}</strong> bonus point?
           other: You've completed all the activities in the <strong>%{title}</strong> programme. Mark it done to score <strong>%{count}</strong> bonus points?
           zero: You've completed all the activities in the <strong>%{title}</strong> programme. Mark it as complete?
         message_html:

--- a/lib/tasks/deployment/20240624130949_complete_started_already_completed_programmes.rake
+++ b/lib/tasks/deployment/20240624130949_complete_started_already_completed_programmes.rake
@@ -1,0 +1,15 @@
+namespace :after_party do
+  desc 'Deployment task: complete_started_already_completed_programmes'
+  task complete_started_already_completed_programmes: :environment do
+    puts "Running deploy task 'complete_started_already_completed_programmes'"
+
+    Programme.started.each do |programme|
+      programme.complete! if programme.all_activities_complete?
+    end
+
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord
+      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+  end
+end

--- a/lib/tasks/deployment/20240624130949_complete_started_already_completed_programmes.rake
+++ b/lib/tasks/deployment/20240624130949_complete_started_already_completed_programmes.rake
@@ -4,7 +4,13 @@ namespace :after_party do
     puts "Running deploy task 'complete_started_already_completed_programmes'"
 
     Programme.started.each do |programme|
-      programme.complete! if programme.all_activities_complete?
+      if programme.all_activities_complete?
+        puts "Setting programme '#{programme.programme_type.title}' to complete for school: #{programme.school.name}"
+        programme.ended_on = programme.started_on
+        programme.status = :completed
+        programme.add_observation
+        programme.save!
+      end
     end
 
     # Update task as completed.  If you remove the line below, the task will

--- a/spec/models/programme_type_spec.rb
+++ b/spec/models/programme_type_spec.rb
@@ -40,13 +40,15 @@ RSpec.describe ProgrammeType, type: :model do
     end
   end
 
-  describe '#activity_types_for_school' do
+  describe '#activity_type_ids_for_school' do
     let!(:programme_type) { create(:programme_type_with_activity_types) }
     let!(:school) { create(:school) }
 
+    subject(:activity_type_ids_for_school) { programme_type.activity_type_ids_for_school(school) }
+
     context 'when no activities have been completed' do
       it 'is empty' do
-        expect(programme_type.activity_types_for_school(school)).to be_empty
+        expect(activity_type_ids_for_school).to be_empty
       end
     end
 
@@ -56,7 +58,7 @@ RSpec.describe ProgrammeType, type: :model do
       end
 
       it 'contains that activity type' do
-        expect(programme_type.activity_types_for_school(school)).to eq([programme_type.activity_types.first])
+        expect(activity_type_ids_for_school).to eq([programme_type.activity_types.first.id])
       end
     end
 
@@ -68,7 +70,7 @@ RSpec.describe ProgrammeType, type: :model do
       end
 
       it 'contains all completed activity types for programme type' do
-        expect(programme_type.activity_types_for_school(school)).to eq(programme_type.activity_types)
+        expect(activity_type_ids_for_school).to eq(programme_type.activity_types.ids)
       end
 
       context 'when an activity has been completed twice' do
@@ -77,8 +79,45 @@ RSpec.describe ProgrammeType, type: :model do
         end
 
         it 'contains all completed activity types for programme type' do
-          expect(programme_type.activity_types_for_school(school)).to eq(programme_type.activity_types)
+          expect(activity_type_ids_for_school).to eq(programme_type.activity_types.ids)
         end
+      end
+    end
+  end
+
+  describe '#all_activity_types_completed_for_school?' do
+    let!(:programme_type) { create(:programme_type_with_activity_types) }
+    let!(:school) { create(:school) }
+
+    subject(:all_activity_types_completed_for_school) { programme_type.all_activity_types_completed_for_school?(school) }
+
+    context 'when no activities have been completed' do
+      it { expect(all_activity_types_completed_for_school).to be false }
+    end
+
+    context 'when one activity has been completed' do
+      before do
+        create(:activity, school: school, activity_type: programme_type.activity_types.first, happened_on: Time.zone.now)
+      end
+
+      it { expect(all_activity_types_completed_for_school).to be false }
+    end
+
+    context 'when school has completed all activities in programme type' do
+      before do
+        programme_type.activity_types.each do |activity_type|
+          create(:activity, school: school, activity_type: activity_type, happened_on: Time.zone.now)
+        end
+      end
+
+      it { expect(all_activity_types_completed_for_school).to be true }
+
+      context 'when an activity has been completed twice' do
+        before do
+          create(:activity, school: school, activity_type: programme_type.activity_types.first, happened_on: Time.zone.now)
+        end
+
+        it { expect(all_activity_types_completed_for_school).to be true }
       end
     end
   end

--- a/spec/models/programme_type_spec.rb
+++ b/spec/models/programme_type_spec.rb
@@ -39,4 +39,47 @@ RSpec.describe ProgrammeType, type: :model do
       end
     end
   end
+
+  describe '#activity_types_for_school' do
+    let!(:programme_type) { create(:programme_type_with_activity_types) }
+    let!(:school) { create(:school) }
+
+    context 'when no activities have been completed' do
+      it 'is empty' do
+        expect(programme_type.activity_types_for_school(school)).to be_empty
+      end
+    end
+
+    context 'when one activity has been completed' do
+      before do
+        create(:activity, school: school, activity_type: programme_type.activity_types.first, happened_on: Time.zone.now)
+      end
+
+      it 'contains that activity type' do
+        expect(programme_type.activity_types_for_school(school)).to eq([programme_type.activity_types.first])
+      end
+    end
+
+    context 'when school has completed all activities in programme type' do
+      before do
+        programme_type.activity_types.each do |activity_type|
+          create(:activity, school: school, activity_type: activity_type, happened_on: Time.zone.now)
+        end
+      end
+
+      it 'contains all completed activity types for programme type' do
+        expect(programme_type.activity_types_for_school(school)).to eq(programme_type.activity_types)
+      end
+
+      context 'when an activity has been completed twice' do
+        before do
+          create(:activity, school: school, activity_type: programme_type.activity_types.first, happened_on: Time.zone.now)
+        end
+
+        it 'contains all completed activity types for programme type' do
+          expect(programme_type.activity_types_for_school(school)).to eq(programme_type.activity_types)
+        end
+      end
+    end
+  end
 end

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -685,8 +685,8 @@ describe School do
       it { expect(programme_types).to include(programme_type_1) }
       it { expect(programme_types.length).to be(1) }
 
-      it 'includes a count of activities completed in programme' do
-        expect(programme_types.first.activity_count).to be(2)
+      it 'includes a count of activity_types completed in programme' do
+        expect(programme_types.first.activity_type_count).to be(2)
       end
 
       context 'when school is already subscribed to programme type' do
@@ -714,8 +714,20 @@ describe School do
       end
 
       it 'includes activity counts' do
-        expect(programme_types.first.activity_count).to be(2)
-        expect(programme_types.second.activity_count).to be(1)
+        expect(programme_types.first.activity_type_count).to be(2)
+        expect(programme_types.second.activity_type_count).to be(1)
+      end
+    end
+
+    context 'when school has completed the same activity several times' do
+      before do
+        create_activity(programme_type_1.activity_types.first)
+        create_activity(programme_type_1.activity_types.first)
+        create_activity(programme_type_1.activity_types.first)
+      end
+
+      it 'includes a counts the activity types once' do
+        expect(programme_types.first.activity_type_count).to be(1)
       end
     end
 

--- a/spec/services/activity_creator_spec.rb
+++ b/spec/services/activity_creator_spec.rb
@@ -114,6 +114,8 @@ describe ActivityCreator do
       activity = build(:activity, activity_type: activity_type, school: school)
       ActivityCreator.new(activity).process
 
+      programme.reload
+
       expect(programme.activities.count).to eq 1
       expect(programme.activities).to include(activity)
     end

--- a/spec/services/programmes/creator_spec.rb
+++ b/spec/services/programmes/creator_spec.rb
@@ -89,13 +89,11 @@ describe Programmes::Creator do
     end
 
     context 'when school has completed all activities in programme this year' do
-      let!(:activities) do
+      before do
         programme_type.activity_types.each do |activity_type|
           create(:activity, school: school, activity_type: activity_type, happened_on: Time.zone.now)
         end
-      end
 
-      before do
         service.create
       end
 

--- a/spec/services/programmes/creator_spec.rb
+++ b/spec/services/programmes/creator_spec.rb
@@ -61,6 +61,10 @@ describe Programmes::Creator do
         expect(programme.activities.any?).to be true
         expect(programme.activities.first).to eq activity
       end
+
+      it 'has a status of started' do
+        expect(programme).to be_started
+      end
     end
 
     context 'when school has multiple activities' do
@@ -77,6 +81,30 @@ describe Programmes::Creator do
       it 'recognises the most recent' do
         expect(programme.programme_activities.count).to be 1
         expect(programme.activities.first).to eq activities.first
+      end
+
+      it 'has a status of started' do
+        expect(programme).to be_started
+      end
+    end
+
+    context 'when school has completed all activities in programme this year' do
+      let!(:activities) do
+        programme_type.activity_types.each do |activity_type|
+          create(:activity, school: school, activity_type: activity_type, happened_on: Time.zone.now)
+        end
+      end
+
+      before do
+        service.create
+      end
+
+      it 'adds programme activity for each type' do
+        expect(programme.programme_activities.count).to eq(programme_type.activity_types.count)
+      end
+
+      it 'marks programme as completed' do
+        expect(programme).to be_completed
       end
     end
 

--- a/spec/support/shared_examples/prompts.rb
+++ b/spec/support/shared_examples/prompts.rb
@@ -31,8 +31,25 @@ RSpec.shared_examples 'a complete programme prompt' do |displayed: true, with_pr
   include_examples 'a standard prompt', displayed: displayed
 end
 
-RSpec.shared_examples 'a join programme prompt' do |displayed: true, programme:, activity_count:|
-  let(:message) { "You've recently completed #{activity_count == 1 ? 'an activity that is' : "#{activity_count} activities that are"} part of the #{programme} programme. Do you want to enroll in the programme?" }
+RSpec.shared_examples 'a join programme prompt' do |displayed: true, programme:, activity_count: nil, completed: false|
+  let(:incomplete) { "You've recently completed #{activity_count == 1 ? 'an activity that is' : "#{activity_count} activities that are"} part of the #{programme} programme. Do you want to enrol in the programme?" }
+  let(:complete) do
+    message = "You've completed all the activities in the <strong>%{title}</strong> programme. "
+    if programme.bonus_points == 0
+      message += 'Mark it as complete?'
+    else
+      message += "Mark it done to score #{programme.bonus_points} bonus points?"
+    end
+    message
+  end
+
+  let(:message) do
+    if completed
+      complete
+    else
+      incomplete
+    end
+  end
 
   include_examples 'a standard prompt', displayed: displayed
 end

--- a/spec/support/shared_examples/prompts.rb
+++ b/spec/support/shared_examples/prompts.rb
@@ -31,14 +31,14 @@ RSpec.shared_examples 'a complete programme prompt' do |displayed: true, with_pr
   include_examples 'a standard prompt', displayed: displayed
 end
 
-RSpec.shared_examples 'a join programme prompt' do |displayed: true, programme:, activity_count: nil, completed: false|
+RSpec.shared_examples 'a join programme prompt' do |displayed: true, programme:, activity_count: nil, bonus_points: nil, completed: false|
   let(:incomplete) { "You've recently completed #{activity_count == 1 ? 'an activity that is' : "#{activity_count} activities that are"} part of the #{programme} programme. Do you want to enrol in the programme?" }
   let(:complete) do
-    message = "You've completed all the activities in the <strong>%{title}</strong> programme. "
-    if programme.bonus_points == 0
+    message = "You've completed all the activities in the #{programme} programme. "
+    if bonus_points == 0
       message += 'Mark it as complete?'
     else
-      message += "Mark it done to score #{programme.bonus_points} bonus points?"
+      message += "Mark it done to score #{bonus_points} bonus points?"
     end
     message
   end

--- a/spec/system/programme_type_spec.rb
+++ b/spec/system/programme_type_spec.rb
@@ -56,6 +56,17 @@ RSpec.describe 'programme types', type: :system, include_application_helper: tru
       it { expect(page).to have_link('Start') }
     end
 
+    context 'when user has several activities' do
+      before do
+        create(:activity, school: school, activity_type: programme.activity_types.first, happened_on: Date.yesterday)
+        create(:activity, school: school, activity_type: programme.activity_types.second, happened_on: Date.yesterday)
+        click_on programme.title
+      end
+
+      it { expect(page).to have_content("You've recently completed 2 activities that are part of this programme. Do you want to enrol in the programme?") }
+      it { expect(page).to have_link('Start') }
+    end
+
     context 'when user has completed all activities' do
       before do
         programme.activity_types.each do |activity_type|

--- a/spec/system/programme_type_spec.rb
+++ b/spec/system/programme_type_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe 'programme types', type: :system, include_application_helper: tru
         click_on programme.title
       end
 
-      it { expect(page).to have_content("You've recently completed an activity that is part of this programme. Do you want to enroll in the programme?") }
+      it { expect(page).to have_content("You've recently completed an activity that is part of this programme. Do you want to enrol in the programme?") }
       it { expect(page).to have_link('Start') }
     end
 

--- a/spec/system/programme_type_spec.rb
+++ b/spec/system/programme_type_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe 'programme types', type: :system, include_application_helper: tru
     end
   end
 
-  shared_examples 'a user that has not yet enrolled to a programme' do
+  shared_examples 'a user that has not yet enrolled in a programme' do
     let!(:programme) { programme_4 }
 
     context 'user has not completed any activities' do
@@ -231,6 +231,7 @@ RSpec.describe 'programme types', type: :system, include_application_helper: tru
 
     it_behaves_like 'a no active programmes prompt'
     it_behaves_like 'a user enrolling in a programme'
+    it_behaves_like 'a user that has not yet enrolled in a programme'
     it_behaves_like 'a user that is enrolled in a programme'
   end
 
@@ -242,7 +243,7 @@ RSpec.describe 'programme types', type: :system, include_application_helper: tru
 
     it_behaves_like 'a no active programmes prompt'
     it_behaves_like 'a user enrolling in a programme'
-    it_behaves_like 'a user that has not yet enrolled to a programme'
+    it_behaves_like 'a user that has not yet enrolled in a programme'
     it_behaves_like 'a user that is enrolled in a programme'
   end
 end

--- a/spec/system/programme_type_spec.rb
+++ b/spec/system/programme_type_spec.rb
@@ -8,6 +8,8 @@ RSpec.describe 'programme types', type: :system, include_application_helper: tru
   let!(:programme_type_1) { create(:programme_type_with_activity_types)}
   let!(:programme_type_2) { create(:programme_type, active: false)}
   let!(:programme_type_3) { create(:programme_type)}
+  let(:bonus_points) { 10 }
+  let!(:programme_4) { create(:programme_type_with_activity_types, bonus_score: bonus_points)}
 
   shared_examples 'a user enrolling in a programme' do
     before do
@@ -29,6 +31,48 @@ RSpec.describe 'programme types', type: :system, include_application_helper: tru
       end.to change(Programme, :count).from(0).to(1)
       expect(page).to have_content('You started this programme')
       expect(school.reload.programmes).not_to be_empty
+    end
+  end
+
+  shared_examples 'a user that has not yet enrolled to a programme' do
+    let!(:programme) { programme_4 }
+
+    context 'user has not completed any activities' do
+      before do
+        click_on programme.title
+      end
+
+      it { expect(page).to have_content('You can enrol your school in this programme') }
+      it { expect(page).to have_link('Start') }
+    end
+
+    context 'when user has completed one activity' do
+      before do
+        create(:activity, school: school, activity_type: programme.activity_types.first, happened_on: Date.yesterday)
+        click_on programme.title
+      end
+
+      it { expect(page).to have_content("You've recently completed an activity that is part of this programme. Do you want to enroll in the programme?") }
+      it { expect(page).to have_link('Start') }
+    end
+
+    context 'when user has completed all activities' do
+      before do
+        programme.activity_types.each do |activity_type|
+          create(:activity, school: school, activity_type: activity_type, happened_on: Date.yesterday)
+        end
+        click_on programme.title
+      end
+
+      it { expect(page).to have_content("You've completed all the activities in this programme. Mark it done to score 10 bonus points?") }
+      it { expect(page).to have_link('Complete') }
+
+      context 'when programme has no bonus points' do
+        let(:bonus_points) { 0 }
+
+        it { expect(page).to have_content("You've completed all the activities in this programme. Mark it as complete?") }
+        it { expect(page).to have_link('Complete') }
+      end
     end
   end
 
@@ -142,7 +186,7 @@ RSpec.describe 'programme types', type: :system, include_application_helper: tru
         expect(page).not_to have_css('i.fa-circle.text-success')
       end
 
-      it 'doesnt prompt to start' do
+      it 'does not prompt to start' do
         expect(page).not_to have_content('You can enrol your school in this programme')
       end
 
@@ -187,6 +231,7 @@ RSpec.describe 'programme types', type: :system, include_application_helper: tru
 
     it_behaves_like 'a no active programmes prompt'
     it_behaves_like 'a user enrolling in a programme'
+    it_behaves_like 'a user that has not yet enrolled to a programme'
     it_behaves_like 'a user that is enrolled in a programme'
   end
 end

--- a/spec/system/schools/recommendations_spec.rb
+++ b/spec/system/schools/recommendations_spec.rb
@@ -85,6 +85,16 @@ describe 'Recommendations Page', type: :system, include_application_helper: true
 
         it_behaves_like 'a join programme prompt', programme: 'Programme A', activity_count: 2
       end
+
+      context 'when all programme activities have been completed' do
+        let(:setup_data) do
+          programme_type.activity_types.each do |activity_type|
+            school.activities.create!(activity_type: activity_type, activity_category: activity_type.activity_category, happened_on: Time.zone.now)
+          end
+        end
+
+        it_behaves_like 'a join programme prompt', programme: 'Programme A', completed: true
+      end
     end
 
     context 'audit prompt' do

--- a/spec/system/schools/recommendations_spec.rb
+++ b/spec/system/schools/recommendations_spec.rb
@@ -67,7 +67,8 @@ describe 'Recommendations Page', type: :system, include_application_helper: true
     end
 
     context 'join programme prompt' do
-      let(:programme_type) { create(:programme_type_with_activity_types, title: 'Programme A') }
+      let(:bonus_points) { 14 }
+      let(:programme_type) { create(:programme_type_with_activity_types, title: 'Programme A', bonus_score: bonus_points) }
 
       context 'when one programme activity has been completed' do
         let(:activity_type) { programme_type.activity_types.first }
@@ -93,7 +94,13 @@ describe 'Recommendations Page', type: :system, include_application_helper: true
           end
         end
 
-        it_behaves_like 'a join programme prompt', programme: 'Programme A', completed: true
+        it_behaves_like 'a join programme prompt', programme: 'Programme A', completed: true, bonus_points: 14
+
+        context 'when there are no bonus points' do
+          let(:bonus_points) { 0 }
+
+          it_behaves_like 'a join programme prompt', programme: 'Programme A', completed: true, bonus_points: 0
+        end
       end
     end
 


### PR DESCRIPTION


New functionality has meant we encourage users to start programmes where a user has already completed activity types that are part of it. Something we'd not thought of is that a user might start a programme having already completed all activity types within a programme, meaning the activity is effectively complete immediately after starting it.

On production, someone had done this - all activities in a programme were marked as complete but the programme wasn't flagged as completed. This is because the programme creator didn't take this into account when starting a programme. This code fixes this. 

When I was working on this I also spotted an issue with the join programmes prompt. It was saying (on my local machine):

"You've recently completed 14 activities that are part of the Beat your baseload programme. Do you want to enroll in the programme?"

When there are only 7 activity types in the programme.

This is because it was counting completed activities and not activity types.

This fixes that now too.

---

Additional work on prompts based on feedback:

- Changes join programme prompt to recognise programmes where all activities are already complete and changes button
- Changes prompt on top of programme page to also recognise this, in addition to programmes that are partially complete
- Also restructure programme view page slightly as the HTML was out. It's slightly better now but not perfect. This can be addressed in the redesign.