### PR TITLE
Fix chart usage controls

### DIFF
--- a/app/assets/stylesheets/colours.scss.erb
+++ b/app/assets/stylesheets/colours.scss.erb
@@ -28,10 +28,3 @@
   }
 }
 
-@function rename($key, $old-name, $new-name) {
-  @if $key == $old-name {
-    @return $new-name;
-  } @else {
-    @return $old-name;
-  }
-}

--- a/app/assets/stylesheets/colours.scss.erb
+++ b/app/assets/stylesheets/colours.scss.erb
@@ -12,11 +12,11 @@
 // $electric-dark: #007EFF;
 // $positive-dark: #10bca2;
 // $exemplar-school: #10bca2;
-<%= Colours.sass_variables :palette, :fuel, :polarity, :comparison, :bootstrap, :theme %>
+<%= Colours.sass_variables :palette, :fuel, :polarity, :comparison, :bootstrap, :theme, :charts %>
 
 // Create SASS maps for each of these keys found in Colours::PALETTE hash
 // These will be named: $colours-fuel etc
-<%= Colours.sass_maps :fuel, :polarity, :comparison %>
+<%= Colours.sass_maps :fuel, :polarity, :comparison, :charts %>
 
 // Get a colour from a generated map
 // not used yet so need to check if working :-)
@@ -35,9 +35,3 @@
     @return $old-name;
   }
 }
-
-// Old / current colour mappings ###
-// These are *not* to be used for new features as we're moving away
-// from them to the colours above
-
-// $dark-blue: $blue-dark; // something weird going on here

--- a/app/assets/stylesheets/school.scss
+++ b/app/assets/stylesheets/school.scss
@@ -55,17 +55,19 @@ div.school-card-row {
 }
 
 // used in _usage_control.html.erb
+// these currently use chart fuel colours as opposed to site fuel colours
 .usage-controls {
   @each $fuel, $tones in $colours-fuel {
-    $fuel-name: rename($fuel, 'electric', 'electricity');
+    $fuel-name: if($fuel == 'electric', 'electricity', $fuel);
+
     //e.g. .electricity-light, .gas-light, .storage-light, .solar-light
     .#{$fuel-name}-light {
-      border: 2px solid map-get($tones, 'light');
+      border: 2px solid colour-get($colours-charts, 'chart', "#{$fuel}_light");
     }
 
     //e.g. .electricity-dark, .gas-dark, .storage-dark, .solar-dark
     .#{$fuel-name}-dark {
-      border: 2px solid map-get($tones, 'dark');
+      border: 2px solid colour-get($colours-charts, 'chart', "#{$fuel}_dark");
     }
   }
 }


### PR DESCRIPTION
This is working as expected locally but not in production, so a bit odd. In production, `$fuel-name` was remaining as `electricity` with each loop iteration, where as locally it is the different fuel name (apart from electric, which is getting changed to electricity, as expected)

Also realised that site fuel colours were being used rather than the old chart ones for this, so have changed that too.