### PR TITLE
Remove forgery protection from JS route

### DIFF
--- a/app/controllers/comparisons/base_controller.rb
+++ b/app/controllers/comparisons/base_controller.rb
@@ -17,6 +17,8 @@ module Comparisons
     helper_method :footnote_cache
     helper_method :unlisted_message
 
+    protect_from_forgery except: :unlisted
+
     def index
       respond_to do |format|
         format.html do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -83,7 +83,7 @@ Rails.application.routes.draw do
   end
 
   concern :unlisted do
-    get :unlisted, on: :collection
+    get :unlisted, on: :collection, :defaults => { :format => 'js' }
   end
 
   namespace :comparisons do


### PR DESCRIPTION
We are getting 2 Rollbar errors from the `:unlisted` concern for comparison reports.

`HEAD` requests without an `Accept` header are triggering `ActionController::UnknownFormat` as the controller can't determine the format. So adding a default format to the routes file.

`GET` requests on the production server are returning an `ActionController::InvalidCrossOriginRequest` because of the request for a JS format. These seem to be crawler requests, rather than users clicking on the modal that this route populates.

Fixed by removing forgery protection from the specific route. This should be safe as there's no user specific content in what is returned, just JS that inlines some HTML. No URL params are included.

