### PR TITLE
New pupil analysis pages

### DIFF
--- a/app/components/dashboard_equivalences_component.rb
+++ b/app/components/dashboard_equivalences_component.rb
@@ -51,6 +51,12 @@ class DashboardEquivalencesComponent < ApplicationComponent
     I18n.t("common.#{equivalence_content.equivalence_type.meter_type}").downcase
   end
 
+  def analysis_category(equivalence_content)
+    fuel_type = equivalence_content.equivalence_type.meter_type
+    return :solar_pv if @school.has_solar_pv? && [:electricity, :solar_pv].include?(fuel_type.to_sym)
+    fuel_type
+  end
+
   # Decide which list of equivalences to show in the 1st (left) carousel
   #
   # If we only have a single fuel type, then just return everything the list

--- a/app/components/dashboard_equivalences_component/dashboard_equivalences_component.html.erb
+++ b/app/components/dashboard_equivalences_component/dashboard_equivalences_component.html.erb
@@ -19,7 +19,7 @@
                   <%= link_to t('pupils.analysis.explore_energy_data_html',
                                 fuel_type: fuel_type_label(equivalence_content)),
                               pupils_school_analysis_path(school,
-                                                          category: equivalence_content.equivalence_type.meter_type),
+                                                          category: analysis_category(equivalence_content)),
                               class: 'btn btn-outline-dark rounded-pill font-weight-bold' %>
                 <% else %>
                   <%= t('pupils.schools.show.how_will_school_compare') %>

--- a/app/components/icon_component.rb
+++ b/app/components/icon_component.rb
@@ -6,14 +6,15 @@
 class IconComponent < ViewComponent::Base
   include ApplicationHelper
 
-  attr_reader :style, :size, :fuel_type, :classes
+  attr_reader :style, :size, :fuel_type, :classes, :icon_set
 
-  def initialize(name: nil, size: 'f5', fuel_type: nil, fixed_width: false, style: :default, classes: '')
+  def initialize(name: nil, size: 'f5', fuel_type: nil, fixed_width: false, icon_set: 'fas', style: :default, classes: '')
     raise 'Unknown icon style' unless [:default, :circle].include?(style)
     @name = name
     @size = size
     @fuel_type = fuel_type
     @style = style
+    @icon_set = icon_set
     @classes = "#{classes} #{size} #{'fa-fw' if fixed_width}"
   end
 

--- a/app/components/icon_component/icon_component.html.erb
+++ b/app/components/icon_component/icon_component.html.erb
@@ -1,15 +1,15 @@
 <% if style == :default %>
   <% if fuel_type.present? %>
     <span class="<%= fuel_type_class(fuel_type) %>">
-      <%= fa_icon("#{icon_name} #{classes}") %>
+      <%= icon(icon_set, "#{icon_name} #{classes}") %>
     </span>
   <% else %>
-    <%= fa_icon("#{icon_name} #{classes}") %>
+    <%= icon(icon_set, "#{icon_name} #{classes}") %>
   <% end %>
 <% elsif style == :circle %>
   <%# Use font-awesome stacking support. %>
   <span class="fa-stack <%= classes %> <%= fuel_type_class(fuel_type) if fuel_type %>">
     <i class="fa-solid fa-circle fa-stack-2x fa-inverse"></i>
-    <%= helpers.fa_icon(icon_name, class: 'fa-stack-1x') %>
+    <%= icon(icon_set, icon_name, class: 'fa-stack-1x') %>
   </span>
 <% end %>

--- a/app/components/pupil_explore_component.rb
+++ b/app/components/pupil_explore_component.rb
@@ -1,0 +1,76 @@
+class PupilExploreComponent < ApplicationComponent
+  attr_reader :school, :fuel_type, :icon, :icon_set
+
+  renders_one :note
+
+  renders_one :link, types: {
+    category: {
+      renders: lambda { |**args| 'PupilExploreComponent::CategoryLink'.constantize.new(school: @school, fuel_type: @fuel_type, **args) },
+      as: :category
+    },
+    chart: {
+       renders: lambda { |**args| 'PupilExploreComponent::ChartLink'.constantize.new(school: @school, fuel_type: @fuel_type, **args) },
+       as: :chart_link
+    },
+    usage_chart: {
+       renders: lambda { |**args| 'PupilExploreComponent::UsageChartLink'.constantize.new(school: @school, fuel_type: @fuel_type, **args) },
+       as: :usage_link
+    }
+  }
+
+  def initialize(school:, fuel_type:, icon:, icon_set: 'fas', id: nil, classes: '')
+    super(id: id, classes: classes)
+    @school = school
+    @fuel_type = fuel_type
+    @icon = icon
+    @icon_set = icon_set
+  end
+
+  def render?
+    link? && link.render?
+  end
+
+  class CategoryLink < ViewComponent::Base
+    def initialize(school:, fuel_type:, link_text:, category:)
+      @school = school
+      @fuel_type = fuel_type
+      @link_text = link_text
+      @category = category
+    end
+
+    def call
+      link_to @link_text, pupils_school_analysis_path(@school, category: @category)
+    end
+  end
+
+  class ChartLink < ViewComponent::Base
+    def initialize(school:, fuel_type:, link_text:, **kwargs)
+      @school = school
+      @fuel_type = fuel_type
+      @link_text = link_text
+      @config = kwargs
+    end
+
+    def call
+      link_to @link_text, pupils_school_analysis_tab_path(@school, @config)
+    end
+
+    def render?
+      !@school.configuration.get_charts(:pupil_analysis_charts, :pupil_analysis_page, *@config.values).empty?
+    end
+  end
+
+  class UsageChartLink < ViewComponent::Base
+    def initialize(school:, fuel_type:, link_text:, supply: nil, **kwargs)
+      @school = school
+      @fuel_type = fuel_type
+      @link_text = link_text
+      @supply = supply
+      @config = kwargs
+    end
+
+    def call
+      link_to @link_text, school_usage_path(@school, { supply: @supply || @fuel_type }.merge(@config))
+    end
+  end
+end

--- a/app/components/pupil_explore_component/pupil_explore_component.html.erb
+++ b/app/components/pupil_explore_component/pupil_explore_component.html.erb
@@ -1,0 +1,25 @@
+<div id="<%= id %>" class="pupil-explore-component col-12 col-md-4 <%= classes %>">
+  <div class="h-100 mb-2 rounded <%= fuel_type_background_class(fuel_type) %>">
+    <div class="row p-4">
+      <div class="col">
+        <div class="row">
+          <div class="col">
+            <h3>
+              <%= component 'icon', name: icon, icon_set: icon_set, style: :circle, size: 'f3' %>
+            </h3>
+          </div>
+        </div>
+        <div class="row">
+          <div class="col">
+            <h3>
+              <%= link %>
+            </h3>
+            <% if note? %>
+              <%= note %>
+            <% end %>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/components/pupil_explore_component/pupil_explore_component.scss
+++ b/app/components/pupil_explore_component/pupil_explore_component.scss
@@ -1,0 +1,3 @@
+.pupil-explore-component a {
+  text-decoration: none;
+}

--- a/app/views/pupils/analysis/_bar_charts.html.erb
+++ b/app/views/pupils/analysis/_bar_charts.html.erb
@@ -1,0 +1,46 @@
+<%= component 'titled_section' do |section| %>
+  <%= section.with_title do %>
+    <h2><%= t('pupils.analysis.i_would_like_to_know') %></h2>
+  <% end %>
+  <%= section.with_body do %>
+    <div class="row">
+      <%= component 'pupil_explore', school: school, icon: 'calendar-days', fuel_type: fuel_type do |c| %>
+        <% c.with_chart_link energy: energy,
+                             presentation: 'Bar',
+                             secondary_presentation: 'Week',
+                             link_text: t('pupils.analysis.how_much_last_year') %>
+      <% end %>
+
+      <%= component 'pupil_explore', school: school, icon: 'calendar', fuel_type: fuel_type do |c| %>
+        <% c.with_chart_link energy: energy,
+                             presentation: 'Bar',
+                             secondary_presentation: 'Year',
+                             link_text: t('pupils.analysis.how_changed_long_term') %>
+      <% end %>
+    </div>
+  <% end %>
+<% end %>
+
+<%= component 'titled_section' do |section| %>
+  <%= section.with_title do %>
+    <h2><%= t('pupils.analysis.i_would_like_to_compare') %></h2>
+  <% end %>
+  <%= section.with_body do %>
+    <div class="row">
+      <%= component 'pupil_explore', school: school, icon: 'scale-balanced', fuel_type: fuel_type do |c| %>
+        <% c.with_chart_link energy: energy,
+                             presentation: 'Bar',
+                             secondary_presentation: 'Bench',
+                             link_text: t('pupils.analysis.compare_electricity_across_schools') %>
+      <% end %>
+      <%= component 'pupil_explore', school: school, icon: 'calendar-day', fuel_type: fuel_type do |c| %>
+        <% c.with_usage_link period: :weekly, link_text: t('pupils.analysis.compare_different_weeks') %>
+      <% end %>
+      <% if @school.filterable_meters(fuel_type).count > 1 %>
+        <%= component 'pupil_explore', school: school, icon: 'gauge', fuel_type: fuel_type do |c| %>
+          <% c.with_usage_link period: :weekly, split_meters: true, link_text: t('pupils.analysis.compare_meters') %>
+        <% end %>
+      <% end %>
+    </div>
+  <% end %>
+<% end %>

--- a/app/views/pupils/analysis/_compare.html.erb
+++ b/app/views/pupils/analysis/_compare.html.erb
@@ -12,7 +12,7 @@
         <% c.with_usage_link period: :daily, link_text: t('pupils.analysis.compare_different_days') %>
       <% end %>
 
-      <% if @school.filterable_meters(fuel_type).count > 1 %>
+      <% if school.filterable_meters(fuel_type).count > 1 %>
         <%= component 'pupil_explore', school: school, icon: 'gauge', fuel_type: fuel_type do |c| %>
           <% c.with_usage_link period: :weekly, split_meters: true, link_text: t('pupils.analysis.compare_meters') %>
         <% end %>

--- a/app/views/pupils/analysis/_compare.html.erb
+++ b/app/views/pupils/analysis/_compare.html.erb
@@ -1,0 +1,22 @@
+<%= component 'titled_section' do |section| %>
+  <%= section.with_title do %>
+    <h2><%= t('pupils.analysis.i_would_like_to_compare') %></h2>
+  <% end %>
+  <%= section.with_body do %>
+    <div class="row">
+      <%= component 'pupil_explore', school: school, icon: 'calendar-week', fuel_type: fuel_type do |c| %>
+        <% c.with_usage_link period: :weekly, link_text: t('pupils.analysis.compare_different_weeks') %>
+      <% end %>
+
+      <%= component 'pupil_explore', school: school, icon: 'calendar-day', fuel_type: fuel_type do |c| %>
+        <% c.with_usage_link period: :daily, link_text: t('pupils.analysis.compare_different_days') %>
+      <% end %>
+
+      <% if @school.filterable_meters(fuel_type).count > 1 %>
+        <%= component 'pupil_explore', school: school, icon: 'gauge', fuel_type: fuel_type do |c| %>
+          <% c.with_usage_link period: :weekly, split_meters: true, link_text: t('pupils.analysis.compare_meters') %>
+        <% end %>
+      <% end %>
+    </div>
+  <% end %>
+<% end %>

--- a/app/views/pupils/analysis/_header.html.erb
+++ b/app/views/pupils/analysis/_header.html.erb
@@ -1,0 +1,17 @@
+<% content_for :page_title,
+               strip_tags(t('pupils.analysis.explore_energy_data_html',
+                            fuel_type: t("common.#{fuel_type}").downcase)) %>
+
+<div class="row">
+  <div class="col d-flex flex-wrap justify-content-between align-items-center">
+    <h1>
+      <%= t('pupils.analysis.explore_energy_data_html', fuel_type: t("common.#{fuel_type}").downcase) %>
+    </h1>
+    <% if local_assigns[:link] %>
+      <%= link_to t('pupils.analysis.explore_all', fuel_type: t("common.#{fuel_type}").downcase),
+                  pupils_school_analysis_path(school,
+                                              category: local_assigns[:category] || fuel_type),
+                  class: 'btn btn-outline-dark' %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/pupils/analysis/_know.html.erb
+++ b/app/views/pupils/analysis/_know.html.erb
@@ -1,0 +1,18 @@
+<%= component 'titled_section' do |section| %>
+  <%= section.with_title do %>
+    <h2><%= t('pupils.analysis.i_would_like_to_know') %></h2>
+  <% end %>
+  <%= section.with_body do %>
+    <div class="row">
+      <%= component 'pupil_explore', school: school, icon: 'clock', fuel_type: fuel_type do |c| %>
+        <% c.with_chart_link energy: energy, presentation: 'kWh', link_text: t('pupils.analysis.when') %>
+      <% end %>
+      <%= component 'pupil_explore', school: school, icon: 'sterling-sign', fuel_type: fuel_type do |c| %>
+        <% c.with_chart_link energy: energy, presentation: 'Cost', link_text: t('pupils.analysis.how_much') %>
+      <% end %>
+      <%= component 'pupil_explore', school: school, icon: 'cloud', fuel_type: fuel_type do |c| %>
+        <% c.with_chart_link energy: energy, presentation: 'CO2', link_text: t('pupils.analysis.how_much_co2') %>
+      <% end %>
+    </div>
+  <% end %>
+<% end %>

--- a/app/views/pupils/analysis/_line_charts.html.erb
+++ b/app/views/pupils/analysis/_line_charts.html.erb
@@ -1,0 +1,36 @@
+<%= component 'titled_section' do |section| %>
+  <%= section.with_title do %>
+    <h2><%= t('pupils.analysis.i_would_like_to_know') %></h2>
+  <% end %>
+  <%= section.with_body do %>
+    <div class="row">
+      <%= component 'pupil_explore', school: school, icon: 'calendar-days', fuel_type: fuel_type do |c| %>
+        <% c.with_chart_link energy: energy, presentation: 'Line', secondary_presentation: '7days',
+                             link_text: t('pupils.analysis.how_much_last_week') %>
+      <% end %>
+
+      <%= component 'pupil_explore', school: school, icon: 'calendar', fuel_type: fuel_type do |c| %>
+        <% c.with_chart_link energy: energy, presentation: 'Line', secondary_presentation: 'Base',
+                             link_text: t('pupils.analysis.how_much_baseload') %>
+      <% end %>
+    </div>
+  <% end %>
+<% end %>
+
+<%= component 'titled_section' do |section| %>
+  <%= section.with_title do %>
+    <h2><%= t('pupils.analysis.i_would_like_to_compare') %></h2>
+  <% end %>
+  <%= section.with_body do %>
+    <div class="row">
+      <%= component 'pupil_explore', school: school, icon: 'calendar-day', fuel_type: fuel_type do |c| %>
+        <% c.with_usage_link period: :daily, link_text: t('pupils.analysis.compare_different_days') %>
+      <% end %>
+      <% if @school.filterable_meters(fuel_type).count > 1 %>
+        <%= component 'pupil_explore', school: school, icon: 'gauge', fuel_type: fuel_type do |c| %>
+          <% c.with_usage_link period: :daily, split_meters: true, link_text: t('pupils.analysis.compare_meters') %>
+        <% end %>
+      <% end %>
+    </div>
+  <% end %>
+<% end %>

--- a/app/views/pupils/analysis/_see.html.erb
+++ b/app/views/pupils/analysis/_see.html.erb
@@ -1,0 +1,20 @@
+<%= component 'titled_section' do |section| %>
+  <%= section.with_title do %>
+    <h2><%= t('pupils.analysis.i_would_like_to_see') %></h2>
+  <% end %>
+  <%= section.with_body do %>
+    <div class="row">
+      <%= component 'pupil_explore', school: school, icon: 'chart-pie', fuel_type: fuel_type do |c| %>
+        <% c.with_chart_link energy: energy, presentation: 'Pie', link_text: t('common.pie_charts') %>
+      <% end %>
+
+      <%= component 'pupil_explore', school: school, icon: 'chart-bar', fuel_type: fuel_type do |c| %>
+        <% c.with_category category: :"#{fuel_type}_bar", link_text: t('common.bar_charts') %>
+      <% end %>
+
+      <%= component 'pupil_explore', school: school, icon: 'chart-line', fuel_type: fuel_type do |c| %>
+        <% c.with_category category: :"#{fuel_type}_line", link_text: t('common.line_graphs') %>
+      <% end %>
+    </div>
+  <% end %>
+<% end %>

--- a/app/views/pupils/analysis/new/electricity.html.erb
+++ b/app/views/pupils/analysis/new/electricity.html.erb
@@ -1,0 +1,4 @@
+<%= render 'header', school: @school, fuel_type: :electricity %>
+<%= render 'know', school: @school, energy: 'Electricity', fuel_type: :electricity %>
+<%= render 'compare', school: @school, fuel_type: :electricity %>
+<%= render 'see', school: @school, energy: 'Electricity', fuel_type: :electricity %>

--- a/app/views/pupils/analysis/new/electricity_bar.html.erb
+++ b/app/views/pupils/analysis/new/electricity_bar.html.erb
@@ -1,0 +1,2 @@
+<%= render 'header', school: @school, fuel_type: :electricity, link: true %>
+<%= render 'bar_charts', school: @school, fuel_type: :electricity, energy: 'Electricity' %>

--- a/app/views/pupils/analysis/new/electricity_line.html.erb
+++ b/app/views/pupils/analysis/new/electricity_line.html.erb
@@ -1,0 +1,2 @@
+<%= render 'header', school: @school, fuel_type: :electricity, link: true %>
+<%= render 'line_charts', school: @school, fuel_type: :electricity, energy: 'Electricity' %>

--- a/app/views/pupils/analysis/new/gas.html.erb
+++ b/app/views/pupils/analysis/new/gas.html.erb
@@ -1,0 +1,4 @@
+<%= render 'header', school: @school, fuel_type: :gas %>
+<%= render 'know', school: @school, energy: 'Gas', fuel_type: :gas %>
+<%= render 'compare', school: @school, fuel_type: :gas %>
+<%= render 'see', school: @school, energy: 'Gas', fuel_type: :gas %>

--- a/app/views/pupils/analysis/new/gas_bar.html.erb
+++ b/app/views/pupils/analysis/new/gas_bar.html.erb
@@ -1,0 +1,2 @@
+<%= render 'header', school: @school, fuel_type: :gas, link: true %>
+<%= render 'bar_charts', school: @school, fuel_type: :gas, energy: 'Gas' %>

--- a/app/views/pupils/analysis/new/gas_line.html.erb
+++ b/app/views/pupils/analysis/new/gas_line.html.erb
@@ -1,0 +1,33 @@
+<%= render 'header', school: @school, fuel_type: :gas, link: true %>
+
+<%= component 'titled_section' do |section| %>
+  <%= section.with_title do %>
+    <h2><%= t('pupils.analysis.i_would_like_to_know') %></h2>
+  <% end %>
+  <%= section.with_body do %>
+    <div class="row">
+      <%= component 'pupil_explore', school: @school, icon: 'calendar-days', fuel_type: :gas do |c| %>
+        <% c.with_chart_link energy: 'Gas', presentation: 'Line', link_text: t('pupils.analysis.how_much_last_week') %>
+      <% end %>
+    </div>
+  <% end %>
+<% end %>
+
+<%= component 'titled_section' do |section| %>
+  <%= section.with_title do %>
+    <h2><%= t('pupils.analysis.i_would_like_to_compare') %></h2>
+  <% end %>
+  <%= section.with_body do %>
+    <div class="row">
+      <%= component 'pupil_explore', school: @school, icon: 'calendar-day', fuel_type: :gas do |c| %>
+        <% c.with_usage_link period: :daily, link_text: t('pupils.analysis.compare_different_days') %>
+      <% end %>
+
+      <% if @school.filterable_meters(:gas).count > 1 %>
+        <%= component 'pupil_explore', school: @school, icon: 'gauge', fuel_type: :gas do |c| %>
+          <% c.with_usage_link period: :daily, split_meters: true, link_text: t('pupils.analysis.compare_meters') %>
+        <% end %>
+      <% end %>
+    </div>
+  <% end %>
+<% end %>

--- a/app/views/pupils/analysis/new/index.html.erb
+++ b/app/views/pupils/analysis/new/index.html.erb
@@ -1,0 +1,67 @@
+<% content_for :page_title, t('pupils.analysis.explore_energy_data') %>
+
+<h1><%= t('pupils.analysis.explore_energy_data') %></h1>
+
+<div class="row">
+  <% if @school.has_solar_pv? %>
+    <%= component 'pupil_explore', school: @school, icon: 'sun', fuel_type: :electricity do |c| %>
+      <% c.with_category category: :solar_pv, link_text: t('common.electricity_and_solar_pv') %>
+      <% c.with_note do %>
+        <div>
+          <% if @school.has_storage_heaters? %>
+            <p class="small">(<%= t('pupils.analysis.without_storage_heaters') %>)</p>
+          <% end %>
+        </div>
+      <% end %>
+    <% end %>
+  <% elsif @school.has_electricity? %>
+    <%= component 'pupil_explore', school: @school, icon: 'bolt', fuel_type: :electricity do |c| %>
+      <% c.with_category category: :electricity, link_text: t('common.electricity') %>
+      <% c.with_note do %>
+        <div>
+          <% if @school.has_storage_heaters? %>
+            <p class="small">(<%= t('pupils.analysis.without_storage_heaters') %>)</p>
+          <% end %>
+        </div>
+      <% end %>
+    <% end %>
+  <% end %>
+  <% if @school.has_gas? %>
+    <%= component 'pupil_explore', school: @school, icon: 'fire', fuel_type: :gas do |c| %>
+      <% c.with_category category: :gas, link_text: t('common.gas') %>
+    <% end %>
+  <% end %>
+  <% if @school.has_storage_heaters? %>
+    <%= component 'pupil_explore', school: @school, icon: 'intercom', icon_set: 'fab', fuel_type: :storage_heaters do |c| %>
+      <% c.with_category category: :storage_heaters, link_text: t('common.storage_heaters') %>
+    <% end %>
+  <% end %>
+</div>
+
+<% if @school.has_live_data? %>
+  <div class="row mt-4">
+      <div class="col-12 col-md-4">
+        <div class="mb-2 rounded h-100 bg-electric-light">
+          <div class="row p-4">
+            <div class="col">
+              <div class="row">
+                <div class="col">
+                  <h3>
+                    <%= component 'icon', name: 'tachometer-alt', style: :circle, size: 'f3' %>
+                  </h3>
+                </div>
+              </div>
+              <div class="row">
+                <div class="col">
+                  <h3>
+                    <%= link_to t('pupils.analysis.live_energy_data'), school_live_data_path(@school),
+                                class: 'text-decoration-none' %>
+                  </h3>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+  </div>
+<% end %>

--- a/app/views/pupils/analysis/new/solar.html.erb
+++ b/app/views/pupils/analysis/new/solar.html.erb
@@ -1,0 +1,42 @@
+<%= render 'header', school: @school, fuel_type: :electricity_and_solar_pv %>
+
+<%= component 'titled_section' do |section| %>
+  <%= section.with_title do %>
+    <h2><%= t('pupils.analysis.i_would_like_to_know') %></h2>
+  <% end %>
+  <%= section.with_body do %>
+    <div class="row">
+      <%= component 'pupil_explore', school: @school, icon: 'clock', fuel_type: :electricity do |c| %>
+        <% c.with_chart_link energy: 'Electricity', presentation: 'kWh', link_text: t('pupils.analysis.when') %>
+      <% end %>
+
+      <%= component 'pupil_explore', school: @school, icon: 'sun', fuel_type: :solar_pv do |c| %>
+        <% c.with_chart_link energy: 'Electricity+Solar PV', presentation: 'Solar',
+                             link_text: t('pupils.analysis.how_much_solar') %>
+      <% end %>
+    </div>
+  <% end %>
+<% end %>
+
+<%= render 'compare', school: @school, fuel_type: :electricity %>
+
+<%= component 'titled_section' do |section| %>
+  <%= section.with_title do %>
+    <h2><%= t('pupils.analysis.i_would_like_to_see') %></h2>
+  <% end %>
+  <%= section.with_body do %>
+    <div class="row">
+      <%= component 'pupil_explore', school: @school, icon: 'chart-pie', fuel_type: :electricity do |c| %>
+        <% c.with_chart_link energy: 'Electricity', presentation: 'Pie', link_text: t('common.pie_charts') %>
+      <% end %>
+
+      <%= component 'pupil_explore', school: @school, icon: 'chart-bar', fuel_type: :electricity do |c| %>
+        <% c.with_category category: :solar_bar, link_text: t('common.bar_charts') %>
+      <% end %>
+
+      <%= component 'pupil_explore', school: @school, icon: 'chart-line', fuel_type: :electricity do |c| %>
+        <% c.with_category category: :solar_line, link_text: t('common.line_graphs') %>
+      <% end %>
+    </div>
+  <% end %>
+<% end %>

--- a/app/views/pupils/analysis/new/solar_bar.html.erb
+++ b/app/views/pupils/analysis/new/solar_bar.html.erb
@@ -1,0 +1,2 @@
+<%= render 'header', school: @school, fuel_type: :electricity_and_solar_pv, category: :solar_pv, link: true %>
+<%= render 'bar_charts', school: @school, fuel_type: :electricity, energy: 'Electricity' %>

--- a/app/views/pupils/analysis/new/solar_line.html.erb
+++ b/app/views/pupils/analysis/new/solar_line.html.erb
@@ -1,0 +1,2 @@
+<%= render 'header', school: @school, fuel_type: :electricity_and_solar_pv, category: :solar_pv, link: true %>
+<%= render 'line_charts', school: @school, fuel_type: :electricity, energy: 'Electricity' %>

--- a/app/views/pupils/analysis/new/storage_heaters.html.erb
+++ b/app/views/pupils/analysis/new/storage_heaters.html.erb
@@ -1,0 +1,23 @@
+<%= render 'header', school: @school, fuel_type: :storage_heater %>
+<%= render 'know', school: @school, energy: 'Storage Heaters', fuel_type: :storage_heaters %>
+
+<%= component 'titled_section' do |section| %>
+  <%= section.with_title do %>
+    <h2><%= t('pupils.analysis.i_would_like_to_see') %></h2>
+  <% end %>
+  <%= section.with_body do %>
+    <div class="row">
+      <%= component 'pupil_explore', school: @school, icon: 'chart-pie', fuel_type: :storage_heaters do |c| %>
+        <% c.with_chart_link energy: 'Storage Heaters', presentation: 'Pie', link_text: t('common.pie_charts') %>
+      <% end %>
+
+      <%= component 'pupil_explore', school: @school, icon: 'chart-bar', fuel_type: :storage_heaters do |c| %>
+        <% c.with_category category: :storage_heaters_bar, link_text: t('common.bar_charts') %>
+      <% end %>
+
+      <%= component 'pupil_explore', school: @school, icon: 'chart-line', fuel_type: :storage_heaters do |c| %>
+        <% c.with_chart_link energy: 'Storage Heaters', presentation: 'Line', link_text: t('common.line_graphs') %>
+      <% end %>
+    </div>
+  <% end %>
+<% end %>

--- a/app/views/pupils/analysis/new/storage_heaters_bar.html.erb
+++ b/app/views/pupils/analysis/new/storage_heaters_bar.html.erb
@@ -1,0 +1,34 @@
+<%= render 'header', school: @school, fuel_type: :storage_heater, category: :storage_heaters, link: true %>
+
+<%= component 'titled_section' do |section| %>
+  <%= section.with_title do %>
+    <h2><%= t('pupils.analysis.i_would_like_to_know') %></h2>
+  <% end %>
+  <%= section.with_body do %>
+    <div class="row">
+      <%= component 'pupil_explore', school: @school, icon: 'calendar-days', fuel_type: :storage_heaters do |c| %>
+        <% c.with_chart_link energy: 'Storage Heaters', presentation: 'Bar', secondary_presentation: 'Week',
+                             link_text: t('pupils.analysis.how_much_last_year') %>
+      <% end %>
+
+      <%= component 'pupil_explore', school: @school, icon: 'calendar', fuel_type: :storage_heaters do |c| %>
+        <% c.with_chart_link energy: 'Storage Heaters', presentation: 'Bar', secondary_presentation: 'Year',
+                             link_text: t('pupils.analysis.how_changed_long_term') %>
+      <% end %>
+    </div>
+  <% end %>
+<% end %>
+
+<%= component 'titled_section' do |section| %>
+  <%= section.with_title do %>
+    <h2><%= t('pupils.analysis.i_would_like_to_compare') %></h2>
+  <% end %>
+  <%= section.with_body do %>
+    <div class="row">
+      <%= component 'pupil_explore', school: @school, icon: 'scale-balanced', fuel_type: :storage_heaters do |c| %>
+        <% c.with_chart_link energy: 'Storage Heaters', presentation: 'Bar', secondary_presentation: 'Bench',
+                             link_text: t('pupils.analysis.compare_electricity_across_schools') %>
+      <% end %>
+    </div>
+  <% end %>
+<% end %>

--- a/app/views/pupils/analysis/show.html.erb
+++ b/app/views/pupils/analysis/show.html.erb
@@ -1,7 +1,11 @@
-<div class="d-flex justify-content-between align-items-center">
-  <h1><%= t('pupils.analysis.explore_energy_data_html', fuel_type: t('common.' + i18n_key_from(@fuel_type))) %></h1>
+<div class="d-flex justify-content-between align-items-center flex-wrap">
+  <h1>
+    <%= t('pupils.analysis.explore_energy_data_html', fuel_type: t("common.#{i18n_key_from(@fuel_type)}")) %>
+  </h1>
   <div>
-    <%= link_to t('pupils.analysis.explore_data'), pupils_school_analysis_path(@school), class: 'btn btn-outline-dark rounded-pill font-weight-bold' %>
+    <%= link_to t('pupils.analysis.explore_data'),
+                pupils_school_analysis_path(@school, category: @category),
+                class: 'btn btn-outline-dark font-weight-bold' %>
   </div>
 </div>
 
@@ -14,7 +18,7 @@
                 school: @school,
                 chart_type: @chart_type.to_s,
                 no_zoom: true,
+                axis_controls: false,
                 chart_config: create_chart_config(@school, @chart_type, apply_preferred_units: false),
-                fuel_type: @fuel_type
-  %>
+                fuel_type: @fuel_type %>
 </div>

--- a/app/views/pupils/schools/new_show.html.erb
+++ b/app/views/pupils/schools/new_show.html.erb
@@ -1,3 +1,5 @@
+<%= content_for :page_title, t('pupils.schools.show.title', school_name: @school.name) %>
+
 <% content_for :dashboard_header do %>
   <%= component 'dashboard_header', school: @school, audience: @audience %>
 <% end %>

--- a/app/views/schools/new_show.html.erb
+++ b/app/views/schools/new_show.html.erb
@@ -1,3 +1,5 @@
+<%= content_for :page_title, t('schools.show.dashboard_title', school_name: @school.name) %>
+
 <% content_for :dashboard_header do %>
   <%= component 'dashboard_header', school: @school, audience: @audience %>
 <% end %>

--- a/config/locales/views/pupils/pupils.yml
+++ b/config/locales/views/pupils/pupils.yml
@@ -2,16 +2,22 @@
 en:
   pupils:
     analysis:
+      compare_different_days: The energy used in two different days
+      compare_different_weeks: The energy used in two different weeks
+      compare_electricity_across_schools: My school's energy use with other schools
       compare_electricity_in_2_weeks: compare the electricity used in two different weeks
       compare_electricity_on_2_days: compare the electricity used on two different days
       compare_electricity_use_by_meters: compare the electricity use by different meters
       compare_gas_in_2_weeks: compare the gas used in two different weeks
       compare_gas_on_2_days: compare the gas used on two different days
       compare_gas_use_by_meters: compare the gas use by different meters
+      compare_meters: The energy used by different meters
       electricity_and_solar_data_html: Here's the <strong>electricity and solar</strong> data for your school
       electricity_data_html: Here's the <strong>electricity</strong> data for your school
+      explore_all: Explore all %{fuel_type} data
       explore_data: Explore data
-      explore_energy_data_html: Explore the <strong>%{fuel_type}</strong> data for your school
+      explore_energy_data: Explore the energy data for your school
+      explore_energy_data_html: Explore the %{fuel_type} data for your school
       find_electricity_comparison: find out how my school's electricity use compares with other schools
       find_electricity_use_7days: find out how much electricity was used in the last 7 days
       find_electricity_use_last_year: find out how much electricity was used last year
@@ -33,12 +39,23 @@ en:
       find_when_gas_used_html: find out <strong>when</strong> the gas was used
       find_when_storage_heaters_used_html: find out <strong>when</strong> the storage heaters used electricity
       gas_data_html: Here's the <strong>gas</strong> data for your school
+      how_changed_long_term: How energy use has changed long term?
+      how_much: How much the energy cost?
+      how_much_baseload: How much energy was used by lights and appliances running all the time
+      how_much_co2: How much carbon dioxide was generated?
+      how_much_last_week: How much energy was used in the last 7 days?
+      how_much_last_year: How much energy was used last year?
+      how_much_solar: How much solar energy was generated?
       i_want_to: I want to…
       i_want_to_look_at: I want to look at…
+      i_would_like_to_compare: I would like to compare…
+      i_would_like_to_know: I would like to know…
+      i_would_like_to_see: I would like to see…
       live_energy_data: Live energy data
       look_at_energy_use: Let's look at the energy use data for your school
       review_energy_analysis: Review energy analysis
       storage_heater_data_html: Here's the <strong>storage heater</strong> data for your school
+      when: When the energy was used?
       without_storage_heaters: without storage heaters
     default_equivalences:
       equivalence_1:

--- a/spec/factories/configuration_factory.rb
+++ b/spec/factories/configuration_factory.rb
@@ -1,6 +1,7 @@
 FactoryBot.define do
   factory :configuration, class: 'Schools::Configuration' do
     analysis_charts {{ main_dashboard_electric: { name: 'Main page', charts: [:chart_1] } }}
+    pupil_analysis_charts {{ pupil_analysis_page: DashboardConfiguration::DASHBOARD_PAGE_GROUPS[:pupil_analysis_page] }}
     fuel_configuration { Schools::FuelConfiguration.new }
     school_target_fuel_types { [] }
   end

--- a/spec/system/pupils/analysis_spec.rb
+++ b/spec/system/pupils/analysis_spec.rb
@@ -1,0 +1,125 @@
+require 'rails_helper'
+
+describe 'Pupil analysis' do
+  let(:school) { create(:school, :with_fuel_configuration) }
+
+  before do
+    Flipper.enable :new_dashboards_2024
+  end
+
+  context 'when visiting analysis index' do
+    before do
+      visit pupils_school_analysis_path(school)
+    end
+
+    context 'with all fuel types' do
+      it {
+        expect(page).to have_link(I18n.t('common.electricity_and_solar_pv'),
+                                     href: pupils_school_analysis_path(school, category: :solar_pv))
+      }
+
+      it { expect(page).to have_no_link(href: pupils_school_analysis_path(school, category: :electricity)) }
+      it { expect(page).to have_link(I18n.t('common.gas'), href: pupils_school_analysis_path(school, category: :gas)) }
+
+      it {
+        expect(page).to have_link(I18n.t('common.storage_heaters'),
+                                     href: pupils_school_analysis_path(school, category: :storage_heaters))
+      }
+
+      it { expect(page).to have_content(I18n.t('pupils.analysis.without_storage_heaters')) }
+    end
+
+    context 'with electricity and no solar' do
+      let(:school) { create(:school, :with_fuel_configuration, has_solar_pv: false) }
+
+      it {
+        expect(page).to have_link(I18n.t('common.electricity'),
+                                     href: pupils_school_analysis_path(school, category: :electricity))
+      }
+
+      it { expect(page).to have_no_link(href: pupils_school_analysis_path(school, category: :solar_pv)) }
+    end
+
+    context 'with only electricity' do
+      let(:school) { create(:school, :with_fuel_configuration, has_gas: false, has_solar_pv: false, has_storage_heaters: false) }
+
+      it { expect(page).to have_link(I18n.t('common.electricity'), href: pupils_school_analysis_path(school, category: :electricity)) }
+
+      [:solar_pv, :gas, :storage_heaters].each do |category|
+        it { expect(page).to have_no_link(href: pupils_school_analysis_path(school, category: category)) }
+      end
+      it { expect(page).not_to have_content(I18n.t('pupils.analysis.without_storage_heaters')) }
+    end
+
+    context 'with only gas' do
+      let(:school) { create(:school, :with_fuel_configuration, has_electricity: false, has_solar_pv: false, has_storage_heaters: false) }
+
+      it { expect(page).to have_link(I18n.t('common.gas'), href: pupils_school_analysis_path(school, category: :gas)) }
+
+      [:solar_pv, :electricity, :storage_heaters].each do |category|
+        it { expect(page).to have_no_link(href: pupils_school_analysis_path(school, category: category)) }
+      end
+
+      it { expect(page).not_to have_content(I18n.t('pupils.analysis.without_storage_heaters')) }
+    end
+
+    context 'with storage heaters' do
+      let(:school) { create(:school, :with_fuel_configuration, has_gas: false, has_solar_pv: false) }
+
+      it {
+        expect(page).to have_link(I18n.t('common.electricity'),
+                                     href: pupils_school_analysis_path(school, category: :electricity))
+      }
+
+      it {
+        expect(page).to have_link(I18n.t('common.storage_heaters'),
+                                     href: pupils_school_analysis_path(school, category: :storage_heaters))
+      }
+
+      [:solar_pv, :gas].each do |category|
+        it { expect(page).to have_no_link(href: pupils_school_analysis_path(school, category: category)) }
+      end
+
+      it { expect(page).to have_content(I18n.t('pupils.analysis.without_storage_heaters')) }
+    end
+  end
+
+  context 'when viewing electricity category' do
+    it 'links to bar charts category'
+    it 'links to line charts category'
+    it 'links to pie chart'
+    it 'links to compare weeks'
+    it 'links to compare days'
+    it 'has not link for meters'
+    context 'with multiple electricity meters' do
+      it 'links to compare meters'
+    end
+
+    it 'links to kwh chart'
+    it 'links to cost chart'
+    it 'links to co2 chart'
+
+    context 'when viewing bar charts' do
+      it 'links to electricity index'
+      it 'links to school comparison'
+      it 'links to long term'
+      it 'links to last year'
+      it 'compares weeks'
+      it 'has not link for meters'
+      context 'with multiple electricity meters' do
+        it 'links to compare meters'
+      end
+    end
+
+    context 'with viewing line charts' do
+      it 'links to electricity index'
+      it 'links to last 7 days'
+      it 'links to baseload'
+      it 'links to compare days'
+      it 'has not link for meters'
+      context 'with multiple electricity meters' do
+        it 'links to compare meters'
+      end
+    end
+  end
+end

--- a/spec/system/pupils/analysis_spec.rb
+++ b/spec/system/pupils/analysis_spec.rb
@@ -84,42 +84,216 @@ describe 'Pupil analysis' do
     end
   end
 
+  def expect_chart_link(school, label, *args)
+    expect(page).to have_link(label, href: pupils_school_analysis_tab_path(school, *args))
+  end
+
+  def expect_usage_chart_link(school, label, **args)
+    expect(page).to have_link(label, href: school_usage_path(school, **args))
+  end
+
+  shared_examples 'it has the right headings and navigation' do |fuel_type:|
+    it { expect(page).to have_title(I18n.t('pupils.analysis.explore_energy_data_html', fuel_type: I18n.t("common.#{fuel_type}").downcase))}
+    it { expect(page).to have_content(I18n.t('pupils.analysis.explore_energy_data_html', fuel_type: I18n.t("common.#{fuel_type}").downcase))}
+    it { expect(page).to have_link(I18n.t('pupils.analysis.explore_all', fuel_type: I18n.t("common.#{fuel_type}").downcase), href: pupils_school_analysis_path(school, category: fuel_type))}
+  end
+
+  shared_examples 'it has a top-level how section' do |energy:|
+    it { expect_chart_link(school, I18n.t('pupils.analysis.when'), energy, 'kWh') }
+    it { expect_chart_link(school, I18n.t('pupils.analysis.how_much'), energy, 'Cost') }
+    it { expect_chart_link(school, I18n.t('pupils.analysis.how_much_co2'), energy, 'CO2') }
+  end
+
+  shared_examples 'it has a top-level compare section' do |fuel_type:|
+    it { expect_usage_chart_link(school, I18n.t('pupils.analysis.compare_different_weeks'), period: :weekly, supply: fuel_type) }
+    it { expect_usage_chart_link(school, I18n.t('pupils.analysis.compare_different_days'), period: :daily, supply: fuel_type) }
+    it { expect(page).to have_no_link(I18n.t('pupils.analysis.compare_meters'), href: school_usage_path(school, period: :weekly, supply: fuel_type, split_meters: true)) }
+
+    context 'with multiple meters and no storage heaters' do
+      let(:school) { create(:school, :with_fuel_configuration, has_storage_heaters: false) }
+
+      before do
+        create_list(:"#{fuel_type}_meter", 2, active: true, school: school)
+        visit pupils_school_analysis_path(school, category: fuel_type)
+      end
+
+      it { expect_usage_chart_link(school, I18n.t('pupils.analysis.compare_meters'), period: :weekly, supply: fuel_type, split_meters: true) }
+    end
+  end
+
+  shared_examples 'it has a top-level see section' do |energy:, fuel_type:|
+    it { expect_chart_link(school, I18n.t('common.pie_charts'), energy, 'Pie') }
+
+    it {
+      expect(page).to have_link(I18n.t('common.bar_charts'),
+                                href: pupils_school_analysis_path(school, category: :"#{fuel_type}_bar"))
+    }
+
+    it {
+      expect(page).to have_link(I18n.t('common.line_graphs'),
+                                href: pupils_school_analysis_path(school, category: :"#{fuel_type}_line"))
+    }
+  end
+
+  shared_examples 'a bar charts category' do |energy:, fuel_type:|
+    it { expect_chart_link(school, I18n.t('pupils.analysis.how_much_last_year'), energy, 'Bar', 'Week')}
+    it { expect_chart_link(school, I18n.t('pupils.analysis.how_changed_long_term'), energy, 'Bar', 'Year')}
+    it { expect_chart_link(school, I18n.t('pupils.analysis.compare_electricity_across_schools'), energy, 'Bar', 'Bench')}
+    it { expect_usage_chart_link(school, I18n.t('pupils.analysis.compare_different_weeks'), period: :weekly, supply: fuel_type) }
+    it { expect(page).to have_no_link(I18n.t('pupils.analysis.compare_meters'), href: school_usage_path(school, period: :weekly, supply: fuel_type, split_meters: true)) }
+
+    context 'with multiple electricity meters and no storage heaters' do
+      let(:school) { create(:school, :with_fuel_configuration, has_storage_heaters: false) }
+
+      before do
+        create_list(:"#{fuel_type}_meter", 2, active: true, school: school)
+        refresh
+      end
+
+      it { expect_usage_chart_link(school, I18n.t('pupils.analysis.compare_meters'), period: :weekly, supply: fuel_type, split_meters: true) }
+    end
+  end
+
+  shared_examples 'a line charts category' do |energy:, fuel_type:|
+    it { expect_chart_link(school, I18n.t('pupils.analysis.how_much_last_week'), energy, 'Line', '7days')}
+    it { expect_chart_link(school, I18n.t('pupils.analysis.how_much_baseload'), energy, 'Line', 'Base')}
+    it { expect_usage_chart_link(school, I18n.t('pupils.analysis.compare_different_days'), period: :daily, supply: fuel_type) }
+    it { expect(page).to have_no_link(I18n.t('pupils.analysis.compare_meters'), href: school_usage_path(school, period: :daily, supply: fuel_type, split_meters: true)) }
+
+    context 'with multiple electricity meters and no storage heaters' do
+      let(:school) { create(:school, :with_fuel_configuration, has_storage_heaters: false) }
+
+      before do
+        create_list(:"#{fuel_type}_meter", 2, active: true, school: school)
+        refresh
+      end
+
+      it { expect_usage_chart_link(school, I18n.t('pupils.analysis.compare_meters'), period: :daily, supply: fuel_type, split_meters: true) }
+    end
+  end
+
   context 'when viewing electricity category' do
-    it 'links to bar charts category'
-    it 'links to line charts category'
-    it 'links to pie chart'
-    it 'links to compare weeks'
-    it 'links to compare days'
-    it 'has not link for meters'
-    context 'with multiple electricity meters' do
-      it 'links to compare meters'
+    before do
+      visit pupils_school_analysis_path(school, category: :electricity)
     end
 
-    it 'links to kwh chart'
-    it 'links to cost chart'
-    it 'links to co2 chart'
+    it_behaves_like 'it has a top-level how section', energy: 'Electricity'
+    it_behaves_like 'it has a top-level compare section', fuel_type: :electricity
+    it_behaves_like 'it has a top-level see section', energy: 'Electricity', fuel_type: :electricity
 
     context 'when viewing bar charts' do
-      it 'links to electricity index'
-      it 'links to school comparison'
-      it 'links to long term'
-      it 'links to last year'
-      it 'compares weeks'
-      it 'has not link for meters'
-      context 'with multiple electricity meters' do
-        it 'links to compare meters'
+      before do
+        click_on I18n.t('common.bar_charts')
       end
+
+      it_behaves_like 'it has the right headings and navigation', fuel_type: :electricity
+      it_behaves_like 'a bar charts category', energy: 'Electricity', fuel_type: :electricity
     end
 
     context 'with viewing line charts' do
-      it 'links to electricity index'
-      it 'links to last 7 days'
-      it 'links to baseload'
-      it 'links to compare days'
-      it 'has not link for meters'
-      context 'with multiple electricity meters' do
-        it 'links to compare meters'
+      before do
+        click_on I18n.t('common.line_graphs')
+      end
+
+      it_behaves_like 'it has the right headings and navigation', fuel_type: :electricity
+      it_behaves_like 'a line charts category', energy: 'Electricity', fuel_type: :electricity
+    end
+  end
+
+  context 'when viewing gas category' do
+    before do
+      visit pupils_school_analysis_path(school, category: :gas)
+    end
+
+    it_behaves_like 'it has a top-level how section', energy: 'Gas'
+    it_behaves_like 'it has a top-level compare section', fuel_type: :gas
+    it_behaves_like 'it has a top-level see section', energy: 'Gas', fuel_type: :gas
+
+    context 'when viewing bar charts' do
+      before do
+        click_on I18n.t('common.bar_charts')
+      end
+
+      it_behaves_like 'it has the right headings and navigation', fuel_type: :gas
+      it_behaves_like 'a bar charts category', energy: 'Gas', fuel_type: :gas
+    end
+
+    context 'when viewing line charts' do
+      before do
+        click_on I18n.t('common.line_graphs')
+      end
+
+      it { expect_chart_link(school, I18n.t('pupils.analysis.how_much_last_week'), 'Gas', 'Line') }
+
+      it { expect_usage_chart_link(school, I18n.t('pupils.analysis.compare_different_days'), period: :daily, supply: :gas) }
+      it { expect(page).to have_no_link(I18n.t('pupils.analysis.compare_meters'), href: school_usage_path(school, period: :daily, supply: :gas, split_meters: true)) }
+
+      context 'with multiple electricity meters and no storage heaters' do
+        let(:school) { create(:school, :with_fuel_configuration, has_storage_heaters: false) }
+
+        before do
+          create_list(:gas_meter, 2, active: true, school: school)
+          refresh
+        end
+
+        it { expect_usage_chart_link(school, I18n.t('pupils.analysis.compare_meters'), period: :daily, supply: :gas, split_meters: true) }
       end
     end
+  end
+
+  context 'when viewing solar_pv category' do
+    before do
+      visit pupils_school_analysis_path(school, category: :solar_pv)
+    end
+
+    it { expect_chart_link(school, I18n.t('pupils.analysis.when'), 'Electricity', 'kWh') }
+    it { expect_chart_link(school, I18n.t('pupils.analysis.how_much_solar'), 'Electricity+Solar PV', 'Solar') }
+
+    it_behaves_like 'it has a top-level compare section', fuel_type: :electricity
+    it_behaves_like 'it has a top-level see section', energy: 'Electricity', fuel_type: :solar
+
+    context 'when viewing bar charts' do
+      before do
+        click_on I18n.t('common.bar_charts')
+      end
+
+      it_behaves_like 'a bar charts category', energy: 'Electricity', fuel_type: :electricity
+
+      it { expect(page).to have_title(I18n.t('pupils.analysis.explore_energy_data_html', fuel_type: I18n.t('common.electricity_and_solar_pv').downcase))}
+      it { expect(page).to have_content(I18n.t('pupils.analysis.explore_energy_data_html', fuel_type: I18n.t('common.electricity_and_solar_pv').downcase))}
+      it { expect(page).to have_link(I18n.t('pupils.analysis.explore_all', fuel_type: I18n.t('common.electricity_and_solar_pv').downcase), href: pupils_school_analysis_path(school, category: :solar_pv))}
+    end
+
+    context 'when viewing line charts' do
+      before do
+        click_on I18n.t('common.line_graphs')
+      end
+
+      it_behaves_like 'a line charts category', energy: 'Electricity', fuel_type: :electricity
+
+      it { expect(page).to have_title(I18n.t('pupils.analysis.explore_energy_data_html', fuel_type: I18n.t('common.electricity_and_solar_pv').downcase))}
+      it { expect(page).to have_content(I18n.t('pupils.analysis.explore_energy_data_html', fuel_type: I18n.t('common.electricity_and_solar_pv').downcase))}
+      it { expect(page).to have_link(I18n.t('pupils.analysis.explore_all', fuel_type: I18n.t('common.electricity_and_solar_pv').downcase), href: pupils_school_analysis_path(school, category: :solar_pv))}
+    end
+  end
+
+  context 'when viewing storage heaters category' do
+    before do
+      visit pupils_school_analysis_path(school, category: :storage_heaters)
+    end
+
+    it { expect_chart_link(school, I18n.t('common.pie_charts'), 'Storage Heaters', 'Pie') }
+
+    context 'when viewing bar charts' do
+      before do
+        click_on I18n.t('common.bar_charts')
+      end
+
+      it { expect(page).to have_title(I18n.t('pupils.analysis.explore_energy_data_html', fuel_type: I18n.t('common.storage_heater').downcase))}
+      it { expect(page).to have_content(I18n.t('pupils.analysis.explore_energy_data_html', fuel_type: I18n.t('common.storage_heater').downcase))}
+      it { expect(page).to have_link(I18n.t('pupils.analysis.explore_all', fuel_type: I18n.t('common.storage_heater').downcase), href: pupils_school_analysis_path(school, category: :storage_heaters))}
+    end
+
+    it { expect_chart_link(school, I18n.t('common.line_graphs'), 'Storage Heaters', 'Line') }
   end
 end

--- a/spec/system/pupils/analysis_spec.rb
+++ b/spec/system/pupils/analysis_spec.rb
@@ -95,7 +95,11 @@ describe 'Pupil analysis' do
   shared_examples 'it has the right headings and navigation' do |fuel_type:|
     it { expect(page).to have_title(I18n.t('pupils.analysis.explore_energy_data_html', fuel_type: I18n.t("common.#{fuel_type}").downcase))}
     it { expect(page).to have_content(I18n.t('pupils.analysis.explore_energy_data_html', fuel_type: I18n.t("common.#{fuel_type}").downcase))}
-    it { expect(page).to have_link(I18n.t('pupils.analysis.explore_all', fuel_type: I18n.t("common.#{fuel_type}").downcase), href: pupils_school_analysis_path(school, category: fuel_type))}
+
+    it {
+      expect(page).to have_link(I18n.t('pupils.analysis.explore_all', fuel_type: I18n.t("common.#{fuel_type}").downcase),
+                                   href: pupils_school_analysis_path(school, category: fuel_type))
+    }
   end
 
   shared_examples 'it has a top-level how section' do |energy:|
@@ -140,7 +144,11 @@ describe 'Pupil analysis' do
     it { expect_chart_link(school, I18n.t('pupils.analysis.how_changed_long_term'), energy, 'Bar', 'Year')}
     it { expect_chart_link(school, I18n.t('pupils.analysis.compare_electricity_across_schools'), energy, 'Bar', 'Bench')}
     it { expect_usage_chart_link(school, I18n.t('pupils.analysis.compare_different_weeks'), period: :weekly, supply: fuel_type) }
-    it { expect(page).to have_no_link(I18n.t('pupils.analysis.compare_meters'), href: school_usage_path(school, period: :weekly, supply: fuel_type, split_meters: true)) }
+
+    it {
+      expect(page).to have_no_link(I18n.t('pupils.analysis.compare_meters'),
+                                      href: school_usage_path(school, period: :weekly, supply: fuel_type, split_meters: true))
+    }
 
     context 'with multiple electricity meters and no storage heaters' do
       let(:school) { create(:school, :with_fuel_configuration, has_storage_heaters: false) }
@@ -158,7 +166,11 @@ describe 'Pupil analysis' do
     it { expect_chart_link(school, I18n.t('pupils.analysis.how_much_last_week'), energy, 'Line', '7days')}
     it { expect_chart_link(school, I18n.t('pupils.analysis.how_much_baseload'), energy, 'Line', 'Base')}
     it { expect_usage_chart_link(school, I18n.t('pupils.analysis.compare_different_days'), period: :daily, supply: fuel_type) }
-    it { expect(page).to have_no_link(I18n.t('pupils.analysis.compare_meters'), href: school_usage_path(school, period: :daily, supply: fuel_type, split_meters: true)) }
+
+    it {
+      expect(page).to have_no_link(I18n.t('pupils.analysis.compare_meters'),
+                                      href: school_usage_path(school, period: :daily, supply: fuel_type, split_meters: true))
+    }
 
     context 'with multiple electricity meters and no storage heaters' do
       let(:school) { create(:school, :with_fuel_configuration, has_storage_heaters: false) }
@@ -226,7 +238,11 @@ describe 'Pupil analysis' do
       it { expect_chart_link(school, I18n.t('pupils.analysis.how_much_last_week'), 'Gas', 'Line') }
 
       it { expect_usage_chart_link(school, I18n.t('pupils.analysis.compare_different_days'), period: :daily, supply: :gas) }
-      it { expect(page).to have_no_link(I18n.t('pupils.analysis.compare_meters'), href: school_usage_path(school, period: :daily, supply: :gas, split_meters: true)) }
+
+      it {
+        expect(page).to have_no_link(I18n.t('pupils.analysis.compare_meters'),
+                                        href: school_usage_path(school, period: :daily, supply: :gas, split_meters: true))
+      }
 
       context 'with multiple electricity meters and no storage heaters' do
         let(:school) { create(:school, :with_fuel_configuration, has_storage_heaters: false) }
@@ -259,9 +275,20 @@ describe 'Pupil analysis' do
 
       it_behaves_like 'a bar charts category', energy: 'Electricity', fuel_type: :electricity
 
-      it { expect(page).to have_title(I18n.t('pupils.analysis.explore_energy_data_html', fuel_type: I18n.t('common.electricity_and_solar_pv').downcase))}
-      it { expect(page).to have_content(I18n.t('pupils.analysis.explore_energy_data_html', fuel_type: I18n.t('common.electricity_and_solar_pv').downcase))}
-      it { expect(page).to have_link(I18n.t('pupils.analysis.explore_all', fuel_type: I18n.t('common.electricity_and_solar_pv').downcase), href: pupils_school_analysis_path(school, category: :solar_pv))}
+      it {
+        expect(page).to have_title(I18n.t('pupils.analysis.explore_energy_data_html',
+                                      fuel_type: I18n.t('common.electricity_and_solar_pv').downcase))
+      }
+
+      it {
+        expect(page).to have_content(I18n.t('pupils.analysis.explore_energy_data_html',
+                                        fuel_type: I18n.t('common.electricity_and_solar_pv').downcase))
+      }
+
+      it {
+        expect(page).to have_link(I18n.t('pupils.analysis.explore_all', fuel_type: I18n.t('common.electricity_and_solar_pv').downcase),
+                                     href: pupils_school_analysis_path(school, category: :solar_pv))
+      }
     end
 
     context 'when viewing line charts' do
@@ -271,9 +298,20 @@ describe 'Pupil analysis' do
 
       it_behaves_like 'a line charts category', energy: 'Electricity', fuel_type: :electricity
 
-      it { expect(page).to have_title(I18n.t('pupils.analysis.explore_energy_data_html', fuel_type: I18n.t('common.electricity_and_solar_pv').downcase))}
-      it { expect(page).to have_content(I18n.t('pupils.analysis.explore_energy_data_html', fuel_type: I18n.t('common.electricity_and_solar_pv').downcase))}
-      it { expect(page).to have_link(I18n.t('pupils.analysis.explore_all', fuel_type: I18n.t('common.electricity_and_solar_pv').downcase), href: pupils_school_analysis_path(school, category: :solar_pv))}
+      it {
+        expect(page).to have_title(I18n.t('pupils.analysis.explore_energy_data_html',
+                                           fuel_type: I18n.t('common.electricity_and_solar_pv').downcase))
+      }
+
+      it {
+        expect(page).to have_content(I18n.t('pupils.analysis.explore_energy_data_html',
+                                        fuel_type: I18n.t('common.electricity_and_solar_pv').downcase))
+      }
+
+      it {
+        expect(page).to have_link(I18n.t('pupils.analysis.explore_all', fuel_type: I18n.t('common.electricity_and_solar_pv').downcase),
+                                     href: pupils_school_analysis_path(school, category: :solar_pv))
+      }
     end
   end
 
@@ -289,9 +327,20 @@ describe 'Pupil analysis' do
         click_on I18n.t('common.bar_charts')
       end
 
-      it { expect(page).to have_title(I18n.t('pupils.analysis.explore_energy_data_html', fuel_type: I18n.t('common.storage_heater').downcase))}
-      it { expect(page).to have_content(I18n.t('pupils.analysis.explore_energy_data_html', fuel_type: I18n.t('common.storage_heater').downcase))}
-      it { expect(page).to have_link(I18n.t('pupils.analysis.explore_all', fuel_type: I18n.t('common.storage_heater').downcase), href: pupils_school_analysis_path(school, category: :storage_heaters))}
+      it {
+        expect(page).to have_title(I18n.t('pupils.analysis.explore_energy_data_html',
+                                      fuel_type: I18n.t('common.storage_heater').downcase))
+      }
+
+      it {
+        expect(page).to have_content(I18n.t('pupils.analysis.explore_energy_data_html',
+                                        fuel_type: I18n.t('common.storage_heater').downcase))
+      }
+
+      it {
+        expect(page).to have_link(I18n.t('pupils.analysis.explore_all', fuel_type: I18n.t('common.storage_heater').downcase),
+                                     href: pupils_school_analysis_path(school, category: :storage_heaters))
+      }
     end
 
     it { expect_chart_link(school, I18n.t('common.line_graphs'), 'Storage Heaters', 'Line') }

--- a/spec/system/pupils/dashboard_spec.rb
+++ b/spec/system/pupils/dashboard_spec.rb
@@ -102,10 +102,6 @@ describe 'Pupil dashboard' do
       expect(page).to have_content('the average school')
       expect(page).to have_content('How will your school compare?')
     end
-
-    it 'shows message', pending: 'Need to decide approach for new design' do
-      expect(page).to have_content("We're setting up this school's energy data and will update this page when it is ready to explore")
-    end
   end
 
   context 'when viewing as guest user' do

--- a/spec/system/pupils/dashboard_spec.rb
+++ b/spec/system/pupils/dashboard_spec.rb
@@ -14,7 +14,7 @@ describe 'Pupil dashboard' do
 
   let(:pupil) { create(:pupil, school: school)}
 
-  context 'when viewing as guest user' do
+  shared_examples 'a pupil dashboard viewed when logged out' do
     before do
       visit pupils_school_path(school)
     end
@@ -22,10 +22,6 @@ describe 'Pupil dashboard' do
     it 'shows login form' do
       expect(page).to have_content('Log in with your email address and password')
       expect(page).to have_content('Log in with your pupil password')
-    end
-
-    it 'shows equivalences' do
-      expect(page).to have_content('Your school spent £2.00 on electricity last year!')
     end
 
     context 'for school with non-public data' do
@@ -40,16 +36,9 @@ describe 'Pupil dashboard' do
     end
   end
 
-  context 'when logged in as pupil' do
+  shared_examples 'a data enabled pupil dashboard' do
     before do
-      sign_in(pupil)
       visit pupils_school_path(school)
-    end
-
-    it 'redirects to pupil dashboard' do
-      visit root_path
-      expect(page).to have_content(school.name.to_s)
-      expect(page).to have_title('Pupil dashboard')
     end
 
     it 'shows equivalences' do
@@ -61,33 +50,23 @@ describe 'Pupil dashboard' do
       expect(page).to have_content('Gwariodd eich ysgol £9.00 ar drydan y llynedd')
     end
 
-    it 'has navigation to adult dashboard' do
-      expect(page).to have_content(school.name.to_s)
-      expect(page).to have_link('Adult dashboard', href: school_path(school, switch: true))
-      click_on 'Adult dashboard'
-      expect(page).to have_title('Adult dashboard')
-      click_on 'Pupil dashboard'
-      expect(page).to have_title('Pupil dashboard')
-    end
-
     context 'with observations' do
+      let(:activity_type) { create(:activity_type) }
+      let(:intervention_type) { create(:intervention_type, name: 'Upgraded insulation') }
+
       before do
-        intervention_type = create(:intervention_type, name: 'Upgraded insulation')
         create(:observation, :intervention, school: school, intervention_type: intervention_type)
-        create(:observation_with_temperature_recording_and_location, school: school)
-        activity_type = create(:activity_type) # doesn't get saved if built with activity below
         create(:activity, school: school, activity_type: activity_type)
         visit pupils_school_path(school)
       end
 
-      it 'displays interventions and temperature recordings in a timeline' do
-        expect(page).to have_content('Recorded indoor temperatures in')
-        expect(page).to have_content('Upgraded insulation')
-        expect(page).to have_content('Completed an activity')
-        click_on 'View all events'
-        expect(page).to have_content('Recorded indoor temperatures in')
-        expect(page).to have_content('Upgraded insulation')
-        expect(page).to have_content('Completed an activity')
+      it 'displays activity and actions in a timeline' do
+        expect(page).to have_content(intervention_type.name)
+        expect(page).to have_content(activity_type.name)
+        expect(page).to have_link(href: school_timeline_path(school))
+        visit school_timeline_path(school)
+        expect(page).to have_content(intervention_type.name)
+        expect(page).to have_content(activity_type.name)
       end
     end
 
@@ -109,7 +88,7 @@ describe 'Pupil dashboard' do
     end
   end
 
-  context 'when school is not data-enabled' do
+  shared_examples 'a non-data enabled pupil dashboard' do
     before do
       school.update!(data_enabled: false)
       visit pupils_school_path(school)
@@ -124,8 +103,88 @@ describe 'Pupil dashboard' do
       expect(page).to have_content('How will your school compare?')
     end
 
-    it 'shows message' do
+    it 'shows message', pending: 'Need to decide approach for new design' do
       expect(page).to have_content("We're setting up this school's energy data and will update this page when it is ready to explore")
+    end
+  end
+
+  context 'when viewing as guest user' do
+    it_behaves_like 'a pupil dashboard viewed when logged out'
+    it_behaves_like 'a data enabled pupil dashboard'
+
+    context 'when school is not data-enabled' do
+      it_behaves_like 'a non-data enabled pupil dashboard'
+    end
+  end
+
+  context 'when logged in as pupil' do
+    before do
+      sign_in(pupil)
+      visit pupils_school_path(school)
+    end
+
+    it 'has navigation to adult dashboard' do
+      expect(page).to have_content(school.name.to_s)
+      expect(page).to have_link('Adult dashboard', href: school_path(school, switch: true))
+      click_on 'Adult dashboard'
+      expect(page).to have_title('Adult dashboard')
+      click_on 'Pupil dashboard'
+      expect(page).to have_title('Pupil dashboard')
+    end
+
+    it 'redirects to pupil dashboard' do
+      visit root_path
+      expect(page).to have_content(school.name.to_s)
+      expect(page).to have_title('Pupil dashboard')
+    end
+
+    it_behaves_like 'a data enabled pupil dashboard'
+
+    context 'when school is not data-enabled' do
+      it_behaves_like 'a non-data enabled pupil dashboard'
+    end
+  end
+
+  context 'with new dashboard enabled' do
+    before do
+      Flipper.enable :new_dashboards_2024
+    end
+
+    context 'when viewing as guest user' do
+      it_behaves_like 'a pupil dashboard viewed when logged out'
+      it_behaves_like 'a data enabled pupil dashboard'
+
+      context 'when school is not data-enabled' do
+        it_behaves_like 'a non-data enabled pupil dashboard'
+      end
+    end
+
+    context 'when logged in as pupil' do
+      before do
+        sign_in(pupil)
+        visit pupils_school_path(school)
+      end
+
+      it 'has navigation to adult dashboard' do
+        expect(page).to have_content(school.name.to_s)
+        expect(page).to have_link('Adult dashboard', href: school_path(school, switch: true))
+        click_on 'Adult dashboard'
+        expect(page).to have_title('Adult dashboard')
+        click_on 'Pupil dashboard'
+        expect(page).to have_title('Pupil dashboard')
+      end
+
+      it 'redirects to pupil dashboard' do
+        visit root_path
+        expect(page).to have_content(school.name.to_s)
+        expect(page).to have_title('Pupil dashboard')
+      end
+
+      it_behaves_like 'a data enabled pupil dashboard'
+
+      context 'when school is not data-enabled' do
+        it_behaves_like 'a non-data enabled pupil dashboard'
+      end
     end
   end
 end


### PR DESCRIPTION
Reworks the pupil analysis pages to refresh the design.

As part of reimplementing this I have:

- written a new `PupilExploreComponent` to handle adding the box-outs. These all have a coloured background, icon and then a link to either another page, or one of two different types of chart pages
- created new versions of the templates in `views/pupils/analysis/new` to make it easier to remove older pages and partials in future
- written specs for all fuel type and chart type variants of the page. It looks like we didn't have any system specs covering this previously
- updated the IconComponent to support using different FontAwesome icon sets, e.g. the brand (`fab`) icons as used on the pupil analysis pages to display an icon for storage heaters
- fixed the page titles on the new dashboard
- corrected the links to the pupil analysis in the DashboardEquivalenceComponent

It's a big PR but mostly templates. Felt it was easier to do this in a block rather than do pages individually.

The different pages for each fuel type don't have a consistent set of charts across all of them. E.g. the gas page doesn't have some charts that are on the electricity pages and the storage heater pages have very limited options.

I've not refactored the controller that drives the pages, or the underlying configuration in the analytics which defines which charts are shown. We should revisit this later as the inconsistent approach to fuel types and configuration keys makes things messy.