### PR TITLE
Changes to My School menu

### DIFF
--- a/app/components/adult_reminders_component.rb
+++ b/app/components/adult_reminders_component.rb
@@ -26,7 +26,7 @@ class AdultRemindersComponent < DashboardRemindersComponent
     site_settings.message_for_no_pupil_accounts && @school.users.pupil.empty? && ability.can?(:manage_users, @school)
   end
 
-  def recent_audit
-    Audits::AuditService.new(@school).recent_audit
+  def last_audit
+    Audits::AuditService.new(@school).last_audit
   end
 end

--- a/app/components/adult_reminders_component/adult_reminders_component.html.erb
+++ b/app/components/adult_reminders_component/adult_reminders_component.html.erb
@@ -64,7 +64,7 @@
   <% end %>
 
   <% add_prompt(id: :audit,
-                check: last_audit,
+                check: last_audit&.tasks_remaining?,
                 list: list,
                 status: :neutral,
                 icon: 'laptop',

--- a/app/components/adult_reminders_component/adult_reminders_component.html.erb
+++ b/app/components/adult_reminders_component/adult_reminders_component.html.erb
@@ -67,7 +67,7 @@
                 check: last_audit,
                 list: list,
                 status: :neutral,
-                icon: 'fa-laptop',
+                icon: 'laptop',
                 link: 'common.labels.view_now',
                 path: last_audit ? school_audit_path(school, last_audit) : nil) do %>
     <p>

--- a/app/components/adult_reminders_component/adult_reminders_component.html.erb
+++ b/app/components/adult_reminders_component/adult_reminders_component.html.erb
@@ -64,14 +64,14 @@
   <% end %>
 
   <% add_prompt(id: :audit,
-                check: recent_audit,
+                check: last_audit,
                 list: list,
                 status: :neutral,
                 icon: 'fa-laptop',
                 link: 'common.labels.view_now',
-                path: recent_audit ? school_audit_path(school, recent_audit) : nil) do %>
+                path: last_audit ? school_audit_path(school, last_audit) : nil) do %>
     <p>
-      <%= Audits::Progress.new(recent_audit).notification %>
+      <%= Audits::Progress.new(last_audit).notification %>
     </p>
   <% end %>
 

--- a/app/controllers/schools_controller.rb
+++ b/app/controllers/schools_controller.rb
@@ -173,7 +173,7 @@ private
       @add_targets = prompt_for_target?
       @set_new_target = prompt_to_set_new_target?
       @review_targets = prompt_to_review_target?
-      @recent_audit = Audits::AuditService.new(@school).recent_audit
+      @last_audit = Audits::AuditService.new(@school).last_audit
       @suggest_estimates_for_fuel_types = suggest_estimates_for_fuel_types(check_data: true)
     end
   end

--- a/app/models/audit.rb
+++ b/app/models/audit.rb
@@ -49,6 +49,18 @@ class Audit < ApplicationRecord
     intervention_types.where(id: school.observations.intervention.where(at: created_at..).pluck(:intervention_type_id))
   end
 
+  def activity_types_remaining
+    activity_types - completed_activity_types
+  end
+
+  def intervention_types_remaining
+    intervention_types - completed_intervention_types
+  end
+
+  def tasks_remaining?
+    activity_types_remaining.any? || intervention_types_remaining.any?
+  end
+
   def activities_completed?
     activity_type_ids = activity_types.pluck(:id)
     return if activity_type_ids.empty?

--- a/app/services/audits/progress.rb
+++ b/app/services/audits/progress.rb
@@ -6,8 +6,14 @@ module Audits
       @audit = audit
     end
 
+    def recent?
+      audit.created_at > 1.year.ago
+    end
+
     def message
-      I18n.t('schools.prompts.audit.message_html',
+      i18n_key = recent? ? 'message_html' : 'message_older_html'
+
+      I18n.t("schools.prompts.audit.#{i18n_key}",
         completed_activities_count: completed_activities_count,
         total_activities_count: total_activities_count,
         completed_actions_count: completed_actions_count,
@@ -18,7 +24,7 @@ module Audits
     def summary
       I18n.t('schools.prompts.audit.summary_html',
         remaining_points: remaining_points,
-        bonus_points: bonus_points
+        count: bonus_points
       )
     end
 
@@ -43,11 +49,11 @@ module Audits
     end
 
     def remaining_activities_score
-      audit.activity_types.sum(&:score) - audit.completed_activity_types.sum(&:score)
+      audit.activity_types_remaining.sum(&:score)
     end
 
     def remaining_actions_score
-      audit.intervention_types.sum(&:score) - audit.completed_intervention_types.sum(&:score)
+      audit.intervention_types_remaining.sum(&:score)
     end
 
     def remaining_points

--- a/app/views/schools/_prompt_audit.html.erb
+++ b/app/views/schools/_prompt_audit.html.erb
@@ -1,9 +1,8 @@
-<% if local_assigns[:audit] %>
+<% if local_assigns[:audit] && audit&.tasks_remaining? %>
   <%= component 'info_bar',
-    status: :neutral,
-    style: local_assigns[:style],
-    title: Audits::Progress.new(audit).notification,
-    icon: fa_icon('fas fa-laptop fa-3x'),
-    buttons:  { t('common.labels.view_now') => school_audit_path(audit.school, audit) }
-  %>
+                status: :neutral,
+                style: local_assigns[:style],
+                title: Audits::Progress.new(audit).notification,
+                icon: fa_icon('fas fa-laptop fa-3x'),
+                buttons: { t('common.labels.view_now') => school_audit_path(audit.school, audit) } %>
 <% end %>

--- a/app/views/schools/show.html.erb
+++ b/app/views/schools/show.html.erb
@@ -29,8 +29,8 @@
   <%= render 'management/schools/prompt_training' %>
 <% end %>
 
-<% if @recent_audit %>
-  <%= render 'schools/prompt_audit', audit: @recent_audit %>
+<% if @last_audit %>
+  <%= render 'schools/prompt_audit', audit: @last_audit %>
 <% end %>
 
 <% if @add_targets %>

--- a/app/views/shared/navigation/second_nav/_my_school_menu.html.erb
+++ b/app/views/shared/navigation/second_nav/_my_school_menu.html.erb
@@ -34,11 +34,6 @@
       <% end %>
     <% end %>
 
-    <!-- Energy audits -->
-    <% if current_user_school.data_enabled? %>
-      <%= link_to t('my_school_menu.energy_audits'), school_audits_path(current_user_school), class: 'dropdown-item' %>
-    <% end %>
-
     <!-- Review targets -->
     <% if current_user_school.data_enabled? %>
       <% if Targets::SchoolTargetService.targets_enabled?(current_user_school) &&

--- a/app/views/shared/navigation/second_nav/_my_school_menu.html.erb
+++ b/app/views/shared/navigation/second_nav/_my_school_menu.html.erb
@@ -1,8 +1,13 @@
 <li class="nav-item dropdown" id="my-school-menu">
   <a class="nav-link dropdown-toggle" href="#" id="my_school" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"><%= t('my_school_menu.my_school') %></a>
   <div class="dropdown-menu" aria-labelledby="my_school">
-    <!--School -->
+    <!-- School -->
     <%= link_to current_user_school.name, school_path(current_user_school), class: 'dropdown-item' %>
+
+    <!-- Energy analysis -->
+    <% if current_user_school.data_enabled? %>
+      <%= link_to t('my_school_menu.energy_analysis'), school_advice_path(current_user_school), class: 'dropdown-item' %>
+    <% end %>
 
     <!-- Electricity, solar, gas and storage heater usage -->
     <% if current_user_school.data_enabled? %>
@@ -29,10 +34,9 @@
       <% end %>
     <% end %>
 
-    <!-- Energy analysis -->
+    <!-- Energy audits -->
     <% if current_user_school.data_enabled? %>
       <%= link_to t('my_school_menu.energy_audits'), school_audits_path(current_user_school), class: 'dropdown-item' %>
-      <%= link_to t('my_school_menu.energy_analysis'), school_advice_path(current_user_school), class: 'dropdown-item' %>
     <% end %>
 
     <!-- Review targets -->
@@ -46,17 +50,9 @@
         <% end %>
     <% end %>
 
-    <% if current_user_school&.school_group&.present? %>
-      <!-- Compare schools -->
-      <%= link_to t('schools.school_group.compare_schools'),
-                  "#{compare_index_path(school_group_ids: [current_user_school.school_group.id])}#groups", class: 'dropdown-item' %>
-    <% end %>
-
-    <!-- Complete pupil activities -->
-    <%= link_to t('my_school_menu.complete_pupil_activities'), activity_categories_path, class: 'dropdown-item' %>
-
-    <!-- Energy saving actions -->
-    <%= link_to t('my_school_menu.energy_saving_actions'), intervention_type_groups_path, class: 'dropdown-item' %>
+    <!-- Recommendations page link -->
+    <%= link_to t('my_school_menu.recommended_activities'),
+                school_recommendations_path(current_user_school), class: 'dropdown-item' %>
 
     <!-- School programmes -->
     <%= link_to t('my_school_menu.school_programmes'), programme_types_path, class: 'dropdown-item' %>
@@ -85,6 +81,13 @@
     <!-- My school group -->
     <% if current_user_school_group %>
       <%= link_to t('my_school_menu.my_school_group'), school_group_path(current_user_school_group),
+                  class: 'dropdown-item' %>
+    <% end %>
+
+    <% if current_user_school&.school_group&.present? %>
+      <!-- Compare schools -->
+      <%= link_to t('schools.school_group.compare_schools'),
+                  "#{compare_index_path(school_group_ids: [current_user_school.school_group.id])}#groups",
                   class: 'dropdown-item' %>
     <% end %>
   </div>

--- a/config/locales/views/schools/schools.yml
+++ b/config/locales/views/schools/schools.yml
@@ -339,7 +339,11 @@ en:
     prompts:
       audit:
         message_html: You have completed <strong>%{completed_activities_count}/%{total_activities_count}</strong> of the activities and <strong>%{completed_actions_count}/%{total_actions_count}</strong> of the actions from your recent energy audit
-        summary_html: Complete the others to score <strong>%{remaining_points}</strong> points and <strong>%{bonus_points}</strong> bonus points for completing all audit tasks
+        message_older_html: You have completed <strong>%{completed_activities_count}/%{total_activities_count}</strong> of the activities and <strong>%{completed_actions_count}/%{total_actions_count}</strong> of the actions from your energy audit
+        summary_html:
+          one: Complete the others to score <strong>%{remaining_points}</strong> points and <strong>%{count}</strong> bonus point for completing all audit tasks
+          other: Complete the others to score <strong>%{remaining_points}</strong> points and <strong>%{count}</strong> bonus points for completing all audit tasks
+          zero: Complete the others to score <strong>%{remaining_points}</strong> points for completing all audit tasks
       completed_programme:
         message_html:
           one: Well done, you've just completed the <strong>%{title}</strong> programme and have earned <strong>%{count}</strong> bonus point!

--- a/config/locales/views/shared/shared.yml
+++ b/config/locales/views/shared/shared.yml
@@ -92,6 +92,7 @@ en:
     my_alerts: My alerts
     my_school: My school
     my_school_group: My school group
+    recommended_activities: Recommended activities
     review_targets: Review targets
     school_programmes: School programmes
     scoreboard: Scoreboard

--- a/spec/components/adult_reminders_component_spec.rb
+++ b/spec/components/adult_reminders_component_spec.rb
@@ -417,8 +417,8 @@ RSpec.describe AdultRemindersComponent, :include_application_helper, :include_ur
       }
     end
 
-    context 'when there has been a recent audit' do
-      let!(:audit) { create(:audit, school: school) }
+    context 'when there has been an audit with unfinished tasks' do
+      let!(:audit) { create(:audit, :with_activity_and_intervention_types, school: school) }
 
       it {
         expect(html).to have_link(I18n.t('common.labels.view_now'),

--- a/spec/services/audits/progress_spec.rb
+++ b/spec/services/audits/progress_spec.rb
@@ -9,6 +9,22 @@ describe Audits::Progress, type: :service do
 
   subject(:service) { Audits::Progress.new(audit) }
 
+  context 'when the audit was created less than a year ago' do
+    let!(:audit) { create(:audit, :with_activity_and_intervention_types, school: school, created_at: 3.days.ago) }
+
+    describe '#notification' do
+      it { expect(service.notification).to include('recent') }
+    end
+  end
+
+  context 'when the audit was created over a year ago' do
+    let!(:audit) { create(:audit, :with_activity_and_intervention_types, school: school, created_at: 2.years.ago) }
+
+    describe '#notification' do
+      it { expect(service.notification).not_to include('recent') }
+    end
+  end
+
   context 'with no actions or activities completed' do
     describe '#notification' do
       it { expect(service.notification).to eq('You have completed <strong>0/3</strong> of the activities and <strong>0/3</strong> of the actions from your recent energy audit<br />Complete the others to score <strong>165</strong> points and <strong>50</strong> bonus points for completing all audit tasks') }
@@ -69,7 +85,7 @@ describe Audits::Progress, type: :service do
     end
   end
 
-  context 'with all activies completed' do
+  context 'with all activies completed (with no bonus points available)' do
     before do
       audit.activity_types.each do |activity_type|
         activity = build(:activity, school: school, activity_type: activity_type, happened_on: 2.days.ago)
@@ -78,7 +94,7 @@ describe Audits::Progress, type: :service do
     end
 
     describe '#notification' do
-      it { expect(service.notification).to eq('You have completed <strong>3/3</strong> of the activities and <strong>0/3</strong> of the actions from your recent energy audit<br />Complete the others to score <strong>90</strong> points and <strong>0</strong> bonus points for completing all audit tasks') }
+      it { expect(service.notification).to eq('You have completed <strong>3/3</strong> of the activities and <strong>0/3</strong> of the actions from your recent energy audit<br />Complete the others to score <strong>90</strong> points for completing all audit tasks') }
     end
   end
 end


### PR DESCRIPTION
**Changes since last review @ldodds**

Now removes the audit link from the my school menu.

Also makes a change to how the audit prompt works. On dashboards etc, we now consistently display the "last audit", rather than the "recent audit". This is displayed if there are still activities or actions left to complete for the audit.

This also changes the prompt text to only use the word "recent", when the audit was created in the last year. i.e.
`You have completed 0/4 of the activities and 0/5 of the actions from your **recent** energy audit
`
Otherwise it would be
`You have completed 0/4 of the activities and 0/5 of the actions from your energy audit
`

Also fixes the icon in the for the audit prompt on the new dashboard.
