### PR TITLE
Rework how the SingleReadConverter drops rows

### DIFF
--- a/app/models/amr_data_feed_config.rb
+++ b/app/models/amr_data_feed_config.rb
@@ -110,6 +110,6 @@ class AmrDataFeedConfig < ApplicationRecord
   # formats can produce days with missing readings due to handling of 23:30-00:00 half-hour.
   def blank_threshold
     return nil unless row_per_reading?
-    return missing_readings_limit || BLANK_THRESHOLD
+    missing_readings_limit || BLANK_THRESHOLD
   end
 end

--- a/app/models/amr_data_feed_config.rb
+++ b/app/models/amr_data_feed_config.rb
@@ -57,6 +57,8 @@ class AmrDataFeedConfig < ApplicationRecord
   validates :identifier, :description, uniqueness: true
   validates_presence_of :identifier, :description
 
+  BLANK_THRESHOLD = 1
+
   def map_of_fields_to_indexes(header = nil)
     this_header = header || header_example
     header_array = this_header.split(',')
@@ -95,5 +97,19 @@ class AmrDataFeedConfig < ApplicationRecord
   def local_bucket_path
     path = ENV['AMR_CONFIG_LOCAL_FILE_BUCKET_PATH'] || 'tmp/amr_files_bucket'
     "#{path}/#{identifier}"
+  end
+
+  # Used in SingleReadConverter to determine whether to drop rows that have missing readings
+  #
+  # Only applicable to row_per_reading formats
+  #
+  # To preserve current loader behaviour this returns either the value of missing_readings_limit, to
+  # allow that to be configured, or a default of 1
+  #
+  # This can later be replaced with missing_reading_limit, but need to resolve how row_per_reading
+  # formats can produce days with missing readings due to handling of 23:30-00:00 half-hour.
+  def blank_threshold
+    return nil unless row_per_reading?
+    return missing_readings_limit || BLANK_THRESHOLD
   end
 end

--- a/app/services/amr/data_feed_validator.rb
+++ b/app/services/amr/data_feed_validator.rb
@@ -87,7 +87,7 @@ module Amr
     # That is done in SingleReadConverter for those configs
     def should_reject_rows?
       return false if @config.row_per_reading?
-      return @config.missing_readings_limit.present?
+      @config.missing_readings_limit.present?
     end
   end
 end

--- a/app/services/amr/data_feed_validator.rb
+++ b/app/services/amr/data_feed_validator.rb
@@ -9,7 +9,7 @@ module Amr
       array_of_rows = handle_header(@array_of_rows)
       array_of_rows = sort_out_off_by_one_array(array_of_rows) if @config.handle_off_by_one && array_of_rows.size > 1
       array_of_rows = array_of_rows.reject { |row| invalid_row?(row) }
-      array_of_rows = array_of_rows.reject { |row| partial_row?(row) } unless @config.missing_readings_limit.nil?
+      array_of_rows = array_of_rows.reject { |row| partial_row?(row) } if should_reject_rows?
       array_of_rows = filter_column_rows_for(array_of_rows) if @config.column_row_filters.present? && headers_as_array
       array_of_rows
     end
@@ -81,6 +81,13 @@ module Amr
       # Reject if row has more than the allowed number of missing readings
       return true unless row.count > index_of_last_reading_field
       row[index_of_first_reading_field..index_of_last_reading_field].count(&:blank?) > @config.missing_readings_limit
+    end
+
+    # Don't apply the missing_readings_limit to reject partial rows for row_per_reading format
+    # That is done in SingleReadConverter for those configs
+    def should_reject_rows?
+      return false if @config.row_per_reading?
+      return @config.missing_readings_limit.present?
     end
   end
 end

--- a/app/services/amr/data_file_to_amr_reading_data.rb
+++ b/app/services/amr/data_file_to_amr_reading_data.rb
@@ -13,7 +13,7 @@ module Amr
       array_of_data_feed_reading_hashes = convert_to_day_per_row_format(array_of_data_feed_reading_hashes) if @config.row_per_reading
       array_of_data_feed_reading_hashes.uniq
 
-      missing_reading_threshold = @config.row_per_reading? ? SingleReadConverter::BLANK_THRESHOLD : 0
+      missing_reading_threshold = @config.row_per_reading? ? @config.blank_threshold : 0
 
       AmrReadingData.new(reading_data: array_of_data_feed_reading_hashes.uniq, date_format: @config.date_format, missing_reading_threshold: missing_reading_threshold)
     end
@@ -21,7 +21,7 @@ module Amr
     private
 
     def convert_to_day_per_row_format(array_of_data_feed_reading_hashes)
-      SingleReadConverter.new(array_of_data_feed_reading_hashes, indexed: @config[:positional_index]).perform
+      SingleReadConverter.new(@config, array_of_data_feed_reading_hashes).perform
     rescue ArgumentError
       {}
     end

--- a/app/services/amr/single_read_converter.rb
+++ b/app/services/amr/single_read_converter.rb
@@ -2,8 +2,8 @@ module Amr
   class SingleReadConverter
     class InvalidTimeStringError < StandardError; end
 
+    # @param AmrDataFeedConfig amr_data_feed_config the data feed configuration used to customise processing
     # @param Array single_reading_array an array of readings
-    # @param boolean indexed whether the array should be interpreted in HH order, rather than via timestamp.
     def initialize(amr_data_feed_config, single_reading_array)
       @amr_data_feed_config = amr_data_feed_config
       @single_reading_array = single_reading_array

--- a/app/services/amr/single_read_converter.rb
+++ b/app/services/amr/single_read_converter.rb
@@ -2,13 +2,12 @@ module Amr
   class SingleReadConverter
     class InvalidTimeStringError < StandardError; end
 
-    BLANK_THRESHOLD = 1
-
     # @param Array single_reading_array an array of readings
     # @param boolean indexed whether the array should be interpreted in HH order, rather than via timestamp.
-    def initialize(single_reading_array, indexed: false)
+    def initialize(amr_data_feed_config, single_reading_array)
+      @amr_data_feed_config = amr_data_feed_config
       @single_reading_array = single_reading_array
-      @indexed = indexed
+      @indexed = @amr_data_feed_config[:positional_index]
       @results_array = []
     end
 
@@ -91,7 +90,7 @@ module Amr
     end
 
     def reject_any_low_reading_days
-      @results_array.reject { |result| result[:readings].count(&:blank?) > BLANK_THRESHOLD }
+      @results_array.reject { |result| result[:readings].count(&:blank?) > @amr_data_feed_config.blank_threshold }
     end
 
     def last_reading_of_day?(reading_index)

--- a/app/views/admin/amr_data_feed_configs/edit.html.erb
+++ b/app/views/admin/amr_data_feed_configs/edit.html.erb
@@ -2,8 +2,11 @@
 
 <%= simple_form_for [:admin, @configuration] do |f| %>
   <%= f.input :description, as: :string, hint: 'A human-readable name for the configuration' %>
-  <%= f.input :notes, as: :rich_text_area, label: 'Notes', hint: 'Provide additional notes about when the configuration is used' %>
-  <%= f.input :import_warning_days, hint: 'This is the number of days after which meter data using this configuration will be considered to be running behing. Used to drive admin import notification emails' %>
-  <%= f.input :missing_readings_limit, hint: 'This is the maximum number of missing data points allowed in a day, above which the entire day will be ignored (without reporting)' %>
-  <%= f.submit 'Update', class: 'btn'%>
+  <%= f.input :notes, as: :rich_text_area, label: 'Notes',
+                      hint: 'Provide additional notes about when the configuration is used' %>
+  <%= f.input :import_warning_days,
+              hint: 'This is the number of days after which meter data using this configuration will be considered to be running behing. Used to drive admin import notification emails' %>
+  <%= f.input :missing_readings_limit,
+              hint: 'This is the maximum number of missing data points allowed in a day, above which the entire day will be ignored (without reporting). For row per reading formats this will currently always be set to 1 unless a number is configured here.' %>
+  <%= f.submit 'Update', class: 'btn' %>
 <% end %>

--- a/spec/services/amr/csv_parser_and_upserter_spec.rb
+++ b/spec/services/amr/csv_parser_and_upserter_spec.rb
@@ -153,7 +153,7 @@ module Amr
           importer.perform
 
           AmrDataFeedReading.all.find_each do |reading_record|
-            expect(reading_record.readings.count(&:blank?)).to be <= SingleReadConverter::BLANK_THRESHOLD
+            expect(reading_record.readings.count(&:blank?)).to be <= highlands_config.blank_threshold
           end
 
           expect(AmrDataFeedReading.count).to be 7


### PR DESCRIPTION
We currently support an option on `AmrDataFeedConfig` called `missing_readings_limit`. If set then any day that has more missing half hourly readings that this limit will automatically be rejected by the data loader. It allows us to silently reject incomplete data without generating lots of warnings for the admins.

While this was previously used on some older configs, it's not currently used. When set it's applied by the `DataFeedValidator`.

Separately the `SingleReadConverter` uses a hard coded `BLANK_THRESHOLD` when it is converting "row per reading" formats into the standard format. The value of that constant has always been 1.

For a new data supplier we need to be more tolerant of some missing half-hourly readings. Currently they are sending us data in a "row per reading" format that regularly has several half-hourly readings that are missing. This means all the data is getting rejected by `SingleReadConverter` which isn't ideal.

This PR changes `SingleReadConverter` so that the threshold is instead configurable using the `missing_readings_limit` parameter on the config.

For backwards compatibility, I've approached this by:

- ensuring the `DataFeedValidator` does not apply `missing_readings_limit` to "row per reading" formats. As the `SingleReadConverter` will handle rejecting any rows. It doesn't make sense for the validator to do this as we haven't get gathered up the individual rows into an array for these format
- changing `SingleReadingConverter` to have access to the `AmrDataFeedConfig` and then read the threshold from there, via a new `.blank_threshold` method which will default to 1 for "row_per_reading" formats if `missing_readings_limit` is not configured
- revised the rest of the behaviour and tests accordingly

I decided not to just set a default value of `missing_readings_limit` of 1 for all "row per reading" formats for the moment. Or set a validation/callback to ensure that any new similar formats have a default. This is because there's another issue to be resolved later around how we are interpreting timestamps in some of those row per reading files. Resolving that may mean that we don't need a default value, so wanted to handle that in the code rather than having to do several database changes.

There's a bit of reworking of some of the specs, but haven't done a full tidy up at the moment.