### PR TITLE
Add additional crawler exclusions

### DIFF
--- a/app/views/robots_txts/allow.raw
+++ b/app/views/robots_txts/allow.raw
@@ -13,14 +13,18 @@ Disallow: /schools/scoreboard
 Disallow: /schools/*/analysis
 Disallow: /schools/*/find_out_more/*
 Disallow: /schools/*/chart.json
+Disallow: /schools/*/usage
 Disallow: /schools/*/advice
 Disallow: /schools/*/advice/*
+Disallow: /schools/*/school_targets
+Disallow: /schools/*/school_targets/*
 Disallow: /pupils/schools/*/analysis
 Disallow: /benchmark
 Disallow: /all_benchmarks
 Disallow: /users/sign_in
 Disallow: /activity_types/search
 Disallow: /compare/*
+Disallow: /comparisons/*
 
 User-agent: SemrushBot
 Disallow: /

--- a/app/views/robots_txts/allow.raw
+++ b/app/views/robots_txts/allow.raw
@@ -17,14 +17,13 @@ Disallow: /schools/*/usage
 Disallow: /schools/*/advice
 Disallow: /schools/*/advice/*
 Disallow: /schools/*/school_targets
-Disallow: /schools/*/school_targets/*
 Disallow: /pupils/schools/*/analysis
 Disallow: /benchmark
 Disallow: /all_benchmarks
 Disallow: /users/sign_in
 Disallow: /activity_types/search
 Disallow: /compare/*
-Disallow: /comparisons/*
+Disallow: /comparisons
 
 User-agent: SemrushBot
 Disallow: /


### PR DESCRIPTION
Plus a couple of gaps in the robots.txt. In particular disallows crawling of the comparison page results which can be slow.

These were previously all blocked, but the rework of the urls meant that this is currently permitted.