### PR TITLE
School group visibility fix

### DIFF
--- a/app/controllers/school_groups_controller.rb
+++ b/app/controllers/school_groups_controller.rb
@@ -132,7 +132,7 @@ class SchoolGroupsController < ApplicationController
 
   def find_schools_and_partners
     # Rely on CanCan to filter the list of schools to those that can be shown to the current user
-    @schools = @school_group.schools.accessible_by(current_ability, :show).by_name
+    @schools = @school_group.schools.active.accessible_by(current_ability, :show).by_name
     @partners = @school_group.partners
   end
 

--- a/app/controllers/schools/school_targets/progress_controller.rb
+++ b/app/controllers/schools/school_targets/progress_controller.rb
@@ -93,7 +93,7 @@ module Schools
           final_month = @school_target.target_date.prev_month.beginning_of_month
           @progress.cumulative_performance[final_month]
         else
-          @progress.current_cumulative_performance_versus_synthetic_last_year
+          @progress.current_cumulative_performance
         end
       end
 

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -531,7 +531,7 @@ class School < ApplicationRecord
   end
 
   def has_expired_target_for_fuel_type?(fuel_type)
-    has_expired_target? && expired_target.try(fuel_type).present?
+    has_expired_target? && expired_target.try(fuel_type).present? && expired_target.saved_progress_report_for(fuel_type).present?
   end
 
   def has_expired_target?

--- a/app/services/targets/generate_progress_service.rb
+++ b/app/services/targets/generate_progress_service.rb
@@ -9,7 +9,7 @@ module Targets
 
     def cumulative_progress(fuel_type)
       target_progress = progress_report(fuel_type)
-      target_progress.present? ? fetch_latest_figures(target_progress.cumulative_performance_versus_synthetic_last_year) : nil
+      target_progress.present? ? fetch_latest_figures(target_progress.cumulative_performance) : nil
     end
 
     def current_monthly_target(fuel_type)

--- a/spec/system/school_groups_spec.rb
+++ b/spec/system/school_groups_spec.rb
@@ -559,6 +559,17 @@ describe 'school groups', :school_groups, type: :system do
     end
 
     it_behaves_like 'school group tabs showing the cluster column'
+
+    context 'when there are archived schools' do
+      before do
+        school_group.schools.first.update(active: false)
+      end
+
+      it 'doesnt show those schools' do
+        visit school_group_path(school_group)
+        expect(page).not_to have_content(school_group.schools.first.name)
+      end
+    end
   end
 
   context 'when logged in as a group admin for a different group' do


### PR DESCRIPTION
Changing to use `accessible_by` on school group dashboard meant that admins now see a list of schools that included inactive (archive/removed) schools which isn't what we want.

This fixes that by always adding the `active` scope.