### PR TITLE
Allow admins to see equivalences before school is data enabled

### DIFF
--- a/app/components/dashboard_equivalences_component.rb
+++ b/app/components/dashboard_equivalences_component.rb
@@ -24,8 +24,7 @@ class DashboardEquivalencesComponent < ApplicationComponent
   end
 
   def data_enabled?
-    return true if user.present? && user.admin? && @school.process_data?
-    @school.data_enabled?
+    user&.admin? && @school.process_data? || @school.data_enabled?
   end
 
   def render?

--- a/app/components/dashboard_equivalences_component.rb
+++ b/app/components/dashboard_equivalences_component.rb
@@ -24,6 +24,7 @@ class DashboardEquivalencesComponent < ApplicationComponent
   end
 
   def data_enabled?
+    return true if user.present? && user.admin? && @school.process_data?
     @school.data_enabled?
   end
 

--- a/app/components/dashboard_learn_more_component.rb
+++ b/app/components/dashboard_learn_more_component.rb
@@ -11,8 +11,7 @@ class DashboardLearnMoreComponent < ApplicationComponent
   end
 
   def data_enabled?
-    return true if user.present? && user.admin? && @school.process_data?
-    @school.data_enabled?
+    user&.admin? && @school.process_data? || @school.data_enabled?
   end
 
   def adult?

--- a/spec/components/dashboard_equivalences_component_spec.rb
+++ b/spec/components/dashboard_equivalences_component_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe DashboardEquivalencesComponent, :include_url_helpers, type: :comp
 
       context 'with admin and school is processing data' do
         let(:school) { create(:school, process_data: true) }
-        let(:user) { create(:admin)}
+        let(:user) { create(:admin) }
 
         it { expect(component.data_enabled?).to be true }
       end

--- a/spec/components/dashboard_equivalences_component_spec.rb
+++ b/spec/components/dashboard_equivalences_component_spec.rb
@@ -45,6 +45,13 @@ RSpec.describe DashboardEquivalencesComponent, :include_url_helpers, type: :comp
       let(:school) { create(:school, data_enabled: false) }
 
       it { expect(component.data_enabled?).to be false }
+
+      context 'with admin and school is processing data' do
+        let(:school) { create(:school, process_data: true) }
+        let(:user) { create(:admin)}
+
+        it { expect(component.data_enabled?).to be true }
+      end
     end
   end
 


### PR DESCRIPTION
Makes the dashboard equivalences component work similar to the components on the adult dashboards.

Normally we allow admins to see the data enabled view even if the flag has not yet been set so they can preview the school's data before making the data live.