### PR TITLE
Schools with limited gas data have failing out of hours analysis

### DIFF
--- a/app/controllers/schools/advice/base_out_of_hours_controller.rb
+++ b/app/controllers/schools/advice/base_out_of_hours_controller.rb
@@ -24,7 +24,7 @@ module Schools
         render 'not_enough_data' and return unless @analysable.enough_data?
         @analysis_dates = analysis_dates
         @annual_usage_breakdown = annual_usage_breakdown_service.usage_breakdown
-        render 'schools/advice/out_of_hours/no_usage' and return if @annual_usage_breakdown&.out_of_hours.kwh.zero?
+        render 'schools/advice/out_of_hours/no_usage' and return if @annual_usage_breakdown&.out_of_hours&.kwh&.zero?
       end
 
       def aggregate_meter

--- a/app/controllers/schools/advice/base_out_of_hours_controller.rb
+++ b/app/controllers/schools/advice/base_out_of_hours_controller.rb
@@ -6,12 +6,14 @@ module Schools
       def insights
         @annual_usage_breakdown = annual_usage_breakdown_service.usage_breakdown
         @benchmarked_usage = benchmark_school(@annual_usage_breakdown)
+        @analysis_dates = analysis_dates
         unless @analysis_dates.one_years_data?
           @well_managed_percent = benchmark_value(:benchmark_school)
         end
       end
 
       def analysis
+        @analysis_dates = analysis_dates
         @annual_usage_breakdown = annual_usage_breakdown_service.usage_breakdown
         @holiday_usage = holiday_usage_calculation_service.school_holiday_calendar_comparison
         @meter_selection = Charts::MeterSelection.new(@school, aggregate_school, advice_page_fuel_type, date_window: 363)

--- a/app/controllers/schools/advice/base_out_of_hours_controller.rb
+++ b/app/controllers/schools/advice/base_out_of_hours_controller.rb
@@ -6,7 +6,6 @@ module Schools
       def insights
         @annual_usage_breakdown = annual_usage_breakdown_service.usage_breakdown
         @benchmarked_usage = benchmark_school(@annual_usage_breakdown)
-        @analysis_dates = analysis_dates
         unless @analysis_dates.one_years_data?
           @well_managed_percent = benchmark_value(:benchmark_school)
         end
@@ -15,11 +14,18 @@ module Schools
       def analysis
         @annual_usage_breakdown = annual_usage_breakdown_service.usage_breakdown
         @holiday_usage = holiday_usage_calculation_service.school_holiday_calendar_comparison
-        @analysis_dates = analysis_dates
         @meter_selection = Charts::MeterSelection.new(@school, aggregate_school, advice_page_fuel_type, date_window: 363)
       end
 
       private
+
+      def check_can_run_analysis
+        @analysable = create_analysable
+        render 'not_enough_data' and return unless @analysable.enough_data?
+        @analysis_dates = analysis_dates
+        @annual_usage_breakdown = annual_usage_breakdown_service.usage_breakdown
+        render 'schools/advice/out_of_hours/no_usage' and return if @annual_usage_breakdown&.out_of_hours.kwh.zero?
+      end
 
       def aggregate_meter
         aggregate_school.aggregate_meter(advice_page_fuel_type)

--- a/app/views/schools/advice/out_of_hours/no_usage.html.erb
+++ b/app/views/schools/advice/out_of_hours/no_usage.html.erb
@@ -1,0 +1,15 @@
+<%= render 'schools/advice/advice_page',
+           school: @school,
+           advice_pages: @advice_pages,
+           advice_page: @advice_page,
+           tab: @tab,
+           data_warning: @data_warning do %>
+  <h2>
+    <%= t('advice_pages.no_usage.title') %>
+  </h2>
+  <p>
+    <%= t('advice_pages.no_usage.message',
+          date: short_dates(@analysis_dates.start_date),
+          fuel_type: I18n.t("common.#{@advice_page.fuel_type}")) %>
+  </p>
+<% end %>

--- a/config/locales/views/advice_pages/advice_pages.yml
+++ b/config/locales/views/advice_pages/advice_pages.yml
@@ -106,6 +106,9 @@ en:
       message: We don't currently have %{fuel_type} data for your school, so are unable to run this analysis
       title: Unable to run requested analysis
     no_recent_data: no recent data
+    no_usage:
+      message: Our data shows that since %{date} your school has not used any %{fuel_type} out of hours. At present we are unable to provide further analysis.
+      title: No usage to report
     not_enough_data:
       available_from: Assuming we continue to regularly receive data we expect this analysis to be available after %{available_from}.
       learn_more_html: In the meantime you can <a href="%{learn_more_link}">learn more</a> about this topic.

--- a/spec/system/schools/advice_pages/gas_out_of_hours_spec.rb
+++ b/spec/system/schools/advice_pages/gas_out_of_hours_spec.rb
@@ -44,6 +44,24 @@ RSpec.describe 'gas out of hours advice page', type: :system do
         expect(page).to have_content(I18n.t('advice_pages.insights.recommendations.title'))
       end
 
+      context 'with all zero readings' do
+        let(:reading_start_date) { 7.days.ago }
+
+        let(:school) do
+          create(:school, :with_basic_configuration_single_meter_and_tariffs,
+            fuel_type: :gas,
+            reading_start_date: reading_start_date,
+            reading_end_date: reading_end_date,
+            reading: 0.0,
+            calendar: create(:calendar, calendar_type: :school)) # create empty calendar initially, see nested tests
+        end
+
+        it 'displays the no usage message' do
+          expect(page).to have_content(I18n.t('advice_pages.no_usage.title'))
+          expect(page).to have_content(reading_start_date.to_fs(:es_short))
+        end
+      end
+
       context 'with very limited meter data' do
         let(:reading_start_date) { 1.day.ago }
 


### PR DESCRIPTION
This change checks to see if the total out of hours usage is zero before allowing a user to access the out of hours usage page.

This cropped up for several schools where there seems to be a data issue as we have around 8 months of all zero data. The meters should have been deactivated, but while they were active the out of hours page triggered an error which isn't ideal. 

In another case a school only had data over the summer period where gas data might legitimately have been zero. E.g. if they had electric heating. In this case we needed a message for the user.

This PR checks to see if the total kwh usage for the reported period is zero before allowing access to the insights/analysis pages. If there's zero usage then there's no much to show them. Works similarly to the special case for hot water, etc.

