### PR TITLE
Todos sure up

### DIFF
--- a/app/models/intervention_type.rb
+++ b/app/models/intervention_type.rb
@@ -79,7 +79,7 @@ class InterventionType < ApplicationRecord
   before_save :copy_searchable_attributes
 
   def actions_for_school(school)
-    observations.for_school(school)
+    observations.visible.for_school(school)
   end
 
   # override default name for this resource in transifex

--- a/app/models/todo.rb
+++ b/app/models/todo.rb
@@ -59,7 +59,7 @@ class Todo < ApplicationRecord
     when 'ActivityType'
       school.activities.where(activity_type: task)
     when 'InterventionType'
-      school.observations.intervention.where(intervention_type: task)
+      school.observations.intervention.visible.where(intervention_type: task)
     else
       raise StandardError, 'Unsupported task type'
     end

--- a/app/models/todo.rb
+++ b/app/models/todo.rb
@@ -49,7 +49,7 @@ class Todo < ApplicationRecord
   end
 
   def latest_recording_for(completable:)
-    recordings_for(school: completable.school).in_academic_year_for(completable.school, Time.zone.now).by_date(:desc).first
+    recordings_for(school: completable.school).in_academic_year_for(completable.school, Time.zone.now).by_date(:asc).order(id: :asc).last
   end
 
   private

--- a/app/services/observation_removal.rb
+++ b/app/services/observation_removal.rb
@@ -9,6 +9,9 @@ class ObservationRemoval
       @observation.destroy
     else
       @observation.update_attribute(:visible, false)
+      if Flipper.enabled?(:todos)
+        CompletedTodo.where(recording: @observation).destroy_all if @observation.intervention?
+      end
     end
   end
 end

--- a/lib/tasks/todos/import.rake
+++ b/lib/tasks/todos/import.rake
@@ -19,7 +19,7 @@ namespace :todos do
 
         ## latest activity for this activity_type completed since the audit was created
         activity = audit.school.activities.where(
-          activity_type: audit_activity_type.activity_type, happened_on: audit.created_at..).order(happened_on: :asc).last
+          activity_type: audit_activity_type.activity_type, happened_on: audit.created_at..).order(happened_on: :asc, id: :asc).last
 
         if activity
           audit.completed_todos.find_or_create_by!(
@@ -37,7 +37,7 @@ namespace :todos do
 
         ## latest observation for this intervention_type completed since the audit was created
         observation = audit.school.observations.intervention.where(
-          intervention_type: audit_intervention_type.intervention_type, at: audit.created_at..).order(at: :asc).last
+          intervention_type: audit_intervention_type.intervention_type, at: audit.created_at..).order(at: :asc, id: :asc).last
         if observation
           audit.completed_todos.find_or_create_by!(
             todo: todo,

--- a/lib/tasks/todos/import.rake
+++ b/lib/tasks/todos/import.rake
@@ -36,7 +36,7 @@ namespace :todos do
           notes: audit_intervention_type.notes)
 
         ## latest observation for this intervention_type completed since the audit was created
-        observation = audit.school.observations.intervention.where(
+        observation = audit.school.observations.intervention.visible.where(
           intervention_type: audit_intervention_type.intervention_type, at: audit.created_at..).order(at: :asc, id: :asc).last
         if observation
           audit.completed_todos.find_or_create_by!(

--- a/spec/support/shared_examples/todos.rb
+++ b/spec/support/shared_examples/todos.rb
@@ -13,6 +13,7 @@ RSpec.shared_examples 'a completable getting latest recording for todo' do
 
     context 'when school has multiple recordings for task' do
       let!(:older) { create(:activity, activity_type:, school:, happened_on: 3.days.ago) }
+      let!(:new) { create(:activity, activity_type:, school:, happened_on: 2.days.ago) }
       let!(:newer) { create(:activity, activity_type:, school:, happened_on: 2.days.ago) }
       let!(:created_last) { create(:activity, activity_type:, school:, happened_on: 4.days.ago) }
 
@@ -58,6 +59,7 @@ RSpec.shared_examples 'a completable getting latest recording for todo' do
 
     context 'when school has multiple recordings for task' do
       let!(:older) { create(:observation, :intervention, intervention_type:, school:, at: 3.days.ago) }
+      let!(:new) { create(:observation, :intervention, intervention_type:, school:, at: 2.days.ago) }
       let!(:newer) { create(:observation, :intervention, intervention_type:, school:, at: 2.days.ago) }
       let!(:created_last) { create(:observation, :intervention, intervention_type:, school:, at: 4.days.ago) }
 


### PR DESCRIPTION
Spotted a couple of things that needed changing after a good poke around. 

Firstly when observations are 'removed' via the frontend (via the ObservationRemoval service), if not in current academic year, visible is set to false, rather than it being removed. If they are in this academic year, they are destroyed, which automatically removes completed todos etc, which is how I assumed it worked all the time. So now this takes note of the visible flag in a number of places and removes completed todos when visible is set to false.

Also made sure that when picking the latest recording for a todo, there is a possibility that more than 1 recording occurs on the same day. Added code to make sure we always pick the last one created. It probably would have done this anyway, just wanted to be intentional.

