### PR TITLE
Rework pupil explore blocks

### DIFF
--- a/app/components/pupil_explore_component.rb
+++ b/app/components/pupil_explore_component.rb
@@ -39,7 +39,9 @@ class PupilExploreComponent < ApplicationComponent
     end
 
     def call
-      link_to @link_text, pupils_school_analysis_path(@school, category: @category)
+      link_to @link_text,
+              pupils_school_analysis_path(@school, category: @category),
+              class: 'stretched-link'
     end
   end
 
@@ -52,7 +54,9 @@ class PupilExploreComponent < ApplicationComponent
     end
 
     def call
-      link_to @link_text, pupils_school_analysis_tab_path(@school, @config)
+      link_to @link_text,
+              pupils_school_analysis_tab_path(@school, @config),
+              class: 'stretched-link'
     end
 
     def render?
@@ -70,7 +74,9 @@ class PupilExploreComponent < ApplicationComponent
     end
 
     def call
-      link_to @link_text, school_usage_path(@school, { supply: @supply || @fuel_type }.merge(@config))
+      link_to @link_text,
+              school_usage_path(@school, { supply: @supply || @fuel_type }.merge(@config)),
+              class: 'stretched-link'
     end
   end
 end

--- a/app/components/pupil_explore_component/pupil_explore_component.html.erb
+++ b/app/components/pupil_explore_component/pupil_explore_component.html.erb
@@ -1,23 +1,19 @@
 <div id="<%= id %>" class="pupil-explore-component col-12 col-md-4 <%= classes %>">
   <div class="h-100 mb-2 rounded <%= fuel_type_background_class(fuel_type) %>">
-    <div class="row p-4">
-      <div class="col">
-        <div class="row">
-          <div class="col">
-            <h3>
-              <%= component 'icon', name: icon, icon_set: icon_set, style: :circle, size: 'f3' %>
-            </h3>
-          </div>
-        </div>
-        <div class="row">
-          <div class="col">
-            <h3>
-              <%= link %>
-            </h3>
-            <% if note? %>
-              <%= note %>
-            <% end %>
-          </div>
+    <div class="row pt-4 pl-4 pr-4">
+      <div class="col-2 d-none d-md-block">
+        <h4>
+          <%= component 'icon', name: icon, icon_set: icon_set, style: :circle, size: 'f4' %>
+        </h4>
+      </div>
+      <div class="col-12 col-xl-10 d-md-flex flex-wrap justify-items-center align-items-center">
+        <div>
+          <h3>
+            <%= link %>
+          </h3>
+          <% if note? %>
+            <%= note %>
+          <% end %>
         </div>
       </div>
     </div>


### PR DESCRIPTION
![Screenshot from 2024-09-05 16-42-36](https://github.com/user-attachments/assets/03eee561-cb0c-4fe8-93b0-507510b3889f)

Reworks the pupil explore component to make the display more compact:

- uses 2 columns for icon and text rather than 2 rows as per original design
- reduce icon size
- reduce padding
- improve responsiveness, hiding icons on small screens
- increase size of link area using bootstrap `stretched-link` class which was used on the old version.