### PR TITLE
Rework reminders and activity prompt

### DIFF
--- a/app/components/adult_reminders_component.rb
+++ b/app/components/adult_reminders_component.rb
@@ -1,10 +1,6 @@
 class AdultRemindersComponent < DashboardRemindersComponent
   include SchoolProgress
 
-  def show_standard_prompts?
-    user&.admin? || can_manage_school?
-  end
-
   def can_manage_school?
     ability.can?(:show_management_dash, @school)
   end

--- a/app/components/adult_reminders_component/adult_reminders_component.html.erb
+++ b/app/components/adult_reminders_component/adult_reminders_component.html.erb
@@ -5,22 +5,44 @@
     <% end %>
   <% end %>
 
-  <% if show_standard_prompts? %>
-    <% messageable.each do |messageable| %>
-      <% add_prompt(id: "#{messageable.class.name.downcase}_dashboard_message",
-                    check: messageable.dashboard_message,
-                    list: list,
-                    status: :neutral,
-                    icon: 'info-circle') do %>
-        <%= messageable.dashboard_message.message %>
-      <% end %>
+  <% messageable.each do |messageable| %>
+    <% add_prompt(id: "#{messageable.class.name.downcase}_dashboard_message",
+                  check: messageable.dashboard_message,
+                  list: list,
+                  status: :negative,
+                  icon: 'info-circle') do %>
+      <%= messageable.dashboard_message.message %>
     <% end %>
   <% end %>
+
+  <% add_prompt(id: :add_pupils,
+                check: prompt_for_pupils?,
+                list: list,
+                status: :negative,
+                icon: 'exclamation-circle',
+                link: 'schools.show.create_pupil_account',
+                path: new_school_pupil_path(school)) do %>
+     <p>
+       <%= t('schools.show.setup_pupil_account') %>
+     </p>
+   <% end %>
+
+   <% add_prompt(id: :add_contacts,
+                 check: prompt_for_contacts?,
+                 list: list,
+                 status: :negative,
+                 icon: 'exclamation-circle',
+                 link: 'schools.show.add_alert_contacts',
+                 path: school_contacts_path(school)) do %>
+     <p>
+       <%= t('schools.show.setup_alert_contacts') %>
+     </p>
+   <% end %>
 
   <% add_prompt(id: :bill,
                 check: prompt_for_bill?,
                 list: list,
-                status: :neutral,
+                status: :negative,
                 icon: 'exclamation-circle',
                 link: 'schools.show.upload_energy_bill',
                 path: school_consent_documents_path(school)) do %>
@@ -89,65 +111,29 @@
     </p>
   <% end %>
 
-  <% if show_standard_prompts? %>
-    <% if programmes_to_prompt.any? %>
-      <% programmes_to_prompt.each do |programme| %>
-        <% add_prompt(id: :programme_reminder,
-                      list: list,
-                      status: :neutral,
-                      icon: 'tasks',
-                      link: 'common.labels.view_now',
-                      path: programme_type_path(programme.programme_type)) do %>
-          <p>
-            <%= Programmes::Progress.new(programme).notification %>
-          </p>
-        <% end %>
-      <% end %>
-    <% else %>
-      <% add_prompt(id: :new_programme,
+  <% if programmes_to_prompt.any? %>
+    <% programmes_to_prompt.each do |programme| %>
+      <% add_prompt(id: :programme_reminder,
                     list: list,
                     status: :neutral,
                     icon: 'tasks',
-                    link: 'schools.prompts.programme.start_a_new_programme',
-                    path: programme_types_path) do %>
+                    link: 'common.labels.view_now',
+                    path: programme_type_path(programme.programme_type)) do %>
         <p>
-          <%= t('schools.prompts.programme.choose_a_new_programme_message') %>
+          <%= Programmes::Progress.new(programme).notification %>
         </p>
       <% end %>
     <% end %>
-    <% add_prompt(id: :choose_activity,
+  <% else %>
+    <% add_prompt(id: :new_programme,
                   list: list,
                   status: :neutral,
-                  icon: 'clipboard-list',
-                  link: 'common.labels.choose_activity',
-                  path: school_recommendations_path(school, scope: :adult)) do %>
+                  icon: 'tasks',
+                  link: 'schools.prompts.programme.start_a_new_programme',
+                  path: programme_types_path) do %>
       <p>
-        <%= t('schools.prompts.recommendations.message') %>
+        <%= t('schools.prompts.programme.choose_a_new_programme_message') %>
       </p>
     <% end %>
   <% end %>
-
-  <% add_prompt(id: :add_pupils,
-                check: prompt_for_pupils?,
-                list: list,
-                status: :neutral,
-                icon: 'exclamation-circle',
-                link: 'schools.show.create_pupil_account',
-                path: new_school_pupil_path(school)) do %>
-     <p>
-       <%= t('schools.show.setup_pupil_account') %>
-     </p>
-   <% end %>
-
-   <% add_prompt(id: :add_contacts,
-                 check: prompt_for_contacts?,
-                 list: list,
-                 status: :neutral,
-                 icon: 'exclamation-circle',
-                 link: 'schools.show.add_alert_contacts',
-                 path: school_contacts_path(school)) do %>
-     <p>
-       <%= t('schools.show.setup_alert_contacts') %>
-     </p>
-   <% end %>
 <% end %>

--- a/app/components/pupil_reminders_component/pupil_reminders_component.html.erb
+++ b/app/components/pupil_reminders_component/pupil_reminders_component.html.erb
@@ -67,15 +67,4 @@
       </p>
     <% end %>
   <% end %>
-  <% add_prompt(id: :choose_activity,
-                list: list,
-                status: :neutral,
-                icon: 'clipboard-list',
-                link: 'common.labels.choose_activity',
-                path: school_recommendations_path(school, scope: :pupil)) do %>
-    <p>
-      <%= t('schools.prompts.recommendations.message') %>
-    </p>
-  <% end %>
-
 <% end %>

--- a/app/components/scoreboard_summary_component.rb
+++ b/app/components/scoreboard_summary_component.rb
@@ -1,15 +1,16 @@
 # frozen_string_literal: true
 
 class ScoreboardSummaryComponent < ApplicationComponent
-  attr_reader :podium, :user
+  attr_reader :podium, :user, :audience
 
   include ApplicationHelper
 
-  def initialize(podium:, title: nil, user: nil, id: nil, classes: '')
+  def initialize(podium:, title: nil, audience: :adult, user: nil, id: nil, classes: '')
     super(id: id, classes: classes)
     @podium = podium
     @title = title
     @user = user
+    @audience = audience
   end
 
   def title

--- a/app/components/scoreboard_summary_component/scoreboard_summary_component.html.erb
+++ b/app/components/scoreboard_summary_component/scoreboard_summary_component.html.erb
@@ -27,7 +27,7 @@
         </div>
         <div class="row">
           <div class="col">
-            <%= link_to t('components.podium.complete_an_activity'), school_recommendations_path(school),
+            <%= link_to t('common.labels.choose_activity'), school_recommendations_path(school, scope: audience),
                         class: 'btn btn-outline-dark' %>
           </div>
         </div>

--- a/app/views/pupils/schools/new_show.html.erb
+++ b/app/views/pupils/schools/new_show.html.erb
@@ -29,6 +29,7 @@
     <%= component 'scoreboard_summary',
                   podium: current_school_podium,
                   user: current_user,
+                  audience: @audience,
                   classes: 'mt-4 pt-4' %>
 
     <%= component 'timeline',

--- a/app/views/schools/new_show.html.erb
+++ b/app/views/schools/new_show.html.erb
@@ -29,6 +29,7 @@
     <%= component 'scoreboard_summary',
                   podium: current_school_podium,
                   user: current_user,
+                  audience: @audience,
                   classes: 'mt-4 pt-4' %>
 
     <%= component 'timeline',

--- a/config/locales/views/components/podium.yml
+++ b/config/locales/views/components/podium.yml
@@ -2,7 +2,6 @@
 en:
   components:
     podium:
-      complete_an_activity: Complete an activity
       complete_an_activity_html: <a href="%{recommendations_path}">Complete an activity</a> to score points on Energy Sparks
       full_position_html: You are in <strong>%{position_ordinal} place</strong> on the <a href='%{scoreboard_path}'>%{scoreboard} scoreboard</a> and <strong>%{national_position_ordinal} place</strong> <a href='%{national_scoreboard_path}'>nationally</a>
       no_points_this_year: Your school hasn't scored any points yet this school year

--- a/config/locales/views/components/scoreboard_summary.yml
+++ b/config/locales/views/components/scoreboard_summary.yml
@@ -2,7 +2,7 @@
 en:
   components:
     scoreboard_summary:
-      intro: Complete our recommended activities and actions to score points on Energy Sparks.
+      intro: Complete our recommended activities and actions to score points and start reducing your energy usage.
       recent_activity: Recent activity across Energy Sparks
       recent_activity_intro: Schools score points by recording their activities to investigate their energy use, learning about energy, and taking energy saving actions around their school.
       recent_scoreboard_activity: Recent activity on your scoreboard

--- a/spec/components/adult_reminders_component_spec.rb
+++ b/spec/components/adult_reminders_component_spec.rb
@@ -21,30 +21,6 @@ RSpec.describe AdultRemindersComponent, :include_application_helper, :include_ur
     }
   end
 
-  describe '#show_standard_prompts?' do
-    context 'with admin' do
-      it { expect(component.show_standard_prompts?).to be(true) }
-    end
-
-    context 'with school admin' do
-      let!(:user) { create(:school_admin, school: school)}
-
-      it { expect(component.show_standard_prompts?).to be(true) }
-    end
-
-    context 'with other' do
-      let!(:user) { create(:school_admin) }
-
-      it { expect(component.show_standard_prompts?).to be(false) }
-    end
-
-    context 'with guest' do
-      let!(:user) { create(:guest) }
-
-      it { expect(component.show_standard_prompts?).to be(false) }
-    end
-  end
-
   describe '#prompt_for_bill?' do
     context 'with admin' do
       it { expect(component.prompt_for_bill?).to be(false) }

--- a/spec/components/adult_reminders_component_spec.rb
+++ b/spec/components/adult_reminders_component_spec.rb
@@ -360,13 +360,6 @@ RSpec.describe AdultRemindersComponent, :include_application_helper, :include_ur
                                    href: programme_types_path)
     }
 
-    it { expect(html).to have_content(I18n.t('schools.prompts.recommendations.message')) }
-
-    it {
-      expect(html).to have_link(I18n.t('common.labels.choose_activity'),
-                                  href: school_recommendations_path(school, scope: :adult))
-    }
-
     context 'when school has an active programme' do
       let!(:programme) { create(:programme, school: school) }
 

--- a/spec/components/pupil_reminders_component_spec.rb
+++ b/spec/components/pupil_reminders_component_spec.rb
@@ -70,13 +70,6 @@ RSpec.describe PupilRemindersComponent, :include_application_helper, :include_ur
                                    href: programme_types_path)
     }
 
-    it { expect(html).to have_content(I18n.t('schools.prompts.recommendations.message')) }
-
-    it {
-      expect(html).to have_link(I18n.t('common.labels.choose_activity'),
-                                  href: school_recommendations_path(school, scope: :pupil))
-    }
-
     context 'when school has an active programme' do
       let!(:programme) { create(:programme, school: school) }
 


### PR DESCRIPTION
Changes following internal review of dashboards

- make notices about metering issues visible to all
- make programme prompts visible to all on adult dash, as they are on pupil
- remove prompt for activity as we have one in the scoreboard summary
- update links and intro in scoreboard summary
- update colours of adult reminders to mark some are negative, change ordering so negative issues are first to highlight them better