### PR TITLE
Reduce repeated text in timeline and scoreboard activity tables

### DIFF
--- a/app/components/scoreboard_activity_component/scoreboard_activity_component.html.erb
+++ b/app/components/scoreboard_activity_component/scoreboard_activity_component.html.erb
@@ -6,6 +6,7 @@
           <th><%= t('common.labels.place') %></th>
         <% end %>
         <th><%= t('common.school') %></th>
+        <th><%= t('programme_types.show.points') %></th>
         <th><%= t('common.labels.activity') %></th>
       </tr>
     </thead>
@@ -19,6 +20,9 @@
           <% end %>
           <td>
             <%= link_to observation.school.name, school_path(observation.school) %>
+          </td>
+          <td>
+            <%= observation.points || '-' %>
           </td>
           <td>
             <%= component 'observation', observation: observation, style: :description %>

--- a/app/components/timeline_component/timeline_component.html.erb
+++ b/app/components/timeline_component/timeline_component.html.erb
@@ -26,6 +26,7 @@
                 <thead>
                   <tr>
                     <th><%= t('common.labels.date') %></th>
+                    <th><%= t('programme_types.show.points') %></th>
                     <th><%= t('common.labels.activity') %></th>
                   </tr>
                 </thead>
@@ -33,6 +34,7 @@
                   <% observations.each do |observation| %>
                     <tr>
                       <td><%= observation.at.to_fs(:es_short) %></td>
+                      <td><%= observation.points || '-' %></td>
                       <td><%= component 'observation', observation: observation, show_actions: show_actions,
                                                        style: :description %></td>
                     </tr>

--- a/config/locales/views/components/observation.yml
+++ b/config/locales/views/components/observation.yml
@@ -8,8 +8,8 @@ en:
           other: <a href="%{school_path}">%{school}</a> scored <strong>%{count} points</strong> after they recorded "<a href="%{compact_path}">%{target}</a>"
           zero: <a href="%{school_path}">%{school}</a> recorded "<a href="%{compact_path}">%{target}</a>"
         description_html:
-          one: Scored <strong>%{count} point</strong> after they recorded "<a href="%{compact_path}">%{target}</a>"
-          other: Scored <strong>%{count} points</strong> after they recorded "<a href="%{compact_path}">%{target}</a>"
+          one: Recorded "<a href="%{compact_path}">%{target}</a>"
+          other: Recorded "<a href="%{compact_path}">%{target}</a>"
           zero: Recorded "<a href="%{compact_path}">%{target}</a>"
         message: Completed an activity
       audit:
@@ -22,8 +22,8 @@ en:
           other: <a href="%{school_path}">%{school}</a> scored <strong>%{count} points</strong> after they <a href="%{compact_path}">completed all energy audit activities</a>
           zero: <a href="%{school_path}">%{school}</a> completed all energy audit activities</a>
         description_html:
-          one: Scored <strong>%{count} point</strong> after they <a href="%{compact_path}">completed all energy audit activities</a>
-          other: Scored <strong>%{count} points</strong> after they <a href="%{compact_path}">completed all energy audit activities</a>
+          one: <a href="%{compact_path}">Completed all energy audit activities</a>
+          other: <a href="%{compact_path}">Completed all energy audit activities</a>
           zero: Completed all energy audit activities
         message: Completed all audit activities
       intervention:
@@ -32,8 +32,8 @@ en:
           other: <a href="%{school_path}">%{school}</a> scored <strong>%{count} points</strong> after they recorded "<a href="%{compact_path}">%{message}</a>"
           zero: <a href="%{school_path}">%{school}</a> recorded "<a href="%{compact_path}">%{message}</a>"
         description_html:
-          one: Scored <strong>%{count} point</strong> after they recorded "<a href="%{compact_path}">%{message}</a>"
-          other: Scored <strong>%{count} points</strong> after they recorded "<a href="%{compact_path}">%{message}</a>"
+          one: Recorded "<a href="%{compact_path}">%{message}</a>"
+          other: Recorded "<a href="%{compact_path}">%{message}</a>"
           zero: Recorded "<a href="%{compact_path}">%{message}</a>"
       programme:
         compact_message_html:
@@ -41,8 +41,8 @@ en:
           other: <a href="%{school_path}">%{school}</a> scored <strong>%{count} points</strong> after they <a href="%{compact_path}">completed a programme</a>
           zero: <a href="%{school_path}">%{school}</a> <a href="%{compact_path}">completed a programme</a>
         description_html:
-          one: Scored <strong>%{count} point</strong> after they <a href="%{compact_path}">completed a programme</a>
-          other: Scored <strong>%{count} points</strong> after they <a href="%{compact_path}">completed a programme</a>
+          one: <a href="%{compact_path}">Completed a programme</a>
+          other: <a href="%{compact_path}">Completed a programme</a>
           zero: <a href="%{compact_path}">Completed a programme</a>
         message: Completed a programme
       school_target:
@@ -55,8 +55,8 @@ en:
           other: <a href="%{school_path}">%{school}</a> scored <strong>%{count} points</strong> by <a href="%{compact_path}">recording indoor temperatures</a>
           zero: <a href="%{school_path}">%{school}</a> <a href="%{compact_path}">recorded indoor temperatures</a>
         description_html:
-          one: Scored <strong>%{count} point</strong> by <a href="%{compact_path}">recording indoor temperatures</a>
-          other: Scored <strong>%{count} points</strong> by <a href="%{compact_path}">recording indoor temperatures</a>
+          one: <a href="%{compact_path}">Recorded indoor temperatures</a>
+          other: <a href="%{compact_path}">Recorded indoor temperatures</a>
           zero: <a href="%{compact_path}">Recorded indoor temperatures</a>
         message: Recorded indoor temperatures in
       transport_survey:

--- a/spec/components/observation_component_spec.rb
+++ b/spec/components/observation_component_spec.rb
@@ -153,7 +153,7 @@ RSpec.describe ObservationComponent, type: :component, include_url_helpers: true
       let(:style) { :description }
 
       it { expect(html).to have_css("i.fa-#{observation.intervention_type.intervention_type_group.icon}") }
-      it { expect(html).to have_content("Scored #{observation.intervention_type.score} points after they recorded \"#{observation.intervention_type.name}\"") }
+      it { expect(html).to have_content("Recorded \"#{observation.intervention_type.name}\"") }
       it { expect(html).to have_link(observation.intervention_type.name, href: school_intervention_path(observation.school, observation)) }
     end
   end
@@ -248,7 +248,7 @@ RSpec.describe ObservationComponent, type: :component, include_url_helpers: true
       let(:style) { :description }
 
       it { expect(html).to have_css('i.fa-temperature-high') }
-      it { expect(html).to have_content('Scored 5 points by recording indoor temperatures') }
+      it { expect(html).to have_content('Recorded indoor temperatures') }
     end
   end
 

--- a/spec/components/scoreboard_activity_component_spec.rb
+++ b/spec/components/scoreboard_activity_component_spec.rb
@@ -39,7 +39,8 @@ RSpec.describe ScoreboardActivityComponent, :include_url_helpers, type: :compone
     expect(html).to have_selector(:table_row, [
                                     '1st',
                                     other_school.name,
-                                    "Scored 10 points after they recorded \"#{activity.display_name}\""
+                                    '10',
+                                    "Recorded \"#{activity.display_name}\""
                                   ])
   end
 
@@ -52,7 +53,8 @@ RSpec.describe ScoreboardActivityComponent, :include_url_helpers, type: :compone
       expect(html).not_to have_content(I18n.t('common.labels.place'))
       expect(html).to have_selector(:table_row, [
                                       other_school.name,
-                                      "Scored 10 points after they recorded \"#{activity.display_name}\""
+                                      '10',
+                                      "Recorded \"#{activity.display_name}\""
                                     ])
     end
   end

--- a/spec/components/timeline_component_spec.rb
+++ b/spec/components/timeline_component_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe TimelineComponent, type: :component, include_url_helpers: true do
-  let(:observation) { create(:observation, :activity) }
+  let(:observation) { create(:observation, :activity, points: 10) }
   let(:school) { observation.school }
   let(:observations) { [observation] }
   let(:show_actions) { true }
@@ -42,7 +42,7 @@ RSpec.describe TimelineComponent, type: :component, include_url_helpers: true do
     it { expect(html).to have_content(I18n.t('schools.dashboards.timeline.intro'))}
     it { expect(html).to have_link(I18n.t('activities.show.all_activities')), href: school_timeline_path(school)}
 
-    it { expect(html).to have_selector(:table_row, [observation.at.to_fs(:es_short), "Recorded \"#{observation.activity.display_name}\""])}
+    it { expect(html).to have_selector(:table_row, [observation.at.to_fs(:es_short), observation.points, "Recorded \"#{observation.activity.display_name}\""])}
 
     it { expect(html).to have_link(observation.activity.display_name, href: school_activity_path(observation.school, observation.activity)) }
   end


### PR DESCRIPTION
Break out point scores into a column and reduce amount of text