### PR TITLE
Fix current target progress

### DIFF
--- a/app/controllers/schools/school_targets/progress_controller.rb
+++ b/app/controllers/schools/school_targets/progress_controller.rb
@@ -78,7 +78,6 @@ module Schools
       def render_school_target_expired
         @progress = @school_target.saved_progress_report_for(@fuel_type)
         @latest_progress = latest_progress
-        final_month_index = @progress.months.find_index(final_month) || 11
         @reporting_months = reporting_months(@progress)
         render :expired
       end

--- a/app/controllers/schools/school_targets/progress_controller.rb
+++ b/app/controllers/schools/school_targets/progress_controller.rb
@@ -93,7 +93,7 @@ module Schools
           final_month = @school_target.target_date.prev_month.beginning_of_month
           @progress.cumulative_performance[final_month]
         else
-          @progress.current_cumulative_performance_versus_synthetic_last_year
+          @progress.current_cumulative_performance
         end
       end
 

--- a/app/controllers/schools/school_targets/progress_controller.rb
+++ b/app/controllers/schools/school_targets/progress_controller.rb
@@ -56,9 +56,7 @@ module Schools
           @recent_data = service.recent_data?
           @progress = service.progress
           @latest_progress = latest_progress
-          # the analytics can return a report with >12 months
-          # but we only want to report on a year at a time
-          @reporting_months = @progress.months[0..11]
+          @reporting_months = reporting_months(@progress)
           @suggest_estimate_important = suggest_estimate_for_fuel_type?(@fuel_type, check_data: true)
           @debug_content = service.analytics_debug_info if current_user.present? && current_user.analytics?
         rescue => e
@@ -80,9 +78,8 @@ module Schools
       def render_school_target_expired
         @progress = @school_target.saved_progress_report_for(@fuel_type)
         @latest_progress = latest_progress
-        # the analytics can return a report with >12 months
-        # but we only want to report on a year at a time
-        @reporting_months = @progress.months[0..11]
+        final_month_index = @progress.months.find_index(final_month) || 11
+        @reporting_months = reporting_months(@progress)
         render :expired
       end
 
@@ -90,11 +87,28 @@ module Schools
       # latest current progress
       def latest_progress
         if @school_target.expired?
-          final_month = @school_target.target_date.prev_month.beginning_of_month
           @progress.cumulative_performance[final_month]
         else
           @progress.current_cumulative_performance
         end
+      end
+
+      # The analytics can return a report with >12 months of data in it.
+      # e.g. if we've been continuining to generate a report for an expired target
+      # So we only want the first 12 months
+      #
+      # But a school might have had limited data at the start of its target period, e.g. if they
+      # had less than a year. So we might not have a full 12 months of progress
+      #
+      # So restrict the months reported on in the table to those that include the months up to
+      # the final month without assuming there's 12
+      def reporting_months(progress)
+        final_month_index = progress.months.find_index(final_month) || 11
+        progress.months[0..final_month_index]
+      end
+
+      def final_month
+        @school_target.target_date.prev_month.beginning_of_month
       end
 
       def bad_estimate?(type)

--- a/app/controllers/schools/school_targets/progress_controller.rb
+++ b/app/controllers/schools/school_targets/progress_controller.rb
@@ -93,7 +93,7 @@ module Schools
       end
 
       # The analytics can return a report with >12 months of data in it.
-      # e.g. if we've been continuining to generate a report for an expired target
+      # e.g. if we've been continuing to generate a report for an expired target
       # So we only want the first 12 months
       #
       # But a school might have had limited data at the start of its target period, e.g. if they

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -531,7 +531,7 @@ class School < ApplicationRecord
   end
 
   def has_expired_target_for_fuel_type?(fuel_type)
-    has_expired_target? && expired_target.try(fuel_type).present?
+    has_expired_target? && expired_target.try(fuel_type).present? && expired_target.saved_progress_report_for(fuel_type).present?
   end
 
   def has_expired_target?

--- a/app/services/targets/generate_progress_service.rb
+++ b/app/services/targets/generate_progress_service.rb
@@ -9,7 +9,7 @@ module Targets
 
     def cumulative_progress(fuel_type)
       target_progress = progress_report(fuel_type)
-      target_progress.present? ? fetch_latest_figures(target_progress.cumulative_performance_versus_synthetic_last_year) : nil
+      target_progress.present? ? fetch_latest_figures(target_progress.cumulative_performance) : nil
     end
 
     def current_monthly_target(fuel_type)

--- a/spec/factories/school_targets.rb
+++ b/spec/factories/school_targets.rb
@@ -18,7 +18,7 @@ FactoryBot.define do
 
       after(:build) do |target, evaluator|
         report = {
-          'fuel_type': 'electricity',
+          'fuel_type': evaluator.fuel_type.to_s,
           'months': ['2024-01-01'],
           'monthly_targets_kwh': [],
           'monthly_usage_kwh': [],

--- a/spec/factories/school_targets.rb
+++ b/spec/factories/school_targets.rb
@@ -10,5 +10,30 @@ FactoryBot.define do
     electricity_progress { {} }
     gas_progress { {} }
     storage_heaters_progress { {} }
+
+    trait :with_progress_report do
+      transient do
+        fuel_type { :electricity }
+      end
+
+      after(:build) do |target, evaluator|
+        report = {
+          'fuel_type': 'electricity',
+          'months': ['2024-01-01'],
+          'monthly_targets_kwh': [],
+          'monthly_usage_kwh': [],
+          'monthly_performance': [],
+          'cumulative_targets_kwh': [],
+          'cumulative_usage_kwh': [],
+          'cumulative_performance': [],
+          'cumulative_performance_versus_synthetic_last_year': [],
+          'monthly_performance_versus_synthetic_last_year': [],
+          'partial_months': [],
+          'percentage_synthetic': []
+        }
+        target["#{evaluator.fuel_type}_report"] = report
+        target
+      end
+    end
   end
 end

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -480,7 +480,23 @@ describe School do
           target.update!(electricity: 5)
         end
 
-        let!(:expired_target) { create(:school_target, start_date: Date.yesterday.prev_year, school: subject, electricity: 5, gas: nil) }
+        let!(:expired_target) do
+          report = {
+            'fuel_type': 'electricity',
+            'months': ['2024-01-01'],
+            'monthly_targets_kwh': [],
+            'monthly_usage_kwh': [],
+            'monthly_performance': [],
+            'cumulative_targets_kwh': [],
+            'cumulative_usage_kwh': [],
+            'cumulative_performance': [],
+            'cumulative_performance_versus_synthetic_last_year': [],
+            'monthly_performance_versus_synthetic_last_year': [],
+            'partial_months': [],
+            'percentage_synthetic': []
+          }
+          create(:school_target, :with_progress_report, start_date: Date.yesterday.prev_year, school: subject, electricity: 5, gas: nil)
+        end
 
         it { expect(subject.has_expired_target_for_fuel_type?(:electricity)).to be true }
         it { expect(subject.has_expired_target_for_fuel_type?(:gas)).to be false }

--- a/spec/models/school_target_spec.rb
+++ b/spec/models/school_target_spec.rb
@@ -141,7 +141,7 @@ RSpec.describe SchoolTarget, type: :model do
         cumulative_targets_kwh: cumulative_targets_kwh,
         cumulative_usage_kwh: cumulative_usage_kwh,
         cumulative_performance: cumulative_performance,
-        cumulative_performance_versus_synthetic_last_year: cumulative_performance,
+        cumulative_performance_versus_synthetic_last_year: nil,
         monthly_performance_versus_synthetic_last_year: monthly_performance,
         partial_months: partial_months,
         percentage_synthetic: percentage_synthetic

--- a/spec/models/school_target_spec.rb
+++ b/spec/models/school_target_spec.rb
@@ -142,7 +142,6 @@ RSpec.describe SchoolTarget, type: :model do
         cumulative_usage_kwh: cumulative_usage_kwh,
         cumulative_performance: cumulative_performance,
         cumulative_performance_versus_synthetic_last_year: nil,
-        monthly_performance_versus_synthetic_last_year: monthly_performance,
         partial_months: partial_months,
         percentage_synthetic: percentage_synthetic
       )
@@ -166,8 +165,6 @@ RSpec.describe SchoolTarget, type: :model do
       expect(report.cumulative_targets_kwh).to eql(progress.cumulative_targets_kwh)
       expect(report.cumulative_usage_kwh).to eql(progress.cumulative_usage_kwh)
       expect(report.cumulative_performance).to eql(progress.cumulative_performance)
-      expect(report.cumulative_performance_versus_synthetic_last_year).to eql(progress.cumulative_performance_versus_synthetic_last_year)
-      expect(report.monthly_performance_versus_synthetic_last_year).to eql(progress.monthly_performance_versus_synthetic_last_year)
       expect(report.partial_months).to eql(progress.partial_months)
       expect(report.percentage_synthetic).to eql(progress.percentage_synthetic)
     end

--- a/spec/models/school_target_spec.rb
+++ b/spec/models/school_target_spec.rb
@@ -141,7 +141,8 @@ RSpec.describe SchoolTarget, type: :model do
         cumulative_targets_kwh: cumulative_targets_kwh,
         cumulative_usage_kwh: cumulative_usage_kwh,
         cumulative_performance: cumulative_performance,
-        cumulative_performance_versus_synthetic_last_year: nil,
+        cumulative_performance_versus_synthetic_last_year: [],
+        monthly_performance_versus_synthetic_last_year: [],
         partial_months: partial_months,
         percentage_synthetic: percentage_synthetic
       )

--- a/spec/services/targets/generate_progress_service_spec.rb
+++ b/spec/services/targets/generate_progress_service_spec.rb
@@ -33,7 +33,7 @@ describe Targets::GenerateProgressService do
       cumulative_targets_kwh: cumulative_targets_kwh,
       cumulative_usage_kwh: cumulative_usage_kwh,
       cumulative_performance: cumulative_performance,
-      cumulative_performance_versus_synthetic_last_year: cumulative_performance,
+      cumulative_performance_versus_synthetic_last_year: nil,
       monthly_performance_versus_synthetic_last_year: monthly_performance,
       partial_months: partial_months,
       percentage_synthetic: percentage_synthetic

--- a/spec/services/targets/generate_progress_service_spec.rb
+++ b/spec/services/targets/generate_progress_service_spec.rb
@@ -33,8 +33,8 @@ describe Targets::GenerateProgressService do
       cumulative_targets_kwh: cumulative_targets_kwh,
       cumulative_usage_kwh: cumulative_usage_kwh,
       cumulative_performance: cumulative_performance,
-      cumulative_performance_versus_synthetic_last_year: nil,
-      monthly_performance_versus_synthetic_last_year: monthly_performance,
+      cumulative_performance_versus_synthetic_last_year: [],
+      monthly_performance_versus_synthetic_last_year: [],
       partial_months: partial_months,
       percentage_synthetic: percentage_synthetic
     )

--- a/spec/system/schools/progress_spec.rb
+++ b/spec/system/schools/progress_spec.rb
@@ -35,8 +35,8 @@ describe 'target progress report', type: :system do
       cumulative_targets_kwh: cumulative_targets_kwh,
       cumulative_usage_kwh: cumulative_usage_kwh,
       cumulative_performance: cumulative_performance,
-      cumulative_performance_versus_synthetic_last_year: nil,
-      monthly_performance_versus_synthetic_last_year: monthly_performance,
+      cumulative_performance_versus_synthetic_last_year: [],
+      monthly_performance_versus_synthetic_last_year: [],
       partial_months: partial_months,
       percentage_synthetic: percentage_synthetic
     )

--- a/spec/system/schools/progress_spec.rb
+++ b/spec/system/schools/progress_spec.rb
@@ -98,7 +98,9 @@ describe 'target progress report', type: :system do
 
       context 'with a link to the expired target report' do
         context 'and an expired target for the same fuel' do
-          let!(:expired_target) { create(:school_target, school: school, start_date: Date.yesterday.prev_year, target_date: Date.yesterday, electricity: 1) }
+          let!(:expired_target) do
+            create(:school_target, :with_progress_report, school: school, start_date: Date.yesterday.prev_year, target_date: Date.yesterday, electricity: 1)
+          end
 
           before { refresh }
 

--- a/spec/system/schools/progress_spec.rb
+++ b/spec/system/schools/progress_spec.rb
@@ -35,7 +35,7 @@ describe 'target progress report', type: :system do
       cumulative_targets_kwh: cumulative_targets_kwh,
       cumulative_usage_kwh: cumulative_usage_kwh,
       cumulative_performance: cumulative_performance,
-      cumulative_performance_versus_synthetic_last_year: cumulative_performance,
+      cumulative_performance_versus_synthetic_last_year: nil,
       monthly_performance_versus_synthetic_last_year: monthly_performance,
       partial_months: partial_months,
       percentage_synthetic: percentage_synthetic


### PR DESCRIPTION
This PR fixes three issues with the current and expired target reports:

- ensures that we're using the right time series for reporting overall progress
- adds an extra check to whether we display a link to the previous years expired target, as we may have only had limited data last year and so there's nothing to actually display in that report
- revises how we decide which months to report on to ensure we only show up to 12 months of data

As most of the tests already cover the general rendering behaviour in most cases I've just tweaked the data setup to ensure only the right time series is available.