### PR TITLE
Add new Energy Assets/Corona format and time format

### DIFF
--- a/app/controllers/admin/amr_uploaded_readings_controller.rb
+++ b/app/controllers/admin/amr_uploaded_readings_controller.rb
@@ -31,8 +31,6 @@ module Admin
         render :new
       end
     rescue => e
-      puts e
-      puts e.backtrace
       Rollbar.error(e)
       @errors = ["Error: #{e.message}"]
       @amr_uploaded_reading = AmrUploadedReading.new(amr_data_feed_config: @amr_data_feed_config)

--- a/app/controllers/admin/amr_uploaded_readings_controller.rb
+++ b/app/controllers/admin/amr_uploaded_readings_controller.rb
@@ -31,6 +31,8 @@ module Admin
         render :new
       end
     rescue => e
+      puts e
+      puts e.backtrace
       Rollbar.error(e)
       @errors = ["Error: #{e.message}"]
       @amr_uploaded_reading = AmrUploadedReading.new(amr_data_feed_config: @amr_data_feed_config)

--- a/app/services/amr/single_read_converter.rb
+++ b/app/services/amr/single_read_converter.rb
@@ -80,7 +80,7 @@ module Amr
     def self.valid_time_string?(time_string)
       return false unless time_string.is_a?(String)
       # Regex matches time formats with and without leading zero (e.g. '1:30' & '01:30') from '0:00' to '23:59'
-      time_string.match?(/^([0-1]?[0-9]|2[0-3]):[0-5][0-9]$/)
+      time_string.match?(/^([0-1]?[0-9]|2[0-3]):[0-5][0-9](:00)?$/)
     end
 
     private

--- a/app/services/amr/single_read_converter.rb
+++ b/app/services/amr/single_read_converter.rb
@@ -80,6 +80,7 @@ module Amr
     def self.valid_time_string?(time_string)
       return false unless time_string.is_a?(String)
       # Regex matches time formats with and without leading zero (e.g. '1:30' & '01:30') from '0:00' to '23:59'
+      # As well as with optional secs, e.g. '00:30:00'
       time_string.match?(/^([0-1]?[0-9]|2[0-3]):[0-5][0-9](:00)?$/)
     end
 

--- a/lib/tasks/deployment/20240627154223_energy_assets_corona_format.rake
+++ b/lib/tasks/deployment/20240627154223_energy_assets_corona_format.rake
@@ -1,0 +1,27 @@
+namespace :after_party do
+  desc 'Deployment task: energy_assets_corona_format'
+  task energy_assets_corona_format: :environment do
+    puts "Running deploy task 'energy_assets_corona_format'"
+
+    identifier = 'energy-assets-corona'
+    AmrDataFeedConfig.create!({
+      identifier: identifier,
+      description: 'Energy Assets Corona',
+      notes: 'New format for the GDST daily gas data',
+      number_of_header_rows: 1,
+      row_per_reading: true,
+      mpan_mprn_field: 'MPRN',
+      reading_date_field: 'Date',
+      date_format: '%d/%m/%Y',
+      reading_time_field: 'Time',
+      positional_index: true,
+      header_example: 'MPRN,Date,Time,Meter Units,Meter Start Read,Consumption,KWH',
+      reading_fields: 'KWH'.split(",")
+    }) unless AmrDataFeedConfig.find_by_identifier(identifier)
+
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord
+      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+  end
+end

--- a/spec/services/amr/single_read_converter_spec.rb
+++ b/spec/services/amr/single_read_converter_spec.rb
@@ -647,6 +647,7 @@ module Amr
         valid_reading_times.each do |time_string|
           expect(Amr::SingleReadConverter).to be_valid_time_string(time_string)
         end
+        expect(Amr::SingleReadConverter).to be_valid_time_string('00:30:00')
       end
 
       it 'returns false if a time string is not in a format valid and usable by TimeOfDay parse' do


### PR DESCRIPTION
Data format has changed for gas data for one of the largest groups.

The PR adds a new data feed config for the format. It uses a row per reading style with separate date and time columns.

The time format is currently rejected by our loader, so have had to tweak that to ensure its accepted