### PR TITLE
Fix fuel type used for solar pv advice page dates

### DIFF
--- a/app/controllers/schools/advice/advice_base_controller.rb
+++ b/app/controllers/schools/advice/advice_base_controller.rb
@@ -161,7 +161,7 @@ module Schools
       end
 
       def set_analysis_dates
-        @analysis_dates = Schools::AnalysisDates.new(@school, @advice_page.fuel_type&.to_sym)
+        @analysis_dates = Schools::AnalysisDates.new(@school, advice_page_fuel_type)
       end
     end
   end

--- a/spec/support/shared_contexts/advice_pages.rb
+++ b/spec/support/shared_contexts/advice_pages.rb
@@ -94,7 +94,7 @@ RSpec.shared_context 'gas advice page' do
 end
 
 RSpec.shared_context 'solar advice page' do
-  let(:fuel_type) { :electricity }
+  let(:fuel_type) { :solar_pv }
   include_context 'advice page base'
   let!(:advice_page) { create(:advice_page, key: key, restricted: false, fuel_type: fuel_type, learn_more: learn_more_content) }
 


### PR DESCRIPTION
Prior to refactoring the solar pv controller was overriding the fuel type used for the advice page to be `:electricity` as that is the meter we are reporting on. I've fixed the base controller to use the `advice_page_fuel_type` method again.

Also fixed the shared context which was using electricity, hence no failures during refactoring.