### PR TITLE
Rework solar panel report report

### DIFF
--- a/app/controllers/admin/reports/solar_panels_controller.rb
+++ b/app/controllers/admin/reports/solar_panels_controller.rb
@@ -2,8 +2,8 @@ module Admin
   module Reports
     class SolarPanelsController < AdminController
       def index
-        @solar_panels = MeterAttribute.solar_panels
-        @number_of_schools = @solar_panels.uniq(&:school_id).count
+        @metered_solar = MeterAttribute.metered_solar
+        @estimated_solar = MeterAttribute.solar_pv
       end
     end
   end

--- a/app/models/meter_attribute.rb
+++ b/app/models/meter_attribute.rb
@@ -50,8 +50,8 @@ class MeterAttribute < ApplicationRecord
     query = <<-SQL.squish
       SELECT ma.id, m.id, s.id, s.name, solar.*
       FROM meter_attributes ma
-      INNER JOIN meters m ON ma.meter_id = m.id
-      INNER JOIN schools s ON m.school_id = s.id,
+      JOIN meters m ON ma.meter_id = m.id
+      JOIN schools s ON m.school_id = s.id,
       JSON_TO_RECORD(ma.input_data) AS solar(
         start_date TEXT,
         end_date TEXT,
@@ -69,16 +69,16 @@ class MeterAttribute < ApplicationRecord
     SQL
     sanitized_query = ActiveRecord::Base.sanitize_sql_array(query)
     MeterAttribute.connection.select_all(sanitized_query).rows.map do |row|
-      OpenStruct.new(
-        meter_attribute_id: row[0],
-        meter: Meter.find(row[1]),
-        school_id: row[2],
-        school_name: row[3],
-        start_date: row[4],
-        end_date: row[5],
-        export_mpan: row[6],
-        production_mpans: [row[7], row[8], row[9], row[10], row[11]].reject(&:blank?)
-      )
+      result = ActiveSupport::OrderedOptions.new
+      result.meter_attribute_id = row[0]
+      result.meter = Meter.find(row[1])
+      result.school_id = row[2]
+      result.school_name = row[3]
+      result.start_date = row[4]
+      result.end_date = row[5]
+      result.export_mpan = row[6]
+      result.production_mpans = [row[7], row[8], row[9], row[10], row[11]].reject(&:blank?)
+      result
     end
   end
 
@@ -86,8 +86,8 @@ class MeterAttribute < ApplicationRecord
     query = <<-SQL.squish
       SELECT ma.id, m.school_id, s.name, ma.meter_id, solar.*
       FROM meter_attributes ma
-      INNER JOIN meters m ON ma.meter_id = m.id
-      INNER JOIN schools s ON m.school_id = s.id,
+      JOIN meters m ON ma.meter_id = m.id
+      JOIN schools s ON m.school_id = s.id,
       JSON_TO_RECORD(ma.input_data) AS solar(start_date TEXT, end_date TEXT, kwp FLOAT)
       WHERE ma.attribute_type='solar_pv' AND ma.deleted_by_id IS NULL AND ma.replaced_by_id IS NULL
       AND s.active = true
@@ -95,15 +95,15 @@ class MeterAttribute < ApplicationRecord
     SQL
     sanitized_query = ActiveRecord::Base.sanitize_sql_array(query)
     MeterAttribute.connection.select_all(sanitized_query).rows.map do |row|
-      OpenStruct.new(
-        meter_attribute_id: row[0],
-        school_id: row[1],
-        school_name: row[2],
-        meter: Meter.find(row[3]),
-        start_date: row[4],
-        end_date: row[5],
-        kwp: row[6]
-      )
+      result = ActiveSupport::OrderedOptions.new
+      result.meter_attribute_id = row[0]
+      result.school_id = row[1]
+      result.school_name = row[2]
+      result.meter = Meter.find(row[3])
+      result.start_date = row[4]
+      result.end_date = row[5]
+      result.kwp = row[6]
+      result
     end
   end
 end

--- a/app/views/admin/reports/solar_panels/index.html.erb
+++ b/app/views/admin/reports/solar_panels/index.html.erb
@@ -2,20 +2,18 @@
 
 <h1>Solar Panel Summary</h1>
 
-<p>
-  This report lists all <strong><%= @number_of_schools %></strong> schools with a "solar_pv" meter attribute. We use this
-  configuration to estimate the school's solar power generation using data from
-  Sheffield University.
-</p>
+<ul>
+  <li><a href="#metered-solar">Metered solar</a></li>
+  <li><a href="#estimated-solar">Estimated solar (Sheffield synthetic data)</a></li>
+</ul>
+
+<h2 id="metered-solar">Metered Solar</h2>
 
 <p>
-  The table lists a number of optional attributes. Only the dates and kwp values are
-  required.
-</p>
-
-<p>
-  Solar panel overrides, which are used to substitute data where we have actual
-  meter solar data are not included here.
+  This table lists all <strong><%= @metered_solar.uniq(&:school_id).count %></strong> active schools that have a
+  <code>solar_pv_meter_mapping</code> attribute that configures their real solar metering. There is one row per
+  attribute, so a school may be present multiple times if they have separate
+  arrays, e.g. on different meters.
 </p>
 
 <div class="row">
@@ -26,30 +24,90 @@
       <th>Meter</th>
       <th>Start date</th>
       <th>End date</th>
-      <th>kwp</th>
-      <th>orientation</th>
-      <th>tilt</th>
-      <th>shading</th>
-      <th>fit_£_per_kwh</th>
+      <th>Export MPAN</th>
+      <th>Production MPANs</th>
       <th></th>
     </tr>
     </thead>
     <tbody>
-    <% @solar_panels.each do |solar_panel_config| %>
+    <% @metered_solar.each do |solar_panel_config| %>
       <tr>
         <td><%= link_to(solar_panel_config.school_name, school_path(solar_panel_config.meter.school)) %></td>
-        <td><%= link_to(solar_panel_config.meter.display_name, school_meter_path(solar_panel_config.meter.school, solar_panel_config.meter)) %></td>
+        <td><%= link_to(solar_panel_config.meter.display_name,
+                        school_meter_path(solar_panel_config.meter.school, solar_panel_config.meter)) %></td>
+        <td><%= solar_panel_config.start_date %></td>
+        <td><%= solar_panel_config.end_date %></td>
+        <td><%= solar_panel_config.export_mpan %></td>
+        <td>
+          <ul class="list-unstyled">
+            <% solar_panel_config.production_mpans.each do |mpan| %>
+              <li><%= mpan %></li>
+            <% end %>
+          </ul>
+        </td>
+        <td>
+          <div class="btn-group">
+            <%= link_to 'Edit', edit_admin_school_meter_attribute_path(solar_panel_config.meter.school,
+                                                                       id: solar_panel_config.meter_attribute_id),
+                        class: 'btn btn-sm' %>
+            <%= link_to('History', admin_school_meter_attribute_path(solar_panel_config.meter.school,
+                                                                     id: solar_panel_config.meter_attribute_id),
+                        class: 'btn btn-sm') %>
+          </div>
+        </td>
+      </tr>
+    <% end %>
+    </tbody>
+  </table>
+</div>
+
+<h2 id="estimated-solar">Estimated Solar</h2>
+
+<p>
+  This report lists all <strong><%= @estimated_solar.uniq(&:school_id).count %></strong> active schools with
+  a <code>solar_pv</code> meter attribute. We use this configuration to estimate the school's solar power generation
+  using data from Sheffield University.
+</p>
+
+<p>
+  Solar panel overrides, which are used to substitute data where we have actual
+  meter solar data are not included here.
+</p>
+
+<p>
+  Schools might have both metered and estimated solar so may be present in both tables. The <code>solar_pv</code>
+  attribute is also sometimes combined with the <code>solar_pv_meter_mapping</code> attribute.
+</p>
+
+<div class="row">
+  <table class="table table-sorted">
+    <thead>
+    <tr>
+      <th>School</th>
+      <th>Meter</th>
+      <th>Start date</th>
+      <th>End date</th>
+      <th>kWp</th>
+      <th></th>
+    </tr>
+    </thead>
+    <tbody>
+    <% @estimated_solar.each do |solar_panel_config| %>
+      <tr>
+        <td><%= link_to(solar_panel_config.school_name, school_path(solar_panel_config.meter.school)) %></td>
+        <td><%= link_to(solar_panel_config.meter.display_name, school_meter_path(solar_panel_config.meter.school,
+                                                                                 solar_panel_config.meter)) %></td>
         <td><%= solar_panel_config.start_date %></td>
         <td><%= solar_panel_config.end_date %></td>
         <td><%= solar_panel_config.kwp %></td>
-        <td><%= solar_panel_config.orientation %></td>
-        <td><%= solar_panel_config.tilt %></td>
-        <td><%= solar_panel_config.shading %></td>
-        <td><%= solar_panel_config.fit_£_per_kwh %></td>
         <td>
           <div class="btn-group">
-            <%= link_to 'Edit', edit_admin_school_meter_attribute_path(solar_panel_config.meter.school, id: solar_panel_config.meter_attribute_id), class: 'btn btn-sm' %>
-            <%= link_to('History', admin_school_meter_attribute_path(solar_panel_config.meter.school, id: solar_panel_config.meter_attribute_id), class: 'btn btn-sm') %>
+            <%= link_to 'Edit', edit_admin_school_meter_attribute_path(solar_panel_config.meter.school,
+                                                                       id: solar_panel_config.meter_attribute_id),
+                        class: 'btn btn-sm' %>
+            <%= link_to('History', admin_school_meter_attribute_path(solar_panel_config.meter.school,
+                                                                     id: solar_panel_config.meter_attribute_id),
+                        class: 'btn btn-sm') %>
           </div>
         </td>
       </tr>

--- a/spec/models/meter_attribute_spec.rb
+++ b/spec/models/meter_attribute_spec.rb
@@ -5,26 +5,26 @@ describe MeterAttribute do
     let(:meter) { build(:electricity_meter) }
 
     it 'passes validation with blank input data' do
-      MeterAttribute.create!(attribute_type: :function_switch, input_data: nil, meter: meter)
+      described_class.create!(attribute_type: :function_switch, input_data: nil, meter: meter)
     end
 
     it 'passes validation with correct input data' do
-      MeterAttribute.create!(attribute_type: :function_switch, input_data: 'heating_only', meter: meter)
+      described_class.create!(attribute_type: :function_switch, input_data: 'heating_only', meter: meter)
     end
 
     it 'fails validation with incorrect input data' do
       expect do
-        MeterAttribute.create!(attribute_type: :function_switch, input_data: 'not_a_value', meter: meter)
+        described_class.create!(attribute_type: :function_switch, input_data: 'not_a_value', meter: meter)
       end.to raise_error(ActiveRecord::RecordInvalid, /Invalid value/)
     end
   end
 
   describe '.to_analytics' do
     it 'aggregates attributes that have an aggregation key' do
-      attribute_1 = MeterAttribute.new(attribute_type: :function_switch, input_data: 'heating_only')
-      attribute_2 = MeterAttribute.new(attribute_type: :function_switch, input_data: 'kitchen_only')
+      attribute_1 = described_class.new(attribute_type: :function_switch, input_data: 'heating_only')
+      attribute_2 = described_class.new(attribute_type: :function_switch, input_data: 'kitchen_only')
 
-      results = MeterAttribute.to_analytics([attribute_1, attribute_2])
+      results = described_class.to_analytics([attribute_1, attribute_2])
 
       expect(results).to eq(
         {
@@ -34,9 +34,9 @@ describe MeterAttribute do
     end
 
     it 'uses the key for normal attribute types' do
-      attribute_1 = MeterAttribute.new(attribute_type: :targeting_and_tracking_profiles_maximum_retries, input_data: { number_of_retries: 1 })
+      attribute_1 = described_class.new(attribute_type: :targeting_and_tracking_profiles_maximum_retries, input_data: { number_of_retries: 1 })
 
-      results = MeterAttribute.to_analytics([attribute_1])
+      results = described_class.to_analytics([attribute_1])
 
       expect(results).to eq(
         {
@@ -46,11 +46,11 @@ describe MeterAttribute do
     end
   end
 
-  describe '.solar_panels' do
-    let(:config) { { start_date: '2022-01-01', kwp: '10', end_date: '2023-01-01', orientation: '0', tilt: '30', shading: '6', fit_£_per_kwh: '0.3' } }
+  describe '.solar_pv' do
+    let(:config) { { start_date: '2022-01-01', kwp: '10', end_date: '2023-01-01' } }
     let!(:solar_attribute) { create(:meter_attribute, attribute_type: :solar_pv, input_data: config)}
     let!(:other_attribute) { create(:meter_attribute, attribute_type: :targeting_and_tracking_profiles_maximum_retries, input_data: { number_of_retries: 1 })}
-    let(:solar_panels)  { MeterAttribute.solar_panels }
+    let(:solar_panels)  { described_class.solar_pv }
     let(:panel)         { solar_panels.first }
 
     it 'returns expected data' do
@@ -61,10 +61,38 @@ describe MeterAttribute do
       expect(panel.school_name).to eq solar_attribute.meter.school_name
       expect(panel.start_date).to eq '2022-01-01'
       expect(panel.end_date).to eq '2023-01-01'
-      expect(panel.orientation).to eq '0'
-      expect(panel.tilt).to eq '30'
-      expect(panel.shading).to eq '6'
-      expect(panel.fit_£_per_kwh).to eq '0.3'
+      expect(panel.kwp).to eq 10
+    end
+  end
+
+  describe '.metered_solar' do
+    let(:config) do
+      {
+        start_date: '2022-01-01',
+        end_date: '2023-01-01',
+        export_mpan: '1234',
+        production_mpan: '1',
+        production_mpan2: '2',
+        production_mpan3: '3',
+        production_mpan4: '4',
+        production_mpan5: '5'
+      }
+    end
+    let!(:solar_attribute) { create(:meter_attribute, attribute_type: :solar_pv_mpan_meter_mapping, input_data: config)}
+    let!(:other_attribute) { create(:meter_attribute, attribute_type: :targeting_and_tracking_profiles_maximum_retries, input_data: { number_of_retries: 1 })}
+    let(:solar_panels) { described_class.metered_solar }
+    let(:mapping) { solar_panels.first }
+
+    it 'returns expected data' do
+      expect(solar_panels.size).to eq 1
+      expect(mapping.meter_attribute_id).to eq solar_attribute.id
+      expect(mapping.meter).to eq solar_attribute.meter
+      expect(mapping.school_id).to eq solar_attribute.meter.school.id
+      expect(mapping.school_name).to eq solar_attribute.meter.school_name
+      expect(mapping.start_date).to eq '2022-01-01'
+      expect(mapping.end_date).to eq '2023-01-01'
+      expect(mapping.export_mpan).to eq('1234')
+      expect(mapping.production_mpans).to eq(%w[1 2 3 4 5])
     end
   end
 end


### PR DESCRIPTION
Reworks the admin solar panel report so that it has:

- one table reporting on schools with metered solar
- one table reporting on schools with estimated solar

Tweaks the text on the page to better describe report and remove unnecessary columns.