### PR TITLE
Fix alignment of school block in dashboard component

### DIFF
--- a/app/components/dashboard_header_component/dashboard_header_component.html.erb
+++ b/app/components/dashboard_header_component/dashboard_header_component.html.erb
@@ -1,5 +1,5 @@
 <div id="<%= id %>" class="dashboard-header-component row <%= classes %>">
-  <div id="dashboard-header-welcome" class="col-12 col-md-9">
+  <div id="dashboard-header-welcome" class="col-12 col-md-8 col-xl-9">
     <div class="row">
       <div class="col">
         <h1><%= t(title) %></h1>
@@ -14,20 +14,22 @@
     </div>
   </div>
   <% if show_school? %>
-    <div id="dashboard-header-school" class="col-12 col-md-3 rounded">
-      <div class="row">
-        <div class="col">
-          <h4><%= school.name %></h4>
+    <div class="col-12 col-md-4 col-xl-3 rounded">
+      <div id="dashboard-header-school" class="px-3 py-2">
+        <div class="row">
+          <div class="col">
+            <h4><%= school.name %></h4>
+          </div>
         </div>
-      </div>
-      <div class="row">
-        <div class="col">
-          <%= school.address %> <%= school.postcode %>
+        <div class="row">
+          <div class="col">
+            <%= school.address %> <%= school.postcode %>
+          </div>
         </div>
-      </div>
-      <div class="row">
-        <div class="col">
-          <span class="badge badge-secondary"><%= t("common.school_types.#{school.school_type}") %></span>
+        <div class="row">
+          <div class="col">
+            <span class="badge badge-secondary"><%= t("common.school_types.#{school.school_type}") %></span>
+          </div>
         </div>
       </div>
     </div>

--- a/app/components/dashboard_header_component/dashboard_header_component.scss
+++ b/app/components/dashboard_header_component/dashboard_header_component.scss
@@ -6,8 +6,10 @@ div.container-fluid.pupil {
   background: white;
 }
 
-div.dashboard-header-component h1 {
-  padding-top: 0px;
+.dashboard-header-component {
+  h1, h4 {
+    padding-top: 0px;
+  }
 }
 
 div.dashboard-header-component.pupil {

--- a/app/components/dashboard_learn_more_component/dashboard_learn_more_component.scss
+++ b/app/components/dashboard_learn_more_component/dashboard_learn_more_component.scss
@@ -1,3 +1,7 @@
+.dashboard-learn-more-component h2 {
+  padding-top: 0px;
+}
+
 .dashboard-learn-more-component.data-enabled.adult {
   background: $adult-light;
 }


### PR DESCRIPTION
Thought I would fix this while working on other similar stuff.

It was like this:
![Screenshot 2025-01-28 at 10 52 29](https://github.com/user-attachments/assets/5b9e1a2d-49ae-4363-8796-907eb5d40399)

It is now like this:
<img width="887" alt="image" src="https://github.com/user-attachments/assets/eceabc2e-a9fc-4780-b391-e0d7817702fc" />

Also reduced the padding on the header of the learn more component, as that was a bit bothersome too.