### PR TITLE
Ignore energy-assets2 recurring error

### DIFF
--- a/.overcommit.yml
+++ b/.overcommit.yml
@@ -33,6 +33,7 @@ PreCommit:
     exclude:
       - 'app/assets/images/**/*'
       - 'vendor/assets/**/*'
+      - 'spec/fixtures/**/*'
   I18nTasks:
     enabled: true
     requires_files: true # only run if specific files changes
@@ -50,4 +51,3 @@ PreCommit:
       - 'vendor/**/*'
       - 'app/assets/images/**/*'
       - 'public/error-fonts/*'
-

--- a/app/services/amr/data_file_parser.rb
+++ b/app/services/amr/data_file_parser.rb
@@ -8,6 +8,8 @@ module Amr
 
     attr_reader :path_and_file_name, :config
 
+    ILLEGAL_QUOTING = 'Illegal quoting in line 1.'.freeze
+
     def initialize(config, path_and_file_name)
       @path_and_file_name = path_and_file_name
       @config = config
@@ -25,10 +27,18 @@ module Amr
         end
       CSV.parse(content, col_sep: @config.column_separator, row_sep: :auto)
     rescue CSV::MalformedCSVError, Roo::Error => e
-      raise Error, e.message
+      if ignorable_error?(e.message)
+        return []
+      else
+        raise Error, e.message
+      end
     end
 
     private
+
+    def ignorable_error?(error)
+      return config.identifier == 'energy-assets2' && error == ILLEGAL_QUOTING
+    end
 
     def clean_csv_data(path_and_file_name)
       data = StringIO.new

--- a/spec/fixtures/amr_upload_data_files/energy_assets_invalid.csv
+++ b/spec/fixtures/amr_upload_data_files/energy_assets_invalid.csv
@@ -1,0 +1,76 @@
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<title>Dataserve - Powered by SenseLogix</title>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+<script type="text/javascript" src="/js/jquery.js"></script>
+<script type="text/javascript" src="/js/jquery-ui.js"></script>
+<script type="text/javascript" src="/js/jquery.tipTip.js"></script>
+<link href="/templates/default/css/style.css" rel="stylesheet" type="text/css" />
+<link href="/templates/default/css/admin.css" rel="stylesheet" type="text/css" />
+<link href="/templates/default/css/jquery-ui.css" rel="stylesheet" type="text/css" />
+<link href="/templates/default/css/tipTip.css" rel="stylesheet" type="text/css" />
+<link href="/templates/default/css/jquery-ui-overrides.css" rel="stylesheet" type="text/css" />
+<link href="/templates/default/css/partner.css" rel="stylesheet" type="text/css" />
+<link href="/templates/default/css/globalserv.css" rel="stylesheet" type="text/css" />
+<link rel="shortcut icon" HREF="favicon.ico">
+<meta name="apple-mobile-web-app-capable" content="yes" />
+<link rel="apple-touch-startup-image"  href="startup.png" />
+<meta name="viewport" content = "width = device-width, initial-scale = 1.1, user-scalable = yes" />
+<meta name="apple-mobile-web-app-status-bar-style" content="black" />
+<link rel="apple-touch-startup-image" sizes="1004x768"  href="startup1024x768.png" />
+<link rel="apple-touch-startup-image" sizes="768x1004"  href="startup768x1024.png" />
+<script type="text/javascript">
+(function ($) {
+$(document).ready(function () {
+$.single=function(a){return function(b){a[0]=b;return a}}($([1]));
+/*@cc_on
+if (!window.XMLHttpRequest) {
+$('.hoverable').each(function () {
+this.attachEvent('onmouseenter', function (evt) { $.single(evt.srcElement).addClass('menu_hover'); });
+this.attachEvent('onmouseleave', function (evt) { $.single(evt.srcElement).removeClass('menu_hover'); });
+});
+$('.hoverbut').each(function () {
+this.attachEvent('onmouseenter', function (evt) { $.single(evt.srcElement).addClass('button_hover'); });
+this.attachEvent('onmouseleave', function (evt) { $.single(evt.srcElement).removeClass('button_hover'); });
+});
+}
+@*/
+});
+}(jQuery));
+</script>
+</head><body>
+<div id="container" class="clearfix">
+<div id="header" class="clearfix">
+<div id="" class="l_float"></div>
+<div id="sense_logo"><a href="index.php?mode=system"><img   src="/templates/default/img/logo.png" border="0" alt="EnergyLogix" class="pngfix"/></a></div>
+</div>
+<div id="page_content_admin" class="clearfix">
+<!--<div class="small button hoverbut" onclick="location.href='index.php?section=login&logout=true';" id="logout">Logout</div>--><div id="main_admin" class="clearfix">
+<div class="frame supersize">		<div class="center">Hi.  This page is currently undergoing maintenance.</div>
+<div class="center">Please use the back button to return to the page that you came from.<br>(You will be redirected to the home page in 10 seconds)</div>
+<script>
+$(document).ready(function () {
+// Handler for .ready() called.
+window.setTimeout(function () {
+location.href = "/index.php";
+}, 10000)
+});
+</script>
+</div>
+</div><!-- main content -->
+</div><!-- Page Content -->
+</div><!--container -->
+<div id="copyright">
+<a href="#">Copyright  2019 EnergyLogix</a>
+</div>
+<script type="text/javascript">
+$(document).ready(function(){
+// stupid ipad and iphone don't like hovering tooltips
+if((navigator.userAgent.match(/iPhone/i)) || (navigator.userAgent.match(/iPod/i)) || (navigator.userAgent.match(/iPad/i))) {
+$('#tiptip_holder').delay(3000).html('');
+}else{
+$(".tooltip").tipTip({edgeOffset: 10, defaultPosition:"top", delay:6000});}
+});
+</script>
+</body>
+</html>

--- a/spec/services/amr/data_file_parser_spec.rb
+++ b/spec/services/amr/data_file_parser_spec.rb
@@ -49,6 +49,30 @@ describe Amr::DataFileParser, type: :service do
         end
       end
     end
+
+    context 'and its an energy assets file' do
+      let!(:config) { create(:amr_data_feed_config, identifier: 'energy-assets2') }
+
+      context 'when its an illegal quoting error' do
+        let(:file_name) { 'energy_assets_invalid.csv' }
+
+        it 'does not raise an error' do
+          expect(parsed_lines).to be_empty
+        end
+      end
+
+      context 'when its some other error' do
+        ['not_a_csv.csv', 'not_a_xlsx.xlsx'].each do |file|
+          context file do
+            let(:file_name) { file }
+
+            it 'raises error' do
+              expect { parsed_lines }.to raise_error(StandardError)
+            end
+          end
+        end
+      end
+    end
   end
 
   context 'xlsx conversion to csv' do


### PR DESCRIPTION
Every so often the energy-assets2 config receives a CSV file which is actually an HTML page containing an error message warning about maintenance.

This causes errors in Rollbar and I have to remove the file. This PR adds a special case in the parser for this error so its treated as an empty file and ignored.