### PR TITLE
Ensure tariff report ignores inactive schools

### DIFF
--- a/app/models/energy_tariff.rb
+++ b/app/models/energy_tariff.rb
@@ -86,8 +86,9 @@ class EnergyTariff < ApplicationRecord
   scope :count_by_school_group, -> { enabled.joins(:school_group).group(:slug).count(:id) }
 
   scope :for_schools_in_group, lambda { |school_group, source = :manually_entered|
-    enabled.where(source:).joins(:school).where({ schools: { school_group: } })
+    enabled.where(source:).joins(:school).where({ schools: { active: true, school_group: } })
   }
+
   scope :count_schools_with_tariff_by_group, lambda { |school_group, source = :manually_entered|
     for_schools_in_group(school_group, source).select(:tariff_holder_id).distinct.count
   }

--- a/app/views/admin/reports/energy_tariffs/index.html.erb
+++ b/app/views/admin/reports/energy_tariffs/index.html.erb
@@ -22,10 +22,16 @@ The following table summarises the energy tariffs currently configured in the sy
     </tr>
   </thead>
   <tbody>
-    <% SchoolGroup.all.order(:name).each do |school_group| %>
+    <% SchoolGroup.with_visible_schools.order(:name).each do |school_group| %>
       <tr>
         <td><%= link_to school_group.name, school_group_energy_tariffs_path(school_group) %></td>
-        <td><%= @count_by_school_group[school_group.slug].present? ? link_to(@count_by_school_group[school_group.slug], school_group_energy_tariffs_path(school_group)) : '-' %></td>
+        <td>
+          <% if @count_by_school_group[school_group.slug].present? %>
+            <%= link_to(@count_by_school_group[school_group.slug], school_group_energy_tariffs_path(school_group)) %>
+          <% else %>
+            -
+          <% end %>
+        </td>
         <td>
           <% count = EnergyTariff.count_schools_with_tariff_by_group(school_group) %>
           <% if count > 0 %>

--- a/spec/models/energy_tariff_spec.rb
+++ b/spec/models/energy_tariff_spec.rb
@@ -372,6 +372,10 @@ describe EnergyTariff do
     let!(:energy_tariff_2)  { create(:energy_tariff, tariff_holder: school, enabled: false)}
     let!(:energy_tariff_3)  { create(:energy_tariff)}
     let!(:energy_tariff_4)  { create(:energy_tariff, tariff_holder: school_group)}
+    let!(:remove_school_tariff) do
+      removed_school = create(:school, school_group: school_group, active: false)
+      create(:energy_tariff, tariff_holder: removed_school)
+    end
 
     it 'returns expected schools' do
       expect(EnergyTariff.for_schools_in_group(school.school_group)).to match_array([energy_tariff])


### PR DESCRIPTION
Revise the admin tariff report to:

- only list groups with visible schools
- only include tariffs from active schools
