### PR TITLE
Add stark portal gas config

### DIFF
--- a/lib/generators/amr_data_feed_config/USAGE
+++ b/lib/generators/amr_data_feed_config/USAGE
@@ -1,0 +1,5 @@
+Description:
+    Generator that will create an after party task to insert a new AmrDataFeedConfig.
+
+Example:
+    bin/rails generate amr_data_feed_config new-feed-identifier --description=description_of_the_config

--- a/lib/generators/amr_data_feed_config/amr_data_feed_config_generator.rb
+++ b/lib/generators/amr_data_feed_config/amr_data_feed_config_generator.rb
@@ -1,0 +1,3 @@
+class AmrDataFeedConfigGenerator < AfterParty::Generators::TaskGenerator
+  source_root File.expand_path('templates', __dir__)
+end

--- a/lib/generators/amr_data_feed_config/templates/deploy.txt.erb
+++ b/lib/generators/amr_data_feed_config/templates/deploy.txt.erb
@@ -1,0 +1,46 @@
+namespace :after_party do
+  desc '<%= task_description %>'
+  task <%= file_name %>: :environment do
+    puts "Running deploy task '<%= file_name %>'"
+
+    # For row per day CSV/Excel feeds use the below template adding the
+    # correct number of header rows, actual date format, and the actual
+    # header and list of reading fields. Other optional fields, including filters
+    # can be defined
+    #
+    # For formats that use serial numbers:
+    #
+    # lookup_by_serial_number: true
+    # mpan_mprn_field: ''
+    # msn_field: ''
+    #
+    # For row per reading formats add:
+    #
+    # row_per_reading: true
+    #
+    # Then, if there is a separate time or period field then also add:
+    #
+    # positional_index: true
+    # period_field: ''
+    # reading_time_field: ''
+    # half_hourly_labelling: :start/:end
+    #
+    identifier = '<%= name %>'
+    AmrDataFeedConfig.create!({
+      identifier: identifier,
+      description: '<%= options.description %>',
+      notes: '',
+      number_of_header_rows: 1,
+      mpan_mprn_field: 'MPRN',
+      reading_date_field: 'Date',
+      date_format: '%d/%m/%Y',
+      header_example: 'MPRN,Date,00:30,01:00,01:30,02:00,02:30,03:00,03:30,04:00,04:30,05:00,05:30,06:00,06:30,07:00,07:30,08:00,08:30,09:00,09:30,10:00,10:30,11:00,11:30,12:00,12:30,13:00,13:30,14:00,14:30,15:00,15:30,16:00,16:30,17:00,17:30,18:00,18:30,19:00,19:30,20:00,20:30,21:00,21:30,22:00,22:30,23:00,23:30,00:00',
+      reading_fields: '00:30,01:00,01:30,02:00,02:30,03:00,03:30,04:00,04:30,05:00,05:30,06:00,06:30,07:00,07:30,08:00,08:30,09:00,09:30,10:00,10:30,11:00,11:30,12:00,12:30,13:00,13:30,14:00,14:30,15:00,15:30,16:00,16:30,17:00,17:30,18:00,18:30,19:00,19:30,20:00,20:30,21:00,21:30,22:00,22:30,23:00,23:30,00:00'.split(',')
+    }) unless AmrDataFeedConfig.find_by_identifier(identifier)
+
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord
+      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+  end
+end

--- a/lib/tasks/deployment/20241113144957_stark_portal_gas.rake
+++ b/lib/tasks/deployment/20241113144957_stark_portal_gas.rake
@@ -1,0 +1,24 @@
+namespace :after_party do
+  desc 'Deployment task: Stark Portal Gas Config'
+  task stark_portal_gas: :environment do
+    puts "Running deploy task 'stark_portal_gas'"
+
+    identifier = 'stark-portal-gas'
+    AmrDataFeedConfig.create!({
+      identifier: identifier,
+      description: 'Stark Portal Gas Config',
+      notes: 'Should be used for gas only. There is a separate format for electricity',
+      number_of_header_rows: 9,
+      mpan_mprn_field: 'MPRN',
+      reading_date_field: 'Date',
+      date_format: '%d/%m/%y',
+      header_example: 'Company Name,Site Name,Online Meter Name,MPRN,Meter ID,Units,Date,00:30,01:00,01:30,02:00,02:30,03:00,03:30,04:00,04:30,05:00,05:30,06:00,06:30,07:00,07:30,08:00,08:30,09:00,09:30,10:00,10:30,11:00,11:30,12:00,12:30,13:00,13:30,14:00,14:30,15:00,15:30,16:00,16:30,17:00,17:30,18:00,18:30,19:00,19:30,20:00,20:30,21:00,21:30,22:00,22:30,23:00,23:30,00:00',
+      reading_fields: '00:30,01:00,01:30,02:00,02:30,03:00,03:30,04:00,04:30,05:00,05:30,06:00,06:30,07:00,07:30,08:00,08:30,09:00,09:30,10:00,10:30,11:00,11:30,12:00,12:30,13:00,13:30,14:00,14:30,15:00,15:30,16:00,16:30,17:00,17:30,18:00,18:30,19:00,19:30,20:00,20:30,21:00,21:30,22:00,22:30,23:00,23:30,00:00'.split(',')
+    }) unless AmrDataFeedConfig.find_by_identifier(identifier)
+
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord
+      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+  end
+end


### PR DESCRIPTION
Adds new data feed config for Stark Portal gas data.

I've also added a rails generator to try and make it easier to add these in future. I often just copy from an existing deploy task.

Generators provides a default config for a row per day format with notes about configuring other variants. Future improvements could be to add more options but this is a quick improvement.