### PR TITLE
Update school label for admins

### DIFF
--- a/app/components/school_search_component.rb
+++ b/app/components/school_search_component.rb
@@ -4,6 +4,8 @@ class SchoolSearchComponent < ApplicationComponent
   DEFAULT_TAB = :schools
   TABS = [:schools, :school_groups].freeze
 
+  # i18n-tasks-use t("components.school_search.schools.total")
+  # i18n-tasks-use t("components.school_search.schools.total_for_admins")
   def initialize(tab: DEFAULT_TAB,
                  schools: School.visible,
                  school_groups: SchoolGroup.with_visible_schools,

--- a/app/components/school_search_component.rb
+++ b/app/components/school_search_component.rb
@@ -1,5 +1,5 @@
 class SchoolSearchComponent < ApplicationComponent
-  attr_reader :schools, :school_groups, :tab, :letter, :keyword
+  attr_reader :schools, :school_groups, :tab, :letter, :keyword, :schools_total_key
 
   DEFAULT_TAB = :schools
   TABS = [:schools, :school_groups].freeze
@@ -8,13 +8,16 @@ class SchoolSearchComponent < ApplicationComponent
                  schools: School.visible,
                  school_groups: SchoolGroup.with_visible_schools,
                  letter: 'A',
-                 keyword: nil, id: nil, classes: '')
+                 keyword: nil,
+                 schools_total_key: 'components.school_search.schools.total',
+                 id: nil, classes: '')
     super(id: id, classes: classes)
     @tab = self.class.sanitize_tab(tab)
     @letter = letter || 'A'
     @keyword = keyword.present? ? keyword : nil
     @schools = schools
     @school_groups = school_groups
+    @schools_total_key = schools_total_key
   end
 
   def self.sanitize_tab(tab)

--- a/app/components/school_search_component/school_search_component.html.erb
+++ b/app/components/school_search_component/school_search_component.html.erb
@@ -9,7 +9,7 @@
       </li>
     <% end %>
     <li class="nav-item ml-auto">
-      <h6><%= t('components.school_search.schools.total', count: schools_count) %></h6>
+      <h6><%= t(schools_total_key, count: schools_count) %></h6>
     </li>
   </ul>
 

--- a/app/views/schools/index.html.erb
+++ b/app/views/schools/index.html.erb
@@ -29,7 +29,8 @@
                 schools: @schools,
                 letter: params[:letter],
                 keyword: params[:keyword],
-                tab: params[:scope] %>
+                tab: params[:scope],
+                schools_total_key: "components.school_search.schools.total#{'_for_admins' if current_user&.admin?}" %>
 
 <% else %>
   <div class="row">

--- a/config/locales/views/components/school_search.yml
+++ b/config/locales/views/components/school_search.yml
@@ -9,3 +9,4 @@ en:
         pagination: School A-Z navigation
         tab: Find Schools
         total: 'Total schools: %{count}'
+        total_for_admins: 'Total schools (visible + onboarding) : %{count}'

--- a/spec/system/schools_spec.rb
+++ b/spec/system/schools_spec.rb
@@ -88,6 +88,7 @@ RSpec.describe 'Schools page' do
     it { expect(page).to have_css('div.school-search-component') }
     it { expect(page).to have_link(I18n.t('schools.index.case_studies'), href: case_studies_path) }
     it { expect(page).to have_content('We have 2 schools') }
+    it { expect(page).to have_content(I18n.t('components.school_search.schools.total', count: 2)) }
   end
 
   context 'with the schools tab' do
@@ -126,6 +127,10 @@ RSpec.describe 'Schools page' do
         before do
           sign_in(create(:admin))
           visit schools_path
+        end
+
+        it 'updates label for school count' do
+          expect(page).to have_content(I18n.t('components.school_search.schools.total_for_admins', count: 3))
         end
 
         it 'shows visible schools' do


### PR DESCRIPTION
Revises the in-page label used for by the school search component so that its clearer than the total for admins is different.