### PR TITLE
Stronger environment checking in Mailchimp jobs

### DIFF
--- a/app/jobs/mailchimp/audience_updater_job.rb
+++ b/app/jobs/mailchimp/audience_updater_job.rb
@@ -1,6 +1,8 @@
 module Mailchimp
-  class AudienceUpdaterJob < ApplicationJob
+  class AudienceUpdaterJob < BaseJob
     def perform
+      return unless can_run?
+
       Mailchimp::AudienceUpdater.new.perform
     rescue => e
       EnergySparks::Log.exception(e, job: :audience_updater)

--- a/app/jobs/mailchimp/base_job.rb
+++ b/app/jobs/mailchimp/base_job.rb
@@ -1,0 +1,7 @@
+module Mailchimp
+  class BaseJob < ApplicationJob
+    def can_run?
+      ENV['ENVIRONMENT_IDENTIFIER'] == 'production'
+    end
+  end
+end

--- a/app/jobs/mailchimp/email_updater_job.rb
+++ b/app/jobs/mailchimp/email_updater_job.rb
@@ -1,6 +1,8 @@
 module Mailchimp
-  class EmailUpdaterJob < ApplicationJob
+  class EmailUpdaterJob < BaseJob
     def perform(user:, original_email:)
+      return unless can_run?
+
       contact = Mailchimp::Contact.from_user(user)
       mailchimp_member = Mailchimp::AudienceManager.new.update_contact(contact, original_email)
       # Update status as well seeing as its returned in the response

--- a/app/jobs/mailchimp/status_checker_job.rb
+++ b/app/jobs/mailchimp/status_checker_job.rb
@@ -1,6 +1,8 @@
 module Mailchimp
-  class StatusCheckerJob < ApplicationJob
+  class StatusCheckerJob < BaseJob
     def perform
+      return unless can_run?
+
       audience_manager = Mailchimp::AudienceManager.new
 
       updated_users = []
@@ -15,6 +17,11 @@ module Mailchimp
       # Any other user with a status that was not just updated must have its status removed
       # Could happen if a user is deleted from Mailchimp, or their email address has changed.
       User.where.not(id: updated_users).where.not(mailchimp_status: nil).update_all(mailchimp_status: nil)
+    end
+
+    # This job can run safely in other environments
+    def can_run?
+      true
     end
   end
 end

--- a/app/jobs/mailchimp/user_deletion_job.rb
+++ b/app/jobs/mailchimp/user_deletion_job.rb
@@ -1,8 +1,10 @@
 module Mailchimp
   # Triggered when we delete a user to reset the users contact details in Mailchimp so that they
   # are switched to being an "Organic" subscriber.
-  class UserDeletionJob < ApplicationJob
+  class UserDeletionJob < BaseJob
     def perform(email_address:, name:, school:)
+      return unless can_run?
+
       contact = Mailchimp::Contact.from_params({ email_address:, name:, school:, interests: {} })
       audience_manager = AudienceManager.new
       mailchimp_member = audience_manager.update_contact(contact)

--- a/lib/tasks/mailchimp/status_check.rake
+++ b/lib/tasks/mailchimp/status_check.rake
@@ -1,11 +1,6 @@
 namespace :mailchimp do
   desc "Check mailchimp status of confirmed users"
   task :status_check, [:dir] => :environment do |t,args|
-    if ENV['ENVIRONMENT_IDENTIFIER'] == "production"
-      Mailchimp::StatusCheckerJob.perform_later
-      puts "Job submitted"
-    else
-      puts "Skipping as not in production"
-    end
+    Mailchimp::StatusCheckerJob.perform_later
   end
 end

--- a/spec/jobs/mailchimp/status_checker_job_spec.rb
+++ b/spec/jobs/mailchimp/status_checker_job_spec.rb
@@ -9,6 +9,17 @@ describe Mailchimp::StatusCheckerJob do
     allow(Mailchimp::AudienceManager).to receive(:new).and_return(double)
   end
 
+  describe '#can_run?' do
+    it 'can run in all environments' do
+      ClimateControl.modify ENVIRONMENT_IDENTIFIER: 'production' do
+        expect(job.can_run?).to be(true)
+      end
+      ClimateControl.modify ENVIRONMENT_IDENTIFIER: 'test' do
+        expect(job.can_run?).to be(true)
+      end
+    end
+  end
+
   describe '#perform' do
     let(:email_address) { 'test@example.org' }
     let!(:user) { create(:user, email: email_address) }

--- a/spec/jobs/mailchimp/user_deletion_job_spec.rb
+++ b/spec/jobs/mailchimp/user_deletion_job_spec.rb
@@ -9,6 +9,17 @@ describe Mailchimp::UserDeletionJob do
     allow(Mailchimp::AudienceManager).to receive(:new).and_return(double)
   end
 
+  describe '#can_run?' do
+    it 'can only run in production' do
+      ClimateControl.modify ENVIRONMENT_IDENTIFIER: 'production' do
+        expect(job.can_run?).to be(true)
+      end
+      ClimateControl.modify ENVIRONMENT_IDENTIFIER: 'test' do
+        expect(job.can_run?).to be(false)
+      end
+    end
+  end
+
   describe '#perform' do
     let(:email_address) { 'test@example.org' }
     let(:name) { 'John Test' }
@@ -24,6 +35,12 @@ describe Mailchimp::UserDeletionJob do
         { 'id' => '789', 'name' => 'Other' }
       ]
       member
+    end
+
+    around do |example|
+      ClimateControl.modify ENVIRONMENT_IDENTIFIER: 'production' do
+        example.run
+      end
     end
 
     before do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -659,6 +659,12 @@ describe User do
     end
 
     context 'when email changed' do
+      around do |example|
+        ClimateControl.modify ENVIRONMENT_IDENTIFIER: 'production' do
+          example.run
+        end
+      end
+
       context 'when user is not in mailchimp' do
         it 'does not update mailchimp' do
           expect(Mailchimp::EmailUpdaterJob).not_to receive(:perform_later)


### PR DESCRIPTION
Realised that there is a loophole in how I've avoided the Mailchimp updates running on the test server.

At the moment everything is restricted so that only users with a `mailchimp_status` will have updates pushed to Mailchimp. While the rake task for the main synchronisation code (`mailchimp:audience_updater`) won't run on the test server, the email update and deletion jobs will still be triggered if someone is testing other updates on the server. We obviously don't want that to happen, although the changes will be later reversed once the next update is pushed from production.

This PR reworks the code to more strongly enforce that certain jobs shouldn't run except in the production environment:

- new base class for the mailchimp jobs with a `can_run?` method that performs the environment check
- all jobs now check whether they can run before doing anything

I've also relaxed the constraints on the `StatusCheckerJob` to allow it to run on the test server. It's only pulling in updates to the local database, so is safe. We can disable if there are any API issues.