### PR TITLE
Skip decommissioned meters in meter breakdown table

### DIFF
--- a/app/controllers/schools/advice/base_long_term_controller.rb
+++ b/app/controllers/schools/advice/base_long_term_controller.rb
@@ -18,11 +18,6 @@ module Schools
         @estimated_savings_vs_exemplar = usage_service.estimated_savings(versus: :exemplar_school)
         @estimated_savings_vs_benchmark = usage_service.estimated_savings(versus: :benchmark_school)
 
-        @multiple_meters = multiple_meters?
-        if @multiple_meters
-          @annual_usage_meter_breakdown = usage_service.annual_usage_meter_breakdown
-          @meters_for_breakdown = sorted_meters_for_breakdown
-        end
         @meter_selection = Charts::MeterSelection.new(@school, aggregate_school, advice_page_fuel_type, date_window: 363)
       end
 
@@ -42,11 +37,6 @@ module Schools
 
       def create_analysable
         usage_service
-      end
-
-      def sorted_meters_for_breakdown
-        meters = aggregate_school.underlying_meters(advice_page_fuel_type)
-        meters.sort_by(&:mpan_mprn).index_by(&:mpan_mprn)
       end
 
       def analysis_dates

--- a/app/controllers/schools/advice/base_meter_breakdown_controller.rb
+++ b/app/controllers/schools/advice/base_meter_breakdown_controller.rb
@@ -2,7 +2,7 @@ module Schools
   module Advice
     class BaseMeterBreakdownController < AdviceBaseController
       before_action :redirect_if_single_meter
-      before_action :set_meters_and_usage_breakdown
+      before_action :set_meters_and_usage_breakdown, only: [:insights, :analysis]
 
       def insights
       end

--- a/app/controllers/schools/advice/base_meter_breakdown_controller.rb
+++ b/app/controllers/schools/advice/base_meter_breakdown_controller.rb
@@ -2,19 +2,25 @@ module Schools
   module Advice
     class BaseMeterBreakdownController < AdviceBaseController
       before_action :redirect_if_single_meter
+      before_action :set_meters_and_usage_breakdown
 
       def insights
-        @annual_usage_meter_breakdown = usage_service.annual_usage_meter_breakdown
-        @meters_for_breakdown = sorted_meters_for_breakdown
       end
 
       def analysis
         @analysis_dates = analysis_dates
-        @annual_usage_meter_breakdown = usage_service.annual_usage_meter_breakdown
-        @meters_for_breakdown = sorted_meters_for_breakdown
       end
 
       private
+
+      def set_meters_and_usage_breakdown
+        @meters_for_breakdown = sorted_meters_for_breakdown
+        @annual_usage_meter_breakdown = usage_service.annual_usage_meter_breakdown
+        # only those meters included in the breakdown, will exclude any old/obsolete meters
+        @annual_usage_breakdown_meters = @meters_for_breakdown.select do |mpan_mprn, _|
+          @annual_usage_meter_breakdown.meters.include?(mpan_mprn)
+        end
+      end
 
       def create_analysable
         days_of_data = (analysis_end_date - analysis_start_date).to_i

--- a/app/views/schools/advice/electricity_meter_breakdown/_analysis.html.erb
+++ b/app/views/schools/advice/electricity_meter_breakdown/_analysis.html.erb
@@ -3,5 +3,6 @@
            analysis_dates: @analysis_dates,
            advice_page: @advice_page,
            meters_for_breakdown: @meters_for_breakdown,
+           annual_usage_breakdown_meters: @annual_usage_breakdown_meters,
            annual_usage_meter_breakdown: @annual_usage_meter_breakdown,
            date_ranges_by_meter: @date_ranges_by_meter %>

--- a/app/views/schools/advice/electricity_meter_breakdown/_insights.html.erb
+++ b/app/views/schools/advice/electricity_meter_breakdown/_insights.html.erb
@@ -15,5 +15,5 @@
            summary: true,
            school: @school,
            analysis_dates: @analysis_dates,
-           meters_for_breakdown: @meters_for_breakdown,
+           annual_usage_breakdown_meters: @annual_usage_breakdown_meters,
            usage_breakdown: @annual_usage_meter_breakdown %>

--- a/app/views/schools/advice/gas_meter_breakdown/_analysis.html.erb
+++ b/app/views/schools/advice/gas_meter_breakdown/_analysis.html.erb
@@ -3,5 +3,6 @@
            analysis_dates: @analysis_dates,
            advice_page: @advice_page,
            meters_for_breakdown: @meters_for_breakdown,
+           annual_usage_breakdown_meters: @annual_usage_breakdown_meters,
            annual_usage_meter_breakdown: @annual_usage_meter_breakdown,
            date_ranges_by_meter: @date_ranges_by_meter %>

--- a/app/views/schools/advice/gas_meter_breakdown/_insights.html.erb
+++ b/app/views/schools/advice/gas_meter_breakdown/_insights.html.erb
@@ -15,5 +15,5 @@
            summary: true,
            school: @school,
            analysis_dates: @analysis_dates,
-           meters_for_breakdown: @meters_for_breakdown,
+           annual_usage_breakdown_meters: @annual_usage_breakdown_meters,
            usage_breakdown: @annual_usage_meter_breakdown %>

--- a/app/views/schools/advice/long_term/_analysis.html.erb
+++ b/app/views/schools/advice/long_term/_analysis.html.erb
@@ -8,9 +8,6 @@
     <li><%= link_to(t("#{locale_key_prefix}.comparison.title"), '#comparison') %></li>
     <li><%= link_to(t("#{locale_key_prefix}.long_term_trends.title"), '#long-term-trends') %></li>
   <% end %>
-  <% if multiple_meters %>
-    <li><%= link_to(t("#{locale_key_prefix}.meter_breakdown.title"), '#meter-breakdown') %></li>
-  <% end %>
 </ul>
 
 <%= render 'schools/advice/long_term/recent_trend',
@@ -33,13 +30,4 @@
   <%= render "schools/advice/#{fuel_type}_long_term/long_term_trend",
              meter_selection: @meter_selection,
              analysis_dates: analysis_dates %>
-<% end %>
-
-<% if multiple_meters %>
-  <%= render "schools/advice/#{fuel_type}_long_term/meter_breakdown",
-             fuel_type: fuel_type,
-             school: school,
-             analysis_dates: analysis_dates,
-             meters_for_breakdown: meters_for_breakdown,
-             annual_usage_meter_breakdown: annual_usage_meter_breakdown %>
 <% end %>

--- a/app/views/schools/advice/meter_breakdown/_analysis.html.erb
+++ b/app/views/schools/advice/meter_breakdown/_analysis.html.erb
@@ -32,7 +32,7 @@
            fuel_type: advice_page.fuel_type,
            school: school,
            analysis_dates: analysis_dates,
-           meters_for_breakdown: meters_for_breakdown,
+           annual_usage_breakdown_meters: annual_usage_breakdown_meters,
            usage_breakdown: annual_usage_meter_breakdown %>
 
 <p><%= t("advice_pages.#{advice_page.fuel_type}_long_term.analysis.meter_breakdown.table_explanation") %></p>

--- a/app/views/schools/advice/meter_breakdown/_usage_breakdown_table.html.erb
+++ b/app/views/schools/advice/meter_breakdown/_usage_breakdown_table.html.erb
@@ -16,6 +16,7 @@
   </thead>
   <tbody>
     <% meters_for_breakdown.each do |mpan_mprn, meter| %>
+      <% next unless usage_breakdown.meters.include?(mpan_mprn) %>
       <tr>
         <td class="text-left"><%= meter.mpan_mprn %></td>
         <td><%= meter.name %></td>

--- a/app/views/schools/advice/meter_breakdown/_usage_breakdown_table.html.erb
+++ b/app/views/schools/advice/meter_breakdown/_usage_breakdown_table.html.erb
@@ -15,8 +15,7 @@
     <th class="text-right"><%= t("advice_pages.#{fuel_type}_long_term.tables.columns.annual_change") %></th>
   </thead>
   <tbody>
-    <% meters_for_breakdown.each do |mpan_mprn, meter| %>
-      <% next unless usage_breakdown.meters.include?(mpan_mprn) %>
+    <% annual_usage_breakdown_meters.each do |mpan_mprn, meter| %>
       <tr>
         <td class="text-left"><%= meter.mpan_mprn %></td>
         <td><%= meter.name %></td>


### PR DESCRIPTION
Fixes an issue in new meter breakdown table.

The table loops through all meters for a fuel type. But some schools have decommissioned/old meters which are active but are not included in the usage breakdown calculations because the meter data is >1 year old.

Added a fix to the template that is breaking to skip over any meters not included in the analysis.