### PR TITLE
Remove blank option from staff role

### DIFF
--- a/app/views/schools/users/_form.html.erb
+++ b/app/views/schools/users/_form.html.erb
@@ -1,4 +1,14 @@
-<%= f.input :name, required: :true, label: t('schools.users.form.name') %>
-<%= f.input :email, required: :true, label: t('schools.users.form.email') %>
-<%= f.input :staff_role_id, label: t('schools.users.form.role'), required: :true, collection: StaffRole.translated_names_and_ids, hint: t('schools.users.form.what_is_their_primary_role') %>
-<%= f.input :preferred_locale, label: t('schools.users.form.preferred_locale'), required: :true, collection: I18n.available_locales.map { |locale| [I18n.t("languages.#{locale}"), locale] }, prompt: '', hint: t('schools.users.form.preferred_locale_hint') %>
+<%= f.input :name, required: true, label: t('schools.users.form.name') %>
+<%= f.input :email, required: true, label: t('schools.users.form.email') %>
+<%= f.input :staff_role_id,
+            label: t('schools.users.form.role'),
+            required: true,
+            collection: StaffRole.translated_names_and_ids,
+            hint: t('schools.users.form.what_is_their_primary_role'),
+            prompt: '' %>
+<%= f.input :preferred_locale,
+            label: t('schools.users.form.preferred_locale'),
+            required: true,
+            collection: I18n.available_locales.map { |locale| [I18n.t("languages.#{locale}"), locale] },
+            prompt: '',
+            hint: t('schools.users.form.preferred_locale_hint') %>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -14,7 +14,8 @@
           <%= f.input :staff_role_id,
                       label: t('schools.users.form.role'),
                       required: true,
-                      collection: StaffRole.translated_names_and_ids %>
+                      collection: StaffRole.translated_names_and_ids,
+                      prompt: '' %>
         <% end %>
 
         <div class="form-group">


### PR DESCRIPTION
The forms to create users have a blank option in the Staff Role field. But a staff role must be set.

Adjust the form so there's an empty prompt instead so that there's no blank option.