### PR TITLE
Error on login form for specific school

### DIFF
--- a/app/controllers/admin/activity_type_previews_controller.rb
+++ b/app/controllers/admin/activity_type_previews_controller.rb
@@ -1,7 +1,7 @@
 module Admin
   class ActivityTypePreviewsController < AdminController
     def create
-      school = params['school_slug'] ? School.find_by(slug: params['school_slug']) : School.process_data.order(:name).first
+      school = params['school_slug'] ? School.find(params['school_slug']) : School.process_data.order(:name).first
       activity_type = ActivityType.new(school_specific_description: school_specific_description(params))
       @activity_type_content = TemplateInterpolation.new(
         activity_type,

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -5,7 +5,7 @@ class SessionsController < Devise::SessionsController
 
   def load_school
     if params[:school].present?
-      @school = School.find_by(slug: params[:school])
+      @school = School.find(params[:school])
     else
       @schools = SchoolCreator.school_list_for_login_form
     end


### PR DESCRIPTION
Traced a Rollbar error from someone visiting the login page to this returning nil:

`School.find_by(slug: params[:school])`

The param is a slug that identifies the school, but it was returning nil.

The reason is that the school name has recently been updated so the slug has changed. Looks like `find_by` with `slug` only checks the current slug but `FriendlyId` maintains a history. 

The School model will check history on a `find` because of this config:

```
friendly_id :slug_candidates, use: [:finders, :slugged, :history]
```

So have changed the form and one other occurence of using `.find_by(slug: ...)` to just use `.find` as its more flexible.