### PR TITLE
Add navigation to school management forms

### DIFF
--- a/app/components/manage_school_navigation_component.rb
+++ b/app/components/manage_school_navigation_component.rb
@@ -1,0 +1,17 @@
+class ManageSchoolNavigationComponent < ApplicationComponent
+  attr_reader :school, :current_user
+
+  def initialize(school:, current_user: nil, id: nil, classes: '')
+    super(id: id, classes: classes)
+    @school = school
+    @current_user = current_user
+  end
+
+  def ability
+    @ability ||= Ability.new(@current_user)
+  end
+
+  def can?(permission, context)
+    ability.can?(permission, context)
+  end
+end

--- a/app/components/manage_school_navigation_component/manage_school_navigation_component.html.erb
+++ b/app/components/manage_school_navigation_component/manage_school_navigation_component.html.erb
@@ -1,0 +1,95 @@
+<%= component 'page_nav', name: t('manage_school_menu.manage_school'),
+                          icon: nil, href: school_path(school),
+                          options: { user: current_user, match_controller: true } do |c| %>
+
+  <% c.with_section name: 'Settings',
+                    options: { match_controller: false } do |s| %>
+    <% s.with_item(name: t('manage_school_menu.edit_school_details'),
+                   href: edit_school_path(school), classes: 'small') %>
+    <% s.with_item(name: t('manage_school_menu.edit_school_times'),
+                   href: edit_school_times_path(school), classes: 'small') %>
+    <% s.with_item(name: t('manage_school_menu.your_school_estate'),
+                   href: edit_school_your_school_estate_path(school), classes: 'small') %>
+    <% if school.calendar && can?(:show, school.calendar) %>
+      <% s.with_item(name: t('manage_school_menu.school_calendar'),
+                     href: calendar_path(school.calendar), classes: 'small') %>
+    <% end %>
+  <% end %>
+
+  <% c.with_section name: 'Users',
+                    options: { match_controller: false } do |s| %>
+    <% s.with_item(name: t('manage_school_menu.manage_users'),
+                   href: school_users_path(school), classes: 'small') %>
+    <% if can? :manage, Contact %>
+      <% s.with_item(name: t('manage_school_menu.manage_alert_contacts'),
+                     href: school_contacts_path(school), classes: 'small') %>
+    <% end %>
+  <% end %>
+
+  <% c.with_section name: 'Metering',
+                    options: { match_controller: false } do |s| %>
+    <% if can? :index, Meter %>
+      <% s.with_item(name: t('manage_school_menu.manage_meters'),
+                     href: school_meters_path(school), classes: 'small') %>
+    <% end %>
+    <% if can? :manage, EnergyTariff %>
+      <% s.with_item(name: t('manage_school_menu.manage_tariffs'),
+                     href: school_energy_tariffs_path(school), classes: 'small') %>
+    <% end %>
+  <% end %>
+
+  <% if current_user.admin? %>
+    <% c.with_section name: 'Admin',
+                      options: { match_controller: false } do |s| %>
+
+      <% if can? :configure, school %>
+        <% s.with_item(name: t('manage_school_menu.school_configuration'),
+                       href: edit_school_configuration_path(school), classes: 'small') %>
+      <% end %>
+      <% if can? :manage, SchoolMeterAttribute %>
+        <% s.with_item(name: t('manage_school_menu.meter_attributes'),
+                       href: admin_school_meter_attributes_path(school), classes: 'small') %>
+      <% end %>
+      <% if can? :manage, Audit %>
+        <% s.with_item(name: t('manage_school_menu.manage_audits'),
+                       href: school_audits_path(school), classes: 'small') %>
+      <% end %>
+      <% if can? :manage, SchoolPartner %>
+        <% s.with_item(name: t('manage_school_menu.manage_partners'),
+                       href: admin_school_partners_path(school), classes: 'small') %>
+      <% end %>
+      <% if can? :manage, Cad %>
+        <% s.with_item(name: t('manage_school_menu.manage_cads'),
+                       href: school_cads_path(school), classes: 'small') %>
+      <% end %>
+      <% if school.school_group && can?(:manage, school.school_group) %>
+        <% s.with_item(name: t('manage_school_menu.manage_school_group'),
+                       href: admin_school_group_path(school.school_group), classes: 'small') %>
+      <% end %>
+      <% if can? :manage, Issue %>
+        <% s.with_item(name: t('manage_school_menu.manage_issues'),
+                       href: admin_school_issues_path(school), classes: 'small') %>
+      <% end %>
+      <% if can? :view_content_reports, school %>
+        <% s.with_item(name: t('manage_school_menu.batch_reports'),
+                       href: school_reports_path(school), classes: 'small') %>
+      <% end %>
+      <% s.with_item(name: t('schools.meters.index.view_target_data'),
+                     href: admin_school_target_data_path(school), classes: 'small') %>
+      <% if Targets::SchoolTargetService.targets_enabled?(school) &&
+             can?(:manage, SchoolTarget) && Targets::SchoolTargetService.new(school).enough_data? %>
+        <% s.with_item(name: t('manage_school_menu.review_targets'),
+                       href: school_school_targets_path(school), classes: 'small') %>
+      <% end %>
+      <% if can? :expert_analyse, school %>
+        <% s.with_item(name: t('manage_school_menu.expert_analysis'),
+                       href: admin_school_analysis_path(school), classes: 'small') %>
+      <% end %>
+      <% if can? :remove_school, school %>
+        <% s.with_item(name: t('manage_school_menu.remove_school'),
+                       href: removal_admin_school_path(school), classes: 'small') %>
+      <% end %>
+    <% end %>
+  <% end %>
+
+<% end %>

--- a/app/views/schools/_school_page_with_navigation.html.erb
+++ b/app/views/schools/_school_page_with_navigation.html.erb
@@ -1,0 +1,12 @@
+<% content_for :page_title, "#{page_title} | #{school.name}" %>
+<h1><%= page_title %></h1>
+
+<div class="row">
+  <div class="col-md-3 col-lg-3 col-xl-2">
+    <%= component 'manage_school_navigation', school: school, current_user: current_user %>
+  </div>
+
+  <div class="col-md-9 col-lg-9 col-xl-10">
+    <%= yield %>
+  </div>
+</div>

--- a/app/views/schools/contacts/index.html.erb
+++ b/app/views/schools/contacts/index.html.erb
@@ -2,95 +2,62 @@
   <%= t('schools.contacts.index.title', school_name: @school.name) %>
 <% end %>
 
-<h1 property="name">
-  <%= t('schools.contacts.index.alert_contacts') %>
-</h1>
+<%= render 'schools/school_page_with_navigation', school: @school,
+                                                  page_title: t('schools.contacts.index.alert_contacts') do %>
 
-<%= render 'shared/contact_explainer' %>
+  <%= render 'shared/contact_explainer' %>
 
-<p>
-  <%= t('schools.contacts.index.alert_contacts_message') %>
-</p>
+  <p>
+    <%= t('schools.contacts.index.alert_contacts_message') %>
+  </p>
 
-<h2>
-  <%= t('schools.contacts.index.account_contacts') %>
-</h2>
+  <h2>
+    <%= t('schools.contacts.index.account_contacts') %>
+  </h2>
 
-<div class="table-responsive mt-2">
-  <table class="table table-striped">
-    <thead>
-      <tr>
-        <th><%= t('schools.contacts.index.name') %></th>
-        <th><%= t('schools.contacts.index.email_address') %></th>
-        <th><%= t('schools.contacts.index.mobile_phone_number') %></th>
-        <th><%= t('schools.contacts.index.receives_alerts') %></th>
-        <th><%= t('schools.contacts.index.role') %></th>
-        <th><%= t('schools.contacts.index.preferred_locale') %></th>
-        <th><%= t('schools.contacts.index.actions') %></th>
-      </tr>
-    </thead>
-    <tbody>
-      <% @account_contacts.each do |contact| %>
-        <tr scope="row">
-          <td><%= contact.name %></td>
-          <td><%= contact.email_address %></td>
-          <td><%= contact.mobile_phone_number %></td>
-          <td><%= y_n(true) %></td>
-          <td><%= contact.staff_role.try(:translated_title) %></td>
-          <td><%= I18n.t("languages.#{contact.preferred_locale}") %></td>
-          <td class="nowrap">
-            <div class="btn-group">
-              <%= link_to t('schools.contacts.edit.disable_alerts'), school_contact_path(@school, contact), method: :delete, data: { confirm: t('common.confirm') }, class: 'btn btn-danger', id: "disable_alerts_#{contact.id}" %>
-              <%= link_to t('schools.contacts.edit.edit_phone_number'), edit_school_contact_path(@school, contact) %>
-            </div>
-          </td>
-        </tr>
-      <% end %>
-      <% @accounts_without_contacts.each do |user| %>
-        <tr scope="row">
-          <td><%= user.name %></td>
-          <td><%= user.email %></td>
-          <td></td>
-          <td><%= y_n(false) %></td>
-          <td><%= user.staff_role.try(:translated_title) %></td>
-          <td><%= I18n.t("languages.#{user.preferred_locale}") %></td>
-          <td class="nowrap">
-            <div class="btn-group">
-              <%= link_to t('schools.contacts.edit.enable_alerts'), new_school_contact_path(@school, user_id: user.id), class: 'btn btn-warning', id: "enable_alerts_#{user.id}", class: 'btn btn-warning' %>
-            </div>
-          </td>
-        </tr>
-      <% end %>
-    </tbody>
-  </table>
-</div>
-
-<% if @standalone_contacts.any? %>
-
-  <h2><%= t('schools.contacts.index.standalone_contacts') %></h2>
-
-  <div class="table-responsive">
+  <div class="table-responsive mt-2">
     <table class="table table-striped">
       <thead>
         <tr>
           <th><%= t('schools.contacts.index.name') %></th>
           <th><%= t('schools.contacts.index.email_address') %></th>
           <th><%= t('schools.contacts.index.mobile_phone_number') %></th>
+          <th><%= t('schools.contacts.index.receives_alerts') %></th>
           <th><%= t('schools.contacts.index.role') %></th>
+          <th><%= t('schools.contacts.index.preferred_locale') %></th>
           <th><%= t('schools.contacts.index.actions') %></th>
         </tr>
       </thead>
       <tbody>
-        <% @standalone_contacts.each do |contact| %>
+        <% @account_contacts.each do |contact| %>
           <tr scope="row">
             <td><%= contact.name %></td>
             <td><%= contact.email_address %></td>
             <td><%= contact.mobile_phone_number %></td>
+            <td><%= y_n(true) %></td>
             <td><%= contact.staff_role.try(:translated_title) %></td>
-            <td>
+            <td><%= I18n.t("languages.#{contact.preferred_locale}") %></td>
+            <td class="nowrap">
               <div class="btn-group">
-                <%= link_to t('common.labels.edit'), edit_school_contact_path(@school, contact), class: 'btn btn-warning' %>
-                <%= link_to t('common.labels.delete'), school_contact_path(@school, contact), method: :delete, data: { confirm: t('common.confirm') }, class: 'btn btn-danger' %>
+                <%= link_to t('schools.contacts.edit.disable_alerts'), school_contact_path(@school, contact),
+                            method: :delete, data: { confirm: t('common.confirm') }, class: 'btn btn-danger', id: "disable_alerts_#{contact.id}" %>
+                <%= link_to t('schools.contacts.edit.edit_phone_number'), edit_school_contact_path(@school, contact) %>
+              </div>
+            </td>
+          </tr>
+        <% end %>
+        <% @accounts_without_contacts.each do |user| %>
+          <tr scope="row">
+            <td><%= user.name %></td>
+            <td><%= user.email %></td>
+            <td></td>
+            <td><%= y_n(false) %></td>
+            <td><%= user.staff_role.try(:translated_title) %></td>
+            <td><%= I18n.t("languages.#{user.preferred_locale}") %></td>
+            <td class="nowrap">
+              <div class="btn-group">
+                <%= link_to t('schools.contacts.edit.enable_alerts'),
+                            new_school_contact_path(@school, user_id: user.id), class: 'btn btn-warning', id: "enable_alerts_#{user.id}", class: 'btn btn-warning' %>
               </div>
             </td>
           </tr>
@@ -98,5 +65,43 @@
       </tbody>
     </table>
   </div>
+
+  <% if @standalone_contacts.any? %>
+
+    <h2><%= t('schools.contacts.index.standalone_contacts') %></h2>
+
+    <div class="table-responsive">
+      <table class="table table-striped">
+        <thead>
+          <tr>
+            <th><%= t('schools.contacts.index.name') %></th>
+            <th><%= t('schools.contacts.index.email_address') %></th>
+            <th><%= t('schools.contacts.index.mobile_phone_number') %></th>
+            <th><%= t('schools.contacts.index.role') %></th>
+            <th><%= t('schools.contacts.index.actions') %></th>
+          </tr>
+        </thead>
+        <tbody>
+          <% @standalone_contacts.each do |contact| %>
+            <tr scope="row">
+              <td><%= contact.name %></td>
+              <td><%= contact.email_address %></td>
+              <td><%= contact.mobile_phone_number %></td>
+              <td><%= contact.staff_role.try(:translated_title) %></td>
+              <td>
+                <div class="btn-group">
+                  <%= link_to t('common.labels.edit'), edit_school_contact_path(@school, contact),
+                              class: 'btn btn-warning' %>
+                  <%= link_to t('common.labels.delete'), school_contact_path(@school, contact), method: :delete,
+                                                                                                data: { confirm: t('common.confirm') }, class: 'btn btn-danger' %>
+                </div>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+
+  <% end %>
 
 <% end %>

--- a/app/views/schools/edit.html.erb
+++ b/app/views/schools/edit.html.erb
@@ -1,11 +1,10 @@
-<div class="row justify-content-md-center">
-  <div class="col col-md-10 col-lg-8">
-    <h1><%= t('schools.school_details.editing') %></h1>
+<%= render 'schools/school_page_with_navigation', school: @school,
+  page_title: t('schools.school_details.editing') do %>
 
-    <%= render 'form', school: @school, submit_text: t('schools.school_details.update_school') %>
+  <%= render 'form', school: @school, submit_text: t('schools.school_details.update_school') %>
 
-    <div class="other-actions">
-      <%= link_to t('common.labels.back'), school_path(@school), class: 'btn btn-secondary' %>
-    </div>
+  <div class="other-actions">
+    <%= link_to t('common.labels.back'), school_path(@school), class: 'btn btn-secondary' %>
   </div>
-</div>
+
+<% end %>

--- a/app/views/schools/times/edit.html.erb
+++ b/app/views/schools/times/edit.html.erb
@@ -1,74 +1,77 @@
-<h1><%= t('schools.times.edit.title') %></h1>
+<%= render 'schools/school_page_with_navigation', school: @school,
+  page_title: t('schools.times.edit.title') do %>
 
-<div class="alert alert-warning">
-  <%= t('schools.times.edit.introduction_message') %>
-</div>
-
-<%= form_for(@school, url: school_times_path(@school)) do |f| %>
-  <%= render 'schools/times/form', f: f %>
-  <div class="actions">
-    <%= f.submit t('schools.times.edit.save_school_times'), class: 'btn btn-primary' %>
+  <div class="alert alert-warning">
+    <%= t('schools.times.edit.introduction_message') %>
   </div>
-<% end %>
 
-<div class="row pt-3">
-  <div class="col">
-    <h1 id="community-use-section"><%= t('schools.times.edit.community_use.title') %></h1>
-  </div>
-</div>
-
-<div class="row">
-  <div class="col">
-  <p>
-    <%= t('schools.times.edit.community_use.school_premises_message') %>.
-  </p>
-
-  <p>
-    <%= t('schools.times.edit.community_use.use_the_form_message') %>.
-  </p>
-
-  <p>
-    <%= t('schools.times.edit.community_use.breakfast_and_after_school_clubs') %>.
-  </p>
-
-  <p>
-    <%= t('schools.times.edit.community_use.twenty_four_hour_format_message') %>.
-  </p>
-  </div>
-</div>
-
-<div class="row pt-2">
-  <div class="col-md-3 mb-3">
-    <label for="day"><strong><%= t('schools.times.edit.community_use.day') %></strong></label>
-  </div>
-  <div class="col-md-2 mb-3">
-    <label for="opening-time"><strong><%= t('schools.times.edit.community_use.opening_time') %></strong></label>
-  </div>
-  <div class="col-md-2 mb-3">
-    <label for="closing-time"><strong><%= t('schools.times.edit.community_use.closing_time') %></strong></label>
-  </div>
-  <div class="col-md-3 mb-3">
-    <label for="term-only"><strong><%= t('schools.times.edit.community_use.time_of_year') %></strong></label>
-  </div>
-</div>
-
-  <%= form_for(@school, url: school_times_path(@school), html: { id: :community_use_form }) do |f| %>
-    <div id="school-times">
-      <%= f.simple_fields_for(:school_times,
-                              f.object.school_times.select { |t| t.usage_type == 'community_use' }
-                              .sort_by { |time| time.day ? SchoolTime.days[time.day] : 99 }) do |school_time| %>
-        <%= render 'schools/times/school_time_fields', f: school_time %>
-      <% end %>
-      <div class="links mt-2">
-        <%= link_to_add_association t('schools.times.edit.community_use.add_time'), f,
-                                    :school_times,
-                                    partial: 'schools/times/school_time_fields',
-                                    wrap_object: proc { |time|
-                                                   time.usage_type = :community_use
-                                                   time.community_use_defaults!
-                                                   time
-                                                 }, class: 'btn' %>
-        <%= f.submit t('schools.times.edit.community_use.save_community_use_times'), class: 'btn btn-primary' %>
-      </div>
+  <%= form_for(@school, url: school_times_path(@school)) do |f| %>
+    <%= render 'schools/times/form', f: f %>
+    <div class="actions">
+      <%= f.submit t('schools.times.edit.save_school_times'), class: 'btn btn-primary' %>
     </div>
   <% end %>
+
+  <div class="row pt-3">
+    <div class="col">
+      <h1 id="community-use-section"><%= t('schools.times.edit.community_use.title') %></h1>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="col">
+    <p>
+      <%= t('schools.times.edit.community_use.school_premises_message') %>.
+    </p>
+
+    <p>
+      <%= t('schools.times.edit.community_use.use_the_form_message') %>.
+    </p>
+
+    <p>
+      <%= t('schools.times.edit.community_use.breakfast_and_after_school_clubs') %>.
+    </p>
+
+    <p>
+      <%= t('schools.times.edit.community_use.twenty_four_hour_format_message') %>.
+    </p>
+    </div>
+  </div>
+
+  <div class="row pt-2">
+    <div class="col-md-3 mb-3">
+      <label for="day"><strong><%= t('schools.times.edit.community_use.day') %></strong></label>
+    </div>
+    <div class="col-md-2 mb-3">
+      <label for="opening-time"><strong><%= t('schools.times.edit.community_use.opening_time') %></strong></label>
+    </div>
+    <div class="col-md-2 mb-3">
+      <label for="closing-time"><strong><%= t('schools.times.edit.community_use.closing_time') %></strong></label>
+    </div>
+    <div class="col-md-3 mb-3">
+      <label for="term-only"><strong><%= t('schools.times.edit.community_use.time_of_year') %></strong></label>
+    </div>
+  </div>
+
+    <%= form_for(@school, url: school_times_path(@school), html: { id: :community_use_form }) do |f| %>
+      <div id="school-times">
+        <%= f.simple_fields_for(:school_times,
+                                f.object.school_times.select { |t| t.usage_type == 'community_use' }
+                                .sort_by { |time| time.day ? SchoolTime.days[time.day] : 99 }) do |school_time| %>
+          <%= render 'schools/times/school_time_fields', f: school_time %>
+        <% end %>
+        <div class="links mt-2">
+          <%= link_to_add_association t('schools.times.edit.community_use.add_time'), f,
+                                      :school_times,
+                                      partial: 'schools/times/school_time_fields',
+                                      wrap_object: proc { |time|
+                                                     time.usage_type = :community_use
+                                                     time.community_use_defaults!
+                                                     time
+                                                   }, class: 'btn' %>
+          <%= f.submit t('schools.times.edit.community_use.save_community_use_times'), class: 'btn btn-primary' %>
+        </div>
+      </div>
+    <% end %>
+
+<% end %>

--- a/app/views/schools/users/index.html.erb
+++ b/app/views/schools/users/index.html.erb
@@ -1,64 +1,81 @@
-<h2><%= t('schools.users.index.title') %></h2>
-<p><%= t('schools.users.index.introduction') %></p>
+<%= render 'schools/school_page_with_navigation', school: @school,
+                                                  page_title: t('schools.users.index.title') do %>
 
-<div class="school_admin">
-  <% if @school_admins.any? %>
-    <%= render 'users', users: @school_admins %>
-  <% else %>
-    <p><%= t('schools.users.index.no_school_admin_accounts') %>.</p>
-  <% end %>
-</div>
+  <p><%= t('schools.users.index.introduction') %></p>
 
-<%= link_to t('schools.users.index.new_school_admin_account'), new_school_user_path(@school, role: :school_admin), class: 'btn btn-primary' %>
-<%= link_to t('schools.users.index.add_existing_user_as_admin'), new_school_cluster_admin_path(@school), class: 'btn btn-primary' %>
+  <div class="school_admin">
+    <% if @school_admins.any? %>
+      <%= render 'users', users: @school_admins %>
+    <% else %>
+      <p><%= t('schools.users.index.no_school_admin_accounts') %>.</p>
+    <% end %>
+  </div>
 
-<h2 class="mt-4"><%= t('schools.users.index.staff_accounts') %></h2>
-<p><%= t('schools.users.index.staff_accounts_have_access_message') %></p>
+  <%= link_to t('schools.users.index.new_school_admin_account'), new_school_user_path(@school, role: :school_admin),
+              class: 'btn btn-primary' %>
+  <%= link_to t('schools.users.index.add_existing_user_as_admin'), new_school_cluster_admin_path(@school),
+              class: 'btn btn-primary' %>
 
-<div class="staff">
-  <% if @staff.any? %>
-    <%= render 'users', users: @staff %>
-  <% else %>
-    <p><%=  t('schools.users.index.no_staff_accounts') %>.</p>
-  <% end %>
-</div>
+  <h2 class="mt-4"><%= t('schools.users.index.staff_accounts') %></h2>
+  <p><%= t('schools.users.index.staff_accounts_have_access_message') %></p>
 
-<%= link_to t('schools.users.index.new_staff_account'), new_school_user_path(@school, role: :staff), class: 'btn btn-primary' %>
+  <div class="staff">
+    <% if @staff.any? %>
+      <%= render 'users', users: @staff %>
+    <% else %>
+      <p><%= t('schools.users.index.no_staff_accounts') %>.</p>
+    <% end %>
+  </div>
 
-<h2 class="mt-4"><%= t('schools.users.index.pupil_accounts') %></h2>
+  <%= link_to t('schools.users.index.new_staff_account'), new_school_user_path(@school, role: :staff),
+              class: 'btn btn-primary' %>
 
-<p>
-  <%= t('schools.users.index.pupil_accounts_message_1') %>
-  <%= t('schools.users.index.pupil_accounts_message_2') %>
-</p>
+  <h2 class="mt-4"><%= t('schools.users.index.pupil_accounts') %></h2>
 
-<% if @pupils.any? %>
-  <table class="table table-condensed pupils">
-    <thead>
-      <tr>
-        <th><%= t('schools.users.index.name') %></th>
-        <th><%= t('schools.users.index.password') %></th>
-        <th></th>
-      </tr>
-    </thead>
+  <p>
+    <%= t('schools.users.index.pupil_accounts_message_1') %>
+    <%= t('schools.users.index.pupil_accounts_message_2') %>
+  </p>
 
-    <tbody>
-      <% @pupils.each do |user| %>
+  <% if @pupils.any? %>
+    <table class="table table-condensed pupils">
+      <thead>
         <tr>
-            <td><%= user.name %></td>
-            <td><%= user.pupil_password rescue t('schools.users.index.could_not_decrypt') %></td>
-            <td>
-              <div class="btn-group">
-                <%= link_to(t('common.labels.edit'), edit_school_pupil_path(@school, user), class: 'btn btn-primary btn-sm') if can?(:edit, user) %>
-                <%= link_to(t('common.labels.delete'), school_user_path(@school, user), method: :delete, data: { confirm: t('common.confirm') }, class: 'btn btn-danger btn-sm') if can?(:delete, user) %>
-              </div>
-            </td>
+          <th><%= t('schools.users.index.name') %></th>
+          <th><%= t('schools.users.index.password') %></th>
+          <th></th>
         </tr>
-      <% end %>
-    </tbody>
-  </table>
-<% else %>
-  <p><%= t('schools.users.index.no_pupil_accounts') %>.</p>
-<% end %>
+      </thead>
 
-<%= link_to t('schools.users.index.new_pupil_account'), new_school_pupil_path(@school), class: 'btn btn-primary' %>
+      <tbody>
+        <% @pupils.each do |user| %>
+          <tr>
+              <td><%= user.name %></td>
+              <td><%= begin
+                        user.pupil_password
+                      rescue StandardError
+                        t('schools.users.index.could_not_decrypt')
+                      end %></td>
+              <td>
+                <div class="btn-group">
+                  <%= if can?(:edit, user)
+                        link_to(t('common.labels.edit'), edit_school_pupil_path(@school, user),
+                                class: 'btn btn-primary btn-sm')
+                      end %>
+                  <%= if can?(:delete, user)
+                        link_to(t('common.labels.delete'), school_user_path(@school, user), method: :delete,
+                                                                                            data: { confirm: t('common.confirm') }, class: 'btn btn-danger btn-sm')
+                      end %>
+                </div>
+              </td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  <% else %>
+    <p><%= t('schools.users.index.no_pupil_accounts') %>.</p>
+  <% end %>
+
+  <%= link_to t('schools.users.index.new_pupil_account'), new_school_pupil_path(@school), class: 'btn btn-primary' %>
+
+<% end %>

--- a/app/views/schools/your_school_estates/edit.html.erb
+++ b/app/views/schools/your_school_estates/edit.html.erb
@@ -1,97 +1,94 @@
-<div class="row justify-content-md-center">
-  <div class="col col-md-10 col-lg-8">
+<%= render 'schools/school_page_with_navigation', school: @school,
+                                                  page_title: t('schools.your_school_estates.edit.title') do %>
 
-    <%= render 'shared/errors', subject: @school, subject_name: 'school' %>
+  <%= render 'shared/errors', subject: @school, subject_name: 'school' %>
 
-    <h1><%= t('schools.your_school_estates.edit.title') %></h1>
+  <p><%= t('schools.your_school_estates.edit.description') %></p>
 
-    <p><%= t('schools.your_school_estates.edit.description') %></p>
+  <%= simple_form_for(@school, url: school_your_school_estate_url(@school)) do |f| %>
+    <h3><%= t('schools.your_school_estates.edit.solar_panels') %></h3>
+    <%= f.input :indicated_has_solar_panels, label: t('schools.your_school_estates.edit.solar_panels_label') %>
 
-    <%= simple_form_for(@school, url: school_your_school_estate_url(@school)) do |f| %>
-      <h3><%= t('schools.your_school_estates.edit.solar_panels') %></h3>
-      <%= f.input :indicated_has_solar_panels, label: t('schools.your_school_estates.edit.solar_panels_label') %>
+    <h3><%= t('schools.your_school_estates.edit.storage_heaters') %></h3>
+    <%= f.input :indicated_has_storage_heaters, label: t('schools.your_school_estates.edit.storage_heaters_label') %>
 
-      <h3><%= t('schools.your_school_estates.edit.storage_heaters') %></h3>
-      <%= f.input :indicated_has_storage_heaters, label: t('schools.your_school_estates.edit.storage_heaters_label') %>
+    <h3><%= t('schools.your_school_estates.edit.swimming_pool') %></h3>
+    <%= f.input :has_swimming_pool, label: t('schools.your_school_estates.edit.swimming_pool_label') %>
 
-      <h3><%= t('schools.your_school_estates.edit.swimming_pool') %></h3>
-      <%= f.input :has_swimming_pool, label: t('schools.your_school_estates.edit.swimming_pool_label') %>
+    <h3><%= t('schools.your_school_estates.edit.alternative_heating_sources.header') %></h3>
+    <p><%= t('schools.your_school_estates.edit.alternative_heating_sources.description_1') %>.</p>
+    <p><%= t('schools.your_school_estates.edit.alternative_heating_sources.description_2') %>.</p>
 
-      <h3><%= t('schools.your_school_estates.edit.alternative_heating_sources.header') %></h3>
-      <p><%= t('schools.your_school_estates.edit.alternative_heating_sources.description_1') %>.</p>
-      <p><%= t('schools.your_school_estates.edit.alternative_heating_sources.description_2') %>.</p>
+    <%= f.input :alternative_heating_oil,
+                label: t('schools.your_school_estates.edit.alternative_heating_sources.oil.label'),
+                input_html: { data: { reveals: '.school_alternative_heating_oil_fields' } } %>
+    <div class='school_alternative_heating_oil_fields' data-revealed-by=".school_alternative_heating_oil">
+      <%= f.input :alternative_heating_oil_percent,
+                  label: t('schools.your_school_estates.edit.alternative_heating_sources.oil.percentage') %>
+      <%= f.input :alternative_heating_oil_notes,
+                  label: t('schools.your_school_estates.edit.alternative_heating_sources.notes') %>
+    </div>
 
-      <%= f.input :alternative_heating_oil,
-                  label: t('.alternative_heating_sources.oil.label'),
-                  input_html: { data: { reveals: '.school_alternative_heating_oil_fields' } } %>
-      <div class='school_alternative_heating_oil_fields' data-revealed-by=".school_alternative_heating_oil">
-        <%= f.input :alternative_heating_oil_percent,
-                    label: t('.alternative_heating_sources.oil.percentage') %>
-        <%= f.input :alternative_heating_oil_notes,
-                    label: t('.alternative_heating_sources.notes') %>
-      </div>
+    <%= f.input :alternative_heating_lpg,
+                label: t('schools.your_school_estates.edit.alternative_heating_sources.lpg.label'),
+                input_html: { data: { reveals: '.school_alternative_lpg_fields' } } %>
+    <div class='school_alternative_lpg_fields' data-revealed-by=".school_alternative_heating_lpg">
+      <%= f.input :alternative_heating_lpg_percent,
+                  label: t('schools.your_school_estates.edit.alternative_heating_sources.lpg.percentage') %>
+      <%= f.input :alternative_heating_lpg_notes,
+                  label: t('schools.your_school_estates.edit.alternative_heating_sources.notes') %>
+    </div>
 
-      <%= f.input :alternative_heating_lpg,
-                  label: t('.alternative_heating_sources.lpg.label'),
-                  input_html: { data: { reveals: '.school_alternative_lpg_fields' } } %>
-      <div class='school_alternative_lpg_fields' data-revealed-by=".school_alternative_heating_lpg">
-        <%= f.input :alternative_heating_lpg_percent,
-                    label: t('.alternative_heating_sources.lpg.percentage') %>
-        <%= f.input :alternative_heating_lpg_notes,
-                    label: t('.alternative_heating_sources.notes') %>
-      </div>
+    <%= f.input :alternative_heating_biomass,
+                label: t('schools.your_school_estates.edit.alternative_heating_sources.biomass.label'),
+                input_html: { data: { reveals: '.school_alternative_biomass_fields' } } %>
+    <div class='school_alternative_biomass_fields' data-revealed-by=".school_alternative_heating_biomass">
+      <%= f.input :alternative_heating_biomass_percent,
+                  label: t('schools.your_school_estates.edit.alternative_heating_sources.biomass.percentage') %>
+      <%= f.input :alternative_heating_biomass_notes,
+                  label: t('schools.your_school_estates.edit.alternative_heating_sources.notes') %>
+    </div>
 
-      <%= f.input :alternative_heating_biomass,
-                  label: t('.alternative_heating_sources.biomass.label'),
-                  input_html: { data: { reveals: '.school_alternative_biomass_fields' } } %>
-      <div class='school_alternative_biomass_fields' data-revealed-by=".school_alternative_heating_biomass">
-        <%= f.input :alternative_heating_biomass_percent,
-                    label: t('.alternative_heating_sources.biomass.percentage') %>
-        <%= f.input :alternative_heating_biomass_notes,
-                    label: t('.alternative_heating_sources.notes') %>
-      </div>
+    <%= f.input :alternative_heating_district_heating,
+                label: t('schools.your_school_estates.edit.alternative_heating_sources.district_heating.label'),
+                input_html: { data: { reveals: '.school_alternative_district_heating_fields' } } %>
+    <div class='school_alternative_district_heating_fields' data-revealed-by=".school_alternative_heating_district_heating">
+      <%= f.input :alternative_heating_district_heating_percent,
+                  label: t('schools.your_school_estates.edit.alternative_heating_sources.district_heating.percentage') %>
+      <%= f.input :alternative_heating_district_heating_notes,
+                  label: t('schools.your_school_estates.edit.alternative_heating_sources.notes') %>
+    </div>
 
-      <%= f.input :alternative_heating_district_heating,
-                  label: t('.alternative_heating_sources.district_heating.label'),
-                  input_html: { data: { reveals: '.school_alternative_district_heating_fields' } } %>
-      <div class='school_alternative_district_heating_fields' data-revealed-by=".school_alternative_heating_district_heating">
-        <%= f.input :alternative_heating_district_heating_percent,
-                    label: t('.alternative_heating_sources.district_heating.percentage') %>
-        <%= f.input :alternative_heating_district_heating_notes,
-                    label: t('.alternative_heating_sources.notes') %>
-      </div>
+    <%= f.input :alternative_heating_ground_source_heat_pump,
+                label: t('schools.your_school_estates.edit.alternative_heating_sources.ground_source_heat_pump.label'),
+                input_html: { data: { reveals: '.school_alternative_ground_source_heat_pump_fields' } } %>
+    <div class='school_alternative_ground_source_heat_pump_fields' data-revealed-by=".school_alternative_heating_ground_source_heat_pump">
+      <%= f.input :alternative_heating_ground_source_heat_pump_percent,
+                  label: t('schools.your_school_estates.edit.alternative_heating_sources.ground_source_heat_pump.percentage') %>
+      <%= f.input :alternative_heating_ground_source_heat_pump_notes,
+                  label: t('schools.your_school_estates.edit.alternative_heating_sources.notes') %>
+    </div>
 
-      <%= f.input :alternative_heating_ground_source_heat_pump,
-                  label: t('.alternative_heating_sources.ground_source_heat_pump.label'),
-                  input_html: { data: { reveals: '.school_alternative_ground_source_heat_pump_fields' } } %>
-      <div class='school_alternative_ground_source_heat_pump_fields' data-revealed-by=".school_alternative_heating_ground_source_heat_pump">
-        <%= f.input :alternative_heating_ground_source_heat_pump_percent,
-                    label: t('.alternative_heating_sources.ground_source_heat_pump.percentage') %>
-        <%= f.input :alternative_heating_ground_source_heat_pump_notes,
-                    label: t('.alternative_heating_sources.notes') %>
-      </div>
+    <%= f.input :alternative_heating_air_source_heat_pump,
+                label: t('schools.your_school_estates.edit.alternative_heating_sources.air_source_heat_pump.label'),
+                input_html: { data: { reveals: '.school_alternative_air_source_heat_pump_fields' } } %>
+    <div class='school_alternative_air_source_heat_pump_fields' data-revealed-by=".school_alternative_heating_air_source_heat_pump">
+      <%= f.input :alternative_heating_air_source_heat_pump_percent,
+                  label: t('schools.your_school_estates.edit.alternative_heating_sources.air_source_heat_pump.percentage') %>
+      <%= f.input :alternative_heating_air_source_heat_pump_notes,
+                  label: t('schools.your_school_estates.edit.alternative_heating_sources.notes') %>
+    </div>
 
-      <%= f.input :alternative_heating_air_source_heat_pump,
-                  label: t('.alternative_heating_sources.air_source_heat_pump.label'),
-                  input_html: { data: { reveals: '.school_alternative_air_source_heat_pump_fields' } } %>
-      <div class='school_alternative_air_source_heat_pump_fields' data-revealed-by=".school_alternative_heating_air_source_heat_pump">
-        <%= f.input :alternative_heating_air_source_heat_pump_percent,
-                    label: t('.alternative_heating_sources.air_source_heat_pump.percentage') %>
-        <%= f.input :alternative_heating_air_source_heat_pump_notes,
-                    label: t('.alternative_heating_sources.notes') %>
-      </div>
+    <%= f.input :alternative_heating_water_source_heat_pump,
+                label: t('schools.your_school_estates.edit.alternative_heating_sources.water_source_heat_pump.label'),
+                input_html: { data: { reveals: '.school_alternative_water_source_heat_pump_fields' } } %>
+    <div class='school_alternative_water_source_heat_pump_fields' data-revealed-by=".school_alternative_heating_water_source_heat_pump">
+      <%= f.input :alternative_heating_water_source_heat_pump_percent,
+                  label: t('schools.your_school_estates.edit.alternative_heating_sources.water_source_heat_pump.percentage') %>
+      <%= f.input :alternative_heating_water_source_heat_pump_notes,
+                  label: t('schools.your_school_estates.edit.alternative_heating_sources.notes') %>
+    </div>
 
-      <%= f.input :alternative_heating_water_source_heat_pump,
-                  label: t('.alternative_heating_sources.water_source_heat_pump.label'),
-                  input_html: { data: { reveals: '.school_alternative_water_source_heat_pump_fields' } } %>
-      <div class='school_alternative_water_source_heat_pump_fields' data-revealed-by=".school_alternative_heating_water_source_heat_pump">
-        <%= f.input :alternative_heating_water_source_heat_pump_percent,
-                    label: t('.alternative_heating_sources.water_source_heat_pump.percentage') %>
-        <%= f.input :alternative_heating_water_source_heat_pump_notes,
-                    label: t('.alternative_heating_sources.notes') %>
-      </div>
-
-      <%= f.submit t('common.labels.save'), class: 'btn btn-primary pt-6' %>
-    <% end %>
-  </div>
-</div>
+    <%= f.submit t('common.labels.save'), class: 'btn btn-primary pt-6' %>
+  <% end %>
+<% end %>


### PR DESCRIPTION
Initial work to implement new nav bar for school management forms.

![Screenshot from 2024-09-13 17-11-51](https://github.com/user-attachments/assets/26064a3b-4904-4d8b-886f-0a4ccd554842)

* [ ] Section highlights and icons?
* [ ] Improve header
* [ ] Add index page
* [ ] Add specs for navigation
* [ ] Add navigation to all forms
* [ ] Only link to expert analysis if school has gas
* [ ] Simplify access control tests
* [ ] Simplify options for admins
* [ ] Share code between nav and manage menu?
* [ ] How to handle meters page?
* [ ] How to handle tariffs page?
* [ ] Should there be a component for page with left nav, with slots for header, nav, main body?