### PR TITLE
Fix date error when loading SolisCloud data

### DIFF
--- a/app/models/solis_cloud_installation.rb
+++ b/app/models/solis_cloud_installation.rb
@@ -34,7 +34,8 @@ class SolisCloudInstallation < ApplicationRecord
   end
 
   def latest_electricity_reading
-    AmrDataFeedReading.where(meter_id: meters).maximum(:reading_date)
+    reading_date = AmrDataFeedReading.where(meter_id: meters).maximum(:reading_date)
+    reading_date ? Date.parse(reading_date) : nil
   end
 
   def update_station_list

--- a/spec/models/solis_cloud_installation_spec.rb
+++ b/spec/models/solis_cloud_installation_spec.rb
@@ -9,7 +9,7 @@ describe SolisCloudInstallation do
     it 'gets a reading' do
       create(:electricity_meter_with_reading, solis_cloud_installation: installation, reading_date_format: '%Y-%m-%d',
                                               reading_count: 2)
-      expect(installation.latest_electricity_reading).to eq('2019-06-01')
+      expect(installation.latest_electricity_reading).to eq(Date.new(2019, 6, 1))
     end
 
     it 'returns nil with no meter' do


### PR DESCRIPTION
`.latest_electricity_reading` returns a string but code in the base class and the upserter was expecting a date. Added a `Date.parse` call and a spec.