### PR TITLE
Fix confirmation email sending service to not contact some users

### DIFF
--- a/app/services/confirmation_reminder.rb
+++ b/app/services/confirmation_reminder.rb
@@ -1,12 +1,16 @@
 # frozen_string_literal: true
 
+# Send confirmation reminders to specific types of user accounts, ignoring deleted or archived schools
+#
+# Do not chase old accounts.
 module ConfirmationReminder
-  # Only send confirmations to these roles
   CONFIRMABLE_ROLES = [:staff, :school_admin, :group_admin, :volunteer].freeze
 
   def self.send
     now = Time.current
-    User.where(role: CONFIRMABLE_ROLES).where('confirmed_at IS NULL AND confirmation_sent_at IS NOT NULL').find_each do |user|
+    User.where(role: CONFIRMABLE_ROLES) # restrict to specific set of roles
+        .where('created_at >= ?', 31.days.ago) # ignore old accounts
+        .where('confirmed_at IS NULL AND confirmation_sent_at IS NOT NULL').find_each do |user|
       next if user.school && user.school.not_active?
       if should_send_reminder(now, user, 30.days)
         EnergySparksDeviseMailer.confirmation_instructions_final_reminder(user, user.confirmation_token).deliver_now

--- a/spec/factories/schools_factory.rb
+++ b/spec/factories/schools_factory.rb
@@ -30,6 +30,16 @@ FactoryBot.define do
       end
     end
 
+    trait :archived do
+      active { false }
+      removal_date { nil }
+    end
+
+    trait :deleted do
+      active { false }
+      removal_date { Date.new(2023, 1, 1) }
+    end
+
     trait :with_calendar do
       after(:create) do |school, _evaluator|
         school.update(calendar: create(:school_calendar))

--- a/spec/factories/users_factory.rb
+++ b/spec/factories/users_factory.rb
@@ -69,5 +69,11 @@ FactoryBot.define do
     trait :has_school_assigned do
       school
     end
+
+    trait :skip_confirmed do
+      after(:build) do |user, _evaluator|
+        user.skip_confirmation_notification!
+      end
+    end
   end
 end

--- a/spec/services/confirmation_reminder_spec.rb
+++ b/spec/services/confirmation_reminder_spec.rb
@@ -51,6 +51,12 @@ describe ConfirmationReminder do
         let!(:user) { create(role, confirmed_at: nil, confirmation_token: 'token', confirmation_sent_at: now) }
 
         it_behaves_like 'it correctly sends emails'
+
+        context 'with an account created a while ago' do
+          let!(:user) { create(role, created_at: 2.months.ago, confirmed_at: nil, confirmation_token: 'token', confirmation_sent_at: 2.months.ago) }
+
+          it_behaves_like 'it ignores sending emails'
+        end
       end
 
       context 'when school is archived' do

--- a/spec/services/confirmation_reminder_spec.rb
+++ b/spec/services/confirmation_reminder_spec.rb
@@ -5,22 +5,104 @@ describe ConfirmationReminder do
 
   before do
     travel_to(now)
-    create(:user, confirmed_at: nil, confirmation_token: 'token', confirmation_sent_at: now)
   end
 
-  it 'sends first and final reminder' do
-    expect { described_class.send }.to(not_change { ActionMailer::Base.deliveries.count })
-    travel_to(now + 7.days)
-    expect { described_class.send }.to change { ActionMailer::Base.deliveries.count }.by(1)
-    expect(ActionMailer::Base.deliveries.last.subject).to eq('Reminder: please confirm your account on Energy Sparks')
-    expect(ActionMailer::Base.deliveries.last.to_s).to include('A user account was recently created')
-    expect { described_class.send }.to(not_change { ActionMailer::Base.deliveries.count })
-    travel_to(now + 29.days)
-    expect { described_class.send }.to(not_change { ActionMailer::Base.deliveries.count })
-    travel_to(now + 30.days)
-    expect { described_class.send }.to change { ActionMailer::Base.deliveries.count }.by(1)
-    expect(ActionMailer::Base.deliveries.last.subject).to \
-      eq('Final reminder: please confirm your account on Energy Sparks')
-    expect { described_class.send }.to(not_change { ActionMailer::Base.deliveries.count })
+  shared_examples 'it ignores sending emails' do
+    it 'does not send at any time' do
+      expect(User.count).to eq(1)
+      expect { described_class.send }.to(not_change { ActionMailer::Base.deliveries.count })
+      travel_to(now + 7.days)
+      expect { described_class.send }.to(not_change { ActionMailer::Base.deliveries.count })
+      travel_to(now + 29.days)
+      expect { described_class.send }.to(not_change { ActionMailer::Base.deliveries.count })
+      travel_to(now + 30.days)
+      expect { described_class.send }.to(not_change { ActionMailer::Base.deliveries.count })
+    end
+  end
+
+  shared_examples 'it correctly sends emails' do
+    it 'sends first and last reminders' do
+      expect { described_class.send }.to(not_change { ActionMailer::Base.deliveries.count })
+      travel_to(now + 7.days)
+      expect { described_class.send }.to change { ActionMailer::Base.deliveries.count }.by(1)
+      expect(ActionMailer::Base.deliveries.last.subject).to eq('Reminder: please confirm your account on Energy Sparks')
+      expect(ActionMailer::Base.deliveries.last.to_s).to include('A user account was recently created')
+      expect { described_class.send }.to(not_change { ActionMailer::Base.deliveries.count })
+      travel_to(now + 29.days)
+      expect { described_class.send }.to(not_change { ActionMailer::Base.deliveries.count })
+      travel_to(now + 30.days)
+      expect { described_class.send }.to change { ActionMailer::Base.deliveries.count }.by(1)
+      expect(ActionMailer::Base.deliveries.last.subject).to \
+        eq('Final reminder: please confirm your account on Energy Sparks')
+      expect { described_class.send }.to(not_change { ActionMailer::Base.deliveries.count })
+    end
+  end
+
+  context 'with group user' do
+    context 'when not confirmed' do
+      context 'when user has been sent confirmation' do
+        let!(:user) { create(:group_admin, confirmed_at: nil, confirmation_token: 'token', confirmation_sent_at: now) }
+
+        it_behaves_like 'it correctly sends emails'
+      end
+    end
+
+    context 'when user is already confirmed' do
+      let!(:user) { create(:group_admin, confirmed_at: now, confirmation_token: 'token', confirmation_sent_at: now) }
+
+      it_behaves_like 'it ignores sending emails'
+    end
+  end
+
+  context 'with adult school user' do
+    context 'when not confirmed' do
+      context 'when user has not yet received any email' do
+        # mimic when users are created during onboarding as we confirm them at the end of the process
+        let!(:user) { create(:school_admin, :skip_confirmed) }
+
+        it_behaves_like 'it ignores sending emails'
+      end
+
+      context 'when user has been sent confirmation' do
+        let!(:user) { create(:school_admin, confirmed_at: nil, confirmation_token: 'token', confirmation_sent_at: now) }
+
+        it_behaves_like 'it correctly sends emails'
+      end
+
+      context 'when school is archived' do
+        let!(:school) { create(:school, :archived) }
+        let!(:user) { create(:school_admin, confirmed_at: nil, confirmation_token: 'token', confirmation_sent_at: now, school: school) }
+
+        it_behaves_like 'it ignores sending emails'
+      end
+
+      context 'when school is deleted' do
+        let!(:school) { create(:school, :deleted) }
+        let!(:user) { create(:school_admin, confirmed_at: nil, confirmation_token: 'token', confirmation_sent_at: now, school: school) }
+
+        it_behaves_like 'it ignores sending emails'
+      end
+    end
+
+    context 'when user is confirmed' do
+      let!(:user) { create(:school_admin, confirmed_at: now, confirmation_token: 'token', confirmation_sent_at: now) }
+
+      it_behaves_like 'it ignores sending emails'
+    end
+  end
+
+  # no email address, auto confirmed at creation
+  context 'with pupil' do
+    let!(:user) { create(:pupil, confirmed_at: now) }
+
+    it_behaves_like 'it ignores sending emails'
+  end
+
+
+  # auto confirmed during onboarding users become school admins when school is created during onboarding
+  context 'with onboarding_user' do
+    let!(:user) { create(:onboarding_user, confirmed_at: now) }
+
+    it_behaves_like 'it ignores sending emails'
   end
 end


### PR DESCRIPTION
Updated the confirmation reminder service so that it:

- [x] only sends reminders to some roles, ignoring admins, pupils and school_onboarding users
- [x] checks to see if the users school is archived or deleted and skips sending email
- [x] ignores users older than ~1 month to avoid chasing old accounts

Specs have been reworked to exercise logic for all roles.