### PR TITLE
Improve public display layout

### DIFF
--- a/app/assets/javascripts/analysis.js
+++ b/app/assets/javascripts/analysis.js
@@ -78,7 +78,7 @@ function chartSuccess(chartConfig, chartData, chart) {
 
   if (chartType == 'bar' || chartType == 'column' || chartType == 'line') {
 
-    barColumnLine(chartData, chart, seriesData, chartConfig);
+    barColumnLine(chartData, chart, seriesData, chartConfig, $chartDiv);
 
   // Scatter
   } else if (chartType == 'scatter') {

--- a/app/assets/javascripts/common_chart_options.js.erb
+++ b/app/assets/javascripts/common_chart_options.js.erb
@@ -133,13 +133,9 @@ function commonChartOptions(clickListener){
   };
 }
 
-function barColumnLine(chartData, highchartsChart, seriesData, chartConfig) {
+function barColumnLine(chartData, highchartsChart, seriesData, chartConfig, $chartDiv) {
   var subChartType = chartData.chart1_subtype;
   var chartType = chartData.chart1_type;
-
-  //console.log(chartType + ': ' + subChartType);
-
-
 
   var xAxisCategories = chartData.x_axis_categories;
   var yAxisLabel = chartData.y_axis_label;
@@ -153,6 +149,8 @@ function barColumnLine(chartData, highchartsChart, seriesData, chartConfig) {
 
   // BAR Charts
   if (chartType == 'bar') {
+    $chartDiv.addClass('bar-chart');
+
     if (chartData.uses_time_of_day) {
       //console.log('time of day set');
       highchartsChart.update({yAxis: { type: 'datetime', dateTimeLabelFormats: { day: '%H:%M'} }})
@@ -171,6 +169,8 @@ function barColumnLine(chartData, highchartsChart, seriesData, chartConfig) {
 
   // LINE charts
   if (chartType == 'line') {
+    $chartDiv.addClass('line-chart');
+
     if (! y2AxisLabel) {
       highchartsChart.update({ plotOptions: { line: { tooltip: { headerFormat: '<b>{point.key}</b><br>',  pointFormat: orderedPointFormat(yAxisLabel) }}}});
     }
@@ -178,6 +178,8 @@ function barColumnLine(chartData, highchartsChart, seriesData, chartConfig) {
 
   // Column charts
   if (chartType == 'column') {
+    $chartDiv.addClass('column-chart');
+
     if (! noZoom) {
       highchartsChart.update({ chart: { zoomType: 'x'}, subtitle: { text: document.ontouchstart === undefined ?  chartData.click_and_drag_message : chartData.pinch_and_zoom_message }});
     }

--- a/app/assets/stylesheets/analysis.scss
+++ b/app/assets/stylesheets/analysis.scss
@@ -38,7 +38,6 @@ div.analysis-chart, div.usage-chart {
   width: 100%;
   text-align: center;
   color: $dark-grey;
-  line-height: 700px;
   font-size: $f7;
   margin: 0 auto;
   padding-bottom: 25px;
@@ -46,7 +45,6 @@ div.analysis-chart, div.usage-chart {
 
   &.pie-chart {
     height: 550px;
-    line-height: 550px;
   }
 
   &.find-out-more {
@@ -58,6 +56,12 @@ div.analysis-chart, div.usage-chart {
 @media (max-width: 1024px) {
   div.analysis-chart {
     height: 500px;
+  }
+}
+
+div.public-display-chart {
+  div.analysis-chart {
+    height: 550px;
   }
 }
 

--- a/app/assets/stylesheets/pupils.scss
+++ b/app/assets/stylesheets/pupils.scss
@@ -9,3 +9,17 @@
   padding: 30px;
   border-radius: 10px;
 }
+
+div.public-display-logo {
+  border-radius: 8px;
+  background-color: #192a52;
+  height: 60px;
+  margin-right: 16px;
+  padding-top: 8px;
+  padding-bottom: 8px;
+  padding-right: 16px;
+  padding-left: 16px;
+  img {
+    height: 40px;
+  }
+}

--- a/app/components/equivalence_component/equivalence_component.scss
+++ b/app/components/equivalence_component/equivalence_component.scss
@@ -39,12 +39,17 @@
 // Used for public display version of equivalence
 // Force the text to match the header height and colours
 // so more readable from a distance
-.equivalence-component.public-displays.horizontal {
+.equivalence-component.public-displays.vertical {
   .trix-content div, div {
     @include font(f1);
     font-family: $header-font-family;
     font-weight: $header-font-weight;
     color: $dark-blue;
     padding-bottom: 10px;
+  }
+  .illustration-wrapper {
+    img {
+      height: 500px;
+    }
   }
 }

--- a/app/controllers/pupils/public_displays_controller.rb
+++ b/app/controllers/pupils/public_displays_controller.rb
@@ -41,10 +41,21 @@ module Pupils
       raise 'Non-public data' unless @school.data_sharing_public?
       raise 'Not data enabled' unless @school.data_enabled?
       @chart_type = params.require(:chart_type).to_sym
+
+      # avoid showing stale date on weekly comparion chart, issue temporary redirect
+      # ensures pages don't break in case of lagging data or a meter fault
+      if lagging_data?(@chart_type)
+        redirect_to pupils_school_public_displays_equivalences_path(@school, @fuel_type) and return
+      end
       @chart = find_chart(@fuel_type, @chart_type)
     end
 
     private
+
+    def lagging_data?(chart_type)
+      return false if chart_type == :out_of_hours
+      (Time.zone.today - @analysis_dates.end_date) > 30
+    end
 
     def set_fuel_type
       @fuel_type = params.require(:fuel_type).to_sym
@@ -86,14 +97,14 @@ module Pupils
       when :electricity
         case chart_type
         when :out_of_hours
-          :pupil_dashboard_daytype_breakdown_electricity
+          :daytype_breakdown_electricity_tolerant
         else
           :public_displays_electricity_weekly_comparison
         end
       when :gas
         case chart_type
         when :out_of_hours
-          :pupil_dashboard_daytype_breakdown_gas
+          :daytype_breakdown_gas_tolerant
         else
           :public_displays_gas_weekly_comparison
         end

--- a/app/views/pupils/public_displays/charts.html.erb
+++ b/app/views/pupils/public_displays/charts.html.erb
@@ -21,11 +21,14 @@
     </div>
   </div>
   <div class="row">
-    <div class="col-12">
+    <div class="col-12 d-flex justify-content-between align-items-center flex-wrap">
       <h4>
         <% display_dates = @analysis_dates.transform_values { |d| short_dates(d) } %>
         <%= t("pupils.public_displays.charts.#{@chart_type}.dates", **display_dates) %>
       </h4>
+      <div class="public-display-logo">
+        <%= image_tag('navigation-brand-transparent-en.png') %>
+      </div>
     </div>
   </div>
 </div>

--- a/app/views/pupils/public_displays/charts.html.erb
+++ b/app/views/pupils/public_displays/charts.html.erb
@@ -1,4 +1,4 @@
-<div class="container-fluid">
+<div class="container">
   <div class="row">
     <div class="col-12">
       <h1>
@@ -9,14 +9,17 @@
       </h2>
     </div>
   </div>
-  <%= component 'chart',
-                school: @school,
-                chart_type: @chart,
-                axis_controls: false,
-                no_zoom: true,
-                analysis_controls: false,
-                chart_config: create_chart_config(@school, @chart) %>
-
+  <div class="row">
+    <div class="col-12 public-display-chart">
+      <%= component 'chart',
+                    school: @school,
+                    chart_type: @chart,
+                    axis_controls: false,
+                    no_zoom: true,
+                    analysis_controls: false,
+                    chart_config: create_chart_config(@school, @chart) %>
+    </div>
+  </div>
   <div class="row">
     <div class="col-12">
       <h4>

--- a/app/views/pupils/public_displays/equivalences.html.erb
+++ b/app/views/pupils/public_displays/equivalences.html.erb
@@ -2,7 +2,7 @@
   <%= component 'equivalence', image_name: @equivalence.equivalence_type.image_name,
                                fuel_type: @equivalence.equivalence_type.meter_type,
                                classes: 'pl-2 public-displays',
-                               layout: :horizontal do |e| %>
+                               layout: :vertical do |e| %>
     <% e.with_header do %>
       <%= @equivalence.equivalence %>
     <% end %>

--- a/app/views/pupils/public_displays/equivalences.html.erb
+++ b/app/views/pupils/public_displays/equivalences.html.erb
@@ -1,4 +1,4 @@
-<div class="container-fluid">
+<div class="container">
   <%= component 'equivalence', image_name: @equivalence.equivalence_type.image_name,
                                fuel_type: @equivalence.equivalence_type.meter_type,
                                classes: 'pl-2 public-displays',

--- a/app/views/pupils/public_displays/equivalences.html.erb
+++ b/app/views/pupils/public_displays/equivalences.html.erb
@@ -7,4 +7,12 @@
       <%= @equivalence.equivalence %>
     <% end %>
   <% end %>
+  <div class="row">
+    <div class="col-12 d-flex justify-content-end">
+      <div class="public-display-logo">
+        <%= image_tag('navigation-brand-transparent-en.png') %>
+      </div>
+    </div>
+  </div>
+
 </div>

--- a/config/locales/views/pupils/public_displays.yml
+++ b/config/locales/views/pupils/public_displays.yml
@@ -27,7 +27,8 @@ en:
         intro_html: |-
           <p>This page provides links to pages suitable for display on digital signage around the school.</p>
           <p>The following sections provide links to pages that are suitable for this school.</p>
-        title: Public display pages
+          <p>If you have questions about using this feature then please contact us at <a href='mailto:hello@energysparks.uk'>hello@energysparks.uk</a></p>
+        title: Digital signage pages
       table:
         columns:
           chart_type: Chart Type

--- a/config/locales/views/pupils/public_displays.yml
+++ b/config/locales/views/pupils/public_displays.yml
@@ -13,7 +13,7 @@ en:
           title: When did your school use %{fuel_type} over the last year?
       index:
         charts:
-          intro_html: Display an energy use chart
+          intro_html: Display an energy use chart.
           last_week:
             description: Chart showing comparison of energy use for last two weeks
             title: Last week
@@ -22,11 +22,11 @@ en:
             title: Out of hours
           title: Energy use charts
         equivalences:
-          intro_html: Display a random equivalence based on recent energy use
+          intro_html: Display a random equivalence based on recent energy use.
           title: Energy equivalences
         intro_html: |-
-          <p>This page provides links to pages suitable for display as part of public signage</p>
-          <p>The following sections provide links that are suitable for this school</p>
+          <p>This page provides links to pages suitable for display on digital signage around the school.</p>
+          <p>The following sections provide links to pages that are suitable for this school.</p>
         title: Public display pages
       table:
         columns:


### PR DESCRIPTION
- Bar chart height was too large, due to default set in CSS. Revise JS to add classes, adjust CSS to fix height on public displays only
- Switch to `container` rather than `container-fluid` to centre page content and aim for fixed aspect ratio
- Switch to vertical layout for equivalence and increase image size
- Add Energy Sparks logo
- Redirect from weekly chart is data is >30 days out of date to avoid showing stale comparisons
- Tweak wording