### PR TITLE
Fix type and missing close tag

### DIFF
--- a/app/components/dashboard_learn_more_component/dashboard_learn_more_component.html.erb
+++ b/app/components/dashboard_learn_more_component/dashboard_learn_more_component.html.erb
@@ -30,4 +30,5 @@
         </div>
      <% end %>
     <% end %>
+  </div>
 </div>

--- a/app/views/schools/new_show.html.erb
+++ b/app/views/schools/new_show.html.erb
@@ -46,6 +46,5 @@
                   classes: 'mt-4' %>
 
     <%= component 'dashboard_login', school: @school, user: current_user %>
-
   </div>
 </div>

--- a/config/locales/views/advice_pages/index.yml
+++ b/config/locales/views/advice_pages/index.yml
@@ -21,7 +21,7 @@ en:
         how_do_you_compare: How does your school compare?
         intro_html: |-
           <a href="#overview-charts">Review overview charts</a>, explore <a href="#detailed-analysis">our detailed analysis</a>,
-          get <a href="#whats-next">start reducing energy use</a> and see how you <a href="#comparison">compare against other schools</a>
+          <a href="#whats-next">start reducing energy use</a> and see how you <a href="#comparison">compare against other schools</a>
         not_applicable: No comparison
         not_available: Not enough data
         notice_html: |-


### PR DESCRIPTION
Fix typo in advice page index text

Add missing `</div>` tag to learn more component, which was breaking the footer.