### PR TITLE
Fix funder not displaying

### DIFF
--- a/app/views/admin/school_groups/_onboarding_schools.html.erb
+++ b/app/views/admin/school_groups/_onboarding_schools.html.erb
@@ -15,7 +15,7 @@
         <tr class="bg-light">
           <td><%= f.check_box :school_onboarding_ids, { multiple: true, checked: false }, onboarding.id, nil %></td>
           <td><%= link_to onboarding.school_name, onboarding_path(onboarding) %></td>
-          <td><%= onboarding&.school&.funder&.name || onboarding&.school_group&.funder&.name %></td>
+          <td><%= onboarding&.school&.funder&.name || onboarding&.funder&.name %></td>
           <td class="wrap"><%= onboarding.contact_email %> <%= link_to fa_icon('edit'), edit_admin_school_onboarding_email_path(onboarding), class: "", title: "Change email address" if onboarding.has_only_sent_email_or_reminder? %></td>
           <td class="nowrap" data-order="<%= onboarding.events.maximum(:created_at) %>">
             <%= nice_date_times(onboarding.events.maximum(:created_at)) %><br />

--- a/app/views/admin/school_onboardings/_form.html.erb
+++ b/app/views/admin/school_onboardings/_form.html.erb
@@ -42,7 +42,7 @@
   <h2>Funder</h2>
   <div class="form-group">
     <%= f.label :funder_id %>
-    <%= f.select :funder_id, options_for_select(Funder.all.order(name: :asc).pluck(:name, :id)),
+    <%= f.select :funder_id, options_for_select(Funder.all.order(name: :asc).pluck(:name, :id), @school_onboarding.funder_id),
                  { include_blank: true }, { class: 'form-control' } %>
   </div>
 

--- a/spec/system/admin/school_onboarding_spec.rb
+++ b/spec/system/admin/school_onboarding_spec.rb
@@ -77,6 +77,7 @@ RSpec.describe 'onboarding', :schools, type: :system do
       onboarding = SchoolOnboarding.first
       expect(onboarding.data_sharing_within_group?).to be true
       expect(onboarding.default_chart_preference).to eq 'carbon'
+      expect(onboarding.funder).to eq funder
 
       email = ActionMailer::Base.deliveries.last
       expect(email.subject).to include('Set up your school on Energy Sparks')
@@ -98,6 +99,7 @@ RSpec.describe 'onboarding', :schools, type: :system do
       click_on 'Edit'
 
       fill_in 'School name', with: 'A new name'
+      select funder.name, from: 'Funder'
       click_on 'Next'
 
       select 'Oxford calendar', from: 'Template calendar'
@@ -111,6 +113,12 @@ RSpec.describe 'onboarding', :schools, type: :system do
       expect(onboarding.template_calendar).to eq(other_template_calendar)
       expect(onboarding.default_chart_preference).to eq 'cost'
       expect(onboarding.country).to eq 'scotland'
+      expect(onboarding.funder).to eq funder
+
+      # check form fields repopulating
+      visit admin_school_onboardings_path
+      click_on 'Edit'
+      expect(page).to have_select('Funder', selected: funder.name)
     end
 
     context 'when completing onboarding as admin without consents' do


### PR DESCRIPTION
On the school onboarding form the funder select box is not populating with the currently selected funder value. This PR fixes that.

The funder shown on the manage school onboardings and manage school group pages is also not showing. Its default to showing the schools funder and then the group. But groups no longer have funders, while the school onboarding does.

Changed it to show the school funder if available otherwise the saved option