### PR TITLE
Fix button spacing and layout of meter index page

### DIFF
--- a/app/assets/stylesheets/base.scss
+++ b/app/assets/stylesheets/base.scss
@@ -277,4 +277,3 @@ input, progress {
     font-weight: bolder;
   }
 }
-

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -534,4 +534,9 @@ module ApplicationHelper
   def email_with_wbr(email)
     email.gsub(/@/, '@<wbr>').html_safe
   end
+
+  def label_with_wbr(label)
+    return '' unless label.present?
+    label.gsub(%r{/}, '/<wbr>').html_safe
+  end
 end

--- a/app/views/schools/meters/_active_meters.html.erb
+++ b/app/views/schools/meters/_active_meters.html.erb
@@ -53,10 +53,6 @@
           <% end %>
         <% end %>
         <%= render 'admin/issues/modal', meter: meter if current_user.admin? %>
-      </div>
-    </td>
-    <td>
-      <div class="btn-group btn-group-sm" role="group">
         <%= if can?(:edit, meter)
               link_to t('common.labels.edit'),
                       edit_school_meter_path(@school, meter),

--- a/app/views/schools/meters/_active_meters.html.erb
+++ b/app/views/schools/meters/_active_meters.html.erb
@@ -43,28 +43,35 @@
     <td class="text-right"><%= meter.gappy_validated_readings.count %></td>
     <td>
       <div class="btn-group btn-group-sm" role="group">
-        <% if can?(:view_meter_attributes, meter) %>
-          <%= link_to t('common.labels.attributes'),
-                      admin_school_single_meter_attribute_path(@school, meter),
-                      class: 'btn btn-sm' %>
-        <% end %>
-        <% if can?(:report_on, meter) && meter.amr_validated_readings.any? %>
-          <%= link_to school_meter_path(@school, meter, format: 'csv'),
-                      class: 'btn btn-secondary btn-sm' do %>
-            <i class="fas fa-file-download"></i>
-          <% end %>
-        <% end %>
-        <%= render 'admin/issues/modal', meter: meter if current_user.admin? %>
         <%= if can?(:edit, meter)
               link_to t('common.labels.edit'),
                       edit_school_meter_path(@school, meter),
                       class: 'btn btn-sm btn-primary'
             end %>
-        <%= if can?(:deactivate, meter)
-              link_to t('common.labels.deactivate'), deactivate_school_meter_path(@school, meter),
+        <% if can?(:view_meter_attributes, meter) %>
+          <%= link_to admin_school_single_meter_attribute_path(@school, meter),
+                      class: 'btn btn-sm', title: t('common.labels.attributes') do %>
+            <i class="fas fa-gear"></i>
+          <% end %>
+        <% end %>
+        <% if can?(:report_on, meter) && meter.amr_validated_readings.any? %>
+          <%= link_to school_meter_path(@school, meter, format: 'csv'),
+                      class: 'btn btn-secondary btn-sm', title: t('schools.meters.index.readings') do %>
+            <i class="fas fa-file-download"></i>
+          <% end %>
+        <% end %>
+        <%= render 'admin/issues/modal', meter: meter if current_user.admin? %>
+        <% if can?(:deactivate, meter) %>
+          <%= link_to deactivate_school_meter_path(@school, meter),
                       method: :put,
-                      class: 'btn btn-sm btn-warning'
-            end %>
+                      class: 'btn btn-sm btn-warning', title: t('common.labels.deactivate') do %>
+                <% if current_user.admin? %>
+                  <i class="fas fa-stop"></i>
+                <% else %>
+                  <% t('common.labels.deactivate') %>
+                <% end %>
+          <% end %>
+        <% end %>
       </div>
     </td>
   </tr>

--- a/app/views/schools/meters/_active_meters.html.erb
+++ b/app/views/schools/meters/_active_meters.html.erb
@@ -1,7 +1,7 @@
 <% active_meters.each do |meter| %>
   <tr scope="row" class="<%= 'table-warning' if @invalid_mpan.include?(meter) %>">
-    <td title="<%= meter.meter_type.to_s.humanize %>"><%= fa_icon(fuel_type_icon(meter.meter_type)) %></td>
-    <td>
+    <td class="fit">
+      <%= fa_icon(fuel_type_icon(meter.meter_type)) %>
       <%= link_to meter.mpan_mprn, school_meter_path(@school, meter) %>
     </td>
     <td><%= meter.name %></td>
@@ -14,37 +14,39 @@
       </td>
       <td>
         <%= if meter.procurement_route
-              link_to meter.procurement_route.try(:organisation_name),
+              link_to label_with_wbr(meter.procurement_route.try(:organisation_name)),
                       admin_procurement_route_path(meter.procurement_route)
             end %>
       </td>
       <td>
         <% if meter.admin_meter_status.nil? && meter.admin_meter_status_label.present? %>
           <span data-toggle="tooltip" title="Default <%= meter.fuel_type.to_s.humanize.downcase %> admin meter status for this school's school group">
-            <%= meter.admin_meter_status_label %>
+            <%= label_with_wbr(meter.admin_meter_status_label) %>
           </span>
         <% else %>
-          <span><%= meter.admin_meter_status_label %></span>
+          <span><%= label_with_wbr(meter.admin_meter_status_label) %></span>
         <% end %>
       </td>
     <% end %>
-    <td><%= meter.amr_data_feed_readings.count %></td>
-    <td><%= meter.number_of_validated_readings %></td>
-    <td><%= short_dates meter.first_validated_reading %></td>
-    <td><%= short_dates meter.last_validated_reading %></td>
-    <td><%= meter.zero_reading_days.count %></td>
-    <td><%= meter.gappy_validated_readings.count %></td>
+    <td class="text-right"><%= meter.amr_data_feed_readings.count %></td>
+    <td class="text-right"><%= meter.number_of_validated_readings %></td>
+    <td class="fit text-right">
+      <% if can?(:report_on, meter) && meter.amr_validated_readings.any? %>
+        <%= link_to admin_reports_amr_validated_reading_path(meter) do %>
+            <%= short_dates meter.first_validated_reading %>-<%= short_dates meter.last_validated_reading %>
+        <% end %>
+      <% else %>
+        <%= short_dates meter.first_validated_reading %>-<%= short_dates meter.last_validated_reading %>
+      <% end %>
+    </td>
+    <td class="text-right"><%= meter.zero_reading_days.count %></td>
+    <td class="text-right"><%= meter.gappy_validated_readings.count %></td>
     <td>
       <div class="btn-group btn-group-sm" role="group">
         <% if can?(:view_meter_attributes, meter) %>
           <%= link_to t('common.labels.attributes'),
                       admin_school_single_meter_attribute_path(@school, meter),
                       class: 'btn btn-sm' %>
-        <% end %>
-        <% if can?(:report_on, meter) && meter.amr_validated_readings.any? %>
-          <%= link_to t('common.labels.report'),
-                      admin_reports_amr_validated_reading_path(meter),
-                      class: 'btn btn-sm btn-secondary' %>
         <% end %>
         <% if can?(:report_on, meter) && meter.amr_validated_readings.any? %>
           <%= link_to school_meter_path(@school, meter, format: 'csv'),

--- a/app/views/schools/meters/_active_meters.html.erb
+++ b/app/views/schools/meters/_active_meters.html.erb
@@ -32,7 +32,7 @@
     <td class="text-right"><%= meter.number_of_validated_readings %></td>
     <td class="fit text-right">
       <% if can?(:report_on, meter) && meter.amr_validated_readings.any? %>
-        <%= link_to admin_reports_amr_validated_reading_path(meter) do %>
+        <%= link_to admin_reports_amr_validated_reading_path(meter), title: t('schools.meters.index.report') do %>
             <%= short_dates meter.first_validated_reading %>-<%= short_dates meter.last_validated_reading %>
         <% end %>
       <% else %>

--- a/app/views/schools/meters/_inactive_meters.html.erb
+++ b/app/views/schools/meters/_inactive_meters.html.erb
@@ -50,10 +50,6 @@
           <% end %>
         <% end %>
         <%= render 'admin/issues/modal', meter: meter if current_user.admin? %>
-      </div>
-    </td>
-    <td>
-      <div class="btn-group btn-group-sm" role="group">
         <%= if can?(:edit, meter)
               link_to t('common.labels.edit'), edit_school_meter_path(@school, meter),
                       class: 'btn btn-sm btn-primary'

--- a/app/views/schools/meters/_inactive_meters.html.erb
+++ b/app/views/schools/meters/_inactive_meters.html.erb
@@ -40,33 +40,45 @@
     <td class="text-right"><%= meter.gappy_validated_readings.count %></td>
     <td>
       <div class="btn-group btn-group-sm" role="group">
-        <% if can?(:view_meter_attributes, meter) %>
-          <%= link_to t('common.labels.attributes'),
-                      admin_school_single_meter_attribute_path(@school, meter),
-                      class: 'btn btn-sm' %>
-        <% end %>
-        <% if can?(:report_on, meter) && meter.amr_validated_readings.any? %>
-          <%= link_to school_meter_path(@school, meter, format: 'csv'),
-                      class: 'btn btn-sm btn-secondary' do %>
-            <%= fa_icon('file-download') %>
-          <% end %>
-        <% end %>
-        <%= render 'admin/issues/modal', meter: meter if current_user.admin? %>
         <%= if can?(:edit, meter)
               link_to t('common.labels.edit'), edit_school_meter_path(@school, meter),
                       class: 'btn btn-sm btn-primary'
             end %>
-        <%= if can?(:activate, meter)
-              link_to t('common.labels.activate'),
-                      activate_school_meter_path(@school, meter),
+        <% if can?(:view_meter_attributes, meter) %>
+          <%= link_to admin_school_single_meter_attribute_path(@school, meter),
+                      class: 'btn btn-sm', title: t('common.labels.attributes') do %>
+            <i class="fas fa-gear"></i>
+          <% end %>
+        <% end %>
+        <% if can?(:report_on, meter) && meter.amr_validated_readings.any? %>
+          <%= link_to school_meter_path(@school, meter, format: 'csv'),
+                      class: 'btn btn-secondary btn-sm', title: t('schools.meters.index.readings') do %>
+            <i class="fas fa-file-download"></i>
+          <% end %>
+        <% end %>
+        <%= render 'admin/issues/modal', meter: meter if current_user.admin? %>
+        <% if can?(:activate, meter) %>
+          <%= link_to activate_school_meter_path(@school, meter),
                       method: :put,
-                      class: 'btn btn-sm btn-warning'
-            end %>
+                      class: 'btn btn-sm btn-warning', title: t('common.labels.activate') do %>
+                <% if current_user.admin? %>
+                  <i class="fas fa-play"></i>
+                <% else %>
+                  <% t('common.labels.activate') %>
+                <% end %>
+          <% end %>
+        <% end %>
         <% if can? :delete, meter %>
-          <%= link_to t('common.labels.delete'), school_meter_path(@school, meter),
+          <%= link_to school_meter_path(@school, meter),
                       method: :delete,
                       data: { confirm: t('common.confirm') },
-                      class: 'btn btn-sm btn-danger' %>
+                      class: 'btn btn-sm btn-danger', title: t('common.labels.delete') do %>
+                <% if current_user.admin? %>
+                  <i class="fas fa-trash"></i>
+                <% else %>
+                  <% t('common.labels.delete') %>
+                <% end %>
+          <% end %>
         <% else %>
           <button class="btn btn-sm"
                   disabled

--- a/app/views/schools/meters/_inactive_meters.html.erb
+++ b/app/views/schools/meters/_inactive_meters.html.erb
@@ -1,7 +1,7 @@
 <% inactive_meters.each do |meter| %>
   <tr scope="row">
-    <td title="<%= meter.meter_type.to_s.humanize %>"><%= fa_icon(fuel_type_icon(meter.meter_type)) %></td>
-    <td>
+    <td class="fit">
+      <%= fa_icon(fuel_type_icon(meter.meter_type)) %>
       <%= link_to meter.mpan_mprn, school_meter_path(@school, meter) %>
     </td>
     <td><%= meter.name %></td>
@@ -11,37 +11,39 @@
       </td>
       <td>
         <%= if meter.data_source
-              link_to meter.data_source.try(:name),
+              link_to label_with_wbr(meter.data_source.try(:name)),
                       admin_data_source_path(meter.data_source)
             end %>
       </td>
       <td>
         <%= if meter.procurement_route
-              link_to meter.procurement_route.try(:organisation_name),
+              link_to label_with_wbr(meter.procurement_route.try(:organisation_name)),
                       admin_procurement_route_path(meter.procurement_route)
             end %>
       </td>
       <td>
-        <%= meter.admin_meter_status_label %>
+        <%= label_with_wbr(meter.admin_meter_status_label) %>
       </td>
     <% end %>
-    <td><%= meter.amr_data_feed_readings.count %></td>
-    <td><%= meter.number_of_validated_readings %></td>
-    <td><%= short_dates meter.first_validated_reading %></td>
-    <td><%= short_dates meter.last_validated_reading %></td>
-    <td><%= meter.zero_reading_days.count %></td>
-    <td><%= meter.gappy_validated_readings.count %></td>
+    <td class="text-right"><%= meter.amr_data_feed_readings.count %></td>
+    <td class="text-right"><%= meter.number_of_validated_readings %></td>
+    <td class="fit text-right">
+      <% if can?(:report_on, meter) && meter.amr_validated_readings.any? %>
+        <%= link_to admin_reports_amr_validated_reading_path(meter) do %>
+            <%= short_dates meter.first_validated_reading %>-<%= short_dates meter.last_validated_reading %>
+        <% end %>
+      <% else %>
+        <%= short_dates meter.first_validated_reading %>-<%= short_dates meter.last_validated_reading %>
+      <% end %>
+    </td>
+    <td class="text-right"><%= meter.zero_reading_days.count %></td>
+    <td class="text-right"><%= meter.gappy_validated_readings.count %></td>
     <td>
       <div class="btn-group btn-group-sm" role="group">
         <% if can?(:view_meter_attributes, meter) %>
           <%= link_to t('common.labels.attributes'),
                       admin_school_single_meter_attribute_path(@school, meter),
                       class: 'btn btn-sm' %>
-        <% end %>
-        <% if can?(:report_on, meter) && meter.amr_validated_readings.any? %>
-          <%= link_to t('schools.meters.index.report'),
-                      admin_reports_amr_validated_reading_path(meter),
-                      class: 'btn btn-sm btn-secondary' %>
         <% end %>
         <% if can?(:report_on, meter) && meter.amr_validated_readings.any? %>
           <%= link_to school_meter_path(@school, meter, format: 'csv'),

--- a/app/views/schools/meters/_inactive_meters.html.erb
+++ b/app/views/schools/meters/_inactive_meters.html.erb
@@ -29,7 +29,7 @@
     <td class="text-right"><%= meter.number_of_validated_readings %></td>
     <td class="fit text-right">
       <% if can?(:report_on, meter) && meter.amr_validated_readings.any? %>
-        <%= link_to admin_reports_amr_validated_reading_path(meter) do %>
+        <%= link_to admin_reports_amr_validated_reading_path(meter), title: t('schools.meters.index.report') do %>
             <%= short_dates meter.first_validated_reading %>-<%= short_dates meter.last_validated_reading %>
         <% end %>
       <% else %>

--- a/app/views/schools/meters/index.html.erb
+++ b/app/views/schools/meters/index.html.erb
@@ -47,7 +47,7 @@
   </div>
 <% end %>
 
-<% colspan = current_user.admin? ? 16 : 11 %>
+<% colspan = current_user.admin? ? 15 : 10 %>
 <% first_colspan = current_user.admin? ? 6 : 2 %>
 
 <div class="table-responsive">
@@ -59,14 +59,12 @@
   <colgroup span="2"></colgroup>
   <thead>
     <tr>
-      <th></th>
       <th colspan="<%= first_colspan %>"></th>
       <th colspan="2"><%= t('schools.meters.index.readings') %></th>
       <th colspan="4"><%= t('schools.meters.index.validated_readings') %></th>
       <th colspan="1"></th>
     </tr>
     <tr>
-      <th scope="col"></th>
       <th scope="col"><%= t('schools.meters.index.meter') %></th>
       <th scope="col"><%= t('schools.meters.index.name') %></th>
       <% if current_user.admin? %>
@@ -75,12 +73,15 @@
         <th scope="col"><%= t('schools.meters.index.procurement_route') %></th>
         <th scope="col"><%= t('schools.meters.index.admin_meter_status') %></th>
       <% end %>
-      <th scope="col"><%= t('schools.meters.index.imported') %></th>
-      <th scope="col"><%= t('schools.meters.index.validated') %></th>
-      <th scope="col"><%= t('schools.meters.index.first') %></th>
-      <th scope="col"><%= t('schools.meters.index.latest') %></th>
-      <th scope="col"><%= t('schools.meters.index.zero_days') %></th>
-      <th scope="col"><%= t('schools.meters.index.large_gaps') %></th>
+      <th scope="col" class="text-right">
+        <%= current_user.admin? ? fa_icon(:database) : t('schools.meters.index.imported') %>
+      </th>
+      <th scope="col" class="text-right">
+        <%= current_user.admin? ? fa_icon('square-check') : t('schools.meters.index.validated') %></th>
+      <th scope="col" class="text-center"><%= t('schools.meters.index.first') %>-<%= t('schools.meters.index.latest') %>
+      </th>
+      <th scope="col" class="text-right"><%= t('schools.meters.index.zero_days') %></th>
+      <th scope="col" class="text-right"><%= t('schools.meters.index.large_gaps') %></th>
       <th scope="col"></th>
     </tr>
   </thead>

--- a/app/views/schools/meters/index.html.erb
+++ b/app/views/schools/meters/index.html.erb
@@ -11,9 +11,14 @@
   <% end %>
   <div class="alert alert-secondary mb-2">
     <% if can?(:validate_meters, @school) && @school.meters_with_readings.any? && @school.process_data? %>
-      <%= link_to t('schools.meters.index.validate_meter_readings'), school_meter_readings_validation_path(@school), method: :post, class: 'btn' %>
+      <%= link_to t('schools.meters.index.validate_meter_readings'), school_meter_readings_validation_path(@school),
+                  method: :post, class: 'btn' %>
     <% else %>
-      <button type="button" class="btn disabled" data-toggle="tooltip" data-placement="top" title="<%= t('schools.meters.index.data_processing_turned_on_message') %>">
+      <button type="button"
+              class="btn disabled"
+              data-toggle="tooltip"
+              data-placement="top"
+              title="<%= t('schools.meters.index.data_processing_turned_on_message') %>">
         <%= t('schools.meters.index.validate_meter_readings') %>
       </button>
     <% end %>
@@ -21,7 +26,8 @@
     <%= link_to t('schools.meters.index.school_downloads'), school_downloads_path(@school), class: 'btn' %>
 
     <% if can? :manage_solar_feed_configuration, School %>
-      <%= link_to t('schools.meters.index.manage_solar_api_feeds'), school_solar_feeds_configuration_index_path(@school), class: 'btn' %>
+      <%= link_to t('schools.meters.index.manage_solar_api_feeds'),
+                  school_solar_feeds_configuration_index_path(@school), class: 'btn' %>
     <% end %>
 
     <% if can? :manage, MeterReview %>
@@ -58,7 +64,6 @@
       <th colspan="2"><%= t('schools.meters.index.readings') %></th>
       <th colspan="4"><%= t('schools.meters.index.validated_readings') %></th>
       <th colspan="1"></th>
-      <th colspan="1"></th>
     </tr>
     <tr>
       <th scope="col"></th>
@@ -76,7 +81,6 @@
       <th scope="col"><%= t('schools.meters.index.latest') %></th>
       <th scope="col"><%= t('schools.meters.index.zero_days') %></th>
       <th scope="col"><%= t('schools.meters.index.large_gaps') %></th>
-      <th scope="col"></th>
       <th scope="col"></th>
     </tr>
   </thead>

--- a/config/locales/views/schools/schools.yml
+++ b/config/locales/views/schools/schools.yml
@@ -265,14 +265,14 @@ en:
         active_meters: Active meters
         active_pseudo_meters: Active pseudo meters
         add_meter: Add meter
-        admin_meter_status: Admin meter status
+        admin_meter_status: Meter status
         data_processing_turned_on_message: Data processing must be turned on for this school before meter readings can be validated
-        data_source: Data source
-        first: First
+        data_source: Source
+        first: From
         imported: Imported
         inactive_meters: Inactive meters
-        large_gaps: Large gaps
-        latest: Latest
+        large_gaps: Gaps
+        latest: To
         manage_solar_api_feeds: Manage Solar API feeds
         meter: Meter
         meter_reviews: Completed DCC meter reviews
@@ -281,7 +281,7 @@ en:
         name: Name
         no_active_meters: No active meters
         only_admins_message: Only admins can delete meters with meter readings
-        procurement_route: Procurement route
+        procurement_route: Contract
         readings: Readings
         report: Report
         review_meters: Pending DCC meter reviews


### PR DESCRIPTION
Reworks the meter index page to:

- add break points to large titles
- combine some columns
- use icons in the admin view to save space

![Screenshot from 2024-10-18 13-29-25](https://github.com/user-attachments/assets/e297f691-b38b-46f9-9778-65c748182b77)

![Screenshot from 2024-10-18 13-29-39](https://github.com/user-attachments/assets/e5d53a88-641f-4995-a385-19a5e357e8d3)
