### PR TITLE
Implement new footer design

### DIFF
--- a/app/assets/stylesheets/bootstrap-overrides.scss
+++ b/app/assets/stylesheets/bootstrap-overrides.scss
@@ -10,6 +10,7 @@ $link-decoration: underline;
 $tooltip-bg: $grey-very-dark;
 
 $btn-font-family: $header-font-family;
+$btn-font-weight: $font-weight-semibold;
 $btn-border-radius: 10rem;
 $btn-border-radius-sm: $btn-border-radius;
 $btn-border-radius-lg: $btn-border-radius;

--- a/app/assets/stylesheets/links.scss
+++ b/app/assets/stylesheets/links.scss
@@ -29,6 +29,12 @@
   color: $teal-very-dark;
 }
 
+// used in the footer newsletter signup form
+.btn-outline-white {
+  background-color: transparent;
+  @include button-outline-variant($white, $yellow-medium, transparent, $yellow-medium);
+}
+
 a.badge {
   text-decoration: none;
   .outline {

--- a/app/assets/stylesheets/nav.scss
+++ b/app/assets/stylesheets/nav.scss
@@ -106,9 +106,8 @@ $togglers: (
     color: $foreground-lozenge;
     background: $background-lozenge;
 
-    &:hover, &:focus {
-      @include font(f9);
-      color: $black !important;
+    &:hover, &:focus, &:active {
+      color: $grey-very-dark;
       background: $grey-medium;
     }
   }

--- a/app/assets/stylesheets/redesign/footer.scss
+++ b/app/assets/stylesheets/redesign/footer.scss
@@ -20,7 +20,7 @@ footer {
       padding-top: 5px;
       padding-bottom: 5px;
       color: $white;
-      font-weight: $font-weight-bold; // 700
+      font-weight: $font-weight-bold; // 700 // design says 600 - semibold
     }
 
     a:hover, a:focus, a:active {

--- a/app/assets/stylesheets/redesign/footer.scss
+++ b/app/assets/stylesheets/redesign/footer.scss
@@ -1,0 +1,32 @@
+@mixin footer {
+  font-family: $header-font-family;
+  color: $white;
+  & a:link, a:hover, a:focus, a:active, a:visited {
+    color: $white;
+    text-decoration: none;
+  }
+}
+
+footer {
+  .footer-top {
+    @include font(f9); // design says 16px (f7)
+    @include footer;
+    background-color: $grey-very-dark;
+    font-weight: $font-weight-semibold; // 600 // design says 500
+
+    h1 {
+      @include font(f6); // design says 24px (f4)
+      padding-top: 5px;
+      padding-bottom: 5px;
+      color: $white;
+      font-weight: $font-weight-bold; // 700
+    }
+  }
+
+  .footer-second {
+    @include font(f9); // design says 14px (f8)
+    @include footer;
+    background-color: $grey-darker;
+    font-weight: $font-weight-normal; // 400
+  }
+}

--- a/app/assets/stylesheets/redesign/footer.scss
+++ b/app/assets/stylesheets/redesign/footer.scss
@@ -6,16 +6,12 @@
     color: $white;
     text-decoration: none;
   }
-
-  a:hover, a:focus, a:active {
-    color: $yellow-medium;
-  }
 }
 
 footer {
   .footer-top {
-    @include font(f9); // design says 16px (f7)
     @include footer;
+    @include font(f9); // design says 16px (f7)
     background-color: $grey-very-dark;
     font-weight: $font-weight-semibold; // 600 // design says 500 - medium
 
@@ -27,21 +23,20 @@ footer {
       font-weight: $font-weight-bold; // 700
     }
 
-    .form-control {
-      font-size: $f9 !important;
+    a:hover, a:focus, a:active {
+      color: $yellow-medium;
     }
 
-    .btn {
-      font-size: $f9
+    .form-control, .btn {
+      font-size: $f9;
     }
   }
 
   .footer-second {
-    @include font(f9); // design says 14px (f8)
     @include footer;
+    @include font(f9); // design says 14px (f8)
     background-color: $grey-darker;
     font-weight: $font-weight-normal; // 400 - as per design
-    padding: 20px 0px;
 
     a:hover, a:focus, a:active {
       color: $grey-dark;

--- a/app/assets/stylesheets/redesign/footer.scss
+++ b/app/assets/stylesheets/redesign/footer.scss
@@ -1,9 +1,14 @@
 @mixin footer {
   font-family: $header-font-family;
   color: $white;
-  & a:link, a:hover, a:focus, a:active, a:visited {
+
+  a:link, a:visited {
     color: $white;
     text-decoration: none;
+  }
+
+  a:hover, a:focus, a:active {
+    color: $yellow-medium;
   }
 }
 
@@ -12,7 +17,7 @@ footer {
     @include font(f9); // design says 16px (f7)
     @include footer;
     background-color: $grey-very-dark;
-    font-weight: $font-weight-semibold; // 600 // design says 500
+    font-weight: $font-weight-semibold; // 600 // design says 500 - medium
 
     h1 {
       @include font(f6); // design says 24px (f4)
@@ -21,12 +26,38 @@ footer {
       color: $white;
       font-weight: $font-weight-bold; // 700
     }
+
+    .form-control {
+      font-size: $f9 !important;
+    }
+
+    .btn {
+      font-size: $f9
+    }
   }
 
   .footer-second {
     @include font(f9); // design says 14px (f8)
     @include footer;
     background-color: $grey-darker;
-    font-weight: $font-weight-normal; // 400
+    font-weight: $font-weight-normal; // 400 - as per design
+    padding: 20px 0px;
+
+    a:hover, a:focus, a:active {
+      color: $grey-dark;
+    }
+
+    ul.list-inline {
+      li.list-inline-item {
+        margin-right: 0;
+
+        a:link, a:visited {
+          color: $grey-darker;
+        }
+        a:hover, a:focus, a:active {
+          color: $grey-dark;
+        }
+      }
+    }
   }
 }

--- a/app/assets/stylesheets/redesign/footer.scss
+++ b/app/assets/stylesheets/redesign/footer.scss
@@ -1,4 +1,4 @@
-@mixin footer {
+footer {
   font-family: $header-font-family;
   color: $white;
 
@@ -6,11 +6,8 @@
     color: $white;
     text-decoration: none;
   }
-}
 
-footer {
   .footer-top {
-    @include footer;
     @include font(f9); // design says 16px (f7)
     background-color: $grey-very-dark;
     font-weight: $font-weight-semibold; // 600 // design says 500 - medium
@@ -33,7 +30,6 @@ footer {
   }
 
   .footer-second {
-    @include footer;
     @include font(f9); // design says 14px (f8)
     background-color: $grey-darker;
     font-weight: $font-weight-normal; // 400 - as per design

--- a/app/views/home/_mailchimp.html.erb
+++ b/app/views/home/_mailchimp.html.erb
@@ -28,7 +28,7 @@
       </div>
     <% end %>
 
-    <div class="col-5 border-left ">
+    <div class="col-5 border-left">
       <h4><%= t('mailchimp.latest_news_title') %></h4>
       <%= form_with(url: new_mailchimp_signup_path, method: :get, local: true) do %>
         <div class="form-group">

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -3,7 +3,7 @@
     <div class="footer-top py-4">
       <div class="container">
         <div class="row">
-          <div class="col-6 col-lg-2">
+          <div id='quick-links' class="col-6 col-lg-2">
             <h1><%= t('footer.quick_links') %></h1>
             <ul class="list-unstyled">
               <li><%= link_to t('common_nav_bar_menus.actions'), intervention_type_groups_path %></li>
@@ -13,7 +13,7 @@
               <li><%= link_to t('about_menu.contact'), contact_path %></li>
             </ul>
           </div>
-          <div class="col-6 col-lg-2">
+          <div id='services' class="col-6 col-lg-2">
             <h1><%= t('footer.services') %></h1>
             <ul class="list-unstyled">
               <li><%= link_to t('our_services_menu.energy_audits'), energy_audits_path %></li>
@@ -23,7 +23,7 @@
               <li><%= link_to t('our_services_menu.for_local_authorities'), for_local_authorities_path %></li>
             </ul>
           </div>
-          <div class="col-6 col-lg-2">
+          <div id='other-links' class="col-6 col-lg-2">
             <h1><%= t('footer.other_links') %></h1>
             <ul class="list-unstyled">
               <li><%= link_to t('about_menu.jobs'), jobs_path %></li><!-- 'Careers' in design -->
@@ -32,7 +32,7 @@
               <li><%= link_to t('about_menu.school_statistics'), school_statistics_path %></li>
             </ul>
           </div>
-          <div class="col-6 col-lg-2">
+          <div id='legal-terms' class="col-6 col-lg-2">
             <h1><%= t('footer.legal_terms') %></h1>
             <ul class="list-unstyled">
               <li><%= link_to t('footer.terms_and_conditions'), terms_and_conditions_path %></li>
@@ -41,7 +41,7 @@
               <li><%= link_to t('footer.child_safeguarding_policy'), child_safeguarding_policy_path %></li>
             </ul>
           </div>
-          <div class="col-12 col-lg-4">
+          <div id='newsletter-signup' class="col-12 col-lg-4">
             <h1><%= t('footer.newsletter_signup') %></h1>
             <%= form_with url: new_mailchimp_signup_path, method: :get, local: true do %>
               <div class="form-group">

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -6,10 +6,10 @@
           <div id='quick-links' class="col-6 col-lg-2">
             <h1><%= t('footer.quick_links') %></h1>
             <ul class="list-unstyled">
-              <li><%= link_to t('common_nav_bar_menus.actions'), intervention_type_groups_path %></li>
               <li><%= link_to t('common_nav_bar_menus.activities'), activity_categories_path %></li>
+              <li><%= link_to t('common_nav_bar_menus.actions'), intervention_type_groups_path %></li>
+              <li><%= link_to t('our_schools_menu.view_schools'), schools_path %></li>
               <li><%= link_to t('our_schools_menu.scoreboards'), scoreboards_path %></li>
-              <li><%= link_to t('our_schools_menu.compare_schools'), compare_index_path %></li>
               <li><%= link_to t('about_menu.contact'), contact_path %></li>
             </ul>
           </div>
@@ -17,19 +17,22 @@
             <h1><%= t('footer.services') %></h1>
             <ul class="list-unstyled">
               <li><%= link_to t('our_services_menu.energy_audits'), energy_audits_path %></li>
-              <li><%= link_to t('our_services_menu.educational_workshops'), education_workshops_path %></li> <!-- is just 'Workshops' in design -->
-              <li><%= link_to t('our_services_menu.for_schools'), for_schools_path %></li>
-              <li><%= link_to t('our_services_menu.for_multi_academy_trusts'), for_multi_academy_trusts_path %></li>
-              <li><%= link_to t('our_services_menu.for_local_authorities'), for_local_authorities_path %></li>
+              <li><%= link_to t('our_services_menu.educational_workshops'), education_workshops_path %></li>
+              <li><%= link_to t('our_services_menu.training'), training_path %></li>
+              <li><%= link_to t('campaigns.find_out_more.find_out_more'), find_out_more_path %></li>
+              <li><%= link_to t('marketing.book_a_demo'), book_demo_campaigns_path %></li>
+              <li><%= link_to t('our_services_menu.case_studies'), case_studies_path %></li>
             </ul>
           </div>
           <div id='other-links' class="col-6 col-lg-2">
             <h1><%= t('footer.other_links') %></h1>
             <ul class="list-unstyled">
-              <li><%= link_to t('about_menu.jobs'), jobs_path %></li><!-- 'Careers' in design -->
+              <li><%= link_to t('about_menu.jobs'), jobs_path %></li>
+              <li><%= link_to t('about_menu.blog'), 'http://blog.energysparks.uk',
+                              target: '_blank', rel: 'noopener' %></li>
+              <li><%= link_to t('about_menu.school_statistics'), school_statistics_path %></li>
               <li><%= link_to t('about_menu.datasets'), attribution_path %></li>
               <li><%= link_to t('about_menu.open_data'), datasets_path %></li>
-              <li><%= link_to t('about_menu.school_statistics'), school_statistics_path %></li>
             </ul>
           </div>
           <div id='legal-terms' class="col-6 col-lg-2">
@@ -37,7 +40,7 @@
             <ul class="list-unstyled">
               <li><%= link_to t('footer.terms_and_conditions'), terms_and_conditions_path %></li>
               <li><%= link_to t('about_menu.privacy_policy'), privacy_and_cookie_policy_path %></li>
-              <li><%= link_to t('cookies.title'), cookies_path %></li><!-- missing from design? -->
+              <li><%= link_to t('cookies.title'), cookies_path %></li>
               <li><%= link_to t('footer.child_safeguarding_policy'), child_safeguarding_policy_path %></li>
             </ul>
           </div>
@@ -45,12 +48,15 @@
             <h1><%= t('footer.newsletter_signup') %></h1>
             <%= form_with url: new_mailchimp_signup_path, method: :get, local: true do %>
               <div class="form-group">
-                <%= label_tag(:email_address, t('mailchimp.latest_news_title'), class: 'mb-0') %>
-                <%= text_field_tag(:email_address, nil, class: 'form-control',
-                                                        placeholder: t('mailchimp.example'),
-                                                        'aria-describedby': 'emailHelp',
-                                                        autocomplete: 'off') %>
-                <%= submit_tag t('mailchimp.signup_now'), class: 'btn btn-outline-white mt-2' %>
+                <%= label_tag(:email_address,
+                              t('mailchimp.latest_news_title'), class: 'mb-0') %>
+                <%= text_field_tag(:email_address, nil,
+                                   class: 'form-control',
+                                   placeholder: t('mailchimp.example'),
+                                   'aria-describedby': 'emailHelp',
+                                   autocomplete: 'off') %>
+                <%= submit_tag t('mailchimp.signup_now'),
+                               class: 'btn btn-outline-white mt-2' %>
                 <span id='emailHelp' class="form-text"><%= t('mailchimp.never_share_your_email_promise') %>.</span>
               </div>
             <% end %>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -4,7 +4,7 @@
       <div class="container">
         <div class="row">
           <div class="col-sm-6 col-lg-2">
-            <h1>Quick Links</h1>
+            <h1><%= t('footer.quick_links') %></h1>
             <ul class="list-unstyled">
               <li><%= link_to t('common_nav_bar_menus.actions'), intervention_type_groups_path %></li>
               <li><%= link_to t('common_nav_bar_menus.activities'), activity_categories_path %></li>
@@ -14,7 +14,7 @@
             </ul>
           </div>
           <div class="col-sm-6 col-lg-2">
-            <h1>Services</h1>
+            <h1><%= t('footer.services') %></h1>
             <ul class="list-unstyled">
               <li><%= link_to t('our_services_menu.energy_audits'), energy_audits_path %></li>
               <li><%= link_to t('our_services_menu.educational_workshops'), education_workshops_path %></li> <!-- is just 'Workshops' in design -->
@@ -24,19 +24,19 @@
             </ul>
           </div>
           <div class="col-sm-6 col-lg-2">
-            <h1>Other Links</h1>
+            <h1><%= t('footer.other_links') %></h1>
             <ul class="list-unstyled">
-              <li><%= link_to t('about_menu.jobs'), jobs_path %></li> <!-- 'Careers' in design -->
+              <li><%= link_to t('about_menu.jobs'), jobs_path %></li><!-- 'Careers' in design -->
               <li><%= link_to t('about_menu.datasets'), attribution_path %></li>
               <li><%= link_to t('about_menu.open_data'), datasets_path %></li>
               <li><%= link_to t('about_menu.school_statistics'), school_statistics_path %></li>
             </ul>
           </div>
           <div class="col-sm-6 col-lg-2">
-            <h1>Legal Terms</h1>
+            <h1><%= t('footer.legal_terms') %></h1>
             <ul class="list-unstyled">
               <li><%= link_to t('footer.terms_and_conditions'), terms_and_conditions_path %></li>
-              <li><%= link_to t('cookies.title'), cookies_path %></li>  <!-- missing from design? -->
+              <li><%= link_to t('cookies.title'), cookies_path %></li><!-- missing from design? -->
               <li><%= link_to t('about_menu.privacy_policy'), privacy_and_cookie_policy_path %></li>
               <li><%= link_to t('footer.child_safeguarding_policy'), child_safeguarding_policy_path %></li>
             </ul>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,5 +1,64 @@
 <% if Flipper.enabled?(:footer, current_user, current_user&.school_group) %>
-  <!-- new footer code to go here -->
+  <footer>
+    <div class="footer-top py-4">
+      <div class="container">
+        <div class="row">
+          <div class="col-2">
+            <h1>Quick Links</h1>
+            <ul class="list-unstyled">
+              <li><%= link_to t('common_nav_bar_menus.actions'), intervention_type_groups_path %></li>
+              <li><%= link_to t('common_nav_bar_menus.activities'), activity_categories_path %></li>
+              <li><%= link_to t('our_schools_menu.scoreboards'), scoreboards_path %></li>
+              <li><%= link_to t('our_schools_menu.compare_schools'), compare_index_path %></li>
+            </ul>
+          </div>
+          <div class="col-2">
+            <h1>Services</h1>
+          </div>
+          <div class="col-2">
+            <h1>Other Links</h1>
+          </div>
+          <div class="col-2">
+            <h1>Legal Terms</h1>
+            <ul class="list-unstyled">
+              <li><%= link_to t('footer.terms_and_conditions'), terms_and_conditions_path %></li>
+<!--              <li><%= link_to t('cookies.title'), cookies_path %></li> -->
+              <li><%= link_to t('about_menu.privacy_policy'), privacy_and_cookie_policy_path %></li>
+              <li><%= link_to t('footer.child_safeguarding_policy'), child_safeguarding_policy_path %></li>
+            </ul>
+          </div>
+          <div class="col-4">
+            <h1>Newsletter Signup</h1>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="footer-second py-4">
+      <div class="container">
+        <div class="row">
+          <div class="col-4">
+            <%= t('footer.cc_licence_notice_html') %>.
+          </div>
+          <div class="col-4">
+            <%= t('footer.registered_charity_notice') %>.
+          </div>
+          <div class="col-4">
+              <ul class="list-inline">
+                <li class="list-inline-item p-2">
+                  <a href="//twitter.com/EnergySparks" class=""><%= fab_icon('twitter fa-2x') %></a>
+                </li>
+                <li class="list-inline-item p-2">
+                  <a href="//www.facebook.com/EnergySparksUK/" class=""><%= fab_icon('facebook-square fa-2x') %></a>
+                </li>
+                <li class="list-inline-item p-2">
+                  <a href="//github.com/energy-sparks/energy-sparks" class=""><%= fab_icon('github fa-2x') %></a>
+                </li>
+              </ul>
+          </div>
+        </div>
+      </div>
+    </div>
+  </footer>
 <% else %>
   <footer>
     <div class="footer-above">

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -36,8 +36,8 @@
             <h1><%= t('footer.legal_terms') %></h1>
             <ul class="list-unstyled">
               <li><%= link_to t('footer.terms_and_conditions'), terms_and_conditions_path %></li>
-              <li><%= link_to t('cookies.title'), cookies_path %></li><!-- missing from design? -->
               <li><%= link_to t('about_menu.privacy_policy'), privacy_and_cookie_policy_path %></li>
+              <li><%= link_to t('cookies.title'), cookies_path %></li><!-- missing from design? -->
               <li><%= link_to t('footer.child_safeguarding_policy'), child_safeguarding_policy_path %></li>
             </ul>
           </div>
@@ -58,7 +58,7 @@
         </div>
       </div>
     </div>
-    <div class="footer-second">
+    <div class="footer-second py-4">
       <div class="container">
         <div class="row d-flex align-items-center">
           <div class="col-md-4">

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -3,7 +3,7 @@
     <div class="footer-top py-4">
       <div class="container">
         <div class="row">
-          <div class="col-sm-6 col-lg-2">
+          <div class="col-6 col-lg-2">
             <h1><%= t('footer.quick_links') %></h1>
             <ul class="list-unstyled">
               <li><%= link_to t('common_nav_bar_menus.actions'), intervention_type_groups_path %></li>
@@ -13,7 +13,7 @@
               <li><%= link_to t('about_menu.contact'), contact_path %></li>
             </ul>
           </div>
-          <div class="col-sm-6 col-lg-2">
+          <div class="col-6 col-lg-2">
             <h1><%= t('footer.services') %></h1>
             <ul class="list-unstyled">
               <li><%= link_to t('our_services_menu.energy_audits'), energy_audits_path %></li>
@@ -23,7 +23,7 @@
               <li><%= link_to t('our_services_menu.for_local_authorities'), for_local_authorities_path %></li>
             </ul>
           </div>
-          <div class="col-sm-6 col-lg-2">
+          <div class="col-6 col-lg-2">
             <h1><%= t('footer.other_links') %></h1>
             <ul class="list-unstyled">
               <li><%= link_to t('about_menu.jobs'), jobs_path %></li><!-- 'Careers' in design -->
@@ -32,7 +32,7 @@
               <li><%= link_to t('about_menu.school_statistics'), school_statistics_path %></li>
             </ul>
           </div>
-          <div class="col-sm-6 col-lg-2">
+          <div class="col-6 col-lg-2">
             <h1><%= t('footer.legal_terms') %></h1>
             <ul class="list-unstyled">
               <li><%= link_to t('footer.terms_and_conditions'), terms_and_conditions_path %></li>
@@ -41,7 +41,7 @@
               <li><%= link_to t('footer.child_safeguarding_policy'), child_safeguarding_policy_path %></li>
             </ul>
           </div>
-          <div class="col-sm-12 col-lg-4">
+          <div class="col-12 col-lg-4">
             <h1><%= t('footer.newsletter_signup') %></h1>
             <%= form_with url: new_mailchimp_signup_path, method: :get, local: true do %>
               <div class="form-group">

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -42,7 +42,7 @@
             </ul>
           </div>
           <div class="col-sm-12 col-lg-4">
-            <h1>Newsletter Signup</h1>
+            <h1><%= t('footer.newsletter_signup') %></h1>
             <%= form_with url: new_mailchimp_signup_path, method: :get, local: true do %>
               <div class="form-group">
                 <%= label_tag(:email_address, t('mailchimp.latest_news_title'), class: 'mb-0') %>
@@ -58,7 +58,7 @@
         </div>
       </div>
     </div>
-    <div class="footer-second py-4">
+    <div class="footer-second py-3">
       <div class="container">
         <div class="row d-flex align-items-center">
           <div class="col-md-4">

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -3,55 +3,91 @@
     <div class="footer-top py-4">
       <div class="container">
         <div class="row">
-          <div class="col-2">
+          <div class="col-sm-6 col-lg-2">
             <h1>Quick Links</h1>
             <ul class="list-unstyled">
               <li><%= link_to t('common_nav_bar_menus.actions'), intervention_type_groups_path %></li>
               <li><%= link_to t('common_nav_bar_menus.activities'), activity_categories_path %></li>
               <li><%= link_to t('our_schools_menu.scoreboards'), scoreboards_path %></li>
               <li><%= link_to t('our_schools_menu.compare_schools'), compare_index_path %></li>
+              <li><%= link_to t('about_menu.contact'), contact_path %></li>
             </ul>
           </div>
-          <div class="col-2">
+          <div class="col-sm-6 col-lg-2">
             <h1>Services</h1>
+            <ul class="list-unstyled">
+              <li><%= link_to t('our_services_menu.energy_audits'), energy_audits_path %></li>
+              <li><%= link_to t('our_services_menu.educational_workshops'), education_workshops_path %></li> <!-- is just 'Workshops' in design -->
+              <li><%= link_to t('our_services_menu.for_schools'), for_schools_path %></li>
+              <li><%= link_to t('our_services_menu.for_multi_academy_trusts'), for_multi_academy_trusts_path %></li>
+              <li><%= link_to t('our_services_menu.for_local_authorities'), for_local_authorities_path %></li>
+            </ul>
           </div>
-          <div class="col-2">
+          <div class="col-sm-6 col-lg-2">
             <h1>Other Links</h1>
+            <ul class="list-unstyled">
+              <li><%= link_to t('about_menu.jobs'), jobs_path %></li> <!-- 'Careers' in design -->
+              <li><%= link_to t('about_menu.datasets'), attribution_path %></li>
+              <li><%= link_to t('about_menu.open_data'), datasets_path %></li>
+              <li><%= link_to t('about_menu.school_statistics'), school_statistics_path %></li>
+            </ul>
           </div>
-          <div class="col-2">
+          <div class="col-sm-6 col-lg-2">
             <h1>Legal Terms</h1>
             <ul class="list-unstyled">
               <li><%= link_to t('footer.terms_and_conditions'), terms_and_conditions_path %></li>
-<!--              <li><%= link_to t('cookies.title'), cookies_path %></li> -->
+              <li><%= link_to t('cookies.title'), cookies_path %></li>  <!-- missing from design? -->
               <li><%= link_to t('about_menu.privacy_policy'), privacy_and_cookie_policy_path %></li>
               <li><%= link_to t('footer.child_safeguarding_policy'), child_safeguarding_policy_path %></li>
             </ul>
           </div>
-          <div class="col-4">
+          <div class="col-sm-12 col-lg-4">
             <h1>Newsletter Signup</h1>
+            <%= form_with url: new_mailchimp_signup_path, method: :get, local: true do %>
+              <div class="form-group">
+                <%= label_tag(:email_address, t('mailchimp.latest_news_title'), class: 'mb-0') %>
+                <%= text_field_tag(:email_address, nil, class: 'form-control',
+                                                        placeholder: t('mailchimp.example'),
+                                                        'aria-describedby': 'emailHelp',
+                                                        autocomplete: 'off') %>
+                <%= submit_tag t('mailchimp.signup_now'), class: 'btn btn-outline-white mt-2' %>
+                <span id='emailHelp' class="form-text"><%= t('mailchimp.never_share_your_email_promise') %>.</span>
+              </div>
+            <% end %>
           </div>
         </div>
       </div>
     </div>
-    <div class="footer-second py-4">
+    <div class="footer-second">
       <div class="container">
-        <div class="row">
-          <div class="col-4">
+        <div class="row d-flex align-items-center">
+          <div class="col-md-4">
             <%= t('footer.cc_licence_notice_html') %>.
           </div>
-          <div class="col-4">
+          <div class="col-md-4">
             <%= t('footer.registered_charity_notice') %>.
           </div>
-          <div class="col-4">
-              <ul class="list-inline">
-                <li class="list-inline-item p-2">
-                  <a href="//twitter.com/EnergySparks" class=""><%= fab_icon('twitter fa-2x') %></a>
+          <div class="col-md-4 d-flex justify-content-md-end">
+              <ul class="list-inline d-flex justify-content-end my-2 my-md-0">
+                <li class="list-inline-item">
+                  <a href="https://x.com/EnergySparks">
+                    <%= component 'icon', icon_set: 'fab', name: 'x-twitter', style: :circle %>
+                  </a>
                 </li>
-                <li class="list-inline-item p-2">
-                  <a href="//www.facebook.com/EnergySparksUK/" class=""><%= fab_icon('facebook-square fa-2x') %></a>
+                <li class="list-inline-item">
+                  <a href="https://www.instagram.com/energysparksuk/">
+                    <%= component 'icon', icon_set: 'fab', name: 'instagram', style: :circle %>
+                  </a>
                 </li>
-                <li class="list-inline-item p-2">
-                  <a href="//github.com/energy-sparks/energy-sparks" class=""><%= fab_icon('github fa-2x') %></a>
+                <li class="list-inline-item">
+                  <a href="https://www.facebook.com/EnergySparksUK/">
+                    <%= component 'icon', icon_set: 'fab', name: 'facebook-square', style: :circle %>
+                  </a>
+                </li>
+                <li class="list-inline-item">
+                  <a href="https://github.com/energy-sparks/energy-sparks">
+                    <%= component 'icon', icon_set: 'fab', name: 'github', style: :circle %>
+                  </a>
                 </li>
               </ul>
           </div>

--- a/app/views/shared/_head.html.erb
+++ b/app/views/shared/_head.html.erb
@@ -21,7 +21,7 @@
 <%= stylesheet_link_tag 'https://cdn.jsdelivr.net/npm/select2@4.0.13/dist/css/select2.min.css' %>
 <%= stylesheet_link_tag \
       'https://cdnjs.cloudflare.com/ajax/libs/select2-bootstrap-theme/0.1.0-beta.10/select2-bootstrap.min.css' %>
-<%= stylesheet_link_tag 'https://fonts.googleapis.com/css?family=Inter:400,600,700|Quicksand:600,700&display=swap' %>
+<%= stylesheet_link_tag 'https://fonts.googleapis.com/css?family=Inter:400,600,700|Quicksand:400,600,700&display=swap' %>
 <%= stylesheet_link_tag 'https://cdn.datatables.net/2.0.2/css/dataTables.bootstrap4.min.css' %>
 
 <% if Flipper.enabled?(:footer, current_user, current_user&.school_group) %>

--- a/app/views/shared/navigation/top_nav/_about_menu.html.erb
+++ b/app/views/shared/navigation/top_nav/_about_menu.html.erb
@@ -3,8 +3,8 @@
   <div id="about-us" class="dropdown-menu" aria-labelledby="aboutDropDown">
     <%= link_to t('about_menu.contact'), contact_path, class: 'dropdown-item' %>
     <%= link_to t('about_menu.team'), team_path, class: 'dropdown-item' %>
-    <%= link_to t('about_menu.blog'), 'http://blog.energysparks.uk', target: '_blank', class: 'dropdown-item',
-                                                                     rel: 'noopener' %>
+    <%= link_to t('about_menu.blog'), 'http://blog.energysparks.uk',
+                target: '_blank', class: 'dropdown-item', rel: 'noopener' %>
     <%= link_to t('about_menu.funders'), funders_path, class: 'dropdown-item' %>
     <%= link_to t('about_menu.jobs'), jobs_path, class: 'dropdown-item' %>
     <%= link_to t('about_menu.terms_and_conditions'), terms_and_conditions_path, class: 'dropdown-item' %>

--- a/app/views/shared/navigation/top_nav/_about_menu.html.erb
+++ b/app/views/shared/navigation/top_nav/_about_menu.html.erb
@@ -11,5 +11,9 @@
     <%= link_to t('about_menu.privacy_policy'), privacy_and_cookie_policy_path, class: 'dropdown-item' %>
     <%= link_to t('about_menu.child_safeguarding'), child_safeguarding_policy_path, class: 'dropdown-item' %>
     <%= link_to t('about_menu.school_statistics'), school_statistics_path, class: 'dropdown-item' %>
+    <% unless Flipper.enabled?(:footer, current_user, current_user&.school_group) %>
+      <%= link_to t('about_menu.datasets'), attribution_path, class: 'dropdown-item' %>
+      <%= link_to t('about_menu.open_data'), datasets_path, class: 'dropdown-item' %>
+    <% end %>
   </div>
 </li>

--- a/app/views/shared/navigation/top_nav/_about_menu.html.erb
+++ b/app/views/shared/navigation/top_nav/_about_menu.html.erb
@@ -11,7 +11,5 @@
     <%= link_to t('about_menu.privacy_policy'), privacy_and_cookie_policy_path, class: 'dropdown-item' %>
     <%= link_to t('about_menu.child_safeguarding'), child_safeguarding_policy_path, class: 'dropdown-item' %>
     <%= link_to t('about_menu.school_statistics'), school_statistics_path, class: 'dropdown-item' %>
-    <%= link_to t('about_menu.datasets'), attribution_path, class: 'dropdown-item' %>
-    <%= link_to t('about_menu.open_data'), datasets_path, class: 'dropdown-item' %>
   </div>
 </li>

--- a/app/views/shared/navigation/top_nav/_our_services_menu.html.erb
+++ b/app/views/shared/navigation/top_nav/_our_services_menu.html.erb
@@ -11,9 +11,5 @@
     <%= link_to t('our_services_menu.case_studies'), case_studies_path, class: 'dropdown-item' %>
     <%= link_to t('our_services_menu.newsletters'), newsletters_path, class: 'dropdown-item' %>
     <%= link_to t('our_services_menu.videos'), user_guide_youtube_path, class: 'dropdown-item' %>
-    <% unless Flipper.enabled?(:footer, current_user, current_user&.school_group) %>
-      <%= link_to t('about_menu.datasets'), attribution_path, class: 'dropdown-item' %>
-      <%= link_to t('about_menu.open_data'), datasets_path, class: 'dropdown-item' %>
-    <% end %>
   </div>
 </li>

--- a/app/views/shared/navigation/top_nav/_our_services_menu.html.erb
+++ b/app/views/shared/navigation/top_nav/_our_services_menu.html.erb
@@ -11,5 +11,9 @@
     <%= link_to t('our_services_menu.case_studies'), case_studies_path, class: 'dropdown-item' %>
     <%= link_to t('our_services_menu.newsletters'), newsletters_path, class: 'dropdown-item' %>
     <%= link_to t('our_services_menu.videos'), user_guide_youtube_path, class: 'dropdown-item' %>
+    <% unless Flipper.enabled?(:footer, current_user, current_user&.school_group) %>
+      <%= link_to t('about_menu.datasets'), attribution_path, class: 'dropdown-item' %>
+      <%= link_to t('about_menu.open_data'), datasets_path, class: 'dropdown-item' %>
+    <% end %>
   </div>
 </li>

--- a/config/initializers/colours.rb
+++ b/config/initializers/colours.rb
@@ -48,7 +48,8 @@ module Colours
         light: '#dcdcdc'.freeze, # generated using: https://www.dannybrien.com/middle/
         medium: '#c3c3c3'.freeze, # was called "table grey" in the original designs
         dark: '#8c8c8c'.freeze, # generated - midway point between pale and very dark
-        very_dark: '#222222'.freeze # from original designs - used in header
+        darker: '#343434'.freeze, # from design - second footer background
+        very_dark: '#222222'.freeze # from original designs - used in header and footer
       },
       cyan: '#17a2b8'.freeze, # bootstrap colour (not in designs)
       white: '#ffffff'.freeze,

--- a/config/locales/views/home/home.yml
+++ b/config/locales/views/home/home.yml
@@ -3,7 +3,7 @@ en:
   case_studies:
     download: Download
     more_case_studies: More case studies
-    title: Case studies
+    title: Case Studies
   home:
     carousel:
       message_1: Help your school save energy, money and prevent climate change.

--- a/config/locales/views/home/home.yml
+++ b/config/locales/views/home/home.yml
@@ -33,9 +33,11 @@ en:
     title: We help schools become more energy efficient and fight climate change.
   mailchimp:
     continue: Continue
+    example: 'eg: hello@example.com'
     latest_news_title: Get the latest news from Energy Sparks in your inbox
     more_newsletters: More newsletters
     never_share_your_email_promise: We'll never share your email with anyone else
+    signup_now: Sign-up now
     title_html: Stay up to date&hellip;
     your_email_address: Your email address
   newsletters:

--- a/config/locales/views/shared/shared.yml
+++ b/config/locales/views/shared/shared.yml
@@ -114,7 +114,7 @@ en:
     scoreboards: Scoreboards
     view_schools: View schools
   our_services_menu:
-    case_studies: Case Studies
+    case_studies: Case studies
     educational_workshops: Educational workshops
     energy_audits: Energy audits
     for_local_authorities: For Local Authorities

--- a/config/locales/views/shared/shared.yml
+++ b/config/locales/views/shared/shared.yml
@@ -51,8 +51,13 @@ en:
     cc_licence_notice_html: Content on this website is published under <a href="https://creativecommons.org/licenses/by/4.0/">a Creative Commons Attribution 4.0 Licence</a>
     child_safeguarding_policy: Child safeguarding policy
     follow_energy_sparks: Follow Energy Sparks
+    legal_terms: Legal Terms
     more_information: More information
+    newsletter_signup: Newsletter Signup
+    other_links: Other Links
+    quick_links: Quick Links
     registered_charity_notice: Energy Sparks is a registered charity in England and Wales, registration 1189273
+    services: Services
     terms_and_conditions: Terms and conditions
   manage_menu:
     admin: Admin

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -44,6 +44,8 @@ RSpec.configure do |config|
   # triggering implicit auto-inclusion in groups with matching metadata.
   config.shared_context_metadata_behavior = :apply_to_host_groups
 
+  config.filter_run focus: true
+  config.run_all_when_everything_filtered = true
 # The settings below are suggested to provide a good initial experience
 # with RSpec, but feel free to customize to your heart's content.
 =begin # rubocop:disable Style/BlockComments:

--- a/spec/system/admin/case_studies_spec.rb
+++ b/spec/system/admin/case_studies_spec.rb
@@ -8,7 +8,9 @@ describe 'Case studies', type: :system do
       sign_in(admin)
       visit root_path
       click_on 'Admin'
-      click_on 'Case studies'
+      within '.application' do
+        click_on 'Case studies'
+      end
     end
 
     it 'allows the user to create, edit and delete a case study' do

--- a/spec/system/footer_spec.rb
+++ b/spec/system/footer_spec.rb
@@ -1,0 +1,112 @@
+require 'rails_helper'
+
+RSpec.describe 'Footer', type: :system do
+  before do
+    Flipper.enable :footer
+    visit terms_and_conditions_path # visit a link that doesn't hit the db for test speed
+  end
+
+  describe 'Top Footer' do
+    describe 'Quick Links' do
+      let(:block) { page.find(:css, 'footer .footer-top #quick-links') }
+
+      it { expect(block).to have_content 'Quick Links' }
+      it { expect(block).to have_link 'Actions', href: intervention_type_groups_path }
+      it { expect(block).to have_link 'Activities', href: activity_categories_path }
+      it { expect(block).to have_link 'Scoreboards', href: scoreboards_path }
+      it { expect(block).to have_link 'Compare schools', href: compare_index_path }
+      it { expect(block).to have_link 'Contact', href: contact_path }
+    end
+
+    describe 'Services' do
+      let(:block) { page.find(:css, 'footer .footer-top #services') }
+
+      it { expect(block).to have_content 'Services' }
+      it { expect(block).to have_link 'Energy audits', href: energy_audits_path }
+      it { expect(block).to have_link 'Educational workshops', href: education_workshops_path }
+      it { expect(block).to have_link 'For Schools', href: for_schools_path }
+      it { expect(block).to have_link 'For Multi-Academy Trusts', href: for_multi_academy_trusts_path }
+      it { expect(block).to have_link 'For Local Authorities', href: for_local_authorities_path }
+    end
+
+    describe 'Other Links' do
+      let(:block) { page.find(:css, 'footer .footer-top #other-links') }
+
+      it { expect(block).to have_content 'Other Links' }
+      it { expect(block).to have_link 'Jobs', href: jobs_path }
+      it { expect(block).to have_link 'Datasets', href: attribution_path }
+      it { expect(block).to have_link 'Open data', href: datasets_path }
+      it { expect(block).to have_link 'School statistics', href: school_statistics_path }
+    end
+
+    describe 'Legal Terms' do
+      let(:block) { page.find(:css, 'footer .footer-top #legal-terms') }
+
+      it { expect(block).to have_content 'Legal Terms' }
+      it { expect(block).to have_link 'Terms and conditions', href: terms_and_conditions_path }
+      it { expect(block).to have_link 'Privacy policy', href: privacy_and_cookie_policy_path }
+      it { expect(block).to have_link 'Cookies', href: cookies_path }
+      it { expect(block).to have_link 'Child safeguarding policy', href: child_safeguarding_policy_path }
+    end
+
+    describe 'Newsletter Signup' do
+      let(:block) { page.find(:css, 'footer .footer-top #newsletter-signup') }
+
+      it { expect(block).to have_content 'Newsletter Signup' }
+      it { expect(block).to have_content 'Get the latest news from Energy Sparks in your inbox' }
+      it { expect(block).to have_field :email_address, placeholder: 'eg: hello@example.com' }
+      it { expect(block).to have_button('Sign-up now') }
+      it { expect(block).to have_content "We'll never share your email with anyone else" }
+
+      # Not doing a full mailchimp test here, just that the form submits to the right place
+      context 'when signing up' do
+        let!(:newsletter) { create(:newsletter) }
+        let(:interests) { [OpenStruct.new(id: 1, name: 'Interest One')] }
+        let(:categories) { [OpenStruct.new(id: 1, title: 'Category One', interests: interests)] }
+        let(:list_with_interests) { OpenStruct.new(id: 1, categories: categories) }
+
+        before do
+          allow_any_instance_of(MailchimpApi).to receive(:list_with_interests).and_return(list_with_interests)
+          allow_any_instance_of(MailchimpApi).to receive(:subscribe).and_return(true)
+        end
+
+        context 'when email provided' do
+          before do
+            within '#newsletter-signup' do
+              fill_in :email_address, with: 'foo@bar.com'
+              click_on 'Sign-up now'
+            end
+          end
+
+          it { expect(page).to have_content('Sign up to the Energy Sparks newsletter') }
+          it { expect(page).to have_field(:email_address, with: 'foo@bar.com') }
+        end
+
+        context 'when email is not provided' do
+          before do
+            within '#newsletter-signup' do
+              fill_in :email_address, with: ''
+              click_on 'Sign-up now'
+            end
+          end
+
+          it { expect(page).to have_content('Sign up to the Energy Sparks newsletter') }
+          it { expect(page).to have_field(:email_address, with: nil) }
+        end
+      end
+    end
+  end
+
+  describe 'Second Footer' do
+    let(:block) { page.find(:css, 'footer .footer-second') }
+
+    it { expect(block).to have_content 'Content on this website is published under a Creative Commons Attribution 4.0 Licence.' }
+    it { expect(block).to have_content 'Energy Sparks is a registered charity in England and Wales, registration 1189273.' }
+
+    it { expect(block).to have_link href: 'https://creativecommons.org/licenses/by/4.0/' }
+    it { expect(block).to have_link href: 'https://x.com/EnergySparks' }
+    it { expect(block).to have_link href: 'https://www.instagram.com/energysparksuk/' }
+    it { expect(block).to have_link href: 'https://www.facebook.com/EnergySparksUK/' }
+    it { expect(block).to have_link href: 'https://github.com/energy-sparks/energy-sparks' }
+  end
+end

--- a/spec/system/footer_spec.rb
+++ b/spec/system/footer_spec.rb
@@ -11,10 +11,10 @@ RSpec.describe 'Footer', type: :system do
       let(:block) { page.find(:css, 'footer .footer-top #quick-links') }
 
       it { expect(block).to have_content 'Quick Links' }
-      it { expect(block).to have_link 'Actions', href: intervention_type_groups_path }
       it { expect(block).to have_link 'Activities', href: activity_categories_path }
+      it { expect(block).to have_link 'Actions', href: intervention_type_groups_path }
+      it { expect(block).to have_link 'View schools', href: schools_path }
       it { expect(block).to have_link 'Scoreboards', href: scoreboards_path }
-      it { expect(block).to have_link 'Compare schools', href: compare_index_path }
       it { expect(block).to have_link 'Contact', href: contact_path }
     end
 
@@ -24,9 +24,10 @@ RSpec.describe 'Footer', type: :system do
       it { expect(block).to have_content 'Services' }
       it { expect(block).to have_link 'Energy audits', href: energy_audits_path }
       it { expect(block).to have_link 'Educational workshops', href: education_workshops_path }
-      it { expect(block).to have_link 'For Schools', href: for_schools_path }
-      it { expect(block).to have_link 'For Multi-Academy Trusts', href: for_multi_academy_trusts_path }
-      it { expect(block).to have_link 'For Local Authorities', href: for_local_authorities_path }
+      it { expect(block).to have_link 'Training', href: training_path }
+      it { expect(block).to have_link 'Find out more', href: find_out_more_path }
+      it { expect(block).to have_link 'Book a demo', href: book_demo_campaigns_path }
+      it { expect(block).to have_link 'Case studies', href: case_studies_path }
     end
 
     describe 'Other Links' do
@@ -34,9 +35,10 @@ RSpec.describe 'Footer', type: :system do
 
       it { expect(block).to have_content 'Other Links' }
       it { expect(block).to have_link 'Jobs', href: jobs_path }
+      it { expect(block).to have_link 'Blog', href: 'http://blog.energysparks.uk' }
+      it { expect(block).to have_link 'School statistics', href: school_statistics_path }
       it { expect(block).to have_link 'Datasets', href: attribution_path }
       it { expect(block).to have_link 'Open data', href: datasets_path }
-      it { expect(block).to have_link 'School statistics', href: school_statistics_path }
     end
 
     describe 'Legal Terms' do

--- a/spec/system/navigation/top_nav_spec.rb
+++ b/spec/system/navigation/top_nav_spec.rb
@@ -70,8 +70,6 @@ RSpec.describe 'Navigation -> top nav', type: :system do
       expect(about_us).to have_link('Privacy policy')
       expect(about_us).to have_link('Child safeguarding')
       expect(about_us).to have_link('School statistics')
-      expect(about_us).to have_link('Datasets')
-      expect(about_us).to have_link('Open data')
     end
   end
 

--- a/spec/system/navigation/top_nav_spec.rb
+++ b/spec/system/navigation/top_nav_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe 'Navigation -> top nav', type: :system do
       expect(our_services).to have_link('Educational workshops')
       expect(our_services).to have_link('Pricing')
       expect(our_services).to have_link('Training')
-      expect(our_services).to have_link('Case Studies')
+      expect(our_services).to have_link('Case studies')
       expect(our_services).to have_link('Newsletters')
       expect(our_services).to have_link('Videos')
     end

--- a/spec/system/navigation/top_nav_spec.rb
+++ b/spec/system/navigation/top_nav_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe 'Navigation -> top nav', type: :system do
   let(:user) {}
 
   before do
-    Flipper.enable :navigation
     sign_in(user) if user
     visit root_path(locale: locale)
   end


### PR DESCRIPTION
The top image is the implemented version, the bottom is the actual design:

![image](https://github.com/user-attachments/assets/36488e1b-47f5-45a7-a7c9-964dba6e28eb)

Differences I see as follows, aside from some text looking slightly bolder than the design and padding variations (looked better when it came to implementation):
'Contact us' is called 'Contact' (as per current top nav)
'Careers' is called 'Jobs' (as per current top nav)
'Workshops' is called 'Educational workshops' (as per current top nav)
'Privacy & Cookies Policy' is split into two separate links (as per current top nav)
Do we want to change these links to the design, and if so, do we want to change those in the top nav too?

Have added social media links based off what I think we have.

Perhaps this can go on test for an easier look when we're ready