### PR TITLE
Optimise dashboard alert queries

### DIFF
--- a/app/components/alerts_component.rb
+++ b/app/components/alerts_component.rb
@@ -30,6 +30,6 @@ class AlertsComponent < PromptListComponent
   def dashboard_alerts_for(alert_types)
     return @dashboard_alerts unless alert_types.present?
     alert_type_ids = alert_types.map(&:id)
-    @dashboard_alerts.select { |dashboard_alert| alert_type_ids.include?(dashboard_alert.alert.alert_type_id) }
+    @dashboard_alerts.select { |dashboard_alert| alert_type_ids.include?(dashboard_alert.alert_type.id) }
   end
 end

--- a/app/components/alerts_component/alerts_component.html.erb
+++ b/app/components/alerts_component/alerts_component.html.erb
@@ -19,16 +19,16 @@
   <% alerts.each do |alert_content| %>
     <%= render PromptComponent.new(
           icon: alert_icon(alert_content.alert),
-          fuel_type: alert_content.alert.alert_type.fuel_type,
+          fuel_type: alert_content.alert_type.fuel_type,
           status: status_for_alert_colour(alert_content.colour)
         ) do |prompt| %>
-          <% if alert_content.alert.alert_type.find_out_more? %>
+          <% if alert_content.find_out_more %>
           <% prompt.with_link do %>
             <%= link_to t('schools.show.find_out_more'),
                         advice_page_path(school,
-                                         alert_content.alert.advice_page,
-                                         alert_content.alert.alert_type.advice_page_tab_for_link_to,
-                                         anchor: alert_content.alert.alert_type.link_to_section) %>
+                                         alert_content.advice_page,
+                                         alert_content.alert_type.advice_page_tab_for_link_to,
+                                         anchor: alert_content.alert_type.link_to_section) %>
           <% end if show_links %>
         <% end %>
         <%= alert_content.send(content_field) %>

--- a/app/controllers/concerns/dashboard_alerts.rb
+++ b/app/controllers/concerns/dashboard_alerts.rb
@@ -2,12 +2,14 @@ module DashboardAlerts
   extend ActiveSupport::Concern
 
   def setup_alerts(alerts, content_field, limit: 2)
-    alerts.includes(:content_version, :find_out_more).by_priority.limit(limit).map do |dashboard_alert|
+    alerts.includes(:content_version, :find_out_more, :alert, { alert: [:alert_type, { alert_type: :advice_page }] }).by_priority.limit(limit).map do |dashboard_alert|
       TemplateInterpolation.new(
         dashboard_alert.content_version,
         with_objects: {
-          find_out_more: dashboard_alert.find_out_more,
+          find_out_more: dashboard_alert.alert.alert_type.find_out_more?,
           alert: dashboard_alert.alert,
+          alert_type: dashboard_alert.alert.alert_type,
+          advice_page: dashboard_alert.alert.alert_type.advice_page,
           priority: dashboard_alert.priority
         },
         proxy: [:colour]

--- a/spec/components/alerts_component_spec.rb
+++ b/spec/components/alerts_component_spec.rb
@@ -15,8 +15,12 @@ RSpec.describe AlertsComponent, type: :component, include_url_helpers: true do
     double(management_dashboard_title: 'adult alert text',
     pupil_dashboard_title: 'pupil alert text',
     colour: :positive,
-    alert: alert)
+    alert: alert,
+    alert_type: alert_type,
+    advice_page: advice_page,
+    find_out_more: true)
   end
+
   let(:dashboard_alerts) { [alert_content] }
   let(:all_params) do
     {


### PR DESCRIPTION
Currently there's several N+1 queries involved in the loading of the dashboard alert content.

PR changes the `setup_alerts` method to add more associations to the `.includes` call so that all of the related objects are loaded in separate queries, rather than one at a time. 

Also restructured the results of the TemplateInterpolation to directly expose some of the objects to ensure the records don't get loaded again when processed by the AlertComponent.

