### PR TITLE
Dashboard error when admin views a non-visible school

### DIFF
--- a/app/components/scoreboard_summary_component/scoreboard_summary_component.html.erb
+++ b/app/components/scoreboard_summary_component/scoreboard_summary_component.html.erb
@@ -9,7 +9,7 @@
             <% end %>
           </div>
         </div>
-        <% if podium.points_to_overtake && podium.school_position.position != 1 %>
+        <% if podium.points_to_overtake && podium&.school_position&.position != 1 %>
           <div class="row">
             <div class="col">
               <h4>

--- a/spec/components/scoreboard_summary_component_spec.rb
+++ b/spec/components/scoreboard_summary_component_spec.rb
@@ -16,6 +16,44 @@ RSpec.describe ScoreboardSummaryComponent, type: :component, include_url_helpers
     render_inline(component)
   end
 
+  context 'with feature active' do
+    before do
+      Flipper.enable(:new_dashboards_2024)
+    end
+
+    context 'when there is another school on the podium' do
+      let!(:other_school) { create :school, :with_points, score_points: 50, scoreboard: scoreboard }
+
+      it 'shows scoreboard activity' do
+        expect(html).to have_content('Recent activity on your scoreboard')
+      end
+    end
+
+    context 'when there is only 1 school on the podium' do
+      it 'shows energysparks activity' do
+        expect(html).to have_content('Recent activity across Energy Sparks')
+      end
+    end
+
+    context 'when school is not visible' do
+      let(:school) { create :school, scoreboard: scoreboard, visible: false }
+
+      context 'when there is another school on the podium' do
+        let!(:other_school) { create :school, :with_points, score_points: 50, scoreboard: scoreboard }
+
+        it 'shows scoreboard activity' do
+          expect(html).to have_content(I18n.t('components.scoreboard_summary.intro'))
+        end
+      end
+
+      context 'when there is only 1 school on the podium' do
+        it 'shows energysparks activity' do
+          expect(html).to have_content(I18n.t('components.scoreboard_summary.intro'))
+        end
+      end
+    end
+  end
+
   context 'when there is another school on the podium' do
     let!(:other_school) { create :school, :with_points, score_points: 50, scoreboard: scoreboard }
 


### PR DESCRIPTION
Found a dashboard error for a school that is not visible. If they're not visible, then they're not included in the podium/scoreboard so don't have a position.

Only affects admins reviewing schools that have not completed onboarding.

Added specs to better test the component.

