### PR TITLE
Make sure only active programme types can be viewed

### DIFF
--- a/app/components/dashboard_reminders_component.rb
+++ b/app/components/dashboard_reminders_component.rb
@@ -27,7 +27,7 @@ class DashboardRemindersComponent < ApplicationComponent
   end
 
   def programmes_to_prompt
-    @school.programmes.last_started
+    @school.programmes.active.last_started
   end
 
   private

--- a/app/controllers/programme_types_controller.rb
+++ b/app/controllers/programme_types_controller.rb
@@ -9,6 +9,7 @@ class ProgrammeTypesController < ApplicationController
   end
 
   def show
+    route_not_found unless @programme_type.active
   end
 
   private

--- a/app/views/schools/recommendations/index.html.erb
+++ b/app/views/schools/recommendations/index.html.erb
@@ -2,8 +2,9 @@
 
 <p><%= t('schools.recommendations.intro') %></p>
 
-<%= render 'schools/prompt_to_complete_programme', programmes: @school.programmes.started.order(started_on: :desc),
-                                                   style: :compact %>
+<%= render 'schools/prompt_to_complete_programme',
+           programmes: @school.programmes.active.started.order(started_on: :desc),
+           style: :compact %>
 <%= render 'schools/prompt_join_programme', school: @school, style: :compact %>
 <%= render 'schools/prompt_audit', audit: Audits::AuditService.new(@school).last_audit, style: :compact %>
 

--- a/app/views/shared/_task_completed.html.erb
+++ b/app/views/shared/_task_completed.html.erb
@@ -53,8 +53,9 @@
               title: t('tasks.completed.share'),
               buttons: { t("tasks.completed.#{task_type}.view_link") => recording_path(recording) } %>
 
-<%= render 'schools/prompt_to_complete_programme', programmes: school.programmes.started.order(started_on: :desc),
-                                                   style: :compact %>
+<%= render 'schools/prompt_to_complete_programme',
+           programmes: school.programmes.active.started.order(started_on: :desc),
+           style: :compact %>
 <%= render 'schools/prompt_join_programme', school: school, style: :compact %>
 <%= render 'schools/prompt_audit', audit: Audits::AuditService.new(school).last_audit, style: :compact %>
 <%= render 'schools/prompt_recommended', scope: recommendations_scope_for(task_type), icon: true, style: :compact %>

--- a/spec/system/programme_type_spec.rb
+++ b/spec/system/programme_type_spec.rb
@@ -486,6 +486,14 @@ RSpec.describe 'programme types', :include_application_helper, type: :system do
             expect(page).to have_content('You can enrol your school in this programme')
           end
         end
+
+        context 'when programme type is not active' do
+          before do
+            visit programme_type_path(programme_type_2)
+          end
+
+          it { expect(page).to have_content('Page not found') }
+        end
       end
     end
 
@@ -574,6 +582,14 @@ RSpec.describe 'programme types', :include_application_helper, type: :system do
             expect(page).to have_content(programme_type_1.title)
             expect(page).to have_content('You can enrol your school in this programme')
           end
+        end
+
+        context 'when programme type is not active' do
+          before do
+            visit programme_type_path(programme_type_2)
+          end
+
+          it { expect(page).to have_content('Page not found') }
         end
       end
     end


### PR DESCRIPTION
I noticed that it is possible to see inactive programme types via the complete programme prompt and also the dashboard reminders prompt. Which led me to see that you could also view programme type pages for those that are inactive. This fixes all issues.