### PR TITLE
Enable meter filtering options on recent change advice pages

### DIFF
--- a/app/controllers/schools/advice/electricity_recent_changes_controller.rb
+++ b/app/controllers/schools/advice/electricity_recent_changes_controller.rb
@@ -9,7 +9,7 @@ module Schools
       end
 
       def analysis
-        @meters = @school.filterable_meters.electricity
+        @meters = @school.filterable_meters(:electricity)
         @chart_config = start_end_dates
       end
 

--- a/app/controllers/schools/advice/gas_recent_changes_controller.rb
+++ b/app/controllers/schools/advice/gas_recent_changes_controller.rb
@@ -9,7 +9,7 @@ module Schools
       end
 
       def analysis
-        @meters = @school.filterable_meters.gas
+        @meters = @school.filterable_meters(:gas)
         @chart_config = start_end_dates
       end
 

--- a/app/controllers/schools/usage_controller.rb
+++ b/app/controllers/schools/usage_controller.rb
@@ -48,11 +48,8 @@ module Schools
     end
 
     def setup_meters(school, supply)
-      case supply
-      when :electricity then school.filterable_meters.electricity
-      when :gas then school.filterable_meters.gas
-      else Meter.none
-      end
+      return Meter.none unless [:electricity, :gas].include?(supply)
+      school.filterable_meters(supply)
     end
 
     def title_key(supply, period, split_meters)

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -463,11 +463,18 @@ class School < ApplicationRecord
     users.pupil.to_a.find {|user| user.pupil_password.casecmp?(pupil_password) }
   end
 
-  def filterable_meters
-    if has_solar_pv? || has_storage_heaters?
-      Meter.none
+  def filterable_meters(fuel_type)
+    case fuel_type
+    when :gas
+      active_meters.gas.real
+    when :electricity
+      if has_solar_pv? || has_storage_heaters?
+        Meter.none
+      else
+        active_meters.electricity.real
+      end
     else
-      active_meters.real
+      Meter.none
     end
   end
 

--- a/app/views/pupils/analysis/electricity.html.erb
+++ b/app/views/pupils/analysis/electricity.html.erb
@@ -35,7 +35,7 @@
     <%= t('pupils.analysis.compare_electricity_on_2_days') %>
   <% end %>
 
-  <% if @school.filterable_meters.electricity.count > 1 %>
+  <% if @school.filterable_meters(:electricity).count > 1 %>
     <%= render 'usage_link', school: @school, energy: :electricity, usage_config: {period: :weekly, split_meters: true} do %>
       <%= t('pupils.analysis.compare_electricity_use_by_meters') %>
     <% end %>

--- a/app/views/pupils/analysis/electricity_bar.html.erb
+++ b/app/views/pupils/analysis/electricity_bar.html.erb
@@ -31,7 +31,7 @@
     <%= t('pupils.analysis.compare_electricity_in_2_weeks') %>
   <% end %>
 
-  <% if @school.filterable_meters.electricity.count > 1 %>
+  <% if @school.filterable_meters(:electricity).count > 1 %>
     <%= render 'usage_link', school: @school, energy: :electricity, usage_config: {period: :weekly, split_meters: true} do %>
       <%= t('pupils.analysis.compare_electricity_use_by_meters') %>
     <% end %>

--- a/app/views/pupils/analysis/electricity_line.html.erb
+++ b/app/views/pupils/analysis/electricity_line.html.erb
@@ -27,7 +27,7 @@
     <%= t('pupils.analysis.compare_electricity_on_2_days') %>
   <% end %>
 
-  <% if @school.filterable_meters.electricity.count > 1 %>
+  <% if @school.filterable_meters(:electricity).count > 1 %>
     <%= render 'usage_link', school: @school, energy: :electricity, usage_config: {period: :daily, split_meters: true} do %>
       <%= t('pupils.analysis.compare_electricity_use_by_meters') %>
     <% end %>

--- a/app/views/pupils/analysis/gas.html.erb
+++ b/app/views/pupils/analysis/gas.html.erb
@@ -35,7 +35,7 @@
     <%= t('pupils.analysis.compare_gas_on_2_days') %>
   <% end %>
 
-  <% if @school.filterable_meters.gas.count > 1 %>
+  <% if @school.filterable_meters(:gas).count > 1 %>
     <%= render 'usage_link', school: @school, energy: :gas, usage_config: {period: :weekly, split_meters: true} do %>
       <%= t('pupils.analysis.compare_gas_use_by_meters') %>
     <% end %>

--- a/app/views/pupils/analysis/gas_bar.html.erb
+++ b/app/views/pupils/analysis/gas_bar.html.erb
@@ -31,7 +31,7 @@
     <%= t('pupils.analysis.compare_gas_in_2_weeks') %>
   <% end %>
 
-  <% if @school.filterable_meters.gas.count > 1 %>
+  <% if @school.filterable_meters(:gas).count > 1 %>
     <%= render 'usage_link', school: @school, energy: :gas, usage_config: {period: :weekly, split_meters: true} do %>
       <%= t('pupils.analysis.compare_gas_use_by_meters') %>
     <% end %>

--- a/app/views/pupils/analysis/gas_line.html.erb
+++ b/app/views/pupils/analysis/gas_line.html.erb
@@ -22,7 +22,7 @@
     <%= t('pupils.analysis.compare_gas_on_2_days') %>
   <% end %>
 
-  <% if @school.filterable_meters.gas.count > 1 %>
+  <% if @school.filterable_meters(:gas).count > 1 %>
     <%= render 'usage_link', school: @school, energy: :gas, usage_config: {period: :daily, split_meters: true} do %>
       <%= t('pupils.analysis.compare_gas_use_by_meters') %>
     <% end %>

--- a/app/views/schools/advice/electricity_recent_changes/_analysis.html.erb
+++ b/app/views/schools/advice/electricity_recent_changes/_analysis.html.erb
@@ -3,14 +3,16 @@
 <p><%= t('advice_pages.electricity_recent_changes.analysis.sections') %></p>
 
 <ul>
-  <li><%= link_to(t('advice_pages.electricity_recent_changes.analysis.compare_recent_weeks.title'), '#compare-recent-weeks') %></li>
-  <li><%= link_to(t('advice_pages.electricity_recent_changes.analysis.compare_recent_days.title'), '#compare-recent-days') %></li>
+  <li><%= link_to(t('advice_pages.electricity_recent_changes.analysis.compare_recent_weeks.title'),
+                  '#compare-recent-weeks') %></li>
+  <li><%= link_to(t('advice_pages.electricity_recent_changes.analysis.compare_recent_days.title'),
+                  '#compare-recent-days') %></li>
   <li><%= link_to(t('advice_pages.electricity_recent_changes.analysis.compare_last_week.title'), '#compare-last-week') %></li>
 </ul>
 
-
 <!--  COMPARISON OF ELECTRICITY USE OVER 2 RECENT WEEKS -->
-<%= render 'schools/advice/section_title', section_id: 'compare-recent-weeks', section_title: t('advice_pages.electricity_recent_changes.analysis.compare_recent_weeks.title') %>
+<%= render 'schools/advice/section_title', section_id: 'compare-recent-weeks',
+                                           section_title: t('advice_pages.electricity_recent_changes.analysis.compare_recent_weeks.title') %>
 
 <div class="charts">
   <%= component 'chart',
@@ -21,47 +23,55 @@
                 chart_config: @chart_config,
                 html_class: 'usage-chart' do |c| %>
     <% c.with_title { t('advice_pages.electricity_recent_changes.analysis.charts.compare_recent_weeks_chart_title') } %>
-    <% c.with_subtitle { t('advice_pages.electricity_recent_changes.analysis.charts.compare_recent_weeks_chart_subtitle') } %>
+    <% c.with_subtitle do
+         t('advice_pages.electricity_recent_changes.analysis.charts.compare_recent_weeks_chart_subtitle')
+       end %>
     <% c.with_header do %>
       <p><%= t('advice_pages.electricity_recent_changes.analysis.charts.compare_recent_weeks_chart_explanation') %></p>
     <% end %>
     <% c.with_footer do %>
-      <%= render 'shared/usage_controls', chart_config: @chart_config, period: :weekly, supply: :electricity, split_meters: false, meters: @meters %>
+      <%= render 'shared/usage_controls', chart_config: @chart_config, period: :weekly, supply: :electricity,
+                                          split_meters: true, meters: @meters %>
     <% end %>
   <% end %>
 </div>
 
 <!--  COMPARISON OF ELECTRICITY USE OVER 2 RECENT DAYS -->
-<%= render 'schools/advice/section_title', section_id: 'compare-recent-days', section_title: t('advice_pages.electricity_recent_changes.analysis.compare_recent_days.title') %>
+<%= render 'schools/advice/section_title', section_id: 'compare-recent-days',
+                                           section_title: t('advice_pages.electricity_recent_changes.analysis.compare_recent_days.title') %>
 
 <div class="charts">
   <%= component 'chart',
-             chart_type: :calendar_picker_electricity_day_example_comparison_chart,
-             school: @school,
-             analysis_controls: false,
-             no_zoom: true,
-             chart_config: @chart_config,
-             axis_controls: false,
-             html_class: 'usage-chart' do |c| %>
+                chart_type: :calendar_picker_electricity_day_example_comparison_chart,
+                school: @school,
+                analysis_controls: false,
+                no_zoom: true,
+                chart_config: @chart_config,
+                axis_controls: false,
+                html_class: 'usage-chart' do |c| %>
     <% c.with_title { t('advice_pages.electricity_recent_changes.analysis.charts.compare_recent_days_chart_title') } %>
-    <% c.with_subtitle { t('advice_pages.electricity_recent_changes.analysis.charts.compare_recent_days_chart_subtitle') } %>
+    <% c.with_subtitle do
+         t('advice_pages.electricity_recent_changes.analysis.charts.compare_recent_days_chart_subtitle')
+       end %>
     <% c.with_header do %>
       <p><%= t('advice_pages.electricity_recent_changes.analysis.charts.compare_recent_days_chart_explanation') %></p>
     <% end %>
     <% c.with_footer do %>
-      <%= render 'shared/usage_controls', chart_config: @chart_config, period: :daily, supply: :electricity, split_meters: false, meters: @meters  %>
+      <%= render 'shared/usage_controls', chart_config: @chart_config, period: :daily, supply: :electricity,
+                                          split_meters: true, meters: @meters %>
     <% end %>
   <% end %>
 </div>
 
-<%= render 'schools/advice/section_title', section_id: 'compare-last-week', section_title: t('advice_pages.electricity_recent_changes.analysis.compare_last_week.title') %>
+<%= render 'schools/advice/section_title', section_id: 'compare-last-week',
+                                           section_title: t('advice_pages.electricity_recent_changes.analysis.compare_last_week.title') %>
 
 <%= component 'chart',
-           chart_type: :intraday_line_school_last7days,
-           school: @school,
-           analysis_controls: true,
-           no_zoom: true,
-           axis_controls: false do |c| %>
+              chart_type: :intraday_line_school_last7days,
+              school: @school,
+              analysis_controls: true,
+              no_zoom: true,
+              axis_controls: false do |c| %>
   <% c.with_title { t('advice_pages.electricity_recent_changes.analysis.charts.compare_last_week_chart_title') } %>
   <% c.with_subtitle { t('advice_pages.electricity_recent_changes.analysis.charts.compare_last_week_chart_subtitle') } %>
   <% c.with_header do %>

--- a/app/views/schools/advice/gas_recent_changes/_analysis.html.erb
+++ b/app/views/schools/advice/gas_recent_changes/_analysis.html.erb
@@ -28,7 +28,7 @@
     <% end %>
     <% c.with_footer do %>
       <%= render 'shared/usage_controls', chart_config: @chart_config, period: :weekly, supply: :gas,
-                                          split_meters: false, meters: @meters %>
+                                          split_meters: true, meters: @meters %>
     <% end %>
   <% end %>
 </div>
@@ -53,7 +53,7 @@
     <% end %>
     <% c.with_footer do %>
       <%= render 'shared/usage_controls', chart_config: @chart_config, period: :daily, supply: :gas,
-                                          split_meters: false, meters: @meters %>
+                                          split_meters: true, meters: @meters %>
       <br>
       <p><%= t('advice_pages.gas_recent_changes.analysis.expected_usage_patterns') %></p>
       <p><%= t('advice_pages.gas_recent_changes.analysis.optimal_start_control') %></p>
@@ -106,7 +106,7 @@
       <% more_detail_url = link_to(t('advice_pages.gas_recent_changes.analysis.see_more_detail'),
                                    'https://www.sustainabilityexchange.ac.uk/files/degree_days_for_energy_management_carbon_trust.pdf', target: '_blank', rel: 'noopener') %>
       <p><%= t('advice_pages.gas_recent_changes.analysis.charts.impact_of_temperature_chart_explanation_html',
-               more_detail_url: more_detail_url) %></p>
+               more_detail_url:) %></p>
     <% end %>
   <% end %>
 </div>

--- a/app/views/shared/_usage_controls.html.erb
+++ b/app/views/shared/_usage_controls.html.erb
@@ -1,19 +1,22 @@
-<%= form_tag "", method: :get, id: "chart-filter" do %>
+<%= form_tag '', method: :get, id: 'chart-filter' do %>
 
   <%= hidden_field_tag :period, period %>
   <%= hidden_field_tag :supply, supply %>
   <%= hidden_field_tag :series_breakdown, :none %>
-  <%= hidden_field_tag :configuration, nil, data: {configuration: chart_config} %>
+  <%= hidden_field_tag :configuration, nil, data: { configuration: chart_config } %>
 
   <div class="row justify-content-md-center">
     <div class="col-12 col-lg-4 col-md-4">
       <div class="<%= supply %>-dark <%= supply %>-dark-<%= period %> p-2 mb-2">
-        <%= label_tag 'first-date-picker', t("charts.usage.date_picker.#{period}.first")%>
+        <%= label_tag 'first-date-picker', t("charts.usage.date_picker.#{period}.first") %>
 
         <div class="form-group">
           <div class="input-group">
-            <div class="input-group date <%= 'week-view' if period == :weekly %>" id="<%= period %>-datetimepicker1" data-target-input="nearest">
-              <%= text_field_tag("first-date-picker", '', class: 'form-control datetimepicker-input', data: { target: "##{period}-datetimepicker1" }, onkeydown: 'return false') %>
+            <div class="input-group date <%= 'week-view' if period == :weekly %>"
+                 id="<%= period %>-datetimepicker1" data-target-input="nearest">
+              <%= text_field_tag('first-date-picker', '', class: 'form-control datetimepicker-input',
+                                                          data: { target: "##{period}-datetimepicker1" },
+                                                          onkeydown: 'return false') %>
 
               <div class="input-group-append" data-target="#<%= period %>-datetimepicker1" data-toggle="datetimepicker">
                 <div class="input-group-text"><i class="fa fa-calendar"></i></div>
@@ -26,12 +29,15 @@
 
     <div class="col-12 col-lg-4 col-md-4">
       <div class="<%= supply %>-light <%= supply %>-light-<%= period %> p-2 mb-2">
-        <%= label_tag 'second-date-picker', t("charts.usage.date_picker.#{period}.second")%>
+        <%= label_tag 'second-date-picker', t("charts.usage.date_picker.#{period}.second") %>
 
         <div class="form-group">
           <div class="input-group">
-            <div class="input-group date <%= 'week-view' if period == :weekly %>" id='<%= "#{period}-datetimepicker2" %>' data-target-input="nearest">
-              <%= text_field_tag("second-date-picker", '', class: 'form-control datetimepicker-input', data: { target: "##{period}-datetimepicker2" }, onkeydown: 'return false') %>
+            <div class="input-group date <%= 'week-view' if period == :weekly %>"
+                 id='<%= "#{period}-datetimepicker2" %>' data-target-input="nearest">
+              <%= text_field_tag('second-date-picker', '', class: 'form-control datetimepicker-input',
+                                                           data: { target: "##{period}-datetimepicker2" },
+                                                           onkeydown: 'return false') %>
 
               <div class="input-group-append" data-target="##{period}-datetimepicker2" data-toggle="datetimepicker">
                 <div class="input-group-text"><i class="fa fa-calendar"></i></div>
@@ -44,11 +50,15 @@
 
     <% if split_meters %>
       <% if meters.count > 1 %>
-        <div class="col-12 col-lg-3 col-md-4">
+        <div class="col-12 col-lg-4 col-md-4">
           <div class="<%= supply %>-dark p-2 mb-2">
             <%= label_tag :meter, t('charts.usage.select_meter.title') %>
             <div class="form-group">
-              <%= select_tag :meter, content_tag(:option, t('charts.usage.select_meter.all_meters'), value: "all") + options_from_collection_for_select(meters, :mpan_mprn, :display_name, nil), class: "form-control" %>
+              <%= select_tag :meter,
+                             content_tag(:option,
+                                         t('charts.usage.select_meter.all_meters'), value: 'all') +
+                                          options_from_collection_for_select(meters, :mpan_mprn, :display_name, nil),
+                                         class: 'form-control' %>
             </div>
           </div>
         </div>
@@ -61,6 +71,8 @@
 
 <div class="row justify-content-md-center">
   <div class="col-md-auto mt-2">
-    <%= I18n.t('charts.usage.show.data_available', supply: supply.to_s.titleize, from_date: nice_dates(chart_config[:earliest_reading]), to_date: nice_dates(chart_config[:last_reading])) %>
+    <%= I18n.t('charts.usage.show.data_available', supply: supply.to_s.titleize,
+                                                   from_date: nice_dates(chart_config[:earliest_reading]),
+                                                   to_date: nice_dates(chart_config[:last_reading])) %>
   </div>
 </div>

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -757,4 +757,35 @@ describe School do
       it { expect(programme_types).to be_empty }
     end
   end
+
+  describe '#filterable_meters' do
+    let!(:gas_meters) { create_list(:gas_meter, 2, school: subject) }
+    let!(:electricity_meters) { create_list(:electricity_meter, 2, school: subject) }
+
+    before do
+      subject.configuration.update!(fuel_configuration: Schools::FuelConfiguration.new(has_electricity: true, has_gas: true))
+    end
+
+    it 'returns gas meters' do
+      expect(subject.filterable_meters(:gas)).to match_array(gas_meters)
+    end
+
+    it 'returns electricity meters' do
+      expect(subject.filterable_meters(:electricity)).to match_array(electricity_meters)
+    end
+
+    context 'with solar' do
+      before do
+        subject.configuration.update!(fuel_configuration: Schools::FuelConfiguration.new(has_electricity: true, has_gas: true, has_solar_pv: true))
+      end
+
+      it 'returns gas meters' do
+        expect(subject.filterable_meters(:gas)).to match_array(gas_meters)
+      end
+
+      it 'returns no electricity meters' do
+        expect(subject.filterable_meters(:electricity)).to be_empty
+      end
+    end
+  end
 end

--- a/spec/system/schools/advice_pages/electricity_recent_changes_spec.rb
+++ b/spec/system/schools/advice_pages/electricity_recent_changes_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe 'electricity recent changes advice page', type: :system do
 
       context 'when school has multiple meters' do
         before do
-          create_list(:electricity_meter, 2, meter_type: :electricity, school: school)
+          create_list(:electricity_meter, 2, school: school)
           school.configuration.update!(fuel_configuration: Schools::FuelConfiguration.new(has_electricity: true))
           refresh
         end

--- a/spec/system/schools/advice_pages/electricity_recent_changes_spec.rb
+++ b/spec/system/schools/advice_pages/electricity_recent_changes_spec.rb
@@ -46,6 +46,30 @@ RSpec.describe 'electricity recent changes advice page', type: :system do
         expect(page).to have_content("Electricity data is available from #{expected_start_date} to #{expected_end_date}")
       end
 
+      it 'does not shows meter filtering chart options for both charts' do
+        all('#chart-filter').each do |filters|
+          within filters do
+            expect(page).not_to have_select('Which meter?')
+          end
+        end
+      end
+
+      context 'when school has multiple meters' do
+        before do
+          create_list(:electricity_meter, 2, meter_type: :electricity, school: school)
+          school.configuration.update!(fuel_configuration: Schools::FuelConfiguration.new(has_electricity: true))
+          refresh
+        end
+
+        it 'shows meter filtering chart options for both charts' do
+          all('#chart-filter').each do |filters|
+            within filters do
+              expect(page).to have_select('Which meter?')
+            end
+          end
+        end
+      end
+
       it 'shows expected content' do
         expect(page).to have_content('Comparison of electricity use over 2 recent weeks')
         expect(page).to have_content('Comparison of electricity use over 2 recent days')

--- a/spec/system/schools/advice_pages/gas_recent_changes_spec.rb
+++ b/spec/system/schools/advice_pages/gas_recent_changes_spec.rb
@@ -64,6 +64,30 @@ RSpec.describe 'gas recent changes advice page', type: :system do
         expected_end_date = end_date.to_fs(:es_full)
         expect(page).to have_content("Gas data is available from #{expected_start_date} to #{expected_end_date}")
       end
+
+      it 'does not shows meter filtering chart options for both charts' do
+        all('#chart-filter').each do |filters|
+          within filters do
+            expect(page).not_to have_select('Which meter?')
+          end
+        end
+      end
+
+      context 'when school has multiple meters' do
+        before do
+          create_list(:gas_meter, 2, school: school)
+          school.configuration.update!(fuel_configuration: Schools::FuelConfiguration.new(has_gas: true))
+          refresh
+        end
+
+        it 'shows meter filtering chart options for both charts' do
+          all('#chart-filter').each do |filters|
+            within filters do
+              expect(page).to have_select('Which meter?')
+            end
+          end
+        end
+      end
     end
 
     context "clicking the 'Learn More' tab" do

--- a/spec/system/schools/advice_pages/gas_recent_changes_spec.rb
+++ b/spec/system/schools/advice_pages/gas_recent_changes_spec.rb
@@ -76,7 +76,6 @@ RSpec.describe 'gas recent changes advice page', type: :system do
       context 'when school has multiple meters' do
         before do
           create_list(:gas_meter, 2, school: school)
-          school.configuration.update!(fuel_configuration: Schools::FuelConfiguration.new(has_gas: true))
           refresh
         end
 


### PR DESCRIPTION
We currently allow pupils to filter some charts by meter. But when we incorporated those charts into the advice pages, we didn't enable that feature.

As part of providing more options for viewing usage by meter, this PR enables that option. The primary functional change is setting `split_meters: true` when we render a partial. The rest of the changes are tidying for ERBLint plus some basic tests.

The PR also fixes a long standing bug in `School.filterable_meters`. Currently this disallows access to filtering any meters, if a school has solar or storage heaters. But they should still have option to filter gas meters. A future PR will revisit whether we disallow filtering of solar/storage.