### PR TITLE
Add rake task to reload zero reading periods from Meteostat

### DIFF
--- a/app/models/weather_observation.rb
+++ b/app/models/weather_observation.rb
@@ -23,6 +23,14 @@ class WeatherObservation < ApplicationRecord
   scope :by_date, -> { order(:reading_date) }
   scope :since, ->(date) { where('reading_date >= ?', date) }
 
+  scope :between, ->(start_date, end_date) do
+    where('reading_date >= :start_date AND reading_date <= :end_date',
+          start_date: start_date,
+          end_date: end_date)
+  end
+
+  scope :any_zero_readings, -> { where('0.0 = ANY(temperature_celsius_x48)') }
+
   def self.download_all_data
     <<~QUERY
       SELECT station.title, obs.reading_date, obs.temperature_celsius_x48

--- a/app/models/weather_observation.rb
+++ b/app/models/weather_observation.rb
@@ -23,11 +23,7 @@ class WeatherObservation < ApplicationRecord
   scope :by_date, -> { order(:reading_date) }
   scope :since, ->(date) { where('reading_date >= ?', date) }
 
-  scope :between, ->(start_date, end_date) do
-    where('reading_date >= :start_date AND reading_date <= :end_date',
-          start_date: start_date,
-          end_date: end_date)
-  end
+  scope :between, ->(start_date, end_date) { where(reading_date: start_date..end_date) }
 
   scope :any_zero_readings, -> { where('0.0 = ANY(temperature_celsius_x48)') }
 

--- a/lib/tasks/data_feeds/meteostat_reload_zero_reading_days.rake
+++ b/lib/tasks/data_feeds/meteostat_reload_zero_reading_days.rake
@@ -1,0 +1,27 @@
+namespace :data_feeds do
+  desc 'Reload Meteostat data where days in period have zero temperature readings'
+  task :meteostat_reload_zero_reading_days, [:start_date, :end_date] => :environment do |_t, args|
+    puts "#{DateTime.now.utc} meteostat_reload_zero_reading_days start"
+
+    start_date = args[:start_date]
+    end_date = args[:end_date]
+
+    abort("Provide start and end dates") unless start_date.present? && end_date.present?
+
+    to_reload = WeatherStation.all.select do |station|
+      # check to see if we have any 0.0 temperature readings between affected dates
+      # zero might be fine during winter, but we've found dates where imported readings were
+      # mostly zeroes during summer/autumn period
+      station.weather_observations.between(start_date, end_date).any_zero_readings.any?
+    end
+
+    # Create loader to import during affected period
+    loader = DataFeeds::MeteostatLoader.new(start_date, end_date)
+    to_reload.each do |station|
+      puts "Reloading #{station.title}"
+      loader.import_station(station)
+    end
+
+    puts "#{DateTime.now.utc} meteostat_reload_zero_reading_days end"
+  end
+end


### PR DESCRIPTION
We've had a period where we seem to have incorrect readings from Meteostat. Reloading data for the period correctly imports updated data. It's affecting 7 weather stations on east of england.

I've added this Rake task to allow days to be selectively reimported if there are any zeroes. I've not done this as an after party task as I prefer to avoid running tasks that depend on external APIs during a release. So I will run the update manually after the next release.



