### PR TITLE
Fix meter attributes forms

### DIFF
--- a/app/views/shared/meter_attributes/_hash.html.erb
+++ b/app/views/shared/meter_attributes/_hash.html.erb
@@ -7,12 +7,12 @@
       end %>
   <%= form.hint field.hint %>
 
-  <% if field_name != 'root' && can_ignore_children?(field) %>
+  <% if field_name.to_s != 'root' && can_ignore_children?(field) %>
     <%= check_box_tag 'disable', false, false, { title: 'Disable section', class: 'disable-attributes' } %>
     <%= label_tag 'disabled-label', '(disabled)', class: 'hidden disabled-label' %>
   <% end %>
 
-  <div class="<%= 'ml-5' unless field_name == 'root' %>">
+  <div class="<%= 'ml-5' unless field_name.to_s == 'root' %>">
     <%= form.simple_fields_for field_name do |form| %>
       <% field.structure.each do |key, structure| %>
         <%= render "shared/meter_attributes/#{structure.type}", value: value ? value[key.to_s] : nil,

--- a/app/views/shared/meter_attributes/_time_of_day.html.erb
+++ b/app/views/shared/meter_attributes/_time_of_day.html.erb
@@ -4,9 +4,9 @@
     <%= form.hint field.hint %>
   </div>
   <div class="col-6">
-    <%= form.input field_name + '[hour]', as: :integer, input_html: {value: value ? value['hour'] : ''}, required: field.required?, min: 0, max: 23, label: 'hour'%>
+    <%= form.input field_name.to_s + '[hour]', as: :integer, input_html: {value: value ? value['hour'] : ''}, required: field.required?, min: 0, max: 23, label: 'hour'%>
   </div>
   <div class="col-6">
-    <%= form.input field_name + '[minutes]', as: :integer, input_html: {value: value ? value['minutes'] : ''},  required: field.required?, min: 0, max: 59, label: 'minutes' %>
+    <%= form.input field_name.to_s + '[minutes]', as: :integer, input_html: {value: value ? value['minutes'] : ''},  required: field.required?, min: 0, max: 59, label: 'minutes' %>
   </div>
 </div>

--- a/app/views/shared/meter_attributes/_time_of_day_30.html.erb
+++ b/app/views/shared/meter_attributes/_time_of_day_30.html.erb
@@ -4,9 +4,9 @@
     <%= form.hint field.hint %>
   </div>
   <div class="col-6">
-    <%= form.input field_name + '[hour]', as: :integer, input_html: {value: value ? value['hour'] : ''}, required: field.required?, min: 0, max: 23, label: 'hour'%>
+    <%= form.input field_name.to_s + '[hour]', as: :integer, input_html: {value: value ? value['hour'] : ''}, required: field.required?, min: 0, max: 23, label: 'hour'%>
   </div>
   <div class="col-6">
-    <%= form.input field_name + '[minutes]', as: :integer, input_html: {value: value ? value['minutes'] : ''}, required: field.required?, min: 0, max: 59, label: 'minutes' %>
+    <%= form.input field_name.to_s + '[minutes]', as: :integer, input_html: {value: value ? value['minutes'] : ''}, required: field.required?, min: 0, max: 59, label: 'minutes' %>
   </div>
 </div>

--- a/app/views/shared/meter_attributes/_time_of_year.html.erb
+++ b/app/views/shared/meter_attributes/_time_of_year.html.erb
@@ -4,9 +4,9 @@
     <%= form.hint field.hint %>
   </div>
   <div class="col-6">
-    <%= form.input field_name + '[month]', as: :integer, input_html: {value: value ? value['month'] : ''},  required: field.required?, min: 1, max: 12, label: 'month'%>
+    <%= form.input field_name.to_s + '[month]', as: :integer, input_html: {value: value ? value['month'] : ''},  required: field.required?, min: 1, max: 12, label: 'month'%>
   </div>
   <div class="col-6">
-    <%= form.input field_name + '[day_of_month]', as: :integer, input_html: {value: value ? value['day_of_month'] : ''}, required: field.required?, min: 1, max: 31, label: 'day of month' %>
+    <%= form.input field_name.to_s + '[day_of_month]', as: :integer, input_html: {value: value ? value['day_of_month'] : ''}, required: field.required?, min: 1, max: 31, label: 'day of month' %>
   </div>
 </div>

--- a/spec/system/admin/meter_attributes_spec.rb
+++ b/spec/system/admin/meter_attributes_spec.rb
@@ -58,6 +58,19 @@ RSpec.describe 'meter attribute management', :meters, type: :system do
     end
 
 
+    it 'displays a form for all attributes' do
+      visit admin_school_single_meter_attribute_path(school, gas_meter)
+      options = find('#type').all('option').collect(&:text)
+
+      options.each do |option|
+        puts option
+        select option, from: 'type'
+        click_on 'New attribute'
+        expect(page).to have_button('Create')
+        visit admin_school_single_meter_attribute_path(school, gas_meter)
+      end
+    end
+
     it 'allow the admin to manage the meter attributes' do
       visit school_path(school)
       click_on 'Meter attributes'


### PR DESCRIPTION
Several of the forms used to create meter attributes are broken. They all have code like this:

```
:some_symbol + 'a string'
```

I've fixed the broken forms and added a spec to confirm that the forms for all attributes successfully display to plug hole in the spec coverage.

These forms were previously working. Am puzzled why its breaking now, so maybe related to a Rails or Ruby upgrade? Sometimes the field names are strings and sometimes symbols.

I've kept this to the smallest change rather than refactoring the forms further as I'm wary about breaking field naming conventions.