### PR TITLE
Change content deletion threshold to 14 days

### DIFF
--- a/.ebextensions/cronjob.config
+++ b/.ebextensions/cronjob.config
@@ -108,7 +108,7 @@ files:
             #
             # Delete old alert content
             #
-            0 0 1 * * root run-webapp-job alerts:delete_alert_content
+            0 1 * * 7 root run-webapp-job alerts:delete_alert_content
             #
             # Send Good Job queue metrics to AWS Cloudwatch
             #

--- a/app/services/alerts/content_deletion_service.rb
+++ b/app/services/alerts/content_deletion_service.rb
@@ -1,6 +1,6 @@
 module Alerts
   class ContentDeletionService
-    DEFAULT_OLDER_THAN = 1.month.ago.beginning_of_month
+    DEFAULT_OLDER_THAN = 14.days.ago.to_date
     attr_reader :older_than
 
     def initialize(older_than = DEFAULT_OLDER_THAN)

--- a/app/services/alerts/delete_alert_generation_run_service.rb
+++ b/app/services/alerts/delete_alert_generation_run_service.rb
@@ -1,6 +1,6 @@
 module Alerts
   class DeleteAlertGenerationRunService
-    DEFAULT_OLDER_THAN = 1.month.ago.beginning_of_month
+    DEFAULT_OLDER_THAN = 14.days.ago.to_date
     attr_reader :older_than
 
     def initialize(older_than = DEFAULT_OLDER_THAN)

--- a/app/services/alerts/delete_content_generation_run_service.rb
+++ b/app/services/alerts/delete_content_generation_run_service.rb
@@ -1,6 +1,6 @@
 module Alerts
   class DeleteContentGenerationRunService
-    DEFAULT_OLDER_THAN = 1.month.ago.beginning_of_month
+    DEFAULT_OLDER_THAN = 14.days.ago.to_date
     attr_reader :older_than
 
     def initialize(older_than = DEFAULT_OLDER_THAN)

--- a/spec/services/alerts/content_deletion_service_spec.rb
+++ b/spec/services/alerts/content_deletion_service_spec.rb
@@ -7,8 +7,8 @@ describe Alerts::ContentDeletionService, type: :service do
   let(:gas_fuel_alert_type)             { create(:alert_type, fuel_type: :gas, frequency: :termly, description: alert_type_description) }
   let(:electricity_fuel_alert_type)     { create(:alert_type, fuel_type: :electricity, frequency: :termly, description: alert_type_description) }
 
-  it 'defaults to beginning of month, 3 months ago' do
-    expect(service.older_than).to eql(1.month.ago.beginning_of_month)
+  it 'defaults to 14 days ago' do
+    expect(service.older_than).to eql(14.days.ago.to_date)
   end
 
   it 'calls delete!' do

--- a/spec/services/alerts/delete_alert_generation_run_service_spec.rb
+++ b/spec/services/alerts/delete_alert_generation_run_service_spec.rb
@@ -7,33 +7,31 @@ describe Alerts::DeleteAlertGenerationRunService, type: :service do
   let(:gas_fuel_alert_type)             { create(:alert_type, fuel_type: :gas, frequency: :termly, description: alert_type_description) }
   let(:electricity_fuel_alert_type)     { create(:alert_type, fuel_type: :electricity, frequency: :termly, description: alert_type_description) }
 
-  it 'defaults to beginning of month, 1 month ago' do
-    expect(service.older_than).to eql(1.month.ago.beginning_of_month)
+  it 'defaults to 14 days ago' do
+    expect(service.older_than).to eql(14.days.ago.to_date)
   end
 
   describe '#delete' do
     it 'doesnt delete new runs' do
-      date_time = (Time.zone.now - 1.month)
+      date_time = (Time.zone.now - 14.days)
       school.alert_generation_runs.create!(created_at: date_time + 1.day)
       school.alert_generation_runs.create!(created_at: date_time + 1.week)
-      school.alert_generation_runs.create!(created_at: date_time + 1.month)
       school.alert_generation_runs.create!(created_at: Time.zone.now)
-      expect(AlertGenerationRun.count).to eq 4
       expect { service.delete! }.not_to change(AlertGenerationRun, :count)
     end
 
     context 'when there are older runs to delete' do
       it 'deletes only the older runs' do
         school.alert_generation_runs.create!(created_at: Time.zone.now)
-        school.alert_generation_runs.create!(created_at: (Time.zone.now - 1.month).beginning_of_month + 1.day)
-        school.alert_generation_runs.create!(created_at: (Time.zone.now - 3.months).beginning_of_month)
-        school.alert_generation_runs.create!(created_at: (Time.zone.now - 6.months).beginning_of_month)
+        school.alert_generation_runs.create!(created_at: Time.zone.now - 13.days)
+        school.alert_generation_runs.create!(created_at: Time.zone.now - 1.month)
+        school.alert_generation_runs.create!(created_at: Time.zone.now - 3.months)
         expect(AlertGenerationRun.count).to eq 4
         expect { service.delete! }.to change(AlertGenerationRun, :count).from(4).to(2)
       end
 
       it 'deletes all of the dependent objects' do
-        date_time = (Time.zone.now - 1.month).beginning_of_month
+        date_time = (Time.zone.now - 1.month)
         alert_generation_run = school.alert_generation_runs.create!(created_at: date_time)
         create(:alert, school: school, alert_type: gas_fuel_alert_type, created_at: date_time, alert_generation_run: alert_generation_run)
         create(:alert, school: school, alert_type: electricity_fuel_alert_type, created_at: date_time, alert_generation_run: alert_generation_run)

--- a/spec/services/alerts/delete_content_generation_run_service_spec.rb
+++ b/spec/services/alerts/delete_content_generation_run_service_spec.rb
@@ -7,17 +7,15 @@ describe Alerts::DeleteContentGenerationRunService, type: :service do
 
   let(:service)   { Alerts::DeleteContentGenerationRunService.new }
 
-  it 'defaults to beginning of month, 1 month ago' do
-    expect(service.older_than).to eql(1.month.ago.beginning_of_month)
+  it 'defaults to two weeks ago' do
+    expect(service.older_than).to eql(14.days.ago.to_date)
   end
 
   it 'doesnt delete new runs' do
-    date_time = (Time.zone.now - 1.month)
+    date_time = (Time.zone.now - 14.days)
     school.content_generation_runs.create!(created_at: date_time + 1.day)
     school.content_generation_runs.create!(created_at: date_time + 1.week)
-    school.content_generation_runs.create!(created_at: date_time + 1.month)
     school.content_generation_runs.create!(created_at: Time.zone.now)
-    expect(ContentGenerationRun.count).to eq 4
     expect { service.delete! }.not_to change(ContentGenerationRun, :count)
   end
 
@@ -29,7 +27,7 @@ describe Alerts::DeleteContentGenerationRunService, type: :service do
     let(:content_version_1) { create(:alert_type_rating_content_version, alert_type_rating: alert_type_rating)}
     let(:alert_1) { create(:alert, alert_type: electricity_fuel_alert_type) }
     let(:alert_2) { create(:alert, alert_type: electricity_fuel_alert_type) }
-    older_than_date = Alerts::DeleteContentGenerationRunService::DEFAULT_OLDER_THAN
+    let(:older_than_date) { Alerts::DeleteContentGenerationRunService::DEFAULT_OLDER_THAN }
     let(:content_generation_run_1) { create(:content_generation_run, school: school, created_at: older_than_date) }
     let(:content_generation_run_2) { create(:content_generation_run, school: school, created_at: older_than_date + 1.day) }
 


### PR DESCRIPTION
The daily regenerations produce a number of database artefacts, the largest being the alert records.

We currently run a job once a month to delete anything older than the start of the previous month. Which means today we have nearly 2 months of older data.

As the database is growing, we need to reduce threshold of what we're storing. In general for support purposes we rarely need more than a few days to a week.

Initially this PR changes the deletion threshold to 14 days and updates the cronjob to run weekly in the early hours of sunday morning.