### PR TITLE
Fix date issues in specs

### DIFF
--- a/spec/support/shared_examples/scorable.rb
+++ b/spec/support/shared_examples/scorable.rb
@@ -5,6 +5,7 @@ RSpec.shared_examples 'a scorable' do
       (1..5).collect do |n|
         create(:school, :with_points, score_points: 6 - n, scoreboard: scoreboard, school_group: school_group,
                                       activities_happened_on: activity_date,
+                                      calendar: subject.scorable_calendar,
                                       template_calendar: subject.scorable_calendar)
       end
     end

--- a/spec/system/schools/advice_pages/electricity_out_of_hours_spec.rb
+++ b/spec/system/schools/advice_pages/electricity_out_of_hours_spec.rb
@@ -163,9 +163,12 @@ RSpec.describe 'electricity out of hours advice page', type: :system do
             end
 
             it 'has holiday usage section' do
-              expect(page).to have_content(I18n.t('advice_pages.electricity_out_of_hours.analysis.holiday_usage.title'))
-              expect(page).to have_css('#chart_wrapper_management_dashboard_group_by_week_electricity')
-              expect(page).to have_css('#holiday-usage-table')
+              travel_to reading_end_date do
+                refresh
+                expect(page).to have_content(I18n.t('advice_pages.electricity_out_of_hours.analysis.holiday_usage.title'))
+                expect(page).to have_css('#chart_wrapper_management_dashboard_group_by_week_electricity')
+                expect(page).to have_css('#holiday-usage-table')
+              end
             end
           end
         end
@@ -192,9 +195,12 @@ RSpec.describe 'electricity out of hours advice page', type: :system do
           end
 
           it 'has a holiday usage section' do
-            expect(page).to have_content(I18n.t('advice_pages.electricity_out_of_hours.analysis.holiday_usage.title'))
-            expect(page).to have_css('#chart_wrapper_alert_group_by_week_electricity_14_months')
-            expect(page).to have_css('#holiday-usage-table')
+            travel_to school.calendar.holidays.last.end_date do
+              refresh
+              expect(page).to have_content(I18n.t('advice_pages.electricity_out_of_hours.analysis.holiday_usage.title'))
+              expect(page).to have_css('#chart_wrapper_alert_group_by_week_electricity_14_months')
+              expect(page).to have_css('#holiday-usage-table')
+            end
           end
         end
       end

--- a/spec/system/schools/advice_pages/gas_out_of_hours_spec.rb
+++ b/spec/system/schools/advice_pages/gas_out_of_hours_spec.rb
@@ -178,9 +178,12 @@ RSpec.describe 'gas out of hours advice page', type: :system do
             end
 
             it 'has holiday usage section' do
-              expect(page).to have_content(I18n.t('advice_pages.gas_out_of_hours.analysis.holiday_usage.title'))
-              expect(page).to have_css('#chart_wrapper_management_dashboard_group_by_week_gas')
-              expect(page).to have_css('#holiday-usage-table')
+              travel_to reading_end_date do
+                refresh
+                expect(page).to have_content(I18n.t('advice_pages.gas_out_of_hours.analysis.holiday_usage.title'))
+                expect(page).to have_css('#chart_wrapper_management_dashboard_group_by_week_gas')
+                expect(page).to have_css('#holiday-usage-table')
+              end
             end
           end
         end
@@ -202,7 +205,7 @@ RSpec.describe 'gas out of hours advice page', type: :system do
         end
 
         context 'with holidays defined' do
-          # create a number of holidays outside usage period
+          # create a number of holidays inside usage period
           let(:school) do
             create(:school, :with_basic_configuration_single_meter_and_tariffs,
               fuel_type: :gas,
@@ -210,9 +213,12 @@ RSpec.describe 'gas out of hours advice page', type: :system do
           end
 
           it 'has a holiday usage section' do
-            expect(page).to have_content(I18n.t('advice_pages.gas_out_of_hours.analysis.holiday_usage.title'))
-            expect(page).to have_css('#chart_wrapper_alert_group_by_week_gas_14_months')
-            expect(page).to have_css('#holiday-usage-table')
+            travel_to school.calendar.holidays.last.end_date do
+              refresh
+              expect(page).to have_content(I18n.t('advice_pages.gas_out_of_hours.analysis.holiday_usage.title'))
+              expect(page).to have_css('#chart_wrapper_alert_group_by_week_gas_14_months')
+              expect(page).to have_css('#holiday-usage-table')
+            end
           end
         end
       end


### PR DESCRIPTION
More date issues in specs as we roll into a new academic year (1st Sept onwards).

- there was a further issue in the scorable tests which was due to the scores for the individual schools not matching expectations because they were created with calendars that did not have the required academic years. Fix was to ensure they're using the same calendar as the scorable.
- there was an issue with the out of hours advice pages which was expecting a holiday usage section but this wasn't appearing as the table is only shown for the current academic year (although this might need changing). Fix was to use `travel_to` to move to relative dates that match the original expectations in the spec (e.g. that the page is being viewed in the same academic year as the holidays)