### PR TITLE
Tune autovacuum for alerts table

### DIFF
--- a/app/models/alert.rb
+++ b/app/models/alert.rb
@@ -39,7 +39,14 @@
 #  fk_rails_...  (comparison_report_id => comparison_reports.id)
 #  fk_rails_...  (school_id => schools.id) ON DELETE => cascade
 #
-
+# Postgres autovacuum specific settings:
+# See: https://www.postgresql.org/docs/current/runtime-config-autovacuum.html
+# Applied using: ALTER TABLE amr_data_feed_readings SET (X = n)
+# autovacuum_vacuum_cost_delay = 0
+# autovacuum_analyze_scale_factor = 0
+# autovacuum_analyze_threshold = 50000
+# autovacuum_vacuum_scale_factor = 0
+# autovacuum_vacuum_threshold = 50000
 class Alert < ApplicationRecord
   include EnumReportingPeriod
   include AlertTypeWithComparisonReport

--- a/lib/tasks/deployment/20241031141954_tune_autovacuum_on_alerts.rake
+++ b/lib/tasks/deployment/20241031141954_tune_autovacuum_on_alerts.rake
@@ -1,0 +1,24 @@
+namespace :after_party do
+  desc 'Deployment task: tune_autovacuum_on_alerts'
+  task tune_autovacuum_on_alerts: :environment do
+    puts "Running deploy task 'tune_autovacuum_on_alerts'"
+
+    # Reduce cost delay to complete autovacuum processes (vacuum, analyse) as quickly as possible
+    ActiveRecord::Base.connection.execute("ALTER TABLE alerts SET (autovacuum_vacuum_cost_delay = 0)")
+
+    #Set scale factor to zero, rather than 0.2 so that we trigger the autovacuum process to run ANALYZE based on number of
+    #records changed, not a % of the table.
+    ActiveRecord::Base.connection.execute("ALTER TABLE alerts SET (autovacuum_analyze_scale_factor = 0)")
+    ActiveRecord::Base.connection.execute("ALTER TABLE alerts SET (autovacuum_analyze_threshold = 50000)")
+
+    #Set scale factor to zero, rather than 0.2 so that we trigger the autovacuum process to run VACUUM based on number of
+    #records changed, not a % of the table.
+    ActiveRecord::Base.connection.execute("ALTER TABLE alerts SET (autovacuum_vacuum_scale_factor = 0)")
+    ActiveRecord::Base.connection.execute("ALTER TABLE alerts SET (autovacuum_vacuum_threshold = 50000)")
+
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord
+      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+  end
+end


### PR DESCRIPTION
Reconfigure the autovacuum options for the alerts table.

- reduces cost to zero to ensure autovacuum runs as quickly as possible when triggered
- change the configuration for the `vacuum` and `analyze` operations so rather than being triggered based on a % of table changed + number of records, they now use a fixed threshold

Similar configuration for the readings table removed some of the database waits and ensuring vacuuming was running more frequently. Currently the table is only getting vacuumed after the monthly (and now weekly) cleanup.

Thresholds are estimated, so may need tweaking in future.