### PR TITLE
Rework how weekly alerts are generated

### DIFF
--- a/app/services/alerts/generate_email_notifications.rb
+++ b/app/services/alerts/generate_email_notifications.rb
@@ -15,6 +15,33 @@ module Alerts
       end
     end
 
+    # Will be renamed to perform once the :batch_send_weekly_alerts is finished
+    # Can later be refactored to store single email and events rather than per contact
+    def batch_send
+      events = @subscription_generation_run.alert_subscription_events.where(status: :pending, communication_type: :email).by_priority
+      return unless events.any? # may not have any pending
+
+      target_prompt = include_target_prompt_in_email?(@subscription_generation_run.school)
+
+      by_contact = events.group_by(&:contact)
+      # all contacts to bcc to this email
+      all_contacts = by_contact.keys
+      # content for email, using contact_events for first contact, will be same for all users
+      common_events = by_contact.first.last
+
+      # send email(s) one for each of the preferred locales
+      AlertMailer.with_user_locales(users: all_contacts, school: @subscription_generation_run.school, events: common_events, target_prompt: target_prompt) do |mailer|
+        mailer.alert_email.deliver_now
+      end
+
+      # generate an Email and mark all as sent
+      by_contact.each do |contact, contact_events|
+        email = Email.create!(contact: contact)
+        contact_events.each {|event| event.update!(status: :sent, email: email) }
+        email.update(sent_at: Time.now.utc)
+      end
+    end
+
     private
 
     def include_target_prompt_in_email?(school)

--- a/app/services/alerts/generate_subscription_events.rb
+++ b/app/services/alerts/generate_subscription_events.rb
@@ -29,13 +29,21 @@ module Alerts
       end
     end
 
+    # If batch feature lag is on, then always create all subscription events as we're
+    # disabling unsubscribe option
     def first_or_create_alert_subscription_event(contact, alert, content_version, find_out_more, priority, communication_type)
-      if contact.alert_type_rating_unsubscriptions.active(Time.zone.today).where(alert_type_rating: content_version.alert_type_rating).empty?
+      if Flipper.enabled?(:batch_send_weekly_alerts) || contact.alert_type_rating_unsubscriptions.active(Time.zone.today).where(alert_type_rating: content_version.alert_type_rating).empty?
+        unsubscription_uuid = if Flipper.enabled?(:batch_send_weekly_alerts)
+                                nil
+                              else
+                                SecureRandom.uuid
+                              end
+
         AlertSubscriptionEvent.create_with(
           content_version: content_version,
           subscription_generation_run: @subscription_generation_run,
           find_out_more: find_out_more,
-          unsubscription_uuid: SecureRandom.uuid,
+          unsubscription_uuid: unsubscription_uuid,
           priority: priority
         ).find_or_create_by!(
           contact: contact, alert: alert, communication_type: communication_type

--- a/app/services/alerts/generate_subscription_events.rb
+++ b/app/services/alerts/generate_subscription_events.rb
@@ -29,8 +29,7 @@ module Alerts
       end
     end
 
-    # If batch feature lag is on, then always create all subscription events as we're
-    # disabling unsubscribe option
+    # If batch feature flag is on, then always create a subscription event as we're disabling unsubscribe option
     def first_or_create_alert_subscription_event(contact, alert, content_version, find_out_more, priority, communication_type)
       if Flipper.enabled?(:batch_send_weekly_alerts) || contact.alert_type_rating_unsubscriptions.active(Time.zone.today).where(alert_type_rating: content_version.alert_type_rating).empty?
         unsubscription_uuid = if Flipper.enabled?(:batch_send_weekly_alerts)

--- a/app/services/alerts/generate_subscriptions.rb
+++ b/app/services/alerts/generate_subscriptions.rb
@@ -11,7 +11,13 @@ module Alerts
         latest_alerts_with_frequency = latest_alerts.joins(:alert_type).where(alert_types: { frequency: subscription_frequency })
         Alerts::GenerateSubscriptionEvents.new(@school, subscription_generation_run: subscription_generation_run).perform(latest_alerts_with_frequency)
       end
-      Alerts::GenerateEmailNotifications.new(subscription_generation_run: subscription_generation_run).perform
+      email_service = Alerts::GenerateEmailNotifications.new(subscription_generation_run: subscription_generation_run)
+      if Flipper.enabled?(:batch_send_weekly_alerts)
+        email_service.batch_send
+      else
+        email_service.perform
+      end
+
       Alerts::GenerateSmsNotifications.new(subscription_generation_run: subscription_generation_run).perform
     end
   end

--- a/lib/tasks/deployment/20240925164205_add_batch_email_feature.rake
+++ b/lib/tasks/deployment/20240925164205_add_batch_email_feature.rake
@@ -1,0 +1,13 @@
+namespace :after_party do
+  desc 'Deployment task: add_batch_email_feature'
+  task add_batch_email_feature: :environment do
+    puts "Running deploy task 'add_batch_email_feature'"
+
+    Flipper.add(:batch_send_weekly_alerts)
+
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord
+      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+  end
+end

--- a/spec/mailers/alert_mailer_spec.rb
+++ b/spec/mailers/alert_mailer_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe AlertMailer do
       context 'when locale is specified' do
         [:en, :cy].each do |locale|
           it "uses #{locale}" do
-            AlertMailer.with(email_address: email_address, school: school, events: [], locale: locale).alert_email.deliver_now
+            AlertMailer.with(users: users, school: school, events: [], locale: locale).alert_email.deliver_now
             expect(email.subject).to eql I18n.t('alert_mailer.alert_email.subject', locale: locale)
           end
         end

--- a/spec/mailers/alert_mailer_spec.rb
+++ b/spec/mailers/alert_mailer_spec.rb
@@ -13,29 +13,79 @@ RSpec.describe AlertMailer do
   end
 
   describe '#alert_email' do
-    it 'sends an email with mailgun tag in header' do
-      AlertMailer.with(email_address: email_address, school: school, events: []).alert_email.deliver_now
-      expect(ActionMailer::Base.deliveries.count).to be 1
-      expect(email.subject).to eql I18n.t('alert_mailer.alert_email.subject', locale: :en)
-      expect(email.mailgun_headers['X-Mailgun-Tag']).to eql 'alerts'
-    end
-
-    it 'uses locale if specified' do
-      AlertMailer.with(email_address: email_address, school: school, events: [], locale: :cy).alert_email.deliver_now
-      expect(email.subject).to eql I18n.t('alert_mailer.alert_email.subject', locale: :cy)
-    end
-
-    it 'uses default locale' do
-      AlertMailer.with(email_address: email_address, school: school, events: []).alert_email.deliver_now
-      expect(email.subject).to eql I18n.t('alert_mailer.alert_email.subject', locale: :en)
-    end
-
-    context 'SEND_AUTOMATED_EMAILS env var is false' do
-      let(:send_automated_emails) { 'false' }
-
-      it 'does not send an email' do
+    context 'to single user' do
+      it 'sends an email with mailgun tag in header' do
         AlertMailer.with(email_address: email_address, school: school, events: []).alert_email.deliver_now
-        expect(ActionMailer::Base.deliveries.count).to be 0
+        expect(ActionMailer::Base.deliveries.count).to be 1
+        expect(email.mailgun_headers['X-Mailgun-Tag']).to eql 'alerts'
+      end
+
+      it 'specifies a subject' do
+        AlertMailer.with(email_address: email_address, school: school, events: []).alert_email.deliver_now
+        expect(email.subject).to eql I18n.t('alert_mailer.alert_email.subject')
+      end
+
+      it 'send to right to address' do
+        AlertMailer.with(email_address: email_address, school: school, events: []).alert_email.deliver_now
+        expect(email.to).to contain_exactly(email_address)
+      end
+
+      context 'when locale is specified' do
+        [:en, :cy].each do |locale|
+          it "uses #{locale}" do
+            AlertMailer.with(email_address: email_address, school: school, events: [], locale: locale).alert_email.deliver_now
+            expect(email.subject).to eql I18n.t('alert_mailer.alert_email.subject', locale: locale)
+          end
+        end
+      end
+
+      context 'SEND_AUTOMATED_EMAILS env var is false' do
+        let(:send_automated_emails) { 'false' }
+
+        it 'does not send an email' do
+          AlertMailer.with(email_address: email_address, school: school, events: []).alert_email.deliver_now
+          expect(ActionMailer::Base.deliveries.count).to be 0
+        end
+      end
+    end
+
+    context 'to multiple users' do
+      let(:users) { create_list(:contact_with_name_email_phone, 2) }
+
+      it 'sends an email with mailgun tag in header' do
+        AlertMailer.with(users: users, school: school, events: []).alert_email.deliver_now
+        expect(ActionMailer::Base.deliveries.count).to be 1
+        expect(email.subject).to eql I18n.t('alert_mailer.alert_email.subject', locale: :en)
+        expect(email.mailgun_headers['X-Mailgun-Tag']).to eql 'alerts'
+      end
+
+      it 'specifies a subject' do
+        AlertMailer.with(users: users, school: school, events: []).alert_email.deliver_now
+        expect(email.subject).to eql I18n.t('alert_mailer.alert_email.subject')
+      end
+
+      it 'send to right cc addresses' do
+        AlertMailer.with(users: users, school: school, events: []).alert_email.deliver_now
+        expect(email.cc).to match_array(users.map(&:email_address))
+        expect(email.to).to be_nil
+      end
+
+      context 'when locale is specified' do
+        [:en, :cy].each do |locale|
+          it "uses #{locale}" do
+            AlertMailer.with(email_address: email_address, school: school, events: [], locale: locale).alert_email.deliver_now
+            expect(email.subject).to eql I18n.t('alert_mailer.alert_email.subject', locale: locale)
+          end
+        end
+      end
+
+      context 'SEND_AUTOMATED_EMAILS env var is false' do
+        let(:send_automated_emails) { 'false' }
+
+        it 'does not send an email' do
+          AlertMailer.with(users: users, school: school, events: []).alert_email.deliver_now
+          expect(ActionMailer::Base.deliveries.count).to be 0
+        end
       end
     end
   end

--- a/spec/services/alerts/generate_email_notifications_spec.rb
+++ b/spec/services/alerts/generate_email_notifications_spec.rb
@@ -11,7 +11,7 @@ describe Alerts::GenerateEmailNotifications do
   let!(:school_admin)        { create(:school_admin, school: school) }
   let!(:email_contact)       { create(:contact_with_name_email, school: school) }
 
-  let(:alert_type_rating_1) { create :alert_type_rating, alert_type: alert_1.alert_type, email_active: true }
+  let(:alert_type_rating_1) { create :alert_type_rating, alert_type: alert_1.alert_type, email_active: true, find_out_more_active: true }
   let(:alert_type_rating_2) { create :alert_type_rating, alert_type: alert_2.alert_type, email_active: true }
 
   let!(:content_version_1) { create :alert_type_rating_content_version, alert_type_rating: alert_type_rating_1, email_title: 'You need to do something!', email_content: 'You really do'}
@@ -28,26 +28,11 @@ describe Alerts::GenerateEmailNotifications do
     end
   end
 
-  describe '#perform' do
-    before do
-      Alerts::GenerateSubscriptionEvents.new(school, subscription_generation_run: subscription_generation_run).perform([alert_1, alert_2])
-      Alerts::GenerateEmailNotifications.new(subscription_generation_run: subscription_generation_run).perform
-      alert_subscription_event_1.reload
-      alert_subscription_event_2.reload
-    end
-
-    it 'sends email' do
+  shared_examples 'an email was sent' do
+    it 'sends email with correct subject' do
       expect(ActionMailer::Base.deliveries.count).to be 1
       email = ActionMailer::Base.deliveries.last
-      expect(email.subject).to include('Energy Sparks alerts')
-    end
-
-    it 'records that emails were sent' do
-      expect(alert_subscription_event_1.status).to eq 'sent'
-      expect(alert_subscription_event_2.status).to eq 'sent'
-      expect(alert_subscription_event_1.email_id).not_to be_nil
-      expect(alert_subscription_event_1.email_id).to eq alert_subscription_event_2.email_id
-      expect(Email.find(alert_subscription_event_1.email_id).sent?).to be true
+      expect(email.subject).to include(email_subject)
     end
 
     context 'when alerts are re-run' do
@@ -61,42 +46,100 @@ describe Alerts::GenerateEmailNotifications do
         expect(Email.count).to be 1
       end
     end
+  end
 
-    context 'when generating email body' do
-      let(:email) { ActionMailer::Base.deliveries.last }
-      let(:email_body)  { email.html_part.decoded }
-      let(:matcher)     { Capybara::Node::Simple.new(email_body.to_s) }
+  shared_examples 'an alert email was sent' do
+    let(:email) { ActionMailer::Base.deliveries.last }
+    let(:email_body)  { email.html_part.decoded }
+    let(:matcher)     { Capybara::Node::Simple.new(email_body.to_s) }
 
-      let(:params) do
-        {
-          "utm_source": 'weekly-alert',
-          "utm_medium": 'email',
-          "utm_campaign": 'alerts'
-        }
-      end
+    let(:params) do
+      {
+        "utm_source": 'weekly-alert',
+        "utm_medium": 'email',
+        "utm_campaign": 'alerts'
+      }
+    end
 
-      it 'includes all alert content' do
-        expect(email_body).to include('You need to do something')
-        expect(email_body).to include('You need to fix something')
-        expect(email_body).not_to include('Find out more')
-      end
+    it 'includes all alert content' do
+      expect(email_body).to include('You need to do something')
+      expect(email_body).to include('You need to fix something')
+      expect(email_body).not_to include('Find out more')
+    end
 
-      it 'includes unsubscription links' do
-        expect(email_body).to include("Don't show me alerts like this")
-        expect(email_body).to include(alert_subscription_event_1.unsubscription_uuid)
-      end
+    it 'include unsubscription section' do
+      expect(email_body).to include('Why am I receiving these emails?')
+      expect(email_body).to include(school_admin.email)
+    end
 
-      it 'include unsubscription section' do
-        expect(email_body).to include('Why am I receiving these emails?')
-        expect(email_body).to include(school_admin.email)
-      end
+    it 'includes links to dashboard and analysis pages' do
+      expect(email_body).to include('Stay up to date')
+      expect(matcher).to have_link('school dashboard', href: school_url(school, params: params, host: 'localhost'))
+      expect(matcher).to have_link('detailed analysis', href: school_advice_url(school, params: params, host: 'localhost'))
+      expect(matcher).to have_link('View your school dashboard', href: school_url(school, params: params, host: 'localhost'))
+    end
 
-      it 'includes links to dashboard and analysis pages' do
-        expect(email_body).to include('Stay up to date')
-        expect(matcher).to have_link('school dashboard', href: school_url(school, params: params, host: 'localhost'))
-        expect(matcher).to have_link('detailed analysis', href: school_advice_url(school, params: params, host: 'localhost'))
-        expect(matcher).to have_link('View your school dashboard', href: school_url(school, params: params, host: 'localhost'))
-      end
+    it 'records that emails were sent' do
+      expect(alert_subscription_event_1.status).to eq 'sent'
+      expect(alert_subscription_event_2.status).to eq 'sent'
+      expect(alert_subscription_event_1.email_id).not_to be_nil
+      expect(alert_subscription_event_1.email_id).to eq alert_subscription_event_2.email_id
+      expect(Email.find(alert_subscription_event_1.email_id).sent?).to be true
+    end
+  end
+
+  describe '#perform' do
+    before do
+      Alerts::GenerateSubscriptionEvents.new(school, subscription_generation_run: subscription_generation_run).perform([alert_1, alert_2])
+      Alerts::GenerateEmailNotifications.new(subscription_generation_run: subscription_generation_run).perform
+      alert_subscription_event_1.reload
+      alert_subscription_event_2.reload
+    end
+
+    let(:email) { ActionMailer::Base.deliveries.last }
+    let(:email_body) { email.html_part.decoded }
+
+    it_behaves_like 'an email was sent' do
+      let(:email_subject) { I18n.t('alert_mailer.alert_email.subject') }
+    end
+
+    it 'send to correct users' do
+      expect(email.to).to contain_exactly(email_contact.email_address)
+    end
+
+    it_behaves_like 'an alert email was sent'
+
+    it 'includes unsubscription links' do
+      expect(email_body).to include("Don't show me alerts like this")
+      expect(email_body).to include(alert_subscription_event_1.unsubscription_uuid)
+    end
+  end
+
+  describe '#batch_send' do
+    before do
+      Flipper.enable(:batch_send_weekly_alerts)
+
+      Alerts::GenerateSubscriptionEvents.new(school, subscription_generation_run: subscription_generation_run).perform([alert_1, alert_2])
+      Alerts::GenerateEmailNotifications.new(subscription_generation_run: subscription_generation_run).batch_send
+      alert_subscription_event_1.reload
+      alert_subscription_event_2.reload
+    end
+
+    let(:email) { ActionMailer::Base.deliveries.last }
+    let(:email_body) { email.html_part.decoded }
+
+    it_behaves_like 'an email was sent' do
+      let(:email_subject) { I18n.t('alert_mailer.alert_email.subject') }
+    end
+
+    it 'send to correct users' do
+      expect(email.cc).to contain_exactly(email_contact.email_address)
+    end
+
+    it_behaves_like 'an alert email was sent'
+
+    it 'does not include unsubscription links' do
+      expect(email_body).not_to include("Don't show me alerts like this")
     end
   end
 


### PR DESCRIPTION
Currently to send out our weekly alerts we do the following:

- generate the `Alert` records with the results of the analysis
- generate `AlertSubscriptionEvent` records, one per `Contact` receiving alerts for each `Alert`
- generate the emails using the above records, sending one email per `Contact`

This was to allow individual users to unsubscribe from receiving specific alerts in their emails. We track which alerts they've unsubscribed to using an `AlertTypeRatingUnsubscription` record. These are created using user specific links that are inserted into each weekly alert email.

This feature is very, very rarely used. Currently we only have a single user that has unsubscribed to a single AlertType.

We hit performance problems this week with the weekly alerts. They are using quite a bit of CPU which looks like its caused by the email generation. Currently we regenerate each email for each user even though the majority of the content is identical. It would be more efficient to generate the email once and then send to all users.

This PR makes that change in the smallest possible way. A new feature flag is added to switch the new behaviour on.

The revised code still generates all the same database models so we still track that users have received emails and what content was included, so its largely backwards compatible. The key functional changes are:

- we only send a single email and all users receiving that email in English or Welsh will be cc'd into it. So we use the `cc` rather than `to` address
- we no longer filter the content to include based on any existing `AlertTypeRatingUnsubscription` records
- we no longer generate an unsubscription id for the `AlertSubscriptionEvent` which means the links don't get added to the emails

I've reworked the existing service and mailer specs to fully test the new behaviour. We're relying on the Rails built-in behaviour of delivering to all `cc` addresses specified in the email.

This also means making fewer API requests to Mailgun which might save a bit of time per school. Currently we make one request per `Contact`.

If this improves performance then we can further rework this code to simplify the database models and fully remove the unsubscription behaviour. This is the first step to try and address the performance issues.

We might still use a lot of CPU per email but this will hopefully be quicker than generating multiple emails.


 