### PR TITLE
Improve admin workflow when school has outdated consent

### DIFF
--- a/app/views/admin/schools/meter_reviews/new.html.erb
+++ b/app/views/admin/schools/meter_reviews/new.html.erb
@@ -19,14 +19,17 @@
 
 <div class="row mb-2">
  <div class="col">
-   <%= fa_icon( @school.consent_up_to_date? ? 'check-circle text-success' : 'times-circle text-danger') %>
+   <%= fa_icon(@school.consent_up_to_date? ? 'check-circle text-success' : 'times-circle text-danger') %>
    <% if @school.consent_up_to_date? %>
-    This school has <%= link_to "granted consent", school_consent_grants_path(@school) %> using the latest consent statement
+    This school has <%= link_to 'granted consent', school_consent_grants_path(@school) %> using the latest consent statement
    <% else %>
-    This school has not <%= link_to "granted consent", school_consent_grants_path(@school) %> using the latest consent statement
-    <div class="alert alert-danger">
+    This school has not <%= link_to 'granted consent', school_consent_grants_path(@school) %> using the latest consent statement
+    <div class="alert alert-danger d-flex flex-wrap justify-content-between">
+      <span>
       We do not have up to date consent for <%= @school.name %> so meters cannot be
       activated. The form is disabled.
+      </span>
+      <%= link_to 'Request consent', new_admin_school_consent_request_path(@school), class: 'btn' %>
     </div>
    <% end %>
  </div>
@@ -40,20 +43,28 @@
       <div class="card-group">
           <div class="card bg-light">
             <div class="card-body">
-              <%= f.association :meters, label: "Which meters can be activated?", as: :check_boxes, collection: @pending_meters, value_method: :id, label_method: :mpan_mprn %>
+              <%= f.association :meters, label: 'Which meters can be activated?', as: :check_boxes,
+                                         collection: @pending_meters, value_method: :id, label_method: :mpan_mprn %>
             </div>
             <div class="card-footer">
-              <%= link_to "View meters", school_meters_path(@school), class: "btn btn-sm btn-default", target: "_blank" %>
+              <%= link_to 'View meters', school_meters_path(@school), class: 'btn btn-sm btn-default',
+                                                                      target: '_blank', rel: 'noopener' %>
             </div>
           </div>
 
           <div class="card bg-light">
             <div class="card-body">
-              <%= f.association :consent_documents, label: "Which documents were checked?", as: :check_boxes, collection: @school.consent_documents, value_method: :id, label_method: :title %>
+              <%= f.association :consent_documents,
+                                label: 'Which documents were checked?',
+                                as: :check_boxes,
+                                collection: @school.consent_documents,
+                                value_method: :id,
+                                label_method: :title %>
             </div>
             <div class="card-footer">
-              <%= link_to "View documents", school_consent_documents_path(@school), class: "btn btn-sm btn-default", target: "_blank" %>
-              <%= link_to "Request bill", new_admin_school_bill_request_path(@school), class: 'btn btn-sm btn-default' %>
+              <%= link_to 'View documents', school_consent_documents_path(@school), class: 'btn btn-sm btn-default',
+                                                                                    target: '_blank', rel: 'noopener' %>
+              <%= link_to 'Request bill', new_admin_school_bill_request_path(@school), class: 'btn btn-sm btn-default' %>
             </div>
           </div>
 
@@ -62,11 +73,12 @@
       <div class="row mt-1 mb-1">
        <div class="col">
          <div class="mt-4">
-           <%= f.button :submit, "Complete review", "data-confirm": 'Are you sure?', disabled: !@school.consent_up_to_date? %>
+           <%= f.button :submit, 'Complete review', "data-confirm": 'Are you sure?',
+                                                    disabled: !@school.consent_up_to_date? %>
          </div>
          <hr>
          <div class="btn-group">
-           <%= link_to "See all pending reviews", admin_meter_reviews_path, class: "btn btn-default" %>
+           <%= link_to 'See all pending reviews', admin_meter_reviews_path, class: 'btn btn-default' %>
          </div>
        </div>
       </div>

--- a/app/views/bill_request_mailer/notify_admin.html.erb
+++ b/app/views/bill_request_mailer/notify_admin.html.erb
@@ -3,11 +3,16 @@
 <p>
   A school administrator at <%= @school.name %> has <%= @updated ? 'updated a previously uploaded' : 'uploaded a new' %> bill.
 </p>
-<%= link_to "View bill", school_consent_document_url(@school, @consent_document), class: 'btn btn-primary mt-3 mb-3' %>
+<%= link_to 'View bill', school_consent_document_url(@school, @consent_document), class: 'btn btn-primary mt-3 mb-3' %>
 
 <% if @school.consent_up_to_date? %>
   <p>
     This school has up to date consent, so its now possible to complete a meter review, if required.
   </p>
-  <%= link_to "Perform review", new_admin_school_meter_review_url(@school), class: 'btn btn-primary mt-3 mb-3' %>
+  <%= link_to 'Perform review', new_admin_school_meter_review_url(@school), class: 'btn btn-primary mt-3 mb-3' %>
+<% else %>
+  <p>
+    This school does not have up-to-date consent. You can request consent to allow a meter review to be completed.
+  </p>
+  <%= link_to 'Request consent', new_admin_school_consent_request_url(@school), class: 'btn btn-primary mt-3 mb-3' %>
 <% end %>

--- a/spec/system/admin/meter_reviews/meter_reviews_spec.rb
+++ b/spec/system/admin/meter_reviews/meter_reviews_spec.rb
@@ -125,6 +125,7 @@ RSpec.describe 'meter_reviews', type: :system do
       it 'does not allow completion' do
         click_on 'Meter Reviews'
         expect(page).not_to have_link('Complete review')
+        expect(page).to have_link('Request consent')
       end
     end
 


### PR DESCRIPTION
Admins needs to do a "meter review" to ensure we have up to date consent to access data and a recent energy bill. If consent is not up to date then the review can't be completed.

From the list of pending reviews we provide buttons that allow an admins to request consent or a bill if needed. But on the meter review form we don't provide those links. So an admin visiting from a notification email or via the meters page can't easily complete the next step.

PR adds additional buttons to the form and a note in the email received when a school uploads a bill.