### PR TITLE
Push local changes to Mailchimp

### DIFF
--- a/app/controllers/concerns/newsletter_subscriber.rb
+++ b/app/controllers/concerns/newsletter_subscriber.rb
@@ -7,11 +7,13 @@ module NewsletterSubscriber
     Mailchimp::Contact.from_user(user, interests: sign_up_params[:interests].transform_values {|v| v == 'true' })
   end
 
-  def subscribe_contact(contact, show_errors: true)
+  def subscribe_contact(contact, user, show_errors: true)
     resp = nil
     if contact.valid?
       begin
-        resp = audience_manager.subscribe_or_update_contact(contact)
+        # as user has explicitly signed up, set their status to be subscribed if they're an existing contact in Mailchimp
+        resp = audience_manager.subscribe_or_update_contact(contact, status: 'subscribed')
+        user.update(mailchimp_status: 'subscribed', mailchimp_updated_at: Time.zone.now) if user
       rescue => e
         Rails.logger.error(e)
         Rollbar.error(e)

--- a/app/controllers/mailchimp_signups_controller.rb
+++ b/app/controllers/mailchimp_signups_controller.rb
@@ -19,7 +19,7 @@ class MailchimpSignupsController < ApplicationController
     else
       @contact = create_contact(sign_up_params)
     end
-    resp = subscribe_contact(@contact)
+    resp = subscribe_contact(@contact, current_user)
     if resp
       redirect_to subscribed_mailchimp_signups_path and return
     end

--- a/app/controllers/passwords_controller.rb
+++ b/app/controllers/passwords_controller.rb
@@ -58,6 +58,6 @@ class PasswordsController < Devise::PasswordsController
 
   def subscribe_newsletter(user, sign_up_params)
     contact = create_contact_from_user(user, sign_up_params)
-    subscribe_contact(contact, show_errors: false)
+    subscribe_contact(contact, user, show_errors: false)
   end
 end

--- a/app/jobs/mailchimp/status_checker_job.rb
+++ b/app/jobs/mailchimp/status_checker_job.rb
@@ -5,9 +5,7 @@ module Mailchimp
 
       audience_manager.process_list_members.each do |member|
         user = User.find_by_email(member.email_address.downcase)
-        # API uses different code to audience export and public docs
-        status = member.status == 'transactional' ? :nonsubscribed : member.status.to_sym
-        user.update(mailchimp_status: status) if user
+        user.update(mailchimp_status: Mailchimp::AudienceManager.status(member.status)) if user
       end
     end
   end

--- a/app/models/mailchimp/contact.rb
+++ b/app/models/mailchimp/contact.rb
@@ -111,10 +111,9 @@ module Mailchimp
     end
 
     # Convert to hash for submitting to mailchimp api
-    def to_mailchimp_hash(status = 'subscribed')
+    def to_mailchimp_hash
       {
         "email_address": email_address,
-        "status": status,
         "merge_fields": merge_fields,
         "interests": interests,
         "tags": tags

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -89,6 +89,8 @@ class User < ApplicationRecord
   enum :role, { guest: 0, staff: 1, admin: 2, school_admin: 3, school_onboarding: 4, pupil: 5,
                 group_admin: 6, analytics: 7, volunteer: 8 }
 
+  enum :mailchimp_status, %w[subscribed unsubscribed cleaned nonsubscribed archived].to_h { |v| [v, v] }, prefix: true
+
   scope :alertable, -> { where(role: [User.roles[:staff], User.roles[:school_admin], User.roles[:volunteer]]) }
 
   scope :mailchimp_roles, -> {

--- a/app/services/mailchimp/audience_manager.rb
+++ b/app/services/mailchimp/audience_manager.rb
@@ -4,6 +4,15 @@ module Mailchimp
       @client = client
     end
 
+    # The Mailchimp documentation and CSV exports use different status names than
+    # the API. Specifically "nonsubscribed" in the documentation is returned as "transactional"
+    # in the API responses. Ensure we're using codes that align with our enum.
+    #
+    # Preferring the documented versions as they will match internal user expectations
+    def self.status(mailchimp_status)
+      mailchimp_status.status == 'transactional' ? :nonsubscribed : mailchimp_status.to_sym
+    end
+
     # Fetch the description of our Mailchimp mailing list
     def list
       @list ||= get_list
@@ -19,10 +28,27 @@ module Mailchimp
       interests['interests'].map { |interest| create_interest(interest) }.sort_by(&:name)
     end
 
-    def subscribe_or_update_contact(mailchimp_contact, status_if_new: 'subscribed')
+    # Calls a Mailchimp API in a way that will add new contacts to the list if they're not already
+    # members or updates an existing contact.
+    #
+    # Care need to be taken with the status flags here, as if a user is already a member then we don't
+    # necessarily want to override their current status (e.g. unsubscribed or archived) unless a user
+    # has requested it.
+    #
+    # Status defaults to `nil` here to enforce a default that respects changes within Mailchimp.
+    def subscribe_or_update_contact(mailchimp_contact, status_if_new: 'subscribed', status: nil)
       hash = mailchimp_contact.to_mailchimp_hash
       hash['status_if_new'] = status_if_new
+      hash['status'] = status if status
       resp = @client.lists.set_list_member(list.id, mailchimp_contact.email_address, hash, subscribe_opts)
+      OpenStruct.new(resp)
+    end
+
+    def update_contact(mailchimp_contact)
+      resp = @client.lists.set_list_member(list.id,
+                                           Digest::MD5.hexdigest(mailchimp_contact.email_address.downcase),
+                                           mailchimp_contact.to_mailchimp_hash,
+                                           subscribe_opts)
       OpenStruct.new(resp)
     end
 

--- a/app/services/mailchimp/audience_updater.rb
+++ b/app/services/mailchimp/audience_updater.rb
@@ -1,0 +1,30 @@
+module Mailchimp
+  class AudienceUpdater
+    def perform
+      audience_manager = Mailchimp::AudienceManager.new
+      User.mailchimp_update_required.mailchimp_roles do |user|
+        begin
+          # Don't specify tags here as update will only add them, not remove
+          # FIXME what about interests?
+          contact = Mailchimp::Contact.from_user(user)
+
+          # FIXME feature flag?
+          # Use update contact here, not subscribe_or_update as we're not adding all users initially
+          mailchimp_member = audience_manager.update_contact(contact)
+
+          # TODO check whether we need to update the tags by checking those in the response versus user
+          # could just add all tags, then remove any that no longer apply??
+          # TODO update tags, if required
+
+          # Update status as well seeing as its returned in the response
+          user.update(
+            mailchimp_updated_at: Time.zone.now,
+            mailchimp_status: Mailchimp::AudienceManager.status(mailchimp_member.status)
+          )
+        rescue => e
+          EnergySparks::Log.exception(e)
+        end
+      end
+    end
+  end
+end

--- a/db/migrate/20250131140228_add_archived_to_mailchimp_status_enum.rb
+++ b/db/migrate/20250131140228_add_archived_to_mailchimp_status_enum.rb
@@ -1,0 +1,5 @@
+class AddArchivedToMailchimpStatusEnum < ActiveRecord::Migration[7.1]
+  def change
+    add_enum_value :mailchimp_status, 'archived'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -22,7 +22,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_01_24_134937) do
   create_enum "data_sharing", ["public", "within_group", "private"]
   create_enum "dcc_meter", ["no", "smets2", "other"]
   create_enum "half_hourly_labelling", ["start", "end"]
-  create_enum "mailchimp_status", ["subscribed", "unsubscribed", "cleaned", "nonsubscribed"]
+  create_enum "mailchimp_status", ["subscribed", "unsubscribed", "cleaned", "nonsubscribed", "archived"]
   create_enum "meter_perse_api", ["half_hourly"]
 
   create_table "academic_years", force: :cascade do |t|

--- a/spec/services/mailchimp/audience_updater_spec.rb
+++ b/spec/services/mailchimp/audience_updater_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+describe Mailchimp::AudienceUpdater do
+  subject(:service) { described_class.new }
+
+  describe '#perform' do
+    context 'when finding contacts' do
+      it 'ignores pupil users'
+    end
+
+    context 'when pushing to mailchimp' do
+      it 'does not add interests'
+      it 'does not throw exception on error'
+      it 'updates attributes on success'
+
+      context 'when user tags need updating' do
+        it 'also updates the tags'
+      end
+    end
+  end
+end


### PR DESCRIPTION
Final main part of the Mailchimp work. Implements pushing local database changes to Mailchimp via their API.

* [ ] Update AudienceManager to support updating contacts
* [ ] Ensure that when we subscribe or update contacts we respect existing status, unless user is requesting to be added to the list again
* [ ] Update local timestamp and status fields when user subscribers via form
* [ ] Update mailchimp_status enum with extra value used in the API, add helper to try and making naming consistent
* [ ] Implement `AudienceUpdater` for pushing updates via the API
* [ ] Add job and rake tasks for `AudienceUpdater`
* [ ] Adjust naming for school and group tags, e.g. `s-xxx` and `sg-xxx`
* [ ] Ensure tags are updated correctly when synchronising
* [ ] Update tags when subscribing user?
* [ ] Add dashboard, group and scoreboard urls as fields
* [ ] Add school type as field
* [ ] Add a FeatureFlag for behaviour of pushing ALL users to Mailchimp, not just subscribers, ensuring interests are defaulted corerctly for new users