### PR TITLE
Minor responsive fixes for dashboards and advice index

### DIFF
--- a/app/components/dashboard_equivalences_component.rb
+++ b/app/components/dashboard_equivalences_component.rb
@@ -73,7 +73,7 @@ class DashboardEquivalencesComponent < ApplicationComponent
 
   def two_column_margin(left = true)
     return '' if single_fuel?
-    "m#{left ? 'r' : 'l'}-2"
+    "m#{left ? 'r' : 'l'}-lg-2" # responsive margin same breakpoint as above
   end
 
   def equivalence_layout

--- a/app/views/shared/_analysis_controls.html.erb
+++ b/app/views/shared/_analysis_controls.html.erb
@@ -1,4 +1,4 @@
-<div class="chart-controls d-flex justify-content-between pt-4">
+<div class="chart-controls d-flex flex-wrap justify-content-between pt-4">
 
   <div>
     <div class="axis-controls" style='display: none;'>
@@ -24,7 +24,7 @@
 
   <div class='analysis-controls' style='display: none;'>
     <% if local_assigns[:analysis_controls] %>
-      <div class="d-flex align-items-center justify-content-between" role="group">
+      <div class="d-flex flex-wrap align-items-center justify-content-between" role="group">
         <span class="mr-2 align-bottom"><%= t('analysis_controls.explore') %></span>
         <div>
           <button class="btn btn-sm btn-outline-dark rounded-pill explore-button move_back" disabled>


### PR DESCRIPTION
- Make the left/right margins added by the dashboard equivalence component only apply at `lg` sizes and above. Avoids unnecessary space on small screen sizes
- Add `flex-wrap` to chart controls and buttons, so on smaller screen sizes the controls wrap onto lines rather than being stretched/squashed.

Before for the chart change:

![Screenshot from 2024-09-11 16-06-00](https://github.com/user-attachments/assets/798c35fa-ed7d-4ce3-b97b-98bc02fd30a4)

After for the chart change:

![Screenshot from 2024-09-11 16-05-27](https://github.com/user-attachments/assets/ea66a1f9-8a45-4b35-97a2-1357c9a6569f)
