### PR TITLE
Allow deleting of users with Observation

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -65,6 +65,9 @@ class User < ApplicationRecord
   has_many :issues_admin_for, class_name: 'SchoolGroup', inverse_of: :default_issues_admin_user,
                               foreign_key: :default_issues_admin_user_id, dependent: nil
 
+  has_many :observations_created, class_name: 'Observation', inverse_of: :created_by, dependent: :nullify
+  has_many :observations_updated, class_name: 'Observation', inverse_of: :updated_by, dependent: :nullify
+
   has_and_belongs_to_many :cluster_schools, class_name: 'School', join_table: :cluster_schools_users
 
   # Include default devise modules. Others available are:

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -340,4 +340,17 @@ describe User do
       end
     end
   end
+
+  describe '#destroy' do
+    it 'allow deletion when there are linked observations' do
+      user = create(:user)
+      obs1 = create(:observation, :intervention, created_by: user)
+      obs2 = create(:observation, :intervention, created_by: create(:user), updated_by: user)
+      user.destroy
+      obs1.reload
+      expect(obs1.created_by).to be_nil
+      obs2.reload
+      expect(obs2.updated_by).to be_nil
+    end
+  end
 end


### PR DESCRIPTION
Observations are created by / updated by Users. Declare the association so we can still delete users.