### PR TITLE
Create IconComponent

### DIFF
--- a/app/components/energy_summary_table_component/energy_summary_table_component.html.erb
+++ b/app/components/energy_summary_table_component/energy_summary_table_component.html.erb
@@ -32,13 +32,13 @@
           <% if row_for_last_week?(data) %>
             <% if Flipper.enabled?(:new_dashboards_2024, user) %>
               <td rowspan="2" class="align-middle icon <%= fuel_type_class(data.fuel_type) %>">
-                <%= fa_icon fuel_type_icon(data.fuel_type) %>
+                <%= component 'icon', fuel_type: data.fuel_type %>
               </td>
               <td rowspan="2" class="align-middle text-left">
                 <%= t("common.#{data.fuel_type}") %>
               </td>
             <% else %>
-              <td class="icon"><%= fa_icon fuel_type_icon(data.fuel_type) %></td>
+              <td class="icon"><%= component 'icon', fuel_type: data.fuel_type %></td>
               <td class="text-left"><%= t("common.#{data.fuel_type}") %></td>
             <% end %>
           <% else %>

--- a/app/components/energy_tariffs_component/energy_tariffs_component.html.erb
+++ b/app/components/energy_tariffs_component/energy_tariffs_component.html.erb
@@ -7,16 +7,16 @@
           <div class="col">
             <h4>
               <span class="<%= fuel_type_class(meter_type) %>">
-                <%= fa_icon( fuel_type_icon(meter_type) ) %>
+                <%= component 'icon', fuel_type: meter_type %>
               </span>
               <%= t("schools.user_tariffs.index.#{meter_type}.header") %>
             </h4>
             <% if @tariff_holder.any_tariffs_of_type?(meter_type, @source, only_enabled: @default_tariffs) %>
               <%= component 'energy_tariff_table',
-                id: table_id(meter_type),
-                tariff_holder: @tariff_holder,
-                tariffs: sorted_tariffs(meter_type),
-                show_actions: @show_actions %>
+                            id: table_id(meter_type),
+                            tariff_holder: @tariff_holder,
+                            tariffs: sorted_tariffs(meter_type),
+                            show_actions: @show_actions %>
             <% else %>
               <p>
                 <% if @source == :dcc %>
@@ -27,10 +27,10 @@
                     <%= t('schools.user_tariffs.index.no_defaults', meter_type: meter_type) %>
                   <% else %>
                     <%= component 'energy_tariff_table',
-                      id: table_id(meter_type),
-                      tariff_holder: SiteSettings.current,
-                      tariffs: tariffs,
-                      show_actions: false %>
+                                  id: table_id(meter_type),
+                                  tariff_holder: SiteSettings.current,
+                                  tariffs: tariffs,
+                                  show_actions: false %>
                   <% end %>
                 <% else %>
                   <%= t("schools.user_tariffs.index.#{meter_type}.there_are_no_#{meter_type}_tariffs_set_up_yet") %>.
@@ -41,8 +41,8 @@
             <% if @show_add_button %>
               <div class="mt-4">
                 <%= link_to t("schools.user_tariffs.index.#{meter_type}.add_label"),
-                  new_energy_tariff_path(@tariff_holder, meter_type: meter_type),
-                  class: 'btn btn-sm btn-success' %>
+                            new_energy_tariff_path(@tariff_holder, meter_type: meter_type),
+                            class: 'btn btn-sm btn-success' %>
               </div>
             <% end %>
           </div>

--- a/app/components/icon_component.rb
+++ b/app/components/icon_component.rb
@@ -1,0 +1,23 @@
+# Displays a font awesome icon. See preview for examples of usage
+#
+# Provides a simple way to insert two types of icon (plain icon and centered in a
+# white circle) into a page. Icons can be resized to match our font sizes. Additional
+# classes can be provided to allow for further customisation
+class IconComponent < ViewComponent::Base
+  include ApplicationHelper
+
+  attr_reader :style, :size, :fuel_type, :classes
+
+  def initialize(name: nil, size: 'f5', fuel_type: nil, fixed_width: false, style: :default, classes: '')
+    raise 'Unknown icon style' unless [:default, :circle].include?(style)
+    @name = name
+    @size = size
+    @fuel_type = fuel_type
+    @style = style
+    @classes = "#{classes} #{size} #{'fa-fw' if fixed_width}"
+  end
+
+  def icon_name
+    @name || fuel_type_icon(@fuel_type)
+  end
+end

--- a/app/components/icon_component/icon_component.html.erb
+++ b/app/components/icon_component/icon_component.html.erb
@@ -1,0 +1,15 @@
+<% if style == :default %>
+  <% if fuel_type.present? %>
+    <span class="<%= fuel_type_class(fuel_type) %>">
+      <%= fa_icon("#{icon_name} #{classes}") %>
+    </span>
+  <% else %>
+    <%= fa_icon("#{icon_name} #{classes}") %>
+  <% end %>
+<% elsif style == :circle %>
+  <%# Use font-awesome stacking support. %>
+  <span class="fa-stack <%= classes %> <%= fuel_type_class(fuel_type) if fuel_type %>">
+    <i class="fa-solid fa-circle fa-stack-2x fa-inverse"></i>
+    <%= helpers.fa_icon(icon_name, class: 'fa-stack-1x') %>
+  </span>
+<% end %>

--- a/app/components/observation_component/observation_base.html.erb
+++ b/app/components/observation_component/observation_base.html.erb
@@ -12,11 +12,12 @@
     </div>
   </div>
 <% elsif style == :description %>
-  <%= icon(classes: 'fa-fw') %> <%= I18n.t(:description_html, scope: i18n_scope,
-                                                              target: target,
-                                                              message: message,
-                                                              count: observation.points || 0,
-                                                              compact_path: compact_path).html_safe %>
+  <%= render IconComponent.new name: icon_name, fixed_width: true, size: 'f5' %>
+  <%= I18n.t(:description_html, scope: i18n_scope,
+                                target: target,
+                                message: message,
+                                count: observation.points || 0,
+                                compact_path: compact_path).html_safe %>
 <% else %>
   <td class="p-3 text-center">
     <%= icon %>

--- a/app/components/prompt_component/prompt_component.html.erb
+++ b/app/components/prompt_component/prompt_component.html.erb
@@ -4,11 +4,7 @@
     <% if icon.present? %>
       <%# Icon is hidden on smallest size, visible from sm and above as single column %>
       <div class="d-none d-sm-block col-1">
-          <%# Use font-awesome stacking support. Additional class to override font size to match our default %>
-          <span class="prompt-component-fa-stack fa-stack fa-2x">
-            <i class="fa-solid fa-circle fa-stack-2x fa-inverse"></i>
-            <%= helpers.fa_icon(icon, class: 'fa-stack-1x') %>
-          </span>
+        <%= component 'icon', name: icon, style: :circle, size: 'f5' %>
       </div>
     <% end %>
     <%# if no icon then use full width row %>

--- a/app/components/prompt_component/prompt_component.scss
+++ b/app/components/prompt_component/prompt_component.scss
@@ -14,7 +14,3 @@
     margin: 0.25rem 0.25rem;
   }
 }
-
-.prompt-component-fa-stack {
-  font-size: $f5;
-}

--- a/spec/components/icon_component_spec.rb
+++ b/spec/components/icon_component_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe IconComponent, type: :component do
+  subject(:component) { described_class.new(**params) }
+
+  let(:params) { {} }
+  let(:html) { render_inline(component) }
+
+  describe '#icon_name' do
+    it 'returns correct names' do
+      expect(described_class.new(fuel_type: :electricity).icon_name).to eq('bolt')
+      expect(described_class.new(fuel_type: :gas).icon_name).to eq('fire')
+      expect(described_class.new(fuel_type: :solar_pv).icon_name).to eq('sun')
+      expect(described_class.new(fuel_type: :storage_heater).icon_name).to eq('fire-alt')
+      expect(described_class.new(fuel_type: :storage_heaters).icon_name).to eq('fire-alt')
+      expect(described_class.new(fuel_type: :exported_solar_pv).icon_name).to eq('arrow-right')
+    end
+  end
+
+  context 'when rendering' do
+    let(:params) do
+      { name: 'info-circle' }
+    end
+
+    it 'renders the icon' do
+      expect(html).to have_css('i.fa-info-circle')
+    end
+
+    context 'with fixed width' do
+      let(:params) do
+        { name: 'info-circle', fixed_width: true }
+      end
+
+      it 'renders the icon' do
+        expect(html).to have_css('i.fa-info-circle.fa-fw')
+      end
+    end
+
+    context 'with fuel type' do
+      let(:params) do
+        { name: 'info-circle', fuel_type: :electricity }
+      end
+
+      it 'renders the icon' do
+        expect(html).to have_css('span.text-electric')
+        expect(html).to have_css('i.fa-info-circle')
+      end
+
+      context 'with fixed width' do
+        let(:params) do
+          { name: 'info-circle', fuel_type: :electricity, fixed_width: true }
+        end
+
+        it 'renders the icon' do
+          expect(html).to have_css('span.text-electric')
+          expect(html).to have_css('i.fa-info-circle.fa-fw')
+        end
+      end
+    end
+
+    context 'when style is circle' do
+      let(:params) do
+        { name: 'info-circle', style: :circle }
+      end
+
+      it 'renders the icon' do
+        expect(html).to have_css('span.fa-stack')
+        expect(html).to have_css('i.fa-solid.fa-stack-2x.fa-inverse')
+        expect(html).to have_css('i.fa-info-circle.fa-stack-1x')
+      end
+    end
+  end
+end

--- a/spec/components/previews/icon_component_preview.rb
+++ b/spec/components/previews/icon_component_preview.rb
@@ -1,0 +1,4 @@
+class IconComponentPreview < ViewComponent::Preview
+  def examples
+  end
+end

--- a/spec/components/previews/icon_component_preview/examples.html.erb
+++ b/spec/components/previews/icon_component_preview/examples.html.erb
@@ -1,0 +1,101 @@
+<div class="row">
+  <div class="col">
+    <h2>Plain</h2>
+
+    <p>
+      The icons will automatically scale to the font size for the selection they are in but
+      can be resized using the <code>size</code> attribute which should be in
+      range <code>f1..f10</code> as defined in our fonts
+    </p>
+
+    <table class="table">
+      <tr>
+        <td>Default</td><td><%= render IconComponent.new(name: 'info-circle') %></td>
+      </tr>
+      <% %w[f1 f2 f3 f4 f5 f6].reverse.each do |size| %>
+        <tr>
+          <td>
+            <code>size: '<%= size %>'</code>
+          </td>
+          <td>
+            <%= render IconComponent.new(name: 'info-circle', size: size) %>
+          </td>
+        </tr>
+      <% end %>
+    </table>
+  </div>
+</div>
+
+<div class="row">
+  <div class="col">
+    <h2>Fixed Width</h2>
+
+    <p>
+      Adds the `fa-fw` class.
+    </p>
+
+    <table class="table">
+      <% %w[info-circle bolt clipboard].reverse.each do |name| %>
+        <tr>
+          <td>
+            <code>name: '<%= name %>', fixed_width: true</code>
+          </td>
+          <td><%= render IconComponent.new(name: name, fixed_width: true) %> text</td>
+        </tr>
+      <% end %>
+    </table>
+  </div>
+</div>
+
+<div class="row" style="background-color: aliceblue;">
+  <div class="col">
+    <h2>Circle</h2>
+
+    <p>
+      Circle style has icon centered in a white circle.
+    </p>
+
+    <table class="table">
+      <% %w[f1 f2 f3 f4 f5 f6].reverse.each do |size| %>
+        <tr>
+          <td>
+            <code>style: :circle, size: '<%= size %>'</code>
+          </td>
+          <td>
+            <%= render IconComponent.new(name: 'bolt', size: size, style: :circle) %>
+          </td>
+        </tr>
+      <% end %>
+    </table>
+  </div>
+</div>
+
+<div class="row">
+  <div class="col">
+    <h2>Coloured by Fuel Type</h2>
+
+    <table class="table">
+      <% %i[electricity gas storage_heater solar_pv export_solar_pv].each do |fuel_type| %>
+        <tr>
+          <td><code>name: 'info-circle', fuel_type: :<%= fuel_type %></code></td>
+          <td><%= render IconComponent.new(name: 'info-circle', fuel_type: fuel_type) %></td>
+        </tr>
+      <% end %>
+    </table>
+  </div>
+</div>
+
+<div class="row">
+  <div class="col">
+    <h2>With Icon Inferred From Fuel Type</h2>
+
+    <table class="table">
+      <% %i[electricity gas storage_heater solar_pv export_solar_pv].each do |fuel_type| %>
+        <tr>
+          <td><code>fuel_type: :<%= fuel_type %></code></td>
+          <td><%= render IconComponent.new(fuel_type: fuel_type) %></td>
+        </tr>
+      <% end %>
+    </table>
+  </div>
+</div>


### PR DESCRIPTION
We regularly add icons across the application, with a standard set and colours for specific fuel types. While there are helpers, there are still repeated blocks of HTML used in different places. The new design also adds a new "icon in circle" icon which will need to be consistently applied.

This PR adds an icon component with support for setting different sizes, that match our font definitions, applying colours from fuel types or deriving correct icon from a specific fuel type.

Updates a few components to use this.