### PR TITLE
Try lookbook

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -131,7 +131,6 @@ group :development, :test do
   gem 'guard-rspec', require: false
   gem 'guard-rubocop', require: false
   gem 'knapsack'
-  gem 'lookbook'
   gem 'rails-controller-testing'
   gem 'rspec-json_expectations'
   gem 'rspec-rails'
@@ -139,6 +138,10 @@ group :development, :test do
   gem 'terminal-notifier-guard', require: false
   gem 'webmock'
   gem 'wisper-rspec', require: false
+end
+
+group :development, :production do
+  gem 'lookbook'
 end
 
 group :development do

--- a/Gemfile
+++ b/Gemfile
@@ -131,6 +131,7 @@ group :development, :test do
   gem 'guard-rspec', require: false
   gem 'guard-rubocop', require: false
   gem 'knapsack'
+  gem 'lookbook'
   gem 'rails-controller-testing'
   gem 'rspec-json_expectations'
   gem 'rspec-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -427,6 +427,18 @@ GEM
     loofah (2.24.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
+    lookbook (2.3.4)
+      activemodel
+      css_parser
+      htmlbeautifier (~> 1.3)
+      htmlentities (~> 4.3.4)
+      marcel (~> 1.0)
+      railties (>= 5.0)
+      redcarpet (~> 3.5)
+      rouge (>= 3.26, < 5.0)
+      view_component (>= 2.0)
+      yard (~> 0.9)
+      zeitwerk (~> 2.5)
     lumberjack (1.2.10)
     mail (2.8.1)
       mini_mime (>= 0.1.1)
@@ -601,6 +613,7 @@ GEM
       ffi (~> 1.0)
     rdoc (6.12.0)
       psych (>= 4.0.0)
+    redcarpet (3.6.0)
     regexp_parser (2.10.0)
     reline (0.6.0)
       io-console (~> 0.5)
@@ -814,6 +827,7 @@ GEM
       rubyzip (>= 1.0.0)
     xpath (3.2.0)
       nokogiri (~> 1.8)
+    yard (0.9.37)
     zeitwerk (2.7.1)
 
 PLATFORMS
@@ -876,6 +890,7 @@ DEPENDENCIES
   knapsack
   listen
   lograge
+  lookbook
   mailgun_rails
   mobility (~> 1.3.2)
   mobility-actiontext (~> 1.1.1)

--- a/app/views/admin/index.html.erb
+++ b/app/views/admin/index.html.erb
@@ -65,10 +65,10 @@
 
     <h2>Development</h2>
     <ul>
-      <li><%= link_to 'Background Jobs', admin_good_job_path %></li>
-      <li><%= link_to 'Component previews', admin_component_previews_path %></li>
+      <li><%= link_to 'Background jobs', admin_good_job_path %></li>
+      <li><%= link_to 'Component previews', admin_components_path %></li>
       <li><%= link_to 'Email previews', admin_mailer_previews_path %></li>
-      <li><%= link_to 'Feature Flags', admin_flipper_path %></li>
+      <li><%= link_to 'Feature flags', admin_flipper_path %></li>
       <li><%= link_to 'Site colour palette', admin_colours_path %></li>
     </ul>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -792,4 +792,8 @@ Rails.application.routes.draw do
   match "/:code", to: "errors#show", via: :all, constraints: {
     code: /#{ErrorsController::CODES.join("|")}/
   }
+
+  if Rails.env.development?
+    mount Lookbook::Engine, at: "/lookbook"
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -491,7 +491,6 @@ Rails.application.routes.draw do
 
   namespace :admin do
     resources :mailer_previews, only: [:index]
-    resources :component_previews, only: [:index]
     resources :styles, only: [:index]
     get 'colours', to: 'styles#index'
 
@@ -747,6 +746,7 @@ Rails.application.routes.draw do
     authenticate :user, ->(user) { user.admin? } do
       mount GoodJob::Engine => 'good_job'
       mount Flipper::UI.app(Flipper) => 'flipper', as: :flipper
+      mount Lookbook::Engine, as: :components, at: 'components'
     end
   end # Admin name space
 
@@ -793,7 +793,4 @@ Rails.application.routes.draw do
     code: /#{ErrorsController::CODES.join("|")}/
   }
 
-  if Rails.env.development?
-    mount Lookbook::Engine, at: "/lookbook"
-  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -746,7 +746,9 @@ Rails.application.routes.draw do
     authenticate :user, ->(user) { user.admin? } do
       mount GoodJob::Engine => 'good_job'
       mount Flipper::UI.app(Flipper) => 'flipper', as: :flipper
-      unless Rails.env.test?
+      if Rails.env.test?
+        get 'components', to: 'component_previews#index'
+      else
         mount Lookbook::Engine, as: :components, at: 'components'
       end
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -746,7 +746,9 @@ Rails.application.routes.draw do
     authenticate :user, ->(user) { user.admin? } do
       mount GoodJob::Engine => 'good_job'
       mount Flipper::UI.app(Flipper) => 'flipper', as: :flipper
-      mount Lookbook::Engine, as: :components, at: 'components'
+      unless Rails.env.test?
+        mount Lookbook::Engine, as: :components, at: 'components'
+      end
     end
   end # Admin name space
 

--- a/spec/factories/meters_factory.rb
+++ b/spec/factories/meters_factory.rb
@@ -128,12 +128,12 @@ FactoryBot.define do
         config        { create(:amr_data_feed_config) }
         end_date      { Date.parse('01/06/2019') }
         start_date    { end_date - (reading_count - 1).days }
-        log           { create(:amr_data_feed_import_log, amr_data_feed_config: config) }
+        import_log    { create(:amr_data_feed_import_log, amr_data_feed_config: config) }
       end
 
       after(:create) do |meter, evaluator|
         (evaluator.start_date.to_date..evaluator.end_date.to_date).each do |this_date|
-          create(:amr_data_feed_reading, meter: meter, reading_date: this_date.strftime('%b %e %Y %I:%M%p'), amr_data_feed_config: evaluator.config, amr_data_feed_import_log: evaluator.log)
+          create(:amr_data_feed_reading, meter: meter, reading_date: this_date.strftime('%b %e %Y %I:%M%p'), amr_data_feed_config: evaluator.config, amr_data_feed_import_log: evaluator.import_log)
         end
       end
     end


### PR DESCRIPTION
Can now be found at `/admin/components` and also in the admin index

Turns out I'd put the gem in the in the `group :development, :test` rather than just the `group :development` as recommended. It's now in the `group :development, :production` so we can use it on the live boxes.

I've also changed the name of the transient variable `log` in the meters factory (and tested it locally), in case we do want to switch this on in test for whatever reason (docs don't mention doing this though).