### PR TITLE
New advice page nav bar design

### DIFF
--- a/app/assets/stylesheets/toggler.scss
+++ b/app/assets/stylesheets/toggler.scss
@@ -1,10 +1,10 @@
-.toggler.collapsed .fa-chevron-down,
-.toggler .fa-chevron-right {
+.toggler.collapsed .fa-chevron-up,
+.toggler .fa-chevron-down {
   display: none;
 }
 
-.toggler.collapsed .fa-chevron-right,
-.toggler .fa-chevron-down {
+.toggler.collapsed .fa-chevron-down,
+.toggler .fa-chevron-up {
   display: inline-block;
 }
 

--- a/app/components/page_nav_component.rb
+++ b/app/components/page_nav_component.rb
@@ -8,18 +8,24 @@ class PageNavComponent < ViewComponent::Base
 
   attr_reader :name, :icon, :classes, :href, :options
 
-  def initialize(name: 'Menu', icon: 'home', href:, classes: nil, options: {})
+  def initialize(name: 'Menu', icon: 'home', href:, classes: nil, user: nil, options: {})
     @name = name
     @icon = icon
     @classes = classes
     @href = href
     @options = options
+    @user = options[:user]
   end
 
   def header
     args = { class: 'nav-link border-bottom' }
     args[:class] += " #{classes}" if classes
-    link_to(helpers.text_with_icon(name, icon), href, args)
+    text = icon.nil? ? name : helpers.text_with_icon(name, icon)
+    link_to(text, href, args)
+  end
+
+  def component_classes
+    Flipper.enabled?(:new_dashboards_2024, @user) ? 'rounded' : 'border rounded'
   end
 
   class SectionComponent < ViewComponent::Base
@@ -30,12 +36,13 @@ class PageNavComponent < ViewComponent::Base
 
     attr_reader :name, :icon, :visible, :classes, :options
 
-    def initialize(name: nil, icon: nil, visible: true, classes: nil, options: {})
+    def initialize(name: nil, icon: nil, visible: true, toggler: true, classes: nil, options: {})
       @name = name
       @classes = classes
       @icon = icon
       @visible = visible
       @options = options
+      @toggler = toggler
     end
 
     def id
@@ -43,7 +50,7 @@ class PageNavComponent < ViewComponent::Base
     end
 
     def link_text
-      helpers.text_with_icon(name, icon) + content_tag(:span, helpers.toggler, class: 'pl-1 float-right')
+      helpers.text_with_icon(name, icon) + content_tag(:span, helpers.toggler, class: 'float-right')
     end
 
     def render?
@@ -51,7 +58,11 @@ class PageNavComponent < ViewComponent::Base
     end
 
     def call
-      args = { class: 'nav-link border-bottom small toggler', 'data-toggle': 'collapse', 'data-target': "##{id}" }
+      if @toggler
+        args = { class: 'nav-link border-bottom toggler', 'data-toggle': 'collapse', 'data-target': "##{id}" }
+      else
+        args = { class: '' }
+      end
       args[:class] += " #{classes}" if classes
       link_to(link_text, "##{id}", args)
     end
@@ -76,10 +87,12 @@ class PageNavComponent < ViewComponent::Base
     end
 
     def call
-      args = { class: 'nav-link border-bottom item small' }
+      args = { class: 'nav-link item' }
       args[:class] += " #{classes}" if classes
       args[:class] += ' current' if current_item?(href)
-      link_to(name, href, args)
+      link_to(href, args) do
+        content_tag(:span, name) + content
+      end
     end
 
     def render?

--- a/app/components/page_nav_component.rb
+++ b/app/components/page_nav_component.rb
@@ -8,7 +8,7 @@ class PageNavComponent < ViewComponent::Base
 
   attr_reader :name, :icon, :classes, :href, :options
 
-  def initialize(name: 'Menu', icon: 'home', href:, classes: nil, user: nil, options: {})
+  def initialize(name: 'Menu', icon: 'home', href:, classes: nil, options: {})
     @name = name
     @icon = icon
     @classes = classes

--- a/app/components/page_nav_component.rb
+++ b/app/components/page_nav_component.rb
@@ -90,9 +90,7 @@ class PageNavComponent < ViewComponent::Base
       args = { class: 'nav-link item' }
       args[:class] += " #{classes}" if classes
       args[:class] += ' current' if current_item?(href)
-      link_to(href, args) do
-        content_tag(:span, name) + content
-      end
+      link_to(name, href, args)
     end
 
     def render?

--- a/app/components/page_nav_component/page_nav_component.html.erb
+++ b/app/components/page_nav_component/page_nav_component.html.erb
@@ -1,4 +1,4 @@
-<div class="collapse d-md-flex border rounded page-nav-component" id="page-nav">
+<div class="page-nav-component collapse d-md-flex <%= component_classes %>" id="page-nav">
   <ul class="nav flex-column flex-nowrap w-100">
     <li class="nav-item header"><%= header %></li>
     <% sections.each do |section| %>

--- a/app/controllers/schools/advice/advice_base_controller.rb
+++ b/app/controllers/schools/advice/advice_base_controller.rb
@@ -23,6 +23,7 @@ module Schools
       before_action :set_data_warning, only: [:insights, :analysis]
       before_action :set_page_subtitle, only: [:insights, :analysis]
       before_action :set_breadcrumbs, only: [:insights, :analysis, :learn_more]
+      before_action :set_counts, only: [:insights, :analysis, :learn_more]
       before_action :set_insights_next_steps, only: [:insights]
       before_action :set_economic_tariffs_change_caveats, only: [:insights, :analysis]
 
@@ -78,6 +79,11 @@ module Schools
           { name: t('advice_pages.breadcrumbs.root'), href: school_advice_path(@school) },
           { name: @advice_page_title, href: advice_page_path(@school, @advice_page) },
         ]
+      end
+
+      def set_counts
+        @priority_count = @school.latest_management_priorities.count
+        @alert_count = @school.latest_dashboard_alerts.management_dashboard.count
       end
 
       def if_exists(key)

--- a/app/controllers/schools/advice_controller.rb
+++ b/app/controllers/schools/advice_controller.rb
@@ -11,7 +11,7 @@ module Schools
     before_action :school_inactive
     before_action :load_advice_pages
     before_action :set_tab_name
-    before_action :set_content
+    before_action :set_counts
     before_action :set_breadcrumbs
 
     def show
@@ -50,7 +50,7 @@ module Schools
       @advice_pages = AdvicePage.all
     end
 
-    def set_content
+    def set_counts
       @priority_count = latest_management_priorities.count
       @alert_count = latest_dashboard_alerts.count
     end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -457,7 +457,7 @@ module ApplicationHelper
   end
 
   def toggler
-    (fa_icon('chevron-down') + fa_icon('chevron-right')).html_safe
+    (fa_icon('chevron-up', class: 'fa-fw') + fa_icon('chevron-down', class: 'fa-fw')).html_safe
   end
 
   def text_with_icon(text, icon)

--- a/app/views/admin/procurement_routes/show.html.erb
+++ b/app/views/admin/procurement_routes/show.html.erb
@@ -7,13 +7,19 @@
     <div class="card-deck">
       <div class="card">
         <div class="card-body">
-          <div>Active meters <span class="float-right badge badge-success"><%= @procurement_route.meters.active.count %></span></div>
-          <div>Inactive meters <span class="float-right badge badge-secondary"><%= @procurement_route.meters.inactive.count %></span></div>
+          <div>Active meters <span class="float-right badge badge-success">
+            <%= @procurement_route.meters.active.count %></span>
+          </div>
+          <div>Inactive meters <span class="float-right badge badge-secondary">
+            <%= @procurement_route.meters.inactive.count %></span>
+          </div>
         </div>
       </div>
       <div class="card">
         <div class="card-body">
-          <div>Associated schools <span class="float-right badge badge-success"><%=  @procurement_route.schools.count %></span></div>
+          <div>Associated schools <span class="float-right badge badge-success">
+            <%= @procurement_route.schools.count %></span>
+          </div>
         </div>
       </div>
     </div>
@@ -22,13 +28,20 @@
 
 <div class="bg-light border rounded py-2 mb-2">
   <div class="col-12 clearfix">
-    <span data-toggle="collapse" href="#procurement-route" role="button" aria-expanded="true" aria-controls="procurement-route" class="badge badge-light toggler text-decoration-none collapsed">
-      <%= fa_icon("chevron-down") %><%= fa_icon("chevron-right") %>
+    <span data-toggle="collapse"
+          href="#procurement-route"
+          role="button" aria-expanded="true" aria-controls="procurement-route"
+          class="badge badge-light toggler text-decoration-none collapsed">
+      <%= fa_icon('chevron-down') %><%= fa_icon('chevron-up') %>
     </span>
     <span class='float-right'>
       <%= render 'email_report_button', procurement_route: @procurement_route, class: 'btn btn-sm' %>
-      <%= link_to 'Edit', edit_admin_procurement_route_path(@procurement_route), class: "btn btn-sm" %>
-      <%= link_to 'Delete', admin_procurement_route_path(@procurement_route), method: :delete, data: { confirm: 'Are you sure?' }, class: "btn btn-sm btn-danger" %>
+      <%= link_to 'Edit', edit_admin_procurement_route_path(@procurement_route), class: 'btn btn-sm' %>
+      <%= link_to 'Delete',
+                  admin_procurement_route_path(@procurement_route),
+                  method: :delete,
+                  data: { confirm: 'Are you sure?' },
+                  class: 'btn btn-sm btn-danger' %>
     </span>
   </div>
   <%= render 'procurement_route', procurement_route: @procurement_route %>

--- a/app/views/schools/advice/_nav.html.erb
+++ b/app/views/schools/advice/_nav.html.erb
@@ -2,17 +2,13 @@
   <%= component 'page_nav', name: t('advice_pages.nav.overview'),
                             icon: nil, href: school_advice_path(@school),
                             options: { user: current_user, match_controller: true } do |c| %>
-    <% c.with_section toggler: false, visible: @priority_count.positive? do |s| %>
-      <% s.with_item(name: t('advice_pages.index.alerts.title'),
-                     href: alerts_school_advice_path(@school), classes: 'border-bottom font-weight-normal') do |item| %>
-                     (<%= @priority_count %>)
-      <% end %>
-    <% end %>
     <% c.with_section toggler: false, visible: @alert_count.positive? do |s| %>
-      <% s.with_item(name: t('advice_pages.index.priorities.title'),
-                     href: priorities_school_advice_path(@school), classes: 'border-bottom font-weight-normal') do |item| %>
-                     (<%= @alert_count %>)
-      <% end %>
+      <% s.with_item(name: "#{t('advice_pages.index.alerts.title')} (#{@alert_count})",
+                     href: alerts_school_advice_path(@school), classes: 'border-bottom font-weight-normal') %>
+    <% end %>
+    <% c.with_section toggler: false, visible: @priority_count.positive? do |s| %>
+      <% s.with_item(name: "#{t('advice_pages.index.priorities.title')} (#{@priority_count})",
+                     href: priorities_school_advice_path(@school), classes: 'border-bottom font-weight-normal') %>
     <% end %>
     <% c.with_section(name: t('advice_pages.nav.sections.electricity'), icon: nil, classes: 'electric-section',
                       visible: @school.has_electricity?) do |s| %>

--- a/app/views/schools/advice/_nav.html.erb
+++ b/app/views/schools/advice/_nav.html.erb
@@ -1,31 +1,78 @@
-<%= component 'page_nav', name: t('advice_pages.nav.name'), icon: 'home', href: school_advice_path(@school),
-                          options: { match_controller: true } do |c| %>
-  <% c.with_section do |s| %>
-    <% s.with_item(name: t('advice_pages.nav.pages.total_energy_use'),
-                   href: school_advice_total_energy_use_path(@school)) %>
-  <% end %>
-  <% c.with_section(name: t('advice_pages.nav.sections.electricity'), icon: 'bolt', classes: 'electric-section',
-                    visible: @school.has_electricity?) do |s| %>
-    <% sort_by_label(advice_pages_for_school_and_fuel(advice_pages, @school, :electricity)).each do |ap| %>
-      <% s.with_item(name: translated_label(ap), href: advice_page_path(@school, ap), classes: 'electric-item') %>
+<% if Flipper.enabled?(:new_dashboards_2024, current_user) %>
+  <%= component 'page_nav', name: t('advice_pages.nav.overview'),
+                            icon: nil, href: school_advice_path(@school),
+                            options: { user: current_user, match_controller: true } do |c| %>
+    <% c.with_section toggler: false, visible: @priority_count.positive? do |s| %>
+      <% s.with_item(name: t('advice_pages.index.alerts.title'),
+                     href: alerts_school_advice_path(@school), classes: 'border-bottom font-weight-normal') do |item| %>
+                     (<%= @priority_count %>)
+      <% end %>
+    <% end %>
+    <% c.with_section toggler: false, visible: @alert_count.positive? do |s| %>
+      <% s.with_item(name: t('advice_pages.index.priorities.title'),
+                     href: priorities_school_advice_path(@school), classes: 'border-bottom font-weight-normal') do |item| %>
+                     (<%= @alert_count %>)
+      <% end %>
+    <% end %>
+    <% c.with_section(name: t('advice_pages.nav.sections.electricity'), icon: nil, classes: 'electric-section',
+                      visible: @school.has_electricity?) do |s| %>
+      <% sort_by_label(advice_pages_for_school_and_fuel(advice_pages, @school, :electricity)).each do |ap| %>
+        <% s.with_item(name: translated_label(ap), href: advice_page_path(@school, ap), classes: 'small') %>
+      <% end %>
+    <% end %>
+    <% c.with_section(name: t('advice_pages.nav.sections.gas'), icon: nil, classes: 'gas-section',
+                      visible: @school.has_gas?) do |s| %>
+      <% sort_by_label(advice_pages_for_school_and_fuel(advice_pages, @school, :gas)).each do |ap| %>
+        <% s.with_item(name: translated_label(ap), href: advice_page_path(@school, ap), classes: 'small') %>
+      <% end %>
+    <% end %>
+    <% c.with_section(name: t('advice_pages.nav.sections.storage_heater'), icon: nil,
+                      classes: 'storage-section', visible: @school.has_storage_heaters?) do |s| %>
+      <% sort_by_label(advice_pages.where(fuel_type: :storage_heater)).each do |ap| %>
+        <% s.with_item(name: translated_label(ap), href: advice_page_path(@school, ap), classes: 'small') %>
+      <% end %>
+    <% end %>
+    <% c.with_section(name: t('advice_pages.nav.sections.solar_pv'), icon: nil, classes: 'solar-section',
+                      visible: @school.has_electricity?) do |s| %>
+      <% sort_by_label(advice_pages.where(fuel_type: :solar_pv)).each do |ap| %>
+        <% s.with_item(name: translated_label(ap), href: advice_page_path(@school, ap), classes: 'small') %>
+      <% end %>
     <% end %>
   <% end %>
-  <% c.with_section(name: t('advice_pages.nav.sections.gas'), icon: 'fire', classes: 'gas-section',
-                    visible: @school.has_gas?) do |s| %>
-    <% sort_by_label(advice_pages_for_school_and_fuel(advice_pages, @school, :gas)).each do |ap| %>
-      <% s.with_item(name: translated_label(ap), href: advice_page_path(@school, ap), classes: 'gas-item') %>
+<% else %>
+  <%= component 'page_nav', name: t('advice_pages.nav.name'), icon: 'home', href: school_advice_path(@school),
+                            options: { match_controller: true } do |c| %>
+    <% c.with_section do |s| %>
+      <% s.with_item(name: t('advice_pages.nav.pages.total_energy_use'),
+                     href: school_advice_total_energy_use_path(@school)) %>
     <% end %>
-  <% end %>
-  <% c.with_section(name: t('advice_pages.nav.sections.storage_heater'), icon: 'window-maximize',
-                    classes: 'storage-section', visible: @school.has_storage_heaters?) do |s| %>
-    <% sort_by_label(advice_pages.where(fuel_type: :storage_heater)).each do |ap| %>
-      <% s.with_item(name: translated_label(ap), href: advice_page_path(@school, ap), classes: 'storage-item') %>
+    <% c.with_section(name: t('advice_pages.nav.sections.electricity'), icon: 'bolt', classes: 'electric-section',
+                      visible: @school.has_electricity?) do |s| %>
+      <% sort_by_label(advice_pages_for_school_and_fuel(advice_pages, @school, :electricity)).each do |ap| %>
+        <% s.with_item(name: translated_label(ap), href: advice_page_path(@school, ap),
+                       classes: 'border-bottom small electric-item') %>
+      <% end %>
     <% end %>
-  <% end %>
-  <% c.with_section(name: t('advice_pages.nav.sections.solar_pv'), icon: 'sun', classes: 'solar-section',
-                    visible: @school.has_electricity?) do |s| %>
-    <% sort_by_label(advice_pages.where(fuel_type: :solar_pv)).each do |ap| %>
-      <% s.with_item(name: translated_label(ap), href: advice_page_path(@school, ap), classes: 'solar-item') %>
+    <% c.with_section(name: t('advice_pages.nav.sections.gas'), icon: 'fire', classes: 'gas-section',
+                      visible: @school.has_gas?) do |s| %>
+      <% sort_by_label(advice_pages_for_school_and_fuel(advice_pages, @school, :gas)).each do |ap| %>
+        <% s.with_item(name: translated_label(ap), href: advice_page_path(@school, ap),
+                       classes: 'border-bottom small gas-item') %>
+      <% end %>
+    <% end %>
+    <% c.with_section(name: t('advice_pages.nav.sections.storage_heater'), icon: 'window-maximize',
+                      classes: 'storage-section', visible: @school.has_storage_heaters?) do |s| %>
+      <% sort_by_label(advice_pages.where(fuel_type: :storage_heater)).each do |ap| %>
+        <% s.with_item(name: translated_label(ap), href: advice_page_path(@school, ap),
+                       classes: 'border-bottom small storage-item') %>
+      <% end %>
+    <% end %>
+    <% c.with_section(name: t('advice_pages.nav.sections.solar_pv'), icon: 'sun', classes: 'solar-section',
+                      visible: @school.has_electricity?) do |s| %>
+      <% sort_by_label(advice_pages.where(fuel_type: :solar_pv)).each do |ap| %>
+        <% s.with_item(name: translated_label(ap), href: advice_page_path(@school, ap),
+                       classes: 'border-bottom small solar-item') %>
+      <% end %>
     <% end %>
   <% end %>
 <% end %>

--- a/config/locales/views/advice_pages/advice_pages.yml
+++ b/config/locales/views/advice_pages/advice_pages.yml
@@ -77,6 +77,7 @@ en:
     loading_data: Loading data...
     nav:
       name: Advice
+      overview: Overview
       pages:
         baseload: Baseload
         electricity_costs: Tariffs and costs

--- a/spec/components/page_nav_component_spec.rb
+++ b/spec/components/page_nav_component_spec.rb
@@ -29,6 +29,12 @@ RSpec.describe PageNavComponent, type: :component do
       it { expect(list_item).to have_link('Menu', href: 'link') }
       it { expect(list_item).to have_css('i.fa-home') }
     end
+
+    context 'with no icon' do
+      let(:header_params) { { href: 'link' } }
+
+      it { expect(list_item).to have_link('Menu', href: 'link') }
+    end
   end
 
   context 'Section' do
@@ -48,6 +54,12 @@ RSpec.describe PageNavComponent, type: :component do
       it { expect(list_item).to have_css('.bg-section') }
       it { expect(list_item).to have_css('.nav-link') }
       it { expect(list_item).to have_css('.toggler') }
+    end
+
+    context 'with toggling for section' do
+      let(:section_params) { { name: 'Section Name', toggler: false, visible: true, classes: 'bg-section' } }
+
+      it { expect(list_item).not_to have_css('.toggler') }
     end
 
     context 'with no name' do


### PR DESCRIPTION
Revises the nav bar shown on the advice page as shown in screenshot with new dashboard feature flag active

![Screenshot from 2024-09-03 16-37-37](https://github.com/user-attachments/assets/6b3e61a6-d0fc-4ced-93fc-08002ca68336)

Most of the changes are in the `_nav.html.erb` partial which swaps in a different nav if the feature flag is active. I've had to move some default classes from the `page_nav_component.html.erb` file into here to make it easier to alter the styling.

I've had to make a couple of additional changes to the component:

- add a `toggler` flag for sections to disable adding the bootstrap toggle behaviour which we won't need for the recent alerts and priority action menu items
- added conditional check for feature flag in the component to allow some classes in the template to be excluded. This can later be removed

The `AdviceBaseController` has been updated to ensure that the counts displayed in the navbar are always available.