### PR TITLE
Simplify validated reading upsert

### DIFF
--- a/app/services/amr/upsert_validated_readings_for_a_meter.rb
+++ b/app/services/amr/upsert_validated_readings_for_a_meter.rb
@@ -13,7 +13,7 @@ module Amr
       validated_amr_data = amr_data.delete_if {|_reading_date, one_day_read| is_nan?(one_day_read) }
       return if validated_amr_data.empty?
 
-      result = do_upsert(convert_to_hash(validated_amr_data))
+      do_upsert(convert_to_hash(validated_amr_data))
 
       Rails.logger.info "Upserted: #{@dashboard_meter}"
       @dashboard_meter.amr_data = validated_amr_data

--- a/spec/services/amr/upsert_validated_readings_for_a_meter_spec.rb
+++ b/spec/services/amr/upsert_validated_readings_for_a_meter_spec.rb
@@ -50,7 +50,6 @@ describe Amr::UpsertValidatedReadingsForAMeter, type: :service do
         let(:first_reading) { active_record_meter.amr_validated_readings.order(reading_date: :asc).first }
 
         it 'inserts all the validated records from the analytics' do
-          expect(service.rows_affected).to eq 3
           expect(AmrValidatedReading.count).to eq expected_readings
           expect(active_record_meter.amr_validated_readings.count).to eq expected_readings
         end
@@ -105,8 +104,6 @@ describe Amr::UpsertValidatedReadingsForAMeter, type: :service do
         end
 
         it 'does not update the database' do
-          # upsert returns zero rows
-          expect(service.rows_affected).to eq 0
           # confirm nothing else changed
           expect(AmrValidatedReading.count).to eq expected_readings
           expect(first_reading.reading_date).to eq start_date
@@ -132,8 +129,8 @@ describe Amr::UpsertValidatedReadingsForAMeter, type: :service do
         end
 
         it 'inserts the new records' do
-          expect(service.rows_affected).to eq 1
           expect(AmrValidatedReading.count).to eq expected_readings
+          expect(active_record_meter.amr_validated_readings.count).to eq expected_readings
         end
       end
 
@@ -158,7 +155,6 @@ describe Amr::UpsertValidatedReadingsForAMeter, type: :service do
         end
 
         it 'updates the existing records' do
-          expect(service.rows_affected).to eq expected_readings
           expect(AmrValidatedReading.count).to eq expected_readings
           expect(first_reading.reading_date).to eq start_date
           expect(first_reading.kwh_data_x48).to eq new_data
@@ -188,7 +184,6 @@ describe Amr::UpsertValidatedReadingsForAMeter, type: :service do
         let(:first_reading) { active_record_meter.amr_validated_readings.order(reading_date: :asc).first }
 
         it 'updates the existing records' do
-          expect(service.rows_affected).to eq expected_readings
           expect(AmrValidatedReading.count).to eq expected_readings
           expect(first_reading.reading_date).to eq start_date
           expect(first_reading.status).to eq status
@@ -212,7 +207,6 @@ describe Amr::UpsertValidatedReadingsForAMeter, type: :service do
         let(:first_reading) { active_record_meter.amr_validated_readings.order(reading_date: :asc).first }
 
         it 'updates the existing records' do
-          expect(service.rows_affected).to eq expected_readings
           expect(AmrValidatedReading.count).to eq expected_readings
           expect(first_reading.reading_date).to eq start_date
           expect(first_reading.status).to eq new_status


### PR DESCRIPTION
Rails 7 supportings additional options for upsert. This includes not adding a `RETURNING` clause to the query.

Have updated our custom query code to remove the clause as we don't do anything with the returned ids. 

This should avoid Rails loading all of the ids of the inserted or updated records. 

For majority of schools this is a small array, e.g. a few hundred integers, but for the largest schools it might be thousands of identifiers (one Bath school has 32960 validated readings).