### PR TITLE
Fix styling of advice page nav

### DIFF
--- a/app/components/page_nav_component/page_nav_component.html.erb
+++ b/app/components/page_nav_component/page_nav_component.html.erb
@@ -1,4 +1,4 @@
-<%= tag.div id: 'page-nav', class: class_names(classes, 'collapse d-md-flex') do %>
+<%= tag.div id: 'page-nav', class: class_names(classes, 'page-nav-component collapse d-md-flex') do %>
   <ul class="nav flex-column flex-nowrap w-100">
     <li class="nav-item"><%= header %></li>
     <% sections.each do |section| %>

--- a/spec/components/page_nav_component_spec.rb
+++ b/spec/components/page_nav_component_spec.rb
@@ -54,6 +54,7 @@ RSpec.describe PageNavComponent, type: :component do
       it { expect(list_item).to have_css('.bg-section') }
       it { expect(list_item).to have_css('.nav-link') }
       it { expect(list_item).to have_css('.toggler') }
+      it { expect(page_nav).to have_css('.page-nav-component') } # css based on this
     end
 
     context 'with toggling for section' do


### PR DESCRIPTION
Add in a missing class required to properly style the page navigation component. Currently all the colour and hover stylings aren't working.

Looks like it might have gotten lost during some component refactoring. ApplicationComponent subclasses now add a HTML class based on the class name automatically, but PageNav doesn't extend that.

Haven't reworked the component for now but may look at as part of changes for the support pages.