### PR TITLE
Improve responsiveness of dashboard table

### DIFF
--- a/app/components/energy_summary_table_component.rb
+++ b/app/components/energy_summary_table_component.rb
@@ -35,6 +35,11 @@ class EnergySummaryTableComponent < ApplicationComponent
     @user&.admin? || @school.data_enabled?
   end
 
+  # Bootstrap classes to allow th/td classes to be hidden on smallest mobile views
+  def hidden_on_mobile
+    'd-none d-sm-table-cell'
+  end
+
   def col(size = 1)
     "col-#{size}" if Flipper.enabled?(:new_dashboards_2024, user)
   end

--- a/app/components/energy_summary_table_component/energy_summary_table_component.html.erb
+++ b/app/components/energy_summary_table_component/energy_summary_table_component.html.erb
@@ -16,11 +16,11 @@
           <th class="icon <%= col(1) %>"></th>
           <th class="text-left"></th>
           <th class="text-left <%= col(4) %>"></th>
-          <th class="text-right <%= col(1) %>"><%= t('common.table.columns.use_kwh') %></th>
-          <th class="text-right <%= col(1) %>"><%= t('common.table.columns.co2_kg') %></th>
-          <th class="text-right <%= col(1) %>"><%= t('common.table.columns.cost_gbp') %></th>
+          <th class="<%= hidden_on_mobile %> text-right <%= col(1) %>"><%= t('common.table.columns.use_kwh') %></th>
+          <th class="<%= hidden_on_mobile %> text-right <%= col(1) %>"><%= t('common.table.columns.co2_kg') %></th>
+          <th class="<%= hidden_on_mobile %> text-right <%= col(1) %>"><%= t('common.table.columns.cost_gbp') %></th>
           <% if show_savings? %>
-            <th class="text-right <%= col(1) %>"><%= t('schools.show.potential_savings') %></th>
+            <th class="<%= hidden_on_mobile %> text-right <%= col(1) %>"><%= t('schools.show.potential_savings') %></th>
           <% end %>
           <th class="text-right <%= col(1) %>"><%= t('schools.show.percentage_change') %></th>
         </tr>
@@ -49,11 +49,11 @@
           <% end %>
           <td class="text-left"><%= data.period %></td>
           <% if data.has_data %>
-            <td class="text-right <%= data.message_class %>"><%= data.usage %></td>
-            <td class="text-right <%= data.message_class %>"><%= data.co2 %></td>
-            <td class="text-right <%= data.message_class %>"><%= data.cost %></td>
+            <td class="<%= hidden_on_mobile %> text-right <%= data.message_class %>"><%= data.usage %></td>
+            <td class="<%= hidden_on_mobile %> text-right <%= data.message_class %>"><%= data.co2 %></td>
+            <td class="<%= hidden_on_mobile %> text-right <%= data.message_class %>"><%= data.cost %></td>
             <% if show_savings? %>
-              <td class="text-right <%= data.message_class %>"><%= data.savings %></td>
+              <td class="<%= hidden_on_mobile %> text-right <%= data.message_class %>"><%= data.savings %></td>
             <% end %>
             <td class="text-right"><%= up_downify(data.change, sanitize: false) %></td>
           <% else %>


### PR DESCRIPTION
Uses Bootstrap 4/5 display utilities to hide some of the columns on the dashboard table at small screen sizes.

![Screenshot from 2024-08-20 15-20-30](https://github.com/user-attachments/assets/44758e9a-6c38-4045-83d6-71644c8e1128)

Rotating the screen or at higher break points all the columns become visible. At `sm` breakpoint and above the table will have a horizontal scroll if needed.