### PR TITLE
Hide data enabled links on recommendations page

### DIFF
--- a/app/views/schools/recommendations/index.html.erb
+++ b/app/views/schools/recommendations/index.html.erb
@@ -2,34 +2,62 @@
 
 <p><%= t('schools.recommendations.intro') %></p>
 
-<%= render 'schools/prompt_to_complete_programme', programmes: @school.programmes.started.order(started_on: :desc), style: :compact %>
+<%= render 'schools/prompt_to_complete_programme', programmes: @school.programmes.started.order(started_on: :desc),
+                                                   style: :compact %>
 <%= render 'schools/prompt_join_programme', school: @school, style: :compact %>
 <%= render 'schools/prompt_audit', audit: Audits::AuditService.new(@school).last_audit, style: :compact %>
 
 <% display_options = { classes: 'pb-4', limit: 5, limit_lg: 3 } %>
+<% display_limit = display_options[:limit] %>
 
-<%= component 'panel_switcher', selected: @scope, title: t("schools.recommendations.energy_usage.title"), description: t("schools.recommendations.energy_usage.description"), id: 'energy-usage' do |switcher| %>
-  <% switcher.with_panel(label: t("common.labels.pupil_activities"), name: 'pupil') do |panel| %>
-    <%= component 'recommendations', recommendations: Recommendations::Activities::new(@school).based_on_energy_use(display_options[:limit]), **display_options %>
+<%= component 'panel_switcher',
+              selected: @scope,
+              title: t('schools.recommendations.energy_usage.title'),
+              description: t('schools.recommendations.energy_usage.description'),
+              id: 'energy-usage' do |switcher| %>
+  <% switcher.with_panel(label: t('common.labels.pupil_activities'), name: 'pupil') do |panel| %>
+    <%= component 'recommendations',
+                  recommendations: Recommendations::Activities.new(@school).based_on_energy_use(display_limit),
+                  **display_options %>
   <% end %>
-  <% switcher.with_panel(label: t("common.labels.adult_actions"), name: 'adult') do |panel| %>
-    <%= component 'recommendations', recommendations: Recommendations::Actions::new(@school).based_on_energy_use(display_options[:limit]), **display_options %>
+  <% switcher.with_panel(label: t('common.labels.adult_actions'), name: 'adult') do |panel| %>
+    <%= component 'recommendations',
+                  recommendations: Recommendations::Actions.new(@school).based_on_energy_use(display_limit),
+                  **display_options %>
   <% end %>
 <% end %>
 
-<%= component 'panel_switcher', selected: @scope, title: t("schools.recommendations.recent_activity.title"), description: t("schools.recommendations.recent_activity.description"), id: 'recent-activity' do |switcher| %>
-  <% switcher.with_panel(label: t("common.labels.pupil_activities"), name: 'pupil') do |panel| %>
-    <%= component 'recommendations', recommendations: Recommendations::Activities::new(@school).based_on_recent_activity(display_options[:limit]), **display_options %>
+<%= component 'panel_switcher',
+              selected: @scope,
+              title: t('schools.recommendations.recent_activity.title'),
+              description: t('schools.recommendations.recent_activity.description'),
+              id: 'recent-activity' do |switcher| %>
+  <% switcher.with_panel(label: t('common.labels.pupil_activities'), name: 'pupil') do |panel| %>
+    <%= component 'recommendations',
+                  recommendations: Recommendations::Activities.new(@school).based_on_recent_activity(display_limit),
+                  **display_options %>
   <% end %>
-  <% switcher.with_panel(label: t("common.labels.adult_actions"), name: 'adult') do |panel| %>
-    <%= component 'recommendations', recommendations: Recommendations::Actions::new(@school).based_on_recent_activity(display_options[:limit]), **display_options %>
+  <% switcher.with_panel(label: t('common.labels.adult_actions'), name: 'adult') do |panel| %>
+    <%= component 'recommendations',
+                  recommendations: Recommendations::Actions.new(@school).based_on_recent_activity(display_limit),
+                  **display_options %>
   <% end %>
 <% end %>
 
-<%= component 'recommendations', title: t("schools.recommendations.more_ideas.title"), description: t("schools.recommendations.more_ideas.description"), id: 'more-ideas', **display_options do |c| %>
-  <% c.with_item(name: t("schools.recommendations.more_ideas.programme"), href: programme_types_path, image: 'recommendations/get-energised.png') %>
-  <% c.with_item(name: t("schools.recommendations.more_ideas.activities", count: ActivityType.count), href: activity_categories_path, image: 'recommendations/opt-in.png') %>
-  <% c.with_item(name:t("schools.recommendations.more_ideas.actions", count: InterventionType.count), href: intervention_type_groups_path, image: 'recommendations/laptop-ipad.png') %>
-  <% c.with_item(name: t("schools.recommendations.more_ideas.analysis"), href: school_advice_path(@school), image: 'recommendations/screen-graph.png') %>
-  <% c.with_item(name:t("schools.recommendations.more_ideas.recent_alerts"), href: alerts_school_advice_path(@school), image: 'recommendations/detective.png') %>
+<%= component 'recommendations',
+              title: t('schools.recommendations.more_ideas.title'),
+              description: t('schools.recommendations.more_ideas.description'),
+              id: 'more-ideas', **display_options do |c| %>
+  <% c.with_item(name: t('schools.recommendations.more_ideas.programme'), href: programme_types_path,
+                 image: 'recommendations/get-energised.png') %>
+  <% c.with_item(name: t('schools.recommendations.more_ideas.activities', count: ActivityType.count),
+                 href: activity_categories_path, image: 'recommendations/opt-in.png') %>
+  <% c.with_item(name: t('schools.recommendations.more_ideas.actions', count: InterventionType.count),
+                 href: intervention_type_groups_path, image: 'recommendations/laptop-ipad.png') %>
+  <% if @school.data_enabled? %>
+    <% c.with_item(name: t('schools.recommendations.more_ideas.analysis'), href: school_advice_path(@school),
+                   image: 'recommendations/screen-graph.png') %>
+    <% c.with_item(name: t('schools.recommendations.more_ideas.recent_alerts'),
+                   href: alerts_school_advice_path(@school), image: 'recommendations/detective.png') %>
+  <% end %>
 <% end %>

--- a/spec/system/schools/recommendations_spec.rb
+++ b/spec/system/schools/recommendations_spec.rb
@@ -180,5 +180,14 @@ describe 'Recommendations Page', type: :system, include_application_helper: true
     it 'has a link to schools recent alerts' do
       expect(section).to have_link(href: "/schools/#{school.slug}/advice/alerts")
     end
+
+    context 'when school is not data enabled' do
+      let!(:school) { create :school, name: 'School Name', key_stages: [key_stage_1], data_enabled: false }
+
+      it 'does not have advice or alerts links' do
+        expect(section).not_to have_link(href: "/schools/#{school.slug}/advice")
+        expect(section).not_to have_link(href: "/schools/#{school.slug}/advice/alerts")
+      end
+    end
   end
 end


### PR DESCRIPTION
The recommendations page has links to a schools advice page and recent alerts. These are still shown even if the school is not currently data enabled.

This PR adds a conditional to check whether those pages are available before adding the links.

The rest of the changes to the template are to make erblint happy.