### PR TITLE
cancel in progress github action when a new one appears

### DIFF
--- a/.github/workflows/knapsack.yml
+++ b/.github/workflows/knapsack.yml
@@ -27,7 +27,7 @@ jobs:
       - run: bundle exec rspec
         env:
           KNAPSACK_GENERATE_REPORT: true
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: knapsack_rspec_report
           path: knapsack_rspec_report.json

--- a/.github/workflows/knapsack.yml
+++ b/.github/workflows/knapsack.yml
@@ -3,6 +3,9 @@ on:
   workflow_dispatch:
   push:
     branches: [ master ]
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 jobs:
   rspec:
     runs-on: ubuntu-latest

--- a/.github/workflows/rubyonrails.yml
+++ b/.github/workflows/rubyonrails.yml
@@ -1,7 +1,7 @@
 name: "Ruby on Rails CI"
 on:
   push:
-    branches: [ master, aws-eb-test, aws-eb-master ]
+    branches: [ aws-eb-test, aws-eb-master ]
   pull_request:
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/rubyonrails.yml
+++ b/.github/workflows/rubyonrails.yml
@@ -3,6 +3,9 @@ on:
   push:
     branches: [ master, aws-eb-test, aws-eb-master ]
   pull_request:
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 jobs:
   rspec:
     runs-on: ubuntu-latest


### PR DESCRIPTION
- from https://turso.tech/blog/simple-trick-to-save-environment-and-money-when-using-github-actions
also
- also updates to use upload-artifact@v4
- stop running job on master push as have linear knapsack timings job doing similar thing