### PR TITLE
Fix date issues in specs

### DIFF
--- a/app/views/schools/meters/show.html.erb
+++ b/app/views/schools/meters/show.html.erb
@@ -101,7 +101,7 @@
           <dt class="col-sm-3"><%= t('schools.meters.show.n3rgy_api_status') %></dt>
           <dd class="col-sm-9"><%= @n3rgy&.status.to_s.humanize %></dd>
           <dt class="col-sm-3"><%= t('schools.meters.show.available_cache_range') %></dt>
-          <dd class="col-sm-9"><%= @n3rgy&.available_data if @n3rgy&.consented? %></dd>
+          <dd class="col-sm-9"><%= @n3rgy&.available_data&.map(&:rfc2822) if @n3rgy&.consented? %></dd>
         </dl>
       <% else %>
         <p><%= t('schools.meters.show.not_configured_as_a_dcc_meter') %></p>

--- a/spec/components/podium_component_spec.rb
+++ b/spec/components/podium_component_spec.rb
@@ -9,6 +9,14 @@ RSpec.describe PodiumComponent, type: :component, include_url_helpers: true do
   let(:all_params) { { podium: podium, classes: 'my-class', id: 'my-id' } }
   let(:params) { all_params }
 
+  # Avoids problem with showing national placing. National Scoreboard only runs from
+  # 1st Sept to 31st Jul.
+  around do |example|
+    travel_to Date.new(2024, 4, 1) do
+      example.run
+    end
+  end
+
   before do
     create(:national_calendar, title: 'England and Wales') # required for podium to show national placing
   end

--- a/spec/system/scoreboard_spec.rb
+++ b/spec/system/scoreboard_spec.rb
@@ -11,6 +11,14 @@ RSpec.describe 'scoreboards', :scoreboards do
     create(:school, :with_points, score_points: points, scoreboard: scoreboard, calendar: calendar)
   end
 
+  # Avoids problem with showing national placing. National Scoreboard only runs from
+  # 1st Sept to 31st Jul.
+  around do |example|
+    travel_to Date.new(2024, 4, 1) do
+      example.run
+    end
+  end
+
   describe 'with public scoreboards', :aggregate_failures do
     describe 'on the index page' do
       before do


### PR DESCRIPTION
- issue with specs that use national scoreboard
- issue with displaying dates from n3rgy, ruby default formatting when turning array of DateTime into string isn't quite RFC2822 (no zero padding on day number), so apply explicit formatting in template