### PR TITLE
Add Transifex Synching for CMS module

### DIFF
--- a/app/models/activity_type.rb
+++ b/app/models/activity_type.rb
@@ -70,6 +70,7 @@ class ActivityType < ApplicationRecord
   scope :for_key_stages, ->(key_stages) { joins(:key_stages).where(key_stages: { id: key_stages.map(&:id) }).distinct }
   scope :for_subjects, ->(subjects) { joins(:subjects).where(subjects: { id: subjects.map(&:id) }).distinct }
   scope :not_including, ->(records = []) { where.not(id: records) }
+  scope :tx_resources, -> { active.order(:id) }
 
   validates_presence_of :name, :activity_category_id, :score
   validates_uniqueness_of :name, scope: :activity_category_id
@@ -134,10 +135,6 @@ class ActivityType < ApplicationRecord
   # override default name for this resource in transifex
   def tx_name
     name
-  end
-
-  def self.tx_resources
-    active.order(:id)
   end
 
   def count_existing_for_academic_year(school, academic_year)

--- a/app/models/cms/base.rb
+++ b/app/models/cms/base.rb
@@ -12,13 +12,10 @@ module Cms
 
     scope :published, -> { where(published: true) }
     scope :by_title, ->(order = :asc) { i18n.order(title: order) }
+    scope :tx_resources, -> { published.order(:id) }
 
     def publishable?
       true
-    end
-
-    def self.tx_resources
-      published.order(:id)
     end
 
     private

--- a/app/models/cms/base.rb
+++ b/app/models/cms/base.rb
@@ -1,6 +1,7 @@
 module Cms
   class Base < ApplicationRecord
     extend Mobility
+    include TransifexSerialisable
 
     self.abstract_class = true
 
@@ -14,6 +15,10 @@ module Cms
 
     def publishable?
       true
+    end
+
+    def self.tx_resources
+      published.order(:id)
     end
 
     private

--- a/app/models/intervention_type.rb
+++ b/app/models/intervention_type.rb
@@ -74,6 +74,7 @@ class InterventionType < ApplicationRecord
   scope :custom_last,           -> { order(:custom) }
   scope :between,               ->(first_date, last_date) { where('at BETWEEN ? AND ?', first_date, last_date) }
   scope :not_including,         ->(records = []) { where.not(id: records) }
+  scope :tx_resources,          -> { active.order(:id) }
 
   before_save :copy_searchable_attributes
 
@@ -84,10 +85,6 @@ class InterventionType < ApplicationRecord
   # override default name for this resource in transifex
   def tx_name
     name
-  end
-
-  def self.tx_resources
-    active.order(:id)
   end
 
   def count_existing_for_academic_year(school, academic_year)

--- a/app/models/programme_type.rb
+++ b/app/models/programme_type.rb
@@ -38,6 +38,7 @@ class ProgrammeType < ApplicationRecord
 
   scope :default_first, -> { order(default: :desc) }
   scope :featured, -> { active.default_first.by_title }
+  scope :tx_resources, -> { active.order(:id) }
 
   # to be removed when todos feature removed
   scope :with_school_activity_type_count, ->(school) {
@@ -114,9 +115,5 @@ class ProgrammeType < ApplicationRecord
   # regardless of having signed up to the programme
   def all_activity_types_completed_for_school?(school)
     (activity_types.pluck(:id) - school.activity_types_in_academic_year.pluck(:id)).empty?
-  end
-
-  def self.tx_resources
-    active.order(:id)
   end
 end

--- a/app/models/testimonial.rb
+++ b/app/models/testimonial.rb
@@ -31,8 +31,5 @@ class Testimonial < ApplicationRecord
   validates :image, :title_en, :name, :quote_en, :organisation, :category, presence: true
 
   scope :active, -> { where(active: true) }
-
-  def self.tx_resources
-    active.order(:id)
-  end
+  scope :tx_resources, -> { active.order(:id) }
 end

--- a/app/models/testimonial.rb
+++ b/app/models/testimonial.rb
@@ -31,4 +31,8 @@ class Testimonial < ApplicationRecord
   validates :image, :title_en, :name, :quote_en, :organisation, :category, presence: true
 
   scope :active, -> { where(active: true) }
+
+  def self.tx_resources
+    active.order(:id)
+  end
 end

--- a/app/services/transifex/loader.rb
+++ b/app/services/transifex/loader.rb
@@ -37,11 +37,18 @@ module Transifex
         synchronise_resources(transifex_load, Comparison::Footnote.tx_resources)
         log('Synchronising Comparison Report Groups')
         synchronise_resources(transifex_load, Comparison::ReportGroup.tx_resources)
-
-        if EnergySparks::FeatureFlags.active?(:sync_advice_page_translations)
-          log('Synchronising Advice Pages')
-          synchronise_resources(transifex_load, AdvicePage.tx_resources)
-        end
+        log('Synchronising Advice Pages')
+        synchronise_resources(transifex_load, AdvicePage.tx_resources)
+        log('Synchronising Scoreboards')
+        synchronise_resources(transifex_load, Scoreboard.tx_resources)
+        log('Synchronising Testimonials')
+        synchronise_resources(transifex_load, Testimonial.tx_resources)
+        log('Synchronising Cms:Category')
+        synchronise_resources(transifex_load, ::Cms::Category.tx_resources)
+        log('Synchronising Cms:Page')
+        synchronise_resources(transifex_load, ::Cms::Page.tx_resources)
+        log('Synchronising Cms:Section')
+        synchronise_resources(transifex_load, ::Cms::Section.tx_resources)
       rescue => error
         # ensure all errors are caught and logged
         log_error(transifex_load, error)

--- a/spec/models/concerns/transifex_serialisable_spec.rb
+++ b/spec/models/concerns/transifex_serialisable_spec.rb
@@ -62,7 +62,9 @@ describe TransifexSerialisable do
       # we have to explicitly require the classes otherwise they're not loaded and
       # check for included modules fails
       Dir[Rails.root.join('app/models/**/*.rb')].sort.each { |f| require f }
-      @tx_serialisables = ApplicationRecord.descendants.select { |c| c.included_modules.include? TransifexSerialisable }
+      @tx_serialisables = ApplicationRecord.descendants.select do |c|
+        c.included_modules.include?(TransifexSerialisable) && !c.abstract_class
+      end
     end
 
     it 'all including models have timestamps and include Mobility' do

--- a/spec/services/transifex/loader_spec.rb
+++ b/spec/services/transifex/loader_spec.rb
@@ -71,6 +71,7 @@ describe Transifex::Loader, type: :service do
     let!(:comparison_report)        { create(:report, report_group: comparison_report_group) }
     let!(:comparison_footnote)      { create(:footnote) }
     let!(:advice_page)              { create(:advice_page, learn_more: advice_page_text) }
+    let!(:category)                 { create(:category, published: true) }
 
     before do
       allow_any_instance_of(Transifex::Synchroniser).to receive(:pull).and_return(true)
@@ -79,37 +80,23 @@ describe Transifex::Loader, type: :service do
     end
 
     it 'updates the pull count' do
-      expect(TransifexLoad.first.pulled).to eq 12
+      expect(TransifexLoad.first.pulled).to eq 14
     end
 
     it 'updates the push count' do
-      expect(TransifexLoad.first.pushed).to eq 12
+      expect(TransifexLoad.first.pushed).to eq 14
     end
 
-    context 'when advice page syncing is enabled' do
-      around do |example|
-        ClimateControl.modify FEATURE_FLAG_SYNC_ADVICE_PAGE_TRANSLATIONS: 'true' do
-          example.run
-        end
-      end
-
-      it 'updates the pull count' do
-        expect(TransifexLoad.first.pulled).to eq 13
-      end
-
-      it 'updates the push count' do
-        expect(TransifexLoad.first.pushed).to eq 13
-      end
-
+    context 'when synching advice pages' do
       context 'when a record has no contents' do
         let!(:advice_page_text) { '' }
 
         it 'skips the pull' do
-          expect(TransifexLoad.first.pulled).to eq 12
+          expect(TransifexLoad.first.pulled).to eq 13
         end
 
         it 'skips the push' do
-          expect(TransifexLoad.first.pushed).to eq 12
+          expect(TransifexLoad.first.pushed).to eq 13
         end
       end
     end


### PR DESCRIPTION
Include the `TransifexSynchronisable` in the `Cms::Base` class and implement `tx_resources` to only synch published content.

Noticed that the `Scoreboard` and `Testimonial` classes were not in the loader so have added those.