### PR TITLE
Remove advice page benchmarks when meters are deactivated

### DIFF
--- a/app/services/schools/advice_page_benchmarks/school_benchmark_generator.rb
+++ b/app/services/schools/advice_page_benchmarks/school_benchmark_generator.rb
@@ -35,7 +35,12 @@ module Schools
       end
 
       def perform
-        return nil unless school_has_fuel_type?
+        unless school_has_fuel_type?
+          # remove any old benchmarks generated when school may have had active meters for this fuel type
+          @school.advice_page_school_benchmarks.where(advice_page: @advice_page).destroy_all
+          return nil
+        end
+
         begin
           benchmarked_as = benchmark_school
           @school_benchmark = @school.advice_page_school_benchmarks.find_or_create_by(advice_page: @advice_page)

--- a/spec/services/schools/advice_page_benchmarks/school_benchmark_generator_spec.rb
+++ b/spec/services/schools/advice_page_benchmarks/school_benchmark_generator_spec.rb
@@ -121,6 +121,15 @@ RSpec.describe Schools::AdvicePageBenchmarks::SchoolBenchmarkGenerator, type: :s
           expect(AdvicePageSchoolBenchmark.count).to eq 0
         end
       end
+
+      context 'and school no longer has fuel type' do
+        let!(:fuel_configuration) { Schools::FuelConfiguration.new(has_electricity: false, has_gas: true, has_storage_heaters: true)}
+
+        it 'removes the benchmark' do
+          expect(result).to eq nil
+          expect(AdvicePageSchoolBenchmark.count).to eq 0
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
We generate and `AdvicePageBenchmark` records for each school to note whether they are an examplar or well managed school. These are updated nightly, with records being removed if we can't generate a benchmark. E.g. because of a bug or if an admin has had to truncate the data

But we don't remove the benchmarks if all the meters for a fuel type are deactivated. This creates a bug in the refactored `ComparisonOverviewComponent` as it is checking for existence of these records before deciding whether to show a comparison.

This PR fixes these problems by:

- ensuring stale `AdvicePageBenchmark` records are removed
- the `ComparisonOverviewComponent` first checks the fuel type before proceeding to check for the benchmarks