### PR TITLE
Small quality of life improvements for school onboardings page

### DIFF
--- a/app/controllers/admin/school_onboardings_controller.rb
+++ b/app/controllers/admin/school_onboardings_controller.rb
@@ -56,7 +56,7 @@ module Admin
         @school_onboardings.order(:school_group_id).incomplete.each do |school_onboarding|
           last_event = school_onboarding.events.order(event: :desc).first
           last_event = last_event.event.to_s.humanize if last_event
-          csv << [school_onboarding.school_name, school_onboarding.school_group.name, school_onboarding.contact_email, school_onboarding.notes, last_event]
+          csv << [school_onboarding.school_name, school_onboarding.school_group&.name, school_onboarding.contact_email, school_onboarding.notes, last_event]
         end
       end
     end

--- a/app/views/admin/school_onboardings/index.html.erb
+++ b/app/views/admin/school_onboardings/index.html.erb
@@ -1,32 +1,47 @@
-<h1>School onboardings in progress</h1>
+<h1>School onboardings currently in progress</h1>
 
-<%= link_to 'New Automatic School Setup', new_admin_school_onboarding_path, class: 'btn' %>
+<%= link_to 'New School Onboarding', new_admin_school_onboarding_path, class: 'btn' %>
 <%= link_to 'Download as CSV', admin_school_onboardings_path(format: :csv), class: 'btn' %>
 
-<br/>
-<br/>
-
-<% @school_groups.each do |school_group| %>
-  <p><%= link_to school_group.name, "##{school_group.slug}" %></p>
-<% end %>
-
-<% @school_groups.each do |school_group| %>
-
-  <div class="nav-anchor">
-    <a name="<%= school_group.slug %>"> </a>
-  </div>
-  <br/>
-
-  <h3><%= school_group.name %></h3>
-
-  <%= link_to 'Download as CSV', admin_school_group_school_onboardings_path(school_group, format: :csv), class: 'btn' %>
-  <br/>
-  <br/>
-
-  <% if school_group.school_onboardings.incomplete.any? %>
-    <p>Schools onboarding: <%= school_group.school_onboardings.incomplete.count %>
-    <%= render 'admin/school_groups/onboarding_schools', school_group: school_group, anchor: '' %>
-  <% else %>
-    <p>No schools are onboarding for <%= school_group.name %></p>
+<div class="mt-4">
+  <p>
+    Quick links:
+  </p>
+  <ul>
+  <% @school_groups.each do |school_group| %>
+    <% if school_group.school_onboardings.incomplete.any? %>
+      <li><%= link_to school_group.name, "##{school_group.slug}" %></li>
+    <% end %>
   <% end %>
+  </ul>
+</div>
+
+<% @school_groups.each do |school_group| %>
+  <% next unless school_group.school_onboardings.incomplete.any? %>
+
+  <hr class="mt-4">
+
+  <div class="d-flex justify-content-between align-items-top">
+    <div>
+      <h2 id="<%= school_group.slug %>" class="scrollable"><%= school_group.name %></h2>
+    </div>
+    <div>
+      <%= link_to '#' do %>
+        <%= t('common.back_to_top') %>
+        <i class="fa fa-arrow-up" data-toggle="tooltip" title="<%= t('common.back_to_top') %>"></i>
+      <% end %>
+    </div>
+  </div>
+
+  <div class="d-flex justify-content-between align-items-top">
+    <div>
+      <p>Schools onboarding: <%= school_group.school_onboardings.incomplete.count %>
+    </div>
+    <div>
+      <%= link_to 'Download as CSV', admin_school_group_school_onboardings_path(school_group, format: :csv),
+                  class: 'btn' %>
+    </div>
+  </div>
+
+  <%= render 'admin/school_groups/onboarding_schools', school_group: school_group, anchor: '' %>
 <% end %>

--- a/spec/system/admin/school_onboarding_spec.rb
+++ b/spec/system/admin/school_onboarding_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe 'onboarding', :schools, type: :system do
 
     it 'allows a new onboarding to be setup and sends an email to the school' do
       click_on 'Manage school onboarding'
-      click_on 'New Automatic School Setup'
+      click_on 'New School Onboarding'
 
       fill_in 'School name', with: school_name
       fill_in 'Contact email', with: 'oldfield@test.com'
@@ -247,7 +247,7 @@ RSpec.describe 'onboarding', :schools, type: :system do
         let(:email_address) { 'different_address@email.com' }
 
         it 'saves' do
-          expect(page).to have_content('School onboardings in progress')
+          expect(page).to have_content('School onboardings currently in progress')
           expect(page).to have_content(email_address)
         end
 


### PR DESCRIPTION
Limits the pages to only groups with incomplete onboardings

Adds link back to the top of the page

Fixes issue with download of all incomplete onboardings, as some records aren't associated with a group