### PR TITLE
Fix setting defaults on school onboarding forms

### DIFF
--- a/app/controllers/admin/school_onboardings/configuration_controller.rb
+++ b/app/controllers/admin/school_onboardings/configuration_controller.rb
@@ -4,15 +4,6 @@ module Admin
       load_and_authorize_resource :school_onboarding, find_by: :uuid
 
       def edit
-        if @school_onboarding.school_group
-          @school_onboarding.template_calendar = @school_onboarding.school_group.default_template_calendar
-          @school_onboarding.solar_pv_tuos_area = @school_onboarding.school_group.default_solar_pv_tuos_area
-          @school_onboarding.dark_sky_area = @school_onboarding.school_group.default_dark_sky_area
-          @school_onboarding.weather_station = @school_onboarding.school_group.default_weather_station
-          @school_onboarding.scoreboard = @school_onboarding.school_group.default_scoreboard
-          @school_onboarding.default_chart_preference = @school_onboarding.school_group.default_chart_preference
-          @school_onboarding.country = @school_onboarding.school_group.default_country
-        end
       end
 
       def update

--- a/app/controllers/admin/school_onboardings_controller.rb
+++ b/app/controllers/admin/school_onboardings_controller.rb
@@ -21,8 +21,7 @@ module Admin
     end
 
     def create
-      @school_onboarding.uuid = SecureRandom.uuid
-      @school_onboarding.created_by = current_user
+      @school_onboarding.populate_default_values(current_user)
       if @school_onboarding.save
         redirect_to edit_admin_school_onboarding_configuration_path(@school_onboarding)
       else

--- a/app/models/school_onboarding.rb
+++ b/app/models/school_onboarding.rb
@@ -74,7 +74,7 @@ class SchoolOnboarding < ApplicationRecord
   enum country: School.countries
 
   def populate_default_values(user)
-    self.assign_attributes({
+    assign_attributes({
       uuid: SecureRandom.uuid,
       created_by: user,
       template_calendar: school_group&.default_template_calendar,

--- a/app/models/school_onboarding.rb
+++ b/app/models/school_onboarding.rb
@@ -73,6 +73,20 @@ class SchoolOnboarding < ApplicationRecord
   enum default_chart_preference: [:default, :carbon, :usage, :cost]
   enum country: School.countries
 
+  def populate_default_values(user)
+    self.assign_attributes({
+      uuid: SecureRandom.uuid,
+      created_by: user,
+      template_calendar: school_group&.default_template_calendar,
+      solar_pv_tuos_area: school_group&.default_solar_pv_tuos_area,
+      dark_sky_area: school_group&.default_dark_sky_area,
+      weather_station: school_group&.default_weather_station,
+      scoreboard: school_group&.default_scoreboard,
+      default_chart_preference: school_group&.default_chart_preference,
+      country: school_group&.default_country
+    })
+  end
+
   def has_event?(event_name)
     events.where(event: event_name).any?
   end

--- a/spec/models/school_onboarding_spec.rb
+++ b/spec/models/school_onboarding_spec.rb
@@ -83,4 +83,51 @@ describe SchoolOnboarding, type: :model do
       end
     end
   end
+
+  describe '.populate_default_values' do
+    let(:user) { create(:admin) }
+    let(:school_onboarding) { create(:school_onboarding) }
+
+    before do
+      school_onboarding.populate_default_values(user)
+    end
+
+    context 'with no group' do
+      it 'assigns user and uuid only' do
+        expect(school_onboarding.uuid).not_to be_nil
+        expect(school_onboarding.created_by).to eq(user)
+        expect(school_onboarding.template_calendar).to be_nil
+      end
+    end
+
+    context 'with a group' do
+      let(:school_group) do
+        create(:school_group,
+          default_template_calendar: create(:regional_calendar),
+          default_solar_pv_tuos_area: create(:solar_pv_tuos_area),
+          default_dark_sky_area: create(:dark_sky_area),
+          default_weather_station: create(:weather_station),
+          default_scoreboard: create(:scoreboard),
+          default_chart_preference: :carbon,
+          default_country: :wales
+        )
+      end
+      let(:school_onboarding) { create(:school_onboarding, school_group: school_group) }
+
+      it 'assigns user and uuid' do
+        expect(school_onboarding.uuid).not_to be_nil
+        expect(school_onboarding.created_by).to eq(user)
+      end
+
+      it 'copies default values from the group' do
+        expect(school_onboarding.template_calendar).to eq(school_group.default_template_calendar)
+        expect(school_onboarding.solar_pv_tuos_area).to eq(school_group.default_solar_pv_tuos_area)
+        expect(school_onboarding.dark_sky_area).to eq(school_group.default_dark_sky_area)
+        expect(school_onboarding.weather_station).to eq(school_group.default_weather_station)
+        expect(school_onboarding.scoreboard).to eq(school_group.default_scoreboard)
+        expect(school_onboarding.default_chart_preference).to eq(school_group.default_chart_preference)
+        expect(school_onboarding.country).to eq(school_group.default_country)
+      end
+    end
+  end
 end

--- a/spec/system/admin/school_onboarding_spec.rb
+++ b/spec/system/admin/school_onboarding_spec.rb
@@ -94,7 +94,11 @@ RSpec.describe 'onboarding', :schools, type: :system do
     end
 
     it 'allows editing of an onboarding setup' do
-      onboarding = create :school_onboarding, :with_events
+      onboarding = create(:school_onboarding,
+                          school_group: school_group,
+                          weather_station: weather_station,
+                          scoreboard: scoreboard)
+
       click_on 'Manage school onboarding'
       click_on 'Edit'
 
@@ -119,6 +123,12 @@ RSpec.describe 'onboarding', :schools, type: :system do
       visit admin_school_onboardings_path
       click_on 'Edit'
       expect(page).to have_select('Funder', selected: funder.name)
+      click_on 'Next'
+      expect(page).to have_select('Template calendar', selected: 'Oxford calendar')
+      expect(page).to have_select('Country', selected: 'Scotland')
+      # unchanged
+      expect(page).to have_select('Weather Station', selected: onboarding.weather_station.title)
+      expect(page).to have_select('Scoreboard', selected: onboarding.scoreboard.name)
     end
 
     context 'when completing onboarding as admin without consents' do


### PR DESCRIPTION
There's a long standing bug in how the admin school onboarding forms were written.

Currently the populating the school onboarding with the default values from the school group are done in the `edit` action on the configuration controller. So when an admin first visits that form the defaults are copied over and can then be accepted or customised.

The bug is that if they visit the form again later as making other changes, then the group default values are reapplied before displaying the form. So the form state looks like any original selections were never saved as its no longer reflecting the database state. 

This PR fixes that bug so that the school group defaults are applied when the school onboarding is initially created.