### PR TITLE
Fix form field creation on Meter Attributes forms

### DIFF
--- a/app/views/shared/meter_attributes/_time_of_day.html.erb
+++ b/app/views/shared/meter_attributes/_time_of_day.html.erb
@@ -4,9 +4,15 @@
     <%= form.hint field.hint %>
   </div>
   <div class="col-6">
-    <%= form.input field_name.to_s + '[hour]', as: :integer, input_html: {value: value ? value['hour'] : ''}, required: field.required?, min: 0, max: 23, label: 'hour'%>
+    <%= form.simple_fields_for field_name do |f| %>
+      <%= f.input 'hour', as: :integer, input_html: { value: value ? value['hour'] : '' }, required: field.required?,
+                          min: 0, max: 23, label: 'hour' %>
+    <% end %>
   </div>
   <div class="col-6">
-    <%= form.input field_name.to_s + '[minutes]', as: :integer, input_html: {value: value ? value['minutes'] : ''},  required: field.required?, min: 0, max: 59, label: 'minutes' %>
+    <%= form.simple_fields_for field_name do |f| %>
+      <%= f.input 'minutes', as: :integer, input_html: { value: value ? value['minutes'] : '' },
+                             required: field.required?, min: 0, max: 59, label: 'minutes' %>
+    <% end %>
   </div>
 </div>

--- a/app/views/shared/meter_attributes/_time_of_day_30.html.erb
+++ b/app/views/shared/meter_attributes/_time_of_day_30.html.erb
@@ -4,9 +4,15 @@
     <%= form.hint field.hint %>
   </div>
   <div class="col-6">
-    <%= form.input field_name.to_s + '[hour]', as: :integer, input_html: {value: value ? value['hour'] : ''}, required: field.required?, min: 0, max: 23, label: 'hour'%>
+    <%= form.simple_fields_for field_name do |f| %>
+      <%= f.input 'hour', as: :integer, input_html: { value: value ? value['hour'] : '' }, required: field.required?,
+                          min: 0, max: 23, label: 'hour' %>
+    <% end %>
   </div>
   <div class="col-6">
-    <%= form.input field_name.to_s + '[minutes]', as: :integer, input_html: {value: value ? value['minutes'] : ''}, required: field.required?, min: 0, max: 59, label: 'minutes' %>
+    <%= form.simple_fields_for field_name do |f| %>
+      <%= form.input 'minutes', as: :integer, input_html: { value: value ? value['minutes'] : '' },
+                                required: field.required?, min: 0, max: 59, label: 'minutes' %>
+    <% end %>
   </div>
 </div>

--- a/app/views/shared/meter_attributes/_time_of_day_30.html.erb
+++ b/app/views/shared/meter_attributes/_time_of_day_30.html.erb
@@ -11,8 +11,8 @@
   </div>
   <div class="col-6">
     <%= form.simple_fields_for field_name do |f| %>
-      <%= form.input 'minutes', as: :integer, input_html: { value: value ? value['minutes'] : '' },
-                                required: field.required?, min: 0, max: 59, label: 'minutes' %>
+      <%= f.input 'minutes', as: :integer, input_html: { value: value ? value['minutes'] : '' },
+                             required: field.required?, min: 0, max: 59, label: 'minutes' %>
     <% end %>
   </div>
 </div>

--- a/app/views/shared/meter_attributes/_time_of_year.html.erb
+++ b/app/views/shared/meter_attributes/_time_of_year.html.erb
@@ -11,8 +11,8 @@
   </div>
   <div class="col-6">
     <%= form.simple_fields_for field_name do |f| %>
-      <%= form.input 'day_of_month', as: :integer, input_html: { value: value ? value['day_of_month'] : '' },
-                                     required: field.required?, min: 1, max: 31, label: 'day of month' %>
+      <%= f.input 'day_of_month', as: :integer, input_html: { value: value ? value['day_of_month'] : '' },
+                                  required: field.required?, min: 1, max: 31, label: 'day of month' %>
     <% end %>
   </div>
 </div>

--- a/app/views/shared/meter_attributes/_time_of_year.html.erb
+++ b/app/views/shared/meter_attributes/_time_of_year.html.erb
@@ -4,9 +4,15 @@
     <%= form.hint field.hint %>
   </div>
   <div class="col-6">
-    <%= form.input field_name.to_s + '[month]', as: :integer, input_html: {value: value ? value['month'] : ''},  required: field.required?, min: 1, max: 12, label: 'month'%>
+    <%= form.simple_fields_for field_name do |f| %>
+      <%= f.input 'month', as: :integer, input_html: { value: value ? value['month'] : '' }, required: field.required?,
+                           min: 1, max: 12, label: 'month' %>
+    <% end %>
   </div>
   <div class="col-6">
-    <%= form.input field_name.to_s + '[day_of_month]', as: :integer, input_html: {value: value ? value['day_of_month'] : ''}, required: field.required?, min: 1, max: 31, label: 'day of month' %>
+    <%= form.simple_fields_for field_name do |f| %>
+      <%= form.input 'day_of_month', as: :integer, input_html: { value: value ? value['day_of_month'] : '' },
+                                     required: field.required?, min: 1, max: 31, label: 'day of month' %>
+    <% end %>
   </div>
 </div>


### PR DESCRIPTION
We had an issue with the meter attributes forms which I thought I had fixed here: https://github.com/Energy-Sparks/energy-sparks/pull/3951

The forms were building fields using a SimpleForm helper. Previously that was all working OK even when the `form.input` helpers was being passed `:charge_start_time + '[hour]'` as a value. It was then correctly creating a nested field, e.g. `attribute[root][charge_start_time][hour]`.

Changing the symbol to a string fixed the concatenation error. But the naming was then broken: `attribute[root][charge_start_time[hour]]`. This has stopped the values being saved and edited correctly.

Am not clear what caused the error to start happening as creating and editing these attributes was previously working.

We've recently upgraded SimpleForm so maybe some changes in how the fields are created?

I've switched the forms to use `simple_fields_for` around the nested fields which is the correct way to build nested fields. And added specs specifically to cover editing meter atttributes that use nested fields.