### PR TITLE
Revise mailchimp export code to apply new defaults

### DIFF
--- a/app/models/mailchimp/contact.rb
+++ b/app/models/mailchimp/contact.rb
@@ -124,12 +124,47 @@ module Mailchimp
       tags
     end
 
+
+    # All the email types
+    # Using the names rather than the ids, as this allows us to test against the
+    # developer account
+    GETTING_THE_MOST = 'Getting the most out of Energy Sparks'.freeze
+    ENGAGING_PUPILS = 'Engaging pupils in energy saving and climate'.freeze
+    LEADERSHIP = 'Energy saving leadership'.freeze
+    TAILORED_ADVICE = 'Tailored advice and support'.freeze
+    TRAINING = 'Training opportunities'.freeze
+
+    LEADERSHIP_INTERESTS = [GETTING_THE_MOST, TRAINING, TAILORED_ADVICE, LEADERSHIP].freeze
+    TEACHING_INTERESTS =   [GETTING_THE_MOST, TRAINING, TAILORED_ADVICE, ENGAGING_PUPILS].freeze
+
+    ALL_INTERESTS = [GETTING_THE_MOST, TRAINING, TAILORED_ADVICE, LEADERSHIP, ENGAGING_PUPILS].freeze
+
+    SCHOOL_USER_INTERESTS = {
+      'Business manager' => LEADERSHIP_INTERESTS,
+      'Building/site manager or caretaker' => LEADERSHIP_INTERESTS,
+      'Governor' => LEADERSHIP_INTERESTS,
+      'Teacher or teaching assistant' => TEACHING_INTERESTS,
+      'Headteacher or Deputy Head' => ALL_INTERESTS,
+      'Council or MAT staff' => LEADERSHIP_INTERESTS,
+      'Parent or volunteer' => TEACHING_INTERESTS,
+      'Public' => [GETTING_THE_MOST, TRAINING, TAILORED_ADVICE]
+    }.freeze
+
+    ORGANIC_SIGN_UP_INTERESTS = [GETTING_THE_MOST, ENGAGING_PUPILS, LEADERSHIP].freeze
+
     # Take Array of interests returned by AudienceManager and turn into hash
     # for use on forms, setting the default opt-in state.
-    #
-    # TODO: change defaults based on user role/staff role
-    def self.default_interests(interests, _user = nil)
-      interests.to_h { |i| [i.id, true] }
+    def self.default_interests(interests, user = nil)
+      interest_list = if user&.group_admin?
+                        ALL_INTERESTS
+                      elsif user&.staff_role && SCHOOL_USER_INTERESTS.key?(user.staff_role.title)
+                        SCHOOL_USER_INTERESTS[user.staff_role.title]
+                      else
+                        ORGANIC_SIGN_UP_INTERESTS
+                      end
+      interests.to_h do |interest|
+        [interest.id, interest_list.include?(interest.name)]
+      end
     end
 
     # Convert to hash for submitting to mailchimp api

--- a/app/services/mailchimp/csv_exporter.rb
+++ b/app/services/mailchimp/csv_exporter.rb
@@ -59,22 +59,24 @@ module Mailchimp
           mailchimp_contact_type = mailchimp_contact_type(user.email)
           # remove matches from list
           contact = @audience[mailchimp_contact_type].delete(user.email)
-          # update user
-          @updated_audience[mailchimp_contact_type] << to_mailchimp_contact(user, contact)
+          # update user, only adding default interests if we're overriding current prefs
+          @updated_audience[mailchimp_contact_type] << to_mailchimp_contact(user, contact, add_default_interests: @add_default_interests)
         else
-          @new_nonsubscribed << to_mailchimp_contact(user)
+          # always add default interests
+          @new_nonsubscribed << to_mailchimp_contact(user, add_default_interests: true)
         end
       end
     end
 
     # Process any Mailchimp contacts that are not registered users
+    # Only add default interests if overriding current prefs
     def process_unmatched_contacts
       @audience.each do |category, contacts|
-        updated_audience[category] = updated_audience[category] + contacts.values.map {|c| copy_contact(c) }
+        updated_audience[category] = updated_audience[category] + contacts.values.map {|c| copy_contact(c, add_default_interests: @add_default_interests) }
       end
     end
 
-    def to_mailchimp_contact(user, existing_contact = nil)
+    def to_mailchimp_contact(user, existing_contact = nil, add_default_interests: false)
       # Convert from comma-separated names to hash
       interests = if existing_contact.present? && existing_contact[:interests].present?
                     existing_contact[:interests].split(',').index_with { |_i| true }
@@ -82,7 +84,7 @@ module Mailchimp
                     {}
                   end
 
-      interests = default_interests(interests, user) if @add_default_interests
+      interests = default_interests(interests, user) if add_default_interests
 
       tags = existing_contact.present? && existing_contact[:tags].present? ? existing_contact[:tags].split(',') : []
       contact = Mailchimp::Contact.from_user(user, tags: tags, interests: interests)
@@ -124,7 +126,7 @@ module Mailchimp
     #
     # This is to allow for migration to be re-run before we tidy up and remove some of
     # the old fields.
-    def copy_contact(existing_contact)
+    def copy_contact(existing_contact, add_default_interests: false)
       # TODO use new model
       contact = ActiveSupport::OrderedOptions.new
       contact.email_address = existing_contact[:email_address]
@@ -135,7 +137,7 @@ module Mailchimp
       # If this is present then we're updating an existing contact that should
       # have Newsletter set already
       # TODO naming
-      contact.interests = @add_default_interests ? default_interests(existing_contact[:interests]) : existing_contact[:interests]
+      contact.interests = add_default_interests ? default_interests(existing_contact[:interests]) : existing_contact[:interests]
 
       # FIXME old fields have been removed, so simplify
       first_and_last_name_fields = existing_contact[:first_name] && existing_contact[:last_name]

--- a/lib/tasks/mailchimp/csv_export.rake
+++ b/lib/tasks/mailchimp/csv_export.rake
@@ -1,8 +1,11 @@
 namespace :mailchimp do
   desc "Export new versions of Mailchimp export CSV files"
-  task :csv_export, [:dir] => :environment do |t,args|
+  task :csv_export, [:dir, :add_defaults] => :environment do |t,args|
+    args.with_defaults(add_defaults: false)
+    add_defaults = ActiveModel::Type::Boolean.new.cast( args.add_defaults )
+
     puts "#{DateTime.now.utc} Mailchimp CSV Export Started"
-    puts "Loading from #{args.dir}"
+    puts "Loading from #{args.dir}, add_defaults #{add_defaults}"
 
     audience = {}
     [:subscribed, :unsubscribed, :nonsubscribed, :cleaned].each do |category|
@@ -10,7 +13,7 @@ namespace :mailchimp do
       audience[category] = CSV.read("#{args.dir}/#{file}", headers: true, header_converters: :symbol)
     end
 
-    service = Mailchimp::CsvExporter.new(**audience)
+    service = Mailchimp::CsvExporter.new(add_default_interests: add_defaults, **audience)
     puts "#{DateTime.now.utc} Fetching data"
 
     service.perform

--- a/spec/services/mailchimp/csv_exporter_spec.rb
+++ b/spec/services/mailchimp/csv_exporter_spec.rb
@@ -1,8 +1,10 @@
 require 'rails_helper'
 
 describe Mailchimp::CsvExporter do
+  include_context 'with a stubbed audience manager'
+
   subject(:service) do
-    described_class.new(subscribed: subscribed, nonsubscribed: nonsubscribed, unsubscribed: unsubscribed, cleaned: cleaned)
+    described_class.new(add_default_interests: true, subscribed: subscribed, nonsubscribed: nonsubscribed, unsubscribed: unsubscribed, cleaned: cleaned)
   end
 
   let(:subscribed) { [] }
@@ -21,11 +23,7 @@ describe Mailchimp::CsvExporter do
 
   shared_examples 'it adds interests correctly' do |newsletter: true|
     it 'adds Newsletter', if: newsletter do
-      expect(contact.interests).to eq 'Newsletter'
-    end
-
-    it 'does not add Newsletter', unless: newsletter do
-      expect(contact.interests).to be_empty
+      expect(contact.interests).to include 'Getting the most out of Energy Sparks'
     end
   end
 
@@ -108,11 +106,12 @@ describe Mailchimp::CsvExporter do
 
       context 'with existing interests' do
         let(:subscribed) do
-          [create_contact(user.email, interests: 'Newsletter,Others')]
+          [create_contact(user.email, interests: 'Getting the most out of Energy Sparks,Others')]
         end
 
         it 'preserves the interests' do
-          expect(contact.interests).to eq('Newsletter,Others')
+          expect(contact.interests).to include('Getting the most out of Energy Sparks')
+          expect(contact.interests).to include('Others')
         end
       end
 
@@ -351,7 +350,7 @@ describe Mailchimp::CsvExporter do
       end
 
       it_behaves_like 'it correctly creates a contact', school_user: true
-      it_behaves_like 'it adds interests correctly', newsletter: false
+      it_behaves_like 'it adds interests correctly'
     end
 
     context 'with a group admin' do
@@ -362,7 +361,7 @@ describe Mailchimp::CsvExporter do
       end
 
       it_behaves_like 'it correctly creates a contact', group_admin: true
-      it_behaves_like 'it adds interests correctly', newsletter: false
+      it_behaves_like 'it adds interests correctly'
     end
 
     context 'with an admin' do
@@ -373,7 +372,7 @@ describe Mailchimp::CsvExporter do
       end
 
       it_behaves_like 'it correctly creates a contact'
-      it_behaves_like 'it adds interests correctly', newsletter: false
+      it_behaves_like 'it adds interests correctly'
     end
 
     context 'with an unconfirmed user' do

--- a/spec/services/mailchimp/csv_exporter_spec.rb
+++ b/spec/services/mailchimp/csv_exporter_spec.rb
@@ -255,87 +255,9 @@ describe Mailchimp::CsvExporter do
       service.perform
     end
 
-    context 'with a pre-migration contact' do
-      let(:subscribed) do
-        [create_contact('user@example.org', first_name: 'John', last_name: 'Smith', school_or_organisation: 'DfE', user_type: 'School management', other_la: 'bhcc', other_mat: 'Unity Schools Partnership', local_authority_and_mats: 'Other', tags: 'trustee,external support,FSM30')]
-      end
-
-      it 'retains the contact' do
-        expect(service.updated_audience[:subscribed].length).to eq(1)
-      end
-
-      it_behaves_like 'it adds interests correctly'
-
-      it 'populates the fields correctly' do
-        expect(contact.email_address).to eq('user@example.org')
-        expect(contact.name).to eq 'John Smith'
-        expect(contact.contact_source).to eq 'Organic'
-        expect(contact.confirmed_date).to be_nil
-        expect(contact.user_role).to be_nil
-        expect(contact.locale).to eq 'en'
-        expect(contact.staff_role).to eq 'School management'
-        expect(contact.school).to eq 'DfE'
-        expect(contact.school_group).to eq 'Unity Schools Partnership'
-      end
-
-      it 'copies tags, stripping free school meal tags' do
-        expect(contact.tags).to eq 'trustee,external support'
-      end
-
-      context 'with name and first name only' do
-        let(:subscribed) do
-          [create_contact('user@example.org', first_name: 'John', name: 'Smith')]
-        end
-
-        it 'builds the name correctly' do
-          expect(contact.name).to eq 'John Smith'
-        end
-      end
-
-      context 'with name only' do
-        let(:subscribed) do
-          [create_contact('user@example.org', name: 'John Smith')]
-        end
-
-        it 'builds the name correctly' do
-          expect(contact.name).to eq 'John Smith'
-        end
-      end
-
-      context 'with first name and name overlapping' do
-        let(:subscribed) do
-          [create_contact('user@example.org', name: 'John Smith', first_name: 'John')]
-        end
-
-        it 'builds the name correctly' do
-          expect(contact.name).to eq 'John Smith'
-        end
-      end
-
-      context 'with first name only' do
-        let(:subscribed) do
-          [create_contact('user@example.org', first_name: 'John')]
-        end
-
-        it 'builds the name correctly' do
-          expect(contact.name).to eq 'John'
-        end
-      end
-
-      context 'with last name only' do
-        let(:subscribed) do
-          [create_contact('user@example.org', last_name: 'Smith')]
-        end
-
-        it 'builds the name correctly' do
-          expect(contact.name).to eq 'Smith'
-        end
-      end
-    end
-
     context 'with a post-migration contact' do
       let(:subscribed) do
-        [create_contact('user@example.org', name: 'John Smith', first_name: 'John', last_name: 'Smith', school: 'DfE', user_type: 'School management', school_group: 'Unity Schools Partnership', school_or_organisation: 'XDfE', other_la: 'Xbhcc', other_mat: 'XUnity Schools Partnership', local_authority_and_mats: 'Other', tags: 'trustee,external support')]
+        [create_contact('user@example.org', name: 'John Smith', staff_role: 'School management', school_group: 'Unity Schools Partnership', school_or_organisation: 'DfE', tags: 'trustee,external support')]
       end
 
       it_behaves_like 'it adds interests correctly'

--- a/spec/system/users/email_management_spec.rb
+++ b/spec/system/users/email_management_spec.rb
@@ -25,13 +25,9 @@ RSpec.describe 'User email management', :include_application_helper do
         allow(audience_manager).to receive(:get_list_member).and_return(nil)
       end
 
-      it 'defaults form to all checked' do
+      it 'some default options are pre-selected' do
         refresh
-        expect(page).to have_checked_field('Getting the most out of Energy Sparks')
-        expect(page).to have_checked_field('Engaging pupils in energy saving and climate')
-        expect(page).to have_checked_field('Energy saving leadership')
-        expect(page).to have_checked_field('Training opportunities')
-        expect(page).to have_checked_field('Tailored advice and support')
+        expect(all('input[type=checkbox]').map(&:checked?)).not_to be_empty
       end
     end
 


### PR DESCRIPTION
Revises the code that creates improved CSV files for importing into Mailchimp, so that it correctly adds in default interests. We will use this when doing the initial imports. The behaviour is optional so we can still run this code after the initial user import and ensure that we preserve interests.

The PR also removes some old code that was mapping between old Mailchimp fields and the new schema. The old fields have been removed from Mailchimp so we no longer need the code and specs.