### PR TITLE
Bump regeneration queue size

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
 web:  bundle exec puma -C config/puma.rb
-worker: bundle exec good_job start --queues=\"regeneration:2;default:5;\"
+worker: bundle exec good_job start --queues=\"regeneration:3;default:5;\"


### PR DESCRIPTION
Old machine had 2 vCPUs. Regenerations with >2 jobs running didn't complete any quicker as the server was CPU bound.

The new machine has 4 vCPUs. Should be possible to increase queue size to 3 without maxing out all CPUs, whilst still reducing time in queue. 

Suggest we try this first to max most use of available resources before adjusting niceness levels so we can see the impacts of both. May not need to adjust nice level if we have spare CPU capacity during regenerations?