### PR TITLE
Fix 'pupil-lead' typos

### DIFF
--- a/config/locales/mailers/mailer.yml
+++ b/config/locales/mailers/mailer.yml
@@ -112,7 +112,7 @@ en:
       header: "%{school_name} is now live on Energy Sparks"
       join_a_webinar: Join a webinar
       need_some_help: Need some help?
-      paragraph_1_html: You can now use Energy Sparks to begin recording your energy saving activities. Explore our pupil-lead <strong><a href="%{activity_categories_url}">activities and educational resources</a></strong>which are designed to teach your pupils about energy whilst saving money for their school.
+      paragraph_1_html: You can now use Energy Sparks to begin recording your energy saving activities. Explore our pupil-led <strong><a href="%{activity_categories_url}">activities and educational resources</a></strong>which are designed to teach your pupils about energy whilst saving money for their school.
       paragraph_2_html: We also have a range of <strong><a href="%{intervention_type_groups_url}">energy saving actions</a></strong> that you, other members of staff and volunteers can carry out to start improving you energy usage.
       paragraph_3_html: View your <a href="%{school_url}">school dashboard</a> for suggestions for how to get started.
       paragraph_4: We will be in touch shortly to confirm when we have completed getting access to your energy data.
@@ -144,7 +144,7 @@ en:
       get_in_touch_message_html: <a href="%{contact_url}">Get in touch</a> if you have any further questions.
       join_a_webinar: Join a webinar
       need_some_help: Need some help?
-      paragraph_1_html: While waiting you can use Energy Sparks to begin recording your energy saving activities. Explore our pupil-lead <strong><a href="%{activity_categories_url}">activities and educational resources</a></strong> which are designed to teach your pupils about energy whilst saving money for their school.
+      paragraph_1_html: While waiting you can use Energy Sparks to begin recording your energy saving activities. Explore our pupil-led <strong><a href="%{activity_categories_url}">activities and educational resources</a></strong> which are designed to teach your pupils about energy whilst saving money for their school.
       paragraph_2_html: We also have a range of <strong><a href="%{intervention_type_groups_url}">energy saving actions</a></strong> that you, other members of staff and volunteers can carry out to start improving you energy usage.
       paragraph_3_html: View your <strong><a href="%{school_url}">school dashboard</a></strong> for suggestions for how to get started.
       paragraph_4_html: For help using Energy Sparks please read our <a href="https://energysparks.uk/resources/12/download">User Guide</a>, watch our <a href="%{user_guide_videos_url}">Training Videos</a> or join one of our <a href="%{training_url}">live webinar training</a> sessions.

--- a/config/locales/views/schools/schools.yml
+++ b/config/locales/views/schools/schools.yml
@@ -71,7 +71,7 @@ en:
         actions_message_1_html: Add any number of adult energy saving actions. The full list can be explored from the public <a href='%{intervention_type_groups_path}'>energy saving action pages</a>
         actions_message_2: To add a custom action, choose "Other" from the appropriate category and include some notes for the user
         activities: Activities
-        activities_message_html: Add any number of pupil-lead activities. The full list can be explored from the public <a href='%{activity_categories_path}'>activity pages</a>
+        activities_message_html: Add any number of pupil-led activities. The full list can be explored from the public <a href='%{activity_categories_path}'>activity pages</a>
         activity_type: Activity Type
         add_a_custom_activity_message: To add a custom activity, choose "Other" from the appropriate category and include some notes for the user
         add_action: Add action
@@ -103,7 +103,7 @@ en:
           one: point
           other: points
         recommended_energy_saving_actions: Recommended energy saving actions
-        recommended_pupil_lead_activities: Recommended pupil-lead activities
+        recommended_pupil_lead_activities: Recommended pupil-led activities
         title: "%{school_name} Audits - %{audit_title}"
         view_all_audits: View all audits
         visibility_note_html: "<strong>Note</strong>: this audit is not visible to users"
@@ -161,7 +161,7 @@ en:
       reminders:
         title: Reminders
       timeline:
-        intro: A list of recent adult and pupil-lead activities at this school
+        intro: A list of recent adult and pupil-led activities at this school
     downloads:
       index:
         aggregated_meter_collection: Aggregated meter collection


### PR DESCRIPTION
Remove several typos. "Pupil-lead" should be "Pupil-led". Spotted on new dashboard text but found other examples.