### PR TITLE
Provide fallback colour for meter report

### DIFF
--- a/app/controllers/admin/reports/amr_validated_readings_controller.rb
+++ b/app/controllers/admin/reports/amr_validated_readings_controller.rb
@@ -68,7 +68,7 @@ module Admin
       def validated_reading_hash(status, substitute_date)
         description = "#{status} #{@amr_types[status][:name]}"
         description = description + " (with #{substitute_date.strftime('%d/%m/%Y')})" if substitute_date
-        colour = @colour_hash[status].to_s
+        colour = @colour_hash.key?(status) ? @colour_hash[status].to_s : Colours.grey_dark
         { description: description, colour: colour }
       end
     end

--- a/app/views/admin/reports/amr_validated_readings/show.html.erb
+++ b/app/views/admin/reports/amr_validated_readings/show.html.erb
@@ -1,5 +1,6 @@
 <h1><%= icon_and_display_name(@meter) %> meter report</h1>
-<p><%= link_to 'School group meter report', admin_school_group_meter_report_path(@meter.school.school_group), class: 'btn btn-success' %></p>
+<p><%= link_to 'School group meter report', admin_school_group_meter_report_path(@meter.school.school_group),
+               class: 'btn btn-success' %></p>
 
 <p>
   This report provides a calendar view of the validated meter readings for this <strong><%= @meter.school.name %></strong> meter. It includes all data, starting from the
@@ -18,7 +19,10 @@
       <p>There are several large gaps in the readings for this meter. In the last two years this includes:</p>
       <ul>
         <% @gappy_validated_readings.each do |gap| %>
-          <li><%= gap.size %> days between <%= short_dates(gap.first.reading_date) %> and <%= short_dates(gap.last.reading_date) %></li>
+          <li>
+            <%= gap.size %> days between
+            <%= short_dates(gap.first.reading_date) %> and <%= short_dates(gap.last.reading_date) %>
+          </li>
         <% end %>
       </ul>
     </div>
@@ -48,8 +52,19 @@
     <div class="legend-scale vertical col-md-4">
       <ul class='legend-labels'>
         <% group.each do |type, colour| %>
-          <li><span style='background:<%= colour %>;'></span><div class="description" style="font-size: 17px;"><small><%= "#{@amr_types[type][:name]}" + (type == 'MISSING' ? "" : "(#{type})") %></small></div></li>
+          <li>
+            <span style='background:<%= colour %>;'></span>
+            <div class="description" style="font-size: 17px;">
+              <small><%= (@amr_types[type][:name]).to_s + (type == 'MISSING' ? '' : "(#{type})") %></small>
+            </div>
+          </li>
         <% end %>
+        <li>
+          <span style='background:<%= Colours.grey_dark %>;'></span>
+          <div class="description" style="font-size: 17px;">
+            <small>Other corrections and substitutions</small>
+          </div>
+        </li>
       </ul>
     </div>
   <% end %>


### PR DESCRIPTION
The meter report colour codes the statuses applied to each days reading by the analytics.

But there are way more status codes that colours defined. At the moment if there's no mapping then we day is not colour coded, making it look like data is missing.

Provide a fallback colour so day with some substitution are always coloured.

A longer term improvement would be to map all the status codes into categories and use those to define colours.