### PR TITLE
Dont show links to meter comparison advice pages if only a single meter

### DIFF
--- a/app/components/advice_page_list_component/advice_page_list_component.html.erb
+++ b/app/components/advice_page_list_component/advice_page_list_component.html.erb
@@ -12,7 +12,7 @@
           <h4>
             <%= t("advice_pages.nav.sections.#{fuel_type}") %>
           </h4>
-          <% sort_by_label(advice_pages.where(fuel_type: fuel_type)).each do |ap| %>
+          <% sort_by_label(advice_pages_for_school_and_fuel(advice_pages, school, fuel_type)).each do |ap| %>
             <%= component 'prompt',
                           icon: fuel_type_icon(fuel_type),
                           style: :compact,

--- a/app/helpers/advice_page_helper.rb
+++ b/app/helpers/advice_page_helper.rb
@@ -144,7 +144,7 @@ module AdvicePageHelper
   end
 
   def advice_pages_for_school_and_fuel(advice_pages, school, fuel_type)
-    if school.multiple_meters?(fuel_type) && Flipper.enabled?(:meter_breakdowns, current_user)
+    if school.multiple_meters?(fuel_type)
       advice_pages.where(fuel_type: fuel_type)
     else
       advice_pages.where(fuel_type: fuel_type, multiple_meters: false)

--- a/spec/components/advice_page_list_component_spec.rb
+++ b/spec/components/advice_page_list_component_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe AdvicePageListComponent, :include_application_helper, :include_ur
   let!(:heating_control) { create(:advice_page, key: :heating_control, fuel_type: 'gas') }
   let!(:solar_pv) { create(:advice_page, key: :solar_pv, fuel_type: 'solar_pv') }
   let!(:storage_heaters) { create(:advice_page, key: :storage_heaters, fuel_type: 'storage_heater') }
+  let!(:electricity_meter_breakdown) { create(:advice_page, key: :electricity_meter_breakdown, multiple_meters: true) }
 
   shared_examples 'a properly rended prompt' do
     let(:expected_summary) { nil }
@@ -68,6 +69,16 @@ RSpec.describe AdvicePageListComponent, :include_application_helper, :include_ur
         let(:expected_path) { insights_school_advice_solar_pv_path(school) }
         let(:expected_summary) { 'solar_pv.no_solar' }
         let(:expected_page) { solar_pv }
+      end
+
+      it { expect(html).to have_no_content(I18n.t("advice_pages.nav.pages.#{electricity_meter_breakdown.key}")) }
+
+      context 'with multiple meters' do
+        before do
+          create_list(:electricity_meter, 2, school: school)
+        end
+
+        it { expect(html).to have_content(I18n.t("advice_pages.nav.pages.#{electricity_meter_breakdown.key}")) }
       end
     end
 


### PR DESCRIPTION
Fixes an existing issue with the advice index page. 

The advice nav bar is only showing links to the meter comparison pages if a school has multiple gas or electricity meters. However the in-page list is still showing the links.

Fixes the component so that it uses the same helper method as the navbar