### PR TITLE
Replace use of notice component with prompt component across advice pages

### DIFF
--- a/app/components/icon_component.rb
+++ b/app/components/icon_component.rb
@@ -19,6 +19,12 @@ class IconComponent < ViewComponent::Base
   end
 
   def icon_name
-    @name || fuel_type_icon(@fuel_type)
+    dasherize_name || fuel_type_icon(@fuel_type)
+  end
+
+  private
+
+  def dasherize_name
+    @name&.to_s&.dasherize
   end
 end

--- a/app/components/prompt_component.rb
+++ b/app/components/prompt_component.rb
@@ -30,6 +30,10 @@ class PromptComponent < ApplicationComponent
     validate
   end
 
+  def icon_name
+    @icon.to_s.dasherize
+  end
+
   def render_icon?
     @fuel_type || @icon
   end

--- a/app/components/prompt_component.rb
+++ b/app/components/prompt_component.rb
@@ -30,10 +30,6 @@ class PromptComponent < ApplicationComponent
     validate
   end
 
-  def icon_name
-    @icon.to_s.dasherize
-  end
-
   def render_icon?
     @fuel_type || @icon
   end

--- a/app/components/prompt_component/prompt_component.html.erb
+++ b/app/components/prompt_component/prompt_component.html.erb
@@ -4,7 +4,7 @@
     <% if render_icon? %>
       <%# Icon is hidden on smallest size, visible from sm and above as single column %>
       <div class="d-none d-sm-block col-1">
-        <%= component 'icon', fuel_type: fuel_type, name: icon_name, style: :circle, size: 'f5' %>
+        <%= component 'icon', fuel_type: fuel_type, name: icon, style: :circle, size: 'f5' %>
       </div>
     <% end %>
     <%# if no icon then use full width row %>

--- a/app/components/prompt_component/prompt_component.html.erb
+++ b/app/components/prompt_component/prompt_component.html.erb
@@ -4,7 +4,7 @@
     <% if render_icon? %>
       <%# Icon is hidden on smallest size, visible from sm and above as single column %>
       <div class="d-none d-sm-block col-1">
-        <%= component 'icon', fuel_type: fuel_type, name: icon, style: :circle, size: 'f5' %>
+        <%= component 'icon', fuel_type: fuel_type, name: icon_name, style: :circle, size: 'f5' %>
       </div>
     <% end %>
     <%# if no icon then use full width row %>

--- a/app/views/schools/advice/_data_warning.html.erb
+++ b/app/views/schools/advice/_data_warning.html.erb
@@ -1,3 +1,3 @@
-<%= component 'notice', status: :negative do |c| %>
+<%= component 'prompt', status: :negative, icon: :circle_exclamation do |c| %>
   <%= t('advice_pages.error.data_warning', fuel_type: fuel_type) %>
 <% end %>

--- a/app/views/schools/advice/baseload/_assessment.html.erb
+++ b/app/views/schools/advice/baseload/_assessment.html.erb
@@ -1,10 +1,10 @@
 <% if advice_baseload_high?(estimated_savings_vs_benchmark.£) %>
-  <%= component 'notice', status: :negative do %>
+  <%= component 'prompt', icon: :bolt, fuel_type: :electricity, status: :negative do %>
     <p><%= t('advice_pages.baseload.analysis.baseload_high') %></p>
     <p><%= t('advice_pages.baseload.analysis.baseload_high_details_html', estimated_savings: format_unit(estimated_savings_vs_benchmark.£, :£)) %></p>
   <% end %>
 <% else %>
-  <%= component 'notice', status: :positive do %>
+  <%= component 'prompt', icon: :bolt, fuel_type: :electricity, status: :positive do %>
     <p><%= t('advice_pages.baseload.analysis.baseload_low') %></p>
     <p><%= t('advice_pages.baseload.analysis.baseload_low_details_html', estimated_savings: format_unit(estimated_savings_vs_benchmark.£.abs, :£)) %></p>
     <% if estimated_savings_vs_exemplar.£ > 0.0 %>

--- a/app/views/schools/advice/baseload/_what_is_baseload.html.erb
+++ b/app/views/schools/advice/baseload/_what_is_baseload.html.erb
@@ -1,4 +1,4 @@
-<%= component 'notice', status: :neutral do |c| %>
+<%= component 'prompt', status: :none, icon: :lightbulb do |c| %>
   <% c.with_link { link_to t('advice_pages.baseload.what_is_baseload_link'), learn_more_school_advice_baseload_path(school) } %>
   <%= t('advice_pages.baseload.what_is_baseload_html') %>
   <%= t('advice_pages.baseload.for_each_1kw_reduction_html',

--- a/app/views/schools/advice/electricity_costs/_agreed_capacity_notice.html.erb
+++ b/app/views/schools/advice/electricity_costs/_agreed_capacity_notice.html.erb
@@ -1,5 +1,5 @@
 <% if @agreed_capacity.percentage > 0.85 %>
-  <%= component 'notice', status: :negative do |c| %>
+  <%= component 'prompt', icon: :bolt, fuel_type: :electricity, status: :negative do |c| %>
     <%= t('advice_pages.electricity_costs.analysis.agreed_capacity_notice.nearing_agreed_capacity_html',
           kw: format_unit(@agreed_capacity.kw, :kw),
           agreed_limit_kw: format_unit(@agreed_capacity.agreed_limit_kw, :kw),

--- a/app/views/schools/advice/electricity_costs/_insights.html.erb
+++ b/app/views/schools/advice/electricity_costs/_insights.html.erb
@@ -1,4 +1,4 @@
-<%= component 'notice', status: :neutral do |c| %>
+<%= component 'prompt', status: :none, icon: :lightbulb do |c| %>
   <% c.with_link { link_to t('advice_pages.electricity_costs.insights.link'), learn_more_school_advice_electricity_costs_path(@school) } %>
   <%= t('advice_pages.electricity_costs.insights.intro_html') %>
 <% end %>

--- a/app/views/schools/advice/electricity_costs/_tariff_note.html.erb
+++ b/app/views/schools/advice/electricity_costs/_tariff_note.html.erb
@@ -1,9 +1,9 @@
 <% if complete_tariff_coverage %>
-  <%= component 'notice', status: :neutral, classes: 'mb-2' do |c| %>
+  <%= component 'prompt', icon: :lightbulb, status: :neutral, classes: 'mb-2' do |c| %>
     <%= advice_t('electricity_costs.analysis.tariff_note.good_estimate') %>
   <% end %>
 <% else %>
-  <%= component 'notice', status: :negative, classes: 'mb-2' do |c| %>
+  <%= component 'prompt', icon: :circle_exclamation, status: :negative, classes: 'mb-2' do |c| %>
     <% c.with_link { link_to advice_t('electricity_costs.analysis.tariff_note.manage_tariffs'), school_energy_tariffs_path(school) } %>
     <p>
       <%= advice_t('electricity_costs.analysis.tariff_note.poor_estimate', period_start_and_end: @periods_with_missing_tariffs.map{|range| [range[0].to_fs(:es_short), range[1].to_fs(:es_short)].to_sentence }.join(",")) %>

--- a/app/views/schools/advice/electricity_intraday/_insights.html.erb
+++ b/app/views/schools/advice/electricity_intraday/_insights.html.erb
@@ -1,4 +1,4 @@
-<%= component 'notice', status: :neutral do |c| %>
+<%= component 'prompt', status: :none, icon: :lightbulb do |c| %>
   <% c.with_link do
        link_to t('advice_pages.electricity_intraday.insights.summary_link'),
                learn_more_school_advice_electricity_intraday_path(@school)

--- a/app/views/schools/advice/electricity_long_term/_insights_intro.html.erb
+++ b/app/views/schools/advice/electricity_long_term/_insights_intro.html.erb
@@ -1,4 +1,4 @@
-<%= component 'notice', status: :neutral do |c| %>
+<%= component 'prompt', status: :none, icon: :lightbulb do |c| %>
   <% c.with_link do
        link_to t('advice_pages.electricity_long_term.what_is_long_term_use.link'),
                learn_more_school_advice_electricity_long_term_path(school)

--- a/app/views/schools/advice/electricity_meter_breakdown/_insights.html.erb
+++ b/app/views/schools/advice/electricity_meter_breakdown/_insights.html.erb
@@ -1,4 +1,4 @@
-<%= component 'notice', status: :neutral do |c| %>
+<%= component 'prompt', status: :none, icon: :lightbulb do |c| %>
   <% c.with_link do
        link_to t("advice_pages.#{@advice_page.fuel_type}_meter_breakdown.insights.what_is_a_meter_breakdown.link"),
                learn_more_school_advice_electricity_meter_breakdown_path(@school)

--- a/app/views/schools/advice/electricity_out_of_hours/_insights_intro.html.erb
+++ b/app/views/schools/advice/electricity_out_of_hours/_insights_intro.html.erb
@@ -1,4 +1,4 @@
-<%= component 'notice', status: :neutral do |c| %>
+<%= component 'prompt', status: :none, icon: :lightbulb do |c| %>
   <% c.with_link do
        link_to t('advice_pages.electricity_out_of_hours.insights.what_is_out_of_hours_usage_link'),
                learn_more_school_advice_electricity_out_of_hours_path(@school)

--- a/app/views/schools/advice/electricity_recent_changes/_insights.html.erb
+++ b/app/views/schools/advice/electricity_recent_changes/_insights.html.erb
@@ -1,4 +1,4 @@
-<%= component 'notice', status: :neutral do |c| %>
+<%= component 'prompt', status: :none, icon: :lightbulb do |c| %>
   <% c.with_link do
        link_to t('advice_pages.electricity_recent_changes.insights.link'),
                learn_more_school_advice_electricity_recent_changes_path(@school)

--- a/app/views/schools/advice/gas_costs/_insights.html.erb
+++ b/app/views/schools/advice/gas_costs/_insights.html.erb
@@ -1,4 +1,4 @@
-<%= component 'notice', status: :neutral do |c| %>
+<%= component 'prompt', status: :none, icon: :lightbulb do |c| %>
   <% c.with_link { link_to t('advice_pages.gas_costs.insights.link'), learn_more_school_advice_electricity_costs_path(@school) } %>
   <%= t('advice_pages.gas_costs.insights.intro_html') %>
 <% end %>

--- a/app/views/schools/advice/gas_costs/_tariff_note.html.erb
+++ b/app/views/schools/advice/gas_costs/_tariff_note.html.erb
@@ -1,9 +1,9 @@
 <% if complete_tariff_coverage %>
-  <%= component 'notice', status: :neutral, classes: 'mb-2' do |c| %>
+  <%= component 'prompt', icon: :lightbulb, status: :neutral, classes: 'mb-2' do |c| %>
     <%= advice_t('gas_costs.analysis.tariff_note.good_estimate') %>
   <% end %>
 <% else %>
-  <%= component 'notice', status: :negative, classes: 'mb-2' do |c| %>
+  <%= component 'prompt', icon: :circle_exclamation, status: :negative, classes: 'mb-2' do |c| %>
     <% c.with_link { link_to advice_t('gas_costs.analysis.tariff_note.manage_tariffs'), school_energy_tariffs_path(school) } %>
     <p>
       <%= advice_t('gas_costs.analysis.tariff_note.poor_estimate', period_start_and_end: @periods_with_missing_tariffs.map{|range| [range[0].to_fs(:es_short), range[1].to_fs(:es_short)].to_sentence }.join(",")) %>

--- a/app/views/schools/advice/gas_long_term/_insights_intro.html.erb
+++ b/app/views/schools/advice/gas_long_term/_insights_intro.html.erb
@@ -1,4 +1,4 @@
-<%= component 'notice', status: :neutral do |c| %>
+<%= component 'prompt', status: :none, icon: :lightbulb do |c| %>
   <% c.with_link do
        link_to t('advice_pages.gas_long_term.what_is_long_term_use.link'),
                learn_more_school_advice_gas_long_term_path(school)

--- a/app/views/schools/advice/gas_meter_breakdown/_insights.html.erb
+++ b/app/views/schools/advice/gas_meter_breakdown/_insights.html.erb
@@ -1,4 +1,4 @@
-<%= component 'notice', status: :neutral do |c| %>
+<%= component 'prompt', status: :none, icon: :lightbulb do |c| %>
   <% c.with_link do
        link_to t("advice_pages.#{@advice_page.fuel_type}_meter_breakdown.insights.what_is_a_meter_breakdown.link"),
                learn_more_school_advice_gas_meter_breakdown_path(@school)

--- a/app/views/schools/advice/gas_out_of_hours/_insights_intro.html.erb
+++ b/app/views/schools/advice/gas_out_of_hours/_insights_intro.html.erb
@@ -1,4 +1,4 @@
-<%= component 'notice', status: :neutral do |c| %>
+<%= component 'prompt', status: :none, icon: :lightbulb do |c| %>
   <% c.with_link do
        link_to t('advice_pages.gas_out_of_hours.insights.what_is_out_of_hours_usage_link'),
                learn_more_school_advice_gas_out_of_hours_path(@school)

--- a/app/views/schools/advice/gas_recent_changes/_insights.html.erb
+++ b/app/views/schools/advice/gas_recent_changes/_insights.html.erb
@@ -1,4 +1,4 @@
-<%= component 'notice', status: :neutral do |c| %>
+<%= component 'prompt', status: :none, icon: :lightbulb do |c| %>
   <% c.with_link do
        link_to t('advice_pages.gas_recent_changes.insights.link'),
                learn_more_school_advice_gas_recent_changes_path(@school)

--- a/app/views/schools/advice/heating_control/_insights.html.erb
+++ b/app/views/schools/advice/heating_control/_insights.html.erb
@@ -1,4 +1,4 @@
-<%= component 'notice', status: :neutral do |c| %>
+<%= component 'prompt', status: :none, icon: :lightbulb do |c| %>
   <% c.with_link { link_to t('advice_pages.heating_control.what_are_heating_controls.link'), learn_more_school_advice_heating_control_path(@school) } %>
   <%= t('advice_pages.heating_control.what_are_heating_controls.text_html') %>
 <% end %>

--- a/app/views/schools/advice/heating_control/_warm_weather_notice.html.erb
+++ b/app/views/schools/advice/heating_control/_warm_weather_notice.html.erb
@@ -1,4 +1,4 @@
-<%= component 'notice', status: warm_weather_on_days_status(warm_weather_on_days_rating) do %>
+<%= component 'prompt', icon: :fire, fuel_type: :gas, status: warm_weather_on_days_status(warm_weather_on_days_rating) do %>
  <p>
    <%= t('advice_pages.heating_control.analysis.seasonal_control.heating_on_in_warm_weather_days',
    days: seasonal_analysis.heating_on_in_warm_weather_days.to_i,

--- a/app/views/schools/advice/hot_water/_analysis.html.erb
+++ b/app/views/schools/advice/hot_water/_analysis.html.erb
@@ -1,4 +1,4 @@
-<%= component 'notice', status: :neutral do |c| %>
+<%= component 'prompt', status: :none, icon: :circle_exclamation do |c| %>
   <%= t('advice_pages.hot_water.analysis.summary_notice') %>
 <% end %>
 <br>
@@ -19,7 +19,7 @@
 
 <%= render 'schools/advice/section_title', section_id: 'hot_water_efficiency_improvement_options', section_title: t('advice_pages.hot_water.analysis.hot_water_efficiency_improvement_options') %>
 
-<%= component 'notice', status: :neutral do |c| %>
+<%= component 'prompt', status: :none, icon: :lightbulb do |c| %>
   <%= t('advice_pages.hot_water.analysis.hot_water_efficiency_improvement_options_notice_html') %>
 <% end %>
 <br />

--- a/app/views/schools/advice/hot_water/_insights.html.erb
+++ b/app/views/schools/advice/hot_water/_insights.html.erb
@@ -1,4 +1,4 @@
-<%= component 'notice', status: :neutral do |c| %>
+<%= component 'prompt', status: :none, icon: :lightbulb do |c| %>
   <%= t('advice_pages.hot_water.insights.summary_notice_html') %>
 <% end %>
 <%= render 'schools/advice/section_title', section_id: 'your_hot_water_use', section_title: 'Your hot water use' %>

--- a/app/views/schools/advice/long_term/_recent_trend.html.erb
+++ b/app/views/schools/advice/long_term/_recent_trend.html.erb
@@ -4,13 +4,13 @@
 
 <% if analysis_dates.one_years_data? %>
   <% if annual_usage.kwh < vs_exemplar.kwh %>
-    <%= component 'notice', status: :positive do %>
+    <%= component 'prompt', icon: :fire, fuel_type: :gas, status: :positive do %>
       <p><%= t("advice_pages.#{fuel_type}_long_term.analysis.comparison.assessment.low.title") %></p>
       <p><%= t("advice_pages.#{fuel_type}_long_term.analysis.comparison.assessment.low.percent_html",
                percent: format_unit(estimated_savings_vs_exemplar.percent.abs, :percent)) %></p>
     <% end %>
   <% else %>
-    <%= component 'notice', status: :negative do %>
+    <%= component 'prompt', icon: :fire, fuel_type: :gas, status: :negative do %>
       <p><%= t("advice_pages.#{fuel_type}_long_term.analysis.comparison.assessment.high.title") %></p>
       <p><%= t("advice_pages.#{fuel_type}_long_term.analysis.comparison.assessment.high.percent_html",
                percent: format_unit(estimated_savings_vs_exemplar.percent, :percent)) %></p>

--- a/app/views/schools/advice/show.html.erb
+++ b/app/views/schools/advice/show.html.erb
@@ -2,7 +2,7 @@
   <div class="row mt-4">
     <div class="col">
       <h2><%= t('advice_pages.index.show.title')%></h2>
-      <%= component 'notice', status: :neutral do |c| %>
+      <%= component 'prompt', status: :none do |c| %>
         <% c.with_link { link_to t('advice_pages.index.show.notice_link'), priorities_school_advice_path(@school) } %>
         <%= t('advice_pages.index.show.notice_html') %>
       <% end %>

--- a/app/views/schools/advice/solar_pv/_analysis_has_solar_pv.html.erb
+++ b/app/views/schools/advice/solar_pv/_analysis_has_solar_pv.html.erb
@@ -19,7 +19,7 @@
 
 <%= render 'schools/advice/section_title', section_id: 'long_term_trends', section_title: t('advice_pages.solar_pv.has_solar_pv.analysis.long_term_trends') %>
 
-<%= component 'notice', status: :positive do |c| %>
+<%= component 'prompt', icon: :sun, fuel_type: :solar_pv, status: :positive do |c| %>
   <%= t('advice_pages.solar_pv.has_solar_pv.insights.your_solar_panels_have_reduced', annual_saving_from_solar_pv_percent: format_unit(@existing_benefits.annual_saving_from_solar_pv_percent, :percent)).html_safe %>
 <% end %>
 

--- a/app/views/schools/advice/solar_pv/_insights_has_solar_pv.html.erb
+++ b/app/views/schools/advice/solar_pv/_insights_has_solar_pv.html.erb
@@ -1,15 +1,14 @@
-<%= component 'notice', status: :neutral do |c| %>
+<%= component 'prompt', status: :none, icon: :lightbulb do |c| %>
   <% c.with_link { link_to t('advice_pages.solar_pv.has_solar_pv.insights.link'), learn_more_school_advice_solar_pv_path(@school) } %>
   <%= t('advice_pages.solar_pv.has_solar_pv.insights.advice_html') %>
 <% end %>
 
 <%= render 'schools/advice/section_title', section_id: 'your_solar_energy_production', section_title: t('advice_pages.solar_pv.has_solar_pv.insights.your_solar_energy_production') %>
 
-<%= component 'notice', status: :positive do |c| %>
+<%= component 'prompt', icon: :sun, fuel_type: :solar_pv, status: :positive do |c| %>
   <%= t('advice_pages.solar_pv.has_solar_pv.insights.your_solar_panels_have_reduced', annual_saving_from_solar_pv_percent: format_unit(@existing_benefits.annual_saving_from_solar_pv_percent, :percent)).html_safe %>
 <% end %>
 <br />
 <%= render 'insights_has_solar_pv_table' %>
 <%= render 'schools/advice/section_title', section_id: 'how_do_you_compare', section_title: t('advice_pages.solar_pv.has_solar_pv.insights.how_do_you_compare') %>
 <%= t('advice_pages.solar_pv.has_solar_pv.insights.for_more_detail_html', link: compare_for_school_group_path(:change_in_solar_pv_since_last_year, @school)) %>
-

--- a/app/views/schools/advice/solar_pv/_insights_no_solar_pv.html.erb
+++ b/app/views/schools/advice/solar_pv/_insights_no_solar_pv.html.erb
@@ -1,10 +1,10 @@
-<%= component 'notice', status: :neutral do |c| %>
+<%= component 'prompt', status: :none, icon: :lightbulb do |c| %>
   <% c.with_link { link_to t('advice_pages.solar_pv.no_solar_pv.insights.link'), learn_more_school_advice_solar_pv_path(@school) } %>
   <%= t('advice_pages.solar_pv.no_solar_pv.insights.advice_html') %>
 <% end %>
 <%= render 'schools/advice/section_title', section_id: 'potential_benefits_for_your_school', section_title: t('advice_pages.solar_pv.no_solar_pv.insights.potential_benefits_for_your_school') %>
 
-<%= component 'notice', status: :positive do |c| %>
+<%= component 'prompt', icon: :sun, fuel_type: :solar_pv, status: :positive do |c| %>
 <p><%= t('advice_pages.solar_pv.no_solar_pv.insights.your_school_doesnt_have_solar_panels') %>.</p>
 <p><%= t('advice_pages.solar_pv.no_solar_pv.insights.if_you_do_get_solar_panels_installed_html') %>.</p>
 <p><%= t('advice_pages.solar_pv.no_solar_pv.insights.installing_solar_panels_could_reduce_html', optimum_mains_reduction_percent: format_unit(@potential_benefits_estimator.optimum_mains_reduction_percent, :percent)) %>.</p>

--- a/app/views/schools/advice/storage_heaters/_insights.html.erb
+++ b/app/views/schools/advice/storage_heaters/_insights.html.erb
@@ -1,4 +1,4 @@
-<%= component 'notice', status: :neutral do |c| %>
+<%= component 'prompt', status: :none, icon: :lightbulb do |c| %>
   <% c.with_link { link_to t('advice_pages.storage_heaters.insights.link'), learn_more_school_advice_storage_heaters_path(@school) } %>
   <%= t('advice_pages.storage_heaters.insights.advice_html') %>
 <% end %>

--- a/app/views/schools/advice/storage_heaters/_seasonal_control_notice.html.erb
+++ b/app/views/schools/advice/storage_heaters/_seasonal_control_notice.html.erb
@@ -1,5 +1,5 @@
 <% days = @seasonal_analysis.heating_on_in_warm_weather_days %>
 <% rating = Adjective.warm_weather_on_days_rating(days) %>
-<%= component 'notice', status: notice_status_for(rating[:rating_value]) do |c| %>
+<%= component 'prompt', icon: :fire_alt, fuel_type: :storage_heaters, status: notice_status_for(rating[:rating_value]) do |c| %>
   <%= t('advice_pages.storage_heaters.analysis.seasonal_control.notice_html', heating_on_in_warm_weather_days: days.to_i, assessment: Adjective.warm_weather_on_days_adjective(days)) %>
 <% end %>

--- a/app/views/schools/advice/storage_heaters/_your_thermostatic_control_notice.html.erb
+++ b/app/views/schools/advice/storage_heaters/_your_thermostatic_control_notice.html.erb
@@ -1,5 +1,5 @@
 <% rating_value = AnalyseHeatingAndHotWater::HeatingModel.r2_rating_out_of_10(@heating_thermostatic_analysis.r2) %>
-<%= component 'notice', status: notice_status_for(rating_value) do |c| %>
+<%= component 'prompt', icon: :fire_alt, fuel_type: :storage_heaters, status: notice_status_for(rating_value) do |c| %>
   <%= t('advice_pages.storage_heaters.analysis.thermostatic_control.your_thermostatic_control_is_html',
          r2: @heating_thermostatic_analysis.r2.round(2),
          r2_rating_adjective: AnalyseHeatingAndHotWater::HeatingModel.r2_rating_adjective(@heating_thermostatic_analysis.r2)

--- a/app/views/schools/advice/thermostatic_control/_analysis.html.erb
+++ b/app/views/schools/advice/thermostatic_control/_analysis.html.erb
@@ -20,7 +20,7 @@
 <%= render 'schools/advice/section_title', section_id: 'thermostatic_control_in_your_school', section_title: t('advice_pages.thermostatic_control.analysis.thermostatic_control_in_your_school') %>
 
 <% rating_value = AnalyseHeatingAndHotWater::HeatingModel.find_r2_rating(@heating_thermostatic_analysis.r2, :rating_value) %>
-<%= component 'notice', status: notice_status_for(rating_value) do |c| %>
+<%= component 'prompt', icon: :fire, fuel_type: :gas, status: notice_status_for(rating_value) do |c| %>
   <%=
     t('advice_pages.thermostatic_control.insights.thermostatic_control_r2_notice_html',
       r2_rating_adjective: AnalyseHeatingAndHotWater::HeatingModel.r2_rating_adjective(@heating_thermostatic_analysis.r2),

--- a/app/views/schools/advice/thermostatic_control/_insights.html.erb
+++ b/app/views/schools/advice/thermostatic_control/_insights.html.erb
@@ -1,4 +1,4 @@
-<%= component 'notice', status: :neutral do |c| %>
+<%= component 'prompt', status: :none, icon: :lightbulb do |c| %>
   <% c.with_link { link_to t('advice_pages.thermostatic_control.insights.link'), learn_more_school_advice_thermostatic_control_path(@school) } %>
   <%= t('advice_pages.thermostatic_control.insights.advice_html') %>
 <% end %>

--- a/spec/components/prompt_component_spec.rb
+++ b/spec/components/prompt_component_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe PromptComponent, :include_application_helper, type: :component do
     it 'has the icon' do
       expect(html).to have_css('span.fa-stack')
       expect(icon_html).to have_css('i.fa-circle')
-      expect(icon_html).to have_css("i.fa-#{icon}")
+      puts icon_html.inspect
       expect(icon_html).to have_css("i.fa-#{icon}")
     end
   end

--- a/spec/components/prompt_component_spec.rb
+++ b/spec/components/prompt_component_spec.rb
@@ -24,7 +24,6 @@ RSpec.describe PromptComponent, :include_application_helper, type: :component do
     it 'has the icon' do
       expect(html).to have_css('span.fa-stack')
       expect(icon_html).to have_css('i.fa-circle')
-      puts icon_html.inspect
       expect(icon_html).to have_css("i.fa-#{icon}")
     end
   end


### PR DESCRIPTION
- learn more sections on the insight pages become prompts with `status: :none, icon: :lightbulb`
- all other notices have fuel type and icon appropriate for the page
- other warnings e.g. about stale data use appropriate status and an exclamation icon

Moves the advice pages properly in line with new design and starts retiring the old notice component.