### PR TITLE
Fix interpolation arguments in updated translations

### DIFF
--- a/config/locales/cy/views/advice_pages/electricity_long_term.yml
+++ b/config/locales/cy/views/advice_pages/electricity_long_term.yml
@@ -33,7 +33,7 @@ cy:
         electricity_by_month_year:
           explanation: Gall y siart hwn fod yn ffordd gyflym o weld a yw ymddygiad arbed ynni a diweddariadau goleuo ac offer yn cael effaith ar eich defnydd o drydan. Mae angen bod yn ofalus wrth gymharu misoedd â gwyliau, yn enwedig y Pasg, sef rhai blynyddoedd ym mis Mawrth ac adegau eraill ym mis Ebrill.
           subtitle_html: Mae'r siart hwn yn dangos y defnydd %{fuel_type} misol o <span class='start-date'>%{start_date}</span> i <span class='end-date'>%{end_date}</span> ar gyfer <span class='meter'>%{meter}</span>
-          subtitle_two_years_html: Mae'r siart hwn yn dangos y gwahaniaeth yn y defnydd o %{fuel_type} ar gyfer y 12 mis yn diweddu ar <span class='end-date'>%{end_date}</span> a'r 12 mis blaenorol ar gyfer <span class='meter'>%{meter}</span>
+          subtitle_two_years_html: Mae'r siart hwn yn dangos y gwahaniaeth yn y defnydd o trydan ar gyfer y 12 mis yn diweddu ar <span class='end-date'>%{end_date}</span> a'r 12 mis blaenorol ar gyfer <span class='meter'>%{meter}</span>
           title: Cymhariaeth defnydd %{fuel_type} misol
           title_two_years: Cymhariaeth defnydd %{fuel_type} misol dros y ddwy flynedd diwethaf
         electricity_longterm_trend:

--- a/config/locales/cy/views/advice_pages/electricity_out_of_hours.yml
+++ b/config/locales/cy/views/advice_pages/electricity_out_of_hours.yml
@@ -29,7 +29,7 @@ cy:
             title: Manylion defnydd trydan
           electricity_by_day_of_week_tolerant_chart:
             footer: Bydd rhywfaint o ddefnydd trydan ar benwythnosau o offer a dyfeisiau sy'n cael eu gadael ymlaen, ond dylai'r ysgol anelu at leihau'r rhain. Mae ysgolion sydd â defnydd isel o drydan ar benwythnosau yn anelu at ddiffodd cymaint o offer â phosibl ar brynhawn dydd Gwener, gan roi rhestr wirio weithiau i'r gofalwr neu'r staff glanhau o'r hyn y dylent fod yn ei ddiffodd.
-            subtitle_html: Mae'r siart hwn yn dangos cyfanswm y trydan a ddefnyddir gan eich ysgol rhwng <span class="start-date">%{start_month_year}</span> a %{end_month_year}, wedi'i ddadansoddi fesul diwrnod yr wythnos ac amser defnyddio
+            subtitle_html: Mae'r siart hwn yn dangos cyfanswm y trydan a ddefnyddir gan eich ysgol rhwng <span class="start-date">%{start_date}</span> a %{end_date}, wedi'i ddadansoddi fesul diwrnod yr wythnos ac amser defnyddio
             title: Defnydd trydan fesul diwrnod yr wythnos
           title: Defnydd fesul diwrnod yr wythnos
       insights:

--- a/config/locales/cy/views/advice_pages/gas_out_of_hours.yml
+++ b/config/locales/cy/views/advice_pages/gas_out_of_hours.yml
@@ -41,7 +41,7 @@ cy:
                 <li>gosodiadau boeler anghywir</li>
 
               <p>Trwy ddileu'r defnydd o nwy ar y penwythnos yn eich ysgol gallech arbed hyd at %{savings_gbp} (%{savings_kwh}kWh) y flwyddyn.</p>
-            subtitle_html: Mae'r siart hwn yn dangos cyfanswm y nwy a ddefnyddwyd gan eich ysgol rhwng <span class="start-date">%{start_month_year}</span> a <span class="end-date">%{end_month_year}</span>, wedi'i dadansoddi yn ôl diwrnod yr wythnos ac amser defnyddio
+            subtitle_html: Mae'r siart hwn yn dangos cyfanswm y nwy a ddefnyddwyd gan eich ysgol rhwng <span class="start-date">%{start_date}</span> a <span class="end-date">%{end_date}</span>, wedi'i dadansoddi yn ôl diwrnod yr wythnos ac amser defnyddio
             title: Defnydd nwy yn ôl diwrnod yr wythnos
           subtitle: Er mwyn deall pam mae eich ysgol yn defnyddio gormod o nwy y tu allan i oriau ysgol, edrychwch yn gyntaf ar ddefnydd nwy yn ôl diwrnod yr wythnos.
           title: Defnydd fesul diwrnod yr wythnos


### PR DESCRIPTION
The rework I did to support meter breakdowns involved renaming some interpolation arguments. I missed a couple in the Welsh translations which are causing errors.

Have reviewed all the pages and only these are affected.