### PR TITLE
Hide inactive schools on group dashboard

### DIFF
--- a/app/controllers/school_groups_controller.rb
+++ b/app/controllers/school_groups_controller.rb
@@ -132,7 +132,7 @@ class SchoolGroupsController < ApplicationController
 
   def find_schools_and_partners
     # Rely on CanCan to filter the list of schools to those that can be shown to the current user
-    @schools = @school_group.schools.accessible_by(current_ability, :show).by_name
+    @schools = @school_group.schools.active.accessible_by(current_ability, :show).by_name
     @partners = @school_group.partners
   end
 

--- a/spec/system/school_groups_spec.rb
+++ b/spec/system/school_groups_spec.rb
@@ -559,6 +559,17 @@ describe 'school groups', :school_groups, type: :system do
     end
 
     it_behaves_like 'school group tabs showing the cluster column'
+
+    context 'when there are archived schools' do
+      before do
+        school_group.schools.first.update(active: false)
+      end
+
+      it 'doesnt show those schools' do
+        visit school_group_path(school_group)
+        expect(page).not_to have_content(school_group.schools.first.name)
+      end
+    end
   end
 
   context 'when logged in as a group admin for a different group' do


### PR DESCRIPTION
Changing to use `accessible_by` on school group dashboard meant that admins now see a list of schools that included inactive (archive/removed) schools which isn't what we want.

This fixes that by always adding the `active` scope.