### PR TITLE
Set role when adding existing user as school admin

### DIFF
--- a/app/controllers/schools/cluster_admins_controller.rb
+++ b/app/controllers/schools/cluster_admins_controller.rb
@@ -12,6 +12,7 @@ module Schools
       if user
         user.add_cluster_school(@school)
         user.add_cluster_school(user.school) unless user.school.nil?
+        user.role = :school_admin
         if user.save
           create_or_update_alert_contact(@school, user) if auto_create_alert_contact?
         end

--- a/lib/tasks/deployment/20250324110936_fix_roles_for_cluster_admins.rake
+++ b/lib/tasks/deployment/20250324110936_fix_roles_for_cluster_admins.rake
@@ -1,0 +1,13 @@
+namespace :after_party do
+  desc 'Deployment task: fix_roles_for_cluster_admins'
+  task fix_roles_for_cluster_admins: :environment do
+    puts "Running deploy task 'fix_roles_for_cluster_admins'"
+
+    User.active.staff.joins(:cluster_schools).distinct.update_all(role: :school_admin)
+
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord
+      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+  end
+end

--- a/spec/system/schools/users_spec.rb
+++ b/spec/system/schools/users_spec.rb
@@ -346,6 +346,20 @@ describe 'School admin user management' do
           expect(other_school_admin.cluster_schools_for_switching).to eq([school])
         end
 
+        context 'when other user is staff' do
+          let!(:other_school_admin) { create(:staff, name: 'Other admin') }
+
+          it 'adds the user' do
+            click_on 'Add an existing Energy Sparks user as a school admin'
+            fill_in 'Email', with: other_school_admin.email
+            click_on 'Add user'
+            expect(page).to have_content(other_school_admin.name)
+            other_school_admin.reload
+            expect(other_school_admin.cluster_schools_for_switching).to eq([school])
+            expect(other_school_admin.role).to eq 'school_admin'
+          end
+        end
+
         it 'adds the user as an alert contact, by default' do
           click_on 'Add an existing Energy Sparks user as a school admin'
           fill_in 'Email', with: other_school_admin.email

--- a/spec/system/schools/users_spec.rb
+++ b/spec/system/schools/users_spec.rb
@@ -318,59 +318,54 @@ describe 'School admin user management' do
       end
 
       context 'when adding an existing user' do
-        let!(:other_school_admin) { create(:school_admin, name: 'Other admin') }
-        let!(:contact) { create(:contact_with_name_email, user: other_school_admin, school: other_school_admin.school) }
-
         before do
           click_on 'Manage users'
+          click_on 'Add an existing Energy Sparks user as a school admin'
         end
 
         it 'has option to add another school admin' do
-          expect(page).to have_content('Add an existing Energy Sparks user as a school admin')
-          click_on 'Add an existing Energy Sparks user as a school admin'
           expect(page).to have_content('Add an existing user as a school admin')
         end
 
         it 'warns if user not found' do
-          click_on 'Add an existing Energy Sparks user as a school admin'
           click_on 'Add user'
           expect(page).to have_content('We were unable to find a user with this email address')
         end
 
-        it 'adds the user' do
-          click_on 'Add an existing Energy Sparks user as a school admin'
-          fill_in 'Email', with: other_school_admin.email
-          click_on 'Add user'
-          expect(page).to have_content(other_school_admin.name)
-          other_school_admin.reload
-          expect(other_school_admin.cluster_schools_for_switching).to eq([school])
-        end
+        context 'when adding a user' do
+          let!(:other_school_admin) { create(:school_admin, :subscribed_to_alerts, name: 'Other admin') }
 
-        context 'when other user is staff' do
-          let!(:other_school_admin) { create(:staff, name: 'Other admin') }
+          before do
+            fill_in 'Email', with: other_school_admin.email
+          end
 
           it 'adds the user' do
-            click_on 'Add an existing Energy Sparks user as a school admin'
-            fill_in 'Email', with: other_school_admin.email
             click_on 'Add user'
             expect(page).to have_content(other_school_admin.name)
             other_school_admin.reload
             expect(other_school_admin.cluster_schools_for_switching).to eq([school])
-            expect(other_school_admin.role).to eq 'school_admin'
           end
-        end
 
-        it 'adds the user as an alert contact, by default' do
-          click_on 'Add an existing Energy Sparks user as a school admin'
-          fill_in 'Email', with: other_school_admin.email
-          expect { click_on 'Add user' }.to change(Contact, :count).by(1)
-        end
+          it 'adds the user as an alert contact, by default' do
+            expect { click_on 'Add user' }.to change(Contact, :count).by(1)
+          end
 
-        it 'doesnt add alert contact if requested' do
-          click_on 'Add an existing Energy Sparks user as a school admin'
-          fill_in 'Email', with: other_school_admin.email
-          uncheck 'Subscribe to school alerts'
-          expect { click_on 'Add user' }.not_to(change(Contact, :count))
+          it 'doesnt add alert contact if requested' do
+            uncheck 'Subscribe to school alerts'
+            expect { click_on 'Add user' }.not_to(change(Contact, :count))
+          end
+
+          context 'when the other user is staff' do
+            let!(:other_school_admin) { create(:staff, name: 'Other admin') }
+
+            it 'adds the user' do
+              click_on 'Add user'
+
+              other_school_admin.reload
+              expect(other_school_admin.cluster_schools_for_switching).to eq([school])
+              expect(other_school_admin.role).to eq 'school_admin'
+            end
+          end
         end
       end
 


### PR DESCRIPTION
When we add an existing user as a school admin, we're not currently setting the role correctly. The school is just added to the users list of schools, but their role is not updated.

Fix the issue in the controller and add a database fix to correct around 20 records.