### PR TITLE
Initial version of new pupil dashboard

### DIFF
--- a/app/components/adult_reminders_component.rb
+++ b/app/components/adult_reminders_component.rb
@@ -33,10 +33,4 @@ class AdultRemindersComponent < DashboardRemindersComponent
   def recent_audit
     Audits::AuditService.new(@school).recent_audit
   end
-
-  private
-
-  def site_settings
-    @site_settings ||= SiteSettings.current
-  end
 end

--- a/app/components/adult_reminders_component/adult_reminders_component.html.erb
+++ b/app/components/adult_reminders_component/adult_reminders_component.html.erb
@@ -23,7 +23,7 @@
                 status: :neutral,
                 icon: 'exclamation-circle',
                 link: 'schools.show.upload_energy_bill',
-                path: school_consent_documents_url(school)) do %>
+                path: school_consent_documents_path(school)) do %>
     <p>
       <%= t('schools.show.energy_bill_required') %>
     </p>

--- a/app/components/dashboard_insights_component/dashboard_insights_component.html.erb
+++ b/app/components/dashboard_insights_component/dashboard_insights_component.html.erb
@@ -8,7 +8,7 @@
   <div class="row">
     <%# split to 2 column view on larger screens if we are displaying alerts %>
     <div class="col-12 <%= displaying_alerts? ? 'col-lg-6' : '' %>">
-      <%= component 'adult_reminders',
+      <%= component "#{audience}_reminders",
                     school: school,
                     user: user,
                     id: "#{audience}-reminders" do |c| %>

--- a/app/components/dashboard_reminders_component.rb
+++ b/app/components/dashboard_reminders_component.rb
@@ -40,4 +40,8 @@ class DashboardRemindersComponent < ApplicationComponent
   def can?(permission, context)
     ability.can?(permission, context)
   end
+
+  def site_settings
+    @site_settings ||= SiteSettings.current
+  end
 end

--- a/app/components/pupil_reminders_component.rb
+++ b/app/components/pupil_reminders_component.rb
@@ -1,0 +1,9 @@
+class PupilRemindersComponent < DashboardRemindersComponent
+  def temperature_observations
+    @school.observations.temperature
+  end
+
+  def show_temperature_observations?
+    site_settings.temperature_recording_month_numbers.include?(Time.zone.today.month)
+  end
+end

--- a/app/components/pupil_reminders_component/pupil_reminders_component.html.erb
+++ b/app/components/pupil_reminders_component/pupil_reminders_component.html.erb
@@ -72,7 +72,7 @@
                 status: :neutral,
                 icon: 'clipboard-list',
                 link: 'common.labels.choose_activity',
-                path: school_recommendations_path(school, scope: :adult)) do %>
+                path: school_recommendations_path(school, scope: :pupil)) do %>
     <p>
       <%= t('schools.prompts.recommendations.message') %>
     </p>

--- a/app/components/pupil_reminders_component/pupil_reminders_component.html.erb
+++ b/app/components/pupil_reminders_component/pupil_reminders_component.html.erb
@@ -1,0 +1,81 @@
+<%= component 'prompt_list', id: id, classes: classes do |list| %>
+  <% if title? %>
+    <% list.with_title do %>
+      <%= title %>
+    <% end %>
+  <% end %>
+
+  <% if show_temperature_observations? %>
+    <% if temperature_observations.empty? %>
+      <% add_prompt(id: :enter_temperatures,
+                    list: list,
+                    status: :neutral,
+                    icon: 'temperature-high',
+                    link: 'pupils.schools.show.enter_temperatures',
+                    path: school_temperature_observations_path(school)) do %>
+          <p>
+            <%= t('pupils.schools.show.measure_temperatures') %>
+          </p>
+      <% end %>
+    <% else %>
+      <% add_prompt(id: :update_temperatures,
+                    list: list,
+                    status: :neutral,
+                    icon: 'temperature-high',
+                    link: 'pupils.schools.show.previous_temperatures',
+                    path: school_temperature_observations_path(school)) do %>
+          <p>
+            <%= t('pupils.schools.show.updating_temperatures') %>
+          </p>
+      <% end %>
+    <% end %>
+  <% end %>
+
+  <% add_prompt(id: :transport_surveys,
+                list: list,
+                status: :neutral,
+                icon: 'car-alt',
+                link: 'pupils.schools.show.start_transport_survey',
+                path: school_transport_surveys_path(school)) do %>
+      <p>
+        <%= t('pupils.schools.show.transport_surveys') %>
+      </p>
+  <% end %>
+
+  <% if programmes_to_prompt.any? %>
+    <% programmes_to_prompt.each do |programme| %>
+      <% add_prompt(id: :programme_reminder,
+                    list: list,
+                    status: :neutral,
+                    icon: 'tasks',
+                    link: 'common.labels.view_now',
+                    path: programme_type_path(programme.programme_type)) do %>
+        <p>
+          <%= Programmes::Progress.new(programme).notification %>
+        </p>
+      <% end %>
+    <% end %>
+  <% else %>
+    <% add_prompt(id: :new_programme,
+                  list: list,
+                  status: :neutral,
+                  icon: 'tasks',
+                  link: 'schools.prompts.programme.start_a_new_programme',
+                  path: programme_types_path) do %>
+      <p>
+        <%= t('schools.prompts.programme.choose_a_new_programme_message') %>
+      </p>
+    <% end %>
+  <% end %>
+  <% add_prompt(id: :choose_activity,
+                list: list,
+                status: :neutral,
+                icon: 'clipboard-list',
+                link: 'common.labels.choose_activity',
+                path: school_recommendations_path(school, scope: :adult)) do %>
+    <p>
+      <%= t('schools.prompts.recommendations.message') %>
+    </p>
+  <% end %>
+
+<% end %>

--- a/app/controllers/pupils/schools_controller.rb
+++ b/app/controllers/pupils/schools_controller.rb
@@ -20,6 +20,11 @@ module Pupils
       @show_data_enabled_features = show_data_enabled_features?
       setup_default_features
       setup_data_enabled_features if @show_data_enabled_features
+      if Flipper.enabled?(:new_dashboards_2024, current_user)
+        render :new_show, layout: 'dashboards'
+      else
+        render :show
+      end
     end
 
   private

--- a/app/views/pupils/schools/new_show.html.erb
+++ b/app/views/pupils/schools/new_show.html.erb
@@ -1,0 +1,33 @@
+<% content_for :dashboard_header do %>
+  <%= component 'dashboard_header', school: @school %>
+<% end %>
+
+<div class="container">
+  <div class="row mt-4">
+    <div class="col">
+      <%= component 'dashboard_insights',
+                    audience: :pupil,
+                    school: @school,
+                    user: current_user,
+                    progress_summary: @progress_summary %>
+    </div>
+  </div>
+</div>
+
+<div class="container-fluid bg-light pb-3">
+  <div class="container">
+    <%= component 'scoreboard_summary',
+                  podium: current_school_podium,
+                  user: current_user,
+                  classes: 'mt-4 pt-4' %>
+
+    <%= component 'timeline',
+                  school: @school,
+                  observations: @observations,
+                  user: current_user,
+                  classes: 'mt-4' %>
+
+    <%= component 'dashboard_login', school: @school, user: current_user %>
+
+  </div>
+</div>

--- a/spec/components/adult_reminders_component_spec.rb
+++ b/spec/components/adult_reminders_component_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe AdultRemindersComponent, :include_application_helper, type: :component do
+RSpec.describe AdultRemindersComponent, :include_application_helper, :include_url_helpers, type: :component do
   subject(:component) do
     described_class.new(**params)
   end
@@ -373,12 +373,37 @@ RSpec.describe AdultRemindersComponent, :include_application_helper, type: :comp
       render_inline(component)
     end
 
+    it { expect(html).to have_content(I18n.t('schools.prompts.programme.choose_a_new_programme_message')) }
+
+    it {
+      expect(html).to have_link(I18n.t('schools.prompts.programme.start_a_new_programme'),
+                                   href: programme_types_path)
+    }
+
+    it { expect(html).to have_content(I18n.t('schools.prompts.recommendations.message')) }
+
+    it {
+      expect(html).to have_link(I18n.t('common.labels.choose_activity'),
+                                  href: school_recommendations_path(school, scope: :adult))
+    }
+
+    context 'when school has an active programme' do
+      let!(:programme) { create(:programme, school: school) }
+
+      it { expect(html).to have_content('You have completed') }
+
+      it {
+        expect(html).to have_link(I18n.t('common.labels.view_now'),
+                                     href: programme_type_path(programme.programme_type))
+      }
+
+      it { expect(html).not_to have_selector('#new_programme') }
+    end
+
     it 'displays the default prompts' do
       within('#custom-id') do
         expect(html).to have_css('#add_pupils')
         expect(html).to have_css('#add_contacts')
-        expect(html).to have_css('#new_programme')
-        expect(html).to have_css('#choose_activity')
         expect(html).to have_css('#set_target')
       end
     end

--- a/spec/components/adult_reminders_component_spec.rb
+++ b/spec/components/adult_reminders_component_spec.rb
@@ -377,6 +377,7 @@ RSpec.describe AdultRemindersComponent, :include_application_helper, type: :comp
       within('#custom-id') do
         expect(html).to have_css('#add_pupils')
         expect(html).to have_css('#add_contacts')
+        expect(html).to have_css('#new_programme')
         expect(html).to have_css('#choose_activity')
         expect(html).to have_css('#set_target')
       end

--- a/spec/components/adult_reminders_component_spec.rb
+++ b/spec/components/adult_reminders_component_spec.rb
@@ -373,6 +373,10 @@ RSpec.describe AdultRemindersComponent, :include_application_helper, :include_ur
       render_inline(component)
     end
 
+    before do
+      SiteSettings.create!(message_for_no_pupil_accounts: true, message_for_no_contacts: true)
+    end
+
     it { expect(html).to have_content(I18n.t('schools.prompts.programme.choose_a_new_programme_message')) }
 
     it {
@@ -399,6 +403,28 @@ RSpec.describe AdultRemindersComponent, :include_application_helper, :include_ur
 
       it { expect(html).not_to have_selector('#new_programme') }
     end
+
+
+    it { expect(html).to have_content(I18n.t('schools.show.setup_pupil_account')) }
+
+    it {
+      expect(html).to have_link(I18n.t('schools.show.create_pupil_account'),
+                                   href: new_school_pupil_path(school))
+    }
+
+    it { expect(html).to have_content(I18n.t('schools.show.setup_alert_contacts')) }
+
+    it {
+      expect(html).to have_link(I18n.t('schools.show.add_alert_contacts'),
+                                   href: school_contacts_path(school))
+    }
+
+    it { expect(html).to have_content(I18n.t('schools.show.set_targets')) }
+
+    it {
+      expect(html).to have_link(I18n.t('schools.show.set_target'),
+                                   href: school_school_targets_path(school))
+    }
 
     it 'displays the default prompts' do
       within('#custom-id') do

--- a/spec/components/pupil_reminders_component_spec.rb
+++ b/spec/components/pupil_reminders_component_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe PupilRemindersComponent, :include_application_helper, type: :component do
+  subject(:component) do
+    described_class.new(**params)
+  end
+
+  let(:id) { 'custom-id'}
+  let(:classes) { 'extra-classes' }
+  let(:user) { create(:admin) }
+  let(:school) { create(:school) }
+
+  let(:params) do
+    {
+      school: school,
+      user: user,
+      id: id,
+      classes: classes
+    }
+  end
+
+  describe '#temperature_observations' do
+    context 'with no observations' do
+      it { expect(component.temperature_observations).to be_empty }
+    end
+
+    context 'with existing observations' do
+      let!(:observation) { create(:observation, :temperature, school: school) }
+
+      it { expect(component.temperature_observations).to eq([observation]) }
+    end
+  end
+
+  describe '#show_temperature_observations?' do
+    before do
+      SiteSettings.create!(temperature_recording_months: %w[10 11 12])
+    end
+
+    context 'when in summer' do
+      before { travel_to(Date.new(2024, 8, 1)) }
+
+      it { expect(component.show_temperature_observations?).to be false }
+    end
+
+    context 'when in winter' do
+      before { travel_to(Date.new(2024, 10, 1)) }
+
+      it { expect(component.show_temperature_observations?).to be true }
+    end
+  end
+
+  context 'when rendering' do
+    let(:html) do
+      render_inline(component)
+    end
+
+    it 'displays the default prompts' do
+      within('#custom-id') do
+        expect(html).to have_css('#transport_surveys')
+        expect(html).to have_css('#new_programme')
+        expect(html).to have_css('#choose_activity')
+      end
+    end
+  end
+end

--- a/spec/components/pupil_reminders_component_spec.rb
+++ b/spec/components/pupil_reminders_component_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe PupilRemindersComponent, :include_application_helper, type: :component do
+RSpec.describe PupilRemindersComponent, :include_application_helper, :include_url_helpers, type: :component do
   subject(:component) do
     described_class.new(**params)
   end
@@ -56,12 +56,38 @@ RSpec.describe PupilRemindersComponent, :include_application_helper, type: :comp
       render_inline(component)
     end
 
-    it 'displays the default prompts' do
-      within('#custom-id') do
-        expect(html).to have_css('#transport_surveys')
-        expect(html).to have_css('#new_programme')
-        expect(html).to have_css('#choose_activity')
-      end
+    it { expect(html).to have_content(I18n.t('pupils.schools.show.transport_surveys')) }
+
+    it {
+      expect(html).to have_link(I18n.t('pupils.schools.show.start_transport_survey'),
+                                   href: school_transport_surveys_path(school))
+    }
+
+    it { expect(html).to have_content(I18n.t('schools.prompts.programme.choose_a_new_programme_message')) }
+
+    it {
+      expect(html).to have_link(I18n.t('schools.prompts.programme.start_a_new_programme'),
+                                   href: programme_types_path)
+    }
+
+    it { expect(html).to have_content(I18n.t('schools.prompts.recommendations.message')) }
+
+    it {
+      expect(html).to have_link(I18n.t('common.labels.choose_activity'),
+                                  href: school_recommendations_path(school, scope: :pupil))
+    }
+
+    context 'when school has an active programme' do
+      let!(:programme) { create(:programme, school: school) }
+
+      it { expect(html).to have_content('You have completed') }
+
+      it {
+        expect(html).to have_link(I18n.t('common.labels.view_now'),
+                                     href: programme_type_path(programme.programme_type))
+      }
+
+      it { expect(html).not_to have_selector('#new_programme') }
     end
   end
 end


### PR DESCRIPTION
Creates initial version of redesigned pupil dashboard:

- conditionally show new template if feature active
- use previously created components to build the page
- add `PupilRemindersComponent` to generate the prompts for pupils to take action
- improve test coverage of the two dashboard reminder components

Adding the equivalences will come in another PR.