### PR TITLE
Add sub headings to list of advice pages

### DIFF
--- a/app/components/advice_page_list_component/advice_page_list_component.html.erb
+++ b/app/components/advice_page_list_component/advice_page_list_component.html.erb
@@ -9,6 +9,9 @@
     <% section.with_body do %>
       <% advice_pages.display_fuel_types.keys.each_with_index do |fuel_type, idx| %>
         <% if display_advice_page?(school, fuel_type) %>
+          <h4>
+            <%= t("advice_pages.nav.sections.#{fuel_type}") %>
+          </h4>
           <% sort_by_label(advice_pages.where(fuel_type: fuel_type)).each do |ap| %>
             <%= component 'prompt',
                           icon: fuel_type_icon(fuel_type),

--- a/spec/components/advice_page_list_component_spec.rb
+++ b/spec/components/advice_page_list_component_spec.rb
@@ -57,6 +57,8 @@ RSpec.describe AdvicePageListComponent, :include_application_helper, :include_ur
         create(:school, :with_fuel_configuration, has_gas: false, has_solar_pv: false, has_storage_heaters: false)
       end
 
+      it { expect(html).to have_content(I18n.t('advice_pages.nav.sections.electricity')) }
+
       it_behaves_like 'a properly rended prompt' do
         let(:expected_path) { insights_school_advice_baseload_path(school) }
         let(:expected_page) { baseload }
@@ -71,6 +73,8 @@ RSpec.describe AdvicePageListComponent, :include_application_helper, :include_ur
 
     context 'when school has gas' do
       let(:school) { create(:school, :with_fuel_configuration, has_solar_pv: false, has_storage_heaters: false) }
+
+      it { expect(html).to have_content(I18n.t('advice_pages.nav.sections.gas')) }
 
       it_behaves_like 'a properly rended prompt' do
         let(:expected_path) { insights_school_advice_heating_control_path(school) }
@@ -87,6 +91,8 @@ RSpec.describe AdvicePageListComponent, :include_application_helper, :include_ur
     context 'when school has storage heaters' do
       let(:school) { create(:school, :with_fuel_configuration, has_solar_pv: false, has_gas: false) }
 
+      it { expect(html).to have_content(I18n.t('advice_pages.nav.sections.storage_heater')) }
+
       it_behaves_like 'a properly rended prompt' do
         let(:expected_path) { insights_school_advice_storage_heaters_path(school) }
         let(:expected_page) { storage_heaters }
@@ -101,6 +107,8 @@ RSpec.describe AdvicePageListComponent, :include_application_helper, :include_ur
 
     context 'when school has solar' do
       let(:school) { create(:school, :with_fuel_configuration, has_storage_heaters: false, has_gas: false) }
+
+      it { expect(html).to have_content(I18n.t('advice_pages.nav.sections.solar_pv')) }
 
       it_behaves_like 'a properly rended prompt' do
         let(:expected_path) { insights_school_advice_baseload_path(school) }


### PR DESCRIPTION
Adds sub-headings back into the list of advice pages shown on the page index.

![Screenshot from 2024-09-05 14-36-34](https://github.com/user-attachments/assets/76e82279-c93d-4f1b-827c-5592ec394c85)
