### PR TITLE
delete related alerts with a comparsion report

### DIFF
--- a/app/models/comparison/report.rb
+++ b/app/models/comparison/report.rb
@@ -43,6 +43,7 @@ class Comparison::Report < ApplicationRecord
 
   belongs_to :custom_period, class_name: 'Comparison::CustomPeriod', optional: true, autosave: true, dependent: :destroy
   belongs_to :report_group, class_name: 'Comparison::ReportGroup'
+  has_many :alerts, inverse_of: :comparison_report, dependent: :destroy
 
   scope :by_title, ->(order = :asc) { i18n.order(title: order) }
 

--- a/app/models/comparison/report.rb
+++ b/app/models/comparison/report.rb
@@ -43,7 +43,8 @@ class Comparison::Report < ApplicationRecord
 
   belongs_to :custom_period, class_name: 'Comparison::CustomPeriod', optional: true, autosave: true, dependent: :destroy
   belongs_to :report_group, class_name: 'Comparison::ReportGroup'
-  has_many :alerts, inverse_of: :comparison_report, dependent: :destroy
+  has_many :alerts, inverse_of: :comparison_report, dependent: :delete_all
+  has_many :alert_errors, inverse_of: :comparison_report, dependent: :delete_all
 
   scope :by_title, ->(order = :asc) { i18n.order(title: order) }
 

--- a/spec/models/comparison/report_spec.rb
+++ b/spec/models/comparison/report_spec.rb
@@ -1,9 +1,11 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
-RSpec.describe Comparison::Report, type: :model do
+RSpec.describe Comparison::Report do
   describe 'validations' do
     context 'with standard validations' do
-      subject(:report) { build :report }
+      subject(:report) { build(:report) }
 
       it { expect(report).to be_valid }
       it { expect(report).to validate_uniqueness_of(:key) }
@@ -15,14 +17,19 @@ RSpec.describe Comparison::Report, type: :model do
   end
 
   describe 'relationships' do
-    subject(:report) { create :report }
+    subject(:report) { create(:report) }
 
     it { expect(report).to belong_to(:report_group).optional(false) }
+
+    it 'destroys related alerts' do
+      create(:alert, comparison_report: report)
+      expect { report.destroy! }.to change(Alert, :count).by(-1)
+    end
   end
 
   describe '#key' do
     context 'when there is a title' do
-      subject(:report) { create :report, title: 'Lovely title' }
+      subject(:report) { create(:report, title: 'Lovely title') }
 
       it 'builds a key on create using :title' do
         expect(report.key).to eq('lovely_title')
@@ -42,7 +49,7 @@ RSpec.describe Comparison::Report, type: :model do
     end
 
     context 'when there is no title' do
-      subject(:report) { build :report, title: '' }
+      subject(:report) { build(:report, title: '') }
 
       it { expect(report).to validate_presence_of(:key) }
       it { expect(report).to validate_presence_of(:title) }

--- a/spec/models/comparison/report_spec.rb
+++ b/spec/models/comparison/report_spec.rb
@@ -1,11 +1,9 @@
-# frozen_string_literal: true
-
 require 'rails_helper'
 
-RSpec.describe Comparison::Report do
+RSpec.describe Comparison::Report, type: :model do
   describe 'validations' do
     context 'with standard validations' do
-      subject(:report) { build(:report) }
+      subject(:report) { build :report }
 
       it { expect(report).to be_valid }
       it { expect(report).to validate_uniqueness_of(:key) }
@@ -17,19 +15,14 @@ RSpec.describe Comparison::Report do
   end
 
   describe 'relationships' do
-    subject(:report) { create(:report) }
+    subject(:report) { create :report }
 
     it { expect(report).to belong_to(:report_group).optional(false) }
-
-    it 'destroys related alerts' do
-      create(:alert, comparison_report: report)
-      expect { report.destroy! }.to change(Alert, :count).by(-1)
-    end
   end
 
   describe '#key' do
     context 'when there is a title' do
-      subject(:report) { create(:report, title: 'Lovely title') }
+      subject(:report) { create :report, title: 'Lovely title' }
 
       it 'builds a key on create using :title' do
         expect(report.key).to eq('lovely_title')
@@ -49,7 +42,7 @@ RSpec.describe Comparison::Report do
     end
 
     context 'when there is no title' do
-      subject(:report) { build(:report, title: '') }
+      subject(:report) { build :report, title: '' }
 
       it { expect(report).to validate_presence_of(:key) }
       it { expect(report).to validate_presence_of(:title) }


### PR DESCRIPTION
- destroy was too slow locally, delete_all seems ok
- assuming it's ok for the weekly vacuum to deal with the fallout if it isn't otherwise triggered