### PR TITLE
Handle completely empty files

### DIFF
--- a/app/services/amr/data_feed_validator.rb
+++ b/app/services/amr/data_feed_validator.rb
@@ -32,7 +32,9 @@ module Amr
     end
 
     def handle_header(array_of_rows)
-      if array_of_rows.first.join(',') == @config.header_example
+      if array_of_rows.empty?
+        array_of_rows
+      elsif array_of_rows.first.join(',') == @config.header_example
         array_of_rows[1, array_of_rows.length]
       elsif @config.number_of_header_rows
         if @config.number_of_header_rows > array_of_rows.length

--- a/spec/services/amr/data_feed_validator_spec.rb
+++ b/spec/services/amr/data_feed_validator_spec.rb
@@ -46,6 +46,11 @@ describe Amr::DataFeedValidator do
   end
 
   context 'with empty files' do
+    it 'handles completely empty files' do
+      results = Amr::DataFeedValidator.new(amr_data_feed_config, []).perform
+      expect(results).to be_empty
+    end
+
     it 'handles empty files when header matches config' do
       only_header = [header_row]
       results = Amr::DataFeedValidator.new(amr_data_feed_config, only_header).perform


### PR DESCRIPTION
Surprised this hasn't happened already, but add spec and fix for when a CSV file is completely empty.