### PR TITLE
Add testimonials model & admin pages

### DIFF
--- a/app/assets/stylesheets/base.scss
+++ b/app/assets/stylesheets/base.scss
@@ -319,5 +319,9 @@ input, progress {
 
   &.theme-accent {
     background-color: $yellow-pale;
+
+    .text-darker {
+      color: $blue-very-dark;
+    }
   }
 }

--- a/app/components/elements/image_component.rb
+++ b/app/components/elements/image_component.rb
@@ -31,7 +31,7 @@ module Elements
     end
 
     def call
-      tag.img(src: image_path(@src), id: @id, class: classes, style: style)
+      image_tag(@src, id: @id, class: classes, style: style)
     end
 
     def validate

--- a/app/components/layout/cards/testimonial_component.rb
+++ b/app/components/layout/cards/testimonial_component.rb
@@ -19,9 +19,11 @@ module Layout
       renders_one :organisation, ->(**kwargs) do
         Elements::TagComponent.new(:div, **merge_classes('small text-darker', kwargs))
       end
-      renders_one :case_study, ->(case_study) do
-        Elements::ButtonComponent.new(t('home.testimonials.read_case_study'),
-          case_study_download_path(case_study), style: :primary, classes: 'mb-1 mr-2')
+      renders_one :case_study, ->(case_study = nil) do
+        if case_study
+          Elements::ButtonComponent.new(t('components.testimonial.read_case_study'),
+            case_study_download_path(case_study), style: :primary, classes: 'mb-1 mr-2')
+        end
       end
     end
   end

--- a/app/components/layout/cards/testimonial_component.rb
+++ b/app/components/layout/cards/testimonial_component.rb
@@ -19,8 +19,9 @@ module Layout
       renders_one :organisation, ->(**kwargs) do
         Elements::TagComponent.new(:div, **merge_classes('small text-darker', kwargs))
       end
-      renders_many :buttons, ->(*args, **kwargs) do
-        Elements::ButtonComponent.new(*args, **merge_classes('mb-1 mr-2', kwargs))
+      renders_one :case_study, ->(case_study) do
+        Elements::ButtonComponent.new(t('home.testimonials.read_case_study'),
+          case_study_download_path(case_study), style: :primary, classes: 'mb-1 mr-2')
       end
     end
   end

--- a/app/components/layout/cards/testimonial_component.rb
+++ b/app/components/layout/cards/testimonial_component.rb
@@ -1,6 +1,9 @@
 module Layout
   module Cards
     class TestimonialComponent < LayoutComponent
+      renders_one :image, ->(**kwargs) do
+        Elements::ImageComponent.new(**merge_classes('rounded-xl fit', kwargs))
+      end
       renders_one :header, ->(**kwargs) do
         Elements::HeaderComponent.new(**kwargs.merge({ level: 4 }))
       end
@@ -13,7 +16,7 @@ module Layout
       renders_one :role, ->(**kwargs) do
         Elements::TagComponent.new(:span, **merge_classes('small text-darker', kwargs))
       end
-      renders_one :location, ->(**kwargs) do
+      renders_one :organisation, ->(**kwargs) do
         Elements::TagComponent.new(:div, **merge_classes('small text-darker', kwargs))
       end
       renders_many :buttons, ->(*args, **kwargs) do

--- a/app/components/layout/cards/testimonial_component.rb
+++ b/app/components/layout/cards/testimonial_component.rb
@@ -5,13 +5,19 @@ module Layout
         Elements::HeaderComponent.new(**kwargs.merge({ level: 4 }))
       end
       renders_one :quote, ->(**kwargs) do
-        Elements::TagComponent.new(:q, **kwargs.merge({ classes: 'small' }))
+        Elements::TagComponent.new(:q, **merge_classes('small', kwargs))
       end
-      renders_one :source, ->(**kwargs) do
-        Elements::TagComponent.new(:p, **kwargs.merge({ classes: 'small text-blue-very-dark' }))
+      renders_one :name, ->(**kwargs) do
+        Elements::TagComponent.new(:span, **merge_classes('small text-darker font-weight-bold', kwargs))
+      end
+      renders_one :role, ->(**kwargs) do
+        Elements::TagComponent.new(:span, **merge_classes('small text-darker', kwargs))
+      end
+      renders_one :location, ->(**kwargs) do
+        Elements::TagComponent.new(:div, **merge_classes('small text-darker', kwargs))
       end
       renders_many :buttons, ->(*args, **kwargs) do
-        Elements::ButtonComponent.new(*args, **kwargs.merge({ classes: 'mb-1 mr-2' }))
+        Elements::ButtonComponent.new(*args, **merge_classes('mb-1 mr-2', kwargs))
       end
     end
   end

--- a/app/components/layout/cards/testimonial_component/testimonial_component.html.erb
+++ b/app/components/layout/cards/testimonial_component/testimonial_component.html.erb
@@ -9,9 +9,12 @@
       <%= name %><%= " - #{role}".html_safe if role %>
       <%= organisation %>
       <div class='mt-3'>
-        <% buttons.each do |button| %>
-          <%= button %>
-        <% end %>
+        <%= case_study %>
+        <%= render Elements::ButtonComponent.new(
+              t('home.testimonials.more_case_studies'),
+              case_studies_path,
+              outline_style: :transparent, classes: 'mb-1'
+            ) %>
       </div>
     <% end %>
   <% end %>

--- a/app/components/layout/cards/testimonial_component/testimonial_component.html.erb
+++ b/app/components/layout/cards/testimonial_component/testimonial_component.html.erb
@@ -1,8 +1,11 @@
 <%= tag.div id: id, class: classes do %>
   <%= header %>
   <%= quote %>
-  <%= source %>
-  <% buttons.each do |button| %>
-    <%= button %>
-  <% end %>
+  <%= name %><%= " - #{role}".html_safe if role %>
+  <%= location %>
+  <div class='mt-3'>
+    <% buttons.each do |button| %>
+      <%= button %>
+    <% end %>
+  </div>
 <% end %>

--- a/app/components/layout/cards/testimonial_component/testimonial_component.html.erb
+++ b/app/components/layout/cards/testimonial_component/testimonial_component.html.erb
@@ -11,7 +11,7 @@
       <div class='mt-3'>
         <%= case_study %>
         <%= render Elements::ButtonComponent.new(
-              t('home.testimonials.more_case_studies'),
+              t('components.testimonial.more_case_studies'),
               case_studies_path,
               outline_style: :transparent, classes: 'mb-1'
             ) %>

--- a/app/components/layout/cards/testimonial_component/testimonial_component.html.erb
+++ b/app/components/layout/cards/testimonial_component/testimonial_component.html.erb
@@ -1,11 +1,18 @@
 <%= tag.div id: id, class: classes do %>
-  <%= header %>
-  <%= quote %>
-  <%= name %><%= " - #{role}".html_safe if role %>
-  <%= location %>
-  <div class='mt-3'>
-    <% buttons.each do |button| %>
-      <%= button %>
+  <%= render Layout::GridComponent.new(cols: 2, cell_classes: 'my-auto') do |grid| %>
+    <%= grid.with_cell do %>
+      <%= image %>
     <% end %>
-  </div>
+    <%= grid.with_cell do %>
+      <%= header %>
+      <%= quote %>
+      <%= name %><%= " - #{role}".html_safe if role %>
+      <%= organisation %>
+      <div class='mt-3'>
+        <% buttons.each do |button| %>
+          <%= button %>
+        <% end %>
+      </div>
+    <% end %>
+  <% end %>
 <% end %>

--- a/app/components/layout/carousel_component.rb
+++ b/app/components/layout/carousel_component.rb
@@ -4,7 +4,8 @@ module Layout
 
     renders_many :panels, types: {
       equivalence: { renders: ->(**kwargs) { EquivalenceComponent.new(**with_classes(**kwargs)) }, as: :equivalence },
-      grid: { renders: ->(**kwargs) { Layout::GridComponent.new(**with_classes(**kwargs)) }, as: :grid }
+      grid: { renders: ->(**kwargs) { Layout::GridComponent.new(**with_classes(**kwargs)) }, as: :grid },
+      testimonial_card: { renders: ->(**kwargs) { Cards::TestimonialComponent.new(**with_classes(**kwargs)) }, as: :testimonial_card }
     }
 
     def with_classes(**kwargs)

--- a/app/components/layout/grid_component.rb
+++ b/app/components/layout/grid_component.rb
@@ -12,17 +12,20 @@ module Layout
       type(:feature_card, Cards::FeatureComponent),
       type(:testimonial_card, Cards::TestimonialComponent),
       type(:statement_card, Cards::StatementComponent),
-      type(:card, CardComponent)
+      type(:card, CardComponent),
+      cell: { renders: ->(**kwargs, &block) { cell(**kwargs) { capture(&block) } }, as: :cell }
     )
 
     private
 
     def wrap(klass, *args, **kwargs, &block)
-      cell_classes = kwargs.delete(:cell_classes)
-
-      tag.div(class: class_names(column_classes, cell_classes, @cell_classes)) do
+      cell(**kwargs) do
         render(klass.new(*args, **kwargs), &block)
       end
+    end
+
+    def cell(**kwargs, &block)
+      tag.div(class: class_names(column_classes, kwargs.delete(:cell_classes), @cell_classes), &block)
     end
 
     def initialize(cols:, rows: 1, cell_classes: '', **_kwargs)

--- a/app/controllers/admin/testimonials_controller.rb
+++ b/app/controllers/admin/testimonials_controller.rb
@@ -1,6 +1,8 @@
 module Admin
   class TestimonialsController < AdminController
     include LocaleHelper
+    include ActiveStorage::SetCurrent
+
     load_and_authorize_resource
 
     def show

--- a/app/controllers/admin/testimonials_controller.rb
+++ b/app/controllers/admin/testimonials_controller.rb
@@ -1,0 +1,37 @@
+module Admin
+  class TestimonialsController < AdminController
+    include LocaleHelper
+    load_and_authorize_resource
+
+    def show
+    end
+
+    def create
+      if @testimonial.save
+        redirect_to admin_testimonials_path, notice: 'Testimonial was successfully created.'
+      else
+        render :new
+      end
+    end
+
+    def update
+      if @testimonial.update(testimonial_params)
+        redirect_to admin_testimonials_path, notice: 'Testimonial was successfully updated.'
+      else
+        render :edit
+      end
+    end
+
+    def destroy
+      @testimonial.destroy
+      redirect_to admin_testimonials_path, notice: 'Testimonial was successfully deleted.'
+    end
+
+    private
+
+    def testimonial_params
+      translated_params = t_params(Testimonial.mobility_attributes)
+      params.require(:testimonial).permit(translated_params, :image, :name, :organisation, :category, :active, :case_study_id)
+    end
+  end
+end

--- a/app/models/testimonial.rb
+++ b/app/models/testimonial.rb
@@ -28,7 +28,7 @@ class Testimonial < ApplicationRecord
 
   enum :category, { default: 0 } # need more here
 
-  validates :image, :title, :name, :quote, :organisation, :category, presence: true
+  validates :image, :title_en, :name, :quote_en, :organisation, :category, presence: true
 
   scope :active, -> { where(active: true) }
 end

--- a/app/models/testimonial.rb
+++ b/app/models/testimonial.rb
@@ -2,14 +2,13 @@
 #
 # Table name: testimonials
 #
+#  active        :boolean          default(FALSE), not null
 #  case_study_id :bigint(8)
+#  category      :integer          default("default"), not null
 #  created_at    :datetime         not null
 #  id            :bigint(8)        not null, primary key
-#  location      :string
 #  name          :string
-#  quote         :text
-#  role          :string
-#  title         :string
+#  organisation  :string
 #  updated_at    :datetime         not null
 #
 # Indexes
@@ -17,8 +16,19 @@
 #  index_testimonials_on_case_study_id  (case_study_id)
 #
 class Testimonial < ApplicationRecord
+  extend Mobility
+  include TransifexSerialisable
+
+  belongs_to :case_study, optional: true
+  has_one_attached :image
+
   translates :title, type: :string, fallbacks: { cy: :en }
   translates :quote, type: :string, fallbacks: { cy: :en }
   translates :role, type: :string, fallbacks: { cy: :en }
-  translates :location, type: :string, fallbacks: { cy: :en }
+
+  enum :category, { default: 0 } # need more here
+
+  validates :image, :title, :name, :quote, :organisation, :category, presence: true
+
+  scope :active, -> { where(active: true) }
 end

--- a/app/models/testimonial.rb
+++ b/app/models/testimonial.rb
@@ -1,0 +1,24 @@
+# == Schema Information
+#
+# Table name: testimonials
+#
+#  case_study_id :bigint(8)
+#  created_at    :datetime         not null
+#  id            :bigint(8)        not null, primary key
+#  location      :string
+#  name          :string
+#  quote         :text
+#  role          :string
+#  title         :string
+#  updated_at    :datetime         not null
+#
+# Indexes
+#
+#  index_testimonials_on_case_study_id  (case_study_id)
+#
+class Testimonial < ApplicationRecord
+  translates :title, type: :string, fallbacks: { cy: :en }
+  translates :quote, type: :string, fallbacks: { cy: :en }
+  translates :role, type: :string, fallbacks: { cy: :en }
+  translates :location, type: :string, fallbacks: { cy: :en }
+end

--- a/app/views/admin/index.html.erb
+++ b/app/views/admin/index.html.erb
@@ -40,19 +40,19 @@
     <h2>Content Management</h2>
     <ul>
       <li><%= link_to 'Case studies', admin_case_studies_path %></li>
+      <li><%= link_to 'Categories', admin_cms_categories_path %></li>
       <li><%= link_to 'Help Pages', admin_help_pages_path %></li>
       <li><%= link_to 'Jobs', admin_jobs_path %></li>
       <li><%= link_to 'Newsletters', admin_newsletters_path %></li>
+      <li><%= link_to 'Pages', admin_cms_pages_path %></li>
       <li><%= link_to 'Resources', admin_resource_files_path %></li>
+      <li><%= link_to 'Sections', admin_cms_sections_path %></li>
       <li><%= link_to 'Team members', admin_team_members_path %></li>
       <li><%= link_to 'Testimonials', admin_testimonials_path %></li>
       <li><%= link_to 'Videos', admin_videos_path %></li>
-      <li><%= link_to 'Categories', admin_cms_categories_path %></li>
-      <li><%= link_to 'Pages', admin_cms_pages_path %></li>
-      <li><%= link_to 'Sections', admin_cms_sections_path %></li>
     </ul>
-
   </div>
+
   <div class="col">
     <h2>Data, Tariffs, Meter attributes</h2>
     <ul>

--- a/app/views/admin/index.html.erb
+++ b/app/views/admin/index.html.erb
@@ -37,15 +37,16 @@
       <li><%= link_to 'Programme Types', admin_programme_types_path %></li>
     </ul>
 
-    <h2>Comparison reports</h2>
+    <h2>Content Management</h2>
     <ul>
-      <li><%= link_to 'Report groups', admin_comparisons_report_groups_path %></li>
-      <li><%= link_to 'Reports', admin_comparisons_reports_path %></li>
-      <li><%= link_to 'Footnotes', admin_comparisons_footnotes_path %></li>
-    </ul>
-
-    <h2>Content management</h2>
-    <ul>
+      <li><%= link_to 'Case studies', admin_case_studies_path %></li>
+      <li><%= link_to 'Help Pages', admin_help_pages_path %></li>
+      <li><%= link_to 'Jobs', admin_jobs_path %></li>
+      <li><%= link_to 'Newsletters', admin_newsletters_path %></li>
+      <li><%= link_to 'Resources', admin_resource_files_path %></li>
+      <li><%= link_to 'Team members', admin_team_members_path %></li>
+      <li><%= link_to 'Testimonials', admin_testimonials_path %></li>
+      <li><%= link_to 'Videos', admin_videos_path %></li>
       <li><%= link_to 'Categories', admin_cms_categories_path %></li>
       <li><%= link_to 'Pages', admin_cms_pages_path %></li>
       <li><%= link_to 'Sections', admin_cms_sections_path %></li>
@@ -81,21 +82,20 @@
       <li><%= link_to 'Chart preview', admin_chart_preview_path %></li>
     </ul>
 
+    <h2>Comparison reports</h2>
+    <ul>
+      <li><%= link_to 'Report groups', admin_comparisons_report_groups_path %></li>
+      <li><%= link_to 'Reports', admin_comparisons_reports_path %></li>
+      <li><%= link_to 'Footnotes', admin_comparisons_footnotes_path %></li>
+    </ul>
+
     <h2>Other</h2>
     <ul>
       <li><%= link_to 'Admin meter statuses', admin_meter_statuses_path %></li>
-      <li><%= link_to 'Case studies', admin_case_studies_path %></li>
       <li><%= link_to 'Funders', admin_funders_path %></li>
-      <li><%= link_to 'Help Pages', admin_help_pages_path %></li>
-      <li><%= link_to 'Jobs', admin_jobs_path %></li>
-      <li><%= link_to 'Newsletters', admin_newsletters_path %></li>
       <li><%= link_to 'Partners', admin_partners_path %></li>
-      <li><%= link_to 'Resources', admin_resource_files_path %></li>
       <li><%= link_to 'Site Settings', admin_settings_path %></li>
-      <li><%= link_to 'Team members', admin_team_members_path %></li>
-      <li><%= link_to 'Testimonials', admin_testimonials_path %></li>
       <li><%= link_to 'Transport Types', admin_transport_types_path %></li>
-      <li><%= link_to 'Videos', admin_videos_path %></li>
     </ul>
   </div>
 </div>

--- a/app/views/admin/index.html.erb
+++ b/app/views/admin/index.html.erb
@@ -93,6 +93,7 @@
       <li><%= link_to 'Resources', admin_resource_files_path %></li>
       <li><%= link_to 'Site Settings', admin_settings_path %></li>
       <li><%= link_to 'Team members', admin_team_members_path %></li>
+      <li><%= link_to 'Testimonials', admin_testimonials_path %></li>
       <li><%= link_to 'Transport Types', admin_transport_types_path %></li>
       <li><%= link_to 'Videos', admin_videos_path %></li>
     </ul>

--- a/app/views/admin/testimonials/_form.html.erb
+++ b/app/views/admin/testimonials/_form.html.erb
@@ -1,0 +1,59 @@
+<div class="border rounded bg-light p-4">
+
+<%= simple_form_for [:admin, testimonial], html: { multipart: true } do |f| %>
+  <div class="row">
+    <div class="col-6">
+      <h3>Quote details</h3>
+      <%= render 'admin/shared/locale_tabs', f: f, field: :title do |locale| %>
+        <%= f.input t_field(:title, locale), label: 'Title' %>
+      <% end %>
+
+      <%= render 'admin/shared/locale_tabs', f: f, field: :quote do |locale| %>
+        <%= f.input t_field(:quote, locale), label: 'Quote', as: :text %>
+      <% end %>
+
+      <%= f.input :case_study_id,
+                  label: 'Case Study',
+                  collection: CaseStudy.order(position: :asc),
+                  label_method: :title,
+                  value_method: :id,
+                  include_blank: 'Select Case Study' %>
+
+      <%= f.input :active, as: :boolean, label: 'Active?' %>
+
+      <%= f.input :category, as: :select, collection: Testimonial.categories.keys, include_blank: false,
+                             label: 'Category' %>
+
+      <div class="form-group">
+        <%= f.input :image, class: 'form-control' %>
+
+        <% if testimonial.image.attached? && testimonial.image.persisted? %>
+          <div class="mt-3">
+            <p>Current Image:</p>
+            <%= image_tag testimonial.image, width: '100%', alt: testimonial.title, class: 'img-thumbnail' %>
+          </div>
+        <% else %>
+          No image attached
+        <% end %>
+      </div>
+    </div>
+
+    <div class="col-6">
+      <h3>Source</h3>
+
+      <%= f.input :name, label: 'Name', hint: 'Name of the person making the quote' %>
+
+      <%= render 'admin/shared/locale_tabs', f: f, field: :role do |locale| %>
+        <%= f.input t_field(:role, locale), label: 'Role' %>
+      <% end %>
+
+      <%= f.input :organisation, label: 'Organisation' %>
+    </div>
+  </div>
+
+  <div class="form-actions">
+    <%= f.submit 'Save Testimonial', class: 'btn btn-primary btn-small' %>
+    <%= link_to 'Back', admin_testimonials_path, class: 'btn btn-secondary btn-small' %>
+  </div>
+<% end %>
+</div>

--- a/app/views/admin/testimonials/_form.html.erb
+++ b/app/views/admin/testimonials/_form.html.erb
@@ -1,4 +1,4 @@
-<div class="border rounded bg-light p-4">
+<div class="border rounded bg-light px-4 pb-4 pt-2">
 
 <%= simple_form_for [:admin, testimonial], html: { multipart: true } do |f| %>
   <div class="row">

--- a/app/views/admin/testimonials/_form.html.erb
+++ b/app/views/admin/testimonials/_form.html.erb
@@ -14,7 +14,7 @@
 
       <%= f.input :case_study_id,
                   label: 'Case Study',
-                  collection: CaseStudy.order(position: :asc),
+                  collection: CaseStudy.order(title: :asc),
                   label_method: :title,
                   value_method: :id,
                   include_blank: 'Select Case Study' %>

--- a/app/views/admin/testimonials/edit.html.erb
+++ b/app/views/admin/testimonials/edit.html.erb
@@ -1,0 +1,3 @@
+<h1>Edit Testimonial</h1>
+
+<%= render 'form', testimonial: @testimonial %>

--- a/app/views/admin/testimonials/index.html.erb
+++ b/app/views/admin/testimonials/index.html.erb
@@ -55,9 +55,7 @@
               <%= card.with_name { testimonial.name } %>
               <%= card.with_role { testimonial.role } %>
               <%= card.with_organisation { testimonial.organisation } %>
-              <%= card.with_button t('home.testimonials.read_case_study'), case_studies_path(testimonial.case_study),
-                                   style: :primary %>
-              <%= card.with_button t('home.testimonials.more_case_studies'), case_studies_path, style: :secondary %>
+              <%= card.with_case_study(testimonial.case_study) %>
             <% end %>
           </div>
         </div>

--- a/app/views/admin/testimonials/index.html.erb
+++ b/app/views/admin/testimonials/index.html.erb
@@ -1,0 +1,67 @@
+<div class="d-flex justify-content-between align-items-center">
+  <h1>
+    <%= 'Testimonials' %>
+    <%= link_to 'New', new_admin_testimonial_path, class: 'btn btn-sm' %>
+  </h1>
+</div>
+
+<div classes='container'>
+  <div class="p-2">
+    <% @testimonials.each do |testimonial| %>
+      <div class='clearfix border rounded bg-light p-2 row mb-2'>
+        <div class='col-md-12'>
+          <h4 class='pb-0'>
+            <span class='d-inline-block text-truncate' style="max-width: 95%"><%= testimonial.title %></span>
+            <span class='float-right pb-2'>
+              <small>
+                <% if testimonial.active %>
+                  <span title='active' data-toggle='tooltip'><%= render IconComponent.new(name: 'eye') %></span>
+                <% else %>
+                  <span title='inactive' data-toggle='tooltip'>
+                    <%= render IconComponent.new(name: 'eye-slash') %>
+                  </span>
+                <% end %>
+              </small>
+            </span>
+          </h4>
+          <div class='pl-2 pb-2'>
+            <span data-toggle="collapse"
+                  href="#testimonial-<%= testimonial.id %>" role="button" aria-expanded="true"
+                  aria-controls="testimonial-<%= testimonial.id %>"
+                  class="toggler text-decoration-none collapsed">
+              <%= toggler %>
+            </span>
+            <span class="badge badge-pill badge-info font-weight-normal">
+              <%= testimonial.category %>
+            </span>
+            <span class="badge badge-pill badge-light font-weight-normal border bg-white">
+              <%= testimonial.name %> • <%= testimonial.role %> • <%= testimonial.organisation %>
+            </span>
+
+            <span class='float-right'>
+              <%= link_to 'Edit', edit_admin_testimonial_path(testimonial), class: 'btn btn-sm' %>
+              <%= link_to 'Delete', admin_testimonial_path(testimonial),
+                          method: :delete,
+                          data: { confirm: 'Are you sure?' },
+                          class: 'btn btn-danger btn-sm' %>
+            </span>
+          </div>
+
+          <div class="collapse" id="testimonial-<%= testimonial.id %>">
+            <%= render Layout::Cards::TestimonialComponent.new(classes: 'p-4 rounded-xl mt-2 mb-2', theme: :light) do |card| %>
+              <%= card.with_image src: testimonial.image.url %>
+              <%= card.with_header title: testimonial.title %>
+              <%= card.with_quote { testimonial.quote } %>
+              <%= card.with_name { testimonial.name } %>
+              <%= card.with_role { testimonial.role } %>
+              <%= card.with_organisation { testimonial.organisation } %>
+              <%= card.with_button t('home.testimonials.read_case_study'), case_studies_path(testimonial.case_study),
+                                   style: :primary %>
+              <%= card.with_button t('home.testimonials.more_case_studies'), case_studies_path, style: :secondary %>
+            <% end %>
+          </div>
+        </div>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/admin/testimonials/new.html.erb
+++ b/app/views/admin/testimonials/new.html.erb
@@ -1,0 +1,3 @@
+<h1>New Testimonial</h1>
+
+<%= render 'form', testimonial: @testimonial %>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -54,17 +54,15 @@
                                              theme: :accent,
                                              classes: 'rounded-xl p-4 mb-4',
                                              show_arrows: :side) do |carousel| %>
-
-      <%# Until we  have more things to go in the carousel, do this for demo purposes %>
-      <% %w[funnel-pupils.png funnel-teachers.png].each do |pic| %>
-        <%= carousel.with_testimonial_card do |testimonial| %>
-          <%= testimonial.with_image(src: pic) %>
-          <%= testimonial.with_header(title: t('home.testimonials.card_1.title')) %>
-          <%= testimonial.with_quote { "#{t('home.testimonials.card_1.quote')}." } %>
-          <%= testimonial.with_name { t('home.testimonials.card_1.source.name') } %>
-          <%= testimonial.with_role { t('home.testimonials.card_1.source.role') } %>
-          <%= testimonial.with_organisation { t('home.testimonials.card_1.source.school') } %>
-          <%= testimonial.with_case_study(CaseStudy.all.last) %>
+      <% Testimonial.all.default.each do |testimonial| %>
+        <%= carousel.with_testimonial_card do |card| %>
+          <%= card.with_image(src: testimonial.image) %>
+          <%= card.with_header(title: testimonial.title) %>
+          <%= card.with_quote { testimonial.quote } %>
+          <%= card.with_name { testimonial.name } %>
+          <%= card.with_role { testimonial.role } %>
+          <%= card.with_organisation { testimonial.organisation } %>
+          <%= card.with_case_study(testimonial.case_study) %>
         <% end %>
       <% end %>
     <% end %>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -54,7 +54,7 @@
                                              theme: :accent,
                                              classes: 'rounded-xl p-4 mb-4',
                                              show_arrows: :side) do |carousel| %>
-      <% Testimonial.all.active.default.each do |testimonial| %>
+      <% Testimonial.all.active.default.shuffle.each do |testimonial| %>
         <%= carousel.with_testimonial_card do |card| %>
           <%= card.with_image(src: testimonial.image) %>
           <%= card.with_header(title: testimonial.title) %>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -54,6 +54,7 @@
                                              theme: :accent,
                                              classes: 'rounded-xl p-4 mb-4',
                                              show_arrows: :side) do |carousel| %>
+
       <%# Until we  have more things to go in the carousel, do this for demo purposes %>
       <% %w[funnel-pupils.png funnel-teachers.png].each do |pic| %>
         <%= carousel.with_testimonial_card do |testimonial| %>
@@ -63,10 +64,7 @@
           <%= testimonial.with_name { t('home.testimonials.card_1.source.name') } %>
           <%= testimonial.with_role { t('home.testimonials.card_1.source.role') } %>
           <%= testimonial.with_organisation { t('home.testimonials.card_1.source.school') } %>
-          <%= testimonial.with_button(t('home.testimonials.read_case_study'), 'case-studies/15', style: :primary) %>
-          <%= testimonial.with_button(
-                t('home.testimonials.more_case_studies'), case_studies_path, outline_style: :transparent
-              ) %>
+          <%= testimonial.with_case_study(CaseStudy.all.last) %>
         <% end %>
       <% end %>
     <% end %>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -61,10 +61,9 @@
           <%= grid.with_testimonial_card do |testimonial| %>
             <%= testimonial.with_header(title: t('home.testimonials.card_1.title')) %>
             <%= testimonial.with_quote { "#{t('home.testimonials.card_1.quote')}." } %>
-            <%= testimonial.with_source(classes: 'text-blue-very-dark') do %>
-              <strong><%= t('home.testimonials.card_1.source.name') %></strong><br>
-                <%= t('home.testimonials.card_1.source.school') %>
-            <% end %>
+            <%= testimonial.with_name { t('home.testimonials.card_1.source.name') } %>
+            <%= testimonial.with_role { t('home.testimonials.card_1.source.role') } %>
+            <%= testimonial.with_location { t('home.testimonials.card_1.source.school') } %>
             <%= testimonial.with_button(t('home.testimonials.read_case_study'), 'case-studies/15', style: :primary) %>
             <%= testimonial.with_button(t('home.testimonials.more_case_studies'), case_studies_path,
                                         outline_style: :transparent) %>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -56,18 +56,17 @@
                                              show_arrows: :side) do |carousel| %>
       <%# Until we  have more things to go in the carousel, do this for demo purposes %>
       <% %w[funnel-pupils.png funnel-teachers.png].each do |pic| %>
-        <%= carousel.with_grid(cols: 2, cell_classes: 'my-auto') do |grid| %>
-          <%= grid.with_image(src: pic, classes: 'rounded-xl fit') %>
-          <%= grid.with_testimonial_card do |testimonial| %>
-            <%= testimonial.with_header(title: t('home.testimonials.card_1.title')) %>
-            <%= testimonial.with_quote { "#{t('home.testimonials.card_1.quote')}." } %>
-            <%= testimonial.with_name { t('home.testimonials.card_1.source.name') } %>
-            <%= testimonial.with_role { t('home.testimonials.card_1.source.role') } %>
-            <%= testimonial.with_location { t('home.testimonials.card_1.source.school') } %>
-            <%= testimonial.with_button(t('home.testimonials.read_case_study'), 'case-studies/15', style: :primary) %>
-            <%= testimonial.with_button(t('home.testimonials.more_case_studies'), case_studies_path,
-                                        outline_style: :transparent) %>
-          <% end %>
+        <%= carousel.with_testimonial_card do |testimonial| %>
+          <%= testimonial.with_image(src: pic) %>
+          <%= testimonial.with_header(title: t('home.testimonials.card_1.title')) %>
+          <%= testimonial.with_quote { "#{t('home.testimonials.card_1.quote')}." } %>
+          <%= testimonial.with_name { t('home.testimonials.card_1.source.name') } %>
+          <%= testimonial.with_role { t('home.testimonials.card_1.source.role') } %>
+          <%= testimonial.with_organisation { t('home.testimonials.card_1.source.school') } %>
+          <%= testimonial.with_button(t('home.testimonials.read_case_study'), 'case-studies/15', style: :primary) %>
+          <%= testimonial.with_button(
+                t('home.testimonials.more_case_studies'), case_studies_path, outline_style: :transparent
+              ) %>
         <% end %>
       <% end %>
     <% end %>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -54,7 +54,7 @@
                                              theme: :accent,
                                              classes: 'rounded-xl p-4 mb-4',
                                              show_arrows: :side) do |carousel| %>
-      <% Testimonial.all.default.each do |testimonial| %>
+      <% Testimonial.all.active.default.each do |testimonial| %>
         <%= carousel.with_testimonial_card do |card| %>
           <%= card.with_image(src: testimonial.image) %>
           <%= card.with_header(title: testimonial.title) %>

--- a/config/locales/views/components/testimonial.yml
+++ b/config/locales/views/components/testimonial.yml
@@ -1,0 +1,6 @@
+---
+en:
+  components:
+    testimonial:
+      more_case_studies: More case studies
+      read_case_study: Read case study

--- a/config/locales/views/home/home.yml
+++ b/config/locales/views/home/home.yml
@@ -86,16 +86,6 @@ en:
       description: We provide data insights, action prompts and educational resources to help schools develop their climate action plans, make big energy and carbon savings, and develop pupils' sustainability skills.
       header: Are you looking to cut energy bills and take action on climate change?
     sub_title: A unique school-specific energy management tool and education programme
-    testimonials:
-      card_1:
-        quote: 'The main thing for me was: don’t assume the heating settings are right without checking; take time to have a look, as it is worth it for everyone'
-        source:
-          name: David Reed
-          role: Facilities Manager
-          school: Northampton Academy
-        title: Energy Sparks helped Northampton Academy reduce energy costs by 40% and £34,000 in their first year
-      more_case_studies: More case studies
-      read_case_study: Read case study
     title: We help schools become more energy efficient and fight climate change.
   mailchimp:
     example: 'eg: hello@example.com'

--- a/config/locales/views/home/home.yml
+++ b/config/locales/views/home/home.yml
@@ -90,7 +90,8 @@ en:
       card_1:
         quote: 'The main thing for me was: don’t assume the heating settings are right without checking; take time to have a look, as it is worth it for everyone'
         source:
-          name: David Reed - Facilities Manager
+          name: David Reed
+          role: Facilities Manager
           school: Northampton Academy
         title: Energy Sparks helped Northampton Academy reduce energy costs by 40% and £34,000 in their first year
       more_case_studies: More case studies

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -675,6 +675,8 @@ Rails.application.routes.draw do
         concerns :issueable
       end
     end
+    resources :testimonials
+
 
     resource :content_generation_run, controller: :content_generation_run
     resources :school_onboardings, path: 'school_setup', only: [:new, :create, :index, :edit, :update, :destroy] do

--- a/db/migrate/20250324154639_create_testimonials.rb
+++ b/db/migrate/20250324154639_create_testimonials.rb
@@ -1,0 +1,14 @@
+class CreateTestimonials < ActiveRecord::Migration[7.2]
+  def change
+    create_table :testimonials do |t|
+      t.string :title
+      t.text :quote
+      t.string :name
+      t.string :role
+      t.string :location
+      t.references :case_study, null: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250324154639_create_testimonials.rb
+++ b/db/migrate/20250324154639_create_testimonials.rb
@@ -1,13 +1,14 @@
 class CreateTestimonials < ActiveRecord::Migration[7.2]
   def change
     create_table :testimonials do |t|
-      t.string :title
-      t.text :quote
+      #t.string :title
+      #t.text :quote
       t.string :name
-      t.string :role
-      t.string :location
+      #t.string :role
+      t.string :organisation
+      t.boolean :active, default: false, null: false
+      t.integer :category, default: 0, null: false
       t.references :case_study, null: true
-
       t.timestamps
     end
   end

--- a/db/migrate/20250324154639_create_testimonials.rb
+++ b/db/migrate/20250324154639_create_testimonials.rb
@@ -1,10 +1,7 @@
 class CreateTestimonials < ActiveRecord::Migration[7.2]
   def change
     create_table :testimonials do |t|
-      #t.string :title
-      #t.text :quote
       t.string :name
-      #t.string :role
       t.string :organisation
       t.boolean :active, default: false, null: false
       t.integer :category, default: 0, null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1938,11 +1938,10 @@ ActiveRecord::Schema[7.2].define(version: 2025_03_24_154639) do
   end
 
   create_table "testimonials", force: :cascade do |t|
-    t.string "title"
-    t.text "quote"
     t.string "name"
-    t.string "role"
-    t.string "location"
+    t.string "organisation"
+    t.boolean "active", default: false, null: false
+    t.integer "category", default: 0, null: false
     t.bigint "case_study_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_03_14_111844) do
+ActiveRecord::Schema[7.2].define(version: 2025_03_24_154639) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pgcrypto"
@@ -1935,6 +1935,18 @@ ActiveRecord::Schema[7.2].define(version: 2025_03_14_111844) do
     t.datetime "updated_at", null: false
     t.index ["location_id"], name: "index_temperature_recordings_on_location_id"
     t.index ["observation_id"], name: "index_temperature_recordings_on_observation_id"
+  end
+
+  create_table "testimonials", force: :cascade do |t|
+    t.string "title"
+    t.text "quote"
+    t.string "name"
+    t.string "role"
+    t.string "location"
+    t.bigint "case_study_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["case_study_id"], name: "index_testimonials_on_case_study_id"
   end
 
   create_table "todos", force: :cascade do |t|

--- a/lib/tasks/deployment/20250326161028_add_testimonial.rake
+++ b/lib/tasks/deployment/20250326161028_add_testimonial.rake
@@ -1,0 +1,29 @@
+namespace :after_party do
+  desc 'Deployment task: add_testimonial'
+  task add_testimonial: :environment do
+    puts "Running deploy task 'add_testimonial'"
+
+    exists = Testimonial.find_by(name: 'David Reed')
+
+    if exists.nil?
+      testimonial = Testimonial.new(
+        quote: 'The main thing for me was: don’t assume the heating settings are right without checking; take time to have a look, as it is worth it for everyone',
+        title: 'Energy Sparks helped Northampton Academy reduce energy costs by 40% and £34,000 in their first year',
+        name: 'David Reed',
+        role: 'Facilities Manager',
+        organisation: 'Northampton Academy',
+        case_study_id: 15,
+        active: true
+      )
+      testimonial.image.attach(io: File.open(Rails.root.join('app/assets/images/funnel-pupils.png')), filename: 'laptop.jpg')
+      testimonial.save!
+    end
+
+    # Put your task implementation HERE.
+
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord
+      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+  end
+end

--- a/spec/components/layout/cards/testimonial_component_spec.rb
+++ b/spec/components/layout/cards/testimonial_component_spec.rb
@@ -10,11 +10,12 @@ RSpec.describe Layout::Cards::TestimonialComponent, :include_application_helper,
 
   let(:html) do
     render_inline(described_class.new(**params)) do |card|
+      card.with_image(src: 'laptop.jpg')
       card.with_header(title: 'Header')
       card.with_quote { 'Quote' }
       card.with_name { 'Source Name' }
       card.with_role { 'Role' }
-      card.with_location { 'Location' }
+      card.with_organisation { 'Organisation' }
       card.with_button('button 1', 'link_to_button_1', style: :primary)
       card.with_button('button 2', 'link_to_button_2', style: :secondary)
     end
@@ -38,7 +39,7 @@ RSpec.describe Layout::Cards::TestimonialComponent, :include_application_helper,
     it { expect(html).to have_content('Quote') }
     it { expect(html).to have_content('Source Name') }
     it { expect(html).to have_content('Role') }
-    it { expect(html).to have_content('Location') }
+    it { expect(html).to have_content('Organisation') }
     it { expect(html).to have_link('button 1', href: 'link_to_button_1') }
     it { expect(html).to have_link('button 2', href: 'link_to_button_2') }
   end

--- a/spec/components/layout/cards/testimonial_component_spec.rb
+++ b/spec/components/layout/cards/testimonial_component_spec.rb
@@ -12,8 +12,9 @@ RSpec.describe Layout::Cards::TestimonialComponent, :include_application_helper,
     render_inline(described_class.new(**params)) do |card|
       card.with_header(title: 'Header')
       card.with_quote { 'Quote' }
-      card.with_source { 'Source Name' }
-
+      card.with_name { 'Source Name' }
+      card.with_role { 'Role' }
+      card.with_location { 'Location' }
       card.with_button('button 1', 'link_to_button_1', style: :primary)
       card.with_button('button 2', 'link_to_button_2', style: :secondary)
     end
@@ -36,6 +37,8 @@ RSpec.describe Layout::Cards::TestimonialComponent, :include_application_helper,
     it { expect(html).to have_content('Header') }
     it { expect(html).to have_content('Quote') }
     it { expect(html).to have_content('Source Name') }
+    it { expect(html).to have_content('Role') }
+    it { expect(html).to have_content('Location') }
     it { expect(html).to have_link('button 1', href: 'link_to_button_1') }
     it { expect(html).to have_link('button 2', href: 'link_to_button_2') }
   end

--- a/spec/components/layout/cards/testimonial_component_spec.rb
+++ b/spec/components/layout/cards/testimonial_component_spec.rb
@@ -2,11 +2,12 @@
 
 require 'rails_helper'
 
-RSpec.describe Layout::Cards::TestimonialComponent, :include_application_helper, type: :component do
+RSpec.describe Layout::Cards::TestimonialComponent, :include_application_helper, :include_url_helpers, type: :component do
   let(:id) { 'custom-id' }
   let(:classes) { 'extra-classes' }
   let(:theme) { :dark }
   let(:base_params) { { id: id, classes: classes, theme: theme } }
+  let(:case_study) { create(:case_study) }
 
   let(:html) do
     render_inline(described_class.new(**params)) do |card|
@@ -16,8 +17,7 @@ RSpec.describe Layout::Cards::TestimonialComponent, :include_application_helper,
       card.with_name { 'Source Name' }
       card.with_role { 'Role' }
       card.with_organisation { 'Organisation' }
-      card.with_button('button 1', 'link_to_button_1', style: :primary)
-      card.with_button('button 2', 'link_to_button_2', style: :secondary)
+      card.with_case_study(case_study)
     end
   end
 
@@ -40,7 +40,7 @@ RSpec.describe Layout::Cards::TestimonialComponent, :include_application_helper,
     it { expect(html).to have_content('Source Name') }
     it { expect(html).to have_content('Role') }
     it { expect(html).to have_content('Organisation') }
-    it { expect(html).to have_link('button 1', href: 'link_to_button_1') }
-    it { expect(html).to have_link('button 2', href: 'link_to_button_2') }
+    it { expect(html).to have_link('Read case study', href: case_study_download_path(case_study)) }
+    it { expect(html).to have_link('More case studies', href: '/case-studies') }
   end
 end

--- a/spec/components/layout/grid_component_spec.rb
+++ b/spec/components/layout/grid_component_spec.rb
@@ -130,4 +130,23 @@ RSpec.describe Layout::GridComponent, :include_application_helper, type: :compon
     it { expect(row).to have_xpath('.//img[contains(@src, "/assets/laptop-")]', visible: :all) }
     it { expect(row).to have_css('img.component-classes', count: 1) }
   end
+
+  context 'with cell' do
+    let(:params) { all_params }
+
+    let(:html) do
+      render_inline(described_class.new(**params)) do |c|
+        c.with_cell { 'cell 1' }
+        c.with_cell { 'cell 2' }
+      end
+    end
+
+    before do
+      puts html
+    end
+
+    it { expect(rows[0]).to have_css('div.col-12.col-md-6', count: 2) }
+    it { expect(html).to have_content('cell 1') }
+    it { expect(html).to have_content('cell 2') }
+  end
 end

--- a/spec/components/previews/layout/cards/testimonial_component_preview.rb
+++ b/spec/components/previews/layout/cards/testimonial_component_preview.rb
@@ -3,9 +3,22 @@ module Layout
     class TestimonialComponentPreview < ViewComponent::Preview
       def default
         render(Layout::Cards::TestimonialComponent.new) do |card|
-          card.with_header title: 'Header'
-          card.with_quote { 'Interesting quote about the above title' }
-          card.with_source { '<strong>Name</strong><br>school'.html_safe }
+          card.with_header title: 'Powering a Greener Tomorrow'
+          card.with_quote { 'Every watt saved is a step towards a brighter future!' }
+          card.with_name { 'Dr Watts' }
+          card.with_role { 'Energy Champion' }
+          card.with_location { 'Greenfields Academy' }
+          card.with_button 'Primary link', '/', style: :primary
+          card.with_button 'Secondary link', '/', style: :secondary
+        end
+      end
+
+      def with_theme_and_without_role
+        render(Layout::Cards::TestimonialComponent.new(theme: :light)) do |card|
+          card.with_header title: 'Powering a Greener Tomorrow'
+          card.with_quote { 'Every watt saved is a step towards a brighter future!' }
+          card.with_name { 'Dr Watts' }
+          card.with_location { 'Greenfields Academy' }
           card.with_button 'Primary link', '/', style: :primary
           card.with_button 'Secondary link', '/', style: :secondary
         end

--- a/spec/components/previews/layout/cards/testimonial_component_preview.rb
+++ b/spec/components/previews/layout/cards/testimonial_component_preview.rb
@@ -9,8 +9,7 @@ module Layout
           card.with_name { 'Dr Watts' }
           card.with_role { 'Energy Champion' }
           card.with_organisation { 'Greenfields Academy' }
-          card.with_button 'Primary link', '/', style: :primary
-          card.with_button 'Secondary link', '/', style: :secondary
+          card.with_case_study(CaseStudy.last)
         end
       end
 
@@ -21,8 +20,7 @@ module Layout
           card.with_quote { 'Every watt saved is a step towards a brighter future!' }
           card.with_name { 'Dr Watts' }
           card.with_organisation { 'Greenfields Academy' }
-          card.with_button 'Primary link', '/', style: :primary
-          card.with_button 'Secondary link', '/', style: :secondary
+          card.with_case_study(CaseStudy.last)
         end
       end
     end

--- a/spec/components/previews/layout/cards/testimonial_component_preview.rb
+++ b/spec/components/previews/layout/cards/testimonial_component_preview.rb
@@ -2,23 +2,25 @@ module Layout
   module Cards
     class TestimonialComponentPreview < ViewComponent::Preview
       def default
-        render(Layout::Cards::TestimonialComponent.new) do |card|
+        render(Layout::Cards::TestimonialComponent.new(classes: 'p-4')) do |card|
+          card.with_image(src: 'laptop.jpg')
           card.with_header title: 'Powering a Greener Tomorrow'
           card.with_quote { 'Every watt saved is a step towards a brighter future!' }
           card.with_name { 'Dr Watts' }
           card.with_role { 'Energy Champion' }
-          card.with_location { 'Greenfields Academy' }
+          card.with_organisation { 'Greenfields Academy' }
           card.with_button 'Primary link', '/', style: :primary
           card.with_button 'Secondary link', '/', style: :secondary
         end
       end
 
       def with_theme_and_without_role
-        render(Layout::Cards::TestimonialComponent.new(theme: :light)) do |card|
+        render(Layout::Cards::TestimonialComponent.new(theme: :light, classes: 'p-4')) do |card|
+          card.with_image(src: 'laptop.jpg')
           card.with_header title: 'Powering a Greener Tomorrow'
           card.with_quote { 'Every watt saved is a step towards a brighter future!' }
           card.with_name { 'Dr Watts' }
-          card.with_location { 'Greenfields Academy' }
+          card.with_organisation { 'Greenfields Academy' }
           card.with_button 'Primary link', '/', style: :primary
           card.with_button 'Secondary link', '/', style: :secondary
         end

--- a/spec/factories/testimonials.rb
+++ b/spec/factories/testimonials.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  factory :testimonial do
+    title { 'Testimonial title' }
+    quote { 'Testimonial quote' }
+    name { 'Testimonial name' }
+    role { 'Testimonial role' }
+    location { 'Testimonial location' }
+  end
+end

--- a/spec/factories/testimonials.rb
+++ b/spec/factories/testimonials.rb
@@ -1,9 +1,19 @@
 FactoryBot.define do
   factory :testimonial do
-    title { 'Testimonial title' }
-    quote { 'Testimonial quote' }
+    active { false }
+    category { :default }
     name { 'Testimonial name' }
-    role { 'Testimonial role' }
-    location { 'Testimonial location' }
+    organisation { 'Testimonial organisation' }
+    image { Rack::Test::UploadedFile.new(Rails.root.join('spec/fixtures/images/placeholder.png'), 'image/png') }
+
+    # Translated attributes
+    title_en { 'Testimonial title in English' }
+    title_cy { 'Testimonial title in Welsh' }
+    quote_en { 'Testimonial quote in English' }
+    quote_cy { 'Testimonial quote in Welsh' }
+    role_en { 'Testimonial role in English' }
+    role_cy { 'Testimonial role in Welsh' }
+
+    association :case_study, factory: :case_study
   end
 end

--- a/spec/models/testimonial_spec.rb
+++ b/spec/models/testimonial_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Testimonial, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/testimonial_spec.rb
+++ b/spec/models/testimonial_spec.rb
@@ -1,5 +1,88 @@
 require 'rails_helper'
 
 RSpec.describe Testimonial, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe 'validations' do
+    context 'with valid attributes' do
+      subject(:testimonial) { create(:testimonial) }
+
+      it { expect(testimonial).to be_valid }
+      it { expect(testimonial).to validate_presence_of(:image) }
+      it { expect(testimonial).to validate_presence_of(:title_en) }
+      it { expect(testimonial).to validate_presence_of(:name) }
+      it { expect(testimonial).to validate_presence_of(:quote_en) }
+      it { expect(testimonial).to validate_presence_of(:organisation) }
+      it { expect(testimonial).to validate_presence_of(:category) }
+    end
+  end
+
+  describe 'associations' do
+    subject(:testimonial) { create(:testimonial) }
+
+    it { expect(testimonial).to belong_to(:case_study).optional }
+    it { expect(testimonial).to have_one_attached(:image) }
+  end
+
+  describe 'scopes' do
+    describe '.active' do
+      let!(:active_testimonial) { create(:testimonial, active: true) }
+      let!(:inactive_testimonial) { create(:testimonial, active: false) }
+
+      it 'includes only active testimonials' do
+        expect(Testimonial.active).to include(active_testimonial)
+        expect(Testimonial.active).not_to include(inactive_testimonial)
+      end
+    end
+  end
+
+  describe 'translations' do
+    let!(:testimonial) do
+      create(
+        :testimonial,
+        title_en: 'English Title',
+        title_cy: 'Welsh Title',
+        quote_en: 'English Quote',
+        quote_cy: 'Welsh Quote',
+        role_en: 'English Role',
+        role_cy: 'Welsh Role'
+      )
+    end
+
+    context 'when locale is English' do
+      around do |example|
+        I18n.with_locale(:en) { example.run }
+      end
+
+      it 'returns English translations' do
+        expect(testimonial.title).to eq('English Title')
+        expect(testimonial.quote).to eq('English Quote')
+        expect(testimonial.role).to eq('English Role')
+      end
+    end
+
+    context 'when locale is Welsh' do
+      around do |example|
+        I18n.with_locale(:cy) { example.run }
+      end
+
+      it 'returns Welsh translations' do
+        expect(testimonial.title).to eq('Welsh Title')
+        expect(testimonial.quote).to eq('Welsh Quote')
+        expect(testimonial.role).to eq('Welsh Role')
+      end
+    end
+
+    context 'when locale is Welsh but no Welsh translation exists' do
+      let!(:testimonial) { create(:testimonial, title_cy: nil, quote_cy: nil, role_cy: nil) }
+
+      around do |example|
+        I18n.with_locale(:cy) { example.run }
+      end
+
+      it 'falls back to English' do
+        expect(testimonial.title).to eq(testimonial.title_en)
+        expect(testimonial.quote).to eq(testimonial.quote_en)
+        expect(testimonial.role).to eq(testimonial.role_en)
+      end
+    end
+  end
 end

--- a/spec/system/admin/testimonials_spec.rb
+++ b/spec/system/admin/testimonials_spec.rb
@@ -1,0 +1,171 @@
+require 'rails_helper'
+
+describe 'admin testimonials', :include_application_helper, type: :system do
+  let!(:admin) { create(:admin) }
+  let!(:case_study) { create(:case_study) }
+  let!(:testimonial) { create(:testimonial) }
+
+  describe 'when not logged in' do
+    context 'when visiting the index' do
+      before do
+        visit admin_testimonials_path
+      end
+
+      it 'does not authorise viewing' do
+        expect(page).to have_content('You need to sign in or sign up before continuing.')
+      end
+    end
+
+    context 'when editing a testimonial' do
+      before do
+        visit edit_admin_testimonial_path(testimonial)
+      end
+
+      it 'does not authorise viewing' do
+        expect(page).to have_content('You need to sign in or sign up before continuing.')
+      end
+    end
+  end
+
+  describe 'when logged in as a non admin user' do
+    let(:staff) { create(:staff) }
+
+    before { sign_in(staff) }
+
+    context 'when visiting the index' do
+      before do
+        visit admin_testimonials_path
+      end
+
+      it 'does not authorise viewing' do
+        expect(page).to have_content('You are not authorized to view that page.')
+      end
+    end
+  end
+
+  describe 'when logged in' do
+    before { sign_in(admin) }
+
+    describe 'Viewing the index' do
+      before do
+        visit admin_testimonials_path
+      end
+
+      it 'lists the testimonial' do
+        expect(page).to have_content(testimonial.title)
+        expect(page).to have_content(testimonial.quote)
+        expect(page).to have_content(testimonial.name)
+        expect(page).to have_content(testimonial.role)
+        expect(page).to have_content(testimonial.organisation)
+        expect(page).to have_content(testimonial.category)
+        expect(page).to have_link('Read case study', href: case_study_download_path(testimonial.case_study))
+      end
+
+      it { expect(page).to have_link('Edit') }
+      it { expect(page).to have_link('New') }
+      it { expect(page).to have_link('Delete') }
+
+      context 'when clicking the edit button' do
+        before { click_link('Edit', match: :first) }
+
+        it 'shows the testimonial edit page' do
+          expect(page).to have_current_path(edit_admin_testimonial_path(testimonial))
+        end
+
+        context 'with invalid attributes' do
+          before do
+            fill_in :testimonial_title_en, with: ''
+            fill_in :testimonial_quote_en, with: ''
+            fill_in 'Name', with: ''
+            fill_in 'Organisation', with: ''
+            click_on 'Save'
+          end
+
+          it { expect(page).to have_content("Title *\ncan't be blank") }
+          it { expect(page).to have_content("Quote *\ncan't be blank") }
+          it { expect(page).to have_content("Name *\ncan't be blank") }
+          it { expect(page).to have_content("Organisation *\ncan't be blank") }
+        end
+
+        context 'with valid attributes' do
+          before do
+            fill_in :testimonial_title_en, with: 'Updated testimonial title'
+            fill_in :testimonial_quote_en, with: 'Updated testimonial quote'
+            fill_in 'Name', with: 'Updated name'
+            fill_in :testimonial_role_en, with: 'Updated role'
+            fill_in 'Organisation', with: 'Updated organisation'
+            select 'default', from: 'Category'
+            check 'Active'
+            click_on 'Save'
+          end
+
+          it { expect(page).to have_content('Testimonial was successfully updated') }
+          it { expect(page).to have_content('Updated testimonial title') }
+          it { expect(page).to have_content('Updated testimonial quote') }
+          it { expect(page).to have_content('Updated name') }
+          it { expect(page).to have_content('Updated role') }
+          it { expect(page).to have_content('Updated organisation') }
+          it { expect(page).to have_content('default') }
+        end
+      end
+
+      context 'when clicking the new button' do
+        before { click_link('New') }
+
+        it 'shows the testimonial new page' do
+          expect(page).to have_current_path(new_admin_testimonial_path)
+        end
+
+        context 'with invalid attributes' do
+          before do
+            # Submit the form without filling in required fields
+            click_on 'Save'
+          end
+
+          it { expect(page).to have_content("Title *\ncan't be blank") }
+          it { expect(page).to have_content("Quote *\ncan't be blank") }
+          it { expect(page).to have_content("Name *\ncan't be blank") }
+          it { expect(page).to have_content("Organisation *\ncan't be blank") }
+        end
+
+        context 'with valid attributes' do
+          before do
+            fill_in :testimonial_title_en, with: 'New testimonial title'
+            fill_in :testimonial_quote_en, with: 'New testimonial quote'
+            fill_in 'Name', with: 'New name'
+            fill_in :testimonial_role_en, with: 'New role'
+            fill_in 'Organisation', with: 'New organisation'
+            select 'default', from: 'Category'
+            check 'Active'
+            attach_file 'Image', Rails.root + 'spec/fixtures/images/placeholder.png'
+            click_on 'Save'
+          end
+
+          it { expect(page).to have_content('Testimonial was successfully created') }
+          it { expect(page).to have_content('New testimonial title') }
+          it { expect(page).to have_content('New testimonial quote') }
+          it { expect(page).to have_content('New name') }
+          it { expect(page).to have_content('New role') }
+          it { expect(page).to have_content('New organisation') }
+          it { expect(page).to have_content('default') }
+        end
+      end
+
+      context 'when clicking the delete button', :js do
+        before do
+          accept_confirm do
+            click_on('Delete', match: :first)
+          end
+        end
+
+        it 'shows the index page' do
+          expect(page).to have_current_path(admin_testimonials_path)
+        end
+
+        it 'no longer lists the testimonial' do
+          expect(page).not_to have_content(testimonial.title)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
* Adds testimonial model - it has an enum called category, so we can filter them for different pages. Not sure if testimonials need to be in multiple categories though, in which case we'll need to add a new category model  / relationship / more admin.
* Adds admin GUI & links to from admin dashboard
* Uses the new model on the front page
* Rearranges the testimonial component to better match the model