### PR TITLE
Shuffle equivalences

### DIFF
--- a/app/components/dashboard_equivalences_component.rb
+++ b/app/components/dashboard_equivalences_component.rb
@@ -83,7 +83,7 @@ class DashboardEquivalencesComponent < ApplicationComponent
   def setup_equivalences(meter_types = :all)
     equivalence_data = Equivalences::RelevantAndTimely.new(@school).equivalences(meter_types: meter_types)
 
-    equivalence_data.map do |equivalence|
+    equivalence_data.shuffle.map do |equivalence|
       TemplateInterpolation.new(
         equivalence.content_version,
         with_objects: { equivalence_type: equivalence.content_version.equivalence_type },


### PR DESCRIPTION
Shuffles the array of equivalences after fetching from the database. This is to inject a bit more randomness into what is displayed on the pupil dashboards.
