### PR TITLE
Build education workshop page from new components

### DIFF
--- a/app/assets/stylesheets/bootstrap-overrides.scss
+++ b/app/assets/stylesheets/bootstrap-overrides.scss
@@ -16,3 +16,12 @@ $btn-border-radius-sm: $btn-border-radius;
 $btn-border-radius-lg: $btn-border-radius;
 
 $custom-control-indicator-checked-bg: darken($teal-dark, 5%); // darkened slightly to match input accent color (base.scss)
+
+$grid-breakpoints: (
+        xs: 0,
+        sm: 576px,
+        md: 768px,
+        lg: 992px,
+        xl: 1200px,
+        xxl: 1600px
+);

--- a/app/assets/stylesheets/links.scss
+++ b/app/assets/stylesheets/links.scss
@@ -105,26 +105,3 @@ section.highlight {
     outline: none;
   }
 }
-/*
-// Extra small devices (portrait phones, less than 576px)
-@media (max-width: 575.98px) {
-  .btn,
-  .btn:hover,
-  .btn:focus,
-  .btn:active,
-  .btn.active {
-    @include font(f9);
-  }
-}
-
-// Small devices (landscape phones, 576px and up)
-@media (min-width: 576px) and (max-width: 767.98px) {
-  .btn,
-  .btn:hover,
-  .btn:focus,
-  .btn:active,
-  .btn.active {
-    @include font(f9);
-  }
-}
-*/

--- a/app/assets/stylesheets/themes.scss
+++ b/app/assets/stylesheets/themes.scss
@@ -50,9 +50,19 @@
     .badge {
       background-color: $yellow-light;
     }
+
+    .btn-secondary {
+      background-color: transparent;
+      @include button-outline-variant($blue-very-dark, $blue-very-dark, $blue-pale);
+    }
   }
 
   &.theme-accent {
     background-color: $yellow-pale;
+
+    .btn-secondary {
+      background-color: transparent;
+      @include button-outline-variant($blue-very-dark, $blue-very-dark, $yellow-light);
+    }
   }
 }

--- a/app/components/elements/image_component.rb
+++ b/app/components/elements/image_component.rb
@@ -1,20 +1,20 @@
 module Elements
   class ImageComponent < ApplicationComponent
-    def initialize(src:, fit: true, collapse: false, width: nil, height: nil, **_kwargs)
+    def initialize(src:, fit: true, collapse: false, width: nil, height: nil, rounded: :all, **_kwargs)
       super
       @src = src
       @fit = fit
       @collapse = collapse
       @width = width
       @height = height
+      @rounded = rounded
       validate
       setup_classes
     end
 
     def setup_classes
-      if @fit
-        add_classes('fit')
-      end
+      add_classes('fit') if @fit
+      add_classes(self.class.rounded[@rounded]) if @rounded
       add_classes('d-none d-md-block') if @collapse
     end
 
@@ -30,15 +30,19 @@ module Elements
     end
 
     def validate
-      raise ArgumentError.new(self.class.stretch_error) if @stretch && !self.class.stretch.include?(@stretch.to_sym)
+      raise ArgumentError.new(self.class.rounded_error) if @rounded && !self.class.rounded.key?(@rounded.to_sym)
     end
 
-    def self.stretch
-      [:left, :right]
+    def self.rounded
+      {
+        top: 'rounded-top-xl',
+        bottom: 'rounded-bottom-xl',
+        all: 'rounded-xl'
+      }
     end
 
-    def self.stretch_error
-      'Stretch must be: ' + self.stretch.to_sentence(two_words_connector: ' or ')
+    def self.rounded_error
+      'Rounded must be: ' + self.rounded.keys.to_sentence(two_words_connector: ' or ')
     end
   end
 end

--- a/app/components/layout/cards/testimonial_component/testimonial_component.html.erb
+++ b/app/components/layout/cards/testimonial_component/testimonial_component.html.erb
@@ -13,7 +13,7 @@
         <%= render Elements::ButtonComponent.new(
               t('components.testimonial.more_case_studies'),
               case_studies_path,
-              outline_style: :transparent, classes: 'mb-1'
+              style: :secondary, classes: 'mb-1'
             ) %>
       </div>
     <% end %>

--- a/app/components/layout/grid_component.rb
+++ b/app/components/layout/grid_component.rb
@@ -44,9 +44,10 @@ module Layout
     def column_classes
       case cols
       when 2
-        'col-12 col-md-6'
+        # 'col-12 col-md-6'
+        'col-12 col-lg-6' # it might look better to go full width on md
       when 3
-        'col-12 col-md-4 col-sm-12'
+        'col-12 col-md-4'
       when 4
         'col-12 col-xl-3 col-sm-6'
       when 6 # not currently in use

--- a/app/components/layout/grid_component.rb
+++ b/app/components/layout/grid_component.rb
@@ -25,7 +25,7 @@ module Layout
     end
 
     def cell(**kwargs, &block)
-      tag.div(class: class_names(column_classes, kwargs.delete(:cell_classes), @cell_classes), &block)
+      tag.div(class: class_names(column_classes, kwargs.delete(:cell_classes), @cell_classes, responsive_classes(**kwargs)), &block)
     end
 
     def initialize(cols:, rows: 1, cell_classes: '', **_kwargs)
@@ -35,6 +35,11 @@ module Layout
       @rows = rows
 
       @cell_classes = cell_classes
+    end
+
+    def responsive_classes(**kwargs)
+      return 'pr-xl-4 pr-xxl-5' if kwargs[:left]
+      return 'pl-xl-4 pl-xxl-5' if kwargs[:right]
     end
 
     def render?

--- a/app/views/home/education_workshops.html.erb
+++ b/app/views/home/education_workshops.html.erb
@@ -1,14 +1,14 @@
 <% content_for :page_title, t('education_workshops.title') %>
 <% if Flipper.enabled?(:new_audits_page, current_user) %>
-  <div class="container-fluid adult mb-5 py-4">
+  <div class="container-fluid adult mb-5 py-5">
     <%= render Layout::GridComponent.new(
-          id: 'hero', cols: 2, classes: 'container'
+          id: 'hero', cols: 2, classes: 'container p-4'
         ) do |grid| %>
-      <% grid.with_feature_card(cell_classes: 'my-auto', size: :xl) do |feature| %>
+      <% grid.with_feature_card(cell_classes: 'my-auto pr-xl-4 pr-xxl-5', size: :xl) do |feature| %>
         <%= feature.with_header title: t('education_workshops.feature.title') %>
         <%= feature.with_description { t('education_workshops.feature.description') } %>
       <% end %>
-      <%= grid.with_image src: 'for-schools/workshop-class.png', classes: 'rounded-xl', cell_classes: 'p-4' %>
+      <%= grid.with_image src: 'for-schools/workshop-class.png', classes: 'rounded-xl', cell_classes: 'pl-xl-4 pl-xxl-5' %>
     <% end %>
   </div>
 
@@ -31,6 +31,46 @@
           <%= stats.with_subtext { card[:description] } %>
         <% end %>
       <% end %>
+    <% end %>
+
+    <%= render Layout::GridComponent.new(
+          id: 'audience',
+          cols: 2,
+          theme: :light,
+          classes: 'rounded-xl p-4 my-4',
+          cell_classes: 'my-auto'
+        ) do |grid| %>
+      <%= grid.with_image(src: 'for-schools/workshop-activity.png') %>
+      <%= grid.with_feature_card(classes: 'mb-4', size: :md) do |feature| %>
+        <%= feature.with_header(title: t('education_workshops.audience.title'), classes: 'mt-3 mt-lg-0') %>
+        <%= feature.with_description { t('education_workshops.audience.description_html') } %>
+        <%= feature.with_button(t('education_workshops.book'),
+                                'https://forms.gle/eREfqJgH5SRYQRah9', style: :primary, classes: 'mr-2') %>
+        <%= feature.with_button(t('common.labels.enquire_now'),
+                                'mailto:hello@energysparks.uk', style: :secondary) %>
+      <% end %>
+    <% end %>
+
+    <%= render Layout::GridComponent.new(
+          id: 'desktop',
+          cols: 2,
+          classes: 'my-4',
+          cell_classes: 'py-4'
+        ) do |grid| %>
+      <%= grid.with_feature_card(size: :lg) do |feature| %>
+        <%= feature.with_header(title: t('education_workshops.details.title')) %>
+        <%= feature.with_price(
+              label: t('common.labels.ranging_from'),
+              price: t('education_workshops.details.price'),
+              classes: 'text-complement pb-1'
+            ) %>
+        <%= feature.with_description { t('education_workshops.details.description_html') } %>
+        <%= feature.with_button(t('education_workshops.book'),
+                                'https://forms.gle/eREfqJgH5SRYQRah9', style: :primary, classes: 'mr-2') %>
+        <%= feature.with_button(t('common.labels.enquire_now'),
+                                'mailto:hello@energysparks.uk', style: :secondary) %>
+      <% end %>
+      <%= grid.with_image(src: 'laptop.jpg') %>
     <% end %>
   </div>
 <% else %>

--- a/app/views/home/education_workshops.html.erb
+++ b/app/views/home/education_workshops.html.erb
@@ -1,27 +1,62 @@
 <% content_for :page_title, t('education_workshops.title') %>
-
-<div class="application container">
-  <h1><%= t('education_workshops.title') %></h1>
-
-  <%= render 'two_column_image_deck',
-             column_one: 'for-schools/workshop-class.png',
-             column_two: 'for-schools/workshop-activity.png' %>
-
-  <div class="row">
-    <div class="col-md-12">
-      <%= t('education_workshops.intro_html') %>
-    </div>
+<% if Flipper.enabled?(:new_audits_page, current_user) %>
+  <div class="container-fluid adult mb-5 py-4">
+    <%= render Layout::GridComponent.new(
+          id: 'hero', cols: 2, classes: 'container'
+        ) do |grid| %>
+      <% grid.with_feature_card(cell_classes: 'my-auto', size: :xl) do |feature| %>
+        <%= feature.with_header title: t('education_workshops.feature.title') %>
+        <%= feature.with_description { t('education_workshops.feature.description') } %>
+      <% end %>
+      <%= grid.with_image src: 'for-schools/workshop-class.png', classes: 'rounded-xl', cell_classes: 'p-4' %>
+    <% end %>
   </div>
 
-  <div class="row">
-    <div class="col-md-12">
-      <p>
-        <%= t('education_workshops.availability') %>
-      </p>
-      <%= t('education_workshops.cost_html') %>
-      <p>
-        <a href="https://forms.gle/eREfqJgH5SRYQRah9" class="btn"><%= t('education_workshops.book') %></a>
-      </p>
+  <div class="container">
+    <%= render Layout::Cards::SectionHeaderComponent.new(
+          classes: '', id: 'workshops-header'
+        ) do |section_header| %>
+      <%= section_header.with_header title: t('education_workshops.workshops.title') %>
+      <%= section_header.with_description { t('education_workshops.workshops.description') } %>
+    <% end %>
+
+    <%= render Layout::GridComponent.new(id: 'workshops',
+                                         cols: 3, rows: 2, classes: 'mb-4',
+                                         cell_classes: 'mb-4',
+                                         component_classes: 'theme theme-dark') do |grid| %>
+      <% I18n.t('education_workshops.workshops.cards').each do |card| %>
+        <% grid.with_stats_card do |stats| %>
+          <%= stats.with_icon name: card[:icon], classes: card[:icon_colour], style: :circle %>
+          <%= stats.with_header title: card[:title] %>
+          <%= stats.with_subtext { card[:description] } %>
+        <% end %>
+      <% end %>
+    <% end %>
+  </div>
+<% else %>
+  <div class="application container">
+    <h1><%= t('education_workshops.title') %></h1>
+
+    <%= render 'two_column_image_deck',
+               column_one: 'for-schools/workshop-class.png',
+               column_two: 'for-schools/workshop-activity.png' %>
+
+    <div class="row">
+      <div class="col-md-12">
+        <%= t('education_workshops.intro_html') %>
+      </div>
+    </div>
+
+    <div class="row">
+      <div class="col-md-12">
+        <p>
+          <%= t('education_workshops.availability') %>
+        </p>
+        <%= t('education_workshops.cost_html') %>
+        <p>
+          <a href="https://forms.gle/eREfqJgH5SRYQRah9" class="btn"><%= t('education_workshops.book') %></a>
+        </p>
+      </div>
     </div>
   </div>
-</div>
+<% end %>

--- a/app/views/home/education_workshops.html.erb
+++ b/app/views/home/education_workshops.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, t('education_workshops.title') %>
-<% if Flipper.enabled?(:new_audits_page, current_user) %>
+<% if Flipper.enabled?(:new_workshops_page, current_user) %>
   <div class="container-fluid adult mb-5 py-5">
     <%= render Layout::GridComponent.new(
           id: 'hero', cols: 2, classes: 'container p-4'
@@ -52,7 +52,7 @@
     <% end %>
 
     <%= render Layout::GridComponent.new(
-          id: 'desktop',
+          id: 'details',
           cols: 2,
           classes: 'my-4',
           cell_classes: 'py-4'

--- a/app/views/home/energy_audits.html.erb
+++ b/app/views/home/energy_audits.html.erb
@@ -1,14 +1,14 @@
 <% content_for :page_title, t('energy_audits.title') %>
 <% if Flipper.enabled?(:new_audits_page, current_user) %>
-  <div class="container-fluid adult mb-5 py-4">
+  <div class="container-fluid adult mb-5 py-5">
     <%= render Layout::GridComponent.new(
-          id: 'hero', cols: 2, classes: 'container', cell_classes: ''
+          id: 'hero', cols: 2, classes: 'container', cell_classes: 'my-auto'
         ) do |grid| %>
-      <% grid.with_feature_card(cell_classes: 'my-auto', size: :xl) do |feature| %>
+      <% grid.with_feature_card(cell_classes: 'px-xl-4', size: :xl) do |feature| %>
         <%= feature.with_header title: t('energy_audits.feature.title') %>
         <%= feature.with_description { t('energy_audits.feature.description') } %>
       <% end %>
-      <%= grid.with_image src: 'audit-image.png', classes: 'rounded-xl', cell_classes: 'p-4' %>
+      <%= grid.with_image src: 'audit-image.png', classes: 'rounded-xl', cell_classes: 'px-xxl-5' %>
     <% end %>
   </div>
 

--- a/app/views/home/energy_audits.html.erb
+++ b/app/views/home/energy_audits.html.erb
@@ -2,7 +2,7 @@
 <% if Flipper.enabled?(:new_audits_page, current_user) %>
   <div class="container-fluid adult mb-5 py-4">
     <%= render Layout::GridComponent.new(
-          id: 'hero', cols: 2, classes: 'container'
+          id: 'hero', cols: 2, classes: 'container', cell_classes: ''
         ) do |grid| %>
       <% grid.with_feature_card(cell_classes: 'my-auto', size: :xl) do |feature| %>
         <%= feature.with_header title: t('energy_audits.feature.title') %>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -6,7 +6,7 @@
       <%= render Layout::GridComponent.new(cols: 2, classes: 'container p-4', id: 'hero') do |grid| %>
         <%= grid.with_image src: 'on-screen.jpg', classes: 'rounded-xl', cell_classes: '', collapse: true %>
         <% grid.with_feature_card size: :xl, theme: :dark, cell_classes: 'my-auto' do |feature| %>
-          <%= feature.with_header title: t('home.feature.header') %>
+          <%= feature.with_header title: t('home.feature.header'), classes: 'mt-md-3' %>
           <%= feature.with_description { t('home.feature.description_html') } %>
           <%= feature.with_button t('nav.enrol'), find_out_more_campaigns_path, style: :success %>
           <%= feature.with_button t('home.buttons.book_a_demo'),

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -2,11 +2,11 @@
   <% content_for :page_title, t('common.labels.home') %>
 
   <% if Flipper.enabled?(:new_home_page, current_user) %>
-    <div class="theme theme-dark mb-5">
+    <div class="container-fluid theme theme-dark mb-5 pt-3 pb-4">
       <%= render Layout::GridComponent.new(cols: 2, classes: 'container p-4', id: 'hero') do |grid| %>
-        <%= grid.with_image src: 'on-screen.jpg', classes: 'rounded-xl', cell_classes: '', collapse: true %>
-        <% grid.with_feature_card size: :xl, theme: :dark, cell_classes: 'my-auto' do |feature| %>
-          <%= feature.with_header title: t('home.feature.header'), classes: 'mt-md-3' %>
+        <%= grid.with_image src: 'on-screen.jpg', cell_classes: 'pr-xl-4', collapse: true %>
+        <% grid.with_feature_card size: :xl, theme: :dark, cell_classes: 'my-auto pl-xl-4' do |feature| %>
+          <%= feature.with_header title: t('home.feature.header'), classes: 'mt-3 mt-lg-0' %>
           <%= feature.with_description { t('home.feature.description_html') } %>
           <%= feature.with_button t('nav.enrol'), find_out_more_campaigns_path, style: :success %>
           <%= feature.with_button t('home.buttons.book_a_demo'),
@@ -18,7 +18,7 @@
 
     <div class="container">
       <%= render Layout::Cards::SectionHeaderComponent.new(
-            classes: '', id: 'stats-header'
+            id: 'stats-header'
           ) do |section_header| %>
         <%= section_header.with_header title: t('home.stats.header') %>
         <%= section_header.with_description { t('home.stats.description') } %>
@@ -100,7 +100,7 @@
             id: 'general',
             cols: 2,
             theme: :light,
-            classes: 'rounded-xl p-4 mb-4 mt-4',
+            classes: 'rounded-xl p-4 my-4',
             cell_classes: 'my-auto'
           ) do |grid| %>
         <%= grid.with_feature_card(classes: 'mb-4', size: :md) do |feature| %>
@@ -108,7 +108,7 @@
           <%= feature.with_description { t('home.general.description_html', count: School.visible.count) } %>
           <%= feature.with_button(t('home.buttons.find_out_more'), find_out_more_path, style: :primary) %>
         <% end %>
-        <%= grid.with_image(src: 'pupils-jumping.jpg', classes: 'rounded-xl bg-white') %>
+        <%= grid.with_image(src: 'pupils-jumping.jpg') %>
       <% end %>
 
       <%= render Layout::Cards::SectionHeaderComponent.new(
@@ -122,12 +122,12 @@
       <%= render Layout::GridComponent.new(
             id: 'organisations',
             cols: 3,
-            classes: 'my-4 pb-4',
+            classes: 'mt-4 mb-5',
             cell_classes: 'mb-4',
             component_classes: 'h-100'
           ) do |grid| %>
         <%= grid.with_card do |card| %>
-          <%= card.with_image(src: 'funnel-pupils.png', classes: 'rounded-top-xl') %>
+          <%= card.with_image(src: 'funnel-pupils.png', rounded: :top) %>
           <%= card.with_feature_card(theme: :dark, size: :sm, classes: 'p-4 rounded-bottom-xl') do |feature| %>
             <%= feature.with_header(title: t('home.organisations.cards.school.title')) %>
             <%= feature.with_description { t('home.organisations.cards.school.description') } %>
@@ -136,7 +136,7 @@
         <% end %>
 
         <%= grid.with_card do |card| %>
-          <%= card.with_image(src: 'funnel-teachers.png', classes: 'rounded-top-xl') %>
+          <%= card.with_image(src: 'funnel-teachers.png', rounded: :top) %>
           <%= card.with_feature_card(theme: :dark, size: :sm, classes: 'p-4 rounded-bottom-xl') do |feature| %>
             <%= feature.with_header(title: t('home.organisations.cards.multi_academy.title')) %>
             <%= feature.with_description { t('home.organisations.cards.multi_academy.description') } %>
@@ -145,7 +145,7 @@
         <% end %>
 
         <%= grid.with_card do |card| %>
-          <%= card.with_image(src: 'laptop.jpg', classes: 'rounded-top-xl') %>
+          <%= card.with_image(src: 'laptop.jpg', rounded: :top) %>
           <%= card.with_feature_card(theme: :dark, size: :sm, classes: 'rounded-bottom-xl') do |feature| %>
             <%= feature.with_header(title: t('home.organisations.cards.local_authority.title')) %>
             <%= feature.with_description(classes: '') { t('home.organisations.cards.local_authority.description') } %>
@@ -170,7 +170,7 @@
               ) %>
           <%= render Elements::ButtonComponent.new(
                 t('home.buttons.view_blog'),
-                'http://blog.energysparks.uk', style: :white, outline: true, classes: ''
+                'http://blog.energysparks.uk', style: :secondary
               ) %>
         </div>
 
@@ -184,7 +184,7 @@
 
           <% @blog.items.first(3).each do |item| %>
             <%= grid.with_card do |card| %>
-              <%= card.with_image(src: item[:image] || 'on-screen.jpg', classes: 'rounded-top-xl') %>
+              <%= card.with_image(src: item[:image] || 'on-screen.jpg', rounded: :top) %>
               <%= card.with_feature_card(theme: :light, size: :sm, classes: 'p-4 rounded-bottom-xl') do |feature| %>
                 <%= feature.with_header(title: item[:title]) %>
                 <%= feature.with_author(href: item[:author_link]) { item[:author] } %>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -29,7 +29,7 @@
                                            cell_classes: 'mb-4',
                                            component_classes: 'theme theme-dark') do |grid| %>
         <% grid.with_stats_card do |card| %>
-          <%= card.with_icon fuel_type: :electricity, style: :circle %>
+          <%= card.with_icon name: 'bolt', style: :circle, classes: 'text-electric' %>
           <%= card.with_header title: t('home.stats.card_1.header') %>
           <%= card.with_figure t('home.stats.card_1.figure') %>
           <%= card.with_subtext { t('home.stats.card_1.subtext') } %>

--- a/config/locales/common.yml
+++ b/config/locales/common.yml
@@ -40,6 +40,7 @@ en:
       edit: Edit
       enable: Enable
       energy_saving_actions: Energy saving actions
+      enquire_now: Enquire now
       finish: Finish
       finished: Finished
       home: Home
@@ -58,6 +59,7 @@ en:
       prices: Prices
       pupil_activities: Pupil activities
       pupil_led_activities: Pupil-led activities
+      ranging_from: Ranging from
       read_more: Read more
       remove: Remove
       report: Report

--- a/config/locales/views/home/education_workshops.yml
+++ b/config/locales/views/home/education_workshops.yml
@@ -29,7 +29,7 @@ en:
     workshops:
       cards:
       - title: Energy warriors
-        icon: user-ninja
+        icon: user-shield
         icon_colour: text-blue-dark
         description: Introduce your pupils to the energy we use in our homes and schools.
       - title: Our school, our climate

--- a/config/locales/views/home/education_workshops.yml
+++ b/config/locales/views/home/education_workshops.yml
@@ -1,9 +1,24 @@
 ---
 en:
   education_workshops:
+    audience:
+      description_html: |-
+        We offer workshops for a variety of audiences, including:
+        <ul>
+          <li>Assemblies</li>
+          <li>Workshops for eco-teams and classes</li>
+          <li>In-person training for estate staff, business managers and sustainability leads on how to use Energy Sparks</li>
+        </ul>
+      title: Motivational workshops for both pupils and staff
     availability: Please note, education workshops are currently only available to schools with an active Energy Sparks account. In-person workshops are available in most areas of England and Wales. We are currently only able to offer virtual workshops in Scotland.
     book: Book a workshop
     cost_html: "<p>Workshops are available on a paid-for basis from £250 to £500 dependent on location and whether provided in-person or online. Discounts are available if we are able to co-ordinate workshops for several schools within the same Multi-Academy Trust or Local Authority to cut down travel. Some schools in designated regions will be eligible for free in-person workshops. We will let you know if you are eligible for a free workshop or provide an accurate quote after you have completed the workshop booking form.</p>"
+    details:
+      description_html: |-
+        Workshops are available on a paid-for basis, with prices ranging from £250 to £500 depending on location and whether provided in-person or online.<br><br>
+        Some schools in designated regions will be eligible for free in-person workshops. We will let you know if you are eligible for a free workshop or provide an accurate quote after you have completed the workshop booking form.
+      price: "£250 to £500 + VAT"
+      title: Workshop details
     feature:
       description: Whether you are looking to inspire the next generation of energy saving champions, or want to encourage your staff to cut costs and emissions, our workshops can help you.
       title: Motivate pupils and staff with our energy education workshops

--- a/config/locales/views/home/education_workshops.yml
+++ b/config/locales/views/home/education_workshops.yml
@@ -4,6 +4,9 @@ en:
     availability: Please note, education workshops are currently only available to schools with an active Energy Sparks account. In-person workshops are available in most areas of England and Wales. We are currently only able to offer virtual workshops in Scotland.
     book: Book a workshop
     cost_html: "<p>Workshops are available on a paid-for basis from £250 to £500 dependent on location and whether provided in-person or online. Discounts are available if we are able to co-ordinate workshops for several schools within the same Multi-Academy Trust or Local Authority to cut down travel. Some schools in designated regions will be eligible for free in-person workshops. We will let you know if you are eligible for a free workshop or provide an accurate quote after you have completed the workshop booking form.</p>"
+    feature:
+      description: Whether you are looking to inspire the next generation of energy saving champions, or want to encourage your staff to cut costs and emissions, our workshops can help you.
+      title: Motivate pupils and staff with our energy education workshops
     intro_html: |-
       <p>
         To support engagement and drive impact, Energy Sparks offers in-person and virtual half day education workshops to participating schools across the UK. Education workshops can include:
@@ -23,3 +26,31 @@ en:
         <li>Spot what’s hot: Learn how to analyse heating charts and explore temperature and heating in your school using a thermal imaging camera</li>
       </ul>
     title: Education Workshops
+    workshops:
+      cards:
+      - title: Energy warriors
+        icon: user-ninja
+        icon_colour: text-blue-dark
+        description: Introduce your pupils to the energy we use in our homes and schools.
+      - title: Our school, our climate
+        icon: earth-europe
+        icon_colour: text-teal-dark
+        description: Learn about how the small changes we make in our school can affect the climate.
+      - title: Energy detectives
+        icon: magnifying-glass-chart
+        icon_colour: text-teal-very-dark
+        description: Learn how to conduct an energy audit and identify energy guzzlers around the school.
+      - title: Spot what's hot
+        icon: fire
+        icon_colour: text-yellow-medium
+        description: Learn how to analyse heating charts, and explore temperature and heating in your school using a thermal imaging camera.
+      - title: Antarctica and Energy Sparks
+        icon: icicles
+        icon_colour: text-electric
+        description: Learn about the impact of climate change on Antarctica, and how pupils can use Energy Sparks to make a difference.
+      - title: Assemblies
+        icon: people-group
+        icon_colour: text-blue-dark
+        description: Suitable for the whole school, a key stage or a year group.
+      description: 'We will work with you to deliver a workshop that meets your school''s needs and interests. Sessions can include:'
+      title: Workshops that inspire

--- a/lib/tasks/deployment/20250508193906_add_new_workshops_page_feature.rake
+++ b/lib/tasks/deployment/20250508193906_add_new_workshops_page_feature.rake
@@ -1,9 +1,9 @@
 namespace :after_party do
-  desc 'Deployment task: add_new_audits_page_feature'
-  task add_new_audits_page_feature: :environment do
-    puts "Running deploy task 'add_new_audits_page_feature'"
+  desc 'Deployment task: add_new_workshops_page_feature'
+  task add_new_workshops_page_feature: :environment do
+    puts "Running deploy task 'add_new_workshops_page_feature'"
 
-    Flipper.add(:new_audits_page)
+    Flipper.add(:new_workshops_page)
 
     # Update task as completed.  If you remove the line below, the task will
     # run with every deploy (or every time you call after_party:run).

--- a/spec/components/layout/grid_component_spec.rb
+++ b/spec/components/layout/grid_component_spec.rb
@@ -37,9 +37,9 @@ RSpec.describe Layout::GridComponent, :include_application_helper, type: :compon
     context 'with 2 cols' do
       let(:cols) { 2 }
 
-      it { expect(rows[0]).to have_css('div.col-12.col-md-6', count: 2) }
-      it { expect(rows[1]).to have_css('div.col-12.col-md-6', count: 2) }
-      it { expect(rows[2]).to have_css('div.col-12.col-md-6', count: 1) }
+      it { expect(rows[0]).to have_css('div.col-12.col-lg-6', count: 2) }
+      it { expect(rows[1]).to have_css('div.col-12.col-lg-6', count: 2) }
+      it { expect(rows[2]).to have_css('div.col-12.col-lg-6', count: 1) }
     end
 
     context 'with 3 cols' do
@@ -104,7 +104,7 @@ RSpec.describe Layout::GridComponent, :include_application_helper, type: :compon
       end
     end
 
-    it { expect(rows[0]).to have_css('div.col-12.col-md-6.cell-classes', count: 2) }
+    it { expect(rows[0]).to have_css('div.col-12.col-lg-6.cell-classes', count: 2) }
   end
 
   context 'with inline cell classes' do
@@ -115,9 +115,8 @@ RSpec.describe Layout::GridComponent, :include_application_helper, type: :compon
       end
     end
 
-    it { expect(row).to have_css('div.col-12.col-md-6.cell-classes', count: 1) }
+    it { expect(row).to have_css('div.col-12.col-lg-6.cell-classes', count: 1) }
   end
-
 
   context 'with image' do
     let(:html) do
@@ -141,11 +140,7 @@ RSpec.describe Layout::GridComponent, :include_application_helper, type: :compon
       end
     end
 
-    before do
-      puts html
-    end
-
-    it { expect(rows[0]).to have_css('div.col-12.col-md-6', count: 2) }
+    it { expect(rows[0]).to have_css('div.col-12.col-lg-6', count: 2) }
     it { expect(html).to have_content('cell 1') }
     it { expect(html).to have_content('cell 2') }
   end

--- a/spec/components/previews/layout/cards/feature_component_preview.rb
+++ b/spec/components/previews/layout/cards/feature_component_preview.rb
@@ -50,7 +50,7 @@ module Layout
         render(Layout::Cards::FeatureComponent.new(theme: :light, classes: 'p-3 rounded-xl')) do |card|
           card.with_tag('Rock bottom prices')
           card.with_header title: 'Header'
-          card.with_price label: 'Starting from:', price: '£2999 + VAT'
+          card.with_price label: 'Starting from', price: '£2999 + VAT'
         end
       end
 

--- a/spec/components/previews/layout/cards/feature_component_preview.rb
+++ b/spec/components/previews/layout/cards/feature_component_preview.rb
@@ -50,7 +50,7 @@ module Layout
         render(Layout::Cards::FeatureComponent.new(theme: :light, classes: 'p-3 rounded-xl')) do |card|
           card.with_tag('Rock bottom prices')
           card.with_header title: 'Header'
-          card.with_price label: 'Starting from', price: '£2999 + VAT'
+          card.with_price label: 'Starting from:', price: '£2999 + VAT'
         end
       end
 

--- a/spec/system/home_spec.rb
+++ b/spec/system/home_spec.rb
@@ -86,6 +86,22 @@ RSpec.describe 'home', type: :system do
     end
   end
 
+  describe 'Education workshops page' do
+    context with_feature: :new_workshops_page do
+      before do
+        visit education_workshops_path
+      end
+
+      it 'renders all the components' do
+        expect(page).to have_css('#hero')
+        expect(page).to have_css('#workshops-header')
+        expect(page).to have_css('#workshops')
+        expect(page).to have_css('#audience')
+        expect(page).to have_css('#details')
+      end
+    end
+  end
+
   it 'allows locale switch retaining extra parameters' do
     visit root_path(foo: :bar)
     expect(page).to have_link('Cymraeg', href: 'http://cy.example.com/?foo=bar')


### PR DESCRIPTION
Builds education workshops page. 

Also - adds xxl viewport, for more flexibility on wider screens

Fiddles with margins / padding a bit more elsewhere and I expect to build this more into standard component behaviour as we build more pages.

Also changes the 2 col layout to break to 1 col on md size screens and lower (tablets). I think this looks better than the squished / misaligned version with 2 columns on this size.

Keen to get this on test if ok'd with you @ldodds as Sarah is reviewing the other pages as we speak.