### PR TITLE
more enum future deprecation warnings

### DIFF
--- a/app/models/alert_type.rb
+++ b/app/models/alert_type.rb
@@ -26,9 +26,6 @@
 #
 
 class AlertType < ApplicationRecord
-  SUB_CATEGORIES = %i[hot_water heating baseload electricity_use solar_pv tariffs co2 boiler_control
-                      overview storage_heaters].freeze
-
   belongs_to :advice_page, optional: true
 
   has_many :alerts
@@ -38,7 +35,8 @@ class AlertType < ApplicationRecord
 
   enum :source, { analytics: 0, system: 1, analysis: 2 }
   enum :fuel_type, { electricity: 0, gas: 1, storage_heater: 2, solar_pv: 3 }, suffix: :fuel_type
-  enum :sub_category, SUB_CATEGORIES
+  enum :sub_category, { hot_water: 0, heating: 1, baseload: 2, electricity_use: 3, solar_pv: 4, tariffs: 5, co2: 6,
+                        boiler_control: 7, overview: 8, storage_heaters: 9 }
   enum :frequency, { termly: 0, weekly: 1, before_each_holiday: 2 }
   enum :group, { advice: 0, benchmarking: 1, change: 2, priority: 3 }
   enum :link_to, { insights_page: 0, analysis_page: 1, learn_more_page: 2 }

--- a/app/models/concerns/enum_fuel_type.rb
+++ b/app/models/concerns/enum_fuel_type.rb
@@ -10,7 +10,7 @@ module EnumFuelType
   }.freeze
 
   included do
-    enum fuel_type: ENUM_FUEL_TYPES
+    enum fuel_type, ENUM_FUEL_TYPES
 
     scope :no_fuel, -> { where(fuel_type: nil) }
   end

--- a/app/models/concerns/enum_fuel_type.rb
+++ b/app/models/concerns/enum_fuel_type.rb
@@ -10,7 +10,7 @@ module EnumFuelType
   }.freeze
 
   included do
-    enum fuel_type, ENUM_FUEL_TYPES
+    enum :fuel_type, ENUM_FUEL_TYPES
 
     scope :no_fuel, -> { where(fuel_type: nil) }
   end

--- a/app/models/concerns/enum_reporting_period.rb
+++ b/app/models/concerns/enum_reporting_period.rb
@@ -15,6 +15,6 @@ module EnumReportingPeriod
   }.freeze
 
   included do
-    enum reporting_period: ENUM_REPORTING_PERIODS
+    enum :reporting_period, ENUM_REPORTING_PERIODS
   end
 end

--- a/app/models/data_source.rb
+++ b/app/models/data_source.rb
@@ -22,7 +22,8 @@
 #  updated_at                  :datetime         not null
 #
 class DataSource < ApplicationRecord
-  enum organisation_type: { energy_supplier: 0, procurement_organisation: 1, meter_operator: 2, council: 3, solar_monitoring_provider: 4 }
+  enum :organisation_type, { energy_supplier: 0, procurement_organisation: 1, meter_operator: 2, council: 3,
+                             solar_monitoring_provider: 4 }
   validates :name, presence: true, uniqueness: true
   has_many :meters
   has_many :issues, as: :issueable, dependent: :destroy
@@ -32,7 +33,7 @@ class DataSource < ApplicationRecord
     CSV.generate(headers: true) do |csv|
       csv << csv_headers
       meters.from_active_schools.order(:created_at).each do |meter|
-        csv << [
+        csv << ([
           meter&.school&.school_group&.name,
           meter&.school&.name,
           meter&.mpan_mprn,
@@ -42,8 +43,8 @@ class DataSource < ApplicationRecord
           meter&.first_validated_reading,
           meter&.last_validated_reading,
           meter&.admin_meter_status_label,
-          meter&.open_issues_count,
-        ] + meter&.open_issues_as_list
+          meter&.open_issues_count
+        ] + meter&.open_issues_as_list)
       end
     end
   end
@@ -51,6 +52,7 @@ class DataSource < ApplicationRecord
   private
 
   def csv_headers
-    ['School group', 'School', 'MPAN/MPRN', 'Meter type', 'Active', 'Half-Hourly', 'First validated meter reading', 'Last validated meter reading', 'Admin Meter Status', 'Open issues count', 'Open issues']
+    ['School group', 'School', 'MPAN/MPRN', 'Meter type', 'Active', 'Half-Hourly', 'First validated meter reading',
+     'Last validated meter reading', 'Admin Meter Status', 'Open issues count', 'Open issues']
   end
 end

--- a/app/models/help_page.rb
+++ b/app/models/help_page.rb
@@ -16,23 +16,21 @@
 #
 class HelpPage < ApplicationRecord
   extend FriendlyId
-  friendly_id :title, use: [:finders, :slugged, :history]
+  friendly_id :title, use: %i[finders slugged history]
 
   extend Mobility
   include TransifexSerialisable
   translates :title, type: :string, fallbacks: { cy: :en }
   translates :description, backend: :action_text
 
-  validates_presence_of :title, :feature
-  validates_uniqueness_of :feature
+  validates :title, :feature, presence: true
+  validates :feature, uniqueness: true
 
   scope :published,            -> { where(published: true) }
   scope :by_title,             -> { i18n.order(title: :asc) }
 
-  enum feature: {
-    school_targets: 0,
-    live_data: 1,
-    management_summary_overview: 2,
-    annual_usage_estimate: 3
-  }
+  enum :feature, { school_targets: 0,
+                   live_data: 1,
+                   management_summary_overview: 2,
+                   annual_usage_estimate: 3 }
 end

--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -65,11 +65,12 @@ class Observation < ApplicationRecord
 
   # If adding a new observation type remember to also modify the timeline component
   # events: 3 has been removed
-  enum observation_type: { temperature: 0, intervention: 1, activity: 2, audit: 4, school_target: 5, programme: 6, audit_activities_completed: 7, transport_survey: 8 }
+  enum :observation_type, { temperature: 0, intervention: 1, activity: 2, audit: 4, school_target: 5, programme: 6,
+                            audit_activities_completed: 7, transport_survey: 8 }
 
   belongs_to :observable, polymorphic: true, optional: true
 
-  validates_presence_of :at, :school
+  validates :at, :school, presence: true
   validates_associated :temperature_recordings
 
   validates :intervention_type_id, presence: { message: 'please select an option' }, if: :intervention?
@@ -84,20 +85,25 @@ class Observation < ApplicationRecord
   scope :for_school, ->(school) { where(school: school) }
   scope :between, ->(first_date, last_date) { where('at BETWEEN ? AND ?', first_date, last_date) }
   scope :in_academic_year, ->(academic_year) { between(academic_year.start_date, academic_year.end_date) }
-  scope :in_academic_year_for, ->(school, date) { (academic_year = school.academic_year_for(date)) ? in_academic_year(academic_year) : none }
-  scope :recorded_in_last_year, -> { where('created_at >= ?', 1.year.ago)}
-  scope :recorded_in_last_week, -> { where('created_at >= ?', 1.week.ago)}
+  scope :in_academic_year_for, lambda { |school, date|
+    (academic_year = school.academic_year_for(date)) ? in_academic_year(academic_year) : none
+  }
+  scope :recorded_in_last_year, -> { where('created_at >= ?', 1.year.ago) }
+  scope :recorded_in_last_week, -> { where('created_at >= ?', 1.week.ago) }
   scope :recorded_since, ->(range) { where(created_at: range) }
   scope :not_including, ->(school) { where.not(school:).recorded_since(school.current_academic_year.start_date..) }
   scope :for_visible_schools, -> { joins(:school).merge(School.visible) }
-  scope :engagement, -> { where(observation_type: [:temperature, :intervention, :activity, :audit, :school_target, :programme, :transport_survey]) }
+  scope :engagement, lambda {
+    where(observation_type: %i[temperature intervention activity audit school_target programme transport_survey])
+  }
 
   has_rich_text :description
 
-  before_save :add_points_for_interventions, if: :intervention?
-  before_save :add_bonus_points_for_included_images, if: proc { |observation| observation.activity? || observation.intervention? }
-
   before_validation :set_defaults, if: -> { observable_id }, on: :create
+  before_save :add_points_for_interventions, if: :intervention?
+  before_save :add_bonus_points_for_included_images, if: proc { |observation|
+    observation.activity? || observation.intervention?
+  }
 
   def description_includes_images?
     if intervention?
@@ -113,11 +119,11 @@ class Observation < ApplicationRecord
     # Only add bonus points if the site wide photo bonus points is set to non zero
     return unless SiteSettings.current.photo_bonus_points&.nonzero?
     # Only add bonus points if the current observation score is non zero
-    return unless self.points&.nonzero?
+    return unless points&.nonzero?
     # Only add bonus points if the description has an image
     return unless description_includes_images?
 
-    self.points = (self.points || 0) + SiteSettings.current.photo_bonus_points
+    self.points = (points || 0) + SiteSettings.current.photo_bonus_points
   end
 
   def add_points_for_interventions
@@ -131,7 +137,7 @@ class Observation < ApplicationRecord
   def set_defaults
     # set the observation type from the observable_type if not already set
     self.observation_type ||= observable_type.underscore.to_sym
-    self.school ||= self.observable.school if self.observable.school
+    self.school ||= observable.school if observable.school
     self.at ||= Time.zone.now
   end
 end

--- a/app/models/programme.rb
+++ b/app/models/programme.rb
@@ -29,7 +29,7 @@ class Programme < ApplicationRecord
   has_many :activities, through: :programme_activities
   has_many :observations, as: :observable, dependent: :destroy
 
-  enum status: { started: 0, completed: 1, abandoned: 2 } do
+  enum status, { started: 0, completed: 1, abandoned: 2 } do
     event :complete do
       after do
         self.update(ended_on: Time.zone.now)

--- a/app/models/programme.rb
+++ b/app/models/programme.rb
@@ -29,7 +29,7 @@ class Programme < ApplicationRecord
   has_many :activities, through: :programme_activities
   has_many :observations, as: :observable, dependent: :destroy
 
-  enum status, { started: 0, completed: 1, abandoned: 2 } do
+  enum :status, { started: 0, completed: 1, abandoned: 2 } do
     event :complete do
       after do
         self.update(ended_on: Time.zone.now)

--- a/app/models/school_onboarding_event.rb
+++ b/app/models/school_onboarding_event.rb
@@ -22,7 +22,7 @@ class SchoolOnboardingEvent < ApplicationRecord
 
   scope :by_event_name, ->(event_name) { where(event: event_name).order(created_at: :asc) }
 
-  enum event: {
+  enum :event, {
     email_sent: 0,
     privacy_policy_agreed: 9,
     permission_given: 10,
@@ -42,6 +42,6 @@ class SchoolOnboardingEvent < ApplicationRecord
     reminder_sent: 90,
     activation_email_sent: 100,
     onboarded_email_sent: 101,
-    data_enabled_email_sent: 102,
+    data_enabled_email_sent: 102
   }
 end

--- a/app/models/school_target_event.rb
+++ b/app/models/school_target_event.rb
@@ -21,9 +21,7 @@ class SchoolTargetEvent < ApplicationRecord
 
   # first_target_sent: have we invited them to set their first target?
   # review_target_sent: have we asked them to set a new target?
-  enum event: {
-    first_target_sent: 0,
-    review_target_sent: 10,
-    first_target_reminder_sent: 20
-  }
+  enum :event, { first_target_sent: 0,
+                 review_target_sent: 10,
+                 first_target_reminder_sent: 20 }
 end


### PR DESCRIPTION
ActiveSupport::DeprecationException:
  DEPRECATION WARNING: Defining enums with keyword arguments is deprecated and will be removed
  in Rails 8.0. Positional arguments should be used instead: