### PR TITLE
New user profile pages

### DIFF
--- a/app/controllers/users/contacts_controller.rb
+++ b/app/controllers/users/contacts_controller.rb
@@ -1,0 +1,40 @@
+module Users
+  class ContactsController < ApplicationController
+    load_resource :user
+    load_and_authorize_resource through: :user
+
+    def index
+      @schools = if @user.group_admin?
+                   @user.school_group.schools.visible.by_name
+                 elsif @user.has_other_schools?
+                   @user.cluster_schools.by_name
+                 else
+                   [@user.school]
+                 end
+      @show_clusters = @schools.any? { |s| s.school_group_cluster.present? }
+      render :index, layout: 'dashboards'
+    end
+
+    # Sometimes creating the contact is failing as its invalid...?
+    # trying to touch! the user model when inserting.
+    def create
+      @contact = Contact.create(
+        user_id: @user.id,
+        school_id: params[:school_id],
+        name: @user.display_name,
+        email_address: @user.email,
+        staff_role: @user.staff_role
+      )
+      if @contact.save
+        redirect_to user_contacts_path(@user), notice: t('users.contacts.create.subscribed')
+      else
+        redirect_to user_contacts_path(@user), notice: t('users.contacts.create.failed')
+      end
+    end
+
+    def destroy
+      @contact.destroy
+      redirect_to user_contacts_path(@user), notice: t('users.contacts.create.unsubscribed')
+    end
+  end
+end

--- a/app/controllers/users/contacts_controller.rb
+++ b/app/controllers/users/contacts_controller.rb
@@ -7,7 +7,7 @@ module Users
       @schools = if @user.group_admin?
                    @user.school_group.schools.visible.by_name
                  elsif @user.has_other_schools?
-                   @user.cluster_schools.by_name
+                   @user.cluster_schools.visible.by_name
                  else
                    [@user.school]
                  end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class UsersController < ApplicationController
+  include ApplicationHelper
+  load_and_authorize_resource
+
+  def show
+    authorize! :read, @user
+    render :show, layout: 'dashboards'
+  end
+
+  def edit
+    authorize! :edit, @user
+    render :edit, layout: 'dashboards'
+  end
+
+  def update
+    authorize! :update, @user
+  end
+
+  private
+
+  def user_params
+    params.require(:user)
+          .permit(:name, :email, :staff_role_id)
+  end
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -16,12 +16,37 @@ class UsersController < ApplicationController
 
   def update
     authorize! :update, @user
+    if @user.update(user_params)
+      redirect_to user_path(@user), notice: I18n.t('users.edit.account_updated')
+    else
+      render :edit, layout: 'dashboards'
+    end
+  end
+
+  def edit_password
+    authorize! :edit, @user
+    render :edit_password, layout: 'dashboards'
+  end
+
+  def update_password
+    authorize! :update, @user
+    if @user.update_with_password(password_params)
+      bypass_sign_in(@user) unless current_user.admin?
+      redirect_to user_path(@user), notice: I18n.t('users.edit_password.password_updated')
+    else
+      render :edit_password, layout: 'dashboards'
+    end
   end
 
   private
 
   def user_params
     params.require(:user)
-          .permit(:name, :email, :staff_role_id)
+          .permit(:name, :email, :staff_role_id, :preferred_locale)
+  end
+
+  def password_params
+    params.require(:user)
+          .permit(:current_password, :password, :password_confirmation)
   end
 end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -123,6 +123,10 @@ class Ability
       can :read, Location
     end
 
+    unless user.pupil? || user.guest?
+      can :manage, User, { id: user.id }
+    end
+
     if user.admin? || user.analytics?
       can :manage, :all
       cannot :read, :my_school_menu

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -125,7 +125,6 @@ class Ability
 
     unless user.pupil? || user.guest? || user.admin?
       can :manage, User, id: user.id
-      can :manage, Contact, user_id: user.id
     end
 
     if user.admin? || user.analytics?
@@ -200,6 +199,8 @@ class Ability
         show show_pupils_dash update manage_school_times manage_users
         show_management_dash read start_programme read_restricted_analysis read_restricted_advice
       ], School, school_scope
+
+      can %i[create update destroy], Contact, user_id: user.id
 
       can :manage, [EstimatedAnnualConsumption, SchoolTarget, Activity, Contact, Observation, TransportSurvey],
           related_school_scope

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -125,6 +125,7 @@ class Ability
 
     unless user.pupil? || user.guest? || user.admin?
       can :manage, User, id: user.id
+      can :manage, Contact, user_id: user.id
     end
 
     if user.admin? || user.analytics?

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -123,8 +123,8 @@ class Ability
       can :read, Location
     end
 
-    unless user.pupil? || user.guest?
-      can :manage, User, { id: user.id }
+    unless user.pupil? || user.guest? || user.admin?
+      can :manage, User, id: user.id
     end
 
     if user.admin? || user.analytics?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -145,6 +145,10 @@ class User < ApplicationRecord
     end
   end
 
+  def has_profile?
+    !(pupil? || school_onboarding?)
+  end
+
   def display_name
     name.presence || email
   end

--- a/app/views/shared/navigation/_second_nav.html.erb
+++ b/app/views/shared/navigation/_second_nav.html.erb
@@ -92,11 +92,13 @@
           <%= render 'shared/navigation/second_nav/my_schools_menu' %>
         <% end %>
 
-        <li class="nav-item nowrap">
-          <% if user_signed_in? && current_user.has_profile? %>
-            <%= link_to fa_icon('user'), user_path(current_user), title: t('nav.my_account'), class: 'nav-link' %>
-          <% end %>
-        </li>
+        <% if Flipper.enabled?(:profile_pages, current_user) %>
+          <li class="nav-item nowrap">
+            <% if user_signed_in? && current_user.has_profile? %>
+              <%= link_to fa_icon('user'), user_path(current_user), title: t('nav.my_account'), class: 'nav-link' %>
+            <% end %>
+          </li>
+        <% end %>
 
         <li class="nav-item nowrap">
           <% if user_signed_in? %>

--- a/app/views/shared/navigation/_second_nav.html.erb
+++ b/app/views/shared/navigation/_second_nav.html.erb
@@ -93,6 +93,12 @@
         <% end %>
 
         <li class="nav-item nowrap">
+          <% if user_signed_in? && current_user.has_profile? %>
+            <%= link_to fa_icon('user'), user_path(current_user), title: t('nav.my_account'), class: 'nav-link' %>
+          <% end %>
+        </li>
+
+        <li class="nav-item nowrap">
           <% if user_signed_in? %>
             <!-- Sign out - context: user signed in -->
             <%= link_to t('nav.sign_out'), destroy_user_session_path, method: :delete, class: 'nav-link' %>

--- a/app/views/users/_my_schools_summary.html.erb
+++ b/app/views/users/_my_schools_summary.html.erb
@@ -33,8 +33,7 @@
     </div>
     <div class="row mt-2 mb-4">
       <div class="col">
-        <%= link_to t('users.show.manage_alerts'), user_path(user), class: 'btn btn-primary' %>
-        <%= link_to t('users.show.update_email_preferences'), user_path(user), class: 'btn btn-success' %>
+        <%= link_to t('users.show.manage_alerts'), user_contacts_path(user), class: 'btn btn-primary' unless user.admin? %>
       </div>
     </div>
   </div>

--- a/app/views/users/_my_schools_summary.html.erb
+++ b/app/views/users/_my_schools_summary.html.erb
@@ -1,0 +1,41 @@
+<% if user.school.present? || user.group_admin? %>
+  <div id="my-schools-summary">
+    <div class="row mt-4">
+      <div class="col">
+        <h2><%= t('nav.my_schools') %></h2>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col">
+        <% if user.group_admin? %>
+          <p>
+            <%= t('users.show.school_summary.group_admin_html',
+                  role: t("role.#{user.role}"),
+                  count: user.school_group.visible_schools_count,
+                  url: school_group_path(user.school_group),
+                  link_text: user.school_group.name) %>.
+          </p>
+        <% elsif user.has_other_schools? %>
+          <p>
+            <%= t('users.show.school_summary.cluster_admin_html',
+                  role: t("role.#{user.role}"),
+                  count: user.cluster_schools.count) %>.
+          </p>
+        <% else %>
+          <p>
+            <%= t('users.show.school_summary.school_user_html',
+                  role: t("role.#{user.role}"),
+                  url: school_path(user.school),
+                  link_text: user.school.name) %>.
+          </p>
+        <% end %>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col">
+        <%= link_to t('users.show.manage_alerts'), user_path(user), class: 'btn btn-primary' %>
+        <%= link_to t('users.show.update_email_preferences'), user_path(user), class: 'btn btn-success' %>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/app/views/users/_my_schools_summary.html.erb
+++ b/app/views/users/_my_schools_summary.html.erb
@@ -31,7 +31,7 @@
         <% end %>
       </div>
     </div>
-    <div class="row">
+    <div class="row mt-2 mb-4">
       <div class="col">
         <%= link_to t('users.show.manage_alerts'), user_path(user), class: 'btn btn-primary' %>
         <%= link_to t('users.show.update_email_preferences'), user_path(user), class: 'btn btn-success' %>

--- a/app/views/users/_profile_footer.html.erb
+++ b/app/views/users/_profile_footer.html.erb
@@ -1,0 +1,9 @@
+<% if user.confirmed_at %>
+  <div id='profile-footer'>
+    <div class="row mt-4">
+      <div class="col col-md-12">
+        <%= t('users.show.joined', date: nice_date_times(user.confirmed_at)) %>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/app/views/users/_profile_footer.html.erb
+++ b/app/views/users/_profile_footer.html.erb
@@ -1,6 +1,6 @@
 <% if user.confirmed_at %>
   <div id='profile-footer'>
-    <div class="row mt-4">
+    <div class="row mt-4 mb-4">
       <div class="col col-md-12">
         <%= t('users.show.joined', date: nice_date_times(user.confirmed_at)) %>
       </div>

--- a/app/views/users/_profile_summary.html.erb
+++ b/app/views/users/_profile_summary.html.erb
@@ -1,0 +1,47 @@
+<div id="profile-summary">
+  <div class="row">
+    <div class="col">
+      <h2><%= t('users.show.my_account') %></h2>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col col-md-3">
+      <%= t('schools.users.index.name') %>
+    </div>
+    <div class="col col-md-9">
+      <%= email_with_wbr(user.name) %>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col col-md-3">
+      <%= t('schools.users.index.email') %>
+    </div>
+    <div class="col col-md-9">
+      <%= email_with_wbr(user.email) %>
+    </div>
+  </div>
+  <% if user.staff_role %>
+  <div class="row">
+    <div class="col col-md-3">
+      <%= t('schools.users.index.role') %>
+    </div>
+    <div class="col col-md-9">
+      <%= user.staff_role.try(:translated_title) %>
+    </div>
+  </div>
+  <% end %>
+  <div class="row">
+    <div class="col col-md-3">
+      <%= t('schools.users.index.preferred_locale') %>
+    </div>
+    <div class="col col-md-9">
+      <%= I18n.t("languages.#{user.preferred_locale}") %>
+    </div>
+  </div>
+  <div class="row mt-2">
+    <div class="col col-md-12">
+      <%= link_to t('users.show.update_account'), edit_user_path(user), class: 'btn btn-primary' %>
+      <%= link_to t('users.show.change_password'), edit_user_path(user), class: 'btn btn-success' %>
+    </div>
+  </div>
+</div>

--- a/app/views/users/_profile_summary.html.erb
+++ b/app/views/users/_profile_summary.html.erb
@@ -38,10 +38,10 @@
       <%= I18n.t("languages.#{user.preferred_locale}") %>
     </div>
   </div>
-  <div class="row mt-2">
+  <div class="row mt-4 mb-4">
     <div class="col col-md-12">
       <%= link_to t('users.show.update_account'), edit_user_path(user), class: 'btn btn-primary' %>
-      <%= link_to t('users.show.change_password'), edit_user_path(user), class: 'btn btn-success' %>
+      <%= link_to t('users.show.change_password'), edit_password_user_path(user), class: 'btn btn-success' %>
     </div>
   </div>
 </div>

--- a/app/views/users/_user_page.html.erb
+++ b/app/views/users/_user_page.html.erb
@@ -1,0 +1,40 @@
+<% content_for :page_title, user.name %>
+
+<% content_for :dashboard_header do %>
+  <div class="row" id="profile-header">
+    <div class="col">
+      <h1><%= user.name %></h1>
+    </div>
+  </div>
+<% end %>
+
+<div class="container">
+  <div class="row mt-2">
+    <div id="profile-page-navigation" class="col-md-3 col-lg-3 col-xl-2">
+      <ul class="nav flex-column flex-nowrap w-100">
+        <li class="nav-item overflow-hidden">
+          <div class="collapse show" id="" aria-expanded="false">
+            <ul class="flex-column pl-0">
+              <li class="nav-item">
+                Account
+              </li>
+              <li class="nav-item">
+                Security
+              </li>
+              <li class="nav-item">
+                Email preferences
+              </li>
+              <li class="nav-item">
+                Schools
+              </li>
+            </ul>
+          </div>
+        </li>
+      </ul>
+    </div>
+
+    <div id="page-body" class="col-md-9 col-lg-9 col-xl-10">
+      <%= yield %>
+    </div>
+  </div>
+</div>

--- a/app/views/users/_user_page.html.erb
+++ b/app/views/users/_user_page.html.erb
@@ -16,10 +16,10 @@
           <div class="collapse show" id="" aria-expanded="false">
             <ul class="flex-column pl-0">
               <li class="nav-item">
-                Account
+                <%= link_to t('nav.my_account'), user_path(user) %>
               </li>
               <li class="nav-item">
-                Security
+                <%= link_to t('users.show.change_password'), edit_password_user_path(user) %>
               </li>
               <li class="nav-item">
                 Email preferences

--- a/app/views/users/_user_page.html.erb
+++ b/app/views/users/_user_page.html.erb
@@ -21,12 +21,11 @@
               <li class="nav-item">
                 <%= link_to t('users.show.change_password'), edit_password_user_path(user) %>
               </li>
-              <li class="nav-item">
-                Email preferences
-              </li>
-              <li class="nav-item">
-                Schools
-              </li>
+              <% unless user.admin? %>
+                <li class="nav-item">
+                  <%= link_to t('nav.my_schools'), user_contacts_path(user) %>
+                </li>
+              <% end %>
             </ul>
           </div>
         </li>

--- a/app/views/users/contacts/index.html.erb
+++ b/app/views/users/contacts/index.html.erb
@@ -1,0 +1,60 @@
+<%= render 'users/user_page', user: @user do %>
+  <div id="my-school-list">
+    <div class="row">
+      <div class="col">
+        <h2><%= t('nav.my_schools') %></h2>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col">
+        <table id="my-schools" class="table table-sm table-sorted">
+          <thead>
+            <tr>
+              <th><%= t('common.school') %></th>
+              <% if @show_clusters %>
+                <th><%= t('school_groups.clusters.labels.cluster') %></th>
+              <% end %>
+              <th data-orderable="false"><%= t('advice_pages.index.alerts.title') %></th>
+              <th></th>
+            </tr>
+          </thead>
+          <tbody>
+            <% @schools.each do |school| %>
+              <tr>
+                <td>
+                  <%= link_to school.name, school_path(school) %>
+                </td>
+                <% if @show_clusters %>
+                  <td>
+                    <% if school.school_group_cluster.present? %>
+                      <%= school.school_group_cluster.name %>
+                    <% end %>
+                  </td>
+                <% end %>
+                <td>
+                  <%= link_to t('common.labels.view_alerts'), alerts_school_advice_path(school) %>
+                </td>
+                <% contact = @user.contacts.for_school(school).first %>
+                <td data-order="<%= contact.present? ? '1' : '0' %>">
+                  <% if contact.present? %>
+                    <%= link_to t('common.labels.unsubscribe'),
+                                user_contact_path(@user, contact),
+                                method: :delete,
+                                data: { confirm: t('common.confirm') },
+                                class: 'btn btn-danger' %>
+                  <% else %>
+                    <%= link_to t('common.labels.subscribe'),
+                                user_contacts_path(@user, school_id: school.id),
+                                method: :post,
+                                data: { confirm: t('common.confirm') },
+                                class: 'btn btn-success' %>
+                  <% end %>
+                </td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,0 +1,23 @@
+<%= render 'user_page', user: @user do %>
+  <div class="row">
+    <div class="col">
+      <h2>Update account</h2>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="col">
+      <%= simple_form_for(@user, html: { class: 'admin-user-form' }) do |f| %>
+        <%= f.input :name %>
+        <%= f.input :email %>
+        <%= f.input :staff_role_id, label: 'Staff role', collection: StaffRole.order(:title), label_method: :title,
+                                    hint: 'For school admins and staff' %>
+        <%= f.submit class: 'btn btn-primary' %>
+      <% end %>
+
+      <div class="other-actions">
+        <%= link_to 'Cancel', user_path(@user), class: 'btn btn-secondary' %>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,23 +1,35 @@
 <%= render 'user_page', user: @user do %>
   <div class="row">
     <div class="col">
-      <h2>Update account</h2>
+      <h2><%= t('users.show.update_account') %></h2>
     </div>
   </div>
 
-  <div class="row">
+  <div class="row mt-4 mb-4">
     <div class="col">
       <%= simple_form_for(@user, html: { class: 'admin-user-form' }) do |f| %>
-        <%= f.input :name %>
-        <%= f.input :email %>
-        <%= f.input :staff_role_id, label: 'Staff role', collection: StaffRole.order(:title), label_method: :title,
-                                    hint: 'For school admins and staff' %>
-        <%= f.submit class: 'btn btn-primary' %>
-      <% end %>
+        <%= f.input :name, required: true, label: t('schools.users.form.name') %>
+        <%= f.input :email, required: true, label: t('schools.users.form.email') %>
+        <% unless @user.admin? || @user.group_admin? %>
+          <%= f.input :staff_role_id,
+                      label: t('schools.users.form.role'),
+                      required: true,
+                      collection: StaffRole.translated_names_and_ids %>
+        <% end %>
 
-      <div class="other-actions">
-        <%= link_to 'Cancel', user_path(@user), class: 'btn btn-secondary' %>
-      </div>
+        <div class="form-group">
+          <%= f.label :preferred_locale, t('schools.users.form.preferred_locale'), class: 'col-form-label' %>
+          <%= f.select :preferred_locale,
+                       options_for_select(I18n.available_locales.map { |locale|
+                         [I18n.t("languages.#{locale}"), locale]
+                       }, @user.preferred_locale),
+                       { include_blank: false },
+                       { class: 'form-control' } %>
+        </div>
+
+        <%= f.submit t('common.labels.update'), class: 'btn btn-primary' %>
+        <%= link_to t('common.labels.cancel'), user_path(@user), class: 'btn btn-secondary' %>
+      <% end %>
     </div>
   </div>
 <% end %>

--- a/app/views/users/edit_password.html.erb
+++ b/app/views/users/edit_password.html.erb
@@ -1,0 +1,25 @@
+<%= render 'user_page', user: @user do %>
+  <div class="row">
+    <div class="col">
+      <h2><%= t('users.show.change_password') %></h2>
+    </div>
+  </div>
+
+  <div class="row mt-4 mb-4">
+    <div class="col">
+      <%= simple_form_for(@user, url: update_password_user_path(@user), html: { class: 'admin-user-form' }) do |f| %>
+        <%= f.input :current_password, required: true, label: t('users.edit_password.current_password') %>
+        <%= f.input :password,
+                    required: true,
+                    label: t('devise.passwords.edit.new_password'),
+                    hint: "#{Devise.password_length.first} #{t('devise.passwords.edit.characters_minimum')}" %>
+        <%= f.input :password_confirmation,
+                    required: true,
+                    label: t('devise.passwords.edit.confirm_new_password') %>
+
+        <%= f.submit t('common.labels.update'), class: 'btn btn-primary' %>
+        <%= link_to t('common.labels.cancel'), user_path(@user), class: 'btn btn-secondary' %>
+      <% end %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,0 +1,5 @@
+<%= render 'user_page', user: @user do %>
+  <%= render 'profile_summary', user: @user %>
+  <%= render 'my_schools_summary', user: @user %>
+  <%= render 'profile_footer', user: @user %>
+<% end %>

--- a/config/locales/common.yml
+++ b/config/locales/common.yml
@@ -62,7 +62,9 @@ en:
       start: Start
       status: Status
       submit: Submit
+      subscribe: Subscribe
       type: Type
+      unsubscribe: Unsubscribe
       update: Update
       upload: Upload
       view: View

--- a/config/locales/views/shared/shared.yml
+++ b/config/locales/views/shared/shared.yml
@@ -118,6 +118,7 @@ en:
     storage_heater_usage: Storage heater usage
   nav:
     enrol: Enrol
+    my_account: My account
     my_schools: My schools
     points: "%{count} points"
     sign_in: Sign In

--- a/config/locales/views/users/users.yml
+++ b/config/locales/views/users/users.yml
@@ -21,4 +21,3 @@ en:
         group_admin_html: You are a %{role} for %{count} schools in <a href="%{url}">%{link_text}</a>
         school_user_html: You are a %{role} user for <a href="%{url}">%{link_text}</a>
       update_account: Update account
-      update_email_preferences: Update email preferences

--- a/config/locales/views/users/users.yml
+++ b/config/locales/views/users/users.yml
@@ -1,6 +1,11 @@
 ---
 en:
   users:
+    contacts:
+      create:
+        failed: Failed to subscribe to alerts
+        subscribed: Subscribed to alerts
+        unsubscribed: Unsubscribed to alerts
     edit:
       account_updated: Account updated
     edit_password:

--- a/config/locales/views/users/users.yml
+++ b/config/locales/views/users/users.yml
@@ -1,13 +1,18 @@
 ---
 en:
   users:
+    edit:
+      account_updated: Account updated
+    edit_password:
+      current_password: Current password
+      password_updated: Password updated
     show:
       change_password: Change password
       joined: You joined Energy Sparks on %{date}
       manage_alerts: Manage alerts
       my_account: My account
       school_summary:
-        cluster_admin_html: You are a %{role} for %{count} schools.
+        cluster_admin_html: You are a %{role} for %{count} schools
         group_admin_html: You are a %{role} for %{count} schools in <a href="%{url}">%{link_text}</a>
         school_user_html: You are a %{role} user for <a href="%{url}">%{link_text}</a>
       update_account: Update account

--- a/config/locales/views/users/users.yml
+++ b/config/locales/views/users/users.yml
@@ -1,0 +1,14 @@
+---
+en:
+  users:
+    show:
+      change_password: Change password
+      joined: You joined Energy Sparks on %{date}
+      manage_alerts: Manage alerts
+      my_account: My account
+      school_summary:
+        cluster_admin_html: You are a %{role} for %{count} schools.
+        group_admin_html: You are a %{role} for %{count} schools in <a href="%{url}">%{link_text}</a>
+        school_user_html: You are a %{role} user for <a href="%{url}">%{link_text}</a>
+      update_account: Update account
+      update_email_preferences: Update email preferences

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -281,6 +281,9 @@ Rails.application.routes.draw do
       get :edit_password
       patch :update_password
     end
+    scope module: :users do
+      resources :contacts, path: 'alerts', only: [:index, :create, :destroy]
+    end
   end
 
   resources :schools do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -277,7 +277,10 @@ Rails.application.routes.draw do
   get 'analysis_page_finder/:urn/:analysis_class', to: 'analysis_page_finder#show', as: :analysis_page_finder
 
   resources :users, path: 'profiles', except: [:index, :new, :destroy] do
-
+    member do
+      get :edit_password
+      patch :update_password
+    end
   end
 
   resources :schools do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -276,6 +276,10 @@ Rails.application.routes.draw do
 
   get 'analysis_page_finder/:urn/:analysis_class', to: 'analysis_page_finder#show', as: :analysis_page_finder
 
+  resources :users, path: 'profiles', except: [:index, :new, :destroy] do
+
+  end
+
   resources :schools do
     resources :activities do
       member do

--- a/lib/tasks/deployment/20250213151427_profiles_feature.rake
+++ b/lib/tasks/deployment/20250213151427_profiles_feature.rake
@@ -1,0 +1,13 @@
+namespace :after_party do
+  desc 'Deployment task: profiles_feature'
+  task profiles_feature: :environment do
+    puts "Running deploy task 'profiles_feature'"
+
+    Flipper.add(:profile_pages)
+
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord
+      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+  end
+end

--- a/spec/factories/users_factory.rb
+++ b/spec/factories/users_factory.rb
@@ -64,6 +64,7 @@ FactoryBot.define do
     end
 
     factory :group_admin do
+      name { 'Group admin'}
       role { :group_admin }
       school_group
     end

--- a/spec/support/shared_examples/account_pages.rb
+++ b/spec/support/shared_examples/account_pages.rb
@@ -1,0 +1,34 @@
+RSpec.shared_examples 'an account page with navigation' do |admin: false|
+  it { expect(page).to have_title(user.name) }
+
+  it 'displays profile header' do
+    expect(page).to have_css('#profile-header')
+    within('#profile-header') do
+      expect(page).to have_content(user.name)
+    end
+  end
+
+  it do
+    within('#profile-page-navigation') do
+      expect(page).to have_link(I18n.t('nav.my_account')), href: user_path(user)
+    end
+  end
+
+  it do
+    within('#profile-page-navigation') do
+      expect(page).to have_link(I18n.t('users.show.change_password'), href: edit_password_user_path(user))
+    end
+  end
+
+  it 'links to schools page', unless: admin do
+    within('#profile-page-navigation') do
+      expect(page).to have_link(I18n.t('nav.my_schools'), href: user_contacts_path(user))
+    end
+  end
+
+  it 'does not link to schools page', if: admin do
+    within('#profile-page-navigation') do
+      expect(page).not_to have_link(I18n.t('nav.my_schools'), href: user_contacts_path(user))
+    end
+  end
+end

--- a/spec/support/shared_examples/page_auth.rb
+++ b/spec/support/shared_examples/page_auth.rb
@@ -1,0 +1,7 @@
+RSpec.shared_examples 'the page requires a login' do
+  it { expect(page).to have_content(I18n.t('devise.sessions.new.title')) }
+end
+
+RSpec.shared_examples 'the user is not authorised' do
+  it { expect(page).to have_content('You are not authorized to access this page') }
+end

--- a/spec/system/navigation/second_nav_spec.rb
+++ b/spec/system/navigation/second_nav_spec.rb
@@ -484,25 +484,25 @@ RSpec.describe 'Navigation -> second nav' do
     context 'when school user signed in' do
       let(:user) { create(:school_admin) }
 
-      it { expect(nav).to have_link(href: user_path(user), title: I18n.t('nav.my_profile')) }
+      it { expect(nav).to have_link(href: user_path(user), title: I18n.t('nav.my_account')) }
     end
 
     context 'when pupil signed in' do
       let(:user) { create(:pupil) }
 
-      it { expect(nav).to have_no_link(href: user_path(user), title: I18n.t('nav.my_profile')) }
+      it { expect(nav).to have_no_link(href: user_path(user), title: I18n.t('nav.my_account')) }
     end
 
     context 'when school onboarding user signed in' do
       let(:user) { create(:onboarding_user) }
 
-      it { expect(nav).to have_no_link(href: user_path(user), title: I18n.t('nav.my_profile')) }
+      it { expect(nav).to have_no_link(href: user_path(user), title: I18n.t('nav.my_account')) }
     end
 
     context 'when user signed out' do
       let(:user) {}
 
-      it { expect(nav).to have_no_link(title: I18n.t('nav.my_profile')) }
+      it { expect(nav).to have_no_link(title: I18n.t('nav.my_account')) }
     end
   end
 end

--- a/spec/system/navigation/second_nav_spec.rb
+++ b/spec/system/navigation/second_nav_spec.rb
@@ -477,4 +477,32 @@ RSpec.describe 'Navigation -> second nav' do
       it { expect(nav).to have_no_link 'Sign Out' }
     end
   end
+
+  describe 'My Profile link' do
+    before { visit home_page_path }
+
+    context 'when school user signed in' do
+      let(:user) { create(:school_admin) }
+
+      it { expect(nav).to have_link(href: user_path(user), title: I18n.t('nav.my_profile')) }
+    end
+
+    context 'when pupil signed in' do
+      let(:user) { create(:pupil) }
+
+      it { expect(nav).to have_no_link(href: user_path(user), title: I18n.t('nav.my_profile')) }
+    end
+
+    context 'when school onboarding user signed in' do
+      let(:user) { create(:onboarding_user) }
+
+      it { expect(nav).to have_no_link(href: user_path(user), title: I18n.t('nav.my_profile')) }
+    end
+
+    context 'when user signed out' do
+      let(:user) {}
+
+      it { expect(nav).to have_no_link(title: I18n.t('nav.my_profile')) }
+    end
+  end
 end

--- a/spec/system/navigation/second_nav_spec.rb
+++ b/spec/system/navigation/second_nav_spec.rb
@@ -478,31 +478,33 @@ RSpec.describe 'Navigation -> second nav' do
     end
   end
 
-  describe 'My Profile link' do
-    before { visit home_page_path }
+  context 'with profile feature', with_feature: :profile_pages do
+    describe 'My Profile link' do
+      before { visit home_page_path }
 
-    context 'when school user signed in' do
-      let(:user) { create(:school_admin) }
+      context 'when school user signed in' do
+        let(:user) { create(:school_admin) }
 
-      it { expect(nav).to have_link(href: user_path(user), title: I18n.t('nav.my_account')) }
-    end
+        it { expect(nav).to have_link(href: user_path(user), title: I18n.t('nav.my_account')) }
+      end
 
-    context 'when pupil signed in' do
-      let(:user) { create(:pupil) }
+      context 'when pupil signed in' do
+        let(:user) { create(:pupil) }
 
-      it { expect(nav).to have_no_link(href: user_path(user), title: I18n.t('nav.my_account')) }
-    end
+        it { expect(nav).to have_no_link(href: user_path(user), title: I18n.t('nav.my_account')) }
+      end
 
-    context 'when school onboarding user signed in' do
-      let(:user) { create(:onboarding_user) }
+      context 'when school onboarding user signed in' do
+        let(:user) { create(:onboarding_user) }
 
-      it { expect(nav).to have_no_link(href: user_path(user), title: I18n.t('nav.my_account')) }
-    end
+        it { expect(nav).to have_no_link(href: user_path(user), title: I18n.t('nav.my_account')) }
+      end
 
-    context 'when user signed out' do
-      let(:user) {}
+      context 'when user signed out' do
+        let(:user) {}
 
-      it { expect(nav).to have_no_link(title: I18n.t('nav.my_account')) }
+        it { expect(nav).to have_no_link(title: I18n.t('nav.my_account')) }
+      end
     end
   end
 end

--- a/spec/system/user_profiles_spec.rb
+++ b/spec/system/user_profiles_spec.rb
@@ -1,0 +1,208 @@
+require 'rails_helper'
+
+RSpec.describe 'User profiles', :include_application_helper do
+  let!(:user) { create(:school_admin) }
+
+  shared_examples 'requires a login' do
+    it { expect(page).to have_content('Sign in to Energy Sparks') }
+  end
+
+  shared_examples 'user is not authorised' do
+    it { expect(page).to have_content('You are not authorized to access this page') }
+  end
+
+  shared_examples 'a profile page layout' do
+    it { expect(page).to have_title(user.name) }
+
+    it 'displays profile header' do
+      expect(page).to have_css('#profile-header')
+      within('#profile-header') do
+        expect(page).to have_content(user.name)
+      end
+    end
+  end
+
+  shared_examples 'a profile page' do |group_admin: false, cluster_admin: false, school_user: true|
+    it 'displays a basic profile summary' do
+      expect(page).to have_css('#profile-summary')
+      within('#profile-summary') do
+        expect(page).to have_content(user.name)
+        expect(page).to have_content(user.email)
+        expect(page).to have_content(I18n.t("languages.#{user.preferred_locale}"))
+        expect(page).to have_link(I18n.t('users.show.update_account'), href: edit_user_path(user))
+        expect(page).to have_link(I18n.t('users.show.change_password'))
+      end
+    end
+
+    it 'displays staff role', if: school_user || cluster_admin do
+      within('#profile-summary') do
+        expect(page).to have_content(user.staff_role.try(:translated_title))
+      end
+    end
+
+    it 'displays links to manage emails', if: school_user || cluster_admin || group_admin do
+      within('#my-schools-summary') do
+        expect(page).to have_link(I18n.t('users.show.update_email_preferences'))
+      end
+    end
+
+    it 'displays links to manage alerts', if: school_user || cluster_admin || group_admin do
+      within('#my-schools-summary') do
+        expect(page).to have_link(I18n.t('users.show.manage_alerts'))
+      end
+    end
+
+    it 'displays summary of my schools', if: school_user do
+      expect(page).to have_css('#my-schools-summary')
+      within('#my-schools-summary') do
+        expect(page.body).to include(I18n.t('users.show.school_summary.school_user_html', role: I18n.t("role.#{user.role}"), url: school_path(user.school), link_text: user.school.name))
+      end
+    end
+
+    it 'displays summary of my schools', if: cluster_admin do
+      expect(page).to have_css('#my-schools-summary')
+      within('#my-schools-summary') do
+        expect(page.body).to include(I18n.t('users.show.school_summary.cluster_admin_html', role: I18n.t("role.#{user.role}"), count: user.cluster_schools.count))
+      end
+    end
+
+    it 'displays summary of my schools', if: group_admin do
+      expect(page).to have_css('#my-schools-summary')
+      within('#my-schools-summary') do
+        expect(page.body).to include(I18n.t('users.show.school_summary.group_admin_html', role: I18n.t("role.#{user.role}"), count: user.school_group.schools.count, url: school_group_path(user.school_group), link_text: user.school_group.name))
+      end
+    end
+
+    it 'displays a profile footer' do
+      expect(page).to have_css('#profile-footer')
+      within('#profile-footer') do
+        expect(page).to have_content(I18n.t('users.show.joined', date: nice_date_times(user.confirmed_at)))
+      end
+    end
+  end
+
+  context 'when not logged in' do
+    before do
+      visit user_path(user)
+    end
+
+    it_behaves_like 'requires a login'
+  end
+
+  context 'when logged in' do
+    context 'when viewing a different users profile' do
+      let!(:signed_in_user) { create(:school_admin) }
+
+      before do
+        sign_in(signed_in_user)
+        visit user_path(user)
+      end
+
+      it_behaves_like 'user is not authorised'
+
+      context 'when I am a school admin from their school' do
+        let!(:signed_in_user) { create(:school_admin, school: user.school) }
+
+        it 'does not allow access'
+      end
+    end
+
+    context 'with a pupil account' do
+      it 'does not show link in navbar'
+      it 'does not allow me to view my profile'
+    end
+
+    context 'with a school admin account' do
+      before do
+        sign_in(user)
+      end
+
+      context 'when viewing my profile' do
+        before { visit user_path(user) }
+
+        it_behaves_like 'a profile page layout'
+        it_behaves_like 'a profile page'
+      end
+
+      context 'when updating my profile' do
+        it 'displays the right form fields'
+        it 'allows me to update my profile'
+      end
+
+      context 'when updating my password' do
+        it 'allows me to update my password'
+      end
+
+      context 'when viewing my email preferences' do
+        it 'show my preferences in Mailchimp'
+        it 'allows me to update my preferences'
+        it 'links to managing alerts'
+      end
+
+      context 'when viewing my schools' do
+        it 'displays my schools'
+        it 'allows me to update my alert preferences'
+      end
+    end
+
+    context 'with a staff account' do
+      let!(:user) { create(:staff) }
+
+      before do
+        sign_in(user)
+      end
+
+      context 'when viewing my profile' do
+        before { visit user_path(user) }
+
+        it_behaves_like 'a profile page layout'
+        it_behaves_like 'a profile page'
+      end
+    end
+
+    context 'with a cluster admin' do
+      let!(:user) { create(:school_admin, :with_cluster_schools) }
+
+      before do
+        sign_in(user)
+      end
+
+      context 'when viewing my profile' do
+        before { visit user_path(user) }
+
+        it_behaves_like 'a profile page layout'
+        it_behaves_like 'a profile page', cluster_admin: true, school_user: false
+      end
+    end
+
+    context 'with a group admin' do
+      let!(:user) { create(:group_admin, school_group: create(:school_group, :with_active_schools)) }
+
+      before do
+        sign_in(user)
+      end
+
+      context 'when viewing my profile' do
+        before { visit user_path(user) }
+
+        it_behaves_like 'a profile page layout'
+        it_behaves_like 'a profile page', group_admin: true, school_user: false
+      end
+    end
+
+    context 'with an admin account' do
+      let!(:user) { create(:admin) }
+
+      before do
+        sign_in(user)
+      end
+
+      context 'when viewing my profile' do
+        before { visit user_path(user) }
+
+        it_behaves_like 'a profile page layout'
+        it_behaves_like 'a profile page', school_user: false
+      end
+    end
+  end
+end

--- a/spec/system/user_profiles_spec.rb
+++ b/spec/system/user_profiles_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'User profiles', :include_application_helper do
+RSpec.describe 'User profile pages and account updates', :include_application_helper do
   let!(:user) { create(:school_admin) }
 
   shared_examples 'requires a login' do
@@ -164,7 +164,6 @@ RSpec.describe 'User profiles', :include_application_helper do
     end
 
     context 'with a pupil account' do
-      it 'does not show link in navbar'
       it 'does not allow me to view my profile'
     end
 

--- a/spec/system/users/accounts_spec.rb
+++ b/spec/system/users/accounts_spec.rb
@@ -1,26 +1,7 @@
 require 'rails_helper'
 
-RSpec.describe 'User profile pages and account updates', :include_application_helper do
+RSpec.describe 'User account page and updates', :include_application_helper do
   let!(:user) { create(:school_admin) }
-
-  shared_examples 'requires a login' do
-    it { expect(page).to have_content('Sign in to Energy Sparks') }
-  end
-
-  shared_examples 'user is not authorised' do
-    it { expect(page).to have_content('You are not authorized to access this page') }
-  end
-
-  shared_examples 'a profile page layout' do
-    it { expect(page).to have_title(user.name) }
-
-    it 'displays profile header' do
-      expect(page).to have_css('#profile-header')
-      within('#profile-header') do
-        expect(page).to have_content(user.name)
-      end
-    end
-  end
 
   shared_examples 'a profile page' do |group_admin: false, cluster_admin: false, school_user: true|
     it 'displays a basic profile summary' do
@@ -37,12 +18,6 @@ RSpec.describe 'User profile pages and account updates', :include_application_he
     it 'displays staff role', if: school_user || cluster_admin do
       within('#profile-summary') do
         expect(page).to have_content(user.staff_role.try(:translated_title))
-      end
-    end
-
-    it 'displays links to manage emails', if: school_user || cluster_admin || group_admin do
-      within('#my-schools-summary') do
-        expect(page).to have_link(I18n.t('users.show.update_email_preferences'))
       end
     end
 
@@ -142,7 +117,7 @@ RSpec.describe 'User profile pages and account updates', :include_application_he
       visit user_path(user)
     end
 
-    it_behaves_like 'requires a login'
+    it_behaves_like 'the page requires a login'
   end
 
   context 'when logged in' do
@@ -154,7 +129,7 @@ RSpec.describe 'User profile pages and account updates', :include_application_he
         visit user_path(user)
       end
 
-      it_behaves_like 'user is not authorised'
+      it_behaves_like 'the user is not authorised'
 
       context 'when I am a school admin from their school' do
         let!(:signed_in_user) { create(:school_admin, school: user.school) }
@@ -175,7 +150,7 @@ RSpec.describe 'User profile pages and account updates', :include_application_he
       context 'when viewing my account' do
         before { visit user_path(user) }
 
-        it_behaves_like 'a profile page layout'
+        it_behaves_like 'an account page with navigation'
         it_behaves_like 'a profile page'
       end
 
@@ -200,17 +175,6 @@ RSpec.describe 'User profile pages and account updates', :include_application_he
 
         it_behaves_like 'a working password form'
       end
-
-      context 'when viewing my email preferences' do
-        it 'show my preferences in Mailchimp'
-        it 'allows me to update my preferences'
-        it 'links to managing alerts'
-      end
-
-      context 'when viewing my schools' do
-        it 'displays my schools'
-        it 'allows me to update my alert preferences'
-      end
     end
 
     context 'with a staff account' do
@@ -223,7 +187,7 @@ RSpec.describe 'User profile pages and account updates', :include_application_he
       context 'when viewing my profile' do
         before { visit user_path(user) }
 
-        it_behaves_like 'a profile page layout'
+        it_behaves_like 'an account page with navigation'
         it_behaves_like 'a profile page'
       end
 
@@ -247,7 +211,7 @@ RSpec.describe 'User profile pages and account updates', :include_application_he
       context 'when viewing my profile' do
         before { visit user_path(user) }
 
-        it_behaves_like 'a profile page layout'
+        it_behaves_like 'an account page with navigation'
         it_behaves_like 'a profile page', cluster_admin: true, school_user: false
       end
 
@@ -271,7 +235,7 @@ RSpec.describe 'User profile pages and account updates', :include_application_he
       context 'when viewing my profile' do
         before { visit user_path(user) }
 
-        it_behaves_like 'a profile page layout'
+        it_behaves_like 'an account page with navigation'
         it_behaves_like 'a profile page', group_admin: true, school_user: false
       end
 
@@ -295,7 +259,7 @@ RSpec.describe 'User profile pages and account updates', :include_application_he
       context 'when viewing my profile' do
         before { visit user_path(user) }
 
-        it_behaves_like 'a profile page layout'
+        it_behaves_like 'an account page with navigation', admin: true
         it_behaves_like 'a profile page', school_user: false
       end
 

--- a/spec/system/users/accounts_spec.rb
+++ b/spec/system/users/accounts_spec.rb
@@ -128,12 +128,6 @@ RSpec.describe 'User account page and updates', :include_application_helper do
       end
 
       it_behaves_like 'the user is not authorised'
-
-      context 'when I am a school admin from their school' do
-        let!(:signed_in_user) { create(:school_admin, school: user.school) }
-
-        it 'does not allow access'
-      end
     end
 
     context 'with a pupil account' do

--- a/spec/system/users/accounts_spec.rb
+++ b/spec/system/users/accounts_spec.rb
@@ -113,9 +113,7 @@ RSpec.describe 'User account page and updates', :include_application_helper do
   end
 
   context 'when not logged in' do
-    before do
-      visit user_path(user)
-    end
+    before { visit user_path(user) }
 
     it_behaves_like 'the page requires a login'
   end
@@ -139,13 +137,19 @@ RSpec.describe 'User account page and updates', :include_application_helper do
     end
 
     context 'with a pupil account' do
-      it 'does not allow me to view my profile'
+      let(:user) { create(:pupil) }
+
+      before { sign_in(user) }
+
+      context 'when viewing my account' do
+        before { visit user_path(user) }
+
+        it_behaves_like 'the user is not authorised'
+      end
     end
 
     context 'with a school admin account' do
-      before do
-        sign_in(user)
-      end
+      before { sign_in(user) }
 
       context 'when viewing my account' do
         before { visit user_path(user) }
@@ -180,9 +184,7 @@ RSpec.describe 'User account page and updates', :include_application_helper do
     context 'with a staff account' do
       let!(:user) { create(:staff) }
 
-      before do
-        sign_in(user)
-      end
+      before { sign_in(user) }
 
       context 'when viewing my profile' do
         before { visit user_path(user) }
@@ -204,9 +206,7 @@ RSpec.describe 'User account page and updates', :include_application_helper do
     context 'with a cluster admin' do
       let!(:user) { create(:school_admin, :with_cluster_schools) }
 
-      before do
-        sign_in(user)
-      end
+      before { sign_in(user) }
 
       context 'when viewing my profile' do
         before { visit user_path(user) }
@@ -228,9 +228,7 @@ RSpec.describe 'User account page and updates', :include_application_helper do
     context 'with a group admin' do
       let!(:user) { create(:group_admin, school_group: create(:school_group, :with_active_schools)) }
 
-      before do
-        sign_in(user)
-      end
+      before { sign_in(user) }
 
       context 'when viewing my profile' do
         before { visit user_path(user) }
@@ -252,9 +250,7 @@ RSpec.describe 'User account page and updates', :include_application_helper do
     context 'with an admin account' do
       let!(:user) { create(:admin) }
 
-      before do
-        sign_in(user)
-      end
+      before { sign_in(user) }
 
       context 'when viewing my profile' do
         before { visit user_path(user) }

--- a/spec/system/users/alert_management_spec.rb
+++ b/spec/system/users/alert_management_spec.rb
@@ -1,0 +1,123 @@
+require 'rails_helper'
+
+RSpec.describe 'User alert management', :include_application_helper do
+  shared_examples 'an alert management page' do
+    it 'lists all schools' do
+      schools.each do |school|
+        expect(page).to have_link(school.name, href: school_path(school))
+        expect(page).to have_link(I18n.t('common.labels.view_alerts'), href: alerts_school_advice_path(school))
+      end
+    end
+
+    it 'displays clusters if found' do
+      cluster = create(:school_group_cluster)
+      schools.first.update!(school_group_cluster: cluster)
+      refresh
+      expect(page).to have_content(cluster.name)
+    end
+
+    context 'when user has an alert', :js do
+      let!(:contact) do
+        Contact.create(
+          user_id: user.id,
+          school_id: schools.first.id,
+          name: user.display_name,
+          email_address: user.email,
+          staff_role: user.staff_role
+        )
+      end
+
+      it 'allows user to unsubscribe' do
+        refresh
+        accept_confirm do
+          find_link(I18n.t('common.labels.unsubscribe'), match: :first).click
+        end
+        expect(page).to have_content(I18n.t('users.contacts.create.unsubscribed'))
+        expect(user.contacts).to be_empty
+      end
+    end
+
+    context 'with no alerts', :js do
+      it 'allows user to subscribe' do
+        accept_confirm do
+          find_link(I18n.t('common.labels.subscribe'), match: :first).click
+        end
+        expect(page).to have_content(I18n.t('users.contacts.create.subscribed'))
+        expect(user.contacts).not_to be_empty
+      end
+    end
+  end
+
+  context 'when logged in' do
+    before do
+      sign_in(user)
+      visit user_path(user)
+    end
+
+    context 'with a school admin' do
+      let(:user) { create(:school_admin) }
+
+      before do
+        within('#profile-page-navigation') do
+          click_on(I18n.t('nav.my_schools'))
+        end
+      end
+
+      it_behaves_like 'an alert management page' do
+        let(:schools) { [user.school] }
+      end
+    end
+
+    context 'with a cluster admin' do
+      let(:user) { create(:school_admin, :with_cluster_schools) }
+
+      before do
+        within('#profile-page-navigation') do
+          click_on(I18n.t('nav.my_schools'))
+        end
+      end
+
+      it_behaves_like 'an alert management page' do
+        let(:schools) { user.cluster_schools }
+      end
+    end
+
+    context 'with a group admin' do
+      let!(:user) { create(:group_admin, school_group: create(:school_group, :with_active_schools)) }
+
+      before do
+        within('#profile-page-navigation') do
+          click_on(I18n.t('nav.my_schools'))
+        end
+      end
+
+      it_behaves_like 'an alert management page' do
+        let(:schools) { user.school_group.schools.visible }
+      end
+    end
+
+    context 'with an admin' do
+      let(:user) { create(:admin) }
+
+      it 'does not show link to my alerts' do
+        expect(page).not_to have_link(I18n.t('users.show.manage_alerts'), href: user_contacts_path(user))
+      end
+
+      context 'when viewing another user' do
+        let(:school_admin) { create(:school_admin) }
+
+        before do
+          visit user_path(school_admin)
+          within('#profile-page-navigation') do
+            click_on(I18n.t('nav.my_schools'))
+          end
+        end
+
+        it_behaves_like 'an alert management page' do
+          let(:user) { school_admin }
+          let(:schools) { [user.school] }
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR adds a new `/profiles` route to allow users to manage their own accounts and preferences.

I've got some additional improvement to make (e.g. managing Mailchimp preferences, some admin options) but this feature covers the basics, so want to get this reviewed first.

There's a feature flag which toggles adding a user icon to the second nav which links to the pages.

Included some redacted screenshots below.

### Account page

![Screenshot from 2025-02-13 15-26-31](https://github.com/user-attachments/assets/8bbed6fa-eb6f-4aee-9fb3-5e729e63c74b)

### Account edit

![Screenshot from 2025-02-13 15-26-44](https://github.com/user-attachments/assets/fbf60c5f-d03a-417e-8bea-a7c8e67b913e)

### Password update

![Screenshot from 2025-02-13 15-26-53](https://github.com/user-attachments/assets/a34c9fea-d5ae-483a-9701-efaa5bc6cd82)

### Alert management

![Screenshot from 2025-02-13 15-27-02](https://github.com/user-attachments/assets/34dd0637-7069-4eeb-99d4-4c3495064c94)
