### PR TITLE
Link to edit dashboard message from icon

### DIFF
--- a/app/assets/stylesheets/base.scss
+++ b/app/assets/stylesheets/base.scss
@@ -201,6 +201,11 @@ input, progress {
   color: $grey-light;
 }
 
+.badge-grey-light {
+  background-color: $grey-light;
+  color: $white;
+}
+
 .text-dark-blue {
   color: $blue-very-dark;
 }

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -445,10 +445,18 @@ module ApplicationHelper
   end
 
   def dashboard_message_icon(messageable)
+    who = messageable.is_a?(SchoolGroup) ? 'schools in this group' : 'school'
+
     if messageable.dashboard_message
       title = 'Dashboard message is shown for '
-      title += messageable.is_a?(SchoolGroup) ? 'schools in this group' : 'school'
+      title += who
       tag.span class: 'badge badge-info', title: "#{title}: #{messageable.dashboard_message.message}" do
+        fa_icon(:info)
+      end
+    else
+      title = 'Dashboard message is not set for '
+      title += who
+      tag.span class: 'badge badge-grey-light', title: title.to_s do
         fa_icon(:info)
       end
     end

--- a/app/views/admin/school_groups/_active_schools.html.erb
+++ b/app/views/admin/school_groups/_active_schools.html.erb
@@ -1,7 +1,8 @@
 <table class="table">
   <% school_group.schools.active.by_name.each do |school| %>
     <tr class="bg-light">
-      <td><%= link_to school.name, school_path(school) %> <%= dashboard_message_icon(school) %></td>
+      <td><%= link_to school.name, school_path(school) %> <%= link_to(dashboard_message_icon(school),
+                                                                      edit_admin_school_dashboard_message_path(school)) %></td>
       <td><%= school.funder&.name || school&.school_group&.funder&.name %></td>
       <td><%= render 'shared/school_status_buttons', school: school %></td>
       <td class="nowrap text-right">

--- a/app/views/admin/school_groups/index.html.erb
+++ b/app/views/admin/school_groups/index.html.erb
@@ -1,6 +1,6 @@
 <h1>Manage School Groups</h1>
 <%= link_to 'New school group', new_admin_school_group_path, class: 'btn btn-primary' %>
-<%= link_to "Export detail", admin_school_groups_path(format: :csv), class: 'btn' %>
+<%= link_to 'Export detail', admin_school_groups_path(format: :csv), class: 'btn' %>
 <p></p>
 <% if @school_groups.any? %>
   <table class="table table-condensed table-sorted">
@@ -22,7 +22,8 @@
       <% @school_groups.each do |school_group| %>
         <tr>
           <td><%= school_group.name %>
-            <%= dashboard_message_icon(school_group) %>
+            <%= link_to(dashboard_message_icon(school_group),
+                        edit_admin_school_group_dashboard_message_path(school_group)) %>
           </td>
           <td>
             <span class="badge badge-pill badge-primary"><%= school_group.group_type.humanize %></span>
@@ -30,9 +31,9 @@
           <td class="d-none d-sm-table-cell">
             <% if school_group.default_issues_admin_user %>
               <span class="badge border badge-pill border-secondary font-weight-normal">
-                <%= link_to (school_group.default_issues_admin_user == current_user ? "You" : school_group.default_issues_admin_user.display_name),
-                  polymorphic_path([:admin, Issue], user: school_group.default_issues_admin_user),
-                  class: 'text-decoration-none' %>
+                <%= link_to (school_group.default_issues_admin_user == current_user ? 'You' : school_group.default_issues_admin_user.display_name),
+                            polymorphic_path([:admin, Issue], user: school_group.default_issues_admin_user),
+                            class: 'text-decoration-none' %>
               </span>
             <% end %>
           </td>


### PR DESCRIPTION
Was using the interface and felt like I should be able to edit a dashboard message by clicking on the info icon. Could be wrong though! This meant the info icon is added in a greyed out form for when a message is not set.
Admin school group / view page
<img width="1107" alt="Screenshot 2025-01-24 at 00 14 00" src="https://github.com/user-attachments/assets/47d53a57-7a1b-4253-8962-13577c8e2f12" />

Admin school group / index page
<img width="1128" alt="Screenshot 2025-01-24 at 00 13 26" src="https://github.com/user-attachments/assets/fe6db50b-0792-4b15-8636-0197e6f37a20" />
