### PR TITLE
Change minimum password length

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -154,7 +154,7 @@ Devise.setup do |config|
 
   # ==> Configuration for :validatable
   # Range for password length.
-  config.password_length = 6..128
+  config.password_length = 12..128
 
   # Email regex used to validate email formats. It simply asserts that
   # one (and only one) @ exists in the given string. This is mainly

--- a/spec/factories/users_factory.rb
+++ b/spec/factories/users_factory.rb
@@ -1,8 +1,8 @@
 FactoryBot.define do
   factory :user do
     sequence(:email) { |n| "user_#{n}@test.com" }
-    password         { 'testpass' }
-    confirmed_at     { Time.zone.now }
+    sequence(:password) { |n| "secure password phrase #{n}" }
+    confirmed_at { Time.zone.now }
 
     factory :school_admin do
       name { 'School manager' }

--- a/spec/system/account_confirmation_spec.rb
+++ b/spec/system/account_confirmation_spec.rb
@@ -10,8 +10,9 @@ describe 'account confirmation' do
 
     current_email.click_link 'Confirm my account'
 
-    fill_in 'New password', with: 'testtest1'
-    fill_in 'Confirm new password', with: 'testtest1'
+    password = 'testtesttest1'
+    fill_in 'New password', with: password
+    fill_in 'Confirm new password', with: password
 
     click_on 'Complete registration'
 

--- a/spec/system/admin/school_users_spec.rb
+++ b/spec/system/admin/school_users_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 RSpec.describe 'School Users', :schools, type: :system do
   let(:confirmation_token) { 'abc123' }
+  let(:valid_password) { 'valid password' }
 
   context 'when confirming new user without school' do
     let!(:user) { create(:user, confirmation_token: confirmation_token, confirmed_at: nil, school: nil, email: 'foo@bar.com', name: 'Foo Bar') }
@@ -45,8 +46,8 @@ RSpec.describe 'School Users', :schools, type: :system do
 
     it 'allows newsletter to be subscribed (the default)' do
       expect_any_instance_of(MailchimpSubscriber).to receive(:subscribe).with(user)
-      fill_in :user_password, with: 'abcdef'
-      fill_in :user_password_confirmation, with: 'abcdef'
+      fill_in :user_password, with: valid_password
+      fill_in :user_password_confirmation, with: valid_password
       check 'privacy'
       click_button 'Complete registration'
       expect(page).to have_content('Your password has been changed successfully. You are now signed in.')
@@ -54,8 +55,8 @@ RSpec.describe 'School Users', :schools, type: :system do
 
     it 'allows newsletter to be unsubscribed' do
       expect_any_instance_of(MailchimpSubscriber).not_to receive(:subscribe)
-      fill_in :user_password, with: 'abcdef'
-      fill_in :user_password_confirmation, with: 'abcdef'
+      fill_in :user_password, with: valid_password
+      fill_in :user_password_confirmation, with: valid_password
       check 'privacy'
       uncheck 'Subscribe to newsletters'
       click_button 'Complete registration'
@@ -63,8 +64,8 @@ RSpec.describe 'School Users', :schools, type: :system do
     end
 
     it 'allows alert to be subscribed (the default)' do
-      fill_in :user_password, with: 'abcdef'
-      fill_in :user_password_confirmation, with: 'abcdef'
+      fill_in :user_password, with: valid_password
+      fill_in :user_password_confirmation, with: valid_password
       check 'privacy'
       click_button 'Complete registration'
       expect(page).to have_content('Your password has been changed successfully. You are now signed in.')
@@ -73,8 +74,8 @@ RSpec.describe 'School Users', :schools, type: :system do
     end
 
     it 'allows alert to be unsubscribed' do
-      fill_in :user_password, with: 'abcdef'
-      fill_in :user_password_confirmation, with: 'abcdef'
+      fill_in :user_password, with: valid_password
+      fill_in :user_password_confirmation, with: valid_password
       check 'privacy'
       uncheck 'Subscribe to school alerts'
       click_button 'Complete registration'
@@ -84,7 +85,7 @@ RSpec.describe 'School Users', :schools, type: :system do
 
     it 'reshows subscription check boxes after failed validation' do
       check 'privacy'
-      fill_in :user_password, with: 'abcdef'
+      fill_in :user_password, with: valid_password
       uncheck 'Subscribe to school alerts'
       uncheck 'Subscribe to newsletters'
       click_button 'Complete registration'
@@ -105,8 +106,8 @@ RSpec.describe 'School Users', :schools, type: :system do
 
     it 'allows password to be set' do
       expect(page).to have_content('Set your password')
-      fill_in :user_password, with: 'abcdef'
-      fill_in :user_password_confirmation, with: 'abcdef'
+      fill_in :user_password, with: valid_password
+      fill_in :user_password_confirmation, with: valid_password
       click_button 'Set my password'
       expect(page).to have_content('Your password has been changed successfully')
     end

--- a/spec/system/password_reset_spec.rb
+++ b/spec/system/password_reset_spec.rb
@@ -45,8 +45,9 @@ describe 'password reset' do
         urls = URI.extract(email.html_part.decoded, ['http'])
         visit urls.last
         expect(page).to have_content('Preferred language')
-        fill_in 'New password', with: 'password'
-        fill_in 'Confirm new password', with: 'password'
+        password = 'new password'
+        fill_in 'New password', with: password
+        fill_in 'Confirm new password', with: password
         select 'English', from: 'Preferred language'
         click_button 'Set my password'
         expect(user.reload.preferred_locale).to eq('en')

--- a/spec/system/school_onboarding_spec.rb
+++ b/spec/system/school_onboarding_spec.rb
@@ -47,8 +47,9 @@ RSpec.describe 'onboarding', :schools, type: :system do
         expect(page).to have_content('Step 1: Create your school administrator account')
         fill_in 'Your name', with: 'A Teacher'
         select 'Headteacher', from: 'Role'
-        fill_in 'Password', with: 'testtest1', match: :prefer_exact
-        fill_in 'Password confirmation', with: 'testtest1'
+        password = 'testtesttest1'
+        fill_in 'Password', with: password, match: :prefer_exact
+        fill_in 'Password confirmation', with: password
         check :privacy
         click_on 'Create my account'
 
@@ -95,8 +96,9 @@ RSpec.describe 'onboarding', :schools, type: :system do
         expect(page).to have_content('Step 1: Create your school administrator account')
         fill_in 'Your name', with: 'A Teacher'
         select 'Headteacher', from: 'Role'
-        fill_in 'Password', with: 'testtest1', match: :prefer_exact
-        fill_in 'Password confirmation', with: 'testtest1'
+        password = 'testtesttest1'
+        fill_in 'Password', with: password, match: :prefer_exact
+        fill_in 'Password confirmation', with: password
         check :privacy
         click_on 'Create my account'
 
@@ -129,8 +131,9 @@ RSpec.describe 'onboarding', :schools, type: :system do
         expect(page).to have_content('I confirm agreement with the Energy Sparks')
         fill_in 'Your name', with: 'A Teacher'
         select 'Headteacher', from: 'Role'
-        fill_in 'Password', with: 'testtest1', match: :prefer_exact
-        fill_in 'Password confirmation', with: 'testtest1'
+        password = 'testtesttest1'
+        fill_in 'Password', with: password, match: :prefer_exact
+        fill_in 'Password confirmation', with: password
 
         check :privacy
         click_on 'Create my account'


### PR DESCRIPTION
Changes minimum password length from 6 to 12 as recommended by CyberEssentials.

I've left the maximum limit in place despite CyberEssentials say it should be unlimited as 128 chars is sufficient for a long passphrase.

I've manually confirmed (via testing and checking the validatable module in Devise) that changing the password length requirements doesn't impact existing users, just new passwords (new users, password resets).

Still need to add validation to pupil account passwords.