### PR TITLE
Create new energy explained component

### DIFF
--- a/app/components/advice_page_list_component.rb
+++ b/app/components/advice_page_list_component.rb
@@ -16,4 +16,8 @@ class AdvicePageListComponent < ApplicationComponent
   def advice_pages
     @advice_pages ||= AdvicePage.all
   end
+
+  def render?
+    advice_pages.any? && school.data_enabled?
+  end
 end

--- a/app/components/advice_page_list_component.rb
+++ b/app/components/advice_page_list_component.rb
@@ -1,0 +1,19 @@
+class AdvicePageListComponent < ApplicationComponent
+  attr_reader :school
+
+  include ApplicationHelper
+  include AdvicePageHelper
+
+  def initialize(school:, id: nil, classes: '')
+    super(id: id, classes: classes)
+    @school = school
+  end
+
+  def advice_page_benchmarks
+    @advice_page_benchmarks ||= @school.advice_page_school_benchmarks
+  end
+
+  def advice_pages
+    @advice_pages ||= AdvicePage.all
+  end
+end

--- a/app/components/advice_page_list_component/advice_page_list_component.html.erb
+++ b/app/components/advice_page_list_component/advice_page_list_component.html.erb
@@ -10,7 +10,10 @@
       <% advice_pages.display_fuel_types.keys.each_with_index do |fuel_type, idx| %>
         <% if display_advice_page?(school, fuel_type) %>
           <% sort_by_label(advice_pages.where(fuel_type: fuel_type)).each do |ap| %>
-            <%= component 'prompt', icon: fuel_type_icon(fuel_type) do |p| %>
+            <%= component 'prompt',
+                          icon: fuel_type_icon(fuel_type),
+                          style: :compact,
+                          classes: fuel_type_background_class(fuel_type) do |p| %>
               <% p.with_title do %>
                 <%= translated_label(ap) %>
               <% end %>
@@ -25,7 +28,7 @@
               <% end %>
 
               <% p.with_link do %>
-                <%= link_to 'XXX', advice_page_path(school, ap) %>
+                <%= link_to t('schools.show.find_out_more'), advice_page_path(school, ap) %>
               <% end %>
 
               <% if ap.key == 'solar_pv' %>

--- a/app/components/advice_page_list_component/advice_page_list_component.html.erb
+++ b/app/components/advice_page_list_component/advice_page_list_component.html.erb
@@ -1,0 +1,44 @@
+<div id="<%= id %>" class="advice-page-list-component <%= classes %>">
+  <%= component 'titled_section' do |section| %>
+    <% section.with_title do %>
+      <h2><%= t('components.advice_page_list.title') %></h2>
+    <% end %>
+    <% section.with_intro do %>
+      <p><%= t('components.advice_page_list.intro') %></p>
+    <% end %>
+    <% section.with_body do %>
+      <% advice_pages.display_fuel_types.keys.each_with_index do |fuel_type, idx| %>
+        <% if display_advice_page?(school, fuel_type) %>
+          <% sort_by_label(advice_pages.where(fuel_type: fuel_type)).each do |ap| %>
+            <%= component 'prompt', icon: fuel_type_icon(fuel_type) do |p| %>
+              <% p.with_title do %>
+                <%= translated_label(ap) %>
+              <% end %>
+
+              <% school_benchmark = advice_page_benchmarks.where(advice_page: ap).first %>
+              <% if school_benchmark.present? %>
+                <% p.with_pill do %>
+                  <span class="badge <%= school_benchmark.benchmarked_as %>">
+                    <%= t("advice_pages.benchmarks.#{school_benchmark.benchmarked_as}") %>
+                  </span>
+                <% end %>
+              <% end %>
+
+              <% p.with_link do %>
+                <%= link_to 'XXX', advice_page_path(school, ap) %>
+              <% end %>
+
+              <% if ap.key == 'solar_pv' %>
+                <% solar_status = @school.has_solar_pv? ? 'has_solar' : 'no_solar' %>
+                <%= t("advice_pages.index.show.page_summary.solar_pv.#{solar_status}") %>
+              <% else %>
+                <%= t("advice_pages.index.show.page_summary.#{ap.key}") %>
+              <% end %>
+
+            <% end %>
+          <% end %>
+        <% end %>
+      <% end %>
+    <% end %>
+  <% end %>
+</div>

--- a/app/components/advice_page_list_component/advice_page_list_component.scss
+++ b/app/components/advice_page_list_component/advice_page_list_component.scss
@@ -1,0 +1,14 @@
+.exemplar_school {
+  background-color: $exemplar-school;
+  color: $white;
+}
+
+.benchmark_school {
+  background-color: $benchmark-school;
+  color: $white;
+}
+
+.other_school {
+  background-color: $other-school;
+  color: $white;
+}

--- a/app/components/prompt_component.rb
+++ b/app/components/prompt_component.rb
@@ -19,12 +19,13 @@ class PromptComponent < ApplicationComponent
   renders_one :title
   renders_one :pill
 
-  attr_reader :icon
+  attr_reader :icon, :style
 
-  def initialize(id: nil, icon: nil, status: :none, classes: '')
+  def initialize(id: nil, icon: nil, status: nil, style: :full, classes: '')
     super(id: id, classes: "#{status} #{classes}")
     @icon = icon
     @status = status
+    @style = style
     validate
   end
 
@@ -33,7 +34,7 @@ class PromptComponent < ApplicationComponent
   end
 
   def validate
-    raise ArgumentError.new(self.class.status_error) unless self.class.statuses.include?(@status.to_sym)
+    raise ArgumentError.new(self.class.status_error) unless @status.nil? || self.class.statuses.include?(@status.to_sym)
   end
 
   def self.statuses

--- a/app/components/prompt_component/prompt_component.html.erb
+++ b/app/components/prompt_component/prompt_component.html.erb
@@ -1,6 +1,6 @@
 <div id="<%= id %>" class="prompt-component mb-2 <%= classes %>">
   <%# Padding added to create space within div %>
-  <div class="row pt-4 pb-4">
+  <div class="row pt-3 pb-3">
     <% if icon.present? %>
       <%# Icon is hidden on smallest size, visible from sm and above as single column %>
       <div class="d-none d-sm-block col-1">
@@ -23,14 +23,25 @@
         </div>
       <% end %>
       <div class="row">
-        <div class="col">
-          <%= content %>
-          <p>
+        <% if style == :compact %>
+          <div class="col-12 col-md-10">
+            <%= content %>
+          </div>
           <% if link %>
-            <%= link %>
+            <div class="col col-md-2">
+              <%= link %>
+            </div>
           <% end %>
-          </p>
-        </div>
+        <% else %>
+          <div class="col">
+            <%= content %>
+            <p>
+            <% if link %>
+              <%= link %>
+            <% end %>
+            </p>
+          </div>
+        <% end %>
       </div>
     </div>
   </div>

--- a/app/components/prompt_component/prompt_component.scss
+++ b/app/components/prompt_component/prompt_component.scss
@@ -1,6 +1,8 @@
 .prompt-component {
   border-radius: 8px;
-  background-color: $light !important;
+  &.none {
+    background-color: $light !important;
+  }
   &.negative {
     background-color: $light-red !important;
   }

--- a/app/views/schools/advice/show.html.erb
+++ b/app/views/schools/advice/show.html.erb
@@ -8,5 +8,10 @@
       <% end %>
     </div>
   </div>
-  <%= render 'schools/advice/index/page_list', school: @school, advice_pages: @advice_pages, advice_page_benchmarks: @advice_page_benchmarks %>
+
+  <% if Flipper.enabled?(:new_dashboards_2024, current_user) %>
+    <%= component 'advice_page_list', school: @school %>
+  <% else %>
+    <%= render 'schools/advice/index/page_list', school: @school, advice_pages: @advice_pages, advice_page_benchmarks: @advice_page_benchmarks %>
+  <% end %>
 <% end %>

--- a/config/locales/views/components/advice_page_list.yml
+++ b/config/locales/views/components/advice_page_list.yml
@@ -1,0 +1,6 @@
+---
+en:
+  components:
+    advice_page_list:
+      intro: These pages provide more insights and analysis into how your school's energy usage. The pages are highlighted to indicate areas that need improvement or where you are doing well.
+      title: Your energy explained

--- a/spec/components/advice_page_list_component_spec.rb
+++ b/spec/components/advice_page_list_component_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe AdvicePageListComponent, :include_application_helper, :include_url_helpers, type: :component do
+  subject(:component) do
+    described_class.new(**params)
+  end
+
+  let(:id) { 'custom-id'}
+  let(:classes) { 'extra-classes' }
+  let(:school) { create(:school, :with_fuel_configuration, has_solar_pv: false, has_gas: false, has_storage_heaters: false) }
+
+  let(:params) do
+    {
+      school: school,
+      id: id,
+      classes: classes
+    }
+  end
+
+  let!(:baseload) { create(:advice_page, key: :baseload) }
+  let!(:heating_control) { create(:advice_page, key: :heating_content, fuel_type: 'gas') }
+  let!(:solar_pv) { create(:advice_page, key: :solar_pv, fuel_type: 'solar_pv') }
+  let!(:storage_heaters) { create(:advice_page, key: :storage_heaters, fuel_type: 'storage_heater') }
+
+  context 'when rendering' do
+    let(:html) do
+      render_inline(component)
+    end
+
+    it_behaves_like 'an application component' do
+      let(:expected_classes) { classes }
+      let(:expected_id) { id }
+    end
+
+    it 'displays links and summary to correct pages'
+
+    context 'when school has gas' do
+      let(:school) { create(:school, :with_fuel_configuration, has_solar_pv: false, has_storage_heaters: false) }
+
+      it 'displays gas page and summary'
+    end
+
+    context 'when school has storage heaters' do
+      let(:school) { create(:school, :with_fuel_configuration, has_solar_pv: false, has_gas: false) }
+
+      it 'displays gas page and summary'
+    end
+
+    context 'when school has solar' do
+      let(:school) { create(:school, :with_fuel_configuration, has_storage_heaters: false, has_gas: false) }
+
+      it 'displays different summary but same link'
+    end
+
+    context 'when school has a benchmark' do
+      it 'displays the feedback'
+    end
+  end
+end

--- a/spec/components/advice_page_list_component_spec.rb
+++ b/spec/components/advice_page_list_component_spec.rb
@@ -20,9 +20,24 @@ RSpec.describe AdvicePageListComponent, :include_application_helper, :include_ur
   end
 
   let!(:baseload) { create(:advice_page, key: :baseload) }
-  let!(:heating_control) { create(:advice_page, key: :heating_content, fuel_type: 'gas') }
+  let!(:heating_control) { create(:advice_page, key: :heating_control, fuel_type: 'gas') }
   let!(:solar_pv) { create(:advice_page, key: :solar_pv, fuel_type: 'solar_pv') }
   let!(:storage_heaters) { create(:advice_page, key: :storage_heaters, fuel_type: 'storage_heater') }
+
+  shared_examples 'a properly rended prompt' do
+    let(:expected_summary) { nil }
+    it { expect(html).to have_link(I18n.t('schools.show.find_out_more'), href: expected_path) }
+    it { expect(html).to have_content(I18n.t("advice_pages.nav.pages.#{expected_page.key}")) }
+    it { expect(html).to have_content(I18n.t("advice_pages.index.show.page_summary.#{expected_summary || expected_page.key}")) }
+  end
+
+  describe '#render?' do
+    context 'when school is not data enabled' do
+      let(:school) { create(:school, data_enabled: false) }
+
+      it { expect(component.render?).to be(false)}
+    end
+  end
 
   context 'when rendering' do
     let(:html) do
@@ -34,28 +49,75 @@ RSpec.describe AdvicePageListComponent, :include_application_helper, :include_ur
       let(:expected_id) { id }
     end
 
-    it 'displays links and summary to correct pages'
+    it { expect(html).to have_content(I18n.t('components.advice_page_list.title')) }
+    it { expect(html).to have_content(I18n.t('components.advice_page_list.intro')) }
+
+    context 'when school has electricity' do
+      let(:school) do
+        create(:school, :with_fuel_configuration, has_gas: false, has_solar_pv: false, has_storage_heaters: false)
+      end
+
+      it_behaves_like 'a properly rended prompt' do
+        let(:expected_path) { insights_school_advice_baseload_path(school) }
+        let(:expected_page) { baseload }
+      end
+
+      it_behaves_like 'a properly rended prompt' do
+        let(:expected_path) { insights_school_advice_solar_pv_path(school) }
+        let(:expected_summary) { 'solar_pv.no_solar' }
+        let(:expected_page) { solar_pv }
+      end
+    end
 
     context 'when school has gas' do
       let(:school) { create(:school, :with_fuel_configuration, has_solar_pv: false, has_storage_heaters: false) }
 
-      it 'displays gas page and summary'
+      it_behaves_like 'a properly rended prompt' do
+        let(:expected_path) { insights_school_advice_heating_control_path(school) }
+        let(:expected_page) { heating_control }
+      end
+
+      it_behaves_like 'a properly rended prompt' do
+        let(:expected_path) { insights_school_advice_solar_pv_path(school) }
+        let(:expected_summary) { 'solar_pv.no_solar' }
+        let(:expected_page) { solar_pv }
+      end
     end
 
     context 'when school has storage heaters' do
       let(:school) { create(:school, :with_fuel_configuration, has_solar_pv: false, has_gas: false) }
 
-      it 'displays gas page and summary'
+      it_behaves_like 'a properly rended prompt' do
+        let(:expected_path) { insights_school_advice_storage_heaters_path(school) }
+        let(:expected_page) { storage_heaters }
+      end
+
+      it_behaves_like 'a properly rended prompt' do
+        let(:expected_path) { insights_school_advice_solar_pv_path(school) }
+        let(:expected_summary) { 'solar_pv.no_solar' }
+        let(:expected_page) { solar_pv }
+      end
     end
 
     context 'when school has solar' do
       let(:school) { create(:school, :with_fuel_configuration, has_storage_heaters: false, has_gas: false) }
 
-      it 'displays different summary but same link'
+      it_behaves_like 'a properly rended prompt' do
+        let(:expected_path) { insights_school_advice_baseload_path(school) }
+        let(:expected_page) { baseload }
+      end
+
+      it_behaves_like 'a properly rended prompt' do
+        let(:expected_path) { insights_school_advice_solar_pv_path(school) }
+        let(:expected_summary) { 'solar_pv.has_solar' }
+        let(:expected_page) { solar_pv }
+      end
     end
 
     context 'when school has a benchmark' do
-      it 'displays the feedback'
+      let!(:benchmark) { create(:advice_page_school_benchmark, school: school, advice_page: baseload) }
+
+      it { expect(html).to have_content(I18n.t("advice_pages.benchmarks.#{benchmark.benchmarked_as}"))}
     end
   end
 end

--- a/spec/components/previews/prompt_component_preview/examples.html.erb
+++ b/spec/components/previews/prompt_component_preview/examples.html.erb
@@ -9,6 +9,9 @@
   <li><a href="#pill">Pills</a></li>
   <li><a href="#status">Status colours</a></li>
   <li><a href="#all">All options</a></li>
+  <li><a href="#custom">Custom background colour</a></li>
+  <li><a href="#compact">Compact style</a></li>
+
   <li><a href="#columns">Rendering within columns</a></li>
 </ul>
 
@@ -93,9 +96,41 @@
   <% end %>
 <% end %>
 
-<h4 id='all'>All options</h4>
+<h4 id='all'>All options (link, title, pill, content)</h4>
 
 <%= render PromptComponent.new status: :neutral, icon: 'calendar-alt' do |c| %>
+  <% c.with_link { link_to 'This is the link', root_path } %>
+  <% c.with_title { 'This is the title' } %>
+  <% c.with_pill do %>
+    <span class="badge badge-warning">Warning</span>
+  <% end %>
+  <p>
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum id lorem dui. Quisque feugiat sollicitudin
+    odio in vestibulum. Duis a semper mi.
+  </p>
+<% end %>
+
+<h4 id='custom'>Custom background colour</h4>
+
+<%= render PromptComponent.new classes: fuel_type_background_class(:gas), icon: 'calendar-alt' do |c| %>
+  <% c.with_link { link_to 'This is the link', root_path } %>
+  <% c.with_title { 'This is the title' } %>
+  <% c.with_pill do %>
+    <span class="badge badge-warning">Warning</span>
+  <% end %>
+  <p>
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum id lorem dui. Quisque feugiat sollicitudin
+    odio in vestibulum. Duis a semper mi.
+  </p>
+<% end %>
+
+<h4 id='compact'>Compact Style</h4>
+
+<p>
+  With <code>:compact</code> style, content should be wrapped in an outer tag. Longer content will force the row to wrap
+</p>
+
+<%= render PromptComponent.new status: :neutral, style: :compact, icon: 'calendar-alt' do |c| %>
   <% c.with_link { link_to 'This is the link', root_path } %>
   <% c.with_title { 'This is the title' } %>
   <% c.with_pill do %>


### PR DESCRIPTION
The new advice page index design has a section "Your energy explained" which lists the links to the advice pages with Bootstrap pills for indicating how the school compares.

I've implemented this as a new component using TitledSection for the basic layout and an updated version of the PromptComponent for displaying each link. The tweaks to the prompt component allow for a `:compact` style which adds the link as a second column rather than below the prompt itself. I've also slightly reduced the padding size.

![Screenshot from 2024-09-03 13-26-10](https://github.com/user-attachments/assets/e86a9c42-b9c3-4cdd-8f74-ed97db6ae2fe)
