### PR TITLE
Allow blank scoreboard option

### DIFF
--- a/app/views/schools/configuration/_form.html.erb
+++ b/app/views/schools/configuration/_form.html.erb
@@ -38,7 +38,7 @@
       <%= f.label :scoreboard_id, 'Scoreboard' %>
       <%= f.select :scoreboard_id,
                    options_from_collection_for_select(@scoreboards, 'id', 'name', @school&.scoreboard&.id),
-                   {},
+                   { include_blank: true },
                    { class: 'form-control' } %>
     </div>
   </div>


### PR DESCRIPTION
Allow blank option in scoreboard drop-down. Otherwise the value defaults to East Midlands scoreboard (alphabetically first in the list) so updates the school when saved. 