### PR TITLE
Ensure only pupil alerts shown on new pupil dash

### DIFF
--- a/app/components/dashboard_insights_component.rb
+++ b/app/components/dashboard_insights_component.rb
@@ -15,11 +15,16 @@ class DashboardInsightsComponent < ApplicationComponent
   end
 
   def alerts
-    @alerts ||= setup_alerts(@school.latest_dashboard_alerts.management_dashboard, content_field)
+    latest_alerts = @school.latest_dashboard_alerts
+    @alerts ||= setup_alerts(adult? ? latest_alerts.management_dashboard : latest_alerts.pupil_dashboard, content_field)
   end
 
   def content_field
-    @audience == :adult ? :management_dashboard_title : :pupil_dashboard_title
+    adult? ? :management_dashboard_title : :pupil_dashboard_title
+  end
+
+  def adult?
+    @audience == :adult
   end
 
   def data_enabled?

--- a/spec/components/dashboard_insights_component_spec.rb
+++ b/spec/components/dashboard_insights_component_spec.rb
@@ -10,13 +10,15 @@ RSpec.describe DashboardInsightsComponent, :include_url_helpers, type: :componen
   let(:classes) { 'extra-classes' }
   let(:progress_summary) { nil }
   let(:user) { create(:school_admin, school: school)}
+  let(:audience) { :adult }
   let(:params) do
     {
       school: school,
       id: id,
       classes: classes,
       progress_summary: progress_summary,
-      user: user
+      user: user,
+      audience: audience
     }
   end
 
@@ -44,6 +46,16 @@ RSpec.describe DashboardInsightsComponent, :include_url_helpers, type: :componen
 
     it 'displays the alert text' do
       expect(html).to have_content('You can save £5,000 on heating in 1 year')
+      expect(html).to have_content('Your baseload is high and is costing £5,000')
+    end
+
+    context 'with pupil audience' do
+      let(:audience) { :pupil }
+
+      it 'displays only the pupil alerts' do
+        expect(html).to have_content('You can save £5,000 on heating in 1 year')
+        expect(html).to have_no_content('Your baseload is high and is costing £5,000')
+      end
     end
 
     context 'with Welsh locale' do

--- a/spec/support/shared_contexts/dashboard_alerts.rb
+++ b/spec/support/shared_contexts/dashboard_alerts.rb
@@ -8,12 +8,15 @@ RSpec.shared_context 'with dashboard alerts' do
       rating_from: 0,
       rating_to: 10,
       management_dashboard_alert_active: true,
+      pupil_dashboard_alert_active: true,
     )
     create(
       :alert_type_rating_content_version,
       alert_type_rating: alert_type_rating,
       management_dashboard_title_en: 'You can save {{average_one_year_saving_gbp}} on heating in {{average_payback_years}}',
       management_dashboard_title_cy: 'Gallwch arbed {{average_one_year_saving_gbp}} mewn {{average_payback_years}}',
+      pupil_dashboard_title_en: 'You can save {{average_one_year_saving_gbp}} on heating in {{average_payback_years}}',
+      pupil_dashboard_title_cy: 'Gallwch arbed {{average_one_year_saving_gbp}} mewn {{average_payback_years}}',
     )
     create(:alert, :with_run,
       alert_type: alert_type,
@@ -40,12 +43,15 @@ RSpec.shared_context 'with dashboard alerts' do
       rating_from: 0,
       rating_to: 10,
       management_dashboard_alert_active: true,
+      pupil_dashboard_alert_active: false,
     )
     create(
       :alert_type_rating_content_version,
       alert_type_rating: alert_type_rating,
       management_dashboard_title_en: 'Your baseload is high and is costing {{average_one_year_saving_gbp}}',
       management_dashboard_title_cy: 'Mae eich llwyth sylfaenol yn uchel ac yn costio {{average_one_year_saving_gbp}}',
+      pupil_dashboard_title_en: 'Your baseload is high and is costing {{average_one_year_saving_gbp}}',
+      pupil_dashboard_title_cy: 'Mae eich llwyth sylfaenol yn uchel ac yn costio {{average_one_year_saving_gbp}}',
     )
     create(:alert, :with_run,
       alert_type: alert_type,


### PR DESCRIPTION
The `DashboardInsightsComponent` was loading only adult alerts, it should be using the audience parameter to load just the alerts to be displayed on each dashboard.

Fixes an issue with empty text being displayed on the pupil dashboard.

