### PR TITLE
Better handling if all schools are filtered on group dashboard

### DIFF
--- a/app/controllers/school_groups_controller.rb
+++ b/app/controllers/school_groups_controller.rb
@@ -130,8 +130,13 @@ class SchoolGroupsController < ApplicationController
   end
 
   def find_schools_and_partners
-    # Rely on CanCan to filter the list of schools to those that can be shown to the current user
-    @schools = @school_group.schools.active.accessible_by(current_ability, :show).by_name
+    if action_name == :map
+      # Display all active schools on the map view
+      @schools = @school_group.schools.active.by_name
+    else
+      # Rely on CanCan to filter the list of schools to those that can be shown to the current user
+      @schools = @school_group.schools.active.accessible_by(current_ability, :show).by_name
+    end
     @partners = @school_group.partners
   end
 

--- a/app/controllers/school_groups_controller.rb
+++ b/app/controllers/school_groups_controller.rb
@@ -5,8 +5,8 @@ class SchoolGroupsController < ApplicationController
 
   load_resource
 
-  before_action :redirect_unless_authorised, only: [:comparisons, :priority_actions, :current_scores]
   before_action :find_schools_and_partners
+  before_action :redirect_unless_authorised, except: [:map]
   before_action :build_breadcrumbs
   before_action :find_school_group_fuel_types
   before_action :set_show_school_group_message
@@ -14,20 +14,16 @@ class SchoolGroupsController < ApplicationController
   skip_before_action :authenticate_user!
 
   def show
-    if can?(:compare, @school_group)
-      respond_to do |format|
-        format.html {}
-        format.csv do
-          send_data SchoolGroups::RecentUsageCsvGenerator.new(
-            school_group: @school_group,
-            schools: @schools,
-            include_cluster: include_cluster
-          ).export,
-          filename: csv_filename_for('recent_usage')
-        end
+    respond_to do |format|
+      format.html {}
+      format.csv do
+        send_data SchoolGroups::RecentUsageCsvGenerator.new(
+          school_group: @school_group,
+          schools: @schools,
+          include_cluster: include_cluster
+        ).export,
+        filename: csv_filename_for('recent_usage')
       end
-    else
-      redirect_to map_school_group_path(@school_group) and return
     end
   end
 
@@ -115,7 +111,10 @@ class SchoolGroupsController < ApplicationController
   end
 
   def redirect_unless_authorised
+    # no permission on group
     redirect_to map_school_group_path(@school_group) and return if cannot?(:compare, @school_group)
+    # no permissions on any current schools in group
+    redirect_to map_school_group_path(@school_group) and return if @schools.empty?
   end
 
   def find_school_group

--- a/spec/factories/school_groups_factory.rb
+++ b/spec/factories/school_groups_factory.rb
@@ -1,5 +1,16 @@
 FactoryBot.define do
   factory :school_group do
     sequence(:name) {|n| "School group #{n}"}
+    public { true }
+
+    trait :with_active_schools do
+      transient do
+        count { 1 }
+      end
+
+      after(:build) do |school_group, evaluator|
+        school_group.schools = create_list(:school, evaluator.count, school_group: school_group, active: true, public: true)
+      end
+    end
   end
 end

--- a/spec/support/shared_examples/energy_tariffs.rb
+++ b/spec/support/shared_examples/energy_tariffs.rb
@@ -10,7 +10,7 @@ RSpec.shared_examples 'the user does not have access to the tariff editor' do
         expect(page).to have_current_path("/schools/#{current_user.school.slug}", ignore_query: true)
       end
     elsif current_user.group_admin?
-      expect(page).to have_current_path("/school_groups/#{current_user.school_group.slug}", ignore_query: true)
+      expect(page).to have_current_path("/school_groups/#{current_user.school_group.slug}/map", ignore_query: true)
     else
       expect(page).to have_current_path('/schools', ignore_query: true)
     end

--- a/spec/system/admin/emails_spec.rb
+++ b/spec/system/admin/emails_spec.rb
@@ -41,12 +41,12 @@ describe 'Emails', type: :system do
       it 'prevents the user from seeing the admin email preview page' do
         sign_in(group_admin)
         visit admin_mailer_previews_path
-        expect(page).to have_current_path("/school_groups/#{group_admin.school_group.slug}", ignore_query: true)
+        expect(page).to have_current_path("/school_groups/#{group_admin.school_group.slug}/map", ignore_query: true)
         preview = ActionMailer::Preview.all.last
         visit admin_mailer_preview_path(preview.preview_name)
-        expect(page).to have_current_path("/school_groups/#{group_admin.school_group.slug}", ignore_query: true)
+        expect(page).to have_current_path("/school_groups/#{group_admin.school_group.slug}/map", ignore_query: true)
         visit admin_mailer_preview_path(preview.preview_name + '/' + preview.emails.first)
-        expect(page).to have_current_path("/school_groups/#{group_admin.school_group.slug}", ignore_query: true)
+        expect(page).to have_current_path("/school_groups/#{group_admin.school_group.slug}/map", ignore_query: true)
       end
     end
 

--- a/spec/system/admin/school_groups_spec.rb
+++ b/spec/system/admin/school_groups_spec.rb
@@ -131,7 +131,7 @@ RSpec.describe 'school groups', :school_groups, type: :system, include_applicati
 
     describe 'Viewing school group page' do
       let!(:issues_admin) { }
-      let!(:school_group) { create :school_group, :with_active_schools, default_issues_admin_user: issues_admin }
+      let!(:school_group) { create :school_group, default_issues_admin_user: issues_admin }
 
       before do
         click_on 'Manage School Groups'
@@ -211,7 +211,7 @@ RSpec.describe 'school groups', :school_groups, type: :system, include_applicati
         context "clicking 'View'" do
           before { click_link 'View' }
 
-          it { expect(page).to have_current_path(school_group_path(school_group)) }
+          it { expect(page).to have_content(school_group.name) }
         end
 
         it { expect(page).to have_link('Edit') }

--- a/spec/system/admin/school_groups_spec.rb
+++ b/spec/system/admin/school_groups_spec.rb
@@ -131,7 +131,7 @@ RSpec.describe 'school groups', :school_groups, type: :system, include_applicati
 
     describe 'Viewing school group page' do
       let!(:issues_admin) { }
-      let!(:school_group) { create :school_group, default_issues_admin_user: issues_admin }
+      let!(:school_group) { create :school_group, :with_active_schools, default_issues_admin_user: issues_admin }
 
       before do
         click_on 'Manage School Groups'

--- a/spec/system/landing_pages_spec.rb
+++ b/spec/system/landing_pages_spec.rb
@@ -171,18 +171,17 @@ describe 'landing pages', type: :system do
   end
 
   context 'when following redirects from emails' do
-    let!(:mat_school_group) { create(:school_group, public: true, group_type: :multi_academy_trust)}
-    let!(:la_school_group) { create(:school_group, public: true, group_type: :local_authority)}
-    let!(:school) { create(:school, data_enabled: true, visible: true, school_group: mat_school_group)}
+    let!(:mat_school_group) { create(:school_group, :with_active_schools, group_type: :multi_academy_trust)}
+    let!(:la_school_group) { create(:school_group, group_type: :local_authority)}
 
     it 'redirects to adult dashboard' do
       visit example_adult_dashboard_campaigns_path
-      expect(page).to have_current_path(school_path(school))
+      expect(page).to have_current_path(school_path(mat_school_group.schools.first))
     end
 
     it 'redirects to pupil dashboard' do
       visit example_pupil_dashboard_campaigns_path
-      expect(page).to have_current_path(pupils_school_path(school))
+      expect(page).to have_current_path(pupils_school_path(mat_school_group.schools.first))
     end
 
     it 'redirects to MAT dashboard' do
@@ -192,7 +191,7 @@ describe 'landing pages', type: :system do
 
     it 'redirects to local authority dashboard' do
       visit example_la_dashboard_campaigns_path
-      expect(page).to have_current_path(school_group_path(la_school_group))
+      expect(page).to have_current_path(map_school_group_path(la_school_group))
     end
   end
 end

--- a/spec/system/school_groups_spec.rb
+++ b/spec/system/school_groups_spec.rb
@@ -386,6 +386,14 @@ describe 'school groups', :school_groups, type: :system do
       end
     end
 
+    context 'with a public school group with no active schools' do
+      before do
+        school_group.schools.update_all(active: false)
+      end
+
+      it_behaves_like 'a private school group dashboard'
+    end
+
     context 'with a private school group' do
       let(:public) { false }
 


### PR DESCRIPTION
If all schools are filtered out for the current user on the school group dashboard, then we get a SQL error.

We're getting errors from crawlers but in some cases these are for groups that are no longer on the site, so they're following cached links. Will do a separate PR to add a flag to mark group as active/inactive

This PR fixes the immediate error by checking to see if the list of schools is empty and, if so, force the user to the map view. This makes it consisent with how we handle a group they don't have permission to view. The map view has been updated to list all the schools.