### PR TITLE
Update status for locked users

### DIFF
--- a/app/models/mailchimp/contact.rb
+++ b/app/models/mailchimp/contact.rb
@@ -22,7 +22,7 @@ module Mailchimp
       contact.contact_source = 'User'
       contact.confirmed_date = user.confirmed_at.to_date.iso8601
       contact.user_role = user.role.humanize
-      contact.user_status = user.access_locked? ? 'Disabled' : 'Active'
+      contact.user_status = user.active? ? 'Active' : 'Disabled'
       contact.locale = user.preferred_locale
       contact.interests = interests
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -57,7 +57,7 @@ require 'securerandom'
 class User < ApplicationRecord
   include MailchimpUpdateable
 
-  watch_mailchimp_fields :confirmed_at, :name, :preferred_locale, :school_id, :school_group_id, :role, :staff_role_id
+  watch_mailchimp_fields :confirmed_at, :name, :preferred_locale, :school_id, :school_group_id, :role, :staff_role_id, :active
   after_destroy :reset_mailchimp_contact
 
   # Email is primary key in Mailchimp, trigger immediate update if its is changed, otherwise

--- a/lib/tasks/deployment/20250217164840_disable_archived_users.rake
+++ b/lib/tasks/deployment/20250217164840_disable_archived_users.rake
@@ -1,0 +1,19 @@
+namespace :after_party do
+  desc 'Deployment task: disable_archived_users'
+  task disable_archived_users: :environment do
+    puts "Running deploy task 'disable_archived_users'"
+
+    # We previously locked users when archiving schools, but we not have the active flag
+    # Find all locked school users, who are linked to inactive (archived, removed) schools
+    # Do not want to disable any temporarily locked accounts
+    User.joins(:school).where(role: [:pupil, :staff, :school_admin, :volunteer]).where.not(locked_at: nil).where(schools: { active: false }).update_all(active: false)
+
+    # Find all group_admins that are locked, and disable them if every school in the group has
+    # been removed
+
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord
+      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+  end
+end

--- a/spec/models/mailchimp/contact_spec.rb
+++ b/spec/models/mailchimp/contact_spec.rb
@@ -134,7 +134,7 @@ describe Mailchimp::Contact do
       end
 
       context 'when account is disabled' do
-        let!(:user) { create(:school_admin, :subscribed_to_alerts, school: school, locked_at: Time.zone.now) }
+        let!(:user) { create(:school_admin, :subscribed_to_alerts, school: school, active: false) }
 
         it 'uses correct status' do
           expect(contact.user_status).to eq 'Disabled'

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -483,7 +483,8 @@ describe User do
           role: :admin,
           school: create(:school),
           school_group: create(:school_group),
-          staff_role: create(:staff_role, :management)
+          staff_role: create(:staff_role, :management),
+          active: false
         }
       end
 


### PR DESCRIPTION
Update status for locked accounts associated with removed/archived schools to set them as inactive. This is now the correct status when removing users like this.

Also updates the Mailchimp code to use the active attribute rather than the access locked status.