### PR TITLE
Only allow regeneration if process_data is on

### DIFF
--- a/app/controllers/schools/batch_runs_controller.rb
+++ b/app/controllers/schools/batch_runs_controller.rb
@@ -11,6 +11,9 @@ module Schools
     end
 
     def create
+      unless @school.process_data?
+        redirect_to(school_batch_runs_path(@school), notice: 'School has not been set to process data') and return
+      end
       school_batch_run = SchoolBatchRun.create!(school: @school)
       SchoolBatchRunJob.perform_later school_batch_run
       redirect_to school_batch_run_path(@school, school_batch_run)

--- a/app/views/schools/batch_runs/index.html.erb
+++ b/app/views/schools/batch_runs/index.html.erb
@@ -2,29 +2,37 @@
 
 <h1>Regenerate data for <%= @school.name %></h1>
 
-<%= simple_form_for [@school, School.new], url: school_batch_runs_path(@school) do |f| %>
-  <%= f.submit 'Start regeneration', class: 'btn' %>
+<% if @school.process_data? %>
+  <%= simple_form_for [@school, School.new], url: school_batch_runs_path(@school) do |f| %>
+    <%= f.submit 'Start regeneration', class: 'btn' %>
+  <% end %>
+<% else %>
+  <%= render(PromptComponent.new(icon: :warning, status: :negative)) do %>
+    <p>Cannot regenerate a school that has not been set to process data. Check school configuration before enabling.</p>
+  <% end %>
 <% end %>
 
-<br/>
+<br>
 
-<h2>Previous runs</h2>
+<% if @school_batch_runs.any? %>
+  <h2>Previous runs</h2>
 
-<table class="table table-striped">
-  <thead>
-  <tr>
-    <th>Date</th>
-    <th>Status</th>
-    <th>Action</th>
-  </tr>
-  </thead>
-  <tbody>
-  <% @school_batch_runs.each do |run| %>
+  <table class="table table-striped">
+    <thead>
     <tr>
-      <td><%= nice_date_times(run.created_at) %></td>
-      <td><%= run.status %></td>
-      <td><%= link_to 'View', school_batch_run_path(@school, run), class: 'btn' %></td>
+      <th>Date</th>
+      <th>Status</th>
+      <th>Action</th>
     </tr>
-  <% end %>
-  </tbody>
-</table>
+    </thead>
+    <tbody>
+    <% @school_batch_runs.each do |run| %>
+      <tr>
+        <td><%= nice_date_times(run.created_at) %></td>
+        <td><%= run.status %></td>
+        <td><%= link_to 'View', school_batch_run_path(@school, run), class: 'btn' %></td>
+      </tr>
+    <% end %>
+    </tbody>
+  </table>
+<% end %>

--- a/app/views/shared/_school_status_buttons.html.erb
+++ b/app/views/shared/_school_status_buttons.html.erb
@@ -34,7 +34,7 @@
   <% end %>
 <% end %>
 
-<% if can?(:regenerate_school_data, school) %>
+<% if school.process_data? && can?(:regenerate_school_data, school) %>
   <%= link_to school_batch_runs_path(school), title: 'Regenerate', class: 'badge badge-pill badge-warning' do %>
     <%= fa_icon('arrows-rotate', 'data-toggle': 'tooltip', title: 'Regenerate') %>
   <% end %>

--- a/spec/system/school_batch_run_spec.rb
+++ b/spec/system/school_batch_run_spec.rb
@@ -3,23 +3,53 @@ require 'rails_helper'
 RSpec.describe 'school batch run', type: :system do
   let!(:school) { create(:school) }
   let!(:user) { create(:admin, school: school)}
-  let!(:school_batch_run) { create(:school_batch_run, school: school) }
 
   before do
-    school_batch_run.info('analysing..')
-    school_batch_run.error('bogus..')
     sign_in(user)
-    visit school_path(school)
+    visit school_batch_runs_path(school)
   end
 
-  it 'shows school batch runs' do
-    click_on('Regenerate')
-    expect(page).to have_button('Start regeneration')
-    expect(page).to have_content('Previous runs')
-    expect(page).to have_content('pending')
-    click_on('View')
-    expect(page).to have_content('Status: pending')
-    expect(page).to have_content('analysing..')
-    expect(page).to have_content('bogus..')
+  context 'when school is not set to process data' do
+    let!(:school) { create(:school, process_data: false) }
+
+    it { expect(page).not_to have_button('Start regeneration')}
+
+    it { expect(page).to have_content('Cannot regenerate a school that has not been set to process data')}
+  end
+
+  context 'when set to process data' do
+    context 'with no existing runs' do
+      it { expect(page).to have_button('Start regeneration')}
+      it { expect(page).not_to have_content('Previous runs')}
+    end
+
+    context 'with an existing run' do
+      let!(:school_batch_run) do
+        school_batch_run = create(:school_batch_run, school: school)
+        school_batch_run.info('analysing..')
+        school_batch_run.error('bogus..')
+        school_batch_run
+      end
+
+      before do
+        visit school_batch_runs_path(school)
+      end
+
+      it { expect(page).to have_button('Start regeneration')}
+      it { expect(page).to have_content('Previous runs')}
+      it { expect(page).to have_content('pending') }
+
+      context 'when viewing run' do
+        before do
+          click_on('View')
+        end
+
+        it 'shows school batch runs' do
+          expect(page).to have_content('Status: pending')
+          expect(page).to have_content('analysing..')
+          expect(page).to have_content('bogus..')
+        end
+      end
+    end
   end
 end

--- a/spec/system/schools/dashboard/manage_school_spec.rb
+++ b/spec/system/schools/dashboard/manage_school_spec.rb
@@ -172,8 +172,10 @@ RSpec.describe 'manage school', type: :system do
         create(:gas_meter, :with_unvalidated_readings, school: school)
         school.update(process_data: false)
         visit school_path(school)
+        expect(page).not_to have_link(href: school_batch_runs_path(school))
         click_on('Process data')
         expect(page).to have_content "#{school.name} will now process data"
+        expect(page).to have_link(href: school_batch_runs_path(school))
         school.reload
         expect(school.process_data).to eq(true)
         click_on('Process data')


### PR DESCRIPTION
Not sure how there wasn't a check for this already. But its currently possible for an admin to run a regenerate even if a school doesn't have the process_data flag set. This by-passes the data validation checks in toggling that attribute and produces alerts with invalid data.

Changes:

- remove navbar link to regenerate if school is not set to process data
- change batch runs page to remove button and add warning message if process data is not set
- add a final check in the controller
