### PR TITLE
Optimise SQL on schools page

### DIFF
--- a/app/controllers/schools_controller.rb
+++ b/app/controllers/schools_controller.rb
@@ -39,10 +39,10 @@ class SchoolsController < ApplicationController
   before_action :set_breadcrumbs
 
   def index
-    @schools = School.visible.by_name
+    @schools = School.visible.by_name.select(:name, :slug)
     @school_groups = SchoolGroup.by_name.select(&:has_visible_schools?)
-    @ungrouped_visible_schools = School.visible.without_group.by_name
-    @schools_not_visible = School.not_visible.by_name
+    @ungrouped_visible_schools = School.visible.without_group.by_name.select(:name, :slug)
+    @schools_not_visible = School.not_visible.by_name.select(:name, :slug)
   end
 
   def show

--- a/app/views/schools/_school_group.html.erb
+++ b/app/views/schools/_school_group.html.erb
@@ -14,7 +14,7 @@
           <% end %>
         </div>
         <div class="padded-row">
-          <% school_group.schools.visible.by_name.each do |school| %>
+          <% school_group.schools.visible.by_name.select(:name, :slug).each do |school| %>
             <%= link_to "#{school.name}", school_path(school), class: 'nav-link' %>
           <% end %>
       </div>

--- a/app/views/schools/index.html.erb
+++ b/app/views/schools/index.html.erb
@@ -11,7 +11,7 @@
 <div class="col-md-12">
 
   <p><%= t('schools.index.introduction_1') %>.</p>
-  <p><%= t('schools.index.introduction_2', count: School.visible.count) %>.</p>
+  <p><%= t('schools.index.introduction_2', count: @schools.length) %>.</p>
   <p><%= t('schools.index.introduction_3') %>.</p>
   <p><%= t('schools.index.introduction_4') %>.</p>
 

--- a/app/views/schools/index.html.erb
+++ b/app/views/schools/index.html.erb
@@ -11,7 +11,7 @@
 <div class="col-md-12">
 
   <p><%= t('schools.index.introduction_1') %>.</p>
-  <p><%= t('schools.index.introduction_2', count: @schools.count) %>.</p>
+  <p><%= t('schools.index.introduction_2', count: School.visible.count) %>.</p>
   <p><%= t('schools.index.introduction_3') %>.</p>
   <p><%= t('schools.index.introduction_4') %>.</p>
 

--- a/spec/controllers/schools_controller_spec.rb
+++ b/spec/controllers/schools_controller_spec.rb
@@ -16,13 +16,13 @@ RSpec.describe SchoolsController, type: :controller do
     it 'assigns schools that are visible but not grouped as @ungrouped_visible_schools' do
       school = FactoryBot.create :school, visible: true
       get :index, params: {}
-      expect(assigns(:ungrouped_visible_schools)).to eq([school])
+      expect(assigns(:ungrouped_visible_schools).length).to eq(1)
     end
 
     it 'assigns not visible schools as @schools_not_visible' do
       school = FactoryBot.create :school, visible: false
       get :index, params: {}
-      expect(assigns(:schools_not_visible)).to eq([school])
+      expect(assigns(:schools_not_visible).length).to eq(1)
     end
   end
 

--- a/spec/controllers/schools_controller_spec.rb
+++ b/spec/controllers/schools_controller_spec.rb
@@ -14,13 +14,13 @@ RSpec.describe SchoolsController, type: :controller do
 
   describe 'GET #index' do
     it 'assigns schools that are visible but not grouped as @ungrouped_visible_schools' do
-      school = FactoryBot.create :school, visible: true
+      FactoryBot.create :school, visible: true
       get :index, params: {}
       expect(assigns(:ungrouped_visible_schools).length).to eq(1)
     end
 
     it 'assigns not visible schools as @schools_not_visible' do
-      school = FactoryBot.create :school, visible: false
+      FactoryBot.create :school, visible: false
       get :index, params: {}
       expect(assigns(:schools_not_visible).length).to eq(1)
     end


### PR DESCRIPTION
We're going to be rebuilding this page, but noticed that this page is still slow on live site which I think is due to the SQL queries. 

Looks like we're loading full school models even though we only need names and links.

So have tweaked the controller and templates to just pull in what is required for now