### PR TITLE
Update robots.txt

### DIFF
--- a/app/views/robots_txts/allow.raw
+++ b/app/views/robots_txts/allow.raw
@@ -45,3 +45,6 @@ Disallow: /
 
 User-agent: rogerbot
 Disallow: /
+
+User-agent: MJ12bot
+Disallow: /

--- a/app/views/robots_txts/allow.raw
+++ b/app/views/robots_txts/allow.raw
@@ -33,3 +33,15 @@ Disallow: /
 
 User-agent: barkrowler
 Disallow: /
+
+User-agent: Bytespider
+Disallow: /
+
+User-agent: AhrefsBot
+Disallow: /
+
+User-agent: dotbot
+Disallow: /
+
+User-agent: rogerbot
+Disallow: /


### PR DESCRIPTION
Block some persistent crawlers that are constantly fetching school pages and some active storage assets.

The AhrefsBot also seems to be accessing chart urls, e.g. for annotations or json.

Bytespider is accessing incorrection activity/action urls.