### PR TITLE
Add report of schools with no alert contacts

### DIFF
--- a/app/controllers/admin/reports/missing_alert_contacts_controller.rb
+++ b/app/controllers/admin/reports/missing_alert_contacts_controller.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Admin
+  module Reports
+    class MissingAlertContactsController < AdminController
+      def index
+        @schools = School.joins(:school_group).visible.missing_alert_contacts.by_name
+      end
+    end
+  end
+end

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -241,6 +241,8 @@ class School < ApplicationRecord
   # TODO
   scope :by_keyword, ->(keyword) { where('name LIKE ?', "%#{keyword}%")}
 
+  scope :missing_alert_contacts, -> { where('schools.id NOT IN (SELECT distinct(school_id) from contacts)') }
+
   def self.with_energy_tariffs
     joins("INNER JOIN energy_tariffs ON energy_tariffs.tariff_holder_id = schools.id AND tariff_holder_type = 'School'")
       .group('schools.id').order('schools.name')

--- a/app/views/admin/reports/index.html.erb
+++ b/app/views/admin/reports/index.html.erb
@@ -18,6 +18,7 @@
       <li><%= link_to 'Funder allocation report', admin_reports_funder_allocations_path %></li>
       <li><%= link_to 'Engaged Schools', admin_reports_engaged_schools_path %></li>
       <li><%= link_to 'User logins', admin_reports_user_logins_path %></li>
+      <li><%= link_to 'Missing Alert Subscribers', admin_reports_missing_alert_contacts_path %></li>
     </ul>
 
     <h3>Activities</h3>

--- a/app/views/admin/reports/missing_alert_contacts/index.html.erb
+++ b/app/views/admin/reports/missing_alert_contacts/index.html.erb
@@ -6,7 +6,7 @@
 </p>
 
 <p>
-  In addition to listing the group, funder and country for each school, the table shows the date they completed
+  In addition to listing the group, funder and country for each school, the table shows the date the school completed
   onboarding, whether the school is data enabled and the number of adult users at the school. Columns can be
   sorted as required.
 </p>

--- a/app/views/admin/reports/missing_alert_contacts/index.html.erb
+++ b/app/views/admin/reports/missing_alert_contacts/index.html.erb
@@ -1,0 +1,49 @@
+<h1>Schools missing alert contacts</h1>
+
+<p>
+  This report lists all visible schools that do not have any alert contacts. This means
+  there are no users at the school who are receiving weekly alerts.
+</p>
+
+<p>
+  In addition to listing the group, funder and country for each school, the table shows the date they completed
+  onboarding, whether the school is data enabled and the number of adult users at the school. Columns can be
+  sorted as required.
+</p>
+
+<table class="table table-sorted table-sm">
+  <thead>
+    <tr>
+      <th>School Group</th>
+      <th>School</th>
+      <th>Funder</th>
+      <th>Country</th>
+      <th>Onboarding completed</th>
+      <th>Data enabled?</th>
+      <th>Users</th>
+      <th>Actions</th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @schools.each do |school| %>
+      <tr>
+        <td><%= link_to school.school_group.name, school_group_path(school.school_group) %></td>
+        <td><%= link_to school.name, school_path(school) %></td>
+        <td><%= school.funder&.name %></td>
+        <td><%= school.country.humanize %></td>
+        <td data-order="<%= school.school_onboarding&.completed_on&.iso8601 || 'last' %>">
+            <% if school.school_onboarding.present? %>
+              <%= nice_dates(school.school_onboarding.completed_on) %>
+            <% else %>
+              N/A
+            <% end %>
+        </td>
+        <td data-order="<%= school.data_enabled? ? '1' : '0' %>">
+          <%= checkmark(school.data_enabled?, off_class: 'text-muted') %>
+        </td>
+        <td><%= school.users.alertable.count %></td>
+        <td><%= link_to 'Users', school_users_path(school) %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -665,6 +665,7 @@ Rails.application.routes.draw do
       resources :engaged_schools, only: [:index]
       resources :community_use, only: [:index]
       resources :intervention_types, only: [:index, :show]
+      resources :missing_alert_contacts, only: [:index]
       resources :work_allocation, only: [:index]
       resources :user_logins, only: [:index]
       resource :unvalidated_readings, only: [:show]

--- a/spec/system/admin/reports/missing_alert_contacts_spec.rb
+++ b/spec/system/admin/reports/missing_alert_contacts_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'Missing Alert Contacts' do
+  let!(:school) do
+    create(:school, :with_school_group, active: true, funder: create(:funder))
+  end
+
+  before do
+    sign_in(create(:admin))
+    visit root_path
+    click_on 'Manage'
+    click_on 'Reports'
+  end
+
+  it 'shows the expected table' do
+    click_on 'Missing Alert Subscribers'
+
+    expect(page).to have_selector(:table_row, {
+                                    'School Group' => school.school_group.name,
+                                    'School' => school.name,
+                                    'Funder' => school.funder.name,
+                                    'Country' => school.country.humanize,
+                                    'Onboarding completed' => 'N/A',
+                                    'Data enabled?' => '',
+                                    'Users' => '0',
+                                    'Actions' => 'Users'
+                                  })
+  end
+end


### PR DESCRIPTION
Adds an admin report that lists all schools that don't have anyone receiving weekly alerts.

Table includes enough context to allow admins to filter schools and decide next steps.