### PR TITLE
Hide notes field from programme admin interface

### DIFF
--- a/app/views/shared/todos/_fields.html.erb
+++ b/app/views/shared/todos/_fields.html.erb
@@ -22,9 +22,11 @@
           </div>
         </div>
       </div>
-      <div class="col-md-5">
-        <%= f.text_area :notes, label: false, class: 'form-control select2' %>
-      </div>
+      <% if assignable.is_a?(Audit) %>
+        <div class="col-md-5">
+          <%= f.text_area :notes, label: false, class: 'form-control select2' %>
+        </div>
+      <% end %>
       <div class="col-md-2">
         <%= link_to_remove_association t('common.labels.remove'), f, class: 'btn' %>
       </div>

--- a/app/views/shared/todos/_task_type_form.html.erb
+++ b/app/views/shared/todos/_task_type_form.html.erb
@@ -15,9 +15,11 @@
   <div class="col-md-5">
     <label for="<%= type %>"><%= label %></label>
   </div>
-  <div class="col-md-5">
-    <label for="notes"><%= t('schools.audits.form.notes') %></label>
-  </div>
+  <% if assignable.is_a?(Audit) %>
+    <div class="col-md-5">
+      <label for="notes"><%= t('schools.audits.form.notes') %></label>
+    </div>
+  <% end %>
   <div class="col-md-2">
   </div>
 </div>
@@ -26,6 +28,7 @@
   <%= f.simple_fields_for "#{type}_todos" do |todo| %>
     <%= render 'shared/todos/fields',
                f: todo,
+               assignable: assignable,
                tasks: tasks,
                task_type: type.camelcase %>
   <% end %>
@@ -37,6 +40,7 @@
                                 partial: 'shared/todos/fields',
                                 render_options: {
                                   locals: {
+                                    assignable: assignable,
                                     tasks: tasks,
                                     task_type: type.camelcase
                                   }

--- a/spec/system/admin/programme_type_spec.rb
+++ b/spec/system/admin/programme_type_spec.rb
@@ -112,7 +112,7 @@ describe 'programme type management', :include_application_helper, type: :system
         displayed_activity_types = all('#activity-type-todos .nested-fields')
         activity_type_todos.each_with_index do |todo, idx|
           expect(displayed_activity_types[idx]).to have_content(todo.task.name)
-          expect(displayed_activity_types[idx]).to have_content(todo.notes)
+          expect(displayed_activity_types[idx]).not_to have_content(todo.notes)
         end
 
         expect(page).to have_css('#intervention-type-todos .nested-fields', count: 3)
@@ -120,7 +120,7 @@ describe 'programme type management', :include_application_helper, type: :system
         displayed_intervention_types = all('#intervention-type-todos .nested-fields')
         intervention_type_todos.each_with_index do |todo, idx|
           expect(displayed_intervention_types[idx]).to have_content(todo.task.name)
-          expect(displayed_intervention_types[idx]).to have_content(todo.notes)
+          expect(displayed_intervention_types[idx]).not_to have_content(todo.notes)
         end
       end
 
@@ -176,9 +176,9 @@ describe 'programme type management', :include_application_helper, type: :system
           it 'changes activity order to THREE, ONE, TWO' do
             displayed_todos = all('#activity-type-todos .nested-fields')
 
-            expect(displayed_todos[0]).to have_content(activity_type_todos[2].notes)
-            expect(displayed_todos[1]).to have_content(activity_type_todos[0].notes)
-            expect(displayed_todos[2]).to have_content(activity_type_todos[1].notes)
+            expect(displayed_todos[0]).to have_content(activity_type_todos[2].task.name)
+            expect(displayed_todos[1]).to have_content(activity_type_todos[0].task.name)
+            expect(displayed_todos[2]).to have_content(activity_type_todos[1].task.name)
           end
 
           context 'when saving' do
@@ -208,9 +208,9 @@ describe 'programme type management', :include_application_helper, type: :system
           it 'changes action order to THREE, ONE, TWO' do
             displayed_todos = all('#intervention-type-todos .nested-fields')
 
-            expect(displayed_todos[0]).to have_content(intervention_type_todos[2].notes)
-            expect(displayed_todos[1]).to have_content(intervention_type_todos[0].notes)
-            expect(displayed_todos[2]).to have_content(intervention_type_todos[1].notes)
+            expect(displayed_todos[0]).to have_content(intervention_type_todos[2].task.name)
+            expect(displayed_todos[1]).to have_content(intervention_type_todos[0].task.name)
+            expect(displayed_todos[2]).to have_content(intervention_type_todos[1].task.name)
           end
 
           context 'when saving' do


### PR DESCRIPTION
Noticed that Nicky had added notes against programme activities and actions [on test](https://test.energysparks.uk/admin/programme_types/17/todos/edit)

It made me realise that notes against todos shouldn't be available to edit for programmes, as they are only intended to be used in audits as they are not translated. Assume this has been traditionally ok for them not to be translated for audits because the audit is all done in English too and not translated either.

https://trello.com/c/Pfi1FogC/3763-revise-programmes-to-include-adult-actions-and-not-just-pupil-activities

If we do want to add a shorter note, perhaps these should be added to activity type or intervention type models and not in the todo model. They would need to be translated too.