### PR TITLE
Tidy and repopulate mailchimp audience

### DIFF
--- a/app/services/mailchimp_tags.rb
+++ b/app/services/mailchimp_tags.rb
@@ -4,19 +4,22 @@ class MailchimpTags
   end
 
   def tags
-    ret = []
-    if @school.percentage_free_school_meals
-      percent = @school.percentage_free_school_meals
-      if percent >= 30
-        ret << 'FSM30'
-      elsif percent >= 25
-        ret << 'FSM25'
-      elsif percent >= 20
-        ret << 'FSM20'
-      elsif percent >= 15
-        ret << 'FSM15'
-      end
+    tags_as_list.join(',')
+  end
+
+  def tags_as_list
+    tags = []
+    return tags unless @school.percentage_free_school_meals
+    percent = @school.percentage_free_school_meals
+    if percent >= 30
+      tags << 'FSM30'
+    elsif percent >= 25
+      tags << 'FSM25'
+    elsif percent >= 20
+      tags << 'FSM20'
+    elsif percent >= 15
+      tags << 'FSM15'
     end
-    ret.join(',')
+    tags
   end
 end

--- a/app/services/marketing/mailchimp_csv_exporter.rb
+++ b/app/services/marketing/mailchimp_csv_exporter.rb
@@ -1,0 +1,135 @@
+module Marketing
+  class MailchimpCsvExporter
+    # hash of four categories, each containing a list of MailchimpContact
+    attr_reader :updated_audience, :new_nonsubscribed
+
+    # List of hashed fields from Mailchimp
+    def initialize(subscribed:, nonsubscribed:, cleaned:, unsubscribed:)
+      @audience = {}
+      @updated_audience = { subscribed: [], nonsubscribed: [], cleaned: [], unsubscribed: [] }
+      @new_nonsubscribed = []
+      populate_audience(subscribed: subscribed, nonsubscribed: nonsubscribed, cleaned: cleaned, unsubscribed: unsubscribed)
+    end
+
+    def perform
+      match_and_update_contacts
+      # Process remaining audience that aren't in the database
+      # relies on matches being deleted in previous step
+      process_remaining_contacts
+    end
+
+    private
+
+    def match_and_update_contacts
+      # Ignore pupils and school onboarding users
+      User.where.not(role: [:pupil, :school_onboarding]).find_each do |user|
+        if in_mailchimp_audience?(user)
+          mailchimp_contact_type = mailchimp_contact_type(user.email)
+          # remove matches
+          contact = @audience[mailchimp_contact_type].delete(user.email)
+          # update user
+          @updated_audience[mailchimp_contact_type] << user_to_mailchimp(user, contact)
+        else
+          @new_nonsubscribed << user_to_mailchimp(user)
+        end
+      end
+    end
+
+    def process_remaining_contacts
+      @audience.each do |category, contacts|
+        updated_audience[category] = updated_audience[category] + contacts.map {|c| process_contact(c) }
+      end
+    end
+
+    # convert User to mailchimp contact, preserving exiting fields if given
+    # TODO
+    def user_to_mailchimp(user, existing_contact = nil)
+      contact = ActiveSupport::OrderedOptions.new
+      contact.email_address = user.email
+      contact.name = user.name
+      contact.contact_source = 'User'
+      contact.confirmed_date = user.confirmed_at.to_date.iso8601
+      contact.user_role = user.role.humanize
+      contact.locale = user.preferred_locale
+
+      # TODO naming
+      if existing_contact && existing_contact[:interests]
+        # If this is present then we're updating an existing contact that should
+        # have Newsletter set already
+        contact.interests = existing_contact[:interests]
+      else
+        contact.interests = 'Newsletter'
+      end
+
+      # TODO cluster users
+      if user.school.present?
+        contact.staff_role = user&.staff_role&.title
+        contact.alert_subscriber = user.contacts.for_school(user.school).any? ? 'Yes' : 'No'
+        contact.school = user.school&.name
+        contact.school_status = if user.school.deleted?
+                                  'Deleted'
+                                elsif user.school.archived?
+                                  'Archived'
+                                else
+                                  'Active'
+                                end
+        contact.scoreboard = user.school&.scoreboard&.name
+        contact.school_group = user.school&.school_group&.name
+        contact.local_authority = user.school&.local_authority_area&.name
+        contact.region = user.school&.region&.humanize
+        contact.country = user.school.country&.humanize
+        contact.funder = user.school&.funder&.name
+
+        existing_tags = non_free_school_meal_tags(existing_contact)
+        if existing_tags.any?
+          contact.tags = "#{existing_tags.join(',')},#{MailchimpTags.new(user.school).tags}"
+        else
+          contact.tags = MailchimpTags.new(user.school).tags
+        end
+      elsif user.group_admin?
+        contact.alert_subscriber = 'No'
+        contact.scoreboard = user.school_group&.default_scoreboard&.name
+        contact.school_group = user.school_group&.name
+        contact.country = user.school_group&.default_country&.humanize
+        contact.tags = existing_contact[:tags] if existing_contact
+      end
+      contact
+    end
+
+    def non_free_school_meal_tags(existing_contact)
+      return [] unless existing_contact.present? && existing_contact[:tags].present?
+      existing_contact[:tags].split(',').reject {|t| t.match?(/FSM/) }
+    end
+
+    # TODO: may need to work before/after schema changes?
+    def process_contact(contact)
+    end
+
+    def in_mailchimp_audience?(user)
+      !mailchimp_contact_type(user.email).nil?
+    end
+
+    def mailchimp_contact_type(email_address)
+      @audience.each do |category, hash|
+        return category if hash.key?(email_address)
+      end
+      nil
+    end
+
+    def mailchimp_contact(email_address)
+      mailchimp_contact_type = mailchimp_contact_type(email_address)
+      return nil if mailchimp_contact_type.nil?
+      @audience[mailchimp_contact_type][email_address]
+    end
+
+    def populate_audience(**categories)
+      categories.each do |category, list|
+        @audience[category] = list_to_hash(list)
+      end
+    end
+
+    def list_to_hash(list)
+      list.index_by {|c| c[:email_address].downcase}
+    end
+  end
+end

--- a/app/services/marketing/mailchimp_csv_exporter.rb
+++ b/app/services/marketing/mailchimp_csv_exporter.rb
@@ -62,7 +62,7 @@ module Marketing
           # update user
           @updated_audience[mailchimp_contact_type] << to_mailchimp_contact(user, contact)
         else
-          @new_nonsubscribed << to_mailchimp_contact(user)
+          @new_nonsubscribed << to_mailchimp_contact(user, newsletter_subscriber: false)
         end
       end
     end
@@ -75,7 +75,7 @@ module Marketing
     end
 
     # convert User to Mailchimp contact, preserving exiting fields if given
-    def to_mailchimp_contact(user, existing_contact = nil)
+    def to_mailchimp_contact(user, existing_contact = nil, newsletter_subscriber: true)
       contact = ActiveSupport::OrderedOptions.new
       contact.email_address = user.email
       contact.name = user.name
@@ -89,7 +89,7 @@ module Marketing
         # If this is present then we're updating an existing contact that should
         # have Newsletter set already
         contact.interests = existing_contact[:interests]
-      else
+      elsif newsletter_subscriber
         contact.interests = 'Newsletter'
       end
 

--- a/app/services/marketing/mailchimp_csv_exporter.rb
+++ b/app/services/marketing/mailchimp_csv_exporter.rb
@@ -171,16 +171,19 @@ module Marketing
       # TODO naming
       contact.interests = existing_contact[:interests] || 'Newsletter'
 
-      # Build combined name field if possible
-      if existing_contact[:name].present?
+      first_and_last_name_fields = existing_contact[:first_name] && existing_contact[:last_name]
+      first_and_name_fields = existing_contact[:first_name] && existing_contact[:name] && !existing_contact[:name].include?(existing_contact[:first_name])
+
+      if first_and_last_name_fields # older Mailchimp only fields
+        contact.name = [existing_contact[:first_name], existing_contact[:last_name]].join(' ')
+      elsif first_and_name_fields # some users have entered first/last names into the first_name and name fields
+        contact.name = [existing_contact[:first_name], existing_contact[:name]].join(' ')
+      elsif existing_contact[:name] # if set, this is usually full name
         contact.name = existing_contact[:name]
-      else
-        both_fields = existing_contact[:first_name] && existing_contact[:last_name]
-        join = both_fields ? ' ' : ''
-        contact.name = [existing_contact[:first_name], existing_contact[:last_name]].join(join)
+      else # combine whatever name fields we have
+        contact.name = [existing_contact[:first_name], existing_contact[:last_name]].join('')
       end
 
-      # TODO: there are some historical fields, may need to rename those and check all of them? This is likely to be the current User type field
       contact.staff_role = existing_contact[:staff_role] || existing_contact[:user_type]
       contact.school = existing_contact[:school] || existing_contact[:school_or_organisation]
 

--- a/app/services/marketing/mailchimp_csv_exporter.rb
+++ b/app/services/marketing/mailchimp_csv_exporter.rb
@@ -94,12 +94,15 @@ module Marketing
       end
 
       if user.group_admin?
+        contact.alert_subscriber = user.contacts.any? ? 'Yes' : 'No'
         contact.scoreboard = user.school_group&.default_scoreboard&.name
         contact.school_group = user.school_group&.name
         contact.country = user.school_group&.default_country&.humanize
         contact.tags = non_fsm_tags(existing_contact).join(',')
       elsif user.school_admin? && user.has_other_schools?
         contact.user_role = 'Cluster admin'
+        contact.staff_role = user&.staff_role&.title
+        contact.alert_subscriber = user.contacts.any? ? 'Yes' : 'No'
         contact.scoreboard = user.school.school_group&.default_scoreboard&.name
         contact.school_group = user.school.school_group&.name
         contact.country = user.school.school_group&.default_country&.humanize
@@ -161,7 +164,7 @@ module Marketing
       contact.email_address = existing_contact[:email_address]
       contact.contact_source = 'Organic'
       contact.locale = 'en'
-      contact.tags = existing_contact[:tags]
+      contact.tags = non_fsm_tags(existing_contact).join(',')
 
       # If this is present then we're updating an existing contact that should
       # have Newsletter set already

--- a/app/services/marketing/mailchimp_csv_exporter.rb
+++ b/app/services/marketing/mailchimp_csv_exporter.rb
@@ -94,14 +94,12 @@ module Marketing
       end
 
       if user.group_admin?
-        contact.alert_subscriber = 'No'
         contact.scoreboard = user.school_group&.default_scoreboard&.name
         contact.school_group = user.school_group&.name
         contact.country = user.school_group&.default_country&.humanize
         contact.tags = non_fsm_tags(existing_contact).join(',')
       elsif user.school_admin? && user.has_other_schools?
         contact.user_role = 'Cluster admin'
-        contact.alert_subscriber = 'No'
         contact.scoreboard = user.school.school_group&.default_scoreboard&.name
         contact.school_group = user.school.school_group&.name
         contact.country = user.school.school_group&.default_country&.humanize

--- a/lib/tasks/marketing/mailchimp_csv_export.rake
+++ b/lib/tasks/marketing/mailchimp_csv_export.rake
@@ -1,0 +1,58 @@
+namespace :marketing do
+  desc "Schools set countries"
+  task :mailchimp_csv_export, [:dir] => :environment do |t,args|
+    puts "Loading from #{args.dir}"
+
+    audience = {}
+    [:subscribed, :unsubscribed, :nonsubscribed, :cleaned].each do |category|
+      file = Dir.glob("#{category}*", base: args.dir).first
+      audience[category] = CSV.read("#{args.dir}/#{file}", headers: true, header_converters: :symbol)
+    end
+
+    service = Marketing::MailchimpCsvExporter.new(**audience)
+    puts "#{DateTime.now.utc} Fetching data"
+
+    service.perform
+
+    puts "#{DateTime.now.utc} Exporting data"
+
+    headers = [
+      :email_address,
+      :name,
+      :locale,
+      :contact_source,
+      :confirmed_date,
+      :user_role,
+      :staff_role,
+      :alert_subscriber,
+      :school,
+      :school_status,
+      :school_group,
+      :local_authority,
+      :region,
+      :country,
+      :scoreboard,
+      :funder,
+      :interests,
+      :tags
+    ]
+
+    service.updated_audience.each do |category,contacts|
+      CSV.open("#{args.dir}/updated-#{category}.csv", "w") do |csv|
+        csv << headers
+        contacts.each do |contact|
+          csv << headers.map { |f| contact[f] }
+        end
+      end
+    end
+
+    CSV.open("#{args.dir}/new-nonsubscribed.csv", "w") do |csv|
+      csv << headers
+      service.new_nonsubscribed.each do |contact|
+        csv << headers.map { |f| contact[f] }
+      end
+    end
+
+    puts "#{DateTime.now.utc} Mailchimp CSV Export Complete"
+  end
+end

--- a/lib/tasks/marketing/mailchimp_csv_export.rake
+++ b/lib/tasks/marketing/mailchimp_csv_export.rake
@@ -39,7 +39,7 @@ namespace :marketing do
 
     service.updated_audience.each do |category,contacts|
       CSV.open("#{args.dir}/updated-#{category}.csv", "w") do |csv|
-        csv << headers
+        csv << headers.map(&:humanize)
         contacts.each do |contact|
           csv << headers.map { |f| contact[f] }
         end
@@ -47,7 +47,7 @@ namespace :marketing do
     end
 
     CSV.open("#{args.dir}/new-nonsubscribed.csv", "w") do |csv|
-      csv << headers
+      csv << headers.map(&:humanize)
       service.new_nonsubscribed.each do |contact|
         csv << headers.map { |f| contact[f] }
       end

--- a/lib/tasks/marketing/mailchimp_csv_export.rake
+++ b/lib/tasks/marketing/mailchimp_csv_export.rake
@@ -39,7 +39,7 @@ namespace :marketing do
 
     service.updated_audience.each do |category,contacts|
       CSV.open("#{args.dir}/updated-#{category}.csv", "w") do |csv|
-        csv << headers.map(&:humanize)
+        csv << headers.map(&:to_s).map(&:humanize)
         contacts.each do |contact|
           csv << headers.map { |f| contact[f] }
         end
@@ -47,7 +47,7 @@ namespace :marketing do
     end
 
     CSV.open("#{args.dir}/new-nonsubscribed.csv", "w") do |csv|
-      csv << headers.map(&:humanize)
+      csv << headers.map(&:to_s).map(&:humanize)
       service.new_nonsubscribed.each do |contact|
         csv << headers.map { |f| contact[f] }
       end

--- a/spec/factories/school_groups_factory.rb
+++ b/spec/factories/school_groups_factory.rb
@@ -3,6 +3,12 @@ FactoryBot.define do
     sequence(:name) {|n| "School group #{n}"}
     public { true }
 
+    trait :with_default_scoreboard do
+      after(:create) do |school_group, _evaluator|
+        school_group.update(default_scoreboard: create(:scoreboard))
+      end
+    end
+
     trait :with_active_schools do
       transient do
         count { 1 }

--- a/spec/factories/schools_factory.rb
+++ b/spec/factories/schools_factory.rb
@@ -30,6 +30,18 @@ FactoryBot.define do
       end
     end
 
+    trait :with_scoreboard do
+      after(:create) do |school, _evaluator|
+        school.update(scoreboard: create(:scoreboard))
+      end
+    end
+
+    trait :with_local_authority do
+      after(:create) do |school, _evaluator|
+        school.update(local_authority_area: create(:local_authority_area))
+      end
+    end
+
     trait :archived do
       active { false }
       removal_date { nil }

--- a/spec/factories/users_factory.rb
+++ b/spec/factories/users_factory.rb
@@ -75,5 +75,11 @@ FactoryBot.define do
         user.skip_confirmation_notification!
       end
     end
+
+    trait :subscribed_to_alerts do
+      after(:build) do |user, _evaluator|
+        user.contacts << create(:contact_with_name_email_phone, school: user.school)
+      end
+    end
   end
 end

--- a/spec/services/marketing/mailchimp_csv_exporter_spec.rb
+++ b/spec/services/marketing/mailchimp_csv_exporter_spec.rb
@@ -283,6 +283,18 @@ describe Marketing::MailchimpCsvExporter do
       it_behaves_like 'it correctly creates a contact'
     end
 
+    context 'with an unconfirmed user' do
+      let!(:user) { create(:school_admin, confirmed_at: nil) }
+
+      before do
+        service.perform
+      end
+
+      it 'ignores the user' do
+        expect(service.new_nonsubscribed).to be_empty
+      end
+    end
+
     context 'with a pupil' do
       let!(:user) { create(:pupil) }
 

--- a/spec/services/marketing/mailchimp_csv_exporter_spec.rb
+++ b/spec/services/marketing/mailchimp_csv_exporter_spec.rb
@@ -1,0 +1,210 @@
+require 'rails_helper'
+
+describe Marketing::MailchimpCsvExporter do
+  subject(:service) do
+    described_class.new(subscribed: subscribed, nonsubscribed: nonsubscribed, unsubscribed: unsubscribed, cleaned: cleaned)
+  end
+
+  let(:subscribed) { [] }
+  let(:nonsubscribed) { [] }
+  let(:unsubscribed) { [] }
+  let(:cleaned) { [] }
+
+  def create_contact(email_address, **fields)
+    contact = ActiveSupport::OrderedOptions.new
+    contact.email_address = email_address
+    fields.each do |keyword, value|
+      contact[keyword] = value
+    end
+    contact
+  end
+
+  shared_examples 'it correctly creates a contact' do |school_user: false, group_admin: false|
+    it 'populates the common fields' do
+      expect(contact.email_address).to eq user.email
+      expect(contact.name).to eq user.name
+      expect(contact.contact_source).to eq 'User'
+      expect(contact.confirmed_date).to eq user.confirmed_at.to_date.iso8601
+      expect(contact.user_role).to eq user.role.humanize
+      expect(contact.locale).to eq user.preferred_locale
+      expect(contact.interests).to eq 'Newsletter'
+    end
+
+    it 'populates school user fields', if: school_user do
+      expect(contact.staff_role).to eq user.staff_role.title
+      expect(contact.alert_subscriber).to eq 'No'
+      expect(contact.school_status).to eq 'Active'
+      expect(contact.school).to eq user.school.name
+      expect(contact.school_group).to eq user.school.school_group.name
+      expect(contact.country).to eq user.school.country.humanize
+      expect(contact.scoreboard).to eq user.school.scoreboard.name
+      expect(contact.local_authority).to eq user.school.local_authority_area.name
+      expect(contact.region).to eq user.school.region.humanize
+    end
+
+    it 'populates group admin fields', if: group_admin do
+      expect(contact.staff_role).to be_nil
+      expect(contact.alert_subscriber).to eq 'No'
+      expect(contact.school_status).to be_nil
+      expect(contact.school).to be_nil
+      expect(contact.scoreboard).to eq user.school_group.default_scoreboard.name
+      expect(contact.school_group).to eq user.school_group.name
+      expect(contact.local_authority).to be_nil
+      expect(contact.region).to be_nil
+      expect(contact.country).to eq user.school_group.default_country.humanize
+    end
+  end
+
+  context 'when all the contacts are Users' do
+    let(:subscribed) do
+      [create_contact(user.email)]
+    end
+
+    let(:contact) do
+      service.updated_audience[:subscribed].first
+    end
+
+    context 'with a school admin' do
+      let!(:school) { create(:school, :with_school_group, :with_scoreboard, :with_local_authority, region: :east_midlands, percentage_free_school_meals: 35) }
+      let!(:user) { create(:school_admin, school: school) }
+
+      before do
+        service.perform
+      end
+
+      it 'matches the contact' do
+        expect(service.updated_audience[:subscribed].length).to eq(1)
+      end
+
+      it_behaves_like 'it correctly creates a contact', school_user: true
+
+      it 'populates tags' do
+        expect(contact.tags).to eq('FSM30')
+      end
+
+      context 'with existing interests' do
+        let(:subscribed) do
+          [create_contact(user.email, interests: 'Newsletter,Others')]
+        end
+
+        it 'preserves the interests' do
+          expect(contact.interests).to eq('Newsletter,Others')
+        end
+      end
+
+      context 'with existing non free school meal tags' do
+        let(:subscribed) do
+          [create_contact(user.email, tags: 'external support')]
+        end
+
+        it 'preserves the tags' do
+          expect(contact.tags).to eq('external support,FSM30')
+        end
+      end
+
+      context 'with existing free school meal tags' do
+        let(:subscribed) do
+          [create_contact(user.email, tags: 'FSM10')]
+        end
+
+        it 'overwrites the tags' do
+          expect(contact.tags).to eq('FSM30')
+        end
+      end
+
+      context 'with mixed case email' do
+        let(:subscribed) do
+          [create_contact(user.email.upcase)]
+        end
+
+        it_behaves_like 'it correctly creates a contact', school_user: true
+      end
+
+      context 'with archived school' do
+        let!(:school) { create(:school, :with_school_group, :with_scoreboard, :with_local_authority, :archived, region: :east_midlands) }
+
+        it 'uses correct status' do
+          expect(contact.school_status).to eq 'Archived'
+        end
+      end
+
+      context 'when subscribed to alerts' do
+        let!(:user) { create(:school_admin, :subscribed_to_alerts, school: school) }
+
+        it 'uses correct status' do
+          expect(contact.alert_subscriber).to eq 'Yes'
+        end
+      end
+
+      context 'when user is unsubscribed' do
+        let(:unsubscribed) do
+          [create_contact(user.email)]
+        end
+        let(:subscribed) { [] }
+
+        let(:contact) do
+          service.updated_audience[:unsubscribed].first
+        end
+
+        it 'preserves the category' do
+          expect(service.updated_audience[:subscribed].length).to eq(0)
+          expect(service.updated_audience[:unsubscribed].length).to eq(1)
+        end
+
+        it_behaves_like 'it correctly creates a contact', school_user: true
+      end
+    end
+
+    context 'with a group admin' do
+      let!(:user) { create(:group_admin, school_group: create(:school_group, :with_default_scoreboard)) }
+
+      before do
+        service.perform
+      end
+
+      it_behaves_like 'it correctly creates a contact', group_admin: true
+    end
+
+    context 'with a cluster admin' do
+      it 'populates the fields correctly'
+    end
+
+    context 'with an admin' do
+      let!(:user) { create(:admin) }
+
+      before do
+        service.perform
+      end
+
+      it_behaves_like 'it correctly creates a contact'
+    end
+  end
+
+  context 'when contacts are not Users' do
+    context 'with a pre-migration contact' do
+      it 'populates the fields correctly'
+
+      context 'with existing groups' do
+        it 'preserves the groups'
+      end
+    end
+
+    context 'with a post-migration contact' do
+      it 'populates the fields correctly'
+    end
+  end
+
+  context 'when there contacts that are Users and some that are not' do
+    it 'creates contacts for both'
+
+    context 'with a pupil' do
+      let!(:user) { create(:pupil) }
+
+      it 'ignores the user'
+    end
+
+    context 'with a school onboarding user' do
+      it 'ignores the user'
+    end
+  end
+end

--- a/spec/services/marketing/mailchimp_csv_exporter_spec.rb
+++ b/spec/services/marketing/mailchimp_csv_exporter_spec.rb
@@ -248,11 +248,61 @@ describe Marketing::MailchimpCsvExporter do
       it 'copies tags, stripping free school meal tags' do
         expect(contact.tags).to eq 'trustee,external support'
       end
+
+      context 'with name and first name only' do
+        let(:subscribed) do
+          [create_contact('user@example.org', first_name: 'John', name: 'Smith')]
+        end
+
+        it 'builds the name correctly' do
+          expect(contact.name).to eq 'John Smith'
+        end
+      end
+
+      context 'with name only' do
+        let(:subscribed) do
+          [create_contact('user@example.org', name: 'John Smith')]
+        end
+
+        it 'builds the name correctly' do
+          expect(contact.name).to eq 'John Smith'
+        end
+      end
+
+      context 'with first name and name overlapping' do
+        let(:subscribed) do
+          [create_contact('user@example.org', name: 'John Smith', first_name: 'John')]
+        end
+
+        it 'builds the name correctly' do
+          expect(contact.name).to eq 'John Smith'
+        end
+      end
+
+      context 'with first name only' do
+        let(:subscribed) do
+          [create_contact('user@example.org', first_name: 'John')]
+        end
+
+        it 'builds the name correctly' do
+          expect(contact.name).to eq 'John'
+        end
+      end
+
+      context 'with last name only' do
+        let(:subscribed) do
+          [create_contact('user@example.org', last_name: 'Smith')]
+        end
+
+        it 'builds the name correctly' do
+          expect(contact.name).to eq 'Smith'
+        end
+      end
     end
 
     context 'with a post-migration contact' do
       let(:subscribed) do
-        [create_contact('user@example.org', name: 'John Smith', first_name: 'John', last_name: 'XSmith', school: 'DfE', user_type: 'School management', school_group: 'Unity Schools Partnership', school_or_organisation: 'XDfE', other_la: 'Xbhcc', other_mat: 'XUnity Schools Partnership', local_authority_and_mats: 'Other', tags: 'trustee,external support')]
+        [create_contact('user@example.org', name: 'John Smith', first_name: 'John', last_name: 'Smith', school: 'DfE', user_type: 'School management', school_group: 'Unity Schools Partnership', school_or_organisation: 'XDfE', other_la: 'Xbhcc', other_mat: 'XUnity Schools Partnership', local_authority_and_mats: 'Other', tags: 'trustee,external support')]
       end
 
       it 'populates the fields correctly' do

--- a/spec/services/marketing/mailchimp_csv_exporter_spec.rb
+++ b/spec/services/marketing/mailchimp_csv_exporter_spec.rb
@@ -19,6 +19,16 @@ describe Marketing::MailchimpCsvExporter do
     contact
   end
 
+  shared_examples 'it adds interests correctly' do |newsletter: true|
+    it 'adds Newsletter', if: newsletter do
+      expect(contact.interests).to eq 'Newsletter'
+    end
+
+    it 'does not add Newsletter', unless: newsletter do
+      expect(contact.interests).to be_nil
+    end
+  end
+
   shared_examples 'it correctly creates a contact' do |school_user: false, group_admin: false, cluster_admin: false|
     it 'populates the common fields' do
       expect(contact.email_address).to eq user.email
@@ -26,7 +36,6 @@ describe Marketing::MailchimpCsvExporter do
       expect(contact.contact_source).to eq 'User'
       expect(contact.confirmed_date).to eq user.confirmed_at.to_date.iso8601
       expect(contact.locale).to eq user.preferred_locale
-      expect(contact.interests).to eq 'Newsletter'
     end
 
     it 'populates school user fields', if: school_user do
@@ -91,6 +100,7 @@ describe Marketing::MailchimpCsvExporter do
       end
 
       it_behaves_like 'it correctly creates a contact', school_user: true
+      it_behaves_like 'it adds interests correctly'
 
       it 'populates tags' do
         expect(contact.tags.split(',')).to contain_exactly('FSM30', user.school.slug)
@@ -132,6 +142,7 @@ describe Marketing::MailchimpCsvExporter do
         end
 
         it_behaves_like 'it correctly creates a contact', school_user: true
+        it_behaves_like 'it adds interests correctly'
       end
 
       context 'with archived school' do
@@ -166,6 +177,7 @@ describe Marketing::MailchimpCsvExporter do
         end
 
         it_behaves_like 'it correctly creates a contact', school_user: true
+        it_behaves_like 'it adds interests correctly'
       end
     end
 
@@ -173,6 +185,7 @@ describe Marketing::MailchimpCsvExporter do
       let!(:user) { create(:group_admin, school_group: create(:school_group, :with_default_scoreboard)) }
 
       it_behaves_like 'it correctly creates a contact', group_admin: true
+      it_behaves_like 'it adds interests correctly'
 
       context 'when subscribed to alerts' do
         let!(:user) do
@@ -193,6 +206,7 @@ describe Marketing::MailchimpCsvExporter do
       let!(:user) { create(:school_admin, :with_cluster_schools, school: school) }
 
       it_behaves_like 'it correctly creates a contact', school_user: false, cluster_admin: true
+      it_behaves_like 'it adds interests correctly'
 
       it 'adds tags for each cluster school' do
         expect(contact.tags.split(',')).to match_array(user.cluster_schools.map(&:slug))
@@ -211,6 +225,7 @@ describe Marketing::MailchimpCsvExporter do
       let!(:user) { create(:admin) }
 
       it_behaves_like 'it correctly creates a contact'
+      it_behaves_like 'it adds interests correctly'
     end
   end
 
@@ -232,6 +247,8 @@ describe Marketing::MailchimpCsvExporter do
         expect(service.updated_audience[:subscribed].length).to eq(1)
       end
 
+      it_behaves_like 'it adds interests correctly'
+
       it 'populates the fields correctly' do
         expect(contact.email_address).to eq('user@example.org')
         expect(contact.name).to eq 'John Smith'
@@ -239,7 +256,6 @@ describe Marketing::MailchimpCsvExporter do
         expect(contact.confirmed_date).to be_nil
         expect(contact.user_role).to be_nil
         expect(contact.locale).to eq 'en'
-        expect(contact.interests).to eq 'Newsletter'
         expect(contact.staff_role).to eq 'School management'
         expect(contact.school).to eq 'DfE'
         expect(contact.school_group).to eq 'Unity Schools Partnership'
@@ -305,6 +321,8 @@ describe Marketing::MailchimpCsvExporter do
         [create_contact('user@example.org', name: 'John Smith', first_name: 'John', last_name: 'Smith', school: 'DfE', user_type: 'School management', school_group: 'Unity Schools Partnership', school_or_organisation: 'XDfE', other_la: 'Xbhcc', other_mat: 'XUnity Schools Partnership', local_authority_and_mats: 'Other', tags: 'trustee,external support')]
       end
 
+      it_behaves_like 'it adds interests correctly'
+
       it 'populates the fields correctly' do
         expect(contact.email_address).to eq('user@example.org')
         expect(contact.name).to eq 'John Smith'
@@ -312,7 +330,6 @@ describe Marketing::MailchimpCsvExporter do
         expect(contact.confirmed_date).to be_nil
         expect(contact.user_role).to be_nil
         expect(contact.locale).to eq 'en'
-        expect(contact.interests).to eq 'Newsletter'
         expect(contact.tags).to eq 'trustee,external support'
 
         expect(contact.staff_role).to eq 'School management'
@@ -334,6 +351,7 @@ describe Marketing::MailchimpCsvExporter do
       end
 
       it_behaves_like 'it correctly creates a contact', school_user: true
+      it_behaves_like 'it adds interests correctly', newsletter: false
     end
 
     context 'with a group admin' do
@@ -344,6 +362,7 @@ describe Marketing::MailchimpCsvExporter do
       end
 
       it_behaves_like 'it correctly creates a contact', group_admin: true
+      it_behaves_like 'it adds interests correctly', newsletter: false
     end
 
     context 'with an admin' do
@@ -354,6 +373,7 @@ describe Marketing::MailchimpCsvExporter do
       end
 
       it_behaves_like 'it correctly creates a contact'
+      it_behaves_like 'it adds interests correctly', newsletter: false
     end
 
     context 'with an unconfirmed user' do

--- a/spec/services/marketing/mailchimp_csv_exporter_spec.rb
+++ b/spec/services/marketing/mailchimp_csv_exporter_spec.rb
@@ -45,7 +45,7 @@ describe Marketing::MailchimpCsvExporter do
     it 'populates cluster admin fields', if: cluster_admin do
       expect(contact.user_role).to eq 'Cluster admin'
       expect(contact.staff_role).to be_nil
-      expect(contact.alert_subscriber).to eq 'No'
+      expect(contact.alert_subscriber).to be_nil
       expect(contact.school_status).to be_nil
       expect(contact.school).to be_nil
       expect(contact.scoreboard).to eq user.school.school_group.default_scoreboard.name
@@ -58,7 +58,7 @@ describe Marketing::MailchimpCsvExporter do
     it 'populates group admin fields', if: group_admin do
       expect(contact.user_role).to eq user.role.humanize
       expect(contact.staff_role).to be_nil
-      expect(contact.alert_subscriber).to eq 'No'
+      expect(contact.alert_subscriber).to be_nil
       expect(contact.school_status).to be_nil
       expect(contact.school).to be_nil
       expect(contact.scoreboard).to eq user.school_group.default_scoreboard.name

--- a/spec/services/marketing/mailchimp_csv_exporter_spec.rb
+++ b/spec/services/marketing/mailchimp_csv_exporter_spec.rb
@@ -182,15 +182,65 @@ describe Marketing::MailchimpCsvExporter do
 
   context 'when contacts are not Users' do
     context 'with a pre-migration contact' do
-      it 'populates the fields correctly'
+      let(:subscribed) do
+        [create_contact('user@example.org', first_name: 'John', last_name: 'Smith', school_or_organisation: 'DfE', user_type: 'School management', other_la: 'bhcc', other_mat: 'Unity Schools Partnership', local_authority_and_mats: 'Other', tags: 'trustee,external support')]
+      end
 
-      context 'with existing groups' do
-        it 'preserves the groups'
+      let(:contact) do
+        service.updated_audience[:subscribed].first
+      end
+
+      before do
+        service.perform
+      end
+
+      it 'retains the contact' do
+        expect(service.updated_audience[:subscribed].length).to eq(1)
+      end
+
+      it 'populates the fields correctly' do
+        expect(contact.email_address).to eq('user@example.org')
+        expect(contact.name).to eq 'John Smith'
+        expect(contact.contact_source).to eq 'Organic'
+        expect(contact.confirmed_date).to be_nil
+        expect(contact.user_role).to be_nil
+        expect(contact.locale).to eq 'en'
+        expect(contact.interests).to eq 'Newsletter'
+        expect(contact.tags).to eq 'trustee,external support'
+
+        expect(contact.staff_role).to eq 'School management'
+        expect(contact.school).to eq 'DfE'
+        expect(contact.school_group).to eq 'Unity Schools Partnership'
       end
     end
 
     context 'with a post-migration contact' do
-      it 'populates the fields correctly'
+      let(:subscribed) do
+        [create_contact('user@example.org', name: 'John Smith', first_name: 'John', last_name: 'XSmith', school: 'DfE', user_type: 'School management', school_group: 'Unity Schools Partnership', school_or_organisation: 'XDfE', user_type: 'School management', other_la: 'Xbhcc', other_mat: 'XUnity Schools Partnership', local_authority_and_mats: 'Other', tags: 'trustee,external support')]
+      end
+
+      let(:contact) do
+        service.updated_audience[:subscribed].first
+      end
+
+      before do
+        service.perform
+      end
+
+      it 'populates the fields correctly' do
+        expect(contact.email_address).to eq('user@example.org')
+        expect(contact.name).to eq 'John Smith'
+        expect(contact.contact_source).to eq 'Organic'
+        expect(contact.confirmed_date).to be_nil
+        expect(contact.user_role).to be_nil
+        expect(contact.locale).to eq 'en'
+        expect(contact.interests).to eq 'Newsletter'
+        expect(contact.tags).to eq 'trustee,external support'
+
+        expect(contact.staff_role).to eq 'School management'
+        expect(contact.school).to eq 'DfE'
+        expect(contact.school_group).to eq 'Unity Schools Partnership'
+      end
     end
   end
 


### PR DESCRIPTION
Adds a new Rake task and service to support repopulating Mailchimp audience with a better structured schema.

Rake task accepts an unzipped audience export and produces new CSV files for manual upload, one for each [Mailchimp Contact Type](https://mailchimp.com/help/about-your-contacts/) plus an additional list of users who are not currently signed up for the Newsletter.

This is first step in improving our use and integration with Mailchimp.