### PR TITLE
Fix gas cost chart when there is a single meter

### DIFF
--- a/app/views/schools/advice/electricity_costs/_analysis.html.erb
+++ b/app/views/schools/advice/electricity_costs/_analysis.html.erb
@@ -45,6 +45,6 @@
     show_school_total: true,
     fuel_type: @advice_page.fuel_type %>
   <% if @analysis_dates.months_of_data > 23 %>
-    <%= render 'cost_comparison', school: @school, analysis_dates: @analysis_dates %>
+    <%= render 'cost_comparison', school: @school, analysis_dates: @analysis_dates, mpan_mprn: @aggregate_meter_mpan_mprn %>
   <% end %>
 <% end %>

--- a/app/views/schools/advice/electricity_costs/_cost_comparison.html.erb
+++ b/app/views/schools/advice/electricity_costs/_cost_comparison.html.erb
@@ -1,6 +1,6 @@
 <%= render 'schools/advice/section_title', section_id: 'comparison', section_title: advice_t('electricity_costs.analysis.comparison.title') %>
 
-<%= component 'chart', chart_type: :electricity_cost_comparison_last_2_years_accounting, school: school do |c| %>
+<%= component 'chart', chart_type: :electricity_cost_comparison_last_2_years_accounting, school: school, chart_config: create_chart_config(school, :electricity_cost_comparison_last_2_years_accounting, mpan_mprn) do |c| %>
   <% c.with_title { advice_t('electricity_costs.charts.cost_comparison_last_2_years_accounting.title') } %>
   <% c.with_subtitle { advice_t('electricity_costs.charts.cost_comparison_last_2_years_accounting.subtitle_html', end_date: analysis_dates.end_date.to_fs(:es_short)) } %>
 <% end %>

--- a/app/views/schools/advice/gas_costs/_analysis.html.erb
+++ b/app/views/schools/advice/gas_costs/_analysis.html.erb
@@ -44,6 +44,6 @@
     aggregate_meter_mpan_mprn: @aggregate_meter_mpan_mprn,
     show_school_total: true %>
   <% if @analysis_dates.months_of_data > 23 %>
-    <%= render 'cost_comparison', school: @school, analysis_dates: @analysis_dates %>
+    <%= render 'cost_comparison', school: @school, analysis_dates: @analysis_dates, mpan_mprn: @aggregate_meter_mpan_mprn %>
   <% end %>
 <% end %>

--- a/app/views/schools/advice/gas_costs/_cost_comparison.html.erb
+++ b/app/views/schools/advice/gas_costs/_cost_comparison.html.erb
@@ -1,6 +1,6 @@
 <%= render 'schools/advice/section_title', section_id: 'comparison', section_title: advice_t('gas_costs.analysis.comparison.title') %>
 
-<%= component 'chart', chart_type: :electricity_cost_comparison_last_2_years_accounting, school: school do |c| %>
+<%= component 'chart', chart_type: :electricity_cost_comparison_last_2_years_accounting, school: school, chart_config: create_chart_config(school, :electricity_cost_comparison_last_2_years_accounting, mpan_mprn) do |c| %>
   <% c.with_title { advice_t('gas_costs.charts.cost_comparison_last_2_years_accounting.title') } %>
   <% c.with_subtitle { advice_t('gas_costs.charts.cost_comparison_last_2_years_accounting.subtitle_html', end_date: analysis_dates.end_date.to_fs(:es_short)) } %>
 <% end %>


### PR DESCRIPTION
Testing #4123 I noticed a long standing issue with the gas costs chart.

The issue only affects schools with a single gas meter and only on the 2 year comparison chart.

The cost pages use charts named with an `electricity_` prefix. The default definition of that is to show the electricity costs. However the charts override that by specifying a meter (either a real gas/electricity meter or the aggregate one), which means the charts then shows the costs for that meter.

When a school has a single meter, the 2 year comparison chart was not specifying a meter, so it was defaulting to the electricity costs.

I've fixed this by updating the partials to build a chart_config for the aggregate (gas or electricity) meter so the right values are used.

The naming is a hold-over from previous versions of these pages and ideally needs tidying up. We should do that as a separate exercise, but there's a lot of other chart configurations to tidy as well.
