### PR TITLE
Ensure automatically created solar meters are inactive on creation

### DIFF
--- a/app/services/solar/low_carbon_hub_upserter.rb
+++ b/app/services/solar/low_carbon_hub_upserter.rb
@@ -22,6 +22,7 @@ module Solar
         ) do |new_record|
           new_record.name = meter_type.to_s.humanize
           new_record.pseudo = true
+          new_record.active = false
           new_record.low_carbon_hub_installation = @low_carbon_hub_installation
         end
 

--- a/app/services/solar/solar_edge_upserter.rb
+++ b/app/services/solar/solar_edge_upserter.rb
@@ -22,6 +22,7 @@ module Solar
         ) do |new_record|
           new_record.name = meter_type.to_s.humanize
           new_record.pseudo = true
+          new_record.active = false
           new_record.solar_edge_installation = @solar_edge_installation
         end
 

--- a/spec/services/solar/low_carbon_hub_upserter_spec.rb
+++ b/spec/services/solar/low_carbon_hub_upserter_spec.rb
@@ -47,10 +47,11 @@ module Solar
     let(:expected_exported_solar_pv_mpan) { "6#{mpan}".to_i }
 
     context 'with no existing meters' do
-      it 'creates new pseudo meters' do
+      it 'creates new inactive pseudo meters' do
         expect do
           LowCarbonHubUpserter.new(installation: low_carbon_hub_installation, readings: readings, import_log: import_log).perform
         end.to change(Meter, :count).by(3)
+        expect(low_carbon_hub_installation.meters.inactive.count).to be(3)
         expect(low_carbon_hub_installation.meters.solar_pv.first.mpan_mprn).to eq(expected_solar_pv_mpan)
         expect(low_carbon_hub_installation.meters.solar_pv.first.name).to eq('Solar pv')
         expect(low_carbon_hub_installation.meters.electricity.last.mpan_mprn).to eq(expected_electricity_mpan)
@@ -83,10 +84,11 @@ module Solar
       let!(:existing_pseudo_meter) { create(:electricity_meter, low_carbon_hub_installation: low_carbon_hub_installation, name: 'Existing meter', mpan_mprn: expected_electricity_mpan, school: low_carbon_hub_installation.school, pseudo: true)}
 
       context 'with all fields' do
-        it 'creates new pseudo meters where required' do
+        it 'creates new inactive pseudo meters where required' do
           expect do
             LowCarbonHubUpserter.new(installation: low_carbon_hub_installation, readings: readings, import_log: import_log).perform
           end.to change(Meter, :count).by(2)
+          expect(low_carbon_hub_installation.meters.inactive.count).to be(2)
           expect(low_carbon_hub_installation.meters.solar_pv.first.mpan_mprn).to eq(expected_solar_pv_mpan)
           expect(low_carbon_hub_installation.meters.solar_pv.first.name).to eq('Solar pv')
           expect(low_carbon_hub_installation.meters.exported_solar_pv.last.mpan_mprn).to eq(expected_exported_solar_pv_mpan)
@@ -112,10 +114,11 @@ module Solar
       context 'with no installation or pseudo flag' do
         let!(:existing_pseudo_meter) { create(:electricity_meter, low_carbon_hub_installation: nil, name: 'Existing meter', mpan_mprn: expected_electricity_mpan, school: low_carbon_hub_installation.school, pseudo: false)}
 
-        it 'creates new pseudo meters where required' do
+        it 'creates new inactive pseudo meters where required' do
           expect do
             LowCarbonHubUpserter.new(installation: low_carbon_hub_installation, readings: readings, import_log: import_log).perform
           end.to change(Meter, :count).by(2)
+          expect(low_carbon_hub_installation.meters.inactive.count).to be(2)
           expect(low_carbon_hub_installation.meters.solar_pv.first.mpan_mprn).to eq(expected_solar_pv_mpan)
           expect(low_carbon_hub_installation.meters.solar_pv.first.name).to eq('Solar pv')
           expect(low_carbon_hub_installation.meters.exported_solar_pv.last.mpan_mprn).to eq(expected_exported_solar_pv_mpan)

--- a/spec/services/solar/solar_edge_upserter_spec.rb
+++ b/spec/services/solar/solar_edge_upserter_spec.rb
@@ -23,10 +23,11 @@ module Solar
     let(:expected_exported_solar_pv_mpan) { "6#{mpan}".to_i }
 
     context 'with no existing meters' do
-      it 'creates new pseudo meters' do
+      it 'creates new inactive pseudo meters' do
         expect do
           SolarEdgeUpserter.new(solar_edge_installation: solar_edge_installation, readings: readings, import_log: import_log).perform
         end.to change(Meter, :count).by(3)
+        expect(solar_edge_installation.meters.inactive.count).to be(3)
         expect(solar_edge_installation.meters.solar_pv.first.mpan_mprn).to eq(expected_solar_pv_mpan)
         expect(solar_edge_installation.meters.solar_pv.first.name).to eq('Solar pv')
         expect(solar_edge_installation.meters.electricity.last.mpan_mprn).to eq(expected_electricity_mpan)
@@ -59,10 +60,11 @@ module Solar
       let!(:existing_pseudo_meter) { create(:electricity_meter, solar_edge_installation: solar_edge_installation, name: 'Existing meter', mpan_mprn: expected_electricity_mpan, school: solar_edge_installation.school, pseudo: true)}
 
       context 'with all fields' do
-        it 'creates new pseudo meters where required' do
+        it 'creates new inactive pseudo meters where required' do
           expect do
             SolarEdgeUpserter.new(solar_edge_installation: solar_edge_installation, readings: readings, import_log: import_log).perform
           end.to change(Meter, :count).by(2)
+          expect(solar_edge_installation.meters.inactive.count).to be(2)
           expect(solar_edge_installation.meters.solar_pv.first.mpan_mprn).to eq(expected_solar_pv_mpan)
           expect(solar_edge_installation.meters.solar_pv.first.name).to eq('Solar pv')
           expect(solar_edge_installation.meters.exported_solar_pv.last.mpan_mprn).to eq(expected_exported_solar_pv_mpan)
@@ -88,10 +90,11 @@ module Solar
       context 'with no installation or pseudo flag' do
         let!(:existing_pseudo_meter) { create(:electricity_meter, solar_edge_installation: nil, name: 'Existing meter', mpan_mprn: expected_electricity_mpan, school: solar_edge_installation.school, pseudo: false)}
 
-        it 'creates new pseudo meters where required' do
+        it 'creates new inactive pseudo meters where required' do
           expect do
             SolarEdgeUpserter.new(solar_edge_installation: solar_edge_installation, readings: readings, import_log: import_log).perform
           end.to change(Meter, :count).by(2)
+          expect(solar_edge_installation.meters.inactive.count).to be(2)
           expect(solar_edge_installation.meters.solar_pv.first.mpan_mprn).to eq(expected_solar_pv_mpan)
           expect(solar_edge_installation.meters.solar_pv.first.name).to eq('Solar pv')
           expect(solar_edge_installation.meters.exported_solar_pv.last.mpan_mprn).to eq(expected_exported_solar_pv_mpan)


### PR DESCRIPTION
We automatically create meters when importing from solar monitoring systems.

This is fine during initial setup but recently we've had some SolarEdge monitoring systems return additional data for export and electricity meters, up to 6 months after we started fetching data. Unclear if this was an API change or due to installation of new metering. 

When these meters are created it can impact how we aggregate data for the school, so its not safe to make them active by default.

PR ensures that meters are inactive by default.