### PR TITLE
Use to not cc

### DIFF
--- a/app/mailers/alert_mailer.rb
+++ b/app/mailers/alert_mailer.rb
@@ -19,11 +19,7 @@ class AlertMailer < LocaleMailer
     @alert_content = self.class.create_content(@events)
     @title = @school.name
 
-    email = if @batch_email
-              make_bootstrap_mail(to: @email_addresses)
-            else
-              make_bootstrap_mail(to: @email_addresses)
-            end
+    email = make_bootstrap_mail(to: @email_addresses)
     add_mg_email_tag(email, 'alerts')
   end
 

--- a/app/mailers/alert_mailer.rb
+++ b/app/mailers/alert_mailer.rb
@@ -20,7 +20,7 @@ class AlertMailer < LocaleMailer
     @title = @school.name
 
     email = if @batch_email
-              make_bootstrap_mail(cc: @email_addresses)
+              make_bootstrap_mail(to: @email_addresses)
             else
               make_bootstrap_mail(to: @email_addresses)
             end

--- a/spec/mailers/alert_mailer_spec.rb
+++ b/spec/mailers/alert_mailer_spec.rb
@@ -66,8 +66,7 @@ RSpec.describe AlertMailer do
 
       it 'send to right cc addresses' do
         AlertMailer.with(users: users, school: school, events: []).alert_email.deliver_now
-        expect(email.cc).to match_array(users.map(&:email_address))
-        expect(email.to).to be_nil
+        expect(email.to).to match_array(users.map(&:email_address))
       end
 
       context 'when locale is specified' do

--- a/spec/mailers/alert_mailer_spec.rb
+++ b/spec/mailers/alert_mailer_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe AlertMailer do
         expect(email.subject).to eql I18n.t('alert_mailer.alert_email.subject')
       end
 
-      it 'send to right cc addresses' do
+      it 'send to right addresses' do
         AlertMailer.with(users: users, school: school, events: []).alert_email.deliver_now
         expect(email.to).to match_array(users.map(&:email_address))
       end

--- a/spec/services/alerts/generate_email_notifications_spec.rb
+++ b/spec/services/alerts/generate_email_notifications_spec.rb
@@ -133,7 +133,7 @@ describe Alerts::GenerateEmailNotifications do
     end
 
     it 'send to correct users' do
-      expect(email.cc).to contain_exactly(email_contact.email_address)
+      expect(email.to).to contain_exactly(email_contact.email_address)
     end
 
     it_behaves_like 'an alert email was sent'


### PR DESCRIPTION
Fixes an issue with revised way of sending alerts (one email per school).

The code was written to `cc` everyone. The rails default mail delivery used in development accepted that without any issues.

However the mailgun ruby library [expects a `to` address without checking if it exists](https://github.com/jorgemanrubia/mailgun_rails/blob/master/lib/mailgun_rails/deliverer.rb#L53C1-L53C41). So we got an error.

The [Mailgun API requires a `to` address](https://documentation.mailgun.com/docs/mailgun/api-reference/openapi-final/tag/Messages/#tag/Messages/operation/httpapi.(*apiHandler).handler-fm-19) as well, so even if the client was more robust there would still be an issue.

So this changes code to use To.

I thought SMTP allowed at least one of TO, CC, BCC but we're limited by Mailgun here.