### PR TITLE
Time shift alert email delivery

### DIFF
--- a/app/mailers/alert_mailer.rb
+++ b/app/mailers/alert_mailer.rb
@@ -28,6 +28,7 @@ class AlertMailer < LocaleMailer
       I18n.t('alert_mailer.alert_email.subject_2024', school_name: @school.name)
     end
     email = make_bootstrap_mail(to: @email_addresses, subject:)
+    email.mailgun_options = { deliverytime: deliverytime }
     add_mg_email_tag(email, 'alerts')
   end
 
@@ -46,6 +47,10 @@ class AlertMailer < LocaleMailer
         with: event.alert.template_variables
       )
     end
+  end
+
+  def deliverytime
+    (Time.zone.now + 15.minutes).rfc822
   end
 
   def prevent_delivery_from_test

--- a/spec/mailers/alert_mailer_spec.rb
+++ b/spec/mailers/alert_mailer_spec.rb
@@ -20,6 +20,14 @@ RSpec.describe AlertMailer do
         expect(email.mailgun_headers['X-Mailgun-Tag']).to eql 'alerts'
       end
 
+      it 'sends an email with a mailgun deliverytime option' do
+        AlertMailer.with(email_address: email_address, school: school, events: []).alert_email.deliver_now
+        expect(ActionMailer::Base.deliveries.count).to be 1
+        deliverytime = email.mailgun_options[:deliverytime]
+        expect(deliverytime).not_to be_nil
+        expect(DateTime.rfc2822(deliverytime)).to be_between(Time.zone.now, Time.zone.now + 15.minutes)
+      end
+
       it 'specifies a subject' do
         AlertMailer.with(email_address: email_address, school: school, events: []).alert_email.deliver_now
         expect(email.subject).to eql I18n.t('alert_mailer.alert_email.subject_2024', school_name: school.name)
@@ -56,6 +64,14 @@ RSpec.describe AlertMailer do
         AlertMailer.with(users: users, school: school, events: []).alert_email.deliver_now
         expect(ActionMailer::Base.deliveries.count).to be 1
         expect(email.mailgun_headers['X-Mailgun-Tag']).to eql 'alerts'
+      end
+
+      it 'sends an email with a mailgun deliverytime option' do
+        AlertMailer.with(users: users, school: school, events: []).alert_email.deliver_now
+        expect(ActionMailer::Base.deliveries.count).to be 1
+        deliverytime = email.mailgun_options[:deliverytime]
+        expect(deliverytime).not_to be_nil
+        expect(DateTime.rfc2822(deliverytime)).to be_between(Time.zone.now, Time.zone.now + 15.minutes)
       end
 
       it 'specifies a subject' do

--- a/spec/mailers/alert_mailer_spec.rb
+++ b/spec/mailers/alert_mailer_spec.rb
@@ -66,14 +66,6 @@ RSpec.describe AlertMailer do
         expect(email.mailgun_headers['X-Mailgun-Tag']).to eql 'alerts'
       end
 
-      it 'sends an email with a mailgun deliverytime option' do
-        AlertMailer.with(users: users, school: school, events: []).alert_email.deliver_now
-        expect(ActionMailer::Base.deliveries.count).to be 1
-        deliverytime = email.mailgun_options[:deliverytime]
-        expect(deliverytime).not_to be_nil
-        expect(DateTime.rfc2822(deliverytime)).to be_between(Time.zone.now, Time.zone.now + 15.minutes)
-      end
-
       it 'specifies a subject' do
         AlertMailer.with(users: users, school: school, events: []).alert_email.deliver_now
         expect(email.subject).to eql I18n.t('alert_mailer.alert_email.subject_2024', school_name: school.name)


### PR DESCRIPTION
Used the Mailgun [o:deliverytime](https://www.mailgun.com/blog/email/tips-tricks-scheduling-email-delivery/) parameter to time shift the alert email deliveries.

Delivery time is set for 15 minutes after the call to send the email, to help offset the peak of Wednesday morning load caused by email generation from the additional load caused by the increase in (automated) traffic from the emails being delivered.

In theory all emails should be delivered around 15 minutes after the last `GenerateSubscriptionsJob`. 