### PR TITLE
Only show scoreboard activity that has points

### DIFF
--- a/app/components/scoreboard_summary_component.rb
+++ b/app/components/scoreboard_summary_component.rb
@@ -35,7 +35,7 @@ class ScoreboardSummaryComponent < ApplicationComponent
 
   def observations
     scope = other_schools? ? scoreboard.observations : Observation
-    scope.for_visible_schools.not_including(school).recorded_since(school.current_academic_year.start_date..).by_date.limit(limit)
+    scope.for_visible_schools.not_including(school).recorded_since(school.current_academic_year.start_date..).by_date.with_points.sample(limit)
   end
 
   def timeline_title

--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -86,6 +86,7 @@ class Observation < ApplicationRecord
 
   accepts_nested_attributes_for :temperature_recordings, reject_if: :reject_temperature_recordings
 
+  scope :with_points, -> { where('points IS NOT NULL AND points > 0') }
   scope :visible, -> { where(visible: true) }
   scope :by_date, ->(order = :desc) { order(at: order) }
   scope :for_school, ->(school) { where(school: school) }

--- a/spec/components/scoreboard_summary_component_spec.rb
+++ b/spec/components/scoreboard_summary_component_spec.rb
@@ -89,4 +89,18 @@ RSpec.describe ScoreboardSummaryComponent, type: :component, include_url_helpers
       it { expect(component.other_schools?).to be(true) }
     end
   end
+
+  describe '#observations' do
+    context 'with points' do
+      let!(:other_school) { create :school, :with_points, score_points: 50, scoreboard: scoreboard }
+
+      it { expect(component.observations).not_to be_empty }
+    end
+
+    context 'with no points' do
+      let!(:other_school) { create :school, :with_points, score_points: 0, scoreboard: scoreboard }
+
+      it { expect(component.observations).to be_empty }
+    end
+  end
 end


### PR DESCRIPTION
Change ScoreboardSummaryComponent so that it:

- only shows point scoring activity from other schools (this excluding, e.g. having an audit or taking temperatures)
- uses `.sample` rather than `.limit` so that we add some randomness to what's displayed, otherwise we always show same recent activity

