### PR TITLE
Remove volunteer role

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -228,7 +228,7 @@ class Ability
 
       can %i[show read index], Audit, related_school_scope
       can :download_school_data, School, school_scope
-    elsif user.staff? || user.volunteer? || user.pupil?
+    elsif user.staff? || user.pupil?
       # abilities that give you access to dashboards for own school
       school_scope = { id: user.school_id, visible: true }
       can %i[show show_pupils_dash show_management_dash], School, school_scope
@@ -255,15 +255,15 @@ class Ability
         can %i[start read update create], TransportSurvey, related_school_scope
         can %i[read create], TransportSurvey::Response, transport_survey: related_school_scope
       end
-      # pupils and volunteers can only read real cost data if their school is set to share data publicly
-      if user.volunteer? || user.pupil?
+      # pupils can only read real cost data if their school is set to share data publicly
+      if user.pupil?
         can %i[read_restricted_analysis read_restricted_advice], School,
             { id: user.school_id, visible: true, data_sharing: :public }
       else
         # but staff can read it regardless
         can %i[read_restricted_analysis read_restricted_advice], School, { id: user.school_id, visible: true }
       end
-      if user.staff? || user.volunteer?
+      if user.staff?
         can :manage, [SchoolTarget, EstimatedAnnualConsumption], school: { id: user.school_id, visible: true }
         can :start_programme, School, id: user.school_id, visible: true
         can :crud, Programme, school: { id: user.school_id, visible: true }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -92,14 +92,15 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable and :omniauthable
   devise :database_authenticatable, :recoverable, :rememberable, :trackable, :validatable, :lockable, :confirmable
 
+  # volunteer has been removed, this was 8
   enum :role, { guest: 0, staff: 1, admin: 2, school_admin: 3, school_onboarding: 4, pupil: 5,
-                group_admin: 6, analytics: 7, volunteer: 8 }
+                group_admin: 6, analytics: 7 }
 
   enum :mailchimp_status, %w[subscribed unsubscribed cleaned nonsubscribed archived].to_h { |v| [v, v] }, prefix: true
 
   scope :active, -> { where(active: true) }
 
-  scope :alertable, -> { where(role: [User.roles[:staff], User.roles[:school_admin], User.roles[:volunteer]]) }
+  scope :alertable, -> { where(role: [User.roles[:staff], User.roles[:school_admin]]) }
 
   scope :mailchimp_roles, -> {
     where.not(role: [:pupil, :school_onboarding]).where.not(confirmed_at: nil)

--- a/app/services/confirmation_reminder.rb
+++ b/app/services/confirmation_reminder.rb
@@ -4,7 +4,7 @@
 #
 # Do not chase old accounts.
 module ConfirmationReminder
-  CONFIRMABLE_ROLES = [:staff, :school_admin, :group_admin, :volunteer].freeze
+  CONFIRMABLE_ROLES = [:staff, :school_admin, :group_admin].freeze
 
   def self.send
     now = Time.current

--- a/app/views/onboarding/users/_form.html.erb
+++ b/app/views/onboarding/users/_form.html.erb
@@ -1,5 +1,20 @@
 <%= f.input :name, required: false %>
 <%= f.input :email, required: true %>
-<%= f.input :role, label: t('onboarding.users.form.type'), required: true, collection: User.roles.except(:guest, :admin, :school_onboarding, :pupil, :group_admin, :analytics, :volunteer).keys, label_method: lambda { |role| t_role(role) }, hint: t('onboarding.users.form.staff_accounts_have_access_hint') %>
-<%= f.input :staff_role_id, label: t('onboarding.users.form.role'), required: true, collection: StaffRole.order(:title), label_method: :translated_title, hint: t('onboarding.users.form.what_is_the_users_relationship_hint') %>
-<%= f.input :preferred_locale, label: t('onboarding.users.form.preferred_locale'), required: :true, collection: I18n.available_locales.map { |locale| [I18n.t("languages.#{locale}"), locale] }, prompt: '', hint: t('onboarding.users.form.preferred_locale_hint'), selected: @user&.new_record? ? current_user&.preferred_locale : @user&.preferred_locale %>
+<%= f.input :role,
+            label: t('onboarding.users.form.type'),
+            required: true,
+            collection: %i[staff school_admin],
+            label_method: ->(role) { t_role(role) },
+            hint: t('onboarding.users.form.staff_accounts_have_access_hint') %>
+<%= f.input :staff_role_id,
+            label: t('onboarding.users.form.role'), required: true,
+            collection: StaffRole.order(:title),
+            label_method: :translated_title,
+            hint: t('onboarding.users.form.what_is_the_users_relationship_hint') %>
+<%= f.input :preferred_locale,
+            label: t('onboarding.users.form.preferred_locale'),
+            required: true,
+            collection: I18n.available_locales.map { |locale| [I18n.t("languages.#{locale}"), locale] },
+            prompt: '',
+            hint: t('onboarding.users.form.preferred_locale_hint'),
+            selected: @user&.new_record? ? current_user&.preferred_locale : @user&.preferred_locale %>

--- a/config/locales/cy/models/lists.yml
+++ b/config/locales/cy/models/lists.yml
@@ -45,7 +45,6 @@ cy:
     school_admin: Gweinyddwr Ysgol
     school_onboarding: Cofrestru
     staff: Staff
-    volunteer: Gwirfoddolwr
   staff_role:
     building_site_manager_or_caretaker: Rheolwr adeilad/safle neu ofalwr
     business_manager: Rheolwr busnes

--- a/config/locales/models/lists.yml
+++ b/config/locales/models/lists.yml
@@ -46,7 +46,6 @@ en:
     school_admin: School Admin
     school_onboarding: Onboarding
     staff: Staff
-    volunteer: Volunteer
   staff_role:
     building_site_manager_or_caretaker: Building/site manager or caretaker
     business_manager: Business manager

--- a/spec/factories/users_factory.rb
+++ b/spec/factories/users_factory.rb
@@ -48,12 +48,6 @@ FactoryBot.define do
       role { :admin }
     end
 
-    factory :volunteer do
-      name { 'Volunteer'}
-      role { :volunteer }
-      school
-    end
-
     factory :analytics do
       name { 'Analytics'}
       role { :analytics }

--- a/spec/models/abilities_spec.rb
+++ b/spec/models/abilities_spec.rb
@@ -346,40 +346,6 @@ describe Ability do
         end
       end
 
-      context 'when user is a volunteer' do
-        let(:user) { create(:volunteer, school: school) }
-
-        it_behaves_like 'a user who cannot manage site wide content'
-
-        context 'when school is visible' do
-          it_behaves_like 'they can access the school dashboard and data'
-          it_behaves_like 'they can record activities for their school'
-          it_behaves_like 'they can set targets'
-          it_behaves_like 'they can manage correct types of tariffs', school_tariffs: false
-
-          it 'allows access to restricted advice' do
-            expect(ability).to be_able_to(:read_restricted_analysis, school)
-            expect(ability).to be_able_to(:read_restricted_advice, school)
-          end
-        end
-
-        context 'when school is not visible' do
-          let(:visible) { false }
-
-          it_behaves_like 'they cannot access the school dashboard and data'
-        end
-
-        it_behaves_like 'they cannot manage other schools, groups and users'
-
-        it_behaves_like 'they can view school group but not manage it'
-
-        it { is_expected.not_to be_able_to(:show_management_dash, create(:school_group))}
-
-        it_behaves_like 'their access to other school dashboards is limited by data sharing settings' do
-          let(:user_group) { school_group }
-        end
-      end
-
       context 'with user is a pupil' do
         let(:user) { create(:pupil, school: school) }
 

--- a/spec/models/mailchimp/contact_spec.rb
+++ b/spec/models/mailchimp/contact_spec.rb
@@ -400,22 +400,6 @@ describe Mailchimp::Contact do
           let(:role) { :school_admin }
         end
       end
-
-      context 'with volunteer' do
-        it_behaves_like 'it maps all the roles correctly' do
-          let(:role) { :volunteer }
-        end
-      end
-
-      context 'with a user with no staff role' do
-        let(:user) { create(:volunteer, staff_role: nil) }
-
-        it_behaves_like 'interests have been selected' do
-          let(:selected) do
-            [Mailchimp::Contact::GETTING_THE_MOST, Mailchimp::Contact::ENGAGING_PUPILS, Mailchimp::Contact::LEADERSHIP]
-          end
-        end
-      end
     end
   end
 end

--- a/spec/services/confirmation_reminder_spec.rb
+++ b/spec/services/confirmation_reminder_spec.rb
@@ -97,7 +97,7 @@ describe ConfirmationReminder do
     end
   end
 
-  [:staff, :school_admin, :volunteer].each do |role|
+  [:staff, :school_admin].each do |role|
     context "with #{role} school user role" do
       it_behaves_like 'a confirmable user role' do
         let(:role) { role }

--- a/spec/services/mailchimp/csv_exporter_spec.rb
+++ b/spec/services/mailchimp/csv_exporter_spec.rb
@@ -388,7 +388,7 @@ describe Mailchimp::CsvExporter do
     let!(:school_admin) { create(:school_admin, school: school) }
     let!(:group_admin) { create(:group_admin, school_group: school_group) }
     let!(:staff) { create(:staff) }
-    let!(:volunteer) { create(:volunteer) }
+    let!(:other_staff) { create(:staff) }
     let!(:admin) { create(:admin) }
 
     let(:subscribed) do
@@ -407,7 +407,7 @@ describe Mailchimp::CsvExporter do
     end
 
     let(:nonsubscribed) do
-      [create_contact(volunteer.email)]
+      [create_contact(other_staff.email)]
     end
 
     before do
@@ -421,7 +421,7 @@ describe Mailchimp::CsvExporter do
 
       expect(service.updated_audience[:cleaned].map(&:email_address)).to contain_exactly(group_admin.email)
 
-      expect(service.updated_audience[:nonsubscribed].map(&:email_address)).to contain_exactly(volunteer.email)
+      expect(service.updated_audience[:nonsubscribed].map(&:email_address)).to contain_exactly(other_staff.email)
 
       expect(service.new_nonsubscribed.first.email_address).to eq admin.email
     end

--- a/spec/system/admin/emails_spec.rb
+++ b/spec/system/admin/emails_spec.rb
@@ -9,7 +9,6 @@ describe 'Emails', type: :system do
   let!(:pupil) { create(:pupil, school: school) }
   let!(:onboarding_user) { create(:onboarding_user, school: school) }
   let!(:staff) { create(:staff, school: school) }
-  let!(:volunteer) { create(:volunteer, school: school) }
 
   describe 'visiting the admin email preview path' do
     context 'as an admin' do
@@ -92,19 +91,6 @@ describe 'Emails', type: :system do
     context 'as a staff user' do
       it 'prevents the user from seeing the admin email preview page' do
         sign_in(staff)
-        visit admin_mailer_previews_path
-        expect(page).to have_current_path("/schools/#{school.slug}", ignore_query: true)
-        preview = ActionMailer::Preview.all.last
-        visit admin_mailer_preview_path(preview.preview_name)
-        expect(page).to have_current_path("/schools/#{school.slug}", ignore_query: true)
-        visit admin_mailer_preview_path(preview.preview_name + '/' + preview.emails.first)
-        expect(page).to have_current_path("/schools/#{school.slug}", ignore_query: true)
-      end
-    end
-
-    context 'as a volunteer user' do
-      it 'prevents the user from seeing the admin email preview page' do
-        sign_in(volunteer)
         visit admin_mailer_previews_path
         expect(page).to have_current_path("/schools/#{school.slug}", ignore_query: true)
         preview = ActionMailer::Preview.all.last

--- a/spec/system/admin/settings/energy_tariffs_spec.rb
+++ b/spec/system/admin/settings/energy_tariffs_spec.rb
@@ -69,15 +69,6 @@ describe 'site settings energy tariffs', type: :system do
     it_behaves_like 'the user does not have access to the tariff editor'
   end
 
-  context 'as a volunteer user' do
-    let!(:current_user) { create(:volunteer) }
-    let(:path)          { admin_settings_energy_tariffs_path }
-
-    before              { sign_in(current_user) }
-
-    it_behaves_like 'the user does not have access to the tariff editor'
-  end
-
   context 'with no signed in user' do
     let!(:current_user) { nil }
     let(:path)          { admin_settings_energy_tariffs_path }

--- a/spec/system/school_groups/energy_tariffs_spec.rb
+++ b/spec/system/school_groups/energy_tariffs_spec.rb
@@ -78,15 +78,6 @@ describe 'school group energy tariffs', type: :system do
     it_behaves_like 'the user does not have access to the tariff editor'
   end
 
-  context 'as a volunteer user' do
-    let!(:current_user) { create(:volunteer) }
-    let(:path)          { school_group_energy_tariffs_path(school_group) }
-
-    before { sign_in(current_user) }
-
-    it_behaves_like 'the user does not have access to the tariff editor'
-  end
-
   context 'with no signed in user' do
     let!(:current_user) { nil }
     let(:path)          { school_group_energy_tariffs_path(school_group) }

--- a/spec/system/schools/energy_tariffs_spec.rb
+++ b/spec/system/schools/energy_tariffs_spec.rb
@@ -77,15 +77,6 @@ describe 'school energy tariffs', type: :system do
       it_behaves_like 'the user does not have access to the tariff editor'
     end
 
-    context 'as a volunteer user' do
-      let!(:current_user) { create(:volunteer, school: school) }
-      let(:path)          { school_energy_tariffs_path(school) }
-
-      before { sign_in(current_user) }
-
-      it_behaves_like 'the user does not have access to the tariff editor'
-    end
-
     context 'as a non school user' do
       let!(:school_2)     { create_active_school }
       let!(:current_user) { create(:user, school: school_2) }


### PR DESCRIPTION
Removes the volunteer role as its no longer needed. Volunteers are flagged as staff users with a staff role of "Parent or Volunteer".

This simplifies some of the code and CanCanCan abilities.