### PR TITLE
Handle zero installed capacity

### DIFF
--- a/lib/data_feeds/pv_live_service.rb
+++ b/lib/data_feeds/pv_live_service.rb
@@ -71,6 +71,9 @@ module DataFeeds
 
         if missing_on_day > 5 && date > start_date
           too_little_data_on_day.push(date)
+        elsif days_data.compact.empty?
+          Rails.logger.error { "No valid readings for #{date}" }
+          too_little_data_on_day.push(date)
         elsif days_data.sum <= 0.0
           Rails.logger.error { "Data sums to zero on #{date}" }
           too_little_data_on_day.push(date)
@@ -138,7 +141,7 @@ module DataFeeds
         time = adjust_to_bst(gmt_time)
         generation = halfhour_data[meta_data_dictionary.index('generation_mw')]
         capacity = halfhour_data[meta_data_dictionary.index('installedcapacity_mwp')]
-        next if generation.nil? || capacity.nil?
+        next if generation.nil? || capacity.nil? || capacity.zero?
 
         yield_pv = generation / capacity
         all_pv_yield[time] = yield_pv

--- a/lib/tasks/deployment/20250425105312_remove_region151_data.rake
+++ b/lib/tasks/deployment/20250425105312_remove_region151_data.rake
@@ -1,0 +1,18 @@
+namespace :after_party do
+  desc 'Deployment task: remove_region151_data'
+  task remove_region151_data: :environment do
+    puts "Running deploy task 'remove_region151_data'"
+
+    # No installed capacity for this id so all data is zeroes. Additional bug at our side
+    # is creating NaN values. None of this should have been inserted
+    area = SolarPvTuosArea.find_by_gsp_id(151)
+    if area
+      area.solar_pv_tuos_readings.destroy_all
+    end
+
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord
+      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+  end
+end


### PR DESCRIPTION
PV Live API is returning zero readings and zero installed capacity for GSP id 151 (IMPK_1)

https://api.pvlive.uk/pvlive/api/v4/gsp/151?start=2025-04-24&extra_fields=installedcapacity_mwp

Causing our loader to insert readings with `NaN` values rather than rejecting the whole day. Add a fix and a logging message.

Waiting to here from Sheffield whether this is to be expected. There was previously capacity at that identifier. Also unclear if we should get some readings for any area.