### PR TITLE
Ensure navbar vars are populated

### DIFF
--- a/app/controllers/schools/advice/advice_base_controller.rb
+++ b/app/controllers/schools/advice/advice_base_controller.rb
@@ -18,12 +18,12 @@ module Schools
       before_action :check_authorisation, only: [:insights, :analysis, :learn_more]
       before_action :load_recommendations, only: [:insights]
       before_action :set_page_title, only: [:insights, :analysis, :learn_more]
+      before_action :set_counts, only: [:insights, :analysis, :learn_more]
       before_action :check_has_fuel_type, only: [:insights, :analysis]
       before_action :check_can_run_analysis, only: [:insights, :analysis]
       before_action :set_data_warning, only: [:insights, :analysis]
       before_action :set_page_subtitle, only: [:insights, :analysis]
       before_action :set_breadcrumbs, only: [:insights, :analysis, :learn_more]
-      before_action :set_counts, only: [:insights, :analysis, :learn_more]
       before_action :set_insights_next_steps, only: [:insights]
       before_action :set_economic_tariffs_change_caveats, only: [:insights, :analysis]
 

--- a/app/views/schools/advice/_nav.html.erb
+++ b/app/views/schools/advice/_nav.html.erb
@@ -2,13 +2,13 @@
   <%= component 'page_nav', name: t('advice_pages.nav.overview'),
                             icon: nil, href: school_advice_path(@school),
                             options: { user: current_user, match_controller: true } do |c| %>
-    <% c.with_section toggler: false, visible: @alert_count.positive?,
+    <% c.with_section toggler: false, visible: @alert_count&.positive?,
                       options: { match_controller: false } do |s| %>
       <% s.with_item(name: "#{t('advice_pages.index.alerts.title')} (#{@alert_count})",
                      href: alerts_school_advice_path(@school), classes: 'section-link') %>
     <% end %>
     <% c.with_section toggler: false,
-                      visible: @priority_count.positive?,
+                      visible: @priority_count&.positive?,
                       options: { match_controller: false }  do |s| %>
       <% s.with_item(name: "#{t('advice_pages.index.priorities.title')} (#{@priority_count})",
                      href: priorities_school_advice_path(@school),

--- a/spec/system/schools/advice_pages/advice_pages_spec.rb
+++ b/spec/system/schools/advice_pages/advice_pages_spec.rb
@@ -64,6 +64,18 @@ RSpec.describe 'advice pages', type: :system do
       allow_any_instance_of(Schools::Advice::AdviceBaseController).to receive(:create_analysable).and_return(analysable)
     end
 
+    context 'with new feature active' do
+      before do
+        Flipper.enable(:new_dashboards_2024)
+      end
+
+      it 'shows the not enough data page' do
+        visit insights_school_advice_total_energy_use_path(school)
+        expect(page).to have_content('Not enough data to run analysis')
+        expect(page).not_to have_content('Assuming we continue to regularly receive data')
+      end
+    end
+
     it 'shows the not enough data page' do
       visit school_advice_path(school)
       within '#page-nav' do

--- a/spec/system/schools/advice_pages/advice_pages_spec.rb
+++ b/spec/system/schools/advice_pages/advice_pages_spec.rb
@@ -24,6 +24,18 @@ RSpec.describe 'advice pages', type: :system do
         expect(page).to have_content('Sorry, something has gone wrong')
         expect(page).to have_content('We encountered an error attempting to generate your analysis')
       end
+
+      context 'with feature active' do
+        before do
+          Flipper.enable(:new_dashboards_2024)
+        end
+
+        it 'shows the error page' do
+          visit learn_more_school_advice_total_energy_use_path(school)
+          expect(page).to have_content('Sorry, something has gone wrong')
+          expect(page).to have_content('We encountered an error attempting to generate your analysis')
+        end
+      end
     end
 
     context 'in test' do
@@ -48,6 +60,17 @@ RSpec.describe 'advice pages', type: :system do
         click_on 'Energy use summary'
       end
       expect(page).to have_content('Unable to run requested analysis')
+    end
+
+    context 'with feature active' do
+      before do
+        Flipper.enable(:new_dashboards_2024)
+      end
+
+      it 'shows the error page' do
+        visit insights_school_advice_total_energy_use_path(school)
+        expect(page).to have_content('Unable to run requested analysis')
+      end
     end
   end
 


### PR DESCRIPTION
The revised advice page nav has some extra variables. These weren't being populated when the school either didn't have the right fuel type for the page or not enough data.

This change ensures the variables are populated earlier in the request cycle and makes the template tolerant to missing vars.