### PR TITLE
run rubocop to change deprecated enum arrays to hashes

### DIFF
--- a/app/models/advice_page_school_benchmark.rb
+++ b/app/models/advice_page_school_benchmark.rb
@@ -22,5 +22,5 @@
 class AdvicePageSchoolBenchmark < ApplicationRecord
   belongs_to :school, inverse_of: :advice_page_school_benchmarks
   belongs_to :advice_page, inverse_of: :advice_page_school_benchmarks
-  enum benchmarked_as: [:other_school, :benchmark_school, :exemplar_school]
+  enum :benchmarked_as, { other_school: 0, benchmark_school: 1, exemplar_school: 2 }
 end

--- a/app/models/alert.rb
+++ b/app/models/alert.rb
@@ -52,7 +52,9 @@ class Alert < ApplicationRecord
   has_many :find_out_mores, inverse_of: :alert
   has_many :alert_subscription_events
 
-  has_many :alert_type_ratings, ->(alert) { alert.rating.present? ? for_rating(alert.rating.to_f.round(1)) : none }, primary_key: 'alert_type_id', foreign_key: 'alert_type_id'
+  has_many :alert_type_ratings, lambda { |alert|
+    alert.rating.present? ? for_rating(alert.rating.to_f.round(1)) : none
+  }, primary_key: 'alert_type_id', foreign_key: 'alert_type_id'
   has_many :intervention_types, through: :alert_type_ratings
   has_many :activity_types, through: :alert_type_ratings
 
@@ -77,19 +79,17 @@ class Alert < ApplicationRecord
   scope :rating_between, ->(from, to) { where('rating BETWEEN ? AND ?', from, to) }
   scope :by_rating, ->(order: :asc) { order(rating: order) }
 
-  enum enough_data: [:enough, :not_enough, :minimum_might_not_be_accurate], _prefix: :data
-  enum relevance: [:relevant, :not_relevant, :never_relevant], _prefix: :relevance
+  enum :enough_data, { enough: 0, not_enough: 1, minimum_might_not_be_accurate: 2 }, prefix: :data
+  enum :relevance, { relevant: 0, not_relevant: 1, never_relevant: 2 }, prefix: :relevance
 
-  scope :without_exclusions, -> { joins(:alert_type).joins('LEFT OUTER JOIN school_alert_type_exclusions ON school_alert_type_exclusions.school_id = alerts.school_id AND school_alert_type_exclusions.alert_type_id = alert_types.id').where(school_alert_type_exclusions: { school_id: nil }) }
+  scope :without_exclusions, lambda {
+    joins(:alert_type).joins('LEFT OUTER JOIN school_alert_type_exclusions ON school_alert_type_exclusions.school_id = alerts.school_id AND school_alert_type_exclusions.alert_type_id = alert_types.id').where(school_alert_type_exclusions: { school_id: nil })
+  }
   scope :displayable, -> { where(displayable: true) }
 
-  def advice_page
-    alert_type.advice_page
-  end
+  delegate :advice_page, to: :alert_type
 
-  def frequency
-    alert_type.frequency
-  end
+  delegate :frequency, to: :alert_type
 
   def formatted_rating
     rating.nil? ? 'Unrated' : "#{rating.round(0)}/10"

--- a/app/models/alert_subscription_event.rb
+++ b/app/models/alert_subscription_event.rb
@@ -42,11 +42,12 @@ class AlertSubscriptionEvent < ApplicationRecord
   belongs_to :email, optional: true
   has_one    :sms_record
   belongs_to :find_out_more, optional: true
-  belongs_to :content_version, class_name: 'AlertTypeRatingContentVersion', foreign_key: :alert_type_rating_content_version_id
+  belongs_to :content_version, class_name: 'AlertTypeRatingContentVersion',
+                               foreign_key: :alert_type_rating_content_version_id
   belongs_to :subscription_generation_run
 
-  enum status: [:pending, :sent, :archived]
-  enum communication_type: [:email, :sms]
+  enum :status, { pending: 0, sent: 1, archived: 2 }
+  enum :communication_type, { email: 0, sms: 1 }
 
   validates :priority, numericality: true
 
@@ -58,7 +59,7 @@ class AlertSubscriptionEvent < ApplicationRecord
 
   def sms_content
     TemplateInterpolation.new(
-      content_version,
+      content_version
     ).interpolate(
       :sms_content,
       with: alert.template_variables

--- a/app/models/alert_type.rb
+++ b/app/models/alert_type.rb
@@ -26,7 +26,8 @@
 #
 
 class AlertType < ApplicationRecord
-  SUB_CATEGORIES = [:hot_water, :heating, :baseload, :electricity_use, :solar_pv, :tariffs, :co2, :boiler_control, :overview, :storage_heaters].freeze
+  SUB_CATEGORIES = %i[hot_water heating baseload electricity_use solar_pv tariffs co2 boiler_control
+                      overview storage_heaters].freeze
 
   belongs_to :advice_page, optional: true
 
@@ -35,12 +36,12 @@ class AlertType < ApplicationRecord
   has_many :ratings, class_name: 'AlertTypeRating'
   has_many :school_alert_type_exclusions
 
-  enum source: [:analytics, :system, :analysis]
-  enum fuel_type: [:electricity, :gas, :storage_heater, :solar_pv], _suffix: :fuel_type
-  enum sub_category: SUB_CATEGORIES
-  enum frequency: [:termly, :weekly, :before_each_holiday]
-  enum group: [:advice, :benchmarking, :change, :priority]
-  enum link_to: [:insights_page, :analysis_page, :learn_more_page]
+  enum :source, { analytics: 0, system: 1, analysis: 2 }
+  enum :fuel_type, { electricity: 0, gas: 1, storage_heater: 2, solar_pv: 3 }, suffix: :fuel_type
+  enum :sub_category, SUB_CATEGORIES
+  enum :frequency, { termly: 0, weekly: 1, before_each_holiday: 2 }
+  enum :group, { advice: 0, benchmarking: 1, change: 2, priority: 3 }
+  enum :link_to, { insights_page: 0, analysis_page: 1, learn_more_page: 2 }
 
   scope :enabled,       -> { where(enabled: true) }
   scope :electricity,   -> { where(fuel_type: :electricity) }
@@ -50,12 +51,13 @@ class AlertType < ApplicationRecord
 
   scope :editable, -> { where.not(background: true) }
 
-  validates_presence_of :frequency, :title, :class_name, :source, :group
+  validates :frequency, :title, :class_name, :source, :group, presence: true
 
   has_rich_text :description
 
   def display_fuel_type
     return 'No fuel type' if fuel_type.nil?
+
     fuel_type.humanize
   end
 

--- a/app/models/alert_type_rating_unsubscription.rb
+++ b/app/models/alert_type_rating_unsubscription.rb
@@ -31,11 +31,10 @@ class AlertTypeRatingUnsubscription < ApplicationRecord
   belongs_to :contact
   belongs_to :alert_subscription_event, optional: true
 
-  enum scope: [:email, :sms]
-  enum unsubscription_period: [:one_month, :six_months, :forever]
+  enum :scope, { email: 0, sms: 1 }
+  enum :unsubscription_period, { one_month: 0, six_months: 1, forever: 2 }
 
-  scope :active, ->(today) { where('effective_until IS NULL OR effective_until < ?', today)}
-
+  scope :active, ->(today) { where('effective_until IS NULL OR effective_until < ?', today) }
 
   validates :alert_type_rating, :reason, :unsubscription_period, presence: true
 
@@ -48,10 +47,10 @@ class AlertTypeRatingUnsubscription < ApplicationRecord
       alert_subscription_event: event,
       contact: event.contact,
       alert_type_rating: event.content_version.alert_type_rating,
-      unsubscription_period: unsubscription_period,
-      effective_until: effective_until,
-      scope: scope,
-      reason: reason
+      unsubscription_period:,
+      effective_until:,
+      scope:,
+      reason:
     )
   end
 end

--- a/app/models/amr_data_feed_config.rb
+++ b/app/models/amr_data_feed_config.rb
@@ -57,8 +57,7 @@ class AmrDataFeedConfig < ApplicationRecord
 
   has_rich_text :notes
 
-  validates :identifier, :description, uniqueness: true
-  validates :identifier, :description, presence: true
+  validates :identifier, :description, uniqueness: true, presence: true
 
   validates :row_per_reading, inclusion: [true], if: :positional_index
   validate :period_or_time_field, if: :positional_index
@@ -70,8 +69,7 @@ class AmrDataFeedConfig < ApplicationRecord
   def period_or_time_field
     return unless positional_index && reading_time_field.blank? && period_field.blank?
 
-    errors.add(:base,
-               'Must specify either period or time field')
+    errors.add(:base, 'Must specify either period or time field')
   end
 
   def map_of_fields_to_indexes(header = nil)

--- a/app/models/amr_reading_warning.rb
+++ b/app/models/amr_reading_warning.rb
@@ -38,7 +38,8 @@ class AmrReadingWarning < ApplicationRecord
     6 => :duplicate_reading
   }.freeze
 
-  enum warning: [:blank_readings, :missing_readings, :missing_mpan_mprn, :missing_reading_date, :invalid_reading_date]
+  enum :warning, { blank_readings: 0, missing_readings: 1, missing_mpan_mprn: 2, missing_reading_date: 3,
+                   invalid_reading_date: 4 }
 
   def messages
     warning_symbols.map { |warning_symbol| AmrReadingData::WARNINGS[warning_symbol] }.join(', ')

--- a/app/models/calendar.rb
+++ b/app/models/calendar.rb
@@ -27,11 +27,11 @@ class Calendar < ApplicationRecord
 
   has_many    :schools
 
-  validates_presence_of :title
+  validates :title, presence: true
 
   delegate :terms, :holidays, :bank_holidays, :inset_days, :outside_term_time, to: :calendar_events
 
-  enum calendar_type: [:national, :regional, :school]
+  enum :calendar_type, { national: 0, regional: 1, school: 2 }
 
   scope :template, -> { regional }
 
@@ -40,7 +40,7 @@ class Calendar < ApplicationRecord
   end
 
   def academic_year_for(date)
-    academic_years.for_date(date).first || based_on && based_on.academic_year_for(date)
+    academic_years.for_date(date).first || (based_on && based_on.academic_year_for(date))
   end
 
   def terms_and_holidays
@@ -52,7 +52,7 @@ class Calendar < ApplicationRecord
   end
 
   def holiday_approaching?(today: Time.zone.today)
-    next_after_today = next_holiday(today: today)
+    next_after_today = next_holiday(today:)
     next_after_today.present? && (next_after_today.start_date - today <= 7)
   end
 end

--- a/app/models/calendar_event_type.rb
+++ b/app/models/calendar_event_type.rb
@@ -26,7 +26,8 @@ class CalendarEventType < ApplicationRecord
   scope :outside_term_time, -> { where(term_time: false) }
   scope :bank_holiday,      -> { where(bank_holiday: true) }
 
-  enum analytics_event_type: [:term_time, :school_holiday, :bank_holiday, :inset_day_in_school, :inset_day_out_of_school]
+  enum :analytics_event_type, { term_time: 0, school_holiday: 1, bank_holiday: 2, inset_day_in_school: 3,
+                                inset_day_out_of_school: 4 }
 
   def i18n_key(field)
     "#{self.class.model_name.i18n_key}.#{title.parameterize.underscore}.#{field}"

--- a/app/models/dashboard_alert.rb
+++ b/app/models/dashboard_alert.rb
@@ -31,9 +31,10 @@ class DashboardAlert < ApplicationRecord
   belongs_to :content_generation_run
   belongs_to :alert
   belongs_to :find_out_more, optional: true
-  belongs_to :content_version, class_name: 'AlertTypeRatingContentVersion', foreign_key: :alert_type_rating_content_version_id
+  belongs_to :content_version, class_name: 'AlertTypeRatingContentVersion',
+                               foreign_key: :alert_type_rating_content_version_id
 
-  enum dashboard: [:teacher, :pupil, :public, :management], _suffix: :dashboard
+  enum :dashboard, { teacher: 0, pupil: 1, public: 2, management: 3 }, suffix: :dashboard
 
   validates :priority, numericality: true
 

--- a/app/models/energy_tariff.rb
+++ b/app/models/energy_tariff.rb
@@ -36,8 +36,12 @@ class EnergyTariff < ApplicationRecord
   belongs_to :tariff_holder, polymorphic: true
 
   # Declaring associations allows us to use .joins(:school) or .joins(:school_group)
-  belongs_to :school, -> { where(energy_tariffs: { tariff_holder_type: 'School' }) }, foreign_key: 'tariff_holder_id', optional: true
-  belongs_to :school_group, -> { where(energy_tariffs: { tariff_holder_type: 'SchoolGroup' }) }, foreign_key: 'tariff_holder_id', optional: true
+  belongs_to :school, lambda {
+    where(energy_tariffs: { tariff_holder_type: 'School' })
+  }, foreign_key: 'tariff_holder_id', optional: true
+  belongs_to :school_group, lambda {
+    where(energy_tariffs: { tariff_holder_type: 'SchoolGroup' })
+  }, foreign_key: 'tariff_holder_id', optional: true
 
   delegated_type :tariff_holder, types: %w[SiteSettings School SchoolGroup]
 
@@ -50,15 +54,15 @@ class EnergyTariff < ApplicationRecord
   belongs_to :created_by, optional: true, class_name: 'User'
   belongs_to :updated_by, optional: true, class_name: 'User'
 
-  enum source: [:manually_entered, :dcc]
-  enum meter_type: [:electricity, :gas, :solar_pv, :exported_solar_pv]
-  enum tariff_type: [:flat_rate, :differential]
+  enum :source, { manually_entered: 0, dcc: 1 }
+  enum :meter_type, { electricity: 0, gas: 1, solar_pv: 2, exported_solar_pv: 3 }
+  enum :tariff_type, { flat_rate: 0, differential: 1 }
 
   # Used as an all_energy_tariff_attributes filter:
   # :half_hourly applies to meters which have a :meter_system of :hh
   # :non_half_hourly applies to meters which have a :meter_system of :nhh_amr, :nhh or :smets2_smart
   # :both applies to meters with all meter :system_type values
-  enum applies_to: [:both, :half_hourly, :non_half_hourly]
+  enum :applies_to, { both: 0, half_hourly: 1, non_half_hourly: 2 }
 
   validates :name, presence: true
   validates :vat_rate, numericality: { greater_than_or_equal_to: 0.0, less_than_or_equal_to: 100.0, allow_nil: true }
@@ -75,20 +79,22 @@ class EnergyTariff < ApplicationRecord
   scope :by_start_date, -> { order(start_date: :asc) }
 
   # Sorts with null start date first, then start date, then end date
-  scope :by_start_and_end, -> {
+  scope :by_start_and_end, lambda {
     order(Arel.sql('(CASE WHEN start_date is NULL THEN 0 ELSE 1 END) ASC, start_date asc, end_date asc'))
   }
 
   scope :count_by_school_group, -> { enabled.joins(:school_group).group(:slug).count(:id) }
 
-  scope :for_schools_in_group, ->(school_group, source = :manually_entered) {
-    enabled.where(source: source).joins(:school).where({ schools: { school_group: school_group } })
+  scope :for_schools_in_group, lambda { |school_group, source = :manually_entered|
+    enabled.where(source:).joins(:school).where({ schools: { school_group: } })
   }
-  scope :count_schools_with_tariff_by_group, ->(school_group, source = :manually_entered) {
+  scope :count_schools_with_tariff_by_group, lambda { |school_group, source = :manually_entered|
     for_schools_in_group(school_group, source).select(:tariff_holder_id).distinct.count
   }
 
-  scope :latest_with_fixed_end_date, ->(meter_type, source = :manually_entered) { where(meter_type: meter_type, source: source).where.not(end_date: nil).order(end_date: :desc) }
+  scope :latest_with_fixed_end_date, lambda { |meter_type, source = :manually_entered|
+    where(meter_type:, source:).where.not(end_date: nil).order(end_date: :desc)
+  }
 
   def applies_to_is_set_to_both
     return if electricity?
@@ -122,10 +128,10 @@ class EnergyTariff < ApplicationRecord
       start_date: (start_date || Date.new(2000, 1, 1)).to_fs(:es_compact),
       end_date: (end_date || Date.new(2050, 1, 1)).to_fs(:es_compact),
       source: source.to_sym,
-      name: name,
+      name:,
       type: flat_rate? ? :flat : :differential,
       sub_type: '',
-      rates: rates,
+      rates:,
       vat: vat_rate.nil? ? nil : "#{vat_rate}%",
       climate_change_levy: ccl,
       asc_limit_kw: (value_for_charge(:asc_limit_kw) if rates_has_availability_charge?(rates)),
@@ -135,9 +141,9 @@ class EnergyTariff < ApplicationRecord
   end
 
   def value_for_charge(type)
-    if (charge = energy_tariff_charges.for_type(type).first)
-      charge.value.to_s
-    end
+    return unless (charge = energy_tariff_charges.for_type(type).first)
+
+    charge.value.to_s
   end
 
   def energy_tariff_refers_to_all_meters?
@@ -166,7 +172,9 @@ class EnergyTariff < ApplicationRecord
     # * it must have more two or more energy tariff price records
     # * the energy tariff price records combined start and end times must cover a full 24 hour period (1440 minutes)
     # * all energy tariff price records must have values set greater than zero
-    return true if energy_tariff_prices.count >= 2 && energy_tariff_prices.complete? && energy_tariff_prices&.map(&:value)&.all? { |value| value&.nonzero? }
+    return true if energy_tariff_prices.count >= 2 && energy_tariff_prices.complete? && energy_tariff_prices&.map(&:value)&.all? do |value|
+      value&.nonzero?
+    end
 
     false
   end
@@ -183,7 +191,8 @@ class EnergyTariff < ApplicationRecord
     return unless start_date.present? && end_date.present?
     return unless start_date > end_date
 
-    errors.add(:start_date, I18n.t('schools.user_tariffs.form.errors.dates.start_date_must_be_earlier_than_or_equal_to_end_date'))
+    errors.add(:start_date,
+               I18n.t('schools.user_tariffs.form.errors.dates.start_date_must_be_earlier_than_or_equal_to_end_date'))
   end
 
   def tariff_holder_symbol
@@ -198,20 +207,22 @@ class EnergyTariff < ApplicationRecord
       end
     else
       energy_tariff_prices.each_with_index do |price, idx|
-        attrs["rate#{idx}".to_sym] = { rate: price.value.to_s, per: price.units.to_s, from: hour_minutes(price.start_time), to: hour_minutes(price.end_time.advance(minutes: -30)) }
+        attrs[:"rate#{idx}"] =
+          { rate: price.value.to_s, per: price.units.to_s, from: hour_minutes(price.start_time),
+            to: hour_minutes(price.end_time.advance(minutes: -30)) }
       end
     end
     energy_tariff_charges.select { |c| c.units.present? }.each do |charge|
       charge_value = { rate: charge.value.to_s, per: charge.units.to_s }
       charge_type = charge.charge_type.to_sym
       # only add these charges if we also have an asc limit
-      if charge.is_type?([:agreed_availability_charge, :excess_availability_charge])
+      if charge.is_type?(%i[agreed_availability_charge excess_availability_charge])
         attrs[charge_type] = charge_value if value_for_charge(:asc_limit_kw).present?
       else
         attrs[charge_type] = charge_value
       end
     end
-    energy_tariff_charges.select { |c| c.is_type?([:duos_red, :duos_amber, :duos_green]) }.each do |charge|
+    energy_tariff_charges.select { |c| c.is_type?(%i[duos_red duos_amber duos_green]) }.each do |charge|
       attrs[charge.charge_type.to_sym] = charge.value.to_s
     end
     attrs[:tnuos] = tnuos

--- a/app/models/equivalence_type.rb
+++ b/app/models/equivalence_type.rb
@@ -13,8 +13,8 @@
 class EquivalenceType < ApplicationRecord
   has_many :content_versions, class_name: 'EquivalenceTypeContentVersion'
 
-  enum meter_type: [:electricity, :gas, :solar_pv, :storage_heaters]
-  enum time_period: {
+  enum :meter_type, { electricity: 0, gas: 1, solar_pv: 2, storage_heaters: 3 }
+  enum :time_period, {
     last_week: 10,
     last_school_week: 15,
     last_work_week: 16,
@@ -23,7 +23,10 @@ class EquivalenceType < ApplicationRecord
     last_academic_year: 31
   }
 
-  enum image_name: [:no_image, :petrol_car, :electric_car, :meal, :solar_panel, :books, :electric_shower, :house, :kettle, :phone, :pizza, :roast_meal, :television, :tree, :video_game, :offshore_wind_turbine, :onshore_wind_turbine, :gas_shower, :solar_panel_bw, :electric_car_bw, :meal_bw]
+  enum :image_name, { no_image: 0, petrol_car: 1, electric_car: 2, meal: 3, solar_panel: 4, books: 5,
+                      electric_shower: 6, house: 7, kettle: 8, phone: 9, pizza: 10, roast_meal: 11, television: 12,
+                      tree: 13, video_game: 14, offshore_wind_turbine: 15, onshore_wind_turbine: 16, gas_shower: 17,
+                      solar_panel_bw: 18, electric_car_bw: 19, meal_bw: 20 }
 
   validates :meter_type, :time_period, :image_name, presence: true
 
@@ -42,7 +45,7 @@ class EquivalenceType < ApplicationRecord
     end
   end
 
-private
+  private
 
   def save_and_replace(content, to_replace)
     transaction do

--- a/app/models/manual_data_load_run.rb
+++ b/app/models/manual_data_load_run.rb
@@ -18,13 +18,13 @@
 #
 class ManualDataLoadRun < ApplicationRecord
   belongs_to :amr_uploaded_reading, dependent: :destroy
-  enum status: [:pending, :running, :done, :failed]
+  enum :status, { pending: 0, running: 1, done: 2, failed: 3 }
   has_many :manual_data_load_run_log_entries, dependent: :destroy
 
   scope :by_date, -> { order(created_at: :desc) }
 
   def complete?
-    %w{done failed}.include?(status)
+    %w[done failed].include?(status)
   end
 
   def info(msg)

--- a/app/models/meter.rb
+++ b/app/models/meter.rb
@@ -62,9 +62,9 @@ class Meter < ApplicationRecord
   has_one :school_group, through: :school
   has_and_belongs_to_many :energy_tariffs, inverse_of: :meters
 
-  CREATABLE_METER_TYPES = [:electricity, :gas, :solar_pv, :exported_solar_pv].freeze
-  MAIN_METER_TYPES = [:electricity, :gas].freeze
-  SUB_METER_TYPES = [:solar_pv, :exported_solar_pv].freeze
+  CREATABLE_METER_TYPES = %i[electricity gas solar_pv exported_solar_pv].freeze
+  MAIN_METER_TYPES = %i[electricity gas].freeze
+  SUB_METER_TYPES = %i[solar_pv exported_solar_pv].freeze
 
   scope :active,   -> { where(active: true) }
   scope :inactive, -> { where(active: false) }
@@ -72,7 +72,9 @@ class Meter < ApplicationRecord
   scope :pseudo, -> { where(pseudo: true) }
   scope :main_meter, -> { where(pseudo: false, meter_type: MAIN_METER_TYPES) }
   scope :sub_meter, -> { where(pseudo: true, meter_type: SUB_METER_TYPES) }
-  scope :no_amr_validated_readings, -> { left_outer_joins(:amr_validated_readings).where(amr_validated_readings: { meter_id: nil }) }
+  scope :no_amr_validated_readings, lambda {
+    left_outer_joins(:amr_validated_readings).where(amr_validated_readings: { meter_id: nil })
+  }
 
   scope :unreviewed_dcc_meter, -> { dcc.where(consent_granted: false, meter_review_id: nil) }
   scope :reviewed_dcc_meter, -> { dcc.where.not(meter_review_id: nil) }
@@ -86,42 +88,44 @@ class Meter < ApplicationRecord
   scope :procurement_route_known, -> { where.not(procurement_route: nil) }
   scope :from_active_schools, -> { joins(:school).where('schools.active = TRUE') }
 
-  scope :with_zero_reading_days_and_dates, -> {
+  scope :with_zero_reading_days_and_dates, lambda {
     left_outer_joins(:amr_validated_readings)
       .group('schools.id', 'meters.id')
       .select(
         "meters.*,
            MIN(amr_validated_readings.reading_date) AS first_validated_reading_date,
            MAX(amr_validated_readings.reading_date) AS last_validated_reading_date,
-           COUNT(1) FILTER (WHERE one_day_kwh = 0.0) AS zero_reading_days_count")
+           COUNT(1) FILTER (WHERE one_day_kwh = 0.0) AS zero_reading_days_count"
+      )
   }
 
   # If adding a new meter_type, add to the amr_validated_reading case statement for downloading data
-  enum meter_type: [:electricity, :gas, :solar_pv, :exported_solar_pv]
+  enum :meter_type, { electricity: 0, gas: 1, solar_pv: 2, exported_solar_pv: 3 }
   # The Meter's meter sytem defaults to NHH AMR (Non Half-Hourly Automatic Meter Reading)
   # Other options are: NHH (Non Half-Hourly), HH (Half-Hourly), and SMETS2/smart (SMETS2 Smart Meters)
-  enum meter_system: [:nhh_amr, :nhh, :hh, :smets2_smart]
+  enum :meter_system, { nhh_amr: 0, nhh: 1, hh: 2, smets2_smart: 3 }
   enum :dcc_meter, %w[no smets2 other].to_h { |v| [v, v] }, prefix: true
 
   delegate :area_name, to: :school
 
-  validates_presence_of :school, :mpan_mprn, :meter_type
-  validates_uniqueness_of :mpan_mprn
+  validates :school, :mpan_mprn, :meter_type, presence: true
+  validates :mpan_mprn, uniqueness: true
 
-  validates_format_of :mpan_mprn, with: /\A[6,7,9]\d{13}\Z/, if: :pseudo?, message: 'for pseudo electricity meters should be a 14 digit number starting with 6, 7 or 9'
-  validates_format_of :mpan_mprn, with: /\A[1-9]{1,3}\d{12}\Z/, if: :real_electric?, message: 'for electricity meters should be a 13 to 14 digit number'
-  validates_format_of :mpan_mprn, with: /\A\d{1,15}\Z/, if: :gas?, message: 'for gas meters should be a 1-15 digit number'
+  validates :mpan_mprn, format: { with: /\A[6,79]\d{13}\Z/, if: :pseudo?,
+                                  message: 'for pseudo electricity meters should be a 14 digit number starting with 6, 7 or 9' }
+  validates :mpan_mprn, format: { with: /\A[1-9]{1,3}\d{12}\Z/, if: :real_electric?,
+                                  message: 'for electricity meters should be a 13 to 14 digit number' }
+  validates :mpan_mprn, format: { with: /\A\d{1,15}\Z/, if: :gas?,
+                                  message: 'for gas meters should be a 1-15 digit number' }
   validate :pseudo_meter_type_not_changed, on: :update, if: :pseudo
   validate :pseudo_mpan_mprn_not_changed, on: :update, if: :pseudo
 
   def self.hash_of_meter_data
     meter_data_array = Meter.pluck(:mpan_mprn, :meter_type, :school_id)
-    meter_data_array.to_h { |record| [record[0].to_s, { fuel_type: record[1], school_id: record[2] }]}
+    meter_data_array.to_h { |record| [record[0].to_s, { fuel_type: record[1], school_id: record[2] }] }
   end
 
-  def school_name
-    school.name
-  end
+  delegate :name, to: :school, prefix: true
 
   def t_meter_system
     I18n.t("meter.meter_system.#{meter_system}")
@@ -144,7 +148,8 @@ class Meter < ApplicationRecord
     last_reading = last_validated_reading
     first_reading = first_validated_reading
     return 0 if last_reading.nil?
-    return (last_reading - first_reading).to_i + 1
+
+    (last_reading - first_reading).to_i + 1
   end
 
   def first_validated_reading
@@ -164,8 +169,11 @@ class Meter < ApplicationRecord
     since_date = Time.zone.today - years.years
     # only interested if there are enough non_ORIG readings
     return [] unless amr_validated_readings.since(since_date).modified.count >= gap_size
+
     # find chunks where consecutive readings were all non-ORIG
-    gaps = amr_validated_readings.since(since_date).by_date.select(:reading_date, :status).chunk_while { |r1, r2| r1.status != 'ORIG' && r2.status != 'ORIG' }
+    gaps = amr_validated_readings.since(since_date).by_date.select(:reading_date, :status).chunk_while do |r1, r2|
+      r1.status != 'ORIG' && r2.status != 'ORIG'
+    end
     # return chunks of specified size or bigger
     gaps.select { |gap| gap.count >= gap_size }
   end
@@ -175,7 +183,7 @@ class Meter < ApplicationRecord
   end
 
   def zero_reading_days_warning?
-    return true if fuel_type == :electricity && zero_reading_days.any?
+    true if fuel_type == :electricity && zero_reading_days.any?
   end
 
   def has_readings?
@@ -183,7 +191,7 @@ class Meter < ApplicationRecord
   end
 
   def name_or_mpan_mprn
-    name.present? ? name : mpan_mprn.to_s
+    name.presence || mpan_mprn.to_s
   end
 
   def mpan_mprn_and_name
@@ -249,6 +257,7 @@ class Meter < ApplicationRecord
 
   def correct_mpan_check_digit?
     return true if gas? || pseudo
+
     mpan = mpan_mprn.to_s.last(13)
     primes = [3, 5, 7, 13, 17, 19, 23, 29, 31, 37, 41, 43]
     expected_check = (0..11).inject(0) { |sum, n| sum + (mpan[n, 1].to_i * primes[n]) } % 11 % 10
@@ -263,9 +272,7 @@ class Meter < ApplicationRecord
     consent_granted
   end
 
-  def open_issues_count
-    open_issues.count
-  end
+  delegate :count, to: :open_issues, prefix: true
 
   def open_issues_as_list
     open_issues.order(created_at: :asc).map { |issue| issue&.description&.body&.to_plain_text }
@@ -277,8 +284,9 @@ class Meter < ApplicationRecord
 
   def has_solar_array?
     return false unless electricity?
+
     meter_attributes.where(
-      attribute_type: [:solar_pv_mpan_meter_mapping, :solar_pv], deleted_by: nil, replaced_by: nil
+      attribute_type: %i[solar_pv_mpan_meter_mapping solar_pv], deleted_by: nil, replaced_by: nil
     ).any?
   end
 

--- a/app/models/rtone_variant_installation.rb
+++ b/app/models/rtone_variant_installation.rb
@@ -31,18 +31,18 @@ class RtoneVariantInstallation < ApplicationRecord
   belongs_to :amr_data_feed_config
   belongs_to :meter
 
-  enum rtone_component_type: [:prod, :in1, :out1, :in2]
+  enum :rtone_component_type, { prod: 0, in1: 1, out1: 2, in2: 3 }
 
-  validates_presence_of :school, :meter, :rtone_meter_id, :rtone_component_type, :username, :password
-  validates_uniqueness_of :rtone_meter_id, scope: :school
+  validates :school, :meter, :rtone_meter_id, :rtone_component_type, :username, :password, presence: true
+  validates :rtone_meter_id, uniqueness: { scope: :school }
 
   def display_name
     rtone_meter_id
   end
 
   def latest_electricity_reading
-    if meter&.amr_data_feed_readings&.any?
-      Date.parse(meter.amr_data_feed_readings.order(reading_date: :desc).first.reading_date)
-    end
+    return unless meter&.amr_data_feed_readings&.any?
+
+    Date.parse(meter.amr_data_feed_readings.order(reading_date: :desc).first.reading_date)
   end
 end

--- a/app/models/school_batch_run.rb
+++ b/app/models/school_batch_run.rb
@@ -20,7 +20,7 @@ class SchoolBatchRun < ApplicationRecord
   belongs_to :school
   has_many :school_batch_run_log_entries
 
-  enum status: [:pending, :running, :done, :failed]
+  enum :status, { pending: 0, running: 1, done: 2, failed: 3 }
 
   scope :by_date, -> { order(created_at: :desc) }
 

--- a/app/models/school_group.rb
+++ b/app/models/school_group.rb
@@ -49,7 +49,7 @@ class SchoolGroup < ApplicationRecord
   include ParentMeterAttributeHolder
   include Scorable
 
-  friendly_id :name, use: [:finders, :slugged, :history]
+  friendly_id :name, use: %i[finders slugged history]
 
   has_many :schools
   has_many :meters, through: :schools
@@ -59,7 +59,7 @@ class SchoolGroup < ApplicationRecord
 
   has_many :school_group_partners, -> { order(position: :asc) }
   has_many :partners, through: :school_group_partners
-  accepts_nested_attributes_for :school_group_partners, reject_if: proc {|attributes| attributes['position'].blank?}
+  accepts_nested_attributes_for :school_group_partners, reject_if: proc { |attributes| attributes['position'].blank? }
 
   has_one :dashboard_message, as: :messageable, dependent: :destroy
   has_many :issues, as: :issueable, dependent: :destroy
@@ -68,18 +68,24 @@ class SchoolGroup < ApplicationRecord
   belongs_to :default_template_calendar, class_name: 'Calendar', optional: true
   belongs_to :default_solar_pv_tuos_area, class_name: 'SolarPvTuosArea', optional: true
   belongs_to :default_dark_sky_area, class_name: 'DarkSkyArea', optional: true
-  belongs_to :default_weather_station, class_name: 'WeatherStation', foreign_key: 'default_weather_station_id', optional: true
+  belongs_to :default_weather_station, class_name: 'WeatherStation',
+                                       optional: true
   belongs_to :default_scoreboard, class_name: 'Scoreboard', optional: true
-  belongs_to :default_issues_admin_user, class_name: 'User', foreign_key: 'default_issues_admin_user_id', optional: true
-  belongs_to :admin_meter_status_electricity, class_name: 'AdminMeterStatus', foreign_key: 'admin_meter_statuses_electricity_id', optional: true
-  belongs_to :admin_meter_status_gas, class_name: 'AdminMeterStatus', foreign_key: 'admin_meter_statuses_gas_id', optional: true
-  belongs_to :admin_meter_status_solar_pv, class_name: 'AdminMeterStatus', foreign_key: 'admin_meter_statuses_solar_pv_id', optional: true
-  belongs_to :default_data_source_electricity, class_name: 'DataSource', foreign_key: 'default_data_source_electricity_id', optional: true
-  belongs_to :default_data_source_gas, class_name: 'DataSource', foreign_key: 'default_data_source_gas_id', optional: true
-  belongs_to :default_data_source_solar_pv, class_name: 'DataSource', foreign_key: 'default_data_source_solar_pv_id', optional: true
-  belongs_to :default_procurement_route_electricity, class_name: 'ProcurementRoute', foreign_key: 'default_procurement_route_electricity_id', optional: true
-  belongs_to :default_procurement_route_gas, class_name: 'ProcurementRoute', foreign_key: 'default_procurement_route_gas_id', optional: true
-  belongs_to :default_procurement_route_solar_pv, class_name: 'ProcurementRoute', foreign_key: 'default_procurement_route_solar_pv_id', optional: true
+  belongs_to :default_issues_admin_user, class_name: 'User', optional: true
+  belongs_to :admin_meter_status_electricity, class_name: 'AdminMeterStatus',
+                                              foreign_key: 'admin_meter_statuses_electricity_id', optional: true
+  belongs_to :admin_meter_status_gas, class_name: 'AdminMeterStatus', foreign_key: 'admin_meter_statuses_gas_id',
+                                      optional: true
+  belongs_to :admin_meter_status_solar_pv, class_name: 'AdminMeterStatus',
+                                           foreign_key: 'admin_meter_statuses_solar_pv_id', optional: true
+  belongs_to :default_data_source_electricity, class_name: 'DataSource', optional: true
+  belongs_to :default_data_source_gas, class_name: 'DataSource',
+                                       optional: true
+  belongs_to :default_data_source_solar_pv, class_name: 'DataSource',
+                                            optional: true
+  belongs_to :default_procurement_route_electricity, class_name: 'ProcurementRoute', optional: true
+  belongs_to :default_procurement_route_gas, class_name: 'ProcurementRoute', optional: true
+  belongs_to :default_procurement_route_solar_pv, class_name: 'ProcurementRoute', optional: true
   belongs_to :funder, optional: true
 
   has_many :meter_attributes, inverse_of: :school_group, class_name: 'SchoolGroupMeterAttribute'
@@ -91,9 +97,9 @@ class SchoolGroup < ApplicationRecord
   scope :is_public, -> { where(public: true) }
   validates :name, presence: true
 
-  enum group_type: [:general, :local_authority, :multi_academy_trust]
-  enum default_chart_preference: [:default, :carbon, :usage, :cost]
-  enum default_country: School.countries
+  enum :group_type, { general: 0, local_authority: 1, multi_academy_trust: 2 }
+  enum :default_chart_preference, { default: 0, carbon: 1, usage: 2, cost: 3 }
+  enum :default_country, School.countries
 
   def visible_schools_count
     schools.visible.count
@@ -102,6 +108,7 @@ class SchoolGroup < ApplicationRecord
   def fuel_types
     school_ids = schools.visible.pluck(:id)
     return [] if school_ids.empty?
+
     query = <<-SQL.squish
       SELECT DISTINCT(fuel_types.key) FROM (
         SELECT
@@ -113,7 +120,9 @@ class SchoolGroup < ApplicationRecord
       WHERE fuel_types.value = 'true';
     SQL
     sanitized_query = ActiveRecord::Base.sanitize_sql_array(query)
-    SchoolGroup.connection.select_all(sanitized_query).rows.flatten.map { |fuel_type| fuel_type.gsub('has_', '').to_sym }
+    SchoolGroup.connection.select_all(sanitized_query).rows.flatten.map do |fuel_type|
+      fuel_type.gsub('has_', '').to_sym
+    end
   end
 
   def has_visible_schools?
@@ -131,6 +140,7 @@ class SchoolGroup < ApplicationRecord
   def safe_destroy
     raise EnergySparks::SafeDestroyError, 'Group has associated schools' if schools.any?
     raise EnergySparks::SafeDestroyError, 'Group has associated users' if users.any?
+
     destroy
   end
 
@@ -158,7 +168,7 @@ class SchoolGroup < ApplicationRecord
   end
 
   def email_locales
-    default_country == 'wales' ? [:en, :cy] : [:en]
+    default_country == 'wales' ? %i[en cy] : [:en]
   end
 
   def parent_tariff_holder

--- a/app/models/staff_role.rb
+++ b/app/models/staff_role.rb
@@ -12,7 +12,7 @@ class StaffRole < ApplicationRecord
   has_many :users
 
   attribute :dashboard, :string
-  enum dashboard: [:management, :teachers]
+  enum :dashboard, { management: 0, teachers: 1 }
 
   def translated_title
     I18n.t(i18n_key)

--- a/app/models/team_member.rb
+++ b/app/models/team_member.rb
@@ -15,7 +15,7 @@ class TeamMember < ApplicationRecord
   has_one_attached :image
   has_rich_text :profile
 
-  enum role: [:staff, :consultant, :trustee]
+  enum :role, { staff: 0, consultant: 1, trustee: 2 }
 
   validates :title, :image, :role, presence: true
   validates :position, numericality: true, presence: true

--- a/app/models/transifex_load.rb
+++ b/app/models/transifex_load.rb
@@ -10,9 +10,9 @@
 #  updated_at :datetime         not null
 #
 class TransifexLoad < ApplicationRecord
-  has_many :transifex_load_errors, :dependent => :destroy
+  has_many :transifex_load_errors, dependent: :destroy
 
-  enum status: [:running, :done]
+  enum :status, { running: 0, done: 1 }
 
   scope :by_date, -> { order(created_at: :desc) }
 

--- a/app/models/transport_survey/response.rb
+++ b/app/models/transport_survey/response.rb
@@ -30,7 +30,7 @@ class TransportSurvey::Response < ApplicationRecord
   belongs_to :transport_survey
   belongs_to :transport_type, inverse_of: :responses
 
-  scope :with_transport_type, -> {joins(:transport_type)}
+  scope :with_transport_type, -> { joins(:transport_type) }
 
   def self.journey_minutes_options
     [5, 10, 15, 20, 30, 45, 60]
@@ -40,11 +40,12 @@ class TransportSurvey::Response < ApplicationRecord
     [1, 2, 3, 4, 5, 6]
   end
 
-  validates :transport_survey_id, :transport_type_id, :passengers, :run_identifier, :surveyed_at, :journey_minutes, :weather, presence: true
+  validates :transport_survey_id, :transport_type_id, :passengers, :run_identifier, :surveyed_at, :journey_minutes,
+            :weather, presence: true
   validates :journey_minutes, inclusion: { in: journey_minutes_options }
   validates :passengers, inclusion: { in: passengers_options }
 
-  enum weather: [:sun, :cloud, :rain, :snow]
+  enum :weather, { sun: 0, cloud: 1, rain: 2, snow: 3 }
 
   def self.weather_images
     { sun: '☀️', cloud: '⛅', rain: '🌧️', snow: '❄️' }
@@ -67,7 +68,7 @@ class TransportSurvey::Response < ApplicationRecord
   end
 
   def self.csv_attributes
-    %w{id run_identifier weather_name journey_minutes transport_type.name passengers carbon_kg_co2 surveyed_at}
+    %w[id run_identifier weather_name journey_minutes transport_type.name passengers carbon_kg_co2 surveyed_at]
   end
 
   def carbon_kg_co2

--- a/app/models/transport_survey/transport_type.rb
+++ b/app/models/transport_survey/transport_type.rb
@@ -35,7 +35,7 @@ class TransportSurvey::TransportType < ApplicationRecord
   validates :kg_co2e_per_km, :speed_km_per_hour, :position, numericality: { greater_than_or_equal_to: 0 }
   validates :name, uniqueness: true
 
-  enum category: [:walking_and_cycling, :car, :public_transport, :park_and_stride]
+  enum :category, { walking_and_cycling: 0, car: 1, public_transport: 2, park_and_stride: 3 }
 
   def self.app_data
     all.select(:id, :name, :image, :kg_co2e_per_km, :speed_km_per_hour, :can_share, :park_and_stride).index_by(&:id)
@@ -47,6 +47,7 @@ class TransportSurvey::TransportType < ApplicationRecord
 
   def safe_destroy
     raise EnergySparks::SafeDestroyError, 'Transport type has associated responses' if responses.any?
+
     destroy
   end
 
@@ -58,6 +59,6 @@ class TransportSurvey::TransportType < ApplicationRecord
   # override default key and slug to use original name pre-moving to module
   # keeps in sync with the data already in transifex
   def resource_key
-    "transport_type_#{self.id}"
+    "transport_type_#{id}"
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -66,7 +66,8 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable and :omniauthable
   devise :database_authenticatable, :recoverable, :rememberable, :trackable, :validatable, :lockable, :confirmable
 
-  enum role: [:guest, :staff, :admin, :school_admin, :school_onboarding, :pupil, :group_admin, :analytics, :volunteer]
+  enum :role, { guest: 0, staff: 1, admin: 2, school_admin: 3, school_onboarding: 4, pupil: 5,
+                group_admin: 6, analytics: 7, volunteer: 8 }
 
   scope :alertable, -> { where(role: [User.roles[:staff], User.roles[:school_admin], User.roles[:volunteer]]) }
 
@@ -98,11 +99,12 @@ class User < ApplicationRecord
   end
 
   def display_name
-    name.present? ? name : email
+    name.presence || email
   end
 
   def staff_role_as_symbol
     return nil unless staff_role
+
     staff_role.as_symbol
   end
 
@@ -126,18 +128,19 @@ class User < ApplicationRecord
 
   def remove_school(school_to_remove)
     cluster_schools.delete(school_to_remove)
-    if school == school_to_remove
-      if cluster_schools.any?
-        update!(school: cluster_schools.last)
-      else
-        update!(school: nil, role: :school_onboarding)
-      end
+    return unless school == school_to_remove
+
+    if cluster_schools.any?
+      update!(school: cluster_schools.last)
+    else
+      update!(school: nil, role: :school_onboarding)
     end
   end
 
   def schools
-    return School.visible.by_name if self.admin?
-    return school_group.schools.visible.by_name if self.school_group
+    return School.visible.by_name if admin?
+    return school_group.schools.visible.by_name if school_group
+
     [school].compact
   end
 
@@ -165,8 +168,8 @@ class User < ApplicationRecord
     new(
       attributes.merge(
         role: :pupil,
-        school: school,
-        email: "#{school.id}-#{SecureRandom.uuid}@pupils.#{ENV['APPLICATION_HOST']}",
+        school:,
+        email: "#{school.id}-#{SecureRandom.uuid}@pupils.#{ENV.fetch('APPLICATION_HOST', nil)}",
         password: SecureRandom.uuid,
         confirmed_at: Time.zone.now
       )
@@ -177,7 +180,7 @@ class User < ApplicationRecord
     new(
       attributes.merge(
         role: :staff,
-        school: school
+        school:
       )
     )
   end
@@ -186,7 +189,7 @@ class User < ApplicationRecord
     new(
       attributes.merge(
         role: :school_admin,
-        school: school
+        school:
       )
     )
   end
@@ -205,7 +208,11 @@ class User < ApplicationRecord
   end
 
   def after_confirmation
-    OnboardingMailer.with_user_locales(users: [self], school: school) { |mailer| mailer.welcome_email.deliver_now } if self.school.present?
+    return unless school.present?
+
+    OnboardingMailer.with_user_locales(users: [self], school:) do |mailer|
+      mailer.welcome_email.deliver_now
+    end
   end
 
   def self.admin_user_export_csv
@@ -222,7 +229,7 @@ class User < ApplicationRecord
         'Staff Role',
         'Locked'
       ]
-      where.not(role: [:pupil, :admin]).order(:email).each do |user|
+      where.not(role: %i[pupil admin]).order(:email).each do |user|
         csv << [
           user.default_school_group_name || '',
           user.school&.name || '',
@@ -239,7 +246,7 @@ class User < ApplicationRecord
     end
   end
 
-protected
+  protected
 
   def preferred_locale_presence_in_available_locales
     return if I18n.available_locales.include? preferred_locale&.to_sym
@@ -252,17 +259,18 @@ protected
   end
 
   def update_contact
-    if (contact = contact_for_school)
-      contact.populate_from_user(self)
-      contact.save
-    end
+    return unless (contact = contact_for_school)
+
+    contact.populate_from_user(self)
+    contact.save
   end
 
   def pupil_password_unique
     return if pupil_password.blank?
+
     existing_user = school.authenticate_pupil(pupil_password)
-    if existing_user && existing_user != self
-      errors.add(:pupil_password, "is already in use for '#{existing_user.name}'")
-    end
+    return unless existing_user && existing_user != self
+
+    errors.add(:pupil_password, "is already in use for '#{existing_user.name}'")
   end
 end


### PR DESCRIPTION
ActiveSupport::DeprecationException: DEPRECATION WARNING: Defining enums with keyword arguments is deprecated and will be removed (ActiveSupport::DeprecationException)