### PR TITLE
Add link highlighting for new advice page nav links

### DIFF
--- a/app/components/page_nav_component.rb
+++ b/app/components/page_nav_component.rb
@@ -2,7 +2,8 @@
 
 class PageNavComponent < ViewComponent::Base
   renders_many :sections, ->(**args) do
-    args[:options] = options
+    args[:options] ||= {}
+    args[:options] = options.merge(args[:options])
     SectionComponent.new(**args)
   end
 

--- a/app/components/page_nav_component/page_nav_component.scss
+++ b/app/components/page_nav_component/page_nav_component.scss
@@ -3,7 +3,12 @@
 }
 
 .page-nav-component a.nav-link.current {
-  font-weight: bolder;
+  font-weight: bolder !important;
+}
+
+.page-nav-component a.nav-link.section-link {
+  border-bottom: 1px solid #dee2e6 !important; // bootstrap border-bottom default
+  font-weight: normal;
 }
 
 @each $tag, $colour in $fuel-colours-light {

--- a/app/views/schools/advice/_nav.html.erb
+++ b/app/views/schools/advice/_nav.html.erb
@@ -2,19 +2,24 @@
   <%= component 'page_nav', name: t('advice_pages.nav.overview'),
                             icon: nil, href: school_advice_path(@school),
                             options: { user: current_user, match_controller: true } do |c| %>
-    <% c.with_section toggler: false, visible: @alert_count.positive? do |s| %>
+    <% c.with_section toggler: false, visible: @alert_count.positive?,
+                      options: { match_controller: false } do |s| %>
       <% s.with_item(name: "#{t('advice_pages.index.alerts.title')} (#{@alert_count})",
-                     href: alerts_school_advice_path(@school), classes: 'border-bottom font-weight-normal') %>
+                     href: alerts_school_advice_path(@school), classes: 'section-link') %>
     <% end %>
-    <% c.with_section toggler: false, visible: @priority_count.positive? do |s| %>
+    <% c.with_section toggler: false,
+                      visible: @priority_count.positive?,
+                      options: { match_controller: false }  do |s| %>
       <% s.with_item(name: "#{t('advice_pages.index.priorities.title')} (#{@priority_count})",
-                     href: priorities_school_advice_path(@school), classes: 'border-bottom font-weight-normal') %>
+                     href: priorities_school_advice_path(@school),
+                     classes: 'section-link') %>
     <% end %>
 
     <% c.with_section toggler: false,
-                      visible: Targets::SchoolTargetService.targets_enabled?(school) && can?(:manage, SchoolTarget) do |s| %>
+                      visible: Targets::SchoolTargetService.targets_enabled?(school) && can?(:manage, SchoolTarget),
+                      options: { match_controller: false } do |s| %>
       <% s.with_item(name: t('manage_school_menu.review_targets'),
-                     href: school_school_targets_path(school), classes: 'border-bottom font-weight-normal') %>
+                     href: school_school_targets_path(school), classes: 'section-link') %>
     <% end %>
 
     <% c.with_section(name: t('advice_pages.nav.sections.electricity'), icon: nil, classes: 'electric-section',


### PR DESCRIPTION
The link highlighting wasn't working for the new alerts and priorities link in the advice nav.

This involved:

- making the `current` class force bold when active
- allowing the sections to override options provided from the main page nav component
- declaring `match_controller: false` on the sections

Also moved some of the classes specified on the items into the SCSS. Couldn't find a suitable bootstrap var to declare the border-bottom.