### PR TITLE
Wrap partner logos in grey background

### DIFF
--- a/app/views/layouts/dashboards.html.erb
+++ b/app/views/layouts/dashboards.html.erb
@@ -15,7 +15,11 @@
     <%= yield %>
 
     <% if show_partner_footer?(@school) %>
-      <%= render 'shared/partners' %>
+      <div class="container-fluid bg-light ">
+        <div class="container">
+          <%= render 'shared/partners' %>
+        </div>
+      </div>
     <% end %>
     <%= render 'shared/cookie_banner' %>
     <%= render 'shared/footer' %>

--- a/app/views/layouts/dashboards.html.erb
+++ b/app/views/layouts/dashboards.html.erb
@@ -15,7 +15,7 @@
     <%= yield %>
 
     <% if show_partner_footer?(@school) %>
-      <div class="container-fluid bg-light ">
+      <div class="container-fluid bg-light">
         <div class="container">
           <%= render 'shared/partners' %>
         </div>


### PR DESCRIPTION
The new dashboards and advice page index have a full-width grey background section for the bottom of the page.

However the partner logos, that acknowledge sponsorship of schools using  Energy Sparks, are not in a similar section so we end up with a white space between the grey background and the footer.

This fixes the problem by updating the dashboard layout. 