### PR TITLE
Remove 'Recorded ' prefix in descriptions

### DIFF
--- a/config/locales/views/components/observation.yml
+++ b/config/locales/views/components/observation.yml
@@ -8,9 +8,9 @@ en:
           other: <a href="%{school_path}">%{school}</a> scored <strong>%{count} points</strong> after they recorded "<a href="%{compact_path}">%{target}</a>"
           zero: <a href="%{school_path}">%{school}</a> recorded "<a href="%{compact_path}">%{target}</a>"
         description_html:
-          one: Recorded "<a href="%{compact_path}">%{target}</a>"
-          other: Recorded "<a href="%{compact_path}">%{target}</a>"
-          zero: Recorded "<a href="%{compact_path}">%{target}</a>"
+          one: <a href="%{compact_path}">%{target}</a>
+          other: <a href="%{compact_path}">%{target}</a>
+          zero: <a href="%{compact_path}">%{target}</a>
         message: Completed an activity
       audit:
         compact_message_html: <a href="%{school_path}">%{school}</a> <a href="%{compact_path}">received an energy audit</a>
@@ -32,9 +32,9 @@ en:
           other: <a href="%{school_path}">%{school}</a> scored <strong>%{count} points</strong> after they recorded "<a href="%{compact_path}">%{message}</a>"
           zero: <a href="%{school_path}">%{school}</a> recorded "<a href="%{compact_path}">%{message}</a>"
         description_html:
-          one: Recorded "<a href="%{compact_path}">%{message}</a>"
-          other: Recorded "<a href="%{compact_path}">%{message}</a>"
-          zero: Recorded "<a href="%{compact_path}">%{message}</a>"
+          one: <a href="%{compact_path}">%{message}</a>
+          other: <a href="%{compact_path}">%{message}</a>
+          zero: <a href="%{compact_path}">%{message}</a>
       programme:
         compact_message_html:
           one: <a href="%{school_path}">%{school}</a> scored <strong>%{count} point</strong> after they <a href="%{compact_path}">completed a programme</a>

--- a/spec/components/observation_component_spec.rb
+++ b/spec/components/observation_component_spec.rb
@@ -58,7 +58,6 @@ RSpec.describe ObservationComponent, type: :component, include_url_helpers: true
       let(:style) { :description }
 
       it { expect(html).to have_css('i.fa-clipboard-check') }
-      it { expect(html).to have_content("Recorded \"#{observation.activity.display_name}\"") }
       it { expect(html).to have_link(observation.activity.display_name, href: school_activity_path(observation.school, observation.activity)) }
     end
   end
@@ -153,7 +152,6 @@ RSpec.describe ObservationComponent, type: :component, include_url_helpers: true
       let(:style) { :description }
 
       it { expect(html).to have_css("i.fa-#{observation.intervention_type.intervention_type_group.icon}") }
-      it { expect(html).to have_content("Recorded \"#{observation.intervention_type.name}\"") }
       it { expect(html).to have_link(observation.intervention_type.name, href: school_intervention_path(observation.school, observation)) }
     end
   end

--- a/spec/components/scoreboard_activity_component_spec.rb
+++ b/spec/components/scoreboard_activity_component_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe ScoreboardActivityComponent, :include_url_helpers, type: :compone
                                     '1st',
                                     other_school.name,
                                     '10',
-                                    "Recorded \"#{activity.display_name}\""
+                                    activity.display_name
                                   ])
   end
 
@@ -54,7 +54,7 @@ RSpec.describe ScoreboardActivityComponent, :include_url_helpers, type: :compone
       expect(html).to have_selector(:table_row, [
                                       other_school.name,
                                       '10',
-                                      "Recorded \"#{activity.display_name}\""
+                                      activity.display_name
                                     ])
     end
   end

--- a/spec/components/timeline_component_spec.rb
+++ b/spec/components/timeline_component_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe TimelineComponent, type: :component, include_url_helpers: true do
     it { expect(html).to have_content(I18n.t('schools.dashboards.timeline.intro'))}
     it { expect(html).to have_link(I18n.t('activities.show.all_activities')), href: school_timeline_path(school)}
 
-    it { expect(html).to have_selector(:table_row, [observation.at.to_fs(:es_short), observation.points, "Recorded \"#{observation.activity.display_name}\""])}
+    it { expect(html).to have_selector(:table_row, [observation.at.to_fs(:es_short), observation.points, observation.activity.display_name])}
 
     it { expect(html).to have_link(observation.activity.display_name, href: school_activity_path(observation.school, observation.activity)) }
   end


### PR DESCRIPTION
Remove some text prefixing activity and intervention descriptions as this looks repetitive when displayed on school dashboards.