### PR TITLE
Optimise loading of schools for sign in form

### DIFF
--- a/app/controllers/schools/visibility_controller.rb
+++ b/app/controllers/schools/visibility_controller.rb
@@ -13,7 +13,7 @@ module Schools
     def destroy
       authorize! :change_visibility, @school
       @school.update!(visible: false)
-      Rails.cache.delete(:schools_for_login_form) # cached in sessions controller
+      SchoolCreator.expire_login_cache!
       redirect_back fallback_location: school_path(@school)
     end
   end

--- a/app/controllers/schools/visibility_controller.rb
+++ b/app/controllers/schools/visibility_controller.rb
@@ -13,6 +13,7 @@ module Schools
     def destroy
       authorize! :change_visibility, @school
       @school.update!(visible: false)
+      Rails.cache.delete(:schools_for_login_form) # cached in sessions controller
       redirect_back fallback_location: school_path(@school)
     end
   end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -6,7 +6,10 @@ class SessionsController < Devise::SessionsController
   def load_school
     if params[:school].present?
       @school = School.find_by(slug: params[:school])
+    else
+      @schools = Rails.cache.fetch(:schools_for_login_form) do
+        School.school_list_for_login_form
+      end
     end
-    @schools = School.visible.order(:name)
   end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -7,9 +7,7 @@ class SessionsController < Devise::SessionsController
     if params[:school].present?
       @school = School.find_by(slug: params[:school])
     else
-      @schools = Rails.cache.fetch(:schools_for_login_form) do
-        School.school_list_for_login_form
-      end
+      @schools = SchoolCreator.school_list_for_login_form
     end
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -470,8 +470,8 @@ module ApplicationHelper
   end
 
   def school_name_group(school)
-    if school.school_group
-      "#{school.name} (#{school.school_group.name})"
+    if school.school_group_name
+      "#{school.name} (#{school.school_group_name})"
     else
       school.name
     end

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -703,7 +703,7 @@ class School < ApplicationRecord
 
   def self.school_list_for_login_form
     query = <<-SQL.squish
-      SELECT schools.name, school_groups.name
+      SELECT schools.id, schools.name, school_groups.name
       FROM schools
       LEFT JOIN school_groups ON schools.school_group_id = school_groups.id
       WHERE schools.visible=TRUE
@@ -712,8 +712,9 @@ class School < ApplicationRecord
     sanitized_query = ActiveRecord::Base.sanitize_sql_array(query)
     School.connection.select_all(sanitized_query).rows.map do |row|
       result = ActiveSupport::OrderedOptions.new
-      result.name = row[0]
-      result.school_group_name = row[1]
+      result.id = row[0]
+      result.name = row[1]
+      result.school_group_name = row[2]
       result
     end
   end

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -701,6 +701,23 @@ class School < ApplicationRecord
     meters.active.where(meter_type: fuel_type).count > 1
   end
 
+  def self.school_list_for_login_form
+    query = <<-SQL.squish
+      SELECT schools.name, school_groups.name
+      FROM schools
+      LEFT JOIN school_groups ON schools.school_group_id = school_groups.id
+      WHERE schools.visible=TRUE
+      ORDER BY schools.name;
+    SQL
+    sanitized_query = ActiveRecord::Base.sanitize_sql_array(query)
+    School.connection.select_all(sanitized_query).rows.map do |row|
+      result = ActiveSupport::OrderedOptions.new
+      result.name = row[0]
+      result.school_group_name = row[1]
+      result
+    end
+  end
+
   private
 
   def valid_uk_postcode

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -702,21 +702,7 @@ class School < ApplicationRecord
   end
 
   def self.school_list_for_login_form
-    query = <<-SQL.squish
-      SELECT schools.id, schools.name, school_groups.name
-      FROM schools
-      LEFT JOIN school_groups ON schools.school_group_id = school_groups.id
-      WHERE schools.visible=TRUE
-      ORDER BY schools.name;
-    SQL
-    sanitized_query = ActiveRecord::Base.sanitize_sql_array(query)
-    School.connection.select_all(sanitized_query).rows.map do |row|
-      result = ActiveSupport::OrderedOptions.new
-      result.id = row[0]
-      result.name = row[1]
-      result.school_group_name = row[2]
-      result
-    end
+    School.left_joins(:school_group).select(:id, :name, 'school_groups.name as school_group_name').where(visible: true).order(:name)
   end
 
   private

--- a/app/services/school_creator.rb
+++ b/app/services/school_creator.rb
@@ -44,6 +44,7 @@ class SchoolCreator
       users = @school.users.reject(&:pupil?)
       onboarding_service.complete_onboarding(@school.school_onboarding, users)
     end
+    Rails.cache.delete(:schools_for_login_form) # cached in sessions controller
     broadcast(:school_made_visible, @school)
   end
 

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -302,9 +302,17 @@ describe ApplicationHelper do
   end
 
   describe '#school_name_group' do
-    let(:school_group)          { create(:school_group, name: 'Some School Group') }
-    let(:school_with_group)     { create(:school, name: 'School One', school_group: school_group) }
-    let(:school_without_group)  { create(:school, name: 'School Two') }
+    let(:school_with_group) do
+      school = ActiveSupport::OrderedOptions.new
+      school.name = 'School One'
+      school.school_group_name = 'Some School Group'
+      school
+    end
+    let(:school_without_group) do
+      school = ActiveSupport::OrderedOptions.new
+      school.name = 'School Two'
+      school
+    end
 
     it 'handles school with group' do
       expect(helper.school_name_group(school_with_group)).to eq('School One (Some School Group)')

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -483,20 +483,6 @@ describe School do
         end
 
         let!(:expired_target) do
-          report = {
-            'fuel_type': 'electricity',
-            'months': ['2024-01-01'],
-            'monthly_targets_kwh': [],
-            'monthly_usage_kwh': [],
-            'monthly_performance': [],
-            'cumulative_targets_kwh': [],
-            'cumulative_usage_kwh': [],
-            'cumulative_performance': [],
-            'cumulative_performance_versus_synthetic_last_year': [],
-            'monthly_performance_versus_synthetic_last_year': [],
-            'partial_months': [],
-            'percentage_synthetic': []
-          }
           create(:school_target, :with_progress_report, start_date: Date.yesterday.prev_year, school: subject, electricity: 5, gas: nil)
         end
 
@@ -788,6 +774,20 @@ describe School do
       it 'returns no electricity meters' do
         expect(subject.filterable_meters(:electricity)).to be_empty
       end
+    end
+  end
+
+  describe '.school_list_for_login_form' do
+    let!(:school) { create(:school, :with_school_group) }
+    let!(:no_school_group) { create(:school) }
+
+    it 'returns all schools' do
+      schools = School.school_list_for_login_form
+      expect(schools.length).to eq(2)
+      expect(schools.first.name).to eq(school.name)
+      expect(schools.first.school_group_name).to eq(school.school_group.name)
+      expect(schools.last.name).to eq(no_school_group.name)
+      expect(schools.last.school_group_name).to eq(nil)
     end
   end
 end


### PR DESCRIPTION
Noticed when making changes to authentication that we are loading the models for all visible schools and school groups when serving the sign in form.

This PR has some optimisations that reduces unnecessary queries and memory usage:

- only load school list if we're not showing login for single school
- adds custom query to load school and school group name, returning a list
- caches results of looking up list of schools, expiring it whenever a new school is made (in)visible

Makes a big difference to speed with which page loads, although unlikely that its hit that often in production.