### PR TITLE
Fix Carousel Indicators

### DIFF
--- a/app/assets/stylesheets/base.scss
+++ b/app/assets/stylesheets/base.scss
@@ -190,6 +190,12 @@ input, progress {
   background-color: white;
 }
 
+.carousel-indicators li {
+  background: $grey-dark;
+  border:2px solid $grey-dark;
+  border-radius: 6px;
+}
+
 // polarity styles
 
 @each $polarity, $tones in $colours-polarity {

--- a/app/assets/stylesheets/home.scss
+++ b/app/assets/stylesheets/home.scss
@@ -160,12 +160,6 @@
     }
   }
 
-  .carousel-indicators li {
-    background: $grey-dark;
-    border:2px solid $grey-dark;
-    border-radius: 6px;
-  }
-
   .home-block {
     margin-top: 53px;
     padding-bottom: 30px;

--- a/app/components/equivalence_carousel_component/equivalence_carousel_component.scss
+++ b/app/components/equivalence_carousel_component/equivalence_carousel_component.scss
@@ -1,4 +1,7 @@
 .equivalence-carousel-component {
+  padding-left: 20px;
+  padding-right: 20px;
+
   .carousel-control-prev, .carousel-control-next, .carousel-indicators {
     height: $f6;
   }


### PR DESCRIPTION
Also have put some padding in the equivalence-carousel-component, as the text was touching the sides:

Before padding:
![Screenshot 2025-02-13 at 10 00 40](https://github.com/user-attachments/assets/9bc5b9ff-86d7-432b-a874-054a795c95d5)
After padding:
![Screenshot 2025-02-13 at 10 00 50](https://github.com/user-attachments/assets/9c48be42-db1a-42f3-97bc-f0793539c488)
