### PR TITLE
Check for national scoreboard position

### DIFF
--- a/app/components/podium_component/podium_component.html.erb
+++ b/app/components/podium_component/podium_component.html.erb
@@ -1,12 +1,19 @@
 <div<%= " id=#{id}" if id %> class="podium-component<%= classes %>">
   <% if podium.includes_school? && podium.school_has_points? %>
     <h4 class="text-center">
-      <%= t('components.podium.full_position_html',
-            position_ordinal: podium.school_position.ordinal,
-            scoreboard: podium.scoreboard.name,
-            scoreboard_path: scoreboard_path(podium.scoreboard),
-            national_position_ordinal: national_podium.school_position.ordinal,
-            national_scoreboard_path: scoreboard_path(national_podium.scoreboard)) %>.
+      <% if national_podium.school_position %>
+        <%= t('components.podium.full_position_html',
+              position_ordinal: podium.school_position.ordinal,
+              scoreboard: podium.scoreboard.name,
+              scoreboard_path: scoreboard_path(podium.scoreboard),
+              national_position_ordinal: national_podium.school_position.ordinal,
+              national_scoreboard_path: scoreboard_path(national_podium.scoreboard)) %>.
+      <% else %>
+        <%= t('components.podium.scoreboard_position_html',
+              position_ordinal: podium.school_position.ordinal,
+              scoreboard: podium.scoreboard.name,
+              scoreboard_path: scoreboard_path(podium.scoreboard)) %>.
+        <% end %>
       </h4>
   <% else %>
     <h4 class="text-center"><%= t('components.podium.no_points_this_year') %></h4>

--- a/config/locales/views/components/podium.yml
+++ b/config/locales/views/components/podium.yml
@@ -7,3 +7,4 @@ en:
       no_points_this_year: Your school hasn't scored any points yet this school year
       points: points
       points_needed_to_overtake: You only need to score %{points} points to overtake the next school!
+      scoreboard_position_html: You are in <strong>%{position_ordinal} place</strong> on the <a href='%{scoreboard_path}'>%{scoreboard} scoreboard</a>


### PR DESCRIPTION
The national scoreboard runs between 1st Sept to 30th June. 

This means when recording activities between 1st July and 31st August, if a school has not recorded any activities in the that time period, then they will not have a position on the national scoreboard. 

This causes an error. As a fix for this I've removed the message about national ranking from the podium.