### PR TITLE
Removing interpolation argument from Welsh key

### DIFF
--- a/config/locales/cy/views/advice_pages/electricity_long_term.yml
+++ b/config/locales/cy/views/advice_pages/electricity_long_term.yml
@@ -32,7 +32,7 @@ cy:
           title: Cymhariaeth defnydd trydan blynyddol ag ysgolion eraill
         electricity_by_month_year:
           explanation: Gall y siart hwn fod yn ffordd gyflym o weld a yw ymddygiad arbed ynni a diweddariadau goleuo ac offer yn cael effaith ar eich defnydd o drydan. Mae angen bod yn ofalus wrth gymharu misoedd â gwyliau, yn enwedig y Pasg, sef rhai blynyddoedd ym mis Mawrth ac adegau eraill ym mis Ebrill.
-          subtitle_html: Mae'r siart hwn yn dangos y defnydd %{fuel_type} misol o <span class='start-date'>%{start_date}</span> i <span class='end-date'>%{end_date}</span> ar gyfer <span class='meter'>%{meter}</span>
+          subtitle_html: Mae'r siart hwn yn dangos y defnydd misol o <span class='start-date'>%{start_date}</span> i <span class='end-date'>%{end_date}</span> ar gyfer <span class='meter'>%{meter}</span>
           subtitle_two_years_html: Mae'r siart hwn yn dangos y gwahaniaeth yn y defnydd o trydan ar gyfer y 12 mis yn diweddu ar <span class='end-date'>%{end_date}</span> a'r 12 mis blaenorol ar gyfer <span class='meter'>%{meter}</span>
           title: Cymhariaeth defnydd %{fuel_type} misol
           title_two_years: Cymhariaeth defnydd %{fuel_type} misol dros y ddwy flynedd diwethaf


### PR DESCRIPTION
Fixes a welsh translation which is failing because of missing interpolation argument. Think this was caused by some rework.

This is a temporary fix. Text will ready "monthly usage" rather than "monthly electricity usage" until we get updated translations after next Transifex sync