### PR TITLE
Make use of solar data more obvious

### DIFF
--- a/app/components/dashboard_learn_more_component.rb
+++ b/app/components/dashboard_learn_more_component.rb
@@ -24,9 +24,13 @@ class DashboardLearnMoreComponent < ApplicationComponent
   end
 
   def title
-    return I18n.t('schools.show.coming_soon') unless data_enabled?
-    return I18n.t("components.dashboard_learn_more.#{audience}.title") unless @school.has_solar_pv? && audience == :adult
-    I18n.t('components.dashboard_learn_more.adult.title_with_solar_pv')
+    if !data_enabled?
+      I18n.t('schools.show.coming_soon')
+    elsif @school.has_solar_pv? && audience == :adult
+      I18n.t('components.dashboard_learn_more.adult.title_with_solar_pv')
+    else
+      I18n.t("components.dashboard_learn_more.#{audience}.title")
+    end
   end
 
   def intro

--- a/app/components/dashboard_learn_more_component.rb
+++ b/app/components/dashboard_learn_more_component.rb
@@ -24,7 +24,9 @@ class DashboardLearnMoreComponent < ApplicationComponent
   end
 
   def title
-    data_enabled? ? I18n.t("components.dashboard_learn_more.#{audience}.title") : I18n.t('schools.show.coming_soon')
+    return I18n.t('schools.show.coming_soon') unless data_enabled?
+    return I18n.t("components.dashboard_learn_more.#{audience}.title") unless @school.has_solar_pv? && audience == :adult
+    I18n.t('components.dashboard_learn_more.adult.title_with_solar_pv')
   end
 
   def intro

--- a/app/components/energy_summary_table_component/energy_summary_table_component.html.erb
+++ b/app/components/energy_summary_table_component/energy_summary_table_component.html.erb
@@ -33,13 +33,26 @@
             <% if Flipper.enabled?(:new_dashboards_2024, user) %>
               <td rowspan="2" class="align-middle icon <%= fuel_type_class(data.fuel_type) %>">
                 <%= component 'icon', fuel_type: data.fuel_type %>
+                <% if data.fuel_type == :electricity && @school.has_solar_pv? %>
+                  <%= component 'icon', fuel_type: :solar_pv %>
+                <% end %>
               </td>
               <td rowspan="2" class="align-middle text-left">
-                <%= t("common.#{data.fuel_type}") %>
+                <% if data.fuel_type == :electricity && @school.has_solar_pv? %>
+                  <%= t('common.electricity_and_solar_pv') %>
+                <% else %>
+                  <%= t("common.#{data.fuel_type}") %>
+                <% end %>
               </td>
             <% else %>
               <td class="icon"><%= component 'icon', fuel_type: data.fuel_type %></td>
-              <td class="text-left"><%= t("common.#{data.fuel_type}") %></td>
+              <td class="text-left">
+                <% if data.fuel_type == :electricity && @school.has_solar_pv? %>
+                  <%= t('common.electricity_and_solar_pv') %>
+                <% else %>
+                  <%= t("common.#{data.fuel_type}") %>
+                <% end %>
+              </td>
             <% end %>
           <% else %>
             <% unless Flipper.enabled?(:new_dashboards_2024, user) %>

--- a/app/components/energy_summary_table_component/energy_summary_table_component.scss
+++ b/app/components/energy_summary_table_component/energy_summary_table_component.scss
@@ -1,3 +1,7 @@
 .energy-summary-table-component td {
   border-bottom: 1px solid #dee2e6;
 }
+
+.energy-summary-table-component td.icon {
+    width: 70px;
+}

--- a/config/locales/views/components/learn_more.yml
+++ b/config/locales/views/components/learn_more.yml
@@ -7,6 +7,7 @@ en:
         intro: View charts, get insights into reducing energy usage and compare performance against other schools
         opportunities: Energy saving opportunities
         title: Learn more about your energy use
+        title_with_solar_pv: Learn more about your energy use and generation
       pupil:
         intro: Learn more about how your school uses energy using these charts
         title: Explore the energy data for your school

--- a/spec/components/dashboard_learn_more_component_spec.rb
+++ b/spec/components/dashboard_learn_more_component_spec.rb
@@ -38,6 +38,14 @@ RSpec.describe DashboardLearnMoreComponent, :include_url_helpers, type: :compone
 
   context 'when school is data enabled' do
     it_behaves_like 'a data enabled panel'
+
+    context 'with solar pv' do
+      before do
+        allow(school).to receive(:has_solar_pv?).and_return(true)
+      end
+
+      it { expect(html).to have_content(I18n.t('components.dashboard_learn_more.adult.title_with_solar_pv'))}
+    end
   end
 
   context 'when school is not data enabled' do

--- a/spec/components/dashboard_learn_more_component_spec.rb
+++ b/spec/components/dashboard_learn_more_component_spec.rb
@@ -40,9 +40,7 @@ RSpec.describe DashboardLearnMoreComponent, :include_url_helpers, type: :compone
     it_behaves_like 'a data enabled panel'
 
     context 'with solar pv' do
-      before do
-        allow(school).to receive(:has_solar_pv?).and_return(true)
-      end
+      let(:school) { create(:school, :with_fuel_configuration, has_solar_pv: true) }
 
       it { expect(html).to have_content(I18n.t('components.dashboard_learn_more.adult.title_with_solar_pv'))}
     end

--- a/spec/components/energy_summary_table_component_spec.rb
+++ b/spec/components/energy_summary_table_component_spec.rb
@@ -70,6 +70,24 @@ RSpec.describe EnergySummaryTableComponent, :include_application_helper, :includ
                                     ])
     end
 
+    context 'when school has solar pv' do
+      before do
+        allow(school).to receive(:has_solar_pv?).and_return(true)
+      end
+
+      it 'renders the table' do
+        expect(html).to have_selector(:table_row, [
+                                        'Electricity and Solar PV',
+                                        I18n.t('classes.tables.summary_table_data.last_week'),
+                                        '100',
+                                        '50',
+                                        '£200',
+                                        '£33',
+                                        '-9.2%'
+                                      ])
+      end
+    end
+
     it 'renders the table footer' do
       expect(html).to have_content('More information')
       expect(html).to have_link(href: help_path(help_page))


### PR DESCRIPTION
Updates the adult dashboard with some changes to make our use of solar data at the school more obvious:

- revise table text to "Electricity and Solar PV"
- add solar icon to table
- change learn more component title to refer to "energy use and generation"

