### PR TITLE
Fix DCC Meter option on form

### DIFF
--- a/app/helpers/meters_helper.rb
+++ b/app/helpers/meters_helper.rb
@@ -44,4 +44,8 @@ module MetersHelper
   def options_for_perse_api
     [['None', nil], ['Half Hourly', 'half_hourly']]
   end
+
+  def options_for_dcc_meters
+    Meter.dcc_meters.transform_keys(&:capitalize)
+  end
 end

--- a/app/views/schools/meters/_form.html.erb
+++ b/app/views/schools/meters/_form.html.erb
@@ -67,10 +67,10 @@
     <% if show_dcc_fields %>
       <p class="alert alert-warning"><%= t('schools.meters.form.admin_only_features_for_n3rgy_integration') %></p>
 
-      <div class="custom-control custom-checkbox">
-        <%= form.label :dcc_meter, t('schools.meters.form.dcc_smart_meter'), class: 'custom-control-label' %>
-        <%= form.check_box :dcc_meter, { class: 'custom-control-input' }, checked_value = 'smets2',
-                           unchecked_value = 'no' %>
+      <div class="form-group">
+        <%= form.label :dcc_meter, t('schools.meters.form.dcc_smart_meter') %>
+        <%= form.select(:dcc_meter, options_for_dcc_meters, { include_blank: false }, class: 'form-control') %>
+
         <small class="form-text text-muted">
           <%= t('schools.meters.form.leave_this_blank_message') %>
         </small>

--- a/config/locales/views/schools/schools.yml
+++ b/config/locales/views/schools/schools.yml
@@ -252,7 +252,7 @@ en:
         data_source: Data source
         dcc_smart_meter: DCC Smart Meter
         editing_disabled_for_pseudo_meters: Editing disabled for pseudo meters
-        leave_this_blank_message: Leave this blank for new meters and system will check it is registered with n3rgy
+        leave_this_blank_message: Leave this as "No" for new meters and system will check it is registered with n3rgy
         meter_point_number: Meter Point Number
         meter_system: Meter system
         name: Name

--- a/spec/system/meter_management_spec.rb
+++ b/spec/system/meter_management_spec.rb
@@ -275,9 +275,10 @@ RSpec.describe 'meter management', :include_application_helper, :meters do
 
       it 'the dcc checkboxes and status are shown on the edit form' do
         click_on 'Edit'
-        check 'DCC Smart Meter'
+        expect(page).to have_select('DCC Smart Meter', selected: 'Smets2')
+        select 'Other', from: 'DCC Smart Meter'
         click_on 'Update Meter'
-        expect(meter.reload.dcc_meter).to eq('smets2')
+        expect(meter.reload.dcc_meter).to eq('other')
       end
 
       def expect_meter_reload


### PR DESCRIPTION
The DCC meter status was recently changed from a boolean to an enum.

However the meter creation and editing form was still setup as a checkbox. This meant that the status wasn't showing or updating correctly. The status was being reset to "no" after an update. I think this might also have been triggering unnecessary re-checks of the status. 

I've updated the form and the spec to ensure the values are available.