### PR TITLE
Fix user destroy issues

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -63,10 +63,15 @@ class User < ApplicationRecord
 
   has_many :school_onboardings, inverse_of: :created_user, foreign_key: :created_user_id
   has_many :issues_admin_for, class_name: 'SchoolGroup', inverse_of: :default_issues_admin_user,
-                              foreign_key: :default_issues_admin_user_id, dependent: nil
+                              foreign_key: :default_issues_admin_user_id, dependent: :nullify
 
   has_many :observations_created, class_name: 'Observation', inverse_of: :created_by, dependent: :nullify
   has_many :observations_updated, class_name: 'Observation', inverse_of: :updated_by, dependent: :nullify
+  has_many :energy_tariffs_created, class_name: 'EnergyTariff', inverse_of: :created_by, dependent: :nullify
+  has_many :energy_tariffs_updated, class_name: 'EnergyTariff', inverse_of: :updated_by, dependent: :nullify
+  has_many :issues_created, class_name: 'Issue', inverse_of: :created_by, dependent: :nullify
+  has_many :issues_updated, class_name: 'Issue', inverse_of: :updated_by, dependent: :nullify
+  has_many :activities_updated, class_name: 'Activity', inverse_of: :updated_by, dependent: :nullify
 
   has_and_belongs_to_many :cluster_schools, class_name: 'School', join_table: :cluster_schools_users
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -342,15 +342,80 @@ describe User do
   end
 
   describe '#destroy' do
-    it 'allow deletion when there are linked observations' do
-      user = create(:user)
-      obs1 = create(:observation, :intervention, created_by: user)
-      obs2 = create(:observation, :intervention, created_by: create(:user), updated_by: user)
-      user.destroy
-      obs1.reload
-      expect(obs1.created_by).to be_nil
-      obs2.reload
-      expect(obs2.updated_by).to be_nil
+    shared_examples 'created by nullified on user destroy' do
+      before { user.destroy! }
+
+      it 'created_by is nullified' do
+        expect(object.reload.created_by).to be_nil
+      end
+    end
+
+    shared_examples 'updated by nullified on user destroy' do
+      before { user.destroy! }
+
+      it 'updated_by is nullified' do
+        expect(object.reload.updated_by).to be_nil
+      end
+    end
+
+    let!(:user) { create(:user) }
+
+    context 'when observation has been created by user' do
+      let!(:object) { create(:observation, :intervention, created_by: user) }
+
+      it_behaves_like 'created by nullified on user destroy'
+    end
+
+    context 'when observation has been updated by user' do
+      let!(:object) { create(:observation, :intervention, created_by: create(:user), updated_by: user) }
+
+      it_behaves_like 'updated by nullified on user destroy'
+    end
+
+    context 'when energy tariff has been created by user' do
+      let!(:object) { create(:energy_tariff, created_by: user) }
+
+      it_behaves_like 'created by nullified on user destroy'
+    end
+
+    context 'when energy tariff has been updated by user' do
+      let!(:object) { create(:energy_tariff, created_by: create(:user), updated_by: user) }
+
+      it_behaves_like 'updated by nullified on user destroy'
+    end
+
+    context 'when issue has been created by user' do
+      let!(:object) { create(:issue, created_by: user) }
+
+      it_behaves_like 'created by nullified on user destroy'
+    end
+
+    context 'when issue has been updated by user' do
+      let!(:object) { create(:issue, updated_by: user) }
+
+      it_behaves_like 'updated by nullified on user destroy'
+    end
+
+    context 'when activity has been updated by user' do
+      let!(:object) { create(:activity, updated_by: user) }
+
+      it_behaves_like 'updated by nullified on user destroy'
+    end
+
+    context 'with linked school groups for issues admin' do
+      let!(:school_group) { create(:school_group, default_issues_admin_user: user) }
+
+      before { user.destroy! }
+
+      it 'default_issues_admin is nullified' do
+        expect(school_group.reload.default_issues_admin_user).to be_nil
+      end
+    end
+
+    context 'when user has been created by another user' do
+      let!(:object) { create(:user, created_by: user) }
+
+      it_behaves_like 'created by nullified on user destroy'
     end
   end
 end


### PR DESCRIPTION
This PR addresses two Trello tickets and also fixes another couple of relationships too. Tickets are as follows:

https://trello.com/c/0snT5p5E/4722-get-an-error-500-message-when-trying-to-delete-user-rhearnphillipslittleheathorguk-from-little-heath-school
```
ActiveRecord::InvalidForeignKey PG::ForeignKeyViolation: ERROR:  update or delete on table "users" violates foreign key constraint "fk_rails_60602a07b3" on table "energy_tariffs"
DETAIL:  Key (id)=(5619) is still referenced from table "energy_tariffs".

```
https://trello.com/c/74BsFqtW/4729-error-message-received-when-deleting-a-user
```
ActiveRecord::InvalidForeignKey PG::ForeignKeyViolation: ERROR:  update or delete on table "users" violates foreign key constraint "fk_rails_40250ac6eb" on table "activities"
DETAIL:  Key (id)=(5213) is still referenced from table "activities".

```

This PR adds relationships to User for models that reference it, so that the reference is nullified when user is removed. Adds tests for each. The relationships added are for the following:

- EnergyTariff#created_by
- EnergyTariff#updated_by
- Activity#updated_by
- Issue#created_by
- Issue#updated_by

Also updates the User#issues_admin_for relationship - dependent was set to nil rather than :nullify. nil according to the documentation 'does nothing' when the record is deleted but it did appear to actually nullify when I tested it. Changed it to be intentional and set to nullify.