### PR TITLE
Refactor Comparison Overview Component

### DIFF
--- a/app/components/comparison_overview_component.rb
+++ b/app/components/comparison_overview_component.rb
@@ -41,7 +41,7 @@ class ComparisonOverviewComponent < ApplicationComponent
   #
   # Delays loading the meter collection from the Rails cache until we know we actually need it
   def existing_benchmark?(fuel_type)
-    advice_page = AdvicePage.find_by_key("#{fuel_type}_long_term".to_sym)
+    advice_page = AdvicePage.find_by_key("#{fuel_type}_long_term")
     @school.advice_page_school_benchmarks.where(advice_page:).any?
   end
 

--- a/app/components/comparison_overview_component.rb
+++ b/app/components/comparison_overview_component.rb
@@ -5,18 +5,17 @@ class ComparisonOverviewComponent < ApplicationComponent
 
   attr_reader :school
 
-  def initialize(school:, meter_collection:, id: nil, classes: '')
+  def initialize(school:, id: nil, classes: '')
     super(id: id, classes: "comparison-overview-component #{classes}")
     @school = school
-    @meter_collection = meter_collection
   end
 
   def can_benchmark_electricity?
-    @school.has_electricity? && electricity_usage_service.enough_data?
+    existing_benchmark?(:electricity)
   end
 
   def can_benchmark_gas?
-    @school.has_gas? && gas_usage_service.enough_data?
+    existing_benchmark?(:gas)
   end
 
   def electricity_benchmarked_usage
@@ -33,6 +32,23 @@ class ComparisonOverviewComponent < ApplicationComponent
 
   private
 
+  # This is an alternative to doing, e.g:
+  #
+  # @school.has_electricity? && electricity_usage_service.enough_data?
+  #
+  # Instead check to see if we've already generated a benchmark assessment for this school using the LongTermUsageService.
+  # If that exists then the school has the fuel type and enough data.
+  #
+  # Delays loading the meter collection from the Rails cache until we know we actually need it
+  def existing_benchmark?(fuel_type)
+    advice_page = AdvicePage.find_by_key("#{fuel_type}_long_term".to_sym)
+    @school.advice_page_school_benchmarks.where(advice_page:).any?
+  end
+
+  def meter_collection
+    @meter_collection ||= AggregateSchoolService.new(@school).aggregate_school
+  end
+
   def gas_usage_service
     @gas_usage_service ||= usage_service(:gas)
   end
@@ -42,6 +58,6 @@ class ComparisonOverviewComponent < ApplicationComponent
   end
 
   def usage_service(fuel_type)
-    Schools::Advice::LongTermUsageService.new(@school, @meter_collection, fuel_type)
+    Schools::Advice::LongTermUsageService.new(@school, meter_collection, fuel_type)
   end
 end

--- a/app/controllers/schools/advice_controller.rb
+++ b/app/controllers/schools/advice_controller.rb
@@ -18,7 +18,6 @@ module Schools
 
     def show
       if Flipper.enabled?(:new_dashboards_2024, current_user)
-        @meter_collection = aggregate_school # for comparison overview component
         render :new_show, layout: 'dashboards'
       else
         @advice_page_benchmarks = @school.advice_page_school_benchmarks

--- a/app/views/schools/advice/new_show.html.erb
+++ b/app/views/schools/advice/new_show.html.erb
@@ -44,7 +44,7 @@
   <div class="container">
     <div class="row">
       <div class="col-12 offset-md-2 offset-xl-2 col-md-9 col-lg-9 col-xl-10">
-        <%= component 'comparison_overview', id: 'comparison', school: @school, meter_collection: @meter_collection %>
+        <%= component 'comparison_overview', id: 'comparison', school: @school %>
       </div>
     </div>
   </div>

--- a/spec/components/comparison_overview_component_spec.rb
+++ b/spec/components/comparison_overview_component_spec.rb
@@ -19,17 +19,20 @@ RSpec.describe ComparisonOverviewComponent, :include_application_helper, :includ
            has_storage_heaters: false)
   end
 
-  let(:meter_collection) do
-    AggregateSchoolService.new(school).aggregate_school
-  end
-
   let(:params) do
     {
       school: school,
-      meter_collection: meter_collection,
       id: id,
       classes: classes
     }
+  end
+
+  before do
+    create(:advice_page, key: :electricity_long_term, fuel_type: :electricity)
+    create(:advice_page, key: :gas_long_term, fuel_type: :gas)
+    meter_collection = AggregateSchoolService.new(school).aggregate_school
+    Schools::AdvicePageBenchmarks::GenerateBenchmarks.new(school: school, aggregate_school: meter_collection).generate!
+    school.reload
   end
 
   describe '#can_benchmark_electricity?' do
@@ -47,7 +50,7 @@ RSpec.describe ComparisonOverviewComponent, :include_application_helper, :includ
       it { expect(component.can_benchmark_electricity?).to be(false) }
     end
 
-    context 'with electricity enough data' do
+    context 'with electricity and enough data' do
       let(:school) { create(:school, :with_basic_configuration_single_meter_and_tariffs) }
 
       it { expect(component.can_benchmark_electricity?).to be(true) }
@@ -61,7 +64,7 @@ RSpec.describe ComparisonOverviewComponent, :include_application_helper, :includ
       it { expect(component.can_benchmark_gas?).to be(false) }
     end
 
-    context 'with electricity but not enough data' do
+    context 'with gas but not enough data' do
       let(:school) do
         create(:school, :with_basic_configuration_single_meter_and_tariffs, fuel_type: :gas, reading_start_date: Time.zone.yesterday)
       end
@@ -69,7 +72,7 @@ RSpec.describe ComparisonOverviewComponent, :include_application_helper, :includ
       it { expect(component.can_benchmark_gas?).to be(false) }
     end
 
-    context 'with electricity enough data' do
+    context 'with gas and enough data' do
       let(:school) do
         create(:school,
                             :with_basic_configuration_single_meter_and_tariffs,

--- a/spec/system/schools/advice_pages/advice_page_index_spec.rb
+++ b/spec/system/schools/advice_pages/advice_page_index_spec.rb
@@ -159,6 +159,13 @@ RSpec.describe 'advice pages', :include_application_helper, type: :system do
     end
 
     context 'with enough data to compare electricity' do
+      before do
+        create(:advice_page, key: :electricity_long_term, fuel_type: :electricity)
+        meter_collection = AggregateSchoolService.new(school).aggregate_school
+        Schools::AdvicePageBenchmarks::GenerateBenchmarks.new(school: school, aggregate_school: meter_collection).generate!
+        refresh
+      end
+
       it 'shows the fuel comparison' do
         expect(page).to have_css('#electricity-comparison')
         expect(page).to have_content(I18n.t('components.comparison_overview.title'))


### PR DESCRIPTION
As originally implemented the ComparisonOverviewComponent requires the controller to full the school's MeterCollection from the Rails cache before it can be constructed.

For schools with limited data we will only end up using the MeterCollection to check if they have enough data for the comparison. 

This PR does a refactor to avoid loading the MeterCollection until it's actually needed to make an assessment. The component now fetches the MeterCollection directly from the cache and relies on the availability of an existing AdvicePageSchoolBenchmark to decide whether it can display a comparison.

Unlikely to make a big change to most schools, but where a school has limited data this removes the need to load the MeterCollection to render the advice page index.