### PR TITLE
Adjust meter data download format

### DIFF
--- a/app/controllers/schools/meters_controller.rb
+++ b/app/controllers/schools/meters_controller.rb
@@ -29,8 +29,8 @@ module Schools
       respond_to do |format|
         format.html
         format.csv do
-          send_data readings_to_csv(AmrValidatedReading.download_query_for_meter(@meter), AmrValidatedReading::CSV_HEADER_FOR_METER),
-                    filename: "meter-amr-readings-#{@meter.mpan_mprn}.csv"
+          send_data readings_to_csv(AmrValidatedReading.download_query_for_meter(@meter), AmrValidatedReading::CSV_HEADER_FOR_SCHOOL),
+                    filename: "#{@meter.mpan_mprn}-readings.csv"
         end
       end
     end

--- a/spec/support/data_helpers.rb
+++ b/spec/support/data_helpers.rb
@@ -28,10 +28,6 @@ module EnergySparksDataHelpers
     CalendarEventType.all
   end
 
-  def amr_validated_reading_to_s(amr)
-    "#{amr.reading_date},#{amr.one_day_kwh},#{amr.status},#{amr.substitute_date},#{amr.kwh_data_x48.join(',')}"
-  end
-
   def amr_data_feed_reading_to_s(meter, amr)
     # Sometimes the DB would return the timestamp with 5 digits of milisecond precision
     # i.e. it would return 1234.56789

--- a/spec/system/schools/downloads_spec.rb
+++ b/spec/system/schools/downloads_spec.rb
@@ -7,6 +7,10 @@ describe 'downloads', type: :system do
   let(:mpan)                      { 1234567890123 }
   let!(:meter)                    { create(:electricity_meter_with_validated_reading, name: 'Electricity meter', school: school, mpan_mprn: mpan) }
 
+  def reading_row(amr)
+    "#{amr.meter.mpan_mprn},#{amr.meter.meter_type.titleize},#{amr.reading_date},#{amr.one_day_kwh},#{amr.status},#{amr.substitute_date},#{amr.kwh_data_x48.join(',')}"
+  end
+
   context 'as teacher' do
     before do
       allow_any_instance_of(AggregateSchoolService).to receive(:aggregate_school).and_return(school)
@@ -29,8 +33,7 @@ describe 'downloads', type: :system do
       # Then check the content
       meter.amr_validated_readings.each do |amr|
         expect(page.source).to have_content AmrValidatedReading::CSV_HEADER_FOR_SCHOOL
-        reading_row = "#{amr.meter.mpan_mprn},#{amr.meter.meter_type.titleize},#{amr.reading_date},#{amr.one_day_kwh},#{amr.status},#{amr.substitute_date},#{amr.kwh_data_x48.join(',')}"
-        expect(page).to have_content reading_row
+        expect(page).to have_content reading_row(amr)
       end
     end
 
@@ -40,12 +43,12 @@ describe 'downloads', type: :system do
       # Make sure the page is a CSV
       header = page.response_headers['Content-Disposition']
       expect(header).to match(/^attachment/)
-      expect(header).to match(/filename=\"meter-amr-readings-#{meter.mpan_mprn}.csv\"/)
+      expect(header).to match(/filename=\"#{meter.mpan_mprn}-readings.csv\"/)
 
       # Then check the content
       meter.amr_validated_readings.each do |amr|
-        expect(page.source).to have_content AmrValidatedReading::CSV_HEADER_FOR_METER
-        expect(page).to have_content amr_validated_reading_to_s(amr)
+        expect(page.source).to have_content AmrValidatedReading::CSV_HEADER_FOR_SCHOOL
+        expect(page).to have_content reading_row(amr)
       end
     end
   end


### PR DESCRIPTION
A user was confused by the individual meter download format:

- the MPXN is in the CSV file name but this gets truncated when imported into Excel which has a limit on size of tab names
- the CSV file itself doesn't contain the MPXN

The user was therefore unsure whether we had given them the right data.

Adjust the downloads to shorten the file name and add the mpxn and meter type into the CSV.
