### PR TITLE
fix bootsnap deploy error

### DIFF
--- a/.ebextensions/bootsnap.config
+++ b/.ebextensions/bootsnap.config
@@ -1,0 +1,11 @@
+# prevents occasional deploy error:
+# An error occurred during execution of command [app-deploy] - [flip ruby application]. Stop running the command.
+# Error: remove current dir failed: unlinkat /var/app/current/tmp/cache/bootsnap/compile-cache-iseq: directory not empty
+
+option_settings:
+  aws:elasticbeanstalk:application:environment:
+    BOOTSNAP_CACHE_DIR: /var/cache/bootsnap
+
+commands:
+    cache_dir:
+        command: install -o "$(/opt/elasticbeanstalk/bin/get-config platformconfig -k AppUser)" -d /var/cache/bootsnap


### PR DESCRIPTION
saw this again

`An error occurred during execution of command [app-deploy] - [flip ruby application]. Stop running the command. Error: remove current dir failed: unlinkat /var/app/current/tmp/cache/bootsnap/compile-cache-iseq: directory not empty`