### PR TITLE
Add a minimum length to pupil passwords

### DIFF
--- a/config/locales/views/onboarding/onboarding.yml
+++ b/config/locales/views/onboarding/onboarding.yml
@@ -134,8 +134,8 @@ en:
       name_hint: This could be the name of a classroom or an eco-team
       name_placeholder: e.g. %{school_name} classroom password
       pupil_password: Pupil password
-      pupil_password_hint: Make it memorable and easy for pupils to type
-      pupil_password_placeholder: e.g. superenergysavers
+      pupil_password_hint: Make it memorable and easy for pupils to type. Must be at least 12 characters.
+      pupil_password_placeholder: ''
       title: 'Step 5: Create your pupil account'
       title_for_update: Update your pupil account
       update: Update pupil account

--- a/spec/factories/users_factory.rb
+++ b/spec/factories/users_factory.rb
@@ -23,7 +23,7 @@ FactoryBot.define do
 
     factory :pupil do
       role { :pupil }
-      pupil_password { 'test' }
+      pupil_password { 'three memorable words' }
       school
     end
 

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -245,18 +245,20 @@ describe School do
 
   describe 'authenticate_pupil' do
     let(:school) { create :school }
-    let!(:pupil) { create :pupil, pupil_password: 'testTest', school: school }
+    let(:valid_password) { 'three memorable Words 123' }
+    let!(:pupil) { create :pupil, pupil_password: valid_password, school: school }
 
     it 'selects pupils with the correct password' do
-      expect(school.authenticate_pupil('testTest')).to eq(pupil)
+      expect(school.authenticate_pupil(valid_password)).to eq(pupil)
     end
 
     it 'returns nothing if the password does not match' do
       expect(school.authenticate_pupil('barp')).to eq(nil)
+      expect(school.authenticate_pupil('three memorable words')).to eq(nil)
     end
 
     it 'is not case sensitive' do
-      expect(school.authenticate_pupil('testtest')).to eq(pupil)
+      expect(school.authenticate_pupil('three memorable words 123')).to eq(pupil)
     end
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -90,12 +90,19 @@ describe User do
 
   describe 'pupil validation' do
     let(:school) { create(:school) }
-    let!(:existing_pupil) { create(:pupil, pupil_password: 'testtest', school: school) }
+    let!(:existing_pupil) { create(:pupil, pupil_password: 'three memorable words', school: school) }
+
+    it 'enforces minimum length' do
+      expect(build(:pupil, school: school, pupil_password: 'abc')).not_to be_valid
+      expect(build(:pupil, school: school, pupil_password: 'test')).not_to be_valid
+      expect(build(:pupil, school: school, pupil_password: 'testtesttest')).to be_valid
+      expect(build(:pupil, school: school, pupil_password: 'some memorable words')).to be_valid
+    end
 
     it 'checks for unique passwords within the school' do
-      expect(build(:pupil, school: school, pupil_password: 'testtest')).not_to be_valid
-      expect(build(:pupil, school: school, pupil_password: 'testtest123')).to be_valid
-      expect(build(:pupil, school: create(:school), pupil_password: 'testtest')).to be_valid
+      expect(build(:pupil, school: school, pupil_password: 'three memorable words')).not_to be_valid
+      expect(build(:pupil, school: school, pupil_password: 'three memorable words 123')).to be_valid
+      expect(build(:pupil, school: create(:school), pupil_password: 'three memorable words')).to be_valid
     end
   end
 

--- a/spec/system/school_onboarding_spec.rb
+++ b/spec/system/school_onboarding_spec.rb
@@ -479,10 +479,11 @@ RSpec.describe 'onboarding', :schools, type: :system do
         visit new_onboarding_completion_path(onboarding)
 
         click_on 'Edit pupil account'
-        fill_in 'Pupil password', with: 'testtest2'
+        password = 'a valid password'
+        fill_in 'Pupil password', with: password
         click_on 'Update pupil account'
         pupil.reload
-        expect(pupil.pupil_password).to eq('testtest2')
+        expect(pupil.pupil_password).to eq(password)
       end
 
       it 'meters can be added' do


### PR DESCRIPTION
Adds a validation for pupil passwords so they're a minimum of 12 characters. Updates the text on the form.