### PR TITLE
Change base uri

### DIFF
--- a/lib/data_feeds/pv_live_api.rb
+++ b/lib/data_feeds/pv_live_api.rb
@@ -4,7 +4,7 @@ module DataFeeds
   class PvLiveApi
     class ApiFailure < StandardError; end
 
-    BASE_URL = 'https://api.solar.sheffield.ac.uk/pvlive/api/v4'
+    BASE_URL = 'https://api.pvlive.uk/pvlive/api/v4'
 
     def gsp_list
       get_data('/gsp_list')


### PR DESCRIPTION
Sheffield PV Live endpoint has changed. Old version still available until February but applying change now.

Have confirmed loading still works correctly.