### PR TITLE
Front page hero tweaks

### DIFF
--- a/app/components/elements/image_component/image_component.scss
+++ b/app/components/elements/image_component/image_component.scss
@@ -1,15 +1,16 @@
 img.elements-image-component {
   &.stretch {
+    position: absolute;
     height: 100%;
     object-fit: cover;
   }
 
   &.right {
-    right: 0;
+    left: 0;
   }
 
   &.left {
-    left: 0;
+    right: 0;
   }
 
   &.fit {

--- a/app/components/layout/cards/feature_component/feature_component.scss
+++ b/app/components/layout/cards/feature_component/feature_component.scss
@@ -16,8 +16,12 @@
 
     padding: 1.5rem 0 1.5rem 1.5rem;
 
+    @include media-breakpoint-down(sm) {
+      padding-left: 0;
+    }
+
     @include media-breakpoint-up(xl) {
-      min-height: 450px; // make sure we show at least 9/10 height of the main image (500px)
+      min-height: 430px; // show a minimum of 430px of the main image (500px)
       padding: 3rem 0 3rem 3rem;
     }
   }

--- a/app/components/layout/cards/feature_component/feature_component.scss
+++ b/app/components/layout/cards/feature_component/feature_component.scss
@@ -10,17 +10,15 @@
   }
 
   &.main {
-    @include responsive-typography;
     p {
       font-family: $header-font-family;
     }
 
-    // break out of container to left on large screens
+    padding: 1.5rem 0 1.5rem 1.5rem;
+
     @include media-breakpoint-up(xl) {
-      padding-left: 30px;
-      width: 50vw;
-      position: absolute;
-      right: 0;
+      min-height: 450px; // make sure we show at least 9/10 height of the main image (500px)
+      padding: 3rem 0 3rem 3rem;
     }
   }
 }

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -4,7 +4,8 @@
   <% if Flipper.enabled?(:new_home_page, current_user) %>
     <div class="theme theme-dark">
       <%= render Layout::GridComponent.new(cols: 2, classes: 'container') do |grid| %>
-        <% grid.with_feature_card main: true, theme: :dark, classes: 'py-4 pr-4' do |feature| %>
+        <%= grid.with_image src: 'on-screen.jpg', stretch: :left, width: '50vw', collapse: true, classes: 'main' %>
+        <% grid.with_feature_card main: true, theme: :dark do |feature| %>
           <%= feature.with_header title: t('home.feature.header') %>
           <%= feature.with_description(classes: 'text-complement') { t('home.feature.description_html') } %>
           <%= feature.with_button t('nav.enrol'), find_out_more_campaigns_path, style: :success %>
@@ -12,7 +13,6 @@
                                   book_demo_campaigns_path,
                                   style: :white, outline: true %>
         <% end %>
-        <%= grid.with_image src: 'on-screen.jpg', stretch: :right, width: '50vw', collapse: true, classes: 'main' %>
       <% end %>
     </div>
 


### PR DESCRIPTION
A few tweaks to the home page hero as follows:

* Remove responsive typography
* Switch image to the left
* Add more padding to hero text on xl viewports
* Add a min height for text area on xl viewports
* Remove padding to text area on sm viewports

Does look better on my screen. Image still takes up lots of vertical space on very wide screens (probably looks awful on @ldodds's :-) ). Open to other suggestions!