### PR TITLE
Filter schools shown on school group recent usage tab and downloads by user permissions

### DIFF
--- a/app/controllers/school_groups_controller.rb
+++ b/app/controllers/school_groups_controller.rb
@@ -15,9 +15,7 @@ class SchoolGroupsController < ApplicationController
   def show
     if can?(:compare, @school_group)
       respond_to do |format|
-        format.html do
-          render 'recent_usage'
-        end
+        format.html {}
         format.csv do
           send_data SchoolGroups::RecentUsageCsvGenerator.new(school_group: @school_group, include_cluster: include_cluster).export,
           filename: csv_filename_for('recent_usage')

--- a/app/controllers/school_groups_controller.rb
+++ b/app/controllers/school_groups_controller.rb
@@ -18,7 +18,11 @@ class SchoolGroupsController < ApplicationController
       respond_to do |format|
         format.html {}
         format.csv do
-          send_data SchoolGroups::RecentUsageCsvGenerator.new(school_group: @school_group, include_cluster: include_cluster).export,
+          send_data SchoolGroups::RecentUsageCsvGenerator.new(
+            school_group: @school_group,
+            schools: @schools,
+            include_cluster: include_cluster
+          ).export,
           filename: csv_filename_for('recent_usage')
         end
       end

--- a/app/controllers/school_groups_controller.rb
+++ b/app/controllers/school_groups_controller.rb
@@ -3,7 +3,8 @@ class SchoolGroupsController < ApplicationController
   include Promptable
   include Scoring
 
-  before_action :find_school_group
+  load_resource
+
   before_action :redirect_unless_authorised, only: [:comparisons, :priority_actions, :current_scores]
   before_action :find_schools_and_partners
   before_action :build_breadcrumbs
@@ -124,7 +125,8 @@ class SchoolGroupsController < ApplicationController
   end
 
   def find_schools_and_partners
-    @schools = @school_group.schools.visible.by_name
+    # Rely on CanCan to filter the list of schools to those that can be shown to the current user
+    @schools = @school_group.schools.accessible_by(current_ability, :show).by_name
     @partners = @school_group.partners
   end
 

--- a/app/services/school_groups/recent_usage_csv_generator.rb
+++ b/app/services/school_groups/recent_usage_csv_generator.rb
@@ -3,15 +3,16 @@ module SchoolGroups
     METRIC_HEADERS = [:change, :usage, :cost, :co2].freeze
     METRICS = [:change, :usage, :cost_text, :co2].freeze
 
-    def initialize(school_group:, include_cluster: false)
+    def initialize(school_group:, schools: school_group.schools.visible, include_cluster: false)
       @school_group = school_group
+      @schools = schools
       @include_cluster = include_cluster
     end
 
     def export
       CSV.generate(headers: true) do |csv|
         csv << headers
-        @school_group.schools.visible.order(:name).each do |school|
+        @schools.order(:name).each do |school|
           recent_usage = school&.recent_usage
           row = []
           row << school.name

--- a/app/views/school_groups/show.html.erb
+++ b/app/views/school_groups/show.html.erb
@@ -13,17 +13,19 @@
     <div class="d-flex justify-content-between">
       <%= form_with url: school_group_path(@school_group), method: :get do |f| %>
         <div>
-          <label class="mr-2"><%= t("school_groups.show.change_units") %>:</label>
-          <% ['change', 'usage', 'cost', 'co2'].each do |metric| %>
+          <label class="mr-2"><%= t('school_groups.show.change_units') %>:</label>
+          <% %w[change usage cost co2].each do |metric| %>
             <div class="form-check form-check-inline">
-              <%= f.radio_button :metric, metric, onclick: 'this.form.submit();', class: 'form-check-input', checked: radio_button_checked_for(metric) %>
+              <%= f.radio_button :metric, metric, onclick: 'this.form.submit();', class: 'form-check-input',
+                                                  checked: radio_button_checked_for(metric) %>
               <%= f.label :metric, t("school_groups.show.metric.#{metric}"), value: metric, class: 'form-check-label' %>
             </div>
           <% end %>
         </div>
       <% end %>
       <div>
-        <%= link_to t('school_groups.download_as_csv'), school_group_path(@school_group, format: :csv), class: 'btn btn-sm btn-outline-dark rounded-pill font-weight-bold' %>
+        <%= link_to t('school_groups.download_as_csv'), school_group_path(@school_group, format: :csv),
+                    class: 'btn btn-sm btn-outline-dark rounded-pill font-weight-bold' %>
       </div>
     </div>
 
@@ -35,13 +37,19 @@
             <th></th>
           <% end %>
           <% if @fuel_types.include?(:electricity) %>
-            <th colspan="2" class="text-center"><%= fa_icon fuel_type_icon(:electricity) %> <%= t('common.electricity') %></th>
+            <th colspan="2" class="text-center">
+              <%= fa_icon fuel_type_icon(:electricity) %> <%= t('common.electricity') %>
+            </th>
           <% end %>
           <% if @fuel_types.include?(:gas) %>
-            <th colspan="2" class="text-center"><%= fa_icon fuel_type_icon(:gas) %> <%= t('common.gas') %></th>
+            <th colspan="2" class="text-center">
+              <%= fa_icon fuel_type_icon(:gas) %> <%= t('common.gas') %>
+            </th>
           <% end %>
           <% if @fuel_types.include?(:storage_heaters) %>
-            <th colspan="2" class="text-center"><%= fa_icon fuel_type_icon(:storage_heaters) %> <%= t('common.storage_heaters') %></th>
+            <th colspan="2" class="text-center">
+              <%= fa_icon fuel_type_icon(:storage_heaters) %> <%= t('common.storage_heaters') %>
+            </th>
           <% end %>
         </tr>
         <tr>
@@ -134,7 +142,7 @@
                 <% end %>
               <% end %>
             <% else %>
-              <% (@fuel_types.reject{|f| f == :solar_pv}.length * 2).times do %>
+              <% (@fuel_types.reject { |f| f == :solar_pv }.length * 2).times do %>
                 <td class="text-right" data-order="'0'">-</td>
               <% end %>
             <% end %>

--- a/app/views/school_groups/show.html.erb
+++ b/app/views/school_groups/show.html.erb
@@ -72,7 +72,7 @@
         </tr>
       </thead>
       <tbody>
-        <% @school_group.schools.visible.order(:name).each do |school| %>
+        <% @schools.order(:name).each do |school| %>
           <tr>
             <td>
               <%= link_to school.name, school_path(school) %>

--- a/spec/services/school_groups/recent_usage_csv_generator_spec.rb
+++ b/spec/services/school_groups/recent_usage_csv_generator_spec.rb
@@ -2,8 +2,8 @@ require 'rails_helper'
 
 RSpec.describe SchoolGroups::RecentUsageCsvGenerator do
   let(:school_group) { create(:school_group) }
-  let!(:school_1)    { create(:school, school_group: school_group, number_of_pupils: 10, floor_area: nil, data_enabled: true, visible: true, active: true, name: 'A school') }
-  let!(:school_2)    { create(:school, school_group: school_group, number_of_pupils: 20, floor_area: 300.0, data_enabled: true, visible: true, active: true, name: 'B school') }
+  let!(:school_1)    { create(:school, school_group: school_group, number_of_pupils: 10, floor_area: nil, name: 'A school') }
+  let!(:school_2)    { create(:school, school_group: school_group, number_of_pupils: 20, floor_area: 300.0, name: 'B school') }
   let!(:cluster)     { create(:school_group_cluster, name: 'A Cluster', school_group: school_group, schools: [school_1]) }
 
   include_context 'school group recent usage'
@@ -26,7 +26,7 @@ RSpec.describe SchoolGroups::RecentUsageCsvGenerator do
   subject(:csv) { SchoolGroups::RecentUsageCsvGenerator.new(**params).export }
 
   context 'returning data' do
-    it 'returns data as a csv for all schools in a school group' do
+    it 'returns data as a csv for all requested schools in the school group' do
       expect(csv.lines.count).to eq(3)
 
       fuel_type_columns = []

--- a/spec/support/shared_examples/school_groups.rb
+++ b/spec/support/shared_examples/school_groups.rb
@@ -400,3 +400,47 @@ RSpec.shared_examples 'school group tabs not showing the cluster column' do
     it_behaves_like 'a page not showing the cluster column in the download'
   end
 end
+
+RSpec.shared_examples 'a page with a recent usage table' do
+  it 'has correct table header' do
+    within '.advice-table' do
+      expect(page).to have_content('Electricity')
+      expect(page).to have_content('Gas')
+      expect(page).to have_content('Storage heaters')
+      expect(page).to have_content('School')
+      expect(page).to have_content('Last week')
+      expect(page).to have_content('Last year')
+    end
+  end
+end
+
+RSpec.shared_examples 'schools are filtered by permissions' do |admin: false, school_admin: false|
+  let(:data_sharing) { :within_group }
+  let!(:filtered_school) { create(:school, school_group: school_group, data_sharing: data_sharing)}
+
+  before do
+    visit school_group_path(school_group)
+  end
+
+  context 'with data sharing set to within_group' do
+    it 'does not show the school', unless: admin || school_admin do
+      expect(page).not_to have_content(filtered_school.name)
+    end
+
+    it 'shows all the schools', if: admin || school_admin do
+      expect(page).to have_content(filtered_school.name)
+    end
+  end
+
+  context 'with data sharing set to private' do
+    let(:data_sharing) { :private }
+
+    it 'does not show the school', unless: admin do
+      expect(page).not_to have_content(filtered_school.name)
+    end
+
+    it 'shows all the schools', if: admin do
+      expect(page).to have_content(filtered_school.name)
+    end
+  end
+end

--- a/spec/system/school_groups_spec.rb
+++ b/spec/system/school_groups_spec.rb
@@ -1,14 +1,13 @@
 require 'rails_helper'
 
 describe 'school groups', :school_groups, type: :system do
+  let!(:school_group) { create(:school_group, public: public, default_template_calendar: create(:template_calendar, :with_previous_and_next_academic_years)) }
   let(:public) { true }
-  let!(:template_calendar) { create :template_calendar, :with_previous_and_next_academic_years }
-  let!(:school_group)          { create(:school_group, public: public, default_template_calendar: template_calendar) }
 
   let!(:user)                  { create(:user) }
 
-  let!(:school_1)              { create(:school, school_group: school_group, number_of_pupils: 10, floor_area: 200.0, data_enabled: true, visible: true, active: true) }
-  let!(:school_2)              { create(:school, school_group: school_group, number_of_pupils: 20, floor_area: 300.0, data_enabled: true, visible: true, active: true) }
+  let!(:school_1)              { create(:school, school_group: school_group, number_of_pupils: 10, floor_area: 200.0) }
+  let!(:school_2)              { create(:school, school_group: school_group, number_of_pupils: 20, floor_area: 300.0) }
 
   before do
     allow_any_instance_of(SchoolGroup).to receive(:fuel_types).and_return([:electricity, :gas, :storage_heaters])
@@ -17,23 +16,20 @@ describe 'school groups', :school_groups, type: :system do
   end
 
   context 'when not logged in' do
-    context 'when school group is public' do
+    context 'with a public school group' do
       let(:public) { true }
 
       it_behaves_like 'a public school group dashboard'
       it_behaves_like 'school group no dashboard notification'
       it_behaves_like 'shows the we are working with message'
 
-      describe 'chart updates' do
-        it 'shows a form to select default chart units' do
-          visit school_group_chart_updates_path(school_group)
-          expect(page).to have_current_path('/users/sign_in', ignore_query: true)
-        end
+      it 'prompts for login when visiting chart updates' do
+        visit school_group_chart_updates_path(school_group)
+        expect(page).to have_current_path('/users/sign_in', ignore_query: true)
       end
 
-      context 'does not show the sub navigation menu' do
-        it_behaves_like 'does not show the sub navigation menu'
-      end
+      it_behaves_like 'does not show the sub navigation menu'
+      it_behaves_like 'schools are filtered by permissions'
 
       describe 'showing recent usage tab' do
         include_context 'school group recent usage'
@@ -47,107 +43,98 @@ describe 'school groups', :school_groups, type: :system do
           let(:breadcrumb)    { 'Group Dashboard' }
         end
 
+        it 'shows intro text' do
+          expect(page).to have_content('A summary of the recent energy usage across schools in this group.')
+        end
+
         it_behaves_like 'a page not showing the cluster column'
+        it_behaves_like 'a page with a recent usage table'
 
-        describe 'changes in metrics params' do
-          it 'shows intro text' do
-            expect(page).to have_content('A summary of the recent energy usage across schools in this group.')
+        it 'shows expected default table content' do
+          visit school_group_path(school_group, {})
+          expect(page).to have_content(school_1.name)
+          expect(page).to have_content(school_2.name)
+          expect(page).to have_content('-16%')
+          expect(page).not_to have_content('910')
+          expect(page).not_to have_content('£137')
+          expect(page).not_to have_content('8,540')
+        end
+
+        describe 'when switching between metrics' do
+          let(:metric) { 'change' }
+
+          before do
+            visit school_group_path(school_group, metric: metric)
           end
 
-          it 'shows expected table content for change when there are no metrics params' do
-            visit school_group_path(school_group, {})
-            expect(page).to have_content('Electricity')
-            expect(page).to have_content('Gas')
-            expect(page).to have_content('Storage heaters')
-            expect(page).to have_content('School')
-            expect(page).to have_content('Last week')
-            expect(page).to have_content('Last year')
-            expect(page).to have_content(school_1.name)
-            expect(page).to have_content(school_2.name)
-            expect(page).to have_content('-16%')
-            expect(page).not_to have_content('910')
-            expect(page).not_to have_content('£137')
-            expect(page).not_to have_content('8,540')
+          context 'with an invalid parameter' do
+            let(:metric) { 'something invalid' }
+
+            it_behaves_like 'a page with a recent usage table'
+            it 'shows defaults to % when param is invalid' do
+              expect(page).to have_content(school_1.name)
+              expect(page).to have_content(school_2.name)
+              expect(page).to have_content('-16%')
+              expect(page).not_to have_content('910')
+              expect(page).not_to have_content('£137')
+              expect(page).not_to have_content('8,540')
+            end
           end
 
-          it 'shows expected table content for change when there is an invalid metrics params' do
-            visit school_group_path(school_group, metric: 'something invalid')
-            expect(page).to have_content('Electricity')
-            expect(page).to have_content('Gas')
-            expect(page).to have_content('Storage heaters')
-            expect(page).to have_content('School')
-            expect(page).to have_content('Last week')
-            expect(page).to have_content('Last year')
-            expect(page).to have_content(school_1.name)
-            expect(page).to have_content(school_2.name)
-            expect(page).to have_content('-16%')
-            expect(page).not_to have_content('910')
-            expect(page).not_to have_content('£137')
-            expect(page).not_to have_content('8,540')
+          context 'when % is requested' do
+            let(:metric) { 'change' }
+
+            it_behaves_like 'a page with a recent usage table'
+            it 'shows the right data' do
+              expect(page).to have_content(school_1.name)
+              expect(page).to have_content(school_2.name)
+              expect(page).to have_content('-16%')
+              expect(page).not_to have_content('910')
+              expect(page).not_to have_content('£137')
+              expect(page).not_to have_content('8,540')
+            end
           end
 
-          it 'shows expected table content for change when there are metrics params for change' do
-            visit school_group_path(school_group, metrics: 'change')
-            expect(page).to have_content('Electricity')
-            expect(page).to have_content('Gas')
-            expect(page).to have_content('Storage heaters')
-            expect(page).to have_content('School')
-            expect(page).to have_content('Last week')
-            expect(page).to have_content('Last year')
-            expect(page).to have_content(school_1.name)
-            expect(page).to have_content(school_2.name)
-            expect(page).to have_content('-16%')
-            expect(page).not_to have_content('910')
-            expect(page).not_to have_content('£137')
-            expect(page).not_to have_content('8,540')
+          context 'when usage is requested' do
+            let(:metric) { 'usage' }
+
+            it_behaves_like 'a page with a recent usage table'
+            it 'shows the right data' do
+              expect(page).to have_content(school_1.name)
+              expect(page).to have_content(school_2.name)
+              expect(page).not_to have_content('-16%')
+              expect(page).to have_content('910')
+              expect(page).not_to have_content('£137')
+              expect(page).not_to have_content('8,540')
+            end
           end
 
-          it 'shows expected table content for usage when there are metrics params for usage' do
-            visit school_group_path(school_group, metric: 'usage')
-            expect(page).to have_content('Electricity')
-            expect(page).to have_content('Gas')
-            expect(page).to have_content('Storage heaters')
-            expect(page).to have_content('School')
-            expect(page).to have_content('Last week')
-            expect(page).to have_content('Last year')
-            expect(page).to have_content(school_1.name)
-            expect(page).to have_content(school_2.name)
-            expect(page).not_to have_content('-16%')
-            expect(page).to have_content('910')
-            expect(page).not_to have_content('£137')
-            expect(page).not_to have_content('8,540')
+          context 'when cost is requested' do
+            let(:metric) { 'cost' }
+
+            it_behaves_like 'a page with a recent usage table'
+            it 'shows the right data' do
+              expect(page).to have_content(school_1.name)
+              expect(page).to have_content(school_2.name)
+              expect(page).not_to have_content('-16%')
+              expect(page).not_to have_content('910')
+              expect(page).to have_content('£137')
+              expect(page).not_to have_content('8,540')
+            end
           end
 
-          it 'shows expected table content for cost when there are metrics params for cost' do
-            visit school_group_path(school_group, metric: 'cost')
-            expect(page).to have_content('Electricity')
-            expect(page).to have_content('Gas')
-            expect(page).to have_content('Storage heaters')
-            expect(page).to have_content('School')
-            expect(page).to have_content('Last week')
-            expect(page).to have_content('Last year')
-            expect(page).to have_content(school_1.name)
-            expect(page).to have_content(school_2.name)
-            expect(page).not_to have_content('-16%')
-            expect(page).not_to have_content('910')
-            expect(page).to have_content('£137')
-            expect(page).not_to have_content('8,540')
-          end
+          context 'when co2 is requested' do
+            let(:metric) { 'co2' }
 
-          it 'shows expected table content for co2 when there are metrics params for co2' do
-            visit school_group_path(school_group, metric: 'co2')
-            expect(page).to have_content('Electricity')
-            expect(page).to have_content('Gas')
-            expect(page).to have_content('Storage heaters')
-            expect(page).to have_content('School')
-            expect(page).to have_content('Last week')
-            expect(page).to have_content('Last year')
-            expect(page).to have_content(school_1.name)
-            expect(page).to have_content(school_2.name)
-            expect(page).not_to have_content('-16%')
-            expect(page).not_to have_content('910')
-            expect(page).not_to have_content('£137')
-            expect(page).to have_content('8,540')
+            it_behaves_like 'a page with a recent usage table'
+            it 'shows the right data' do
+              expect(page).to have_content(school_1.name)
+              expect(page).to have_content(school_2.name)
+              expect(page).not_to have_content('-16%')
+              expect(page).not_to have_content('910')
+              expect(page).not_to have_content('£137')
+              expect(page).to have_content('8,540')
+            end
           end
 
           it 'allows a csv download of recent data metrics' do
@@ -399,7 +386,7 @@ describe 'school groups', :school_groups, type: :system do
       end
     end
 
-    context 'when school group is private' do
+    context 'with a private school group' do
       let(:public) { false }
 
       it_behaves_like 'a private school group dashboard'
@@ -420,20 +407,22 @@ describe 'school groups', :school_groups, type: :system do
       it_behaves_like 'does not show the sub navigation menu'
     end
 
-    context 'when school group is public' do
+    context 'with a public school group' do
       let(:public) { true }
 
       it_behaves_like 'a public school group dashboard'
       it_behaves_like 'school group dashboard notification'
       it_behaves_like 'visiting chart updates redirects to group page'
+      it_behaves_like 'schools are filtered by permissions', school_admin: true
     end
 
-    context 'when school group is private' do
+    context 'with a private school group' do
       let(:public) { false }
 
       it_behaves_like 'a public school group dashboard'
       it_behaves_like 'school group dashboard notification'
       it_behaves_like 'visiting chart updates redirects to group page'
+      it_behaves_like 'schools are filtered by permissions', school_admin: true
     end
 
     it_behaves_like 'school group tabs not showing the cluster column'
@@ -450,15 +439,16 @@ describe 'school groups', :school_groups, type: :system do
       it_behaves_like 'does not show the sub navigation menu'
     end
 
-    context 'when school group is public' do
+    context 'with a public school group' do
       let(:public) { true }
 
       it_behaves_like 'a public school group dashboard'
       it_behaves_like 'school group no dashboard notification'
       it_behaves_like 'visiting chart updates redirects to group page'
+      it_behaves_like 'schools are filtered by permissions'
     end
 
-    context 'when school group is private' do
+    context 'with a private school group' do
       let(:public) { false }
 
       it_behaves_like 'a private school group dashboard'
@@ -503,16 +493,18 @@ describe 'school groups', :school_groups, type: :system do
       it_behaves_like 'school group dashboard notification'
     end
 
-    context 'when school group is public' do
+    context 'with a public school group' do
       let(:public) { true }
 
       it_behaves_like 'a public school group dashboard'
+      it_behaves_like 'schools are filtered by permissions', admin: true
     end
 
-    context 'when school group is private' do
+    context 'with a private school group' do
       let(:public) { false }
 
       it_behaves_like 'a public school group dashboard'
+      it_behaves_like 'schools are filtered by permissions', admin: true
     end
 
     it_behaves_like 'school group tabs showing the cluster column'
@@ -552,24 +544,25 @@ describe 'school groups', :school_groups, type: :system do
       it_behaves_like 'school group dashboard notification'
     end
 
-    context 'when school group is public' do
+    context 'with a public school group' do
       let(:public) { true }
 
       it_behaves_like 'a public school group dashboard'
+      it_behaves_like 'schools are filtered by permissions', admin: true
     end
 
-    context 'when school group is private' do
+    context 'with a private school group' do
       let(:public) { false }
 
       it_behaves_like 'a public school group dashboard'
+      it_behaves_like 'schools are filtered by permissions', admin: true
     end
 
     it_behaves_like 'school group tabs showing the cluster column'
   end
 
   context 'when logged in as a group admin for a different group' do
-    let!(:school_group_2)     { create(:school_group, public: false) }
-    let!(:user)               { create(:group_admin, school_group: school_group_2) }
+    let!(:user) { create(:group_admin, school_group: create(:school_group)) }
 
     before do
       sign_in(user)
@@ -581,15 +574,16 @@ describe 'school groups', :school_groups, type: :system do
       it_behaves_like 'does not show the sub navigation menu'
     end
 
-    context 'when school group is public' do
+    context 'with a public school group' do
       let(:public) { true }
 
       it_behaves_like 'a public school group dashboard'
       it_behaves_like 'school group no dashboard notification'
       it_behaves_like 'visiting chart updates redirects to group page'
+      it_behaves_like 'schools are filtered by permissions', admin: false
     end
 
-    context 'when school group is private' do
+    context 'with a private school group' do
       let(:public) { false }
 
       it_behaves_like 'a private school group dashboard'


### PR DESCRIPTION
Currently we are showing all visible schools to everyone that can access the group. Using the new access control settings we should only be showing the schools that are visible to that user. User should also only be able to download CSV file with same list of schools.

* [x] Update controller and template to use list of schools in group loaded schools using CanCan `accessible_by`
* [x] Add specs to confirm that list of schools is filtered on page for all user types and visibility settings
* [x] Ensure CSV downloads of recent usage are also filtered