### PR TITLE
Extend FileStore

### DIFF
--- a/app/services/aggregate_school_service.rb
+++ b/app/services/aggregate_school_service.rb
@@ -41,9 +41,13 @@ class AggregateSchoolService
   # To avoid fetching the item from disk twice for the common case, we just
   # attempt to fetch the item here.
   def in_cache?
-    # Fetch but do not aggregate
-    @meter_collection = Rails.cache.fetch(cache_key)
-    @meter_collection != nil
+    if Rails.cache.respond_to?(:exists_on_disk?)
+      Rails.cache.exists_on_disk?(cache_key)
+    else
+      # Fetch but do not aggregate
+      @meter_collection = Rails.cache.fetch(cache_key)
+      @meter_collection != nil
+    end
   end
 
   def in_cache_or_cache_off?

--- a/app/services/aggregate_school_service.rb
+++ b/app/services/aggregate_school_service.rb
@@ -38,8 +38,11 @@ class AggregateSchoolService
   # The common case for us is that the meter_collection will be in the cache.
   # If it isn't, then we serve a holding page whilst the school is aggregated.
   #
-  # To avoid fetching the item from disk twice for the common case, we just
-  # attempt to fetch the item here.
+  # To avoid fetching the item from disk we rely on a custom cache implementation
+  # that checks for a cached file, but not expiry.
+  #
+  # If that method is not available, then we just fetch the item rather than calling
+  # exists.
   def in_cache?
     if Rails.cache.respond_to?(:exists_on_disk?)
       Rails.cache.exists_on_disk?(cache_key)

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,4 +1,5 @@
 require "active_support/core_ext/integer/time"
+require './lib/energy_sparks/file_store'
 
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
@@ -123,7 +124,8 @@ Rails.application.configure do
   # session cookie has configurable name so that live and test logins are separated
   config.session_store :cookie_store, key: ENV.fetch('SESSION_COOKIE_NAME', '_energy-sparks_session'),
                                       domain: ENV.fetch('SESSION_COOKIE_DOMAIN', '.energysparks.uk')
-  config.cache_store = :file_store, "/var/cache/rails_cache_store"
+
+  config.cache_store = EnergySparks::FileStore.new("/var/cache/rails_cache_store")
   # Default good job execution mode configuration for production
   # See https://github.com/bensheldon/good_job#configuration-options
   config.active_job.queue_adapter = :good_job

--- a/lib/energy_sparks/file_store.rb
+++ b/lib/energy_sparks/file_store.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module EnergySparks
+  class FileStore < ActiveSupport::Cache::FileStore
+    def exists_on_disk?(cache_key)
+      internal_key = normalize_key(cache_key, merged_options(nil))
+      File.exist?(internal_key)
+    end
+  end
+end

--- a/lib/energy_sparks/file_store.rb
+++ b/lib/energy_sparks/file_store.rb
@@ -2,6 +2,12 @@
 
 module EnergySparks
   class FileStore < ActiveSupport::Cache::FileStore
+    # Check to see if there is a file for the corresponding cache key.
+    #
+    # This is a more optimal way of checking whether an item is in the
+    # cache for large, unversioned entries that do not expire.
+    #
+    # Only used in AggregateSchoolService.in_cache?
     def exists_on_disk?(cache_key)
       internal_key = normalize_key(cache_key, merged_options(nil))
       File.exist?(internal_key)


### PR DESCRIPTION
Extends FileStore to provide a method that checks if an cache entry exists on disk, but without loading it to check for expiry.

While not suitable for use in all cases, this avoids the need to actually load a MeterCollection when we just need to check whether it's in the cache. This means when we're caching partials we can completely remove loading the MeterCollection from the request.

Its reliant on there being no expiry on the cached meter collections, but we're unlikely to change that any time soon.

Try locally:

```
require './lib/energy_sparks/file_store'
config.cache_store = EnergySparks::FileStore.new("tmp/rails_cache_store")
```

