### PR TITLE
Fix organic contact interests

### DIFF
--- a/app/services/mailchimp/csv_exporter.rb
+++ b/app/services/mailchimp/csv_exporter.rb
@@ -133,14 +133,8 @@ module Mailchimp
       contact.locale = 'en'
       contact.tags = non_fsm_tags(existing_contact).join(',')
 
-      # Turn existing interests into a hash to make it easier to set
-      # defaults
-      interests = if existing_contact[:interests].present?
-                    existing_contact[:interests].split(',').index_with { |_i| true }
-                  else
-                    {}
-                  end
 
+      interests = (existing_contact&.dig(:interests)&.split(',') || []).index_with { true }
       contact.interests = add_default_interests ? default_interests(interests) : interests
 
       # Convert interests back into a string for the CSV export

--- a/app/services/mailchimp/csv_exporter.rb
+++ b/app/services/mailchimp/csv_exporter.rb
@@ -133,6 +133,8 @@ module Mailchimp
       contact.locale = 'en'
       contact.tags = non_fsm_tags(existing_contact).join(',')
 
+      # Turn existing interests into a hash to make it easier to set
+      # defaults
       interests = if existing_contact[:interests].present?
                     existing_contact[:interests].split(',').index_with { |_i| true }
                   else
@@ -140,10 +142,15 @@ module Mailchimp
                   end
 
       contact.interests = add_default_interests ? default_interests(interests) : interests
+
+      # Convert interests back into a string for the CSV export
+      contact.interests = contact.interests.keys.join(',')
+
       contact.name = existing_contact[:name]
       contact.staff_role = existing_contact[:staff_role]
       contact.school = existing_contact[:school_or_organisation]
       contact.school_group = existing_contact[:school_group]
+
       contact
     end
 

--- a/spec/services/mailchimp/csv_exporter_spec.rb
+++ b/spec/services/mailchimp/csv_exporter_spec.rb
@@ -23,7 +23,8 @@ describe Mailchimp::CsvExporter do
   end
 
   shared_examples 'it adds interests correctly' do
-    it 'adds emails types' do
+    it 'adds emails types as a comma-separated list' do
+      expect(contact.interests).to be_a(String)
       expect(contact.interests).to include 'Getting the most out of Energy Sparks'
     end
   end
@@ -278,10 +279,17 @@ describe Mailchimp::CsvExporter do
         expect(contact.user_role).to be_nil
         expect(contact.locale).to eq 'en'
         expect(contact.tags).to eq 'trustee,external support'
-
         expect(contact.staff_role).to eq 'School management'
         expect(contact.school).to eq 'DfE'
         expect(contact.school_group).to eq 'Unity Schools Partnership'
+      end
+
+      context 'when not adding in default interests' do
+        let(:add_default_interests) { false }
+
+        it 'does not add any interests' do
+          expect(contact.interests).to eq('')
+        end
       end
     end
   end

--- a/spec/services/mailchimp/csv_exporter_spec.rb
+++ b/spec/services/mailchimp/csv_exporter_spec.rb
@@ -24,8 +24,7 @@ describe Mailchimp::CsvExporter do
 
   shared_examples 'it adds interests correctly' do
     it 'adds emails types as a comma-separated list' do
-      expect(contact.interests).to be_a(String)
-      expect(contact.interests).to include 'Getting the most out of Energy Sparks'
+      expect(contact.interests.split(',')).to include 'Getting the most out of Energy Sparks'
     end
   end
 


### PR DESCRIPTION
Fixes an issue with creating the list of emails associated with each contact in the CSV export.

Internally we manage the list of interests as a hash of name/id to true/false for each preference. But this has to be turned into a comma-separated list for the CSV export.

The interests for "organic" contacts was not being converted to a string. Bug crept through because Hash responds to `include`. So have added a check for the type of object as well as its contents.