### PR TITLE
Handle HEAD requests to all advice pages

### DIFF
--- a/app/controllers/schools/advice/advice_base_controller.rb
+++ b/app/controllers/schools/advice/advice_base_controller.rb
@@ -39,7 +39,7 @@ module Schools
       # Generic action used to respond to HEAD requests
       # See routes.rb for routing
       def handle_head
-        return head(:ok)
+        head(:ok)
       end
 
       def show

--- a/app/controllers/schools/advice/advice_base_controller.rb
+++ b/app/controllers/schools/advice/advice_base_controller.rb
@@ -36,6 +36,12 @@ module Schools
         end
       end
 
+      # Generic action used to respond to HEAD requests
+      # See routes.rb for routing
+      def handle_head
+        return head(:ok)
+      end
+
       def show
         redirect_to url_for([:insights, @school, :advice, advice_page_key])
       end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -294,6 +294,13 @@ Rails.application.routes.draw do
          :hot_water,
          :solar_pv,
          :storage_heaters].each do |page|
+
+          # Override Rails default behaviour of mapping HEAD request to a GET and send to a
+          # generic action method that returns OK with no content.
+          [:insights, :analysis, :learn_more].each do |action|
+            match "#{page}/#{action}", controller: "advice/#{page}", action: 'handle_head', via: :head
+          end
+
           resource page, controller: "advice/#{page}", only: [:show] do
             member do
               get :insights

--- a/spec/support/shared_examples/advice_pages.rb
+++ b/spec/support/shared_examples/advice_pages.rb
@@ -16,6 +16,15 @@ RSpec.shared_examples 'an advice page' do
   end
 end
 
+RSpec.shared_examples 'it responds to HEAD requests' do
+  [:insights, :analysis, :learn_more].each do |action|
+    it "return :ok with HEAD request to #{action}" do
+      process :head, polymorphic_path([action, school, :advice, advice_page.key.to_sym])
+      expect(response).to have_http_status(:ok)
+    end
+  end
+end
+
 RSpec.shared_examples 'an advice page tab' do |tab:|
   it_behaves_like 'an advice page'
 

--- a/spec/system/schools/advice_pages/baseload_spec.rb
+++ b/spec/system/schools/advice_pages/baseload_spec.rb
@@ -6,6 +6,8 @@ RSpec.describe 'Baseload advice page', type: :system do
 
   include_context 'electricity advice page'
 
+  it_behaves_like 'it responds to HEAD requests'
+
   context 'as a school admin' do
     let(:user)  { create(:school_admin, school: school) }
 

--- a/spec/system/schools/advice_pages/electricity_costs_spec.rb
+++ b/spec/system/schools/advice_pages/electricity_costs_spec.rb
@@ -6,6 +6,8 @@ RSpec.describe 'electricity costs advice page', type: :system do
 
   include_context 'electricity advice page'
 
+  it_behaves_like 'it responds to HEAD requests'
+
   context 'as school admin' do
     let(:user) { create(:school_admin, school: school) }
 

--- a/spec/system/schools/advice_pages/electricity_intraday_spec.rb
+++ b/spec/system/schools/advice_pages/electricity_intraday_spec.rb
@@ -6,6 +6,8 @@ RSpec.describe 'electricity intraday advice page', :aggregate_failures do
 
   include_context 'electricity advice page'
 
+  it_behaves_like 'it responds to HEAD requests'
+
   context 'as school admin' do
     let(:user) { create(:school_admin, school: school) }
 

--- a/spec/system/schools/advice_pages/electricity_long_term_spec.rb
+++ b/spec/system/schools/advice_pages/electricity_long_term_spec.rb
@@ -23,6 +23,8 @@ RSpec.describe 'electricity long term advice page', :aggregate_failures do
     end
   end
 
+  it_behaves_like 'it responds to HEAD requests'
+
   context 'when a school admin' do
     before do
       sign_in(create(:school_admin, school:))

--- a/spec/system/schools/advice_pages/electricity_long_term_spec.rb
+++ b/spec/system/schools/advice_pages/electricity_long_term_spec.rb
@@ -23,7 +23,10 @@ RSpec.describe 'electricity long term advice page', :aggregate_failures do
     end
   end
 
-  it_behaves_like 'it responds to HEAD requests'
+  it_behaves_like 'it responds to HEAD requests' do
+    let(:advice_page) { AdvicePage.find_by_key(:electricity_long_term) }
+  end
+
 
   context 'when a school admin' do
     before do

--- a/spec/system/schools/advice_pages/electricity_long_term_spec.rb
+++ b/spec/system/schools/advice_pages/electricity_long_term_spec.rb
@@ -27,7 +27,6 @@ RSpec.describe 'electricity long term advice page', :aggregate_failures do
     let(:advice_page) { AdvicePage.find_by_key(:electricity_long_term) }
   end
 
-
   context 'when a school admin' do
     before do
       sign_in(create(:school_admin, school:))

--- a/spec/system/schools/advice_pages/electricity_out_of_hours_spec.rb
+++ b/spec/system/schools/advice_pages/electricity_out_of_hours_spec.rb
@@ -21,7 +21,9 @@ RSpec.describe 'electricity out of hours advice page', type: :system do
     end
   end
 
-  it_behaves_like 'it responds to HEAD requests'
+  it_behaves_like 'it responds to HEAD requests' do
+    let(:advice_page) { AdvicePage.find_by_key(:electricity_out_of_hours) }
+  end
 
   context 'as school admin' do
     before do

--- a/spec/system/schools/advice_pages/electricity_out_of_hours_spec.rb
+++ b/spec/system/schools/advice_pages/electricity_out_of_hours_spec.rb
@@ -21,6 +21,8 @@ RSpec.describe 'electricity out of hours advice page', type: :system do
     end
   end
 
+  it_behaves_like 'it responds to HEAD requests'
+
   context 'as school admin' do
     before do
       sign_in(create(:school_admin, school: school))

--- a/spec/system/schools/advice_pages/electricity_recent_changes_spec.rb
+++ b/spec/system/schools/advice_pages/electricity_recent_changes_spec.rb
@@ -6,6 +6,8 @@ RSpec.describe 'electricity recent changes advice page', type: :system do
 
   include_context 'electricity advice page'
 
+  it_behaves_like 'it responds to HEAD requests'
+
   context 'as school admin' do
     let(:user) { create(:school_admin, school: school) }
 

--- a/spec/system/schools/advice_pages/gas_costs_spec.rb
+++ b/spec/system/schools/advice_pages/gas_costs_spec.rb
@@ -6,6 +6,8 @@ RSpec.describe 'gas costs advice page', type: :system do
 
   include_context 'gas advice page'
 
+  it_behaves_like 'it responds to HEAD requests'
+
   context 'as school admin' do
     let(:user) { create(:school_admin, school: school) }
 

--- a/spec/system/schools/advice_pages/gas_long_term_spec.rb
+++ b/spec/system/schools/advice_pages/gas_long_term_spec.rb
@@ -23,6 +23,8 @@ RSpec.describe 'gas long term advice page', :aggregate_failures do
     end
   end
 
+  it_behaves_like 'it responds to HEAD requests'
+
   context 'when a school admin' do
     before do
       sign_in(create(:school_admin, school:))

--- a/spec/system/schools/advice_pages/gas_long_term_spec.rb
+++ b/spec/system/schools/advice_pages/gas_long_term_spec.rb
@@ -23,7 +23,9 @@ RSpec.describe 'gas long term advice page', :aggregate_failures do
     end
   end
 
-  it_behaves_like 'it responds to HEAD requests'
+  it_behaves_like 'it responds to HEAD requests' do
+    let(:advice_page) { AdvicePage.find_by_key(:gas_long_term) }
+  end
 
   context 'when a school admin' do
     before do

--- a/spec/system/schools/advice_pages/gas_out_of_hours_spec.rb
+++ b/spec/system/schools/advice_pages/gas_out_of_hours_spec.rb
@@ -21,6 +21,8 @@ RSpec.describe 'gas out of hours advice page', type: :system do
     end
   end
 
+  it_behaves_like 'it responds to HEAD requests'
+
   context 'as school admin' do
     before do
       sign_in(create(:school_admin, school: school))

--- a/spec/system/schools/advice_pages/gas_out_of_hours_spec.rb
+++ b/spec/system/schools/advice_pages/gas_out_of_hours_spec.rb
@@ -21,7 +21,9 @@ RSpec.describe 'gas out of hours advice page', type: :system do
     end
   end
 
-  it_behaves_like 'it responds to HEAD requests'
+  it_behaves_like 'it responds to HEAD requests' do
+    let(:advice_page) { AdvicePage.find_by_key(:gas_out_of_hours) }
+  end
 
   context 'as school admin' do
     before do

--- a/spec/system/schools/advice_pages/gas_recent_changes_spec.rb
+++ b/spec/system/schools/advice_pages/gas_recent_changes_spec.rb
@@ -13,6 +13,8 @@ RSpec.describe 'gas recent changes advice page', type: :system do
     let(:alert_text) { alert_notice }
   end
 
+  it_behaves_like 'it responds to HEAD requests'
+
   context 'as school admin' do
     let(:user) { create(:school_admin, school: school) }
 

--- a/spec/system/schools/advice_pages/heating_control_spec.rb
+++ b/spec/system/schools/advice_pages/heating_control_spec.rb
@@ -30,6 +30,8 @@ RSpec.describe 'heating control advice page', type: :system do
     )
   end
 
+  it_behaves_like 'it responds to HEAD requests'
+
   context 'as school admin' do
     let(:user) { create(:school_admin, school: school) }
 

--- a/spec/system/schools/advice_pages/hot_water_spec.rb
+++ b/spec/system/schools/advice_pages/hot_water_spec.rb
@@ -6,6 +6,8 @@ RSpec.describe 'hot water advice page', type: :system do
 
   include_context 'gas advice page'
 
+  it_behaves_like 'it responds to HEAD requests'
+
   context 'as school admin' do
     let(:user) { create(:school_admin, school: school) }
     let(:saving_£_percent) { 0.28327380733860796 }

--- a/spec/system/schools/advice_pages/meter_breakdown_spec.rb
+++ b/spec/system/schools/advice_pages/meter_breakdown_spec.rb
@@ -148,6 +148,8 @@ RSpec.describe 'meter comparison advice pages', :aggregate_failures do
 
     let(:meters) { school.meters.active.electricity }
 
+    it_behaves_like 'it responds to HEAD requests'
+
     it_behaves_like 'a meter breakdown page' do
       let(:path) { school_advice_electricity_meter_breakdown_path(school) }
     end
@@ -206,6 +208,8 @@ RSpec.describe 'meter comparison advice pages', :aggregate_failures do
     end
 
     let(:meters) { school.meters.active.gas }
+
+    it_behaves_like 'it responds to HEAD requests'
 
     it_behaves_like 'a meter breakdown page' do
       let(:path) { school_advice_gas_meter_breakdown_path(school) }

--- a/spec/system/schools/advice_pages/meter_breakdown_spec.rb
+++ b/spec/system/schools/advice_pages/meter_breakdown_spec.rb
@@ -148,7 +148,9 @@ RSpec.describe 'meter comparison advice pages', :aggregate_failures do
 
     let(:meters) { school.meters.active.electricity }
 
-    it_behaves_like 'it responds to HEAD requests'
+    it_behaves_like 'it responds to HEAD requests' do
+      let(:advice_page) { AdvicePage.find_by_key(key) }
+    end
 
     it_behaves_like 'a meter breakdown page' do
       let(:path) { school_advice_electricity_meter_breakdown_path(school) }
@@ -209,7 +211,9 @@ RSpec.describe 'meter comparison advice pages', :aggregate_failures do
 
     let(:meters) { school.meters.active.gas }
 
-    it_behaves_like 'it responds to HEAD requests'
+    it_behaves_like 'it responds to HEAD requests' do
+      let(:advice_page) { AdvicePage.find_by_key(key) }
+    end
 
     it_behaves_like 'a meter breakdown page' do
       let(:path) { school_advice_gas_meter_breakdown_path(school) }

--- a/spec/system/schools/advice_pages/solar_pv_spec.rb
+++ b/spec/system/schools/advice_pages/solar_pv_spec.rb
@@ -11,6 +11,8 @@ RSpec.describe 'solar pv advice page', :aggregate_failures do
     school.has_solar_pv? ? 'Solar PV generation' : 'Benefits of installing solar panels'
   end
 
+  it_behaves_like 'it responds to HEAD requests'
+
   context 'as school admin' do
     let(:user) { create(:school_admin, school:) }
 

--- a/spec/system/schools/advice_pages/storage_heaters_spec.rb
+++ b/spec/system/schools/advice_pages/storage_heaters_spec.rb
@@ -6,6 +6,8 @@ RSpec.describe 'storage heaters advice page', type: :system do
 
   include_context 'storage advice page'
 
+  it_behaves_like 'it responds to HEAD requests'
+
   context 'as school admin' do
     let(:user) { create(:school_admin, school: school) }
     let(:school_period) { Holiday.new(:xmas, 'Xmas 2021/2022', Date.new(2021, 12, 18), Date.new(2022, 0o1, 3), nil) }

--- a/spec/system/schools/advice_pages/thermostatic_control_spec.rb
+++ b/spec/system/schools/advice_pages/thermostatic_control_spec.rb
@@ -6,6 +6,8 @@ RSpec.describe 'thermostatic control advice page', type: :system do
 
   include_context 'gas advice page'
 
+  it_behaves_like 'it responds to HEAD requests'
+
   context 'as school admin' do
     let(:user) { create(:school_admin, school: school) }
 


### PR DESCRIPTION
Introduces some extra routing to intercept HEAD requests to the insights, analysis and learn_more actions for all advice pages. The requests are handled by a generic action that returns OK and no content. The majority of the before_actions in the controller will be skipped as well, so its should be a quick response.

Rails default behaviour is to respond to a HEAD request by treating it as a GET request, running the same action and then throwing away the rendered content to just return the default headers. While it does allow actions to set additional headers, its wasteful in most cases. And particularly on our advice pages.

Seems like the email scanners that are doing these requests during our weekly alert email sending, don't always wait for the response anyway, as nginx is logging a 499 request for many of them.

We could apply a more general approach across the site, but these are the most performance sensitive routes so have just prioritised these for now.

The fix is simple but has some downsides if we were to use it elsewhere. The main one is that the headers aren't always identical. E.g. there's no ETag header. So browsers/caches/CDNs inspecting that those via a HEAD request may expire their content. However its more normal when using ETags to do a Conditional GET not a HEAD request, so browsers should be fine. In any case, Rails handling of ETags is also not ideal, so think this approach is OK here.
