### PR TITLE
Remove old alerts

### DIFF
--- a/app/controllers/admin/alert_types_controller.rb
+++ b/app/controllers/admin/alert_types_controller.rb
@@ -5,7 +5,6 @@ module Admin
     def index
       @standard_alert_types = AlertType.analytics.editable.order(:title)
       @system_alert_types = AlertType.system.editable.order(:title)
-      @analysis_alert_types = AlertType.analysis.editable.order(:title)
     end
 
     def show

--- a/app/views/admin/alert_types/index.html.erb
+++ b/app/views/admin/alert_types/index.html.erb
@@ -4,9 +4,9 @@
   <li class="nav-item">
     <a class="nav-link disabled" href="#">Jump to</a>
   </li>
-  <% ['Standard', 'System', 'Analysis'].each do |section| %>
+  <% %w[Standard System].each do |section| %>
     <li class="nav-item">
-      <%= link_to "#{section}", "##{section}", class: 'nav-link' %>
+      <%= link_to section.to_s, "##{section}", class: 'nav-link' %>
     </li>
   <% end %>
 </ul>
@@ -22,9 +22,3 @@
 </div>
 <h2>System</h2>
 <%= render 'table', alert_types: @system_alert_types, show_full: true %>
-
-<div class="nav-anchor">
-  <a name="Analysis"> </a>
-</div>
-<h2>Old Analysis Pages</h2>
-<%= render 'table', alert_types: @analysis_alert_types %>

--- a/lib/tasks/deployment/20240705133728_remove_old_alerts.rake
+++ b/lib/tasks/deployment/20240705133728_remove_old_alerts.rake
@@ -1,0 +1,22 @@
+namespace :after_party do
+  desc 'Deployment task: remove_old_alerts'
+  task remove_old_alerts: :environment do
+    puts "Running deploy task 'remove_old_alerts'"
+
+    # Disable last few of the old analysis pages
+    AlertType.where(class_name: ['AdviceGasBoilerFrost', 'AdviceElectricityMeterBreakdownBase', 'AdviceGasMeterBreakdownBase']).update_all(enabled: false)
+
+    # Remove all disabled AlertTypes. This includes
+    # - the alerts responsible for old analysis pages, including the above
+    #   these were disabled and haven't been used in last year
+    #
+    # - some older alerts responsible for comparison reports and some unused dashboard reports
+    #   these were also disabled some time ago so haven't been run
+    AlertType.where(enabled: false).destroy_all
+
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord
+      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+  end
+end


### PR DESCRIPTION
There are a number of alerts in the analytics that we haven't used for some time this includes:

- the "alerts" that generated the content for the old versions of the analysis pages. These are no longer available so the alerts can be safely disabled and removed
- some other alerts that were responsible for doing some old comparison reports, or which were just never used. These were all disabled some time ago. So this PR just removes the records as we won't be re-enabling them.

As the alerts were all disabled some time ago there's no other content to clear up as any historical analysis will already have been cleared out.

Largely just a clear out but will make it easier to start removing some code from the analytics where we know its not used.