### PR TITLE
Allow schools to complete programmes each academic year

### DIFF
--- a/app/controllers/schools/programmes_controller.rb
+++ b/app/controllers/schools/programmes_controller.rb
@@ -1,7 +1,8 @@
+# frozen_string_literal: true
+
 module Schools
   class ProgrammesController < ApplicationController
     load_and_authorize_resource :school
-    load_and_authorize_resource :programme, except: [:create]
 
     def create
       programme_type = ProgrammeType.find(params[:programme_type_id])

--- a/app/controllers/schools/programmes_controller.rb
+++ b/app/controllers/schools/programmes_controller.rb
@@ -6,7 +6,7 @@ module Schools
 
     def create
       programme_type = ProgrammeType.find(params[:programme_type_id])
-      Programmes::Creator.new(@school, programme_type).create
+      Programmes::Creator.new(@school, programme_type).create(repeat: true)
       redirect_to programme_type_path(programme_type)
     end
   end

--- a/app/models/programme.rb
+++ b/app/models/programme.rb
@@ -52,8 +52,7 @@ class Programme < ApplicationRecord
   delegate :title, :description, :short_description, :document_link, :image, to: :programme_type
 
   def points_for_completion
-    # Only apply the bonus points if the programme is completed in the same academic year
-    school.academic_year_for(started_on)&.current? ? programme_type.bonus_score : 0
+    programme_type.bonus_score
   end
 
   def activity_types_completed

--- a/app/services/programmes/creator.rb
+++ b/app/services/programmes/creator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Programmes
   class Creator
     def initialize(school, programme_type)
@@ -6,11 +8,8 @@ module Programmes
     end
 
     def create
-      return if already_enrolled?
-      programme = @school.programmes.create(
-        programme_type: @programme_type,
-        started_on: Time.zone.today
-      )
+      @school.programmes.where(programme_type: @programme_type).where.not(status: 'completed').update(status: 'abandoned')
+      programme = @school.programmes.create(programme_type: @programme_type, started_on: Time.zone.today)
       recognise_existing_progress(programme)
       programme
     end
@@ -21,14 +20,15 @@ module Programmes
       @programme_type.programme_type_activity_types.each do |programme_type_activity_type|
         activity = latest_activity_this_academic_year(programme_type_activity_type.activity_type)
         if activity.present?
-          programme.programme_activities.create!(activity_type: programme_type_activity_type.activity_type, activity: activity)
+          programme.programme_activities.create!(activity_type: programme_type_activity_type.activity_type,
+                                                 activity:)
         end
       end
       programme.complete! if programme.all_activities_complete?
     end
 
     def latest_activity_this_academic_year(activity_type)
-      activities = @school.activities.where(activity_type: activity_type).order(happened_on: :desc)
+      activities = @school.activities.where(activity_type:).order(happened_on: :desc)
       activities.find { |activity| academic_year_for(activity).present? && academic_year_for(activity).current? }
     end
 
@@ -36,8 +36,8 @@ module Programmes
       @school.academic_year_for(activity.happened_on)
     end
 
-    def already_enrolled?
-      @school.programmes.any? { |programme| programme.programme_type == @programme_type }
+    def find_existing_programme
+      @school.programmes.where(programme_type: @programme_type).where.not(status: 'closed')
     end
   end
 end

--- a/app/services/programmes/creator.rb
+++ b/app/services/programmes/creator.rb
@@ -7,8 +7,13 @@ module Programmes
       @programme_type = programme_type
     end
 
-    def create
-      @school.programmes.where(programme_type: @programme_type).where.not(status: 'completed').update(status: 'abandoned')
+    def create(repeat: false)
+      if repeat
+        @school.programmes.where(programme_type: @programme_type).where.not(status: 'completed')
+               .update(status: 'abandoned')
+      elsif already_enrolled?
+        return
+      end
       programme = @school.programmes.create(programme_type: @programme_type, started_on: Time.zone.today)
       recognise_existing_progress(programme)
       programme
@@ -36,8 +41,8 @@ module Programmes
       @school.academic_year_for(activity.happened_on)
     end
 
-    def find_existing_programme
-      @school.programmes.where(programme_type: @programme_type).where.not(status: 'closed')
+    def already_enrolled?
+      @school.programmes.any? { |programme| programme.programme_type == @programme_type }
     end
   end
 end

--- a/app/views/programme_types/_completed.html.erb
+++ b/app/views/programme_types/_completed.html.erb
@@ -5,10 +5,16 @@
         <i class="fas fa-check fa-2x"></i>
       </div>
       <div class="col-md-8 align-self-center">
-        <%= t('programme_types.completed.you_completed_this_programme_on') %>
-        <%= nice_dates(programme_type.programme_for_school(school).ended_on) %>
+        <%= t('programme_types.completed.you_completed_this_programme_on',
+              date: nice_dates(programme_type.programme_for_school(school).ended_on)) %>
       </div>
       <div class="col-md-3">
+        <% if school.programmes.where(programme_type: @programme_type).completed
+                    .where(ended_on: ..school.current_academic_year.start_date).any? %>
+          <%= link_to t('programme_types.completed.repeat'),
+                      school_programmes_path(school, programme_type_id: @programme_type),
+                      method: :post, class: 'btn btn-info btn-sm' %>
+        <% end %>
       </div>
     </div>
   </div>

--- a/app/views/programme_types/_started.html.erb
+++ b/app/views/programme_types/_started.html.erb
@@ -5,10 +5,14 @@
         <i class="fas fa-check fa-2x"></i>
       </div>
       <div class="col-md-8 align-self-center">
-        <%= t('programme_types.started.you_started_this_programme_on') %>
-        <%= nice_dates(programme_type.programme_for_school(school).started_on) %>
+        <%= t('programme_types.started.you_started_this_programme_on',
+              date: nice_dates(programme_type.programme_for_school(school).started_on)) %>
       </div>
       <div class="col-md-3">
+        <%= link_to t('programme_types.started.restart'),
+                    school_programmes_path(school, programme_type_id: @programme_type),
+                    method: :post, class: 'btn btn-info btn-sm' %>
+
       </div>
     </div>
   </div>

--- a/config/locales/cy/views/programme_types/programme_types.yml
+++ b/config/locales/cy/views/programme_types/programme_types.yml
@@ -7,7 +7,7 @@ cy:
       you_have_already_completed_this_programme: Rydych chi eisoes wedi cwblhau'r rhaglen hon
       you_have_already_started_this_programme: Rydych chi eisoes wedi dechrau'r rhaglen hon
     completed:
-      you_completed_this_programme_on: Gwnaethoch chi gwblhau'r rhaglen hon ar
+      you_completed_this_programme_on: Gwnaethoch chi gwblhau'r rhaglen hon ar %{date}
     index:
       introduction_1: Rhaglenni byr o weithgareddau cysylltiedig y gall disgyblion weithio drwyddynt gam wrth gam i gael mwy o effaith
       introduction_2: Fel defnyddiwr Sbarcynni gallwch chi gofrestru ar unrhyw un o'n rhaglenni a chofnodi gweithgareddau i olrhain eich cynnydd a sgorio pwyntiau ar gyfer eich ysgol.
@@ -25,4 +25,4 @@ cy:
       points: Pwyntiau
       view_all_programmes: Gweld pob rhaglen
     started:
-      you_started_this_programme_on: Gwnaethoch chi ddechrau'r rhaglen hon ar
+      you_started_this_programme_on: Gwnaethoch chi ddechrau'r rhaglen hon ar %{date}

--- a/config/locales/views/programme_types/programme_types.yml
+++ b/config/locales/views/programme_types/programme_types.yml
@@ -8,7 +8,8 @@ en:
       you_have_already_completed_this_programme: You have already completed this programme
       you_have_already_started_this_programme: You have already started this programme
     completed:
-      you_completed_this_programme_on: You completed this programme on
+      repeat: Repeat
+      you_completed_this_programme_on: You completed this programme on %{date}
     index:
       introduction_1: Short programmes of related activities that pupils can work through step-by-step to achieve greater impact
       introduction_2: As an Energy Sparks user you can enrol in any of our programmes and record activities to track your progress and score points for your school
@@ -35,4 +36,5 @@ en:
       points: Points
       view_all_programmes: View all programmes
     started:
-      you_started_this_programme_on: You started this programme on
+      restart: Restart
+      you_started_this_programme_on: You started this programme on %{date}

--- a/spec/models/programme_spec.rb
+++ b/spec/models/programme_spec.rb
@@ -1,11 +1,13 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 describe 'Programme' do
-  let(:school) { create :school }
+  let(:school) { create(:school) }
   let(:programme_type) { create(:programme_type, bonus_score: 12) }
 
   let(:status) { :started }
-  let(:programme) { create(:programme, programme_type: programme_type, started_on: '2020-01-01', school: school, status: status) }
+  let(:programme) { create(:programme, programme_type:, started_on: '2020-01-01', school:, status:) }
   let(:last_observation) { programme.observations.last }
 
   it { expect(programme.observations.count).to eq(0) }
@@ -40,29 +42,6 @@ describe 'Programme' do
 
         it 'adds points' do
           expect(last_observation.points).to eq(12)
-        end
-      end
-    end
-
-    context 'when programme is completed outside of the academic year it was started' do
-      let(:current_year) { false }
-
-      it 'marks programme as complete' do
-        expect(programme).to be_completed
-      end
-
-      it 'adds ended_on date to programme' do
-        expect(programme.ended_on).not_to be_nil
-      end
-
-      context 'with observation' do
-        it { expect(programme.observations.count).to eq(1) }
-        it { expect(last_observation.at).to eq(programme.ended_on) }
-        it { expect(last_observation.school).to eq(school) }
-        it { expect(last_observation.observation_type).to eq('programme') }
-
-        it "doesn't add points" do
-          expect(last_observation.points).to eq(0)
         end
       end
     end
@@ -110,13 +89,13 @@ describe 'Programme' do
   end
 
   describe '.recently_ended' do
+    subject(:programmes) { Programme.recently_ended }
+
     before { freeze_time }
 
     let!(:ended_today) { create(:programme, ended_on: Time.zone.today) }
     let!(:ended_yesterday) { create(:programme, ended_on: 1.day.ago) }
     let!(:ended_older) { create(:programme, ended_on: 2.days.ago) }
-
-    subject(:programmes) { Programme.recently_ended }
 
     it 'includes programmes ended today or yesterday' do
       expect(programmes).to include(ended_today)

--- a/spec/models/programme_spec.rb
+++ b/spec/models/programme_spec.rb
@@ -19,13 +19,10 @@ describe 'Programme' do
     let(:current_year) { true }
 
     before do
-      allow_any_instance_of(School).to receive(:academic_year_for) { OpenStruct.new(current?: current_year) }
       programme.complete!
     end
 
-    context 'when programme is completed within the same academic year' do
-      let(:current_year) { true }
-
+    context 'when programme is completed' do
       it 'marks programme as complete' do
         expect(programme).to be_completed
       end

--- a/spec/services/programmes/creator_spec.rb
+++ b/spec/services/programmes/creator_spec.rb
@@ -38,14 +38,26 @@ describe Programmes::Creator do
         expect(school.programmes.first.activities.any?).to be false
       end
 
-      it 'abandons an existing programme' do
+      it 'doesnt enrol twice' do
         service.create
+        expect(school.programmes.count).to be 1
+      end
+
+      it 'doesnt enrol twice when multiple programmes' do
+        programme_type_other = create(:programme_type)
+        school.programmes << create(:programme, programme_type: programme_type_other, started_on: Time.zone.now)
+        service.create
+        expect(school.programmes.count).to be 2
+      end
+
+      it 'abandons an existing programme' do
+        service.create(repeat: true)
         expect(school.programmes.order(:started_on).pluck(:status)).to eq %w[abandoned started]
       end
 
       it 'repeats an existing programme' do
         programme.complete!
-        service.create
+        service.create(repeat: true)
         expect(school.programmes.order(:started_on).pluck(:status)).to eq %w[completed started]
       end
     end

--- a/spec/services/programmes/progress_spec.rb
+++ b/spec/services/programmes/progress_spec.rb
@@ -1,45 +1,48 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 describe Programmes::Progress, type: :service do
   let!(:school) { create(:school) }
   let!(:activity_types) { create_list(:activity_type, 3, score: 25) }
-  let!(:programme_type) { create(:programme_type, activity_types: activity_types, bonus_score: 12) }
-  let!(:programme) { create(:programme, programme_type: programme_type, started_on: '2020-01-01', school: school) }
+  let!(:programme_type) { create(:programme_type, activity_types:, bonus_score: 12) }
+  let!(:programme) { create(:programme, programme_type:, started_on: '2020-01-01', school:) }
 
-  let(:service) { Programmes::Progress.new(programme) }
+  let(:service) { described_class.new(programme) }
 
-  context 'a programme activity has been completed' do
-    let(:activity) { build(:activity, school: school, activity_type: activity_types.first, happened_on: Date.yesterday) }
+  context 'when a programme activity has been completed' do
+    let(:activity) do
+      build(:activity, school:, activity_type: activity_types.first, happened_on: Date.yesterday)
+    end
 
     before do
       ActivityCreator.new(activity, nil).process
     end
 
     describe '#notification' do
-      context 'when the programme is completed within the same academic year as started' do
+      context 'with bonus points' do
         it 'returns the full notification text used on the school dashboard' do
-          allow_any_instance_of(School).to receive(:academic_year_for) { OpenStruct.new(current?: true) }
-          expect(service.notification).to eq("You have completed <strong>1/3</strong> of the activities in the <strong>#{programme_type.title}</strong> programme<br />Complete the final <strong>2</strong> activities now to score <strong>50</strong> points and <strong>12</strong> bonus points for completing the programme")
+          expect(service.notification).to eq('You have completed <strong>1/3</strong> of the activities in the ' \
+                                             "<strong>#{programme_type.title}</strong> programme<br />Complete the " \
+                                             'final <strong>2</strong> activities now to score <strong>50</strong> ' \
+                                             'points and <strong>12</strong> bonus points for completing the programme')
         end
       end
 
-      context 'when the programme is completed outside of the academic year as started' do
+      context 'with no bonus points' do
         it 'returns the full notification text used on the school dashboard' do
-          allow_any_instance_of(School).to receive(:academic_year_for) { OpenStruct.new(current?: false) }
-          expect(service.notification).to eq("You have completed <strong>1/3</strong> of the activities in the <strong>#{programme_type.title}</strong> programme<br />Complete the final <strong>2</strong> activities now to score <strong>50</strong> points")
+          programme_type.update!(bonus_score: 0)
+          expect(service.notification).to eq('You have completed <strong>1/3</strong> of the activities in the ' \
+                                             "<strong>#{programme_type.title}</strong> programme<br />Complete the " \
+                                             'final <strong>2</strong> activities now to score <strong>50</strong> ' \
+                                             'points')
         end
       end
     end
 
     describe '#programme_points_for_completion' do
-      it 'includes bonus points if the programme is completed within the same academic year as started' do
-        allow_any_instance_of(School).to receive(:academic_year_for) { OpenStruct.new(current?: true) }
+      it 'includes bonus points' do
         expect(service.programme_points_for_completion).to eq(12)
-      end
-
-      it 'excludes bonus points if the programme is completed outside of the academic year as started' do
-        allow_any_instance_of(School).to receive(:academic_year_for) { OpenStruct.new(current?: false) }
-        expect(service.programme_points_for_completion).to eq(0)
       end
     end
 
@@ -87,7 +90,9 @@ describe Programmes::Progress, type: :service do
 
     describe '#activity_types_uncompleted_count' do
       it 'returns the difference between the number of activity types for the programme and those completed' do
-        allow_any_instance_of(Programme).to receive(:activity_types_completed) { programme.programme_type.activity_types.limit(1) }
+        allow_any_instance_of(Programme).to receive(:activity_types_completed) {
+                                              programme.programme_type.activity_types.limit(1)
+                                            }
         expect(service.activity_types_uncompleted_count).to eq(2)
       end
     end
@@ -103,11 +108,13 @@ describe Programmes::Progress, type: :service do
   end
 
   context 'with 1 activity left to complete' do
-    let(:activity) { build(:activity, school: school, activity_type: activity_types.first, happened_on: Date.yesterday) }
+    let(:activity) do
+      build(:activity, school:, activity_type: activity_types.first, happened_on: Date.yesterday)
+    end
 
     before do
       activity_types.first(2).each do |activity_type|
-        activity = build(:activity, school: school, activity_type: activity_type, happened_on: Date.yesterday)
+        activity = build(:activity, school:, activity_type:, happened_on: Date.yesterday)
         ActivityCreator.new(activity, nil).process
       end
     end

--- a/spec/system/programme_type_spec.rb
+++ b/spec/system/programme_type_spec.rb
@@ -1,15 +1,17 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
-RSpec.describe 'programme types', type: :system, include_application_helper: true do
-  let!(:school) { create(:school)}
-  let!(:school_admin) { create(:school_admin, school: school)}
-  let!(:pupil) { create(:pupil, school: school)}
+RSpec.describe 'programme types', :include_application_helper do
+  let!(:school) { create(:school) }
+  let!(:school_admin) { create(:school_admin, school:) }
+  let!(:pupil) { create(:pupil, school:) }
 
-  let!(:programme_type_1) { create(:programme_type_with_activity_types)}
-  let!(:programme_type_2) { create(:programme_type, active: false)}
-  let!(:programme_type_3) { create(:programme_type)}
+  let!(:programme_type_1) { create(:programme_type_with_activity_types) }
+  let!(:programme_type_2) { create(:programme_type, active: false) }
+  let!(:programme_type_3) { create(:programme_type) }
   let(:bonus_points) { 10 }
-  let!(:programme_4) { create(:programme_type_with_activity_types, bonus_score: bonus_points)}
+  let!(:programme_4) { create(:programme_type_with_activity_types, bonus_score: bonus_points) }
 
   shared_examples 'a user enrolling in a programme' do
     before do
@@ -21,8 +23,8 @@ RSpec.describe 'programme types', type: :system, include_application_helper: tru
     end
 
     it 'does not prompt to login' do
-      expect(page).not_to have_content('Are you an Energy Sparks user?')
-      expect(page).not_to have_link('Sign in now')
+      expect(page).to have_no_content('Are you an Energy Sparks user?')
+      expect(page).to have_no_link('Sign in now')
     end
 
     it 'successfully enrols the school' do
@@ -48,40 +50,52 @@ RSpec.describe 'programme types', type: :system, include_application_helper: tru
 
     context 'when user has completed one activity' do
       before do
-        create(:activity, school: school, activity_type: programme.activity_types.first, happened_on: Date.yesterday)
+        create(:activity, school:, activity_type: programme.activity_types.first, happened_on: Date.yesterday)
         click_on programme.title
       end
 
-      it { expect(page).to have_content("You've recently completed an activity that is part of this programme. Do you want to enrol in the programme?") }
+      it {
+        expect(page).to have_content("You've recently completed an activity that is part of this programme. Do you want to enrol in the programme?")
+      }
+
       it { expect(page).to have_link('Start') }
     end
 
     context 'when user has several activities' do
       before do
-        create(:activity, school: school, activity_type: programme.activity_types.first, happened_on: Date.yesterday)
-        create(:activity, school: school, activity_type: programme.activity_types.second, happened_on: Date.yesterday)
+        create(:activity, school:, activity_type: programme.activity_types.first, happened_on: Date.yesterday)
+        create(:activity, school:, activity_type: programme.activity_types.second, happened_on: Date.yesterday)
         click_on programme.title
       end
 
-      it { expect(page).to have_content("You've recently completed 2 activities that are part of this programme. Do you want to enrol in the programme?") }
+      it {
+        expect(page).to have_content("You've recently completed 2 activities that are part of this programme. Do you want to enrol in the programme?")
+      }
+
       it { expect(page).to have_link('Start') }
     end
 
     context 'when user has completed all activities' do
       before do
         programme.activity_types.each do |activity_type|
-          create(:activity, school: school, activity_type: activity_type, happened_on: Date.yesterday)
+          create(:activity, school:, activity_type:, happened_on: Date.yesterday)
         end
         click_on programme.title
       end
 
-      it { expect(page).to have_content("You've completed all the activities in this programme. Mark it done to score 10 bonus points?") }
+      it {
+        expect(page).to have_content("You've completed all the activities in this programme. Mark it done to score 10 bonus points?")
+      }
+
       it { expect(page).to have_link('Complete') }
 
       context 'when programme has no bonus points' do
         let(:bonus_points) { 0 }
 
-        it { expect(page).to have_content("You've completed all the activities in this programme. Mark it as complete?") }
+        it {
+          expect(page).to have_content("You've completed all the activities in this programme. Mark it as complete?")
+        }
+
         it { expect(page).to have_link('Complete') }
       end
     end
@@ -89,7 +103,7 @@ RSpec.describe 'programme types', type: :system, include_application_helper: tru
 
   shared_examples 'a user that is enrolled in a programme' do
     let(:activity_type) { programme_type_1.activity_types.first }
-    let(:activity)      { create(:activity, school: school, activity_type: activity_type, happened_on: Date.yesterday)}
+    let(:activity)      { create(:activity, school:, activity_type:, happened_on: Date.yesterday) }
 
     before do
       # this is because the Enroller relies on this currently
@@ -103,6 +117,7 @@ RSpec.describe 'programme types', type: :system, include_application_helper: tru
       expect(page).to have_content('You started this programme')
       expect(page).to have_content('Current Progress')
       expect(page).to have_content(nice_dates(school.programmes.first.started_on))
+      expect(page).to have_link('Restart', href: school_programmes_path(school, programme_type_id: programme_type_1.id))
     end
 
     it 'indicates I have not completed some activities' do
@@ -116,7 +131,7 @@ RSpec.describe 'programme types', type: :system, include_application_helper: tru
 
     it 'doesnt link to activities that are completed' do
       expect(page).to have_content(activity_type.name)
-      expect(page).not_to have_link(href: activity_type_path(activity_type))
+      expect(page).to have_no_link(href: activity_type_path(activity_type))
       expect(page).to have_link(href: activity_type_path(programme_type_1.activity_types.last))
     end
 
@@ -136,7 +151,7 @@ RSpec.describe 'programme types', type: :system, include_application_helper: tru
 
     context 'after completing the programme' do
       before do
-        programme_type_1.programme_for_school(school).complete!
+        travel_to(1.year.ago) { programme_type_1.programme_for_school(school).complete! }
       end
 
       context 'when viewing the programme types index page' do
@@ -149,6 +164,7 @@ RSpec.describe 'programme types', type: :system, include_application_helper: tru
           expect(page).to have_link('View', href: programme_type_path(programme_type_1))
           visit programme_type_path(programme_type_1)
           expect(page).to have_content('You completed this programme on')
+          expect(page).to have_link('Repeat', href: school_programmes_path(school, programme_type_id: programme_type_1))
         end
 
         it_behaves_like 'a no active programmes prompt', displayed: true
@@ -171,7 +187,7 @@ RSpec.describe 'programme types', type: :system, include_application_helper: tru
     it 'shows only active programme types' do
       expect(page).to have_content(programme_type_1.title)
       expect(page).to have_content(programme_type_3.title)
-      expect(page).not_to have_content(programme_type_2.title)
+      expect(page).to have_no_content(programme_type_2.title)
     end
 
     context 'viewing a programme type' do
@@ -193,12 +209,12 @@ RSpec.describe 'programme types', type: :system, include_application_helper: tru
       end
 
       it 'does not have checklist' do
-        expect(page).not_to have_css('i.fa-circle.text-muted')
-        expect(page).not_to have_css('i.fa-circle.text-success')
+        expect(page).to have_no_css('i.fa-circle.text-muted')
+        expect(page).to have_no_css('i.fa-circle.text-success')
       end
 
       it 'does not prompt to start' do
-        expect(page).not_to have_content('You can enrol your school in this programme')
+        expect(page).to have_no_content('You can enrol your school in this programme')
       end
 
       it 'prompts to login' do
@@ -207,7 +223,7 @@ RSpec.describe 'programme types', type: :system, include_application_helper: tru
       end
 
       context 'when logging in to enrol' do
-        let!(:staff) { create(:staff, school: school)}
+        let!(:staff) { create(:staff, school:) }
 
         it 'redirects back to programme after login' do
           click_on 'Sign in now'

--- a/spec/system/programme_type_spec.rb
+++ b/spec/system/programme_type_spec.rb
@@ -136,7 +136,8 @@ RSpec.describe 'programme types', :include_application_helper do
 
     it 'allows restarting' do
       click_on('Restart')
-      expect(school.programmes.order(:started_on).pluck(:status)).to eq %w[abandoned started]
+      expect(school.programmes.where(programme_type: programme_type_1).order(:started_on).pluck(:status)).to \
+        eq %w[abandoned started]
     end
 
     context 'when viewing the programme types index page' do


### PR DESCRIPTION
- have assume not changing functionality via admin pages
- [x] bonus points independent of academic year
- [x] repeat
- [x] restart
- [x] keep prompt to start programme functionality
  - looks like programme_types.prompt.message_html - already looking at last academic year so seems like it should just work
