### PR TITLE
Disallow advice page index

### DIFF
--- a/app/views/robots_txts/allow.raw
+++ b/app/views/robots_txts/allow.raw
@@ -6,8 +6,6 @@
 
 Sitemap: https://energysparks.uk/sitemap.xml.gz
 
-Sitemap: https://energysparks.uk/sitemap.xml.gz
-
 User-agent: *
 Disallow: /admin/
 Disallow: /rails/*

--- a/app/views/robots_txts/allow.raw
+++ b/app/views/robots_txts/allow.raw
@@ -15,6 +15,7 @@ Disallow: /schools/scoreboard
 Disallow: /schools/*/analysis
 Disallow: /schools/*/find_out_more/*
 Disallow: /schools/*/chart.json
+Disallow: /schools/*/advice
 Disallow: /schools/*/advice/*
 Disallow: /pupils/schools/*/analysis
 Disallow: /benchmark


### PR DESCRIPTION
Add a `Disallow` directive to mark the advice page index as not crawlable.

Also removes a duplicate line as we're linking to the sitemap twice.