### PR TITLE
Fix currently holiday comparison date check

### DIFF
--- a/app/controllers/comparisons/shared/consumption_during_holiday_controller.rb
+++ b/app/controllers/comparisons/shared/consumption_during_holiday_controller.rb
@@ -17,7 +17,7 @@ module Comparisons
       def load_data
         model.for_schools(@schools)
              .where.not(holiday_projected_usage_gbp: nil)
-             .where(holiday_start_date: Time.zone.today..)
+             .where('holiday_start_date <= :today AND holiday_end_date >= :today', today: Time.zone.today)
              .order(holiday_projected_usage_gbp: :desc)
       end
 


### PR DESCRIPTION
Fixes the query so it checks whether today is within the holiday start and end dates, rather than whether today is the start of the holiday.