### PR TITLE
Update cron timings and queue for amr loads and regeneration

### DIFF
--- a/.ebextensions/cronjob.config
+++ b/.ebextensions/cronjob.config
@@ -48,7 +48,7 @@ files:
             #
             # Import CSV files
             #
-            15 5 * * * root run-webapp-job amr:import_all
+            15 5,22 * * * root run-webapp-job amr:import_all
             20 4 * * * root run-webapp-job solar:import_rtone_variant_readings
             #
             # Import Solar Edge data
@@ -66,7 +66,7 @@ files:
             #
             # Start daily regeneration jobs
             #
-            0 6 * * * root run-webapp-job school:daily_regeneration
+            40 5 * * * root run-webapp-job school:daily_regeneration
             #
             # Generate subscriptions
             #

--- a/app/jobs/amr_import_job.rb
+++ b/app/jobs/amr_import_job.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class AmrImportJob < ApplicationJob
-  queue_as :default
+  queue_as :regeneration
 
   def perform(config, bucket, filename)
     Amr::Importer.new(config, bucket:).import(filename)


### PR DESCRIPTION
The timings for when we receive data has changed over the last few years. Mostly due to changes in which portals and data providers are supplying us and when they send out their automated emails.

We now receive a small number of files between 2-5am but the bulk of the data is received from around 6am onwards, with some not arriving until around midday.

This PR:

- adds a second daily run of the AMR import at 22:15pm. This will end up processing the bulk of the data that arrives during the day, with the existing 5.15am run remaining to catch any files from the early hours.
- moves the population of the regeneration queue to 5.40am, so that it should complete earlier
- updates the amr import job to use the regeneration queue, so that any remaining files in the queue from the morning run, which should be a smaller number will get processed before the regeneration.
