### PR TITLE
Support merging of readings in data loader

### DIFF
--- a/app/jobs/manual_data_load_run_job.rb
+++ b/app/jobs/manual_data_load_run_job.rb
@@ -18,7 +18,7 @@ class ManualDataLoadRunJob < ApplicationJob
 
       amr_data_feed_import_log = create_import_log(amr_data_feed_config, amr_uploaded_reading.file_name)
 
-      Amr::ProcessAmrReadingData.new(amr_data_feed_import_log).perform(amr_uploaded_reading.valid_readings, amr_uploaded_reading.warnings)
+      Amr::ProcessAmrReadingData.new(amr_data_feed_config, amr_data_feed_import_log).perform(amr_uploaded_reading.valid_readings, amr_uploaded_reading.warnings)
 
       manual_data_load_run.info('Finished processing')
       amr_uploaded_reading.update!(imported: true)

--- a/app/models/amr_data_feed_config.rb
+++ b/app/models/amr_data_feed_config.rb
@@ -2,6 +2,7 @@
 #
 # Table name: amr_data_feed_configs
 #
+#  allow_merging           :boolean          default(FALSE), not null
 #  column_row_filters      :jsonb
 #  column_separator        :text             default(","), not null
 #  convert_to_kwh          :boolean          default(FALSE)

--- a/app/services/amr/csv_parser_and_upserter.rb
+++ b/app/services/amr/csv_parser_and_upserter.rb
@@ -17,7 +17,7 @@ module Amr
         amr_reading_data = DataFileToAmrReadingData.new(@config, "#{@config.local_bucket_path}/#{@file_name}").perform
 
         if amr_reading_data.valid?
-          ProcessAmrReadingData.new(amr_data_feed_import_log).perform(amr_reading_data.valid_records, amr_reading_data.warnings)
+          ProcessAmrReadingData.new(@config, amr_data_feed_import_log).perform(amr_reading_data.valid_records, amr_reading_data.warnings)
         else
           amr_data_feed_import_log.update(error_messages: amr_reading_data.error_messages_joined, records_imported: 0, records_updated: 0)
         end

--- a/app/services/amr/data_feed_upserter.rb
+++ b/app/services/amr/data_feed_upserter.rb
@@ -1,6 +1,7 @@
 module Amr
   class DataFeedUpserter
-    def initialize(array_of_data_feed_reading_hashes, amr_data_feed_import_log)
+    def initialize(amr_data_feed_config, amr_data_feed_import_log, array_of_data_feed_reading_hashes)
+      @amr_data_feed_config = amr_data_feed_config
       @array_of_data_feed_reading_hashes = array_of_data_feed_reading_hashes
       @amr_data_feed_import_log = amr_data_feed_import_log
     end

--- a/app/services/amr/data_feed_upserter.rb
+++ b/app/services/amr/data_feed_upserter.rb
@@ -7,6 +7,8 @@ module Amr
     end
 
     def perform
+      log_changes(0, 0) and return if @array_of_data_feed_reading_hashes.empty?
+
       records_count_before = count_by_mpan
 
       add_import_log_id_and_dates_to_hash
@@ -15,12 +17,15 @@ module Amr
       inserted_count = count_by_mpan - records_count_before
       updated_count = result.rows.flatten.size - inserted_count
 
-      @amr_data_feed_import_log.update(records_imported: inserted_count, records_updated: updated_count)
-
-      Rails.logger.info "Updated #{updated_count} Inserted #{inserted_count}"
+      log_changes(inserted_count, updated_count)
     end
 
   private
+
+    def log_changes(inserted, updated)
+      @amr_data_feed_import_log.update(records_imported: inserted, records_updated: updated)
+      Rails.logger.info "Updated #{updated} Inserted #{inserted}"
+    end
 
     def count_by_mpan
       mpans = []

--- a/app/services/amr/data_feed_upserter.rb
+++ b/app/services/amr/data_feed_upserter.rb
@@ -1,5 +1,53 @@
 module Amr
   class DataFeedUpserter
+    # This is used to specify the update clause for when we are merging into existing
+    # data rather than just replacing.
+    #
+    # The clause needs to specify all columns that will be updated when a duplicate is
+    # found during the upsert
+    #
+    # In a Postgres upsert statement the new data is referenced via a set called "excluded"
+    # So the new readings to be inserted can be referenced as "excluded.readings"
+    #
+    # We define this update clause to provide logic that defines how to create the array of
+    # updated readings to be stored in the database
+    #
+    # The query uses the set returning function generate_series to generate indexes
+    # for the array (1..48). The single column returned by that set is aliased as i.
+    #
+    # The new array to be inserted is created using the array_agg function
+    # and a CASE statement. The CASE statement essentially iterates over each array entry
+    # to decide how to merge the values, returning one row per entry. The array_agg function
+    # then turns those rows into a single array value.
+    #
+    # The logic in the CASE statement is that if we have missing entries in the data
+    # to be inserted then we will merge that with the currently saved array. Otherwise
+    # the new values overwrite anything already stored.
+    #
+    # This allows new data to override anything already in the system, but where we have
+    # partial days, we end up with a merged array.
+    #
+    # Postgres has no built in functions to do this type of array merging. This approach also
+    # avoids having to declare a custom function
+    #
+    # For all the other columns we just take the values from the incoming data.
+    ON_DUPLICATE_UPDATE_CLAUSE = <<-SQL.squish
+     readings = (
+         SELECT array_agg(
+           CASE
+             WHEN (amr_data_feed_readings.readings)[s.i] IS NOT NULL AND (excluded.readings)[s.i] IS NULL
+                  THEN (amr_data_feed_readings.readings)[s.i]
+             ELSE (excluded.readings)[s.i]
+           END)
+         FROM generate_series(1, 48) AS s(i)
+     ),
+     amr_data_feed_config_id = excluded.amr_data_feed_config_id,
+     meter_id = excluded.meter_id,
+     amr_data_feed_import_log_id = excluded.amr_data_feed_import_log_id,
+     created_at = excluded.created_at,
+     updated_at = excluded.updated_at
+    SQL
+
     def initialize(amr_data_feed_config, amr_data_feed_import_log, array_of_data_feed_reading_hashes)
       @amr_data_feed_config = amr_data_feed_config
       @array_of_data_feed_reading_hashes = array_of_data_feed_reading_hashes
@@ -12,7 +60,7 @@ module Amr
       records_count_before = count_by_mpan
 
       add_import_log_id_and_dates_to_hash
-      result = AmrDataFeedReading.upsert_all(@array_of_data_feed_reading_hashes, unique_by: [:mpan_mprn, :reading_date])
+      result = do_upsert
 
       inserted_count = count_by_mpan - records_count_before
       updated_count = result.rows.flatten.size - inserted_count
@@ -21,6 +69,17 @@ module Amr
     end
 
   private
+
+    def do_upsert
+      if @amr_data_feed_config.allow_merging
+        AmrDataFeedReading.upsert_all(@array_of_data_feed_reading_hashes,
+                                      unique_by: [:mpan_mprn, :reading_date],
+                                      on_duplicate: Arel.sql(ON_DUPLICATE_UPDATE_CLAUSE))
+      else
+        AmrDataFeedReading.upsert_all(@array_of_data_feed_reading_hashes,
+                                      unique_by: [:mpan_mprn, :reading_date])
+      end
+    end
 
     def log_changes(inserted, updated)
       @amr_data_feed_import_log.update(records_imported: inserted, records_updated: updated)

--- a/app/services/amr/data_feed_upserter.rb
+++ b/app/services/amr/data_feed_upserter.rb
@@ -71,14 +71,10 @@ module Amr
   private
 
     def do_upsert
-      if @amr_data_feed_config.allow_merging
-        AmrDataFeedReading.upsert_all(@array_of_data_feed_reading_hashes,
-                                      unique_by: [:mpan_mprn, :reading_date],
-                                      on_duplicate: Arel.sql(ON_DUPLICATE_UPDATE_CLAUSE))
-      else
-        AmrDataFeedReading.upsert_all(@array_of_data_feed_reading_hashes,
-                                      unique_by: [:mpan_mprn, :reading_date])
-      end
+      on_duplicate = @amr_data_feed_config.allow_merging ? Arel.sql(ON_DUPLICATE_UPDATE_CLAUSE) : :update
+      AmrDataFeedReading.upsert_all(@array_of_data_feed_reading_hashes,
+                                    unique_by: [:mpan_mprn, :reading_date],
+                                    on_duplicate: on_duplicate)
     end
 
     def log_changes(inserted, updated)

--- a/app/services/amr/n3rgy_readings_upserter.rb
+++ b/app/services/amr/n3rgy_readings_upserter.rb
@@ -12,7 +12,7 @@ module Amr
     def perform
       return if @readings.empty? || meter_readings.empty?
       Rails.logger.info "Upserting #{meter_readings} for #{@meter.mpan_mprn} at #{@meter.school.name}"
-      DataFeedUpserter.new(data_feed_reading_array(meter_readings), @amr_data_feed_import_log).perform
+      DataFeedUpserter.new(@amr_data_feed_config, @amr_data_feed_import_log, data_feed_reading_array(meter_readings)).perform
       Rails.logger.info "Upserted #{@amr_data_feed_import_log.records_updated} inserted #{@amr_data_feed_import_log.records_imported} for #{@meter.mpan_mprn} at #{@meter.school.name}"
     end
 

--- a/app/services/amr/process_amr_reading_data.rb
+++ b/app/services/amr/process_amr_reading_data.rb
@@ -1,12 +1,13 @@
 module Amr
   class ProcessAmrReadingData
-    def initialize(amr_data_feed_import_log)
+    def initialize(amr_data_feed_config, amr_data_feed_import_log)
+      @amr_data_feed_config = amr_data_feed_config
       @amr_data_feed_import_log = amr_data_feed_import_log
       @meter_data = Meter.hash_of_meter_data
     end
 
     def perform(valid_readings, warning_readings)
-      DataFeedUpserter.new(valid_readings, @amr_data_feed_import_log).perform
+      DataFeedUpserter.new(@amr_data_feed_config, @amr_data_feed_import_log, valid_readings).perform
       create_warnings(warning_readings) unless warning_readings.empty?
       @amr_data_feed_import_log
     end

--- a/app/services/amr/single_read_converter.rb
+++ b/app/services/amr/single_read_converter.rb
@@ -89,6 +89,7 @@ module Amr
     end
 
     def reject_any_low_reading_days
+      return @results_array if @amr_data_feed_config.allow_merging
       @results_array.reject { |result| result[:readings].count(&:blank?) > @amr_data_feed_config.blank_threshold }
     end
 

--- a/app/services/solar/low_carbon_hub_upserter.rb
+++ b/app/services/solar/low_carbon_hub_upserter.rb
@@ -27,7 +27,7 @@ module Solar
 
         update_existing_meter_if_needed(meter)
 
-        Amr::DataFeedUpserter.new(data_feed_reading_array(readings_hash, meter.id, mpan_mprn), @amr_data_feed_import_log).perform
+        Amr::DataFeedUpserter.new(@amr_data_feed_config, @amr_data_feed_import_log, data_feed_reading_array(readings_hash, meter.id, mpan_mprn)).perform
         Rails.logger.info "Upserted #{@amr_data_feed_import_log.records_updated} inserted #{@amr_data_feed_import_log.records_imported}for #{@low_carbon_hub_installation.rbee_meter_id} at #{@low_carbon_hub_installation.school.name}"
       end
     end

--- a/app/services/solar/rtone_variant_upserter.rb
+++ b/app/services/solar/rtone_variant_upserter.rb
@@ -11,7 +11,7 @@ module Solar
     def perform
       Rails.logger.info "Upserting #{@readings.count} for #{@rtone_variant_installation.rtone_meter_id} at #{@rtone_variant_installation.school.name}"
 
-      Amr::DataFeedUpserter.new(data_feed_reading_array(@readings[:readings]), @import_log).perform
+      Amr::DataFeedUpserter.new(@rtone_variant_installation.amr_data_feed_config, @import_log, data_feed_reading_array(@readings[:readings])).perform
 
       Rails.logger.info "Upserted #{@import_log.records_updated} inserted #{@import_log.records_imported}for #{@rtone_variant_installation.rtone_meter_id} at #{@rtone_variant_installation.school.name}"
     end

--- a/app/services/solar/solar_edge_upserter.rb
+++ b/app/services/solar/solar_edge_upserter.rb
@@ -27,7 +27,7 @@ module Solar
 
         update_existing_meter_if_needed(meter)
 
-        Amr::DataFeedUpserter.new(data_feed_reading_array(readings_hash, meter.id, mpan_mprn), @amr_data_feed_import_log).perform
+        Amr::DataFeedUpserter.new(@amr_data_feed_config, @amr_data_feed_import_log, data_feed_reading_array(readings_hash, meter.id, mpan_mprn)).perform
         Rails.logger.info "Upserted #{@amr_data_feed_import_log.records_updated} inserted #{@amr_data_feed_import_log.records_imported}for #{@solar_edge_installation.site_id} at #{@solar_edge_installation.school.name}"
       end
     end

--- a/app/views/admin/amr_data_feed_configs/edit.html.erb
+++ b/app/views/admin/amr_data_feed_configs/edit.html.erb
@@ -6,7 +6,13 @@
                       hint: 'Provide additional notes about when the configuration is used' %>
   <%= f.input :import_warning_days,
               hint: 'This is the number of days after which meter data using this configuration will be considered to be running behing. Used to drive admin import notification emails' %>
+
+  <% if @configuration.allow_merging %>
+    <% hint = 'This format supports partial readings so this field just configures a warning threshold for admins. Partial days will still be inserted.' %>
+  <% else %>
+    <% hint = 'This is the maximum number of missing data points allowed in a day, above which the entire day will be ignored (without reporting). For row per reading formats this will currently always be set to 1 unless a number is configured here.' %>
+  <% end %>
   <%= f.input :missing_readings_limit,
-              hint: 'This is the maximum number of missing data points allowed in a day, above which the entire day will be ignored (without reporting). For row per reading formats this will currently always be set to 1 unless a number is configured here.' %>
+              hint: hint %>
   <%= f.submit 'Update', class: 'btn' %>
 <% end %>

--- a/app/views/admin/amr_uploaded_readings/new.html.erb
+++ b/app/views/admin/amr_uploaded_readings/new.html.erb
@@ -74,6 +74,16 @@
       <ul>
         <% if @amr_data_feed_config.row_per_reading %>
           <li>One <b>row per half hour reading</b></li>
+
+          <% if @amr_data_feed_config.half_hourly_labelling %>
+            <li>Half hourly readings are labelled at the <%= @amr_data_feed_config.half_hourly_labelling %> of the period</li>
+          <% end %>
+
+          <% if @amr_data_feed_config.allow_merging %>
+            <li>Partial days of readings are allowed and will be merged if updates are available. Warnings are still
+              given for more than <%= @amr_data_feed_config.blank_threshold %> missing readings.</li>
+          <% end %>
+
         <% else %>
           <li>One <b>row per day</b>, with all half-hourly periods in columns</li>
         <% end %>

--- a/db/migrate/20241015163950_add_allow_merging_to_data_feed_config.rb
+++ b/db/migrate/20241015163950_add_allow_merging_to_data_feed_config.rb
@@ -1,0 +1,5 @@
+class AddAllowMergingToDataFeedConfig < ActiveRecord::Migration[7.1]
+  def change
+    add_column :amr_data_feed_configs, :allow_merging, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_10_10_131742) do
+ActiveRecord::Schema[7.1].define(version: 2024_10_15_163950) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pgcrypto"
@@ -418,6 +418,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_10_131742) do
     t.boolean "convert_to_kwh", default: false
     t.boolean "delayed_reading", default: false, null: false
     t.enum "half_hourly_labelling", enum_type: "half_hourly_labelling"
+    t.boolean "allow_merging", default: false, null: false
     t.index ["description"], name: "index_amr_data_feed_configs_on_description", unique: true
     t.index ["identifier"], name: "index_amr_data_feed_configs_on_identifier", unique: true
   end

--- a/lib/tasks/deployment/20241016103355_allow_merging_in_edf_config.rake
+++ b/lib/tasks/deployment/20241016103355_allow_merging_in_edf_config.rake
@@ -1,0 +1,13 @@
+namespace :after_party do
+  desc 'Deployment task: allow_merging_in_edf_config'
+  task allow_merging_in_edf_config: :environment do
+    puts "Running deploy task 'allow_merging_in_edf_config'"
+
+    AmrDataFeedConfig.where(identifier: :edf).update_all(allow_merging: true)
+
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord
+      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+  end
+end

--- a/spec/services/amr/data_feed_upserter_spec.rb
+++ b/spec/services/amr/data_feed_upserter_spec.rb
@@ -1,0 +1,168 @@
+require 'rails_helper'
+
+describe Amr::DataFeedUpserter do
+  subject(:service) { described_class.new(amr_data_feed_config, amr_data_feed_import_log, array_of_readings)}
+
+  let!(:meter) { create(:electricity_meter) }
+  let!(:amr_data_feed_config) { create(:amr_data_feed_config) }
+  let!(:amr_data_feed_import_log) { create(:amr_data_feed_import_log, amr_data_feed_config: amr_data_feed_config)}
+  let(:array_of_readings) { [] }
+
+  def create_reading(meter, date = Time.zone.today.iso8601, readings = Array.new(48, '1.0'))
+    {
+      mpan_mprn: meter.mpan_mprn,
+      meter_id: meter.id,
+      reading_date: date,
+      readings: readings,
+      amr_data_feed_config_id: amr_data_feed_config.id
+    }
+  end
+
+  describe '#perform' do
+    context 'with empty database' do
+      context 'with no data to insert' do
+        it 'does nothing' do
+          expect { service.perform }.not_to change(AmrDataFeedReading, :count)
+        end
+      end
+
+      context 'with data to insert' do
+        let(:array_of_readings) do
+          [create_reading(meter)]
+        end
+
+        it 'inserts new records' do
+          expect { service.perform }.to change(AmrDataFeedReading, :count).by(1)
+        end
+
+        it 'adds import log' do
+          service.perform
+          expect(meter.amr_data_feed_readings.first.amr_data_feed_import_log).to eq(amr_data_feed_import_log)
+        end
+
+        it 'adds timestamps' do
+          service.perform
+          expect(meter.amr_data_feed_readings.first.created_at).not_to be_nil
+          expect(meter.amr_data_feed_readings.first.updated_at).not_to be_nil
+        end
+
+        it 'updates import log with statistics' do
+          service.perform
+          amr_data_feed_import_log.reload
+          expect(amr_data_feed_import_log.records_imported).to eq 1
+          expect(amr_data_feed_import_log.records_updated).to eq 0
+        end
+
+        context 'with multiple rows' do
+          let(:array_of_readings) do
+            [create_reading(meter, '2024-01-01'), create_reading(meter, '2024-01-02')]
+          end
+
+          it 'inserts new records' do
+            expect { service.perform }.to change(AmrDataFeedReading, :count).by(2)
+            expect(AmrDataFeedReading.all.pluck(:reading_date)).to match_array(%w[2024-01-01 2024-01-02])
+          end
+        end
+      end
+    end
+
+    context 'with existing records' do
+      context 'with no data to insert' do
+        before do
+          create(:amr_data_feed_reading, mpan_mprn: meter.mpan_mprn)
+        end
+
+        it 'does nothing' do
+          expect { service.perform }.not_to change(AmrDataFeedReading, :count)
+        end
+      end
+
+      context 'with data for same meter and dates' do
+        let!(:todays_reading) { create(:amr_data_feed_reading, mpan_mprn: meter.mpan_mprn, reading_date: Time.zone.today.iso8601, readings: Array.new(48, 2.0)) }
+
+        let(:array_of_readings) do
+          [create_reading(meter)]
+        end
+
+        before do
+          create(:amr_data_feed_reading, mpan_mprn: meter.mpan_mprn, reading_date: '2024-01-01', readings: Array.new(48, '2.0'))
+        end
+
+        it 'does not insert new data' do
+          expect { service.perform }.not_to change(AmrDataFeedReading, :count)
+        end
+
+        it 'updates the readings' do
+          service.perform
+          todays_reading.reload
+          expect(todays_reading.readings).to eq(Array.new(48, '1.0'))
+        end
+
+        it 'updates import log with statistics' do
+          service.perform
+          amr_data_feed_import_log.reload
+          expect(amr_data_feed_import_log.records_imported).to eq 0
+          expect(amr_data_feed_import_log.records_updated).to eq 1
+        end
+
+        it 'updates the other attributes' do
+          service.perform
+          todays_reading.reload
+          expect(todays_reading.amr_data_feed_config).to eq(amr_data_feed_config)
+          expect(todays_reading.amr_data_feed_import_log).to eq(amr_data_feed_import_log)
+          expect(todays_reading.created_at).not_to be_nil
+          expect(todays_reading.updated_at).not_to be_nil
+        end
+      end
+
+      context 'with data for different meter' do
+        let!(:todays_reading) { create(:amr_data_feed_reading, reading_date: Time.zone.today.iso8601, readings: Array.new(48, '2.0')) }
+
+        let(:array_of_readings) do
+          [create_reading(meter)]
+        end
+
+        it 'inserts new records' do
+          expect { service.perform }.to change(AmrDataFeedReading, :count).by(1)
+          todays_reading.reload
+          expect(todays_reading.readings).to eq(Array.new(48, '2.0'))
+          expect(meter.amr_data_feed_readings.first.readings).to eq(Array.new(48, '1.0'))
+        end
+
+        it 'updates import log with statistics' do
+          service.perform
+          amr_data_feed_import_log.reload
+          expect(amr_data_feed_import_log.records_imported).to eq 1
+          expect(amr_data_feed_import_log.records_updated).to eq 0
+        end
+      end
+
+      context 'with data for same meter but different date formats' do
+        let!(:todays_reading) do
+          create(:amr_data_feed_reading,
+          meter: meter,
+          reading_date: Time.zone.today.strftime('%d %b %Y %H:%M'),
+          readings: Array.new(48, '2.0'))
+        end
+
+        let(:array_of_readings) do
+          [create_reading(meter)]
+        end
+
+        it 'inserts new records' do
+          expect { service.perform }.to change(AmrDataFeedReading, :count).by(1)
+          todays_reading.reload
+          expect(todays_reading.readings).to eq(Array.new(48, '2.0'))
+          expect(AmrDataFeedReading.all.order(:updated_at).last.readings).to eq(Array.new(48, '1.0'))
+        end
+
+        it 'updates import log with statistics' do
+          service.perform
+          amr_data_feed_import_log.reload
+          expect(amr_data_feed_import_log.records_imported).to eq 1
+          expect(amr_data_feed_import_log.records_updated).to eq 0
+        end
+      end
+    end
+  end
+end

--- a/spec/services/amr/data_feed_upserter_spec.rb
+++ b/spec/services/amr/data_feed_upserter_spec.rb
@@ -18,7 +18,7 @@ describe Amr::DataFeedUpserter do
     }
   end
 
-  describe '#perform' do
+  shared_examples 'it correctly inserts when there is no saved data' do
     context 'with empty database' do
       context 'with no data to insert' do
         it 'does nothing' do
@@ -65,6 +65,99 @@ describe Amr::DataFeedUpserter do
         end
       end
     end
+  end
+
+  shared_examples 'it correctly identifies records when upserting' do
+    context 'with data for different meter' do
+      let!(:todays_reading) { create(:amr_data_feed_reading, reading_date: Time.zone.today.iso8601, readings: Array.new(48, '2.0')) }
+
+      let(:array_of_readings) do
+        [create_reading(meter)]
+      end
+
+      it 'inserts new records' do
+        expect { service.perform }.to change(AmrDataFeedReading, :count).by(1)
+        todays_reading.reload
+        expect(todays_reading.readings).to eq(Array.new(48, '2.0'))
+        expect(meter.amr_data_feed_readings.first.readings).to eq(Array.new(48, '1.0'))
+      end
+
+      it 'updates import log with statistics' do
+        service.perform
+        amr_data_feed_import_log.reload
+        expect(amr_data_feed_import_log.records_imported).to eq 1
+        expect(amr_data_feed_import_log.records_updated).to eq 0
+      end
+    end
+
+    context 'with data for same meter but different date formats' do
+      let!(:todays_reading) do
+        create(:amr_data_feed_reading,
+        meter: meter,
+        reading_date: Time.zone.today.strftime('%d %b %Y %H:%M'),
+        readings: Array.new(48, '2.0'))
+      end
+
+      let(:array_of_readings) do
+        [create_reading(meter)]
+      end
+
+      it 'inserts new records' do
+        expect { service.perform }.to change(AmrDataFeedReading, :count).by(1)
+        todays_reading.reload
+        expect(todays_reading.readings).to eq(Array.new(48, '2.0'))
+        expect(AmrDataFeedReading.all.order(:updated_at).last.readings).to eq(Array.new(48, '1.0'))
+      end
+
+      it 'updates import log with statistics' do
+        service.perform
+        amr_data_feed_import_log.reload
+        expect(amr_data_feed_import_log.records_imported).to eq 1
+        expect(amr_data_feed_import_log.records_updated).to eq 0
+      end
+    end
+  end
+
+  shared_examples 'it updates existing readings' do
+    let!(:todays_reading) { create(:amr_data_feed_reading, mpan_mprn: meter.mpan_mprn, reading_date: Time.zone.today.iso8601, readings: Array.new(48, 2.0)) }
+
+    let(:array_of_readings) do
+      [create_reading(meter)]
+    end
+
+    before do
+      create(:amr_data_feed_reading, mpan_mprn: meter.mpan_mprn, reading_date: '2024-01-01', readings: Array.new(48, '2.0'))
+    end
+
+    it 'does not insert new data' do
+      expect { service.perform }.not_to change(AmrDataFeedReading, :count)
+    end
+
+    it 'updates the readings' do
+      service.perform
+      todays_reading.reload
+      expect(todays_reading.readings).to eq(Array.new(48, '1.0'))
+    end
+
+    it 'updates import log with statistics' do
+      service.perform
+      amr_data_feed_import_log.reload
+      expect(amr_data_feed_import_log.records_imported).to eq 0
+      expect(amr_data_feed_import_log.records_updated).to eq 1
+    end
+
+    it 'updates the other attributes' do
+      service.perform
+      todays_reading.reload
+      expect(todays_reading.amr_data_feed_config).to eq(amr_data_feed_config)
+      expect(todays_reading.amr_data_feed_import_log).to eq(amr_data_feed_import_log)
+      expect(todays_reading.created_at).not_to be_nil
+      expect(todays_reading.updated_at).not_to be_nil
+    end
+  end
+
+  describe '#perform' do
+    it_behaves_like 'it correctly inserts when there is no saved data'
 
     context 'with existing records' do
       context 'with no data to insert' do
@@ -78,90 +171,99 @@ describe Amr::DataFeedUpserter do
       end
 
       context 'with data for same meter and dates' do
-        let!(:todays_reading) { create(:amr_data_feed_reading, mpan_mprn: meter.mpan_mprn, reading_date: Time.zone.today.iso8601, readings: Array.new(48, 2.0)) }
-
-        let(:array_of_readings) do
-          [create_reading(meter)]
-        end
-
-        before do
-          create(:amr_data_feed_reading, mpan_mprn: meter.mpan_mprn, reading_date: '2024-01-01', readings: Array.new(48, '2.0'))
-        end
-
-        it 'does not insert new data' do
-          expect { service.perform }.not_to change(AmrDataFeedReading, :count)
-        end
-
-        it 'updates the readings' do
-          service.perform
-          todays_reading.reload
-          expect(todays_reading.readings).to eq(Array.new(48, '1.0'))
-        end
-
-        it 'updates import log with statistics' do
-          service.perform
-          amr_data_feed_import_log.reload
-          expect(amr_data_feed_import_log.records_imported).to eq 0
-          expect(amr_data_feed_import_log.records_updated).to eq 1
-        end
-
-        it 'updates the other attributes' do
-          service.perform
-          todays_reading.reload
-          expect(todays_reading.amr_data_feed_config).to eq(amr_data_feed_config)
-          expect(todays_reading.amr_data_feed_import_log).to eq(amr_data_feed_import_log)
-          expect(todays_reading.created_at).not_to be_nil
-          expect(todays_reading.updated_at).not_to be_nil
-        end
+        it_behaves_like 'it updates existing readings'
       end
 
-      context 'with data for different meter' do
-        let!(:todays_reading) { create(:amr_data_feed_reading, reading_date: Time.zone.today.iso8601, readings: Array.new(48, '2.0')) }
+      it_behaves_like 'it correctly identifies records when upserting'
+    end
 
-        let(:array_of_readings) do
-          [create_reading(meter)]
+    context 'with config that allows merging' do
+      let!(:amr_data_feed_config) { create(:amr_data_feed_config, allow_merging: true) }
+
+      it_behaves_like 'it correctly inserts when there is no saved data'
+
+      context 'with existing readings' do
+        context 'with no data to insert' do
+          before do
+            create(:amr_data_feed_reading, mpan_mprn: meter.mpan_mprn)
+          end
+
+          it 'does nothing' do
+            expect { service.perform }.not_to change(AmrDataFeedReading, :count)
+          end
         end
 
-        it 'inserts new records' do
-          expect { service.perform }.to change(AmrDataFeedReading, :count).by(1)
-          todays_reading.reload
-          expect(todays_reading.readings).to eq(Array.new(48, '2.0'))
-          expect(meter.amr_data_feed_readings.first.readings).to eq(Array.new(48, '1.0'))
+        context 'with data for same meter and dates' do
+          context 'when existing and new are both full days' do
+            it_behaves_like 'it updates existing readings'
+          end
+
+          context 'when the new partial readings do not overlap the existing' do
+            let!(:existing) do
+              create(:amr_data_feed_reading, mpan_mprn: meter.mpan_mprn, reading_date: Time.zone.today.iso8601, readings: Array.new(48) { |i| i < 2 ? '1.0' : nil })
+            end
+
+            let(:array_of_readings) do
+              [create_reading(meter, Time.zone.today.iso8601, Array.new(48) { |i| i >= 2 ? '2.0' : nil })]
+            end
+
+            it 'merges the readings' do
+              expect { service.perform }.not_to change(AmrDataFeedReading, :count)
+              existing.reload
+              expect(existing.readings).to eq(Array.new(2, '1.0') + Array.new(46, '2.0'))
+            end
+          end
+
+          context 'when the new partial readings partially overlap the existing' do
+            let!(:existing) do
+              create(:amr_data_feed_reading, mpan_mprn: meter.mpan_mprn, reading_date: Time.zone.today.iso8601, readings: Array.new(48) { |i| i < 3 ? '1.0' : nil })
+            end
+
+            let(:array_of_readings) do
+              [create_reading(meter, Time.zone.today.iso8601, Array.new(48) { |i| i >= 2 ? '2.0' : nil })]
+            end
+
+            it 'merges the readings, but overwrites the overlaps' do
+              expect { service.perform }.not_to change(AmrDataFeedReading, :count)
+              existing.reload
+              expect(existing.readings).to eq(Array.new(2, '1.0') + Array.new(46, '2.0'))
+            end
+          end
+
+          context 'with a full day of new readings' do
+            let!(:existing) do
+              create(:amr_data_feed_reading, mpan_mprn: meter.mpan_mprn, reading_date: Time.zone.today.iso8601, readings: Array.new(48) { |i| i < 2 ? '2.0' : nil })
+            end
+
+            let(:array_of_readings) do
+              [create_reading(meter)]
+            end
+
+            it 'overwrites the existing readings' do
+              expect { service.perform }.not_to change(AmrDataFeedReading, :count)
+              existing.reload
+              expect(existing.readings).to eq(Array.new(48, '1.0'))
+            end
+          end
+
+          context 'when there are still gaps in new data' do
+            let!(:existing) do
+              create(:amr_data_feed_reading, mpan_mprn: meter.mpan_mprn, reading_date: Time.zone.today.iso8601, readings: Array.new(48) { |i| i < 2 ? '1.0' : nil })
+            end
+
+            let(:array_of_readings) do
+              [create_reading(meter, Time.zone.today.iso8601, Array.new(48) { |i| i >= 2 && i < 10 ? '2.0' : nil })]
+            end
+
+            it 'merges the readings' do
+              expect { service.perform }.not_to change(AmrDataFeedReading, :count)
+              existing.reload
+              expect(existing.readings).to eq(Array.new(2, '1.0') + Array.new(8, '2.0') + Array.new(38))
+            end
+          end
         end
 
-        it 'updates import log with statistics' do
-          service.perform
-          amr_data_feed_import_log.reload
-          expect(amr_data_feed_import_log.records_imported).to eq 1
-          expect(amr_data_feed_import_log.records_updated).to eq 0
-        end
-      end
-
-      context 'with data for same meter but different date formats' do
-        let!(:todays_reading) do
-          create(:amr_data_feed_reading,
-          meter: meter,
-          reading_date: Time.zone.today.strftime('%d %b %Y %H:%M'),
-          readings: Array.new(48, '2.0'))
-        end
-
-        let(:array_of_readings) do
-          [create_reading(meter)]
-        end
-
-        it 'inserts new records' do
-          expect { service.perform }.to change(AmrDataFeedReading, :count).by(1)
-          todays_reading.reload
-          expect(todays_reading.readings).to eq(Array.new(48, '2.0'))
-          expect(AmrDataFeedReading.all.order(:updated_at).last.readings).to eq(Array.new(48, '1.0'))
-        end
-
-        it 'updates import log with statistics' do
-          service.perform
-          amr_data_feed_import_log.reload
-          expect(amr_data_feed_import_log.records_imported).to eq 1
-          expect(amr_data_feed_import_log.records_updated).to eq 0
-        end
+        it_behaves_like 'it correctly identifies records when upserting'
       end
     end
   end

--- a/spec/services/amr/process_amr_reading_data_spec.rb
+++ b/spec/services/amr/process_amr_reading_data_spec.rb
@@ -2,15 +2,18 @@ require 'rails_helper'
 
 module Amr
   describe ProcessAmrReadingData do
-    let!(:amr_data_feed_import_log) { create(:amr_data_feed_import_log) }
-    let(:reading_data_first)        { { :mpan_mprn => '123', :reading_date => Date.parse('2019-01-01'), readings: Array.new(48, '0.0'), amr_data_feed_config_id: amr_data_feed_import_log.amr_data_feed_config_id } }
-    let(:reading_data_second)       { { :mpan_mprn => '123', :reading_date => Date.parse('2019-01-02'), readings: Array.new(48, '0.0'), amr_data_feed_config_id: amr_data_feed_import_log.amr_data_feed_config_id } }
-    let(:reading_data_third)        { { :mpan_mprn => '123', :reading_date => Date.parse('2019-01-03'), readings: Array.new(48, '0.0'), amr_data_feed_config_id: amr_data_feed_import_log.amr_data_feed_config_id } }
-    let(:reading_data_warning)      { { :mpan_mprn => '1234567890123', :reading_date => Date.parse('2019-01-03'), readings: Array.new(40, '0.0'), amr_data_feed_config_id: amr_data_feed_import_log.amr_data_feed_config_id, warnings: [:missing_readings] } }
+    subject(:service) { ProcessAmrReadingData.new(amr_data_feed_config, amr_data_feed_import_log) }
+
+    let!(:amr_data_feed_config) { create(:amr_data_feed_config) }
+    let!(:amr_data_feed_import_log) { create(:amr_data_feed_import_log, amr_data_feed_config: amr_data_feed_config) }
+    let(:reading_data_first)        { { :mpan_mprn => '123', :reading_date => Date.parse('2019-01-01'), readings: Array.new(48, '0.0'), amr_data_feed_config_id: amr_data_feed_config.id } }
+    let(:reading_data_second)       { { :mpan_mprn => '123', :reading_date => Date.parse('2019-01-02'), readings: Array.new(48, '0.0'), amr_data_feed_config_id: amr_data_feed_config.id } }
+    let(:reading_data_third)        { { :mpan_mprn => '123', :reading_date => Date.parse('2019-01-03'), readings: Array.new(48, '0.0'), amr_data_feed_config_id: amr_data_feed_config.id } }
+    let(:reading_data_warning)      { { :mpan_mprn => '1234567890123', :reading_date => Date.parse('2019-01-03'), readings: Array.new(40, '0.0'), amr_data_feed_config_id: amr_data_feed_config.id, warnings: [:missing_readings] } }
     let(:valid_reading_data)        { [reading_data_first, reading_data_second, reading_data_third] }
 
     it 'processes a valid amr reading data' do
-      expect { ProcessAmrReadingData.new(amr_data_feed_import_log).perform(valid_reading_data, [])}.to change(AmrDataFeedReading, :count).by(3)
+      expect { service.perform(valid_reading_data, [])}.to change(AmrDataFeedReading, :count).by(3)
       expect(amr_data_feed_import_log.error_messages).to be_blank
       expect(amr_data_feed_import_log.amr_reading_warnings).to be_empty
     end
@@ -19,7 +22,7 @@ module Amr
       it 'creates a warning if required' do
         school = create(:school)
         meter = create(:electricity_meter, school: school, mpan_mprn: 1234567890123)
-        expect { ProcessAmrReadingData.new(amr_data_feed_import_log).perform(valid_reading_data, [reading_data_warning])}.to change(AmrDataFeedReading, :count).by(3).and change(AmrReadingWarning, :count).by(1)
+        expect { service.perform(valid_reading_data, [reading_data_warning])}.to change(AmrDataFeedReading, :count).by(3).and change(AmrReadingWarning, :count).by(1)
 
         first_warning = AmrReadingWarning.first
 

--- a/spec/services/amr/single_read_converter_spec.rb
+++ b/spec/services/amr/single_read_converter_spec.rb
@@ -247,6 +247,24 @@ module Amr
         it 'rejects the row' do
           expect(converter.perform).to be_empty
         end
+
+        context 'with merging allowed' do
+          let(:config) { create(:amr_data_feed_config, :with_positional_index, allow_merging: true) }
+          let(:mpan_mprn) { '1710035168313' }
+          let(:reading_date) { '26 Aug 2019' }
+
+          let(:readings) do
+            44.times.collect { |hh| create_reading_for_period(config, mpan_mprn, reading_date, (hh + 1).to_s, [(hh + 1).to_s]) }
+          end
+
+          let(:expected_output) do
+            [create_reading(config, mpan_mprn, Date.parse(reading_date), Array.new(48) {|i| i < 44 ? (i + 1).to_f : nil })]
+          end
+
+          it 'does not reject the row' do
+            expect(converter.perform).to eq(expected_output)
+          end
+        end
       end
     end
 


### PR DESCRIPTION
A couple of "row per reading" formats that we are receiving contain data for partial days. For example we receive:

- 47 readings for one day
- 1 reading for the next

The next update does not contain a full reading for either day. We just get a cycle of partial readings. 

Our loader currently expects that a data file will contain all available data for a meter, rather than a rolling set of readings. This means we currently end up rejecting the days with very limited readings whilst loading the days that have partial readings that never get filled in.

This PR provides support for merging readings during our normal upsert. The behaviour is configured on individual feed formats and is currently only fully tested with "row per reading" files.

The new behaviour has been implemented by:

- revising the `DataFeedUpserter` to use new Rails 7 features to support specifying the update clause when there is a conflict on the upsert
- building a merged array of 48 half-hourly readings from the existing and new data, using the Postgres `array_agg` and `generate_series` functions
- adding a configuration setting to activate the behaviour and refactoring the existing code to expose that in the right places

New tests have been written for the upserter to test both the current and new behaviour is a range of scenarios.

I've also tweaked a few of the admin pages to help document the new settings.

There is also a database update to activate this behaviour for the EDF generic feed.