### PR TITLE
Fix incorrect lookup on PROB data report

### DIFF
--- a/app/views/admin/prob_data_reports/index.html.erb
+++ b/app/views/admin/prob_data_reports/index.html.erb
@@ -23,7 +23,7 @@
           <%= link_to [row[4], row[5]].reject(&:blank?).join(': '),
                       admin_reports_amr_validated_reading_url(meter_id: row[6]) %>
         </td>
-        <td><%= Meter.meter_types.key(row[3]).humanize %></td>
+        <td><%= row[3] %></td>
         <td>
           <%= row[7] %>
         </td>


### PR DESCRIPTION
Fixes an incorrect attempt to lookup meter type on the PROB data report.

Unclear why this has broken. Was originally working, then broke [here](https://github.com/Energy-Sparks/energy-sparks/pull/3399).