### PR TITLE
Fix missing places on dashboard

### DIFF
--- a/app/components/scoreboard_activity_component.rb
+++ b/app/components/scoreboard_activity_component.rb
@@ -17,6 +17,13 @@ class ScoreboardActivityComponent < ApplicationComponent
   end
 
   def position(school)
-    @podium.position_for(school)
+    position = scored_schools.position(school)
+    "#{position}#{position.ordinal}" unless position.nil?
+  end
+
+  private
+
+  def scored_schools
+    @scored_schools ||= @podium.scoreboard.scored_schools.with_points(always_include: @podium.school)
   end
 end

--- a/app/components/scoreboard_activity_component/scoreboard_activity_component.html.erb
+++ b/app/components/scoreboard_activity_component/scoreboard_activity_component.html.erb
@@ -15,7 +15,7 @@
         <tr>
           <% if show_positions? %>
             <td>
-              <%= position(observation.school)&.ordinal || '-' %>
+              <%= position(observation.school) || '-' %>
             </td>
           <% end %>
           <td>


### PR DESCRIPTION
The scoreboard activity component was relying on the Podium for the current school to work out the position of other schools.

But the Podium is only constructed with up to three schools, so unless the other school was in the top position it wasn't included.

This changes fixes that bug by switching to use the scored schools for the podium instead. The list is cached to avoid refetching from the database when rendering the dashboard.