### PR TITLE
Add Meter Loading Report

### DIFF
--- a/app/controllers/admin/reports/meter_loading_reports_controller.rb
+++ b/app/controllers/admin/reports/meter_loading_reports_controller.rb
@@ -12,7 +12,7 @@ module Admin
         if params[:mpxn].present?
           AmrDataFeedReading.meter_loading_report(params[:mpxn])
         else
-          []
+          AmrDataFeedReading.none
         end
       end
     end

--- a/app/controllers/admin/reports/meter_loading_reports_controller.rb
+++ b/app/controllers/admin/reports/meter_loading_reports_controller.rb
@@ -1,0 +1,19 @@
+module Admin
+  module Reports
+    class MeterLoadingReportsController < AdminController
+      def index
+        @results = run_report
+      end
+
+      private
+
+      def run_report
+        if params[:mpxn].present?
+          AmrDataFeedReading.meter_loading_report(params[:mpxn])
+        else
+          []
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/admin/reports/meter_loading_reports_controller.rb
+++ b/app/controllers/admin/reports/meter_loading_reports_controller.rb
@@ -1,8 +1,9 @@
 module Admin
   module Reports
     class MeterLoadingReportsController < AdminController
+      include Pagy::Backend
       def index
-        @results = run_report
+        @pagy, @results = pagy(run_report, limit: 30)
       end
 
       private

--- a/app/helpers/s3_helper.rb
+++ b/app/helpers/s3_helper.rb
@@ -1,0 +1,9 @@
+module S3Helper
+  def s3_csv_download_url(identifier, file_name)
+    signer = Aws::S3::Presigner.new
+    url, = signer.presigned_request(
+      :get_object, bucket: ENV.fetch('AWS_S3_AMR_DATA_FEEDS_BUCKET'), key: "archive-#{identifier}/#{file_name}"
+    )
+    url
+  end
+end

--- a/app/models/amr_data_feed_reading.rb
+++ b/app/models/amr_data_feed_reading.rb
@@ -52,6 +52,30 @@ class AmrDataFeedReading < ApplicationRecord
 
   CSV_HEADER_DATA_FEED_READING = 'School URN,Name,Mpan Mprn,Meter Type,Reading Date,Reading Date Format,Record Last Updated,00:30,01:00,01:30,02:00,02:30,03:00,03:30,04:00,04:30,05:00,05:30,06:00,06:30,07:00,07:30,08:00,08:30,09:00,09:30,10:00,10:30,11:00,11:30,12:00,12:30,13:00,13:30,14:00,14:30,15:00,15:30,16:00,16:30,17:00,17:30,18:00,18:30,19:00,19:30,20:00,20:30,21:00,21:30,22:00,22:30,23:00,23:30,00:00'.freeze
 
+  PARSED_DATE = <<~SQL.squish.freeze.squish
+    CASE
+    WHEN reading_date ~ '\\d{1,2}-(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)-\\d{2}' THEN to_date(reading_date, 'DD-MON-YY')
+    WHEN date_format='%d-%b-%y' AND reading_date~'\\d{4}-\\d{2}-\\d{2}' THEN to_date(reading_date, 'YYYY-MM-DD')
+    WHEN date_format='%d-%m-%Y' AND reading_date~'\\d{4}-\\d{2}-\\d{2}' THEN to_date(reading_date, 'YYYY-MM-DD')
+    WHEN date_format='%d-%m-%Y' THEN to_date(reading_date, 'DD-MM-YYYY')
+    WHEN date_format='%d/%m/%Y' AND reading_date~'\\d{4}-\\d{2}-\\d{2}' THEN to_date(reading_date, 'YYYY-MM-DD')
+    WHEN date_format='%d/%m/%Y' THEN to_date(reading_date, 'DD/MM/YYYY')
+    WHEN date_format='%d/%m/%y' AND reading_date~'\\d{4}-\\d{2}-\\d{2}' THEN to_date(reading_date, 'YYYY-MM-DD')
+    WHEN date_format='%d/%m/%y' THEN to_date(reading_date, 'DD/MM/YY')
+    WHEN date_format='%Y-%m-%d' AND reading_date~'\\d{2}/\\d{2}/\\d{4}' THEN to_date(reading_date, 'DD/MM/YYYY')
+    WHEN date_format='%Y-%m-%d' THEN to_date(reading_date, 'YYYY-MM-DD')
+    WHEN date_format='%Y-%m-%d' THEN to_date(reading_date, 'YYYY-MM-DD ')
+    WHEN date_format='%y-%m-%d' THEN to_date(reading_date, 'YY-MM-DD ')
+    WHEN date_format='"%d-%m-%Y"' THEN to_date(reading_date, '"DD-MM-YYYY"')
+    WHEN date_format='%d/%m/%Y %H:%M:%S' THEN to_date(reading_date, 'DD/MM/YYYY HH24:MI::SS')
+    WHEN date_format='%H:%M:%S %a %d/%m/%Y' THEN to_date(reading_date, 'HH24:MI::SS Dy DD/MM/YYYY')
+    WHEN date_format='%e %b %Y %H:%M:%S' AND reading_date~'\\d{4}-\\d{2}-\\d{2}' THEN to_date(reading_date, 'YYYY-MM-DD')
+    WHEN date_format='%e %b %Y %H:%M:%S' THEN to_date(reading_date, 'DD Mon YYYY HH24:MI::SS')
+    WHEN date_format='%b %e %Y %I:%M%p' THEN to_date(reading_date, 'Mon DD YYYY HH12:MIam')
+    ELSE NULL
+    END parsed_date
+  SQL
+
   def self.download_all_data
     <<~QUERY
       SELECT s.urn,
@@ -89,6 +113,19 @@ class AmrDataFeedReading < ApplicationRecord
     QUERY
   end
 
+  def self.meter_loading_report(mpxn)
+    query = <<~QUERY
+      SELECT amr_data_feed_import_logs.file_name, reading_date, identifier, amr_uploaded_readings.imported AS manual_import, amr_data_feed_configs.id as config_id, #{PARSED_DATE}
+      FROM amr_data_feed_readings
+      JOIN amr_data_feed_import_logs ON amr_data_feed_readings.amr_data_feed_import_log_id = amr_data_feed_import_logs.id
+      JOIN amr_data_feed_configs ON amr_data_feed_configs.id = amr_data_feed_readings.amr_data_feed_config_id
+      LEFT JOIN amr_uploaded_readings ON amr_uploaded_readings.file_name = amr_data_feed_import_logs.file_name
+      WHERE mpan_mprn = '#{mpxn}'
+      ORDER BY parsed_date DESC NULLS LAST
+    QUERY
+    ActiveRecord::Base.connection.execute(ActiveRecord::Base.sanitize_sql(query))
+  end
+
   def self.build_unvalidated_data_report_query(mpans, amr_data_feed_config_ids)
     amr_data_feed_config_ids = amr_data_feed_config_ids.reject { |id| id.blank? || id.zero? }
     amr_data_feed_config_ids = AmrDataFeedConfig.all.pluck(:id) if amr_data_feed_config_ids.empty?
@@ -99,27 +136,7 @@ class AmrDataFeedReading < ApplicationRecord
     <<~QUERY
       SELECT mpan_mprn, meter_id, identifier, description, MIN(parsed_date) as earliest_reading, MAX(parsed_date) as latest_reading FROM (
         SELECT mpan_mprn, meter_id, identifier, amr_data_feed_configs.description, reading_date,
-        CASE
-          WHEN reading_date ~ '\\d{1,2}-(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)-\\d{2}' THEN to_date(reading_date, 'DD-MON-YY')
-          WHEN date_format='%d-%b-%y' AND reading_date~'\\d{4}-\\d{2}-\\d{2}' THEN to_date(reading_date, 'YYYY-MM-DD')
-          WHEN date_format='%d-%m-%Y' AND reading_date~'\\d{4}-\\d{2}-\\d{2}' THEN to_date(reading_date, 'YYYY-MM-DD')
-          WHEN date_format='%d-%m-%Y' THEN to_date(reading_date, 'DD-MM-YYYY')
-          WHEN date_format='%d/%m/%Y' AND reading_date~'\\d{4}-\\d{2}-\\d{2}' THEN to_date(reading_date, 'YYYY-MM-DD')
-          WHEN date_format='%d/%m/%Y' THEN to_date(reading_date, 'DD/MM/YYYY')
-          WHEN date_format='%d/%m/%y' AND reading_date~'\\d{4}-\\d{2}-\\d{2}' THEN to_date(reading_date, 'YYYY-MM-DD')
-          WHEN date_format='%d/%m/%y' THEN to_date(reading_date, 'DD/MM/YY')
-          WHEN date_format='%Y-%m-%d' AND reading_date~'\\d{2}/\\d{2}/\\d{4}' THEN to_date(reading_date, 'DD/MM/YYYY')
-          WHEN date_format='%Y-%m-%d' THEN to_date(reading_date, 'YYYY-MM-DD')
-          WHEN date_format='%Y-%m-%d' THEN to_date(reading_date, 'YYYY-MM-DD ')
-          WHEN date_format='%y-%m-%d' THEN to_date(reading_date, 'YY-MM-DD ')
-          WHEN date_format='"%d-%m-%Y"' THEN to_date(reading_date, '"DD-MM-YYYY"')
-          WHEN date_format='%d/%m/%Y %H:%M:%S' THEN to_date(reading_date, 'DD/MM/YYYY HH24:MI::SS')
-          WHEN date_format='%H:%M:%S %a %d/%m/%Y' THEN to_date(reading_date, 'HH24:MI::SS Dy DD/MM/YYYY')
-          WHEN date_format='%e %b %Y %H:%M:%S' AND reading_date~'\\d{4}-\\d{2}-\\d{2}' THEN to_date(reading_date, 'YYYY-MM-DD')
-          WHEN date_format='%e %b %Y %H:%M:%S' THEN to_date(reading_date, 'DD Mon YYYY HH24:MI::SS')
-          WHEN date_format='%b %e %Y %I:%M%p' THEN to_date(reading_date, 'Mon DD YYYY HH12:MIam')
-          ELSE NULL
-        END parsed_date
+        #{PARSED_DATE}
         FROM amr_data_feed_readings
         JOIN amr_data_feed_configs ON amr_data_feed_configs.id = amr_data_feed_readings.amr_data_feed_config_id
         WHERE mpan_mprn IN (#{list_of_mpans}) AND amr_data_feed_readings.amr_data_feed_config_id IN (#{list_of_amr_data_feed_config_ids})

--- a/app/models/amr_data_feed_reading.rb
+++ b/app/models/amr_data_feed_reading.rb
@@ -52,7 +52,7 @@ class AmrDataFeedReading < ApplicationRecord
 
   CSV_HEADER_DATA_FEED_READING = 'School URN,Name,Mpan Mprn,Meter Type,Reading Date,Reading Date Format,Record Last Updated,00:30,01:00,01:30,02:00,02:30,03:00,03:30,04:00,04:30,05:00,05:30,06:00,06:30,07:00,07:30,08:00,08:30,09:00,09:30,10:00,10:30,11:00,11:30,12:00,12:30,13:00,13:30,14:00,14:30,15:00,15:30,16:00,16:30,17:00,17:30,18:00,18:30,19:00,19:30,20:00,20:30,21:00,21:30,22:00,22:30,23:00,23:30,00:00'.freeze
 
-  PARSED_DATE = <<~SQL.squish.freeze.squish
+  PARSED_DATE = <<~SQL.squish.freeze
     CASE
     WHEN reading_date ~ '\\d{1,2}-(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)-\\d{2}' THEN to_date(reading_date, 'DD-MON-YY')
     WHEN date_format='%d %b %Y %H:%M:%S' AND reading_date~'\\d{4}-\\d{2}-\\d{2}' THEN to_date(reading_date, 'YYYY-MM-DD')
@@ -116,7 +116,7 @@ class AmrDataFeedReading < ApplicationRecord
   end
 
   def self.meter_loading_report(mpxn)
-    AmrDataFeedReading.where(mpan_mprn: mpxn).joins(
+    where(mpan_mprn: mpxn).joins(
       :amr_data_feed_import_log,
       :amr_data_feed_config,
       'LEFT JOIN amr_uploaded_readings ON amr_uploaded_readings.file_name = amr_data_feed_import_logs.file_name'

--- a/app/models/amr_data_feed_reading.rb
+++ b/app/models/amr_data_feed_reading.rb
@@ -58,6 +58,7 @@ class AmrDataFeedReading < ApplicationRecord
     WHEN date_format='%d %b %Y %H:%M:%S' AND reading_date~'\\d{4}-\\d{2}-\\d{2}' THEN to_date(reading_date, 'YYYY-MM-DD')
     WHEN date_format='%d-%b-%y' AND reading_date~'\\d{4}-\\d{2}-\\d{2}' THEN to_date(reading_date, 'YYYY-MM-DD')
     WHEN date_format='%d-%m-%Y' AND reading_date~'\\d{4}-\\d{2}-\\d{2}' THEN to_date(reading_date, 'YYYY-MM-DD')
+    WHEN date_format='%Y%m%d' AND reading_date~'\\d{4}-\\d{2}-\\d{2}' THEN to_date(reading_date, 'YYYY-MM-DD')
     WHEN date_format='%d-%m-%Y' THEN to_date(reading_date, 'DD-MM-YYYY')
     WHEN date_format='%d/%m/%Y' AND reading_date~'\\d{4}-\\d{2}-\\d{2}' THEN to_date(reading_date, 'YYYY-MM-DD')
     WHEN date_format='%d/%m/%Y' THEN to_date(reading_date, 'DD/MM/YYYY')
@@ -115,7 +116,23 @@ class AmrDataFeedReading < ApplicationRecord
   end
 
   def self.meter_loading_report(mpxn)
-    AmrDataFeedReading.where(mpan_mprn: mpxn).joins(:amr_data_feed_import_log, :amr_data_feed_config, 'LEFT JOIN amr_uploaded_readings ON amr_uploaded_readings.file_name = amr_data_feed_import_logs.file_name').select(:created_at, :reading_date, 'amr_data_feed_import_logs.file_name', :amr_data_feed_import_log_id, :amr_data_feed_config_id, 'amr_data_feed_configs.identifier', 'amr_uploaded_readings.imported', PARSED_DATE).order(parsed_date: :desc)
+    AmrDataFeedReading.where(mpan_mprn: mpxn).joins(
+      :amr_data_feed_import_log,
+      :amr_data_feed_config,
+      'LEFT JOIN amr_uploaded_readings ON amr_uploaded_readings.file_name = amr_data_feed_import_logs.file_name'
+    ).select(
+      :created_at,
+      :reading_date,
+      'amr_data_feed_import_logs.file_name',
+      :amr_data_feed_import_log_id,
+      :amr_data_feed_config_id,
+      'amr_data_feed_configs.identifier',
+      'amr_data_feed_configs.source_type', 'amr_uploaded_readings.imported',
+      PARSED_DATE
+    ).order(
+      parsed_date: :desc,
+      created_at: :desc
+    )
   end
 
   def self.build_unvalidated_data_report_query(mpans, amr_data_feed_config_ids)

--- a/app/views/admin/reports/index.html.erb
+++ b/app/views/admin/reports/index.html.erb
@@ -43,6 +43,7 @@
       <li><%= link_to 'Unvalidated readings', admin_reports_unvalidated_readings_path %></li>
       <li><%= link_to 'Recent manual imports', admin_reports_data_loads_path %></li>
       <li><%= link_to 'AMR File imports report', admin_reports_amr_data_feed_import_logs_path %></li>
+      <li><%= link_to 'Meter loading report', admin_reports_meter_loading_reports_path %></li>
       <li><%= link_to 'School group meter reports', admin_reports_meter_reports_path %></li>
       <li><%= link_to 'DCC Meter Status', admin_reports_dcc_status_index_path %></li>
       <li><%= link_to 'PROB data report', admin_prob_data_reports_path %></li>

--- a/app/views/admin/reports/meter_loading_reports/index.html.erb
+++ b/app/views/admin/reports/meter_loading_reports/index.html.erb
@@ -9,19 +9,18 @@
   <%= f.submit :Search, class: 'btn btn-primary' %>
 <% end %>
 
-<ul>
-  <li>Reading date - date of reading as interpreted by the system</li>
-  <li>File name - the name of the latest file to provide readings on this date. For feeds that send partial readings, the
-  data might have been compiled from several CSV files.</li>
-  <li>Load type - whether this was a manual or automated upload. Downloads of CSV files are only available for automated uploads</li>
+<ul class="mt-4">
+  <li>Loaded - timestamp of when the reading was loaded. Most recently loaded reading will be used in preference to any earlier readings</li>
+  <li>Reading date - date of reading as interpreted by the system. (Blanks may be a formatting issue and not an actual bug)</li>
+  <li>File name - the name of the latest file to provide readings on this date. For feeds that send partial readings, the data might have been compiled from several CSV files. In which case this is the most recent file that contributed readings for this date</li>
+  <li>Load type - whether this was a manual upload, automated api request or automated load from an emailed CSV or FTP server. Downloads of CSV files are only available for automated loads</li>
   <li>Config - the data feed config used to load the data</li>
-  <li>Original date - the reading date as provided in the CSV file. Useful in case there are date format issues in the CSV files</li>
+  <li>Original date - the reading date as provided in the CSV file. Useful in case there are date formatting issues in the reading date</li>
 </ul>
 
 <p>
   Note: some automated feeds send files with the same name. We only store the latest version of each file, so its possible that
-  the linked to CSV file may contain different data if the supplier resent a file with the same name. Or, for a manual upload, an admin used the same
-  CSV file name to upload the data. We also only store downloadable CSV files for automated uploads.
+  the linked to CSV file may contain different data if the supplier has resent a file with the same name.
 </p>
 
 <% if @results.any? %>
@@ -43,12 +42,22 @@
         <tr>
           <td><%= result.created_at.iso8601 %></td>
           <td><%= result.parsed_date %></td>
-          <td><%= result.file_name %></td>
+          <td>
+            <% if result.imported || result.source_type == 2 %>
+              result.file_name
+            <% else %>
+              <%= link_to result.file_name, s3_csv_download_url(result.identifier, result.file_name) %>
+            <% end %>
+
+            <%= result.file_name %>
+          </td>
           <td>
             <% if result.imported %>
               Manual
+            <% elsif result.source_type == 2 %>
+              API
             <% else %>
-              <%= link_to 'Automated', s3_csv_download_url(result.identifier, result.file_name) %>
+              <%= link_to 'Data Feed', s3_csv_download_url(result.identifier, result.file_name) %>
             <% end %>
           </td>
           <td><%= link_to result.identifier, admin_amr_data_feed_config_path(id: result.amr_data_feed_config_id) %></td>

--- a/app/views/admin/reports/meter_loading_reports/index.html.erb
+++ b/app/views/admin/reports/meter_loading_reports/index.html.erb
@@ -44,12 +44,10 @@
           <td><%= result.parsed_date %></td>
           <td>
             <% if result.imported || result.source_type == 2 %>
-              result.file_name
+              <%= result.file_name %>
             <% else %>
               <%= link_to result.file_name, s3_csv_download_url(result.identifier, result.file_name) %>
             <% end %>
-
-            <%= result.file_name %>
           </td>
           <td>
             <% if result.imported %>

--- a/app/views/admin/reports/meter_loading_reports/index.html.erb
+++ b/app/views/admin/reports/meter_loading_reports/index.html.erb
@@ -1,7 +1,7 @@
 <h1>Meter Loading Report</h1>
 
 <p>
-  Find the most recent 30 days of readings for a meter to identify the source of each reading.
+  View the most readings for a meter to identify the source of each reading.
 </p>
 
 <%= simple_form_for admin_reports_meter_loading_reports_path, method: :get, html: { class: 'form' } do |f| %>
@@ -25,8 +25,13 @@
 </p>
 
 <% if @results.any? %>
+  <div class="d-flex justify-content-center pt-4">
+    <%= render partial: 'shared/pagy/bootstrap_nav', locals: { pagy: @pagy } %>
+  </div>
+
   <table class="table advice-table mt-4">
     <thead>
+      <th>Loaded</th>
       <th>Reading date</th>
       <th>File name</th>
       <th>Load Type</th>
@@ -36,17 +41,18 @@
     <tbody>
       <% @results.each do |result| %>
         <tr>
-          <td><%= result['parsed_date'] %></td>
-          <td><%= result['file_name'] %></td>
+          <td><%= result.created_at.iso8601 %></td>
+          <td><%= result.parsed_date %></td>
+          <td><%= result.file_name %></td>
           <td>
-            <% if result['manual_import'] %>
+            <% if result.imported %>
               Manual
             <% else %>
-              <%= link_to 'Automated', s3_csv_download_url(result['identifier'], result['file_name']) %>
+              <%= link_to 'Automated', s3_csv_download_url(result.identifier, result.file_name) %>
             <% end %>
           </td>
-          <td><%= link_to result['identifier'], admin_amr_data_feed_config_path(id: result['config_id']) %></td>
-          <td><%= result['reading_date'] %></td>
+          <td><%= link_to result.identifier, admin_amr_data_feed_config_path(id: result.amr_data_feed_config_id) %></td>
+          <td><%= result.reading_date %></td>
         </tr>
       <% end %>
     </tbody>

--- a/app/views/admin/reports/meter_loading_reports/index.html.erb
+++ b/app/views/admin/reports/meter_loading_reports/index.html.erb
@@ -1,0 +1,54 @@
+<h1>Meter Loading Report</h1>
+
+<p>
+  Find the most recent 30 days of readings for a meter to identify the source of each reading.
+</p>
+
+<%= simple_form_for admin_reports_meter_loading_reports_path, method: :get, html: { class: 'form' } do |f| %>
+  <%= f.input :mpxn, label: 'MPAN/MPRN', autofocus: true, input_html: { name: :mpxn, value: params[:mpxn] } %>
+  <%= f.submit :Search, class: 'btn btn-primary' %>
+<% end %>
+
+<ul>
+  <li>Reading date - date of reading as interpreted by the system</li>
+  <li>File name - the name of the latest file to provide readings on this date. For feeds that send partial readings, the
+  data might have been compiled from several CSV files.</li>
+  <li>Load type - whether this was a manual or automated upload. Downloads of CSV files are only available for automated uploads</li>
+  <li>Config - the data feed config used to load the data</li>
+  <li>Original date - the reading date as provided in the CSV file. Useful in case there are date format issues in the CSV files</li>
+</ul>
+
+<p>
+  Note: some automated feeds send files with the same name. We only store the latest version of each file, so its possible that
+  the linked to CSV file may contain different data if the supplier resent a file with the same name. Or, for a manual upload, an admin used the same
+  CSV file name to upload the data. We also only store downloadable CSV files for automated uploads.
+</p>
+
+<% if @results.any? %>
+  <table class="table advice-table mt-4">
+    <thead>
+      <th>Reading date</th>
+      <th>File name</th>
+      <th>Load Type</th>
+      <th>Config</th>
+      <th>Original date</th>
+    </thead>
+    <tbody>
+      <% @results.each do |result| %>
+        <tr>
+          <td><%= result['parsed_date'] %></td>
+          <td><%= result['file_name'] %></td>
+          <td>
+            <% if result['manual_import'] %>
+              Manual
+            <% else %>
+              <%= link_to 'Automated', s3_csv_download_url(result['identifier'], result['file_name']) %>
+            <% end %>
+          </td>
+          <td><%= link_to result['identifier'], admin_amr_data_feed_config_path(id: result['config_id']) %></td>
+          <td><%= result['reading_date'] %></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -670,6 +670,7 @@ Rails.application.routes.draw do
       resources :missing_alert_contacts, only: [:index]
       resources :work_allocation, only: [:index]
       resources :user_logins, only: [:index]
+      resources :meter_loading_reports, only: :index
       resource :unvalidated_readings, only: [:show]
       resource :funder_allocations, only: [:show] do
         post :deliver

--- a/spec/models/amr_data_feed_reading_spec.rb
+++ b/spec/models/amr_data_feed_reading_spec.rb
@@ -66,4 +66,76 @@ describe AmrDataFeedReading do
       end
     end
   end
+
+  describe '.meter_loading_report' do
+    subject(:results) do
+      described_class.meter_loading_report(mpan_mprn)
+    end
+
+    let(:mpan_mprn) { '2200012304567' }
+
+    let!(:reading) do
+      create(:amr_data_feed_reading, mpan_mprn: mpan_mprn, reading_date: '2024-12-25')
+    end
+
+    before do
+      create_list(:amr_data_feed_reading, 1)
+    end
+
+    context 'with an imported csv' do
+      it 'returns the selected columns' do
+        expect(results.size).to eq(1)
+        expect(results.first.file_name).to eq(reading.amr_data_feed_import_log.file_name)
+        expect(results.first.parsed_date).to eq(Date.parse('2024-12-25'))
+        expect(results.first.identifier).to eq(reading.amr_data_feed_config.identifier)
+        expect(results.first.imported).to be_nil
+      end
+    end
+
+    context 'with a manually uploaded csv' do
+      let!(:amr_uploaded_reading) do
+        create(:amr_uploaded_reading,
+          amr_data_feed_config: reading.amr_data_feed_config,
+          file_name: reading.amr_data_feed_import_log.file_name,
+          imported: true)
+      end
+
+      before do
+        create_list(:amr_uploaded_reading, 1,
+          amr_data_feed_config: reading.amr_data_feed_config,
+          imported: false)
+      end
+
+      it 'joins to the uploaded readings' do
+        expect(results.size).to eq(1)
+        expect(results.first.imported).to be(true)
+      end
+    end
+
+    context 'with several readings' do
+      let!(:duplicate) do
+        create(:amr_data_feed_reading, mpan_mprn: mpan_mprn, reading_date: '25/12/2024', created_at: reading.created_at - 1.day)
+      end
+
+      let!(:earlier) do
+        create(:amr_data_feed_reading, mpan_mprn: mpan_mprn, reading_date: '2024-12-24')
+      end
+
+      it 'sorts by the dates' do
+        expect(results.size).to eq(3)
+
+        expect(results.map(&:parsed_date)).to eq([
+                                                   Date.parse(reading.reading_date),
+                                                   Date.parse(duplicate.reading_date),
+                                                   Date.parse(earlier.reading_date)
+                                                 ])
+
+        expect(results.map(&:file_name)).to eq([
+                                                 reading.amr_data_feed_import_log.file_name,
+                                                 duplicate.amr_data_feed_import_log.file_name,
+                                                 earlier.amr_data_feed_import_log.file_name
+                                               ])
+      end
+    end
+  end
 end

--- a/spec/system/admin/reports/meter_loading_report_spec.rb
+++ b/spec/system/admin/reports/meter_loading_report_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+describe 'meter loading report' do
+  let!(:admin)       { create(:admin) }
+  let!(:reading)     { create(:amr_data_feed_reading, reading_date: '2024-12-25') }
+
+  before do
+    sign_in(admin)
+    visit root_path
+    click_on('Reports')
+    click_on('Meter loading report')
+  end
+
+  it 'displays the results' do
+    expect(page).to have_content('Meter Loading Report')
+
+    fill_in('mpxn', with: reading.mpan_mprn)
+    click_on 'Search'
+
+    expect(page).to have_content(reading.reading_date)
+    expect(page).to have_link(reading.amr_data_feed_import_log.file_name)
+    expect(page).to have_link(reading.amr_data_feed_config.identifier, href: admin_amr_data_feed_config_path(reading.amr_data_feed_config))
+  end
+end

--- a/spec/system/admin/reports/meter_loading_report_spec.rb
+++ b/spec/system/admin/reports/meter_loading_report_spec.rb
@@ -5,6 +5,7 @@ describe 'meter loading report' do
   let!(:reading)     { create(:amr_data_feed_reading, reading_date: '2024-12-25') }
 
   before do
+    allow_any_instance_of(S3Helper).to receive(:s3_csv_download_url).and_return('https://example.org')
     sign_in(admin)
     visit root_path
     click_on('Reports')
@@ -18,7 +19,7 @@ describe 'meter loading report' do
     click_on 'Search'
 
     expect(page).to have_content(reading.reading_date)
-    expect(page).to have_link(reading.amr_data_feed_import_log.file_name)
+    expect(page).to have_link(reading.amr_data_feed_import_log.file_name, href: 'https://example.org')
     expect(page).to have_link(reading.amr_data_feed_config.identifier, href: admin_amr_data_feed_config_path(reading.amr_data_feed_config))
   end
 end


### PR DESCRIPTION
Adds a new admin report to summarise the loading activity for a specific meter.

Debugging loading issues for individual meters is tricky as you need to look across the original CSV files, the unvalidated readings and the loading logs in the database. Naming conventions for CSV files from suppliers are not obvious so can take a while to find out which files contain which data for which meters and when those were processed.

This report allows an admin to search for an MPXN and then we summarise the recently loaded data. The report includes what reading dates were loaded, from which files and the original sources. I've used a customised query to optimise things a little. And incorporated pagy to allow looking back over historical data.

For data provided via CSV there's a link to download the original data file from S3.