### PR TITLE
Add dashboard insights component

### DIFF
--- a/app/components/adult_reminders_component.rb
+++ b/app/components/adult_reminders_component.rb
@@ -1,0 +1,55 @@
+class AdultRemindersComponent < DashboardRemindersComponent
+  def messageable
+    [@school, @school.try(:school_group)].compact
+  end
+
+  def prompt_for_bill?
+    can_manage_school? && @school.bill_requested && can?(:index, ConsentDocument)
+  end
+
+  def prompt_for_training?
+    can_manage_school? && show_data_enabled_features? && user.confirmed_at > 30.days.ago
+  end
+
+  def prompt_for_contacts?
+    site_settings.message_for_no_contacts && @school.contacts.empty? && can?(:manage, Contact)
+  end
+
+  def prompt_for_pupils?
+    site_settings.message_for_no_pupil_accounts && @school.users.pupil.empty? && can?(:manage_users, @school)
+  end
+
+  def recent_audit
+    Audits::AuditService.new(@school).recent_audit
+  end
+
+  def prompt_for_target?
+    Targets::SchoolTargetService.targets_enabled?(@school) && can?(:manage, SchoolTarget) && !@school.has_target? && target_service.enough_data?
+  end
+
+  def prompt_to_review_target?
+    Targets::SchoolTargetService.targets_enabled?(@school) && can?(:manage, SchoolTarget) && target_service.prompt_to_review_target?
+  end
+
+  def prompt_to_set_new_target?
+    Targets::SchoolTargetService.targets_enabled?(@school) && can?(:manage, SchoolTarget) && @school.has_expired_target? && !@school.has_current_target?
+  end
+
+  def suggest_estimates_for_fuel_types(check_data: true)
+    if can?(:manage, EstimatedAnnualConsumption)
+      Targets::SuggestEstimatesService.new(@school).suggestions(check_data: check_data)
+    else
+      []
+    end
+  end
+
+  private
+
+  def site_settings
+    @site_settings ||= SiteSettings.current
+  end
+
+  def target_service
+    @target_service ||= Targets::SchoolTargetService.new(@school)
+  end
+end

--- a/app/components/adult_reminders_component.rb
+++ b/app/components/adult_reminders_component.rb
@@ -1,55 +1,45 @@
 class AdultRemindersComponent < DashboardRemindersComponent
+  include SchoolProgress
+
+  def show_standard_prompts?
+    return true if user && user.admin?
+    return true if can_manage_school?
+    false
+  end
+
+  def can_manage_school?
+    ability.can?(:show_management_dash, @school)
+  end
+
   def messageable
     [@school, @school.try(:school_group)].compact
   end
 
   def prompt_for_bill?
-    can_manage_school? && @school.bill_requested && can?(:index, ConsentDocument)
+    can_manage_school? && @school.bill_requested && ability.can?(:index, ConsentDocument)
   end
 
   def prompt_for_training?
+    return false if user && user.admin?
+    # binding.pry
     can_manage_school? && show_data_enabled_features? && user.confirmed_at > 30.days.ago
   end
 
   def prompt_for_contacts?
-    site_settings.message_for_no_contacts && @school.contacts.empty? && can?(:manage, Contact)
+    site_settings.message_for_no_contacts && can_manage_school? && @school.contacts.empty? && ability.can?(:manage, Contact)
   end
 
   def prompt_for_pupils?
-    site_settings.message_for_no_pupil_accounts && @school.users.pupil.empty? && can?(:manage_users, @school)
+    site_settings.message_for_no_pupil_accounts && @school.users.pupil.empty? && ability.can?(:manage_users, @school)
   end
 
   def recent_audit
     Audits::AuditService.new(@school).recent_audit
   end
 
-  def prompt_for_target?
-    Targets::SchoolTargetService.targets_enabled?(@school) && can?(:manage, SchoolTarget) && !@school.has_target? && target_service.enough_data?
-  end
-
-  def prompt_to_review_target?
-    Targets::SchoolTargetService.targets_enabled?(@school) && can?(:manage, SchoolTarget) && target_service.prompt_to_review_target?
-  end
-
-  def prompt_to_set_new_target?
-    Targets::SchoolTargetService.targets_enabled?(@school) && can?(:manage, SchoolTarget) && @school.has_expired_target? && !@school.has_current_target?
-  end
-
-  def suggest_estimates_for_fuel_types(check_data: true)
-    if can?(:manage, EstimatedAnnualConsumption)
-      Targets::SuggestEstimatesService.new(@school).suggestions(check_data: check_data)
-    else
-      []
-    end
-  end
-
   private
 
   def site_settings
     @site_settings ||= SiteSettings.current
-  end
-
-  def target_service
-    @target_service ||= Targets::SchoolTargetService.new(@school)
   end
 end

--- a/app/components/adult_reminders_component/adult_reminders_component.html.erb
+++ b/app/components/adult_reminders_component/adult_reminders_component.html.erb
@@ -135,7 +135,7 @@
                 link: 'schools.show.create_pupil_account',
                 path: new_school_pupil_path(school)) do %>
      <p>
-       <%= t('schools.prompts.recommendations.message') %>
+       <%= t('schools.show.setup_pupil_account') %>
      </p>
    <% end %>
 

--- a/app/components/adult_reminders_component/adult_reminders_component.html.erb
+++ b/app/components/adult_reminders_component/adult_reminders_component.html.erb
@@ -1,0 +1,153 @@
+<%= component 'prompt_list', id: id, classes: classes do |list| %>
+  <% if title? %>
+    <% list.with_title do %>
+      <%= title %>
+    <% end %>
+  <% end %>
+
+  <% if show_standard_prompts? %>
+    <% messageable.each do |messageable| %>
+      <% add_prompt(id: "#{messageable.class.name.downcase}_dashboard_message",
+                    check: messageable.dashboard_message,
+                    list: list,
+                    status: :neutral,
+                    icon: 'info-circle') do %>
+        <%= messageable.dashboard_message.message %>
+      <% end %>
+    <% end %>
+  <% end %>
+
+  <% add_prompt(id: :bill,
+                check: prompt_for_bill?,
+                list: list,
+                status: :neutral,
+                icon: 'exclamation-circle',
+                link: 'schools.show.upload_energy_bill',
+                path: school_consent_documents_url(school)) do %>
+    <p>
+      <%= t('schools.show.energy_bill_required') %>
+    </p>
+  <% end %>
+
+  <% add_prompt(id: :training,
+                check: prompt_for_training?,
+                list: list,
+                status: :neutral,
+                icon: 'info-circle',
+                link: 'schools.show.find_training',
+                path: training_path) do %>
+    <p>
+      <%= t('schools.show.online_training_signup') %>
+    </p>
+  <% end %>
+
+  <% add_prompt(id: :audit,
+                check: recent_audit,
+                list: list,
+                status: :neutral,
+                icon: 'fa-laptop',
+                link: 'common.labels.view_now',
+                path: recent_audit ? school_audit_path(school, recent_audit) : nil) do %>
+    <p>
+      <%= Audits::Progress.new(recent_audit).notification %>
+    </p>
+  <% end %>
+
+  <% add_prompt(id: :set_target,
+                check: show_data_enabled_features? && prompt_for_target?,
+                list: list,
+                status: :neutral,
+                icon: 'tachometer-alt',
+                link: 'schools.show.set_target',
+                path: school_school_targets_path(school)) do %>
+    <p>
+      <%= t('schools.show.set_targets') %>
+    </p>
+  <% end %>
+
+  <% add_prompt(id: :review_target,
+                check: show_data_enabled_features? && prompt_to_review_target?,
+                list: list,
+                status: :neutral,
+                icon: 'tachometer-alt',
+                link: 'schools.show.review_target',
+                path: school_school_targets_path(school)) do %>
+    <p>
+      <%= t('schools.show.revisit_targets') %>
+    </p>
+  <% end %>
+
+  <% add_prompt(id: :new_target,
+                check: show_data_enabled_features? && prompt_to_set_new_target?,
+                list: list,
+                status: :neutral,
+                icon: 'tachometer-alt',
+                link: 'schools.show.review_progress',
+                path: school_school_targets_path(school)) do %>
+    <p>
+      <%= t('schools.show.set_new_target', target_date: I18n.l(school.expired_target.target_date, format: '%B %Y')) %>
+    </p>
+  <% end %>
+
+  <% if show_standard_prompts? %>
+    <% if programmes_to_prompt.any? %>
+      <% programmes_to_prompt.each do |programme| %>
+        <% add_prompt(id: :programme_reminder,
+                      list: list,
+                      status: :neutral,
+                      icon: 'tasks',
+                      link: 'common.labels.view_now',
+                      path: programme_type_path(programme.programme_type)) do %>
+          <p>
+            <%= Programmes::Progress.new(programme).notification %>
+          </p>
+        <% end %>
+      <% end %>
+    <% else %>
+      <% add_prompt(id: :new_programme,
+                    list: list,
+                    status: :neutral,
+                    icon: 'tasks',
+                    link: 'schools.prompts.programme.start_a_new_programme',
+                    path: programme_types_path) do %>
+        <p>
+          <%= t('schools.prompts.programme.choose_a_new_programme_message') %>
+        </p>
+      <% end %>
+    <% end %>
+    <% add_prompt(id: :choose_activity,
+                  list: list,
+                  status: :neutral,
+                  icon: 'clipboard-list',
+                  link: 'common.labels.choose_activity',
+                  path: school_recommendations_path(school, scope: :adult)) do %>
+      <p>
+        <%= t('schools.prompts.recommendations.message') %>
+      </p>
+    <% end %>
+  <% end %>
+
+  <% add_prompt(id: :add_pupils,
+                check: prompt_for_pupils?,
+                list: list,
+                status: :neutral,
+                icon: 'exclamation-circle',
+                link: 'schools.show.create_pupil_account',
+                path: new_school_pupil_path(school)) do %>
+     <p>
+       <%= t('schools.prompts.recommendations.message') %>
+     </p>
+   <% end %>
+
+   <% add_prompt(id: :add_contacts,
+                 check: prompt_for_contacts?,
+                 list: list,
+                 status: :neutral,
+                 icon: 'exclamation-circle',
+                 link: 'schools.show.add_alert_contacts',
+                 path: school_contacts_path(school)) do %>
+     <p>
+       <%= t('schools.show.setup_alert_contacts') %>
+     </p>
+   <% end %>
+<% end %>

--- a/app/components/alerts_component.rb
+++ b/app/components/alerts_component.rb
@@ -4,7 +4,6 @@ class AlertsComponent < PromptListComponent
   attr_reader :school, :show_links, :show_icons, :user
 
   include AdvicePageHelper
-  include ApplicationHelper
 
   def initialize(school:, dashboard_alerts:, alert_types: nil, audience: :adult, show_links: true, show_icons: true, id: nil, classes: '', user: nil)
     super(id: id, classes: classes)

--- a/app/components/alerts_component.rb
+++ b/app/components/alerts_component.rb
@@ -1,17 +1,23 @@
 # frozen_string_literal: true
 
-class AlertsComponent < ViewComponent::Base
-  attr_reader :school, :show_links, :show_icons
+class AlertsComponent < ApplicationComponent
+  attr_reader :school, :show_links, :show_icons, :user
 
   include AdvicePageHelper
   include ApplicationHelper
 
-  def initialize(school:, dashboard_alerts:, alert_types:, show_links: true, show_icons: true)
+  renders_one :title
+  renders_one :link
+
+  def initialize(school:, dashboard_alerts:, alert_types: nil, audience: :adult, show_links: true, show_icons: true, id: nil, classes: '', user: nil)
+    super(id: id, classes: classes)
     @school = school
     @dashboard_alerts = dashboard_alerts
     @alert_types = alert_types
     @show_links = show_links
     @show_icons = show_icons
+    @audience = audience
+    @user = user
   end
 
   def alerts
@@ -19,10 +25,11 @@ class AlertsComponent < ViewComponent::Base
   end
 
   def content_field
-    :management_dashboard_title
+    @audience == :adult ? :management_dashboard_title : :pupil_dashboard_title
   end
 
   def dashboard_alerts_for(alert_types)
+    return @dashboard_alerts unless alert_types.present?
     alert_type_ids = alert_types.map(&:id)
     @dashboard_alerts.select { |dashboard_alert| alert_type_ids.include?(dashboard_alert.alert.alert_type_id) }
   end

--- a/app/components/alerts_component.rb
+++ b/app/components/alerts_component.rb
@@ -1,13 +1,10 @@
 # frozen_string_literal: true
 
-class AlertsComponent < ApplicationComponent
+class AlertsComponent < PromptListComponent
   attr_reader :school, :show_links, :show_icons, :user
 
   include AdvicePageHelper
   include ApplicationHelper
-
-  renders_one :title
-  renders_one :link
 
   def initialize(school:, dashboard_alerts:, alert_types: nil, audience: :adult, show_links: true, show_icons: true, id: nil, classes: '', user: nil)
     super(id: id, classes: classes)
@@ -22,6 +19,10 @@ class AlertsComponent < ApplicationComponent
 
   def alerts
     @alerts ||= dashboard_alerts_for(@alert_types)
+  end
+
+  def render?
+    prompts? || alerts.any?
   end
 
   def content_field

--- a/app/components/alerts_component/alerts_component.html.erb
+++ b/app/components/alerts_component/alerts_component.html.erb
@@ -1,30 +1,35 @@
 <div id="<%= id %>" class="alerts-component <%= classes %>">
   <% if Flipper.enabled?(:new_dashboards_2024, user) %>
-    <%= component 'prompt_list' do |list| %>
-      <% if title? %>
-        <% list.with_title do %>
-          <%= title %>
-        <% end %>
-      <% end %>
-      <% if link? %>
-        <% list.with_link do %>
-          <%= link %>
-        <% end %>
-      <% end %>
-      <% alerts.each do |alert_content| %>
-        <%= list.with_prompt icon: alert_icon(alert_content.alert),
-                             status: status_for_alert_colour(alert_content.colour) do |prompt| %>
-            <% if alert_content.alert.advice_page.present? %>
-              <% prompt.with_link do %>
-                <%= link_to t('advice_pages.index.alerts.view_analysis'),
-                            advice_page_path(school,
-                                             alert_content.alert.advice_page,
-                                             alert_content.alert.alert_type.advice_page_tab_for_link_to,
-                                             anchor: alert_content.alert.alert_type.link_to_section) %>
-              <% end %>
+    <% if title? || link? %>
+      <div class="row">
+        <div class="col d-flex flex-wrap justify-content-between align-items-center">
+          <% if title? %>
+            <h3><%= title %></h3>
+          <% end %>
+          <% if link? %>
+            <div>
+              <%= link %>
+            </div>
+          <% end %>
+        </div>
+      </div>
+    <% end %>
+    <% prompts.each do |prompt| %>
+      <%= prompt %>
+    <% end %>
+    <% alerts.each do |alert_content| %>
+      <%= component 'prompt', icon: alert_icon(alert_content.alert),
+                              status: status_for_alert_colour(alert_content.colour) do |prompt| %>
+          <% if alert_content.alert.advice_page.present? %>
+            <% prompt.with_link do %>
+              <%= link_to t('advice_pages.index.alerts.view_analysis'),
+                          advice_page_path(school,
+                                           alert_content.alert.advice_page,
+                                           alert_content.alert.alert_type.advice_page_tab_for_link_to,
+                                           anchor: alert_content.alert.alert_type.link_to_section) %>
             <% end %>
-            <%= alert_content.send(content_field) %>
-        <% end %>
+          <% end %>
+          <%= alert_content.send(content_field) %>
       <% end %>
     <% end %>
   <% else %>

--- a/app/components/alerts_component/alerts_component.html.erb
+++ b/app/components/alerts_component/alerts_component.html.erb
@@ -1,21 +1,56 @@
-<div class="alerts-component">
-  <% alerts.each do |alert_content|%>
-    <%= component 'notice', classes: 'mt-4', status: status_for_alert_colour(alert_content.colour) do |c| %>
-      <div class="row">
-        <% if show_icons %>
-          <div class="col-md-1 d-flex align-items-center">
-            <%= fa_icon( alert_icon(alert_content.alert, 'fa-3x') ) %>
+<div id="<%= id %>" class="alerts-component <%= classes %>">
+  <% if Flipper.enabled?(:new_dashboards_2024, user) %>
+    <%= component 'prompt_list' do |list| %>
+      <% if title? %>
+        <% list.with_title do %>
+          <%= title %>
+        <% end %>
+      <% end %>
+      <% if link? %>
+        <% list.with_link do %>
+          <%= link %>
+        <% end %>
+      <% end %>
+      <% alerts.each do |alert_content| %>
+        <%= list.with_prompt icon: alert_icon(alert_content.alert),
+                             status: status_for_alert_colour(alert_content.colour) do |prompt| %>
+            <% if alert_content.alert.advice_page.present? %>
+              <% prompt.with_link do %>
+                <%= link_to t('advice_pages.index.alerts.view_analysis'),
+                            advice_page_path(school,
+                                             alert_content.alert.advice_page,
+                                             alert_content.alert.alert_type.advice_page_tab_for_link_to,
+                                             anchor: alert_content.alert.alert_type.link_to_section) %>
+              <% end %>
+            <% end %>
+            <%= alert_content.send(content_field) %>
+        <% end %>
+      <% end %>
+    <% end %>
+  <% else %>
+    <%# old style formatting used on advice pages will be removed %>
+    <% alerts.each do |alert_content| %>
+        <%= component 'notice', classes: 'mt-4', status: status_for_alert_colour(alert_content.colour) do |c| %>
+          <div class="row">
+            <% if show_icons %>
+              <div class="col-md-1 d-flex align-items-center">
+                <%= fa_icon(alert_icon(alert_content.alert, 'fa-3x')) %>
+              </div>
+            <% end %>
+            <div class="<%= show_icons ? 'col-md-11' : 'col-md-12' %>">
+              <%= alert_content.send(content_field) %>
+              <% if show_links && alert_content.alert.advice_page.present? %>
+                <div class="text-right">
+                  <%= link_to t('advice_pages.index.alerts.view_analysis'),
+                              advice_page_path(school,
+                                               alert_content.alert.advice_page,
+                                               alert_content.alert.alert_type.advice_page_tab_for_link_to,
+                                               anchor: alert_content.alert.alert_type.link_to_section) %>
+                </div>
+              <% end %>
+            </div>
           </div>
         <% end %>
-        <div class="<%= show_icons ? "col-md-11" : "col-md-12" %>">
-          <%= alert_content.send(content_field) %>
-          <% if show_links && alert_content.alert.advice_page.present? %>
-            <div class="text-right">
-              <%= link_to t('advice_pages.index.alerts.view_analysis'), advice_page_path(school, alert_content.alert.advice_page, alert_content.alert.alert_type.advice_page_tab_for_link_to, anchor: alert_content.alert.alert_type.link_to_section) %>
-            </div>
-          <% end %>
-        </div>
-      </div>
     <% end %>
   <% end %>
 </div>

--- a/app/components/application_component.rb
+++ b/app/components/application_component.rb
@@ -1,4 +1,7 @@
 class ApplicationComponent < ViewComponent::Base
+  include ApplicationHelper
+  include LocaleHelper
+
   attr_reader :id, :classes
 
   def initialize(id: nil, classes: '')

--- a/app/components/application_component.rb
+++ b/app/components/application_component.rb
@@ -1,0 +1,8 @@
+class ApplicationComponent < ViewComponent::Base
+  attr_reader :id, :classes
+
+  def initialize(id: nil, classes: '')
+    @id = id
+    @classes = classes
+  end
+end

--- a/app/components/dashboard_insights_component.rb
+++ b/app/components/dashboard_insights_component.rb
@@ -1,14 +1,42 @@
 # frozen_string_literal: true
 
 class DashboardInsightsComponent < ApplicationComponent
-  attr_reader :school, :alerts, :progress_summary
+  include TargetsHelper
+  include DashboardAlerts
 
-  def initialize(school:, audience: :adult, alerts: [], progress_summary: nil, user: nil, id: nil, classes: '')
+  attr_reader :school, :progress_summary, :user, :audience
+
+  def initialize(school:, audience: :adult, progress_summary: nil, user: nil, id: nil, classes: '')
     super(id: id, classes: classes)
     @school = school
     @audience = audience
     @user = user
-    @alerts = alerts
     @progress_summary = progress_summary
+  end
+
+  def alerts
+    @alerts ||= setup_alerts(@school.latest_dashboard_alerts.management_dashboard, content_field)
+  end
+
+  def content_field
+    @audience == :adult ? :management_dashboard_title : :pupil_dashboard_title
+  end
+
+  def data_enabled?
+    return true if user.present? && user.admin?
+    @school.data_enabled?
+  end
+
+  # display the alert column if the the school is data enabled and we have any content for that column
+  def displaying_alerts?
+    data_enabled? && (alerts.any? || any_passing_targets? || any_failing_targets?)
+  end
+
+  def any_passing_targets?
+    reportable_progress?(@progress_summary) && @progress_summary.any_passing_targets?
+  end
+
+  def any_failing_targets?
+    reportable_progress?(@progress_summary) && @progress_summary.any_failing_targets?
   end
 end

--- a/app/components/dashboard_insights_component.rb
+++ b/app/components/dashboard_insights_component.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class DashboardInsightsComponent < ApplicationComponent
+  attr_reader :school, :alerts, :progress_summary
+
+  def initialize(school:, audience: :adult, alerts: [], progress_summary: nil, user: nil, id: nil, classes: '')
+    super(id: id, classes: classes)
+    @school = school
+    @audience = audience
+    @user = user
+    @alerts = alerts
+    @progress_summary = progress_summary
+  end
+end

--- a/app/components/dashboard_insights_component/dashboard_insights_component.html.erb
+++ b/app/components/dashboard_insights_component/dashboard_insights_component.html.erb
@@ -1,41 +1,53 @@
-<div class="row">
-  <div class="col-12">
-    <h2><%= t('schools.show.insights_and_actions') %></h2>
-  </div>
-</div>
-
-<div class="row">
-  <div class="col-12 col-lg-6">
-    <%= component 'adult_reminders', school: school, user: user do |c| %>
-      <% c.with_title { 'Reminders' } %>
-    <% end %>
+<div id="<%= id %>" class="dashboard-insights-component <%= classes %>">
+  <div class="row">
+    <div class="col-12">
+      <h2><%= t('schools.dashboards.insights.title') %></h2>
+    </div>
   </div>
 
-  <% unless alerts.empty? %>
-    <div class="col-12 col-lg-6">
-      <%= component 'alerts', school: school, dashboard_alerts: alerts, user: user do |c| %>
-        <% c.with_title { t('advice_pages.index.alerts.title') } %>
-        <% c.with_link do %>
-          <%= link_to t('schools.show.view_more_alerts'), alerts_school_advice_path(school) %>
-        <% end %>
-        <% if reportable_progress?(progress_summary) && progress_summary.any_passing_targets? %>
-          <%= c.with_prompt icon: 'tachometer-alt', status: :positive do |p| %>
-            <%= t('schools.show.making_progress',
-                  fuels: t_fuels_as_sentence(progress_summary.passing_fuel_targets)) %>
-            <% p.with_link do %>
-              <%= link_to t('schools.show.review_progress'), school_school_targets_path(school) %>
-            <% end %>
-          <% end %>
-        <% elsif reportable_progress?(progress_summary) && progress_summary.any_failing_targets? %>
-          <%= c.with_prompt icon: 'tachometer-alt', status: :negative do |p| %>
-            <%= t('schools.show.not_meeting_target',
-                  fuels: t_fuels_as_sentence(progress_summary.failing_fuel_targets)) %>
-            <% p.with_link do %>
-              <%= link_to t('schools.show.review_progress'), school_school_targets_path(school) %>
-            <% end %>
-          <% end %>
-        <% end %>
+  <div class="row">
+    <%# split to 2 column view on larger screens if we are displaying alerts %>
+    <div class="col-12 <%= displaying_alerts? ? 'col-lg-6' : '' %>">
+      <%= component 'adult_reminders',
+                    school: school,
+                    user: user,
+                    id: "#{audience}-reminders" do |c| %>
+        <% c.with_title { t('schools.dashboards.reminders.title') } %>
       <% end %>
     </div>
-  <% end %>
+
+    <% if displaying_alerts? %>
+      <div class="col-12 col-lg-6">
+        <%= component 'alerts',
+                      school: school,
+                      audience: audience,
+                      dashboard_alerts: alerts,
+                      user: user,
+                      id: "#{audience}-alerts" do |c| %>
+          <% c.with_title { t('advice_pages.index.alerts.title') } %>
+          <% c.with_link do %>
+            <%= link_to t('schools.show.view_more_alerts'), alerts_school_advice_path(school) %>
+          <% end %>
+          <% if any_failing_targets? %>
+            <%= c.with_prompt icon: 'tachometer-alt', status: :negative do |p| %>
+              <%= t('schools.show.not_meeting_target',
+                    fuels: t_fuels_as_sentence(progress_summary.failing_fuel_targets)) %>
+              <% p.with_link do %>
+                <%= link_to t('schools.show.review_progress'), school_school_targets_path(school) %>
+              <% end %>
+            <% end %>
+          <% end %>
+          <% if any_passing_targets? %>
+            <%= c.with_prompt icon: 'tachometer-alt', status: :positive do |p| %>
+              <%= t('schools.show.making_progress',
+                    fuels: t_fuels_as_sentence(progress_summary.passing_fuel_targets)) %>
+              <% p.with_link do %>
+                <%= link_to t('schools.show.review_progress'), school_school_targets_path(school) %>
+              <% end %>
+            <% end %>
+          <% end %>
+        <% end %>
+      </div>
+    <% end %>
+  </div>
 </div>

--- a/app/components/dashboard_insights_component/dashboard_insights_component.html.erb
+++ b/app/components/dashboard_insights_component/dashboard_insights_component.html.erb
@@ -1,0 +1,41 @@
+<div class="row">
+  <div class="col-12">
+    <h2><%= t('schools.show.insights_and_actions') %></h2>
+  </div>
+</div>
+
+<div class="row">
+  <div class="col-12 col-lg-6">
+    <%= component 'adult_reminders', school: school, user: user do |c| %>
+      <% c.with_title { 'Reminders' } %>
+    <% end %>
+  </div>
+
+  <% unless alerts.empty? %>
+    <div class="col-12 col-lg-6">
+      <%= component 'alerts', school: school, dashboard_alerts: alerts, user: user do |c| %>
+        <% c.with_title { t('advice_pages.index.alerts.title') } %>
+        <% c.with_link do %>
+          <%= link_to t('schools.show.view_more_alerts'), alerts_school_advice_path(school) %>
+        <% end %>
+        <% if reportable_progress?(progress_summary) && progress_summary.any_passing_targets? %>
+          <%= c.with_prompt icon: 'tachometer-alt', status: :positive do |p| %>
+            <%= t('schools.show.making_progress',
+                  fuels: t_fuels_as_sentence(progress_summary.passing_fuel_targets)) %>
+            <% p.with_link do %>
+              <%= link_to t('schools.show.review_progress'), school_school_targets_path(school) %>
+            <% end %>
+          <% end %>
+        <% elsif reportable_progress?(progress_summary) && progress_summary.any_failing_targets? %>
+          <%= c.with_prompt icon: 'tachometer-alt', status: :negative do |p| %>
+            <%= t('schools.show.not_meeting_target',
+                  fuels: t_fuels_as_sentence(progress_summary.failing_fuel_targets)) %>
+            <% p.with_link do %>
+              <%= link_to t('schools.show.review_progress'), school_school_targets_path(school) %>
+            <% end %>
+          <% end %>
+        <% end %>
+      <% end %>
+    </div>
+  <% end %>
+</div>

--- a/app/components/dashboard_reminders_component.rb
+++ b/app/components/dashboard_reminders_component.rb
@@ -1,16 +1,11 @@
 class DashboardRemindersComponent < ApplicationComponent
   include ApplicationHelper
 
-  delegate :can?, to: :helpers
-  delegate :user_signed_in?, to: :helpers
-
   attr_reader :school, :user
-
   renders_one :title
 
-  def initialize(school:, user:, heading: nil, id: nil, classes: '')
+  def initialize(school:, user:, id: nil, classes: '')
     super(id: id, classes: classes)
-    @heading = heading
     @school = school
     @user = user
   end
@@ -27,25 +22,24 @@ class DashboardRemindersComponent < ApplicationComponent
 
   def show_data_enabled_features?
     if user && user.admin?
-      # TODO
+      # TODO params[:no_data] ? false : true
       true
-      # params[:no_data] ? false : true
     else
       @school.data_enabled?
     end
   end
 
-  def show_standard_prompts?
-    return true if user && user.admin?
-    return true if can?(:show_management_dash, @school)
-    false
-  end
-
-  def can_manage_school?
-    can?(:show_management_dash, @school)
-  end
-
   def programmes_to_prompt
     @school.programmes.last_started
+  end
+
+  private
+
+  def ability
+    @ability ||= Ability.new(@user)
+  end
+
+  def can?(permission, context)
+    ability.can?(permission, context)
   end
 end

--- a/app/components/dashboard_reminders_component.rb
+++ b/app/components/dashboard_reminders_component.rb
@@ -1,0 +1,51 @@
+class DashboardRemindersComponent < ApplicationComponent
+  include ApplicationHelper
+
+  delegate :can?, to: :helpers
+  delegate :user_signed_in?, to: :helpers
+
+  attr_reader :school, :user
+
+  renders_one :title
+
+  def initialize(school:, user:, heading: nil, id: nil, classes: '')
+    super(id: id, classes: classes)
+    @heading = heading
+    @school = school
+    @user = user
+  end
+
+  def add_prompt(list:, status:, icon:, check: true, id: nil, link: nil, path: nil)
+    return unless check
+    list.with_prompt id: id, status: status, icon: icon do |p|
+      yield
+      if link
+        p.with_link { helpers.link_to I18n.t(link), path }
+      end
+    end
+  end
+
+  def show_data_enabled_features?
+    if user && user.admin?
+      # TODO
+      true
+      # params[:no_data] ? false : true
+    else
+      @school.data_enabled?
+    end
+  end
+
+  def show_standard_prompts?
+    return true if user && user.admin?
+    return true if can?(:show_management_dash, @school)
+    false
+  end
+
+  def can_manage_school?
+    can?(:show_management_dash, @school)
+  end
+
+  def programmes_to_prompt
+    @school.programmes.last_started
+  end
+end

--- a/app/components/prompt_component.rb
+++ b/app/components/prompt_component.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+# Promopts are coloured by a status, which can be:
+# :none (grey?)
+# :positive
+# :negative
+# :neutral (blue)
+
+# Basic versions has:
+# icon on left
+# colour based on status, so a symbol or class?
+#
+#
+#
+# text via content
+# link via slot
+class PromptComponent < ApplicationComponent
+  include ApplicationHelper
+
+  renders_one :link
+  renders_one :title
+  renders_one :pill
+
+  attr_reader :icon
+
+  def initialize(id: nil, icon: nil, status: :none, classes: '')
+    super(id: id, classes: "#{status} #{classes}")
+    @icon = icon
+    @status = status
+    validate
+  end
+
+  def render?
+    content
+  end
+
+  def validate
+    raise ArgumentError.new(self.class.status_error) unless self.class.statuses.include?(@status.to_sym)
+  end
+
+  def self.statuses
+    [:none, :positive, :negative, :neutral]
+  end
+
+  def self.status_error
+    'Status must be: ' + self.statuses.to_sentence(last_word_connector: ' or ')
+  end
+end

--- a/app/components/prompt_component.rb
+++ b/app/components/prompt_component.rb
@@ -15,8 +15,6 @@
 # text via content
 # link via slot
 class PromptComponent < ApplicationComponent
-  include ApplicationHelper
-
   renders_one :link
   renders_one :title
   renders_one :pill

--- a/app/components/prompt_component/prompt_component.html.erb
+++ b/app/components/prompt_component/prompt_component.html.erb
@@ -1,0 +1,41 @@
+<div id="<%= id %>" class="prompt-component mb-2 <%= classes %>">
+  <%# Padding added to create space within div %>
+  <div class="row pt-4 pb-4">
+    <% if icon.present? %>
+      <%# Icon is hidden on smallest size, visible from sm and above as single column %>
+      <div class="d-none d-sm-block col-1">
+          <%# Use font-awesome stacking support. Additional class to override font size to match our default %>
+          <span class="prompt-component-fa-stack fa-stack fa-2x">
+            <i class="fa-solid fa-circle fa-stack-2x fa-inverse"></i>
+            <%= helpers.fa_icon(icon, class: 'fa-stack-1x') %>
+          </span>
+      </div>
+    <% end %>
+    <%# if no icon then use full width row %>
+    <%# Below md use full width, so text column wraps below icon. from md above use 2 cols %>
+    <div class="<%= icon.present? ? 'col-12 col-md-11' : 'col-12' %>">
+      <% if title? || pill? %>
+        <div class="row">
+          <div class="col">
+            <% if title? %>
+              <strong><%= title %></strong>
+            <% end %>
+            <% if pill? %>
+              <%= pill %>
+            <% end %>
+          </div>
+        </div>
+      <% end %>
+      <div class="row">
+        <div class="col">
+          <%= content %>
+          <p>
+          <% if link %>
+              <%= link %>
+          <% end %>
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/components/prompt_component/prompt_component.scss
+++ b/app/components/prompt_component/prompt_component.scss
@@ -1,0 +1,20 @@
+.prompt-component {
+  border-radius: 8px;
+  background-color: $light !important;
+  &.negative {
+    background-color: $light-red !important;
+  }
+  &.positive {
+    background-color: $green !important;
+  }
+  &.neutral {
+    background-color: $electric-light !important;
+  }
+  div.row {
+    margin: 0.25rem 0.25rem;
+  }
+}
+
+.prompt-component-fa-stack {
+  font-size: $f5;
+}

--- a/app/components/prompt_list_component.rb
+++ b/app/components/prompt_list_component.rb
@@ -1,0 +1,11 @@
+class PromptListComponent < ApplicationComponent
+  include ApplicationHelper
+
+  renders_one :title
+  renders_one :link
+  renders_many :prompts, PromptComponent
+
+  def render?
+    prompts?
+  end
+end

--- a/app/components/prompt_list_component.rb
+++ b/app/components/prompt_list_component.rb
@@ -1,6 +1,4 @@
 class PromptListComponent < ApplicationComponent
-  include ApplicationHelper
-
   renders_one :title
   renders_one :link
   renders_many :prompts, PromptComponent

--- a/app/components/prompt_list_component/prompt_list_component.html.erb
+++ b/app/components/prompt_list_component/prompt_list_component.html.erb
@@ -1,0 +1,19 @@
+<div id="<%= id %>" class="prompt-list-component <%= classes %>">
+  <% if title? || link? %>
+    <div class="row">
+      <div class="col d-flex flex-wrap justify-content-between align-items-center">
+        <% if title? %>
+          <h3><%= title %></h3>
+        <% end %>
+        <% if link? %>
+          <div>
+            <%= link %>
+          </div>
+        <% end %>
+      </div>
+    </div>
+  <% end %>
+  <% prompts.each do |prompt| %>
+    <%= prompt %>
+  <% end %>
+</div>

--- a/app/controllers/concerns/school_progress.rb
+++ b/app/controllers/concerns/school_progress.rb
@@ -8,14 +8,17 @@ private
   end
 
   def prompt_for_target?
+    return false unless can?(:show_management_dash, @school)
     Targets::SchoolTargetService.targets_enabled?(@school) && can?(:manage, SchoolTarget) && !@school.has_target? && target_service.enough_data?
   end
 
   def prompt_to_review_target?
+    return false unless can?(:show_management_dash, @school)
     Targets::SchoolTargetService.targets_enabled?(@school) && can?(:manage, SchoolTarget) && target_service.prompt_to_review_target?
   end
 
   def prompt_to_set_new_target?
+    return false unless can?(:show_management_dash, @school)
     Targets::SchoolTargetService.targets_enabled?(@school) && can?(:manage, SchoolTarget) && @school.has_expired_target? && !@school.has_current_target?
   end
 

--- a/app/controllers/schools_controller.rb
+++ b/app/controllers/schools_controller.rb
@@ -57,6 +57,8 @@ class SchoolsController < ApplicationController
 
     if params[:report] && @show_data_enabled_features
       render template: 'management/schools/report', layout: 'report'
+    elsif Flipper.enabled?(:new_dashboards_2024, current_user)
+      render :new_show, layout: 'dashboards'
     else
       render :show
     end

--- a/app/services/targets/school_target_service.rb
+++ b/app/services/targets/school_target_service.rb
@@ -28,7 +28,6 @@ module Targets
           return true if @school.configuration.enough_data_to_set_target_for_fuel_type?(fuel_type)
         end
       end
-      false
     end
 
     def refresh_target(target)

--- a/app/services/targets/school_target_service.rb
+++ b/app/services/targets/school_target_service.rb
@@ -28,6 +28,7 @@ module Targets
           return true if @school.configuration.enough_data_to_set_target_for_fuel_type?(fuel_type)
         end
       end
+      false
     end
 
     def refresh_target(target)

--- a/app/views/layouts/dashboards.html.erb
+++ b/app/views/layouts/dashboards.html.erb
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="<%= I18n.locale %>">
+  <head>
+    <%= render 'shared/head' %>
+  </head>
+  <body vocab="http://schema.org/">
+    <%= render 'shared/navigation' %>
+    <div class="container-fluid bg-light pb-3">
+      <div class="container<%= nav_margin_classes %>">
+        <%= render 'shared/breadcrumbs' %>
+        <%= render 'shared/alerts' if flash.any? %>
+        <%= yield :dashboard_header %>
+      </div>
+    </div>
+    <%= yield %>
+
+    <% if show_partner_footer?(@school) %>
+      <%= render 'shared/partners' %>
+    <% end %>
+    <%= render 'shared/cookie_banner' %>
+    <%= render 'shared/footer' %>
+  </body>
+  <%= render 'layouts/set_mobility_locale' %>
+</html>

--- a/app/views/schools/new_show.html.erb
+++ b/app/views/schools/new_show.html.erb
@@ -1,0 +1,46 @@
+<% content_for :dashboard_header do %>
+  <%= render 'shared/dashboards/header', school: @school %>
+<% end %>
+
+<div class="container">
+  <div class="row">
+    <div class="col-12">
+      <h2><%= t('schools.show.insights_and_actions') %></h2>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="col-12 col-lg-6">
+      <%= render AdultRemindersComponent.new(school: @school, user: current_user) do |c| %>
+        <% c.with_title { 'Reminders' } %>
+      <% end %>
+    </div>
+
+    <%# add progress notice, @progress_summary %>
+    <% unless @dashboard_alerts.empty? %>
+      <div class="col-12 col-lg-6">
+        <%= component 'prompt_list' do |list| %>
+          <% list.with_title { t('advice_pages.index.alerts.title') } %>
+          <% list.with_link do %>
+            <%= link_to t('schools.show.view_more_alerts'), alerts_school_advice_path(@school) %>
+          <% end %>
+          <% @dashboard_alerts.each do |alert_content| %>
+            <%= list.with_prompt icon: alert_icon(alert_content.alert),
+                                 status: status_for_alert_colour(alert_content.colour) do |prompt| %>
+                <% if alert_content.alert.advice_page.present? %>
+                  <% prompt.with_link do %>
+                    <%= link_to t('advice_pages.index.alerts.view_analysis'),
+                                advice_page_path(@school,
+                                                 alert_content.alert.advice_page,
+                                                 alert_content.alert.alert_type.advice_page_tab_for_link_to,
+                                                 anchor: alert_content.alert.alert_type.link_to_section) %>
+                  <% end %>
+                <% end %>
+                <%= alert_content.send(:management_dashboard_title) %>
+            <% end %>
+          <% end %>
+        <% end %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/schools/new_show.html.erb
+++ b/app/views/schools/new_show.html.erb
@@ -11,7 +11,7 @@
 
   <div class="row">
     <div class="col-12 col-lg-6">
-      <%= render AdultRemindersComponent.new(school: @school, user: current_user) do |c| %>
+      <%= component 'adult_reminders', school: @school, user: current_user do |c| %>
         <% c.with_title { 'Reminders' } %>
       <% end %>
     </div>
@@ -19,25 +19,10 @@
     <%# add progress notice, @progress_summary %>
     <% unless @dashboard_alerts.empty? %>
       <div class="col-12 col-lg-6">
-        <%= component 'prompt_list' do |list| %>
-          <% list.with_title { t('advice_pages.index.alerts.title') } %>
-          <% list.with_link do %>
+        <%= component 'alerts', school: @school, dashboard_alerts: @dashboard_alerts, user: current_user do |c| %>
+          <% c.with_title { t('advice_pages.index.alerts.title') } %>
+          <% c.with_link do %>
             <%= link_to t('schools.show.view_more_alerts'), alerts_school_advice_path(@school) %>
-          <% end %>
-          <% @dashboard_alerts.each do |alert_content| %>
-            <%= list.with_prompt icon: alert_icon(alert_content.alert),
-                                 status: status_for_alert_colour(alert_content.colour) do |prompt| %>
-                <% if alert_content.alert.advice_page.present? %>
-                  <% prompt.with_link do %>
-                    <%= link_to t('advice_pages.index.alerts.view_analysis'),
-                                advice_page_path(@school,
-                                                 alert_content.alert.advice_page,
-                                                 alert_content.alert.alert_type.advice_page_tab_for_link_to,
-                                                 anchor: alert_content.alert.alert_type.link_to_section) %>
-                  <% end %>
-                <% end %>
-                <%= alert_content.send(:management_dashboard_title) %>
-            <% end %>
           <% end %>
         <% end %>
       </div>

--- a/app/views/schools/new_show.html.erb
+++ b/app/views/schools/new_show.html.erb
@@ -16,13 +16,29 @@
       <% end %>
     </div>
 
-    <%# add progress notice, @progress_summary %>
     <% unless @dashboard_alerts.empty? %>
       <div class="col-12 col-lg-6">
         <%= component 'alerts', school: @school, dashboard_alerts: @dashboard_alerts, user: current_user do |c| %>
           <% c.with_title { t('advice_pages.index.alerts.title') } %>
           <% c.with_link do %>
             <%= link_to t('schools.show.view_more_alerts'), alerts_school_advice_path(@school) %>
+          <% end %>
+          <% if reportable_progress?(@progress_summary) && @progress_summary.any_passing_targets? %>
+            <%= c.with_prompt icon: 'tachometer-alt', status: :positive do |p| %>
+              <%= t('schools.show.making_progress',
+                    fuels: t_fuels_as_sentence(@progress_summary.passing_fuel_targets)) %>
+              <% p.with_link do %>
+                <%= link_to t('schools.show.review_progress'), school_school_targets_path(@school) %>
+              <% end %>
+            <% end %>
+          <% elsif reportable_progress?(@progress_summary) && @progress_summary.any_failing_targets? %>
+            <%= c.with_prompt icon: 'tachometer-alt', status: :negative do |p| %>
+              <%= t('schools.show.not_meeting_target',
+                    fuels: t_fuels_as_sentence(@progress_summary.failing_fuel_targets)) %>
+              <% p.with_link do %>
+                <%= link_to t('schools.show.review_progress'), school_school_targets_path(@school) %>
+              <% end %>
+            <% end %>
           <% end %>
         <% end %>
       </div>

--- a/app/views/schools/new_show.html.erb
+++ b/app/views/schools/new_show.html.erb
@@ -3,45 +3,9 @@
 <% end %>
 
 <div class="container">
-  <div class="row">
-    <div class="col-12">
-      <h2><%= t('schools.show.insights_and_actions') %></h2>
-    </div>
-  </div>
-
-  <div class="row">
-    <div class="col-12 col-lg-6">
-      <%= component 'adult_reminders', school: @school, user: current_user do |c| %>
-        <% c.with_title { 'Reminders' } %>
-      <% end %>
-    </div>
-
-    <% unless @dashboard_alerts.empty? %>
-      <div class="col-12 col-lg-6">
-        <%= component 'alerts', school: @school, dashboard_alerts: @dashboard_alerts, user: current_user do |c| %>
-          <% c.with_title { t('advice_pages.index.alerts.title') } %>
-          <% c.with_link do %>
-            <%= link_to t('schools.show.view_more_alerts'), alerts_school_advice_path(@school) %>
-          <% end %>
-          <% if reportable_progress?(@progress_summary) && @progress_summary.any_passing_targets? %>
-            <%= c.with_prompt icon: 'tachometer-alt', status: :positive do |p| %>
-              <%= t('schools.show.making_progress',
-                    fuels: t_fuels_as_sentence(@progress_summary.passing_fuel_targets)) %>
-              <% p.with_link do %>
-                <%= link_to t('schools.show.review_progress'), school_school_targets_path(@school) %>
-              <% end %>
-            <% end %>
-          <% elsif reportable_progress?(@progress_summary) && @progress_summary.any_failing_targets? %>
-            <%= c.with_prompt icon: 'tachometer-alt', status: :negative do |p| %>
-              <%= t('schools.show.not_meeting_target',
-                    fuels: t_fuels_as_sentence(@progress_summary.failing_fuel_targets)) %>
-              <% p.with_link do %>
-                <%= link_to t('schools.show.review_progress'), school_school_targets_path(@school) %>
-              <% end %>
-            <% end %>
-          <% end %>
-        <% end %>
-      </div>
-    <% end %>
-  </div>
+  <%= component 'dashboard_insights',
+                audience: :adult,
+                school: @school,
+                user: current_user,
+                progress_summary: @progress_summary %>
 </div>

--- a/app/views/shared/dashboards/_header.html.erb
+++ b/app/views/shared/dashboards/_header.html.erb
@@ -1,0 +1,22 @@
+<div id='dashboard-header' class="row">
+  <div class="col-12 col-md-9">
+    <h1>Welcome</h1>
+  </div>
+  <div class="col-12 col-md-3 bg-white rounded">
+    <div class="row">
+      <div class="col">
+        <h4><%= school.name %></h4>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col">
+        <%= school.address %> <%= school.postcode %>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col">
+        <span class="badge badge-secondary"><%= t("common.school_types.#{school.school_type}") %></span>
+      </div>
+    </div>
+  </div>
+</div>

--- a/config/locales/views/schools/schools.yml
+++ b/config/locales/views/schools/schools.yml
@@ -591,6 +591,7 @@ en:
       energy_saving_opportunities: Energy saving opportunities
       find_out_more: Find out more
       find_training: Find training
+      insights_and_actions: Insights and actions
       making_progress: Well done, you are making progress towards achieving your target to reduce your %{fuels} usage!
       more_information: More information
       not_meeting_target: Unfortunately you are not meeting your target to reduce your %{fuels} usage
@@ -609,6 +610,7 @@ en:
       setup_pupil_account: Set up a pupil account for your school to give your pupils direct access to the pupil dashboard. No email address is needed for a pupil account.
       summary_of_recent_energy_usage: Summary of recent energy usage
       upload_energy_bill: Upload a bill
+      view_more_alerts: View more alerts
     timeline:
       no_events: No events to show
       title: What's been going on?

--- a/config/locales/views/schools/schools.yml
+++ b/config/locales/views/schools/schools.yml
@@ -147,6 +147,11 @@ en:
         enable_alerts: Enable alerts
         enable_alerts_for: Enable alerts for %{user_name}
         sign_up_for_email_or_text_alerts: Sign up for email or text alerts
+    dashboards:
+      insights:
+        title: Insights and actions
+      reminders:
+        title: Reminders
     downloads:
       index:
         aggregated_meter_collection: Aggregated meter collection
@@ -591,7 +596,6 @@ en:
       energy_saving_opportunities: Energy saving opportunities
       find_out_more: Find out more
       find_training: Find training
-      insights_and_actions: Insights and actions
       making_progress: Well done, you are making progress towards achieving your target to reduce your %{fuels} usage!
       more_information: More information
       not_meeting_target: Unfortunately you are not meeting your target to reduce your %{fuels} usage

--- a/lib/tasks/deployment/20240807133613_add_new_dashboard_feature.rake
+++ b/lib/tasks/deployment/20240807133613_add_new_dashboard_feature.rake
@@ -1,0 +1,13 @@
+namespace :after_party do
+  desc 'Deployment task: add_new_dashboard_feature'
+  task add_new_dashboard_feature: :environment do
+    puts "Running deploy task 'add_new_dashboard_feature'"
+
+    Flipper.add(:new_dashboards_2024)
+
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord
+      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+  end
+end

--- a/spec/components/adult_reminders_component_spec.rb
+++ b/spec/components/adult_reminders_component_spec.rb
@@ -232,13 +232,13 @@ RSpec.describe AdultRemindersComponent, type: :component, include_application_he
   describe '#prompt_to_review_target?' do
     context 'with no target' do
       context 'with admin' do
-        it { expect(component.send(:prompt_to_review_target?)).to eq(false) }
+        it { expect(component.send(:prompt_to_review_target?)).to eq(nil) }
       end
 
       context 'with school admin' do
         let!(:user) { create(:school_admin, school: school)}
 
-        it { expect(component.send(:prompt_to_review_target?)).to eq(false) }
+        it { expect(component.send(:prompt_to_review_target?)).to eq(nil) }
       end
 
       context 'with other' do

--- a/spec/components/adult_reminders_component_spec.rb
+++ b/spec/components/adult_reminders_component_spec.rb
@@ -1,0 +1,385 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe AdultRemindersComponent, type: :component, include_application_helper: true do
+  subject(:component) do
+    described_class.new(**params)
+  end
+
+  let(:id) { 'custom-id'}
+  let(:classes) { 'extra-classes' }
+  let(:user) { create(:admin) }
+  let(:school) { create(:school) }
+
+  let(:params) do
+    {
+      school: school,
+      user: user,
+      id: id,
+      classes: classes
+    }
+  end
+
+  describe '#show_standard_prompts?' do
+    context 'with admin' do
+      it { expect(component.show_standard_prompts?).to eq(true) }
+    end
+
+    context 'with school admin' do
+      let!(:user) { create(:school_admin, school: school)}
+
+      it { expect(component.show_standard_prompts?).to eq(true) }
+    end
+
+    context 'with other' do
+      let!(:user) { create(:school_admin) }
+
+      it { expect(component.show_standard_prompts?).to eq(false) }
+    end
+
+    context 'with guest' do
+      let!(:user) { create(:guest) }
+
+      it { expect(component.show_standard_prompts?).to eq(false) }
+    end
+  end
+
+  describe '#prompt_for_bill?' do
+    context 'with admin' do
+      it { expect(component.prompt_for_bill?).to eq(false) }
+    end
+
+    context 'with bill requested' do
+      let(:school) { create(:school, bill_requested: true) }
+
+      context 'with admin' do
+        it { expect(component.prompt_for_bill?).to eq(true) }
+      end
+
+      context 'with school admin' do
+        let(:user) { create(:school_admin, school: school)}
+
+        it { expect(component.prompt_for_bill?).to eq(true) }
+      end
+
+      context 'with other' do
+        let(:user) { create(:school_admin) }
+
+        it { expect(component.prompt_for_bill?).to eq(false) }
+      end
+
+      context 'with guest' do
+        let(:user) { create(:guest) }
+
+        it { expect(component.prompt_for_bill?).to eq(false) }
+      end
+    end
+  end
+
+  describe '#prompt_for_training?' do
+    context 'with admin' do
+      it { expect(component.prompt_for_training?).to eq(false) }
+    end
+
+    context 'when school is data enabled' do
+      let!(:school) { create(:school, data_enabled: true) }
+
+      context 'with school admin' do
+        context 'when recently confirmed' do
+          let!(:user) { create(:school_admin, confirmed_at: Time.zone.now, school: school)}
+
+          it { expect(component.prompt_for_training?).to eq(true) }
+        end
+
+        context 'when confirmed some time ago' do
+          let!(:user) { create(:school_admin, confirmed_at: 1.year.ago, school: school)}
+
+          it { expect(component.prompt_for_training?).to eq(false) }
+        end
+      end
+
+      context 'with other' do
+        let!(:user) { create(:school_admin) }
+
+        it { expect(component.prompt_for_training?).to eq(false) }
+      end
+
+      context 'with guest' do
+        let!(:user) { create(:guest) }
+
+        it { expect(component.prompt_for_training?).to eq(false) }
+      end
+    end
+
+    context 'with other' do
+      let!(:user) { create(:school_admin) }
+
+      it { expect(component.prompt_for_training?).to eq(false) }
+    end
+
+    context 'with guest' do
+      let!(:user) { create(:guest) }
+
+      it { expect(component.prompt_for_training?).to eq(false) }
+    end
+  end
+
+  describe '#prompt_for_contacts?' do
+    before do
+      SiteSettings.create!(message_for_no_contacts: true)
+    end
+
+    context 'with admin' do
+      it { expect(component.prompt_for_contacts?).to eq(true) }
+    end
+
+    context 'with contacts' do
+      before do
+        create(:contact_with_name_email_phone, school: school)
+      end
+
+      context 'with school admin' do
+        let!(:user) { create(:school_admin, school: school)}
+
+        it { expect(component.prompt_for_contacts?).to eq(false) }
+      end
+    end
+
+    context 'with school admin' do
+      let!(:user) { create(:school_admin, school: school)}
+
+      it { expect(component.prompt_for_contacts?).to eq(true) }
+    end
+
+    context 'with other' do
+      let!(:user) { create(:school_admin) }
+
+      it { expect(component.prompt_for_contacts?).to eq(false) }
+    end
+
+    context 'with guest' do
+      let!(:user) { create(:guest) }
+
+      it { expect(component.prompt_for_contacts?).to eq(false) }
+    end
+  end
+
+  describe '#prompt_for_pupils?' do
+    before do
+      SiteSettings.create!(message_for_no_pupil_accounts: true)
+    end
+
+    context 'with admin' do
+      it { expect(component.prompt_for_pupils?).to eq(true) }
+    end
+
+    context 'with pupil login' do
+      before do
+        create(:pupil, school: school)
+      end
+
+      context 'with school admin' do
+        let!(:user) { create(:school_admin, school: school)}
+
+        it { expect(component.prompt_for_pupils?).to eq(false) }
+      end
+    end
+
+    context 'with school admin' do
+      let!(:user) { create(:school_admin, school: school)}
+
+      it { expect(component.prompt_for_pupils?).to eq(true) }
+    end
+
+    context 'with other' do
+      let!(:user) { create(:school_admin) }
+
+      it { expect(component.prompt_for_pupils?).to eq(false) }
+    end
+
+    context 'with guest' do
+      let!(:user) { create(:guest) }
+
+      it { expect(component.prompt_for_pupils?).to eq(false) }
+    end
+  end
+
+  describe '#prompt_for_target?' do
+    context 'with admin' do
+      it { expect(component.send(:prompt_for_target?)).to eq(true) }
+    end
+
+    context 'with school admin' do
+      let!(:user) { create(:school_admin, school: school)}
+
+      it { expect(component.send(:prompt_for_target?)).to eq(true) }
+    end
+
+    context 'with other' do
+      let!(:user) { create(:school_admin) }
+
+      it { expect(component.send(:prompt_for_target?)).to eq(false) }
+    end
+
+    context 'with guest' do
+      let!(:user) { create(:guest) }
+
+      it { expect(component.send(:prompt_for_target?)).to eq(false) }
+    end
+  end
+
+  describe '#prompt_to_review_target?' do
+    context 'with no target' do
+      context 'with admin' do
+        it { expect(component.send(:prompt_to_review_target?)).to eq(false) }
+      end
+
+      context 'with school admin' do
+        let!(:user) { create(:school_admin, school: school)}
+
+        it { expect(component.send(:prompt_to_review_target?)).to eq(false) }
+      end
+
+      context 'with other' do
+        let!(:user) { create(:school_admin) }
+
+        it { expect(component.send(:prompt_to_review_target?)).to eq(false) }
+      end
+
+      context 'with guest' do
+        let!(:user) { create(:guest) }
+
+        it { expect(component.send(:prompt_to_review_target?)).to eq(false) }
+      end
+    end
+
+    context 'with target needing review' do
+      before do
+        create(:school_target, school: school)
+        service = instance_double(Targets::SchoolTargetService)
+        allow(service).to receive(:prompt_to_review_target?).and_return(true)
+        allow(Targets::SchoolTargetService).to receive(:new).and_return(service)
+      end
+
+      context 'with admin' do
+        it { expect(component.send(:prompt_to_review_target?)).to eq(true) }
+      end
+
+      context 'with school admin' do
+        let!(:user) { create(:school_admin, school: school)}
+
+        it { expect(component.send(:prompt_to_review_target?)).to eq(true) }
+      end
+
+      context 'with other' do
+        let!(:user) { create(:school_admin) }
+
+        it { expect(component.send(:prompt_to_review_target?)).to eq(false) }
+      end
+
+      context 'with guest' do
+        let!(:user) { create(:guest) }
+
+        it { expect(component.send(:prompt_to_review_target?)).to eq(false) }
+      end
+    end
+  end
+
+  describe '#prompt_to_set_new_target?' do
+    context 'with no target' do
+      context 'with admin' do
+        it { expect(component.send(:prompt_to_set_new_target?)).to eq(false) }
+      end
+
+      context 'with school admin' do
+        let!(:user) { create(:school_admin, school: school)}
+
+        it { expect(component.send(:prompt_to_set_new_target?)).to eq(false) }
+      end
+
+      context 'with other' do
+        let!(:user) { create(:school_admin) }
+
+        it { expect(component.send(:prompt_to_set_new_target?)).to eq(false) }
+      end
+
+      context 'with guest' do
+        let!(:user) { create(:guest) }
+
+        it { expect(component.send(:prompt_to_set_new_target?)).to eq(false) }
+      end
+    end
+
+    context 'with current target' do
+      before do
+        create(:school_target, school: school)
+      end
+
+      context 'with admin' do
+        it { expect(component.send(:prompt_to_set_new_target?)).to eq(false) }
+      end
+
+      context 'with school admin' do
+        let!(:user) { create(:school_admin, school: school)}
+
+        it { expect(component.send(:prompt_to_set_new_target?)).to eq(false) }
+      end
+
+      context 'with other' do
+        let!(:user) { create(:school_admin) }
+
+        it { expect(component.send(:prompt_to_set_new_target?)).to eq(false) }
+      end
+
+      context 'with guest' do
+        let!(:user) { create(:guest) }
+
+        it { expect(component.send(:prompt_to_set_new_target?)).to eq(false) }
+      end
+    end
+
+    context 'with expired target' do
+      before do
+        create(:school_target, school: school, start_date: Date.yesterday.prev_year, target_date: Date.yesterday)
+      end
+
+      context 'with admin' do
+        it { expect(component.send(:prompt_to_set_new_target?)).to eq(true) }
+      end
+
+      context 'with school admin' do
+        let!(:user) { create(:school_admin, school: school)}
+
+        it { expect(component.send(:prompt_to_set_new_target?)).to eq(true) }
+      end
+
+      context 'with other' do
+        let!(:user) { create(:school_admin) }
+
+        it { expect(component.send(:prompt_to_set_new_target?)).to eq(false) }
+      end
+
+      context 'with guest' do
+        let!(:user) { create(:guest) }
+
+        it { expect(component.send(:prompt_to_set_new_target?)).to eq(false) }
+      end
+    end
+  end
+
+  context 'when rendering' do
+    let(:html) do
+      render_inline(component)
+    end
+
+    it 'displays the default prompts' do
+      within('#custom-id') do
+        expect(html).to have_css('#add_pupils')
+        expect(html).to have_css('#add_contacts')
+        expect(html).to have_css('#choose_activity')
+        expect(html).to have_css('#set_target')
+      end
+    end
+  end
+end

--- a/spec/components/alerts_component_spec.rb
+++ b/spec/components/alerts_component_spec.rb
@@ -9,22 +9,43 @@ RSpec.describe AlertsComponent, type: :component, include_url_helpers: true do
   let(:advice_page) { create(:advice_page, key: :baseload) }
   let(:alert_type) { create(:alert_type, advice_page: advice_page) }
   let(:alert) { create(:alert, alert_type: alert_type) }
-  let(:alert_content) { double(management_dashboard_title: 'some alert text', colour: :positive, alert: alert) }
-  let(:dashboard_alerts) { [alert_content] }
-  let(:all_params) { { dashboard_alerts: dashboard_alerts, alert_types: [alert_type], school: school, show_links: show_links, show_icons: show_icons } }
+  let(:id) { 'custom-id' }
+  let(:classes) { 'extra-classes' }
 
-  let(:html) { render_inline(AlertsComponent.new(**params)) }
+  let(:alert_content) do
+    double(management_dashboard_title: 'adult alert text',
+    pupil_dashboard_title: 'pupil alert text',
+    colour: :positive,
+    alert: alert)
+  end
+  let(:dashboard_alerts) { [alert_content] }
+  let(:all_params) do
+    {
+      dashboard_alerts: dashboard_alerts,
+      alert_types: [alert_type],
+      school: school,
+      show_links: show_links,
+      show_icons: show_icons,
+      id: id,
+      classes: classes
+    }
+  end
+
+  let(:html) { render_inline(AlertsComponent.new(**all_params)) }
 
   context 'with all params' do
-    let(:params) { all_params }
-
     it 'adds specified classes' do
       expect(html).to have_css('div.alerts-component')
       expect(html).to have_css('div.positive')
     end
 
+    it_behaves_like 'an application component' do
+      let(:expected_classes) { classes }
+      let(:expected_id) { id }
+    end
+
     it 'displays alert content' do
-      expect(html).to have_content('some alert text')
+      expect(html).to have_content('adult alert text')
     end
 
     it 'displays links' do
@@ -57,6 +78,46 @@ RSpec.describe AlertsComponent, type: :component, include_url_helpers: true do
       it 'has 12 columns' do
         expect(html).to have_css('div.col-md-12')
       end
+    end
+  end
+
+  context 'with different audience' do
+    let(:all_params) do
+      {
+        dashboard_alerts: dashboard_alerts,
+        school: school,
+        audience: :pupil,
+        show_links: show_links,
+        show_icons: show_icons
+      }
+    end
+
+    it 'displays alert content' do
+      expect(html).not_to have_content('adult alert text')
+      expect(html).to have_content('pupil alert text')
+    end
+
+    it 'displays links' do
+      expect(html).to have_link('View analysis')
+    end
+  end
+
+  context 'with no filtering of alert types' do
+    let(:all_params) do
+      {
+        dashboard_alerts: dashboard_alerts,
+        school: school,
+        show_links: show_links,
+        show_icons: show_icons
+      }
+    end
+
+    it 'displays alert content' do
+      expect(html).to have_content('adult alert text')
+    end
+
+    it 'displays links' do
+      expect(html).to have_link('View analysis')
     end
   end
 end

--- a/spec/components/dashboard_insights_component_spec.rb
+++ b/spec/components/dashboard_insights_component_spec.rb
@@ -3,26 +3,129 @@
 require 'rails_helper'
 
 RSpec.describe DashboardInsightsComponent, type: :component, include_url_helpers: true do
+  subject(:component) { described_class.new(**params) }
+
   let(:school) { create(:school) }
   let(:id) { 'custom-id' }
   let(:classes) { 'extra-classes' }
-  let(:alerts) { [] }
   let(:progress_summary) { nil }
-
+  let(:user) { create(:school_admin, school: school)}
   let(:params) do
     {
       school: school,
       id: id,
       classes: classes,
-      alerts: alerts,
-      progress_summary: progress_summary
+      progress_summary: progress_summary,
+      user: user
     }
   end
 
-  let(:html) { render_inline(described_class.new(**params)) }
+  let(:html) { render_inline(component) }
 
   it_behaves_like 'an application component' do
     let(:expected_classes) { classes }
     let(:expected_id) { id }
+  end
+
+  it 'displays the reminders column' do
+    expect(html).to have_css('#adult-reminders')
+  end
+
+  it 'does not display the alerts' do
+    expect(html).not_to have_css('#adult-alerts')
+  end
+
+  context 'with alerts' do
+    include_context 'with dashboard alerts'
+
+    it 'displays the alerts column' do
+      expect(html).to have_css('#adult-alerts')
+    end
+
+    it 'displays the alert text' do
+      expect(html).to have_content('You can save £5,000 on heating in 1 year')
+    end
+
+    context 'with Welsh locale' do
+      around do |example|
+        I18n.with_locale :cy do
+          example.run
+        end
+      end
+
+      it 'displays the alert text' do
+        expect(html).to have_content('Gallwch arbed £7,000 mewn 1 flwyddyn')
+      end
+    end
+
+    context 'when school is not data enabled' do
+      let(:school) { create(:school, data_enabled: false) }
+
+      it 'does not display the alerts' do
+        expect(html).not_to have_css('#adult-alerts')
+      end
+
+      context 'with an admin' do
+        let(:user) { create(:admin) }
+
+        it 'displays the alerts' do
+          expect(html).to have_css('#adult-alerts')
+        end
+      end
+    end
+  end
+
+  context 'with a target progress summary' do
+    before do
+      Flipper.enable :new_dashboards_2024 # alert component has conditional
+    end
+
+    let!(:school_target)   { create(:school_target, school: school) }
+    let(:progress_summary) { build(:progress_summary, school_target: school_target) }
+
+    it 'displays the prompt' do
+      expect(html).to have_css('#adult-alerts')
+      expect(html).to have_content('Well done, you are making progress towards achieving your target')
+    end
+
+    it 'links to target page' do
+      expect(html).to have_link('Review progress', href: school_school_targets_path(school))
+    end
+
+    context 'when one fuel is failing' do
+      let(:progress_summary) { build(:progress_summary_with_failed_target, school_target: school_target) }
+
+      it 'displays the correct prompts' do
+        expect(html).to have_content('Unfortunately you are not meeting your target to reduce your gas usage')
+        expect(html).to have_content('Well done, you are making progress towards achieving your target to reduce your electricity and storage heater usage')
+      end
+    end
+
+    context 'when target has expired' do
+      let!(:school_target)    { create(:school_target, school: school, start_date: 1.year.ago, target_date: Date.yesterday) }
+      let(:progress_summary)  { build(:progress_summary, school_target: school_target) }
+
+      it 'does not display a prompt' do
+        expect(html).not_to have_content('Well done, you are making progress towards achieving your target')
+      end
+    end
+
+    context 'with lagging data' do
+      let(:electricity_progress) { build(:fuel_progress, recent_data: false)}
+      let(:progress_summary) { build(:progress_summary, electricity: electricity_progress, school_target: school_target) }
+
+      it 'displays a notice for the other fuel types' do
+        expect(html).not_to have_content('Unfortunately you are not meeting your target')
+        expect(html).to have_content('Well done, you are making progress towards achieving your target to reduce your gas and storage heater usage')
+      end
+    end
+
+    context 'when school is not data enabled' do
+      let(:school) { create(:school, data_enabled: false) }
+
+      it 'does not display the alerts' do
+        expect(html).not_to have_css('#adult-alerts')
+      end
+    end
   end
 end

--- a/spec/components/dashboard_insights_component_spec.rb
+++ b/spec/components/dashboard_insights_component_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe DashboardInsightsComponent, type: :component, include_url_helpers: true do
+  let(:school) { create(:school) }
+  let(:id) { 'custom-id' }
+  let(:classes) { 'extra-classes' }
+  let(:alerts) { [] }
+  let(:progress_summary) { nil }
+
+  let(:params) do
+    {
+      school: school,
+      id: id,
+      classes: classes,
+      alerts: alerts,
+      progress_summary: progress_summary
+    }
+  end
+
+  let(:html) { render_inline(described_class.new(**params)) }
+
+  it_behaves_like 'an application component' do
+    let(:expected_classes) { classes }
+    let(:expected_id) { id }
+  end
+end

--- a/spec/components/previews/adult_reminders_component_preview.rb
+++ b/spec/components/previews/adult_reminders_component_preview.rb
@@ -1,0 +1,11 @@
+class AdultRemindersComponentPreview < ViewComponent::Preview
+  def example(slug: nil, title: 'Reminders')
+    school = slug ? School.find(slug) : School.active.sample
+    user = User.admin.first
+    component = AdultRemindersComponent.new(school: school, user: user)
+    component.with_title do
+      "#{title} (#{school.name})"
+    end
+    render(component)
+  end
+end

--- a/spec/components/previews/prompt_component_preview.rb
+++ b/spec/components/previews/prompt_component_preview.rb
@@ -1,0 +1,4 @@
+class PromptComponentPreview < ViewComponent::Preview
+  def examples
+  end
+end

--- a/spec/components/previews/prompt_component_preview/examples.html.erb
+++ b/spec/components/previews/prompt_component_preview/examples.html.erb
@@ -1,0 +1,151 @@
+<h1>Examples</h1>
+
+<ul>
+  <li><a href="#basic">Basic format</a></li>
+  <li><a href="#longer-text">Longer text</a></li>
+  <li><a href="#with-link">Link</a></li>
+  <li><a href="#icon">Icon</a></li>
+  <li><a href="#title">Title</a></li>
+  <li><a href="#pill">Pills</a></li>
+  <li><a href="#status">Status colours</a></li>
+  <li><a href="#all">All options</a></li>
+  <li><a href="#columns">Rendering within columns</a></li>
+</ul>
+
+<h4 id='basic'>Basic format</h4>
+<%= render PromptComponent.new do |c| %>
+  <p>
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum id lorem dui. Quisque feugiat sollicitudin
+    odio in vestibulum. Duis a semper mi.
+  </p>
+<% end %>
+
+<h4 id='longer-text'>Longer text</h4>
+<%= render PromptComponent.new do |c| %>
+  <p>
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas aliquam sem ac fermentum feugiat. Curabitur in
+    nunc mi. Etiam magna ipsum, feugiat sed est et, pretium consequat odio. .statusesconubia nostra, per inceptos himenaeos.
+    Integer nisl nibh, tincidunt efficitur metus sed, facilisis semper ante. Nam tincidunt imperdiet ex.
+    Maecenas tempus porta mollis. Aliquam luctus enim sed ipsum suscipit, nec lacinia ante auctor. Etiam varius dui
+    et velit molestie, vel accumsan mauris interdum. Nunc efficitur nibh nec nulla rhoncus posuere. In quis lacus
+    cursus, ornare dolor eget, lacinia velit. Cras ac velit nec elit volutpat pulvinar.
+  </p>
+<% end %>
+
+<h4 id='with-link'>Link</h4>
+<%= render PromptComponent.new do |c| %>
+  <% c.with_link { link_to 'This is the link', root_path } %>
+  <p>
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum id lorem dui. Quisque feugiat sollicitudin
+    odio in vestibulum. Duis a semper mi.
+  </p>
+<% end %>
+
+<h4 id='icon'>Icon</h4>
+<%= render PromptComponent.new icon: 'bolt' do |c| %>
+  <% c.with_link { link_to 'This is the link', root_path } %>
+  <p>
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum id lorem dui. Quisque feugiat sollicitudin
+    odio in vestibulum. Duis a semper mi.
+  </p>
+<% end %>
+
+<h4 id='title'>Title</h4>
+<%= render PromptComponent.new do |c| %>
+  <% c.with_link { link_to 'This is the link', root_path } %>
+  <% c.with_title { 'This is the title' } %>
+  <p>
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum id lorem dui. Quisque feugiat sollicitudin
+    odio in vestibulum. Duis a semper mi.
+  </p>
+<% end %>
+
+<h4 id='pill'>Pill</h4>
+<%= render PromptComponent.new do |c| %>
+  <% c.with_link { link_to 'This is the link', root_path } %>
+  <% c.with_pill do %>
+    <span class="badge badge-warning">Warning</span>
+  <% end %>
+  <p>
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum id lorem dui. Quisque feugiat sollicitudin
+    odio in vestibulum. Duis a semper mi.
+  </p>
+<% end %>
+
+<%= render PromptComponent.new do |c| %>
+  <% c.with_link { link_to 'This is the link', root_path } %>
+  <% c.with_title { 'Title and a pill' } %>
+  <% c.with_pill do %>
+    <span class="badge badge-warning">Warning</span>
+  <% end %>
+  <p>
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum id lorem dui. Quisque feugiat sollicitudin
+    odio in vestibulum. Duis a semper mi.
+  </p>
+<% end %>
+
+<h4 id='status'>Status colours</h4>
+<% PromptComponent.statuses.each do |status| %>
+  <%= render PromptComponent.new status: status do |c| %>
+    <p>
+      <%= status %>
+    </p>
+  <% end %>
+<% end %>
+
+<h4 id='all'>All options</h4>
+
+<%= render PromptComponent.new status: :neutral, icon: 'calendar-alt' do |c| %>
+  <% c.with_link { link_to 'This is the link', root_path } %>
+  <% c.with_title { 'This is the title' } %>
+  <% c.with_pill do %>
+    <span class="badge badge-warning">Warning</span>
+  <% end %>
+  <p>
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum id lorem dui. Quisque feugiat sollicitudin
+    odio in vestibulum. Duis a semper mi.
+  </p>
+<% end %>
+
+<h4 id='columns'>Rendering within columns</h4>
+
+<div class="row">
+  <div class="col-12 col-lg-6">
+    <%= render PromptComponent.new do |c| %>
+      <p>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum id lorem dui. Quisque feugiat sollicitudin
+        odio in vestibulum. Duis a semper mi.
+      </p>
+    <% end %>
+    <%= render PromptComponent.new status: :neutral, icon: 'calendar-alt' do |c| %>
+      <% c.with_link { link_to 'This is the link', root_path } %>
+      <% c.with_title { 'This is the title' } %>
+      <% c.with_pill do %>
+        <span class="badge badge-warning">Warning</span>
+      <% end %>
+      <p>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum id lorem dui. Quisque feugiat sollicitudin
+        odio in vestibulum. Duis a semper mi.
+      </p>
+    <% end %>
+  </div>
+  <div class="col-12 col-lg-6">
+    <%= render PromptComponent.new do |c| %>
+      <p>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum id lorem dui. Quisque feugiat sollicitudin
+        odio in vestibulum. Duis a semper mi.
+      </p>
+    <% end %>
+    <%= render PromptComponent.new status: :neutral, icon: 'calendar-alt' do |c| %>
+      <% c.with_link { link_to 'This is the link', root_path } %>
+      <% c.with_title { 'This is the title' } %>
+      <% c.with_pill do %>
+        <span class="badge badge-warning">Warning</span>
+      <% end %>
+      <p>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum id lorem dui. Quisque feugiat sollicitudin
+        odio in vestibulum. Duis a semper mi.
+      </p>
+    <% end %>
+  </div>
+</div>

--- a/spec/components/previews/prompt_list_component_preview.rb
+++ b/spec/components/previews/prompt_list_component_preview.rb
@@ -1,0 +1,4 @@
+class PromptListComponentPreview < ViewComponent::Preview
+  def examples
+  end
+end

--- a/spec/components/previews/prompt_list_component_preview/examples.html.erb
+++ b/spec/components/previews/prompt_list_component_preview/examples.html.erb
@@ -1,0 +1,71 @@
+<h2>Simple list</h2>
+
+<%= render PromptListComponent.new do |list| %>
+  <% list.with_title { 'List title' } %>
+  <% list.with_link do %>
+    <% link_to 'More information', root_path %>
+  <% end %>
+  <% list.with_prompt icon: 'bolt' do |prompt| %>
+    <%= prompt.with_title { 'Positive prompt' } %>
+    <p>
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum id lorem dui. Quisque feugiat sollicitudin
+      odio in vestibulum. Duis a semper mi.
+    </p>
+  <% end %>
+  <% list.with_prompt icon: 'fire' do |prompt| %>
+    <%= prompt.with_title { 'Negative prompt' } %>
+    <p>
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum id lorem dui. Quisque feugiat sollicitudin
+      odio in vestibulum. Duis a semper mi.
+    </p>
+  <% end %>
+<% end %>
+
+<h2>Rendering in two columns</h2>
+
+<div class="row">
+  <div class="col-12 col-lg-6">
+    <%= render PromptListComponent.new do |list| %>
+      <% list.with_title { 'Column 1' } %>
+      <% list.with_link do %>
+        <% link_to 'More information', root_path %>
+      <% end %>
+      <% list.with_prompt icon: 'bolt', status: :positive do |prompt| %>
+        <%= prompt.with_title { 'Positive prompt' } %>
+        <p>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum id lorem dui. Quisque feugiat sollicitudin
+          odio in vestibulum. Duis a semper mi.
+        </p>
+      <% end %>
+      <% list.with_prompt icon: 'fire', status: :negative do |prompt| %>
+        <%= prompt.with_title { 'Positive prompt' } %>
+        <p>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum id lorem dui. Quisque feugiat sollicitudin
+          odio in vestibulum. Duis a semper mi.
+        </p>
+      <% end %>
+    <% end %>
+  </div>
+  <div class="col-12 col-lg-6">
+    <%= render PromptListComponent.new do |list| %>
+      <% list.with_title { 'Column 2' } %>
+      <% list.with_link do %>
+        <% link_to 'More information', root_path %>
+      <% end %>
+      <% list.with_prompt icon: 'calendar-alt', status: :none do |prompt| %>
+        <%= prompt.with_title { 'Positive prompt' } %>
+        <p>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum id lorem dui. Quisque feugiat sollicitudin
+          odio in vestibulum. Duis a semper mi.
+        </p>
+      <% end %>
+      <% list.with_prompt icon: 'sun', status: :neutral do |prompt| %>
+        <%= prompt.with_title { 'Positive prompt' } %>
+        <p>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum id lorem dui. Quisque feugiat sollicitudin
+          odio in vestibulum. Duis a semper mi.
+        </p>
+      <% end %>
+    <% end %>
+  </div>
+</div>

--- a/spec/components/prompt_component_spec.rb
+++ b/spec/components/prompt_component_spec.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe PromptComponent, type: :component, include_application_helper: true do
+  let(:all_params) { { id: id, status: :neutral, icon: icon, classes: classes } }
+  let(:id) { 'custom-id' }
+  let(:classes) { 'extra-classes' }
+  let(:params) { all_params }
+  let(:content) { '<p>Content</p>' }
+  let(:title) { 'Title' }
+  let(:icon) { 'bolt' }
+  let(:pill) { ActionController::Base.helpers.content_tag(:span, 'Warning', class: 'badge badge-warning')}
+  let(:link) { ActionController::Base.helpers.link_to 'Link text', 'href' }
+
+  context 'with all params' do
+    let(:html) do
+      render_inline(described_class.new(**params)) do |c|
+        c.with_link { link }
+        c.with_title { title }
+        c.with_pill { pill }
+        content
+      end
+    end
+
+    it 'has the status class' do
+      expect(html).to have_css('div.prompt-component.neutral')
+    end
+
+    it_behaves_like 'an application component' do
+      let(:expected_classes) { classes }
+      let(:expected_id) { id }
+    end
+
+    it 'has additional classes' do
+      expect(html).to have_css('div.prompt-component.extra-classes')
+    end
+
+    it { expect(html).to have_text(title) }
+    it { expect(html).to have_text('Warning') }
+
+    it { expect(html).to have_link('Link text', href: 'href') }
+    it { expect(html).to have_text(content) }
+
+    it 'has the icon' do
+      expect(html).to have_css('span.fa-stack')
+      within('span.fa-stack') do
+        expect(html).to have_css('i.fa-circle')
+        expect(html).to have_css("i.fa-#{icon}")
+      end
+    end
+
+    context 'with unrecognised status' do
+      let(:params) { all_params.update(status: :unrecognised) }
+
+      it { expect { html }.to raise_error(ArgumentError, 'Status must be: none, positive, negative or neutral') }
+    end
+
+    context 'with recognised statuses' do
+      [:positive, :negative, :neutral].each do |status|
+        let(:params) { all_params.update(status: status) }
+        it "recognises #{status}" do
+          expect { html }.not_to raise_error
+        end
+      end
+    end
+  end
+
+  context 'with no link' do
+    let(:html) do
+      render_inline(described_class.new(**params)) do |_c|
+        content
+      end
+    end
+
+    it { expect(html).to have_text(content) }
+    it { expect(html).not_to have_link('Link text', href: 'href') }
+  end
+
+  context 'with no content' do
+    let(:html) do
+      render_inline(described_class.new(**params)) do |c|
+        c.with_link { link }
+      end
+    end
+
+    it { expect(html.to_html).to be_blank }
+  end
+end

--- a/spec/components/prompt_component_spec.rb
+++ b/spec/components/prompt_component_spec.rb
@@ -32,10 +32,6 @@ RSpec.describe PromptComponent, type: :component, include_application_helper: tr
       let(:expected_id) { id }
     end
 
-    it 'has additional classes' do
-      expect(html).to have_css('div.prompt-component.extra-classes')
-    end
-
     it { expect(html).to have_text(title) }
     it { expect(html).to have_text('Warning') }
 

--- a/spec/components/prompt_list_component_spec.rb
+++ b/spec/components/prompt_list_component_spec.rb
@@ -39,15 +39,14 @@ RSpec.describe PromptListComponent, type: :component, include_application_helper
   end
 
   context 'with no prompts it does not render' do
-    let(:html) do
-      render_inline(described_class.new(**params)) do |c|
+    let(:component) do
+      described_class.new(**params) do |c|
         c.with_title { title }
         c.with_link { link }
       end
     end
 
-    it { expect(html).not_to have_text(title) }
-    it { expect(html).not_to have_link('Link text', href: 'href') }
+    it { expect(component.render?).to eq(false) }
   end
 
   context 'with no link' do

--- a/spec/components/prompt_list_component_spec.rb
+++ b/spec/components/prompt_list_component_spec.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe PromptListComponent, type: :component, include_application_helper: true do
+  let(:all_params) { { id: id, classes: classes } }
+  let(:id) { 'custom-id' }
+  let(:classes) { 'extra-classes' }
+  let(:params) { all_params }
+  let(:title) { 'Title' }
+  let(:prompt_text) { 'Prompt text' }
+  let(:pill) { ActionController::Base.helpers.content_tag(:span, 'Warning', class: 'badge badge-warning')}
+  let(:link) { ActionController::Base.helpers.link_to 'Link text', 'href' }
+
+  context 'with all params' do
+    let(:html) do
+      render_inline(described_class.new(**params)) do |c|
+        c.with_title { title }
+        c.with_link { link }
+        c.with_prompt id: 'prompt-id' do
+          prompt_text
+        end
+      end
+    end
+
+    it_behaves_like 'an application component' do
+      let(:expected_classes) { classes }
+      let(:expected_id) { id }
+    end
+
+    it { expect(html).to have_text(title) }
+    it { expect(html).to have_link('Link text', href: 'href') }
+
+    it 'includes prompt' do
+      within('#prompt-id') do
+        expect(html).to have_text(prompt_text)
+      end
+    end
+  end
+
+  context 'with no prompts it does not render' do
+    let(:html) do
+      render_inline(described_class.new(**params)) do |c|
+        c.with_title { title }
+        c.with_link { link }
+      end
+    end
+
+    it { expect(html).not_to have_text(title) }
+    it { expect(html).not_to have_link('Link text', href: 'href') }
+  end
+
+  context 'with no link' do
+    let(:html) do
+      render_inline(described_class.new(**params)) do |c|
+        c.with_title { title }
+        c.with_prompt id: 'prompt-id' do
+          'Prompt text'
+        end
+      end
+    end
+
+    it { expect(html).to have_text(title) }
+    it { expect(html).not_to have_link('Link text', href: 'href') }
+  end
+
+  context 'with no title' do
+    let(:html) do
+      render_inline(described_class.new(**params)) do |c|
+        c.with_link { link }
+        c.with_prompt id: 'prompt-id' do
+          'Prompt text'
+        end
+      end
+    end
+
+    it { expect(html).to have_link('Link text', href: 'href') }
+    it { expect(html).not_to have_text(title) }
+  end
+end

--- a/spec/support/shared_contexts/dashboard_alerts.rb
+++ b/spec/support/shared_contexts/dashboard_alerts.rb
@@ -1,0 +1,70 @@
+RSpec.shared_context 'with dashboard alerts' do
+  let(:alert_run) { create(:alert_generation_run, school: school) }
+  let!(:gas_alert) do
+    alert_type = create(:alert_type, fuel_type: :gas)
+    alert_type_rating = create(
+      :alert_type_rating,
+      alert_type: alert_type,
+      rating_from: 0,
+      rating_to: 10,
+      management_dashboard_alert_active: true,
+    )
+    create(
+      :alert_type_rating_content_version,
+      alert_type_rating: alert_type_rating,
+      management_dashboard_title_en: 'You can save {{average_one_year_saving_gbp}} on heating in {{average_payback_years}}',
+      management_dashboard_title_cy: 'Gallwch arbed {{average_one_year_saving_gbp}} mewn {{average_payback_years}}',
+    )
+    create(:alert, :with_run,
+      alert_type: alert_type,
+      alert_generation_run: alert_run,
+      run_on: Time.zone.today,
+      school: school,
+      rating: 9.0,
+      template_data: {
+        average_one_year_saving_gbp: '£5,000',
+        average_payback_years: '1 year'
+      },
+      template_data_cy: {
+        average_one_year_saving_gbp: '£7,000',
+        average_payback_years: '1 flwyddyn'
+      }
+    )
+  end
+
+  let!(:electricity_alert) do
+    alert_type = create(:alert_type, fuel_type: :electricity)
+    alert_type_rating = create(
+      :alert_type_rating,
+      alert_type: alert_type,
+      rating_from: 0,
+      rating_to: 10,
+      management_dashboard_alert_active: true,
+    )
+    create(
+      :alert_type_rating_content_version,
+      alert_type_rating: alert_type_rating,
+      management_dashboard_title_en: 'Your baseload is high and is costing {{average_one_year_saving_gbp}}',
+      management_dashboard_title_cy: 'Mae eich llwyth sylfaenol yn uchel ac yn costio {{average_one_year_saving_gbp}}',
+    )
+    create(:alert, :with_run,
+      alert_type: alert_type,
+      alert_generation_run: alert_run,
+      run_on: Time.zone.today,
+      school: school,
+      rating: 9.0,
+      template_data: {
+        average_one_year_saving_gbp: '£5,000',
+        average_payback_years: '1 year'
+      },
+      template_data_cy: {
+        average_one_year_saving_gbp: '£7,000',
+        average_payback_years: '1 flwyddyn'
+      }
+    )
+  end
+
+  before do
+    Alerts::GenerateContent.new(school).perform
+  end
+end

--- a/spec/support/shared_examples/component.rb
+++ b/spec/support/shared_examples/component.rb
@@ -1,0 +1,9 @@
+RSpec.shared_examples_for 'an application component' do
+  it 'has additional classes on root element' do
+    expect(html).to have_css("div.#{described_class.name.underscore.dasherize}.#{expected_classes}")
+  end
+
+  it 'has an id' do
+    expect(html).to have_css("##{expected_id}")
+  end
+end


### PR DESCRIPTION
Refactors code in new dashboard page to extract a DashboardInsightsComponent which will show correct reminders and prompts across both dashboards. Currently implemented and tested for adult dashboard.