### PR TITLE
Cache out of hours pages

### DIFF
--- a/app/services/schools/advice/out_of_hours_usage_service.rb
+++ b/app/services/schools/advice/out_of_hours_usage_service.rb
@@ -1,0 +1,66 @@
+module Schools
+  module Advice
+    class OutOfHoursUsageService
+      include AnalysableMixin
+
+      def initialize(school, aggregate_school_service, fuel_type)
+        @school = school
+        @aggregate_school_service = aggregate_school_service
+        @fuel_type = fuel_type
+      end
+
+      def enough_data?
+        @enough_data ||= annual_usage_breakdown_service.enough_data?
+      end
+
+      def data_available_from
+        @data_available_from ||= annual_usage_breakdown_service.data_available_from
+      end
+
+      def annual_usage_breakdown
+        @annual_usage_breakdown ||= annual_usage_breakdown_service.usage_breakdown
+      end
+
+      def benchmarked_usage
+        @benchmarked_usage ||= Schools::Comparison.new(
+          school_value: annual_usage_breakdown.out_of_hours.kwh,
+          benchmark_value: (annual_usage_breakdown.total.kwh * benchmark_value(:benchmark_school)),
+          exemplar_value: (annual_usage_breakdown.total.kwh * benchmark_value(:exemplar_school)),
+          unit: :kwh
+        )
+      end
+
+      def benchmark_value(comparison)
+        Schools::AdvicePageBenchmarks::OutOfHoursUsageBenchmarkGenerator.benchmark(compare: comparison, fuel_type: @fuel_type)
+      end
+
+      def holiday_usage
+        @holiday_usage ||= holiday_usage_calculation_service.school_holiday_calendar_comparison
+      end
+
+      private
+
+      def aggregate_meter
+        aggregate_school.aggregate_meter(@fuel_type)
+      end
+
+      def aggregate_school
+        @aggregate_school_service.meter_collection
+      end
+
+      def annual_usage_breakdown_service
+        @annual_usage_breakdown_service ||= Usage::UsageBreakdownService.new(
+          meter_collection: aggregate_school,
+          fuel_type: @fuel_type
+        )
+      end
+
+      def holiday_usage_calculation_service
+        @holiday_usage_calculation_service ||= Usage::HolidayUsageCalculationService.new(
+          aggregate_meter,
+          aggregate_school.holidays
+        )
+      end
+    end
+  end
+end

--- a/app/views/schools/advice/electricity_out_of_hours/_analysis.html.erb
+++ b/app/views/schools/advice/electricity_out_of_hours/_analysis.html.erb
@@ -1,50 +1,52 @@
-<p><%= t('advice_pages.electricity_out_of_hours.analysis.summary') %></p>
-<ul>
-  <li>
-    <a href='#last_twelve_months'>
-      <% if @analysis_dates.one_years_data? %>
-        <%= t('advice_pages.electricity_out_of_hours.analysis.last_twelve_months.title') %>
-      <% else %>
-        <%= t('advice_pages.electricity_long_term.analysis.recent_trend.title') %>
-      <% end %>
-    </a>
-  </li>
-  <li>
-    <a href='#usage_by_day_of_week'>
-      <%= t('advice_pages.electricity_out_of_hours.analysis.usage_by_day_of_week.title') %>
-    </a>
-  </li>
-  <% if show_holiday_usage_section?(@holiday_usage) %>
+<% cache [@school.latest_content, I18n.locale], expires_in: 4.hours do %>
+  <p><%= t('advice_pages.electricity_out_of_hours.analysis.summary') %></p>
+  <ul>
     <li>
-      <a href='#holiday-usage'>
-        <%= t('advice_pages.electricity_out_of_hours.analysis.holiday_usage.title') %>
+      <a href='#last_twelve_months'>
+        <% if @analysis_dates.one_years_data? %>
+          <%= t('advice_pages.electricity_out_of_hours.analysis.last_twelve_months.title') %>
+        <% else %>
+          <%= t('advice_pages.electricity_long_term.analysis.recent_trend.title') %>
+        <% end %>
       </a>
     </li>
-  <% end %>
-</ul>
+    <li>
+      <a href='#usage_by_day_of_week'>
+        <%= t('advice_pages.electricity_out_of_hours.analysis.usage_by_day_of_week.title') %>
+      </a>
+    </li>
+    <% if show_holiday_usage_section?(@out_of_hours_usage_service.holiday_usage) %>
+      <li>
+        <a href='#holiday-usage'>
+          <%= t('advice_pages.electricity_out_of_hours.analysis.holiday_usage.title') %>
+        </a>
+      </li>
+    <% end %>
+  </ul>
 
-<%= render 'schools/advice/out_of_hours/last_year',
-           analysis_dates: @analysis_dates,
-           meter_selection: @meter_selection,
-           usage_categories: @usage_categories,
-           annual_usage_breakdown: @annual_usage_breakdown,
-           fuel_type: :electricity,
-           chart: :daytype_breakdown_electricity_tolerant %>
-
-<%= render 'by_day',
-           school: @school,
-           meter_selection: @meter_selection,
-           analysis_dates: @analysis_dates %>
-
-<% if show_holiday_usage_section?(@holiday_usage) %>
-  <%= render 'schools/advice/out_of_hours/holidays',
-             school: @school,
+  <%= render 'schools/advice/out_of_hours/last_year',
              analysis_dates: @analysis_dates,
+             meter_selection: @meter_selection,
+             usage_categories: @usage_categories,
+             annual_usage_breakdown: @out_of_hours_usage_service.annual_usage_breakdown,
              fuel_type: :electricity,
-             dashboard_alerts: @dashboard_alerts,
-             alert_classes: [AlertElectricityUsageDuringCurrentHoliday, AlertPreviousHolidayComparisonElectricity,
-                             AlertPreviousYearHolidayComparisonElectricity],
-             full_chart: :alert_group_by_week_electricity_14_months,
-             limited_chart: :management_dashboard_group_by_week_electricity,
-             holiday_usage: @holiday_usage %>
+             chart: :daytype_breakdown_electricity_tolerant %>
+
+  <%= render 'by_day',
+             school: @school,
+             meter_selection: @meter_selection,
+             analysis_dates: @analysis_dates %>
+
+  <% if show_holiday_usage_section?(@out_of_hours_usage_service.holiday_usage) %>
+    <%= render 'schools/advice/out_of_hours/holidays',
+               school: @school,
+               analysis_dates: @analysis_dates,
+               fuel_type: :electricity,
+               dashboard_alerts: @dashboard_alerts,
+               alert_classes: [AlertElectricityUsageDuringCurrentHoliday, AlertPreviousHolidayComparisonElectricity,
+                               AlertPreviousYearHolidayComparisonElectricity],
+               full_chart: :alert_group_by_week_electricity_14_months,
+               limited_chart: :management_dashboard_group_by_week_electricity,
+               holiday_usage: @out_of_hours_usage_service.holiday_usage %>
+  <% end %>
 <% end %>

--- a/app/views/schools/advice/electricity_out_of_hours/_insights.html.erb
+++ b/app/views/schools/advice/electricity_out_of_hours/_insights.html.erb
@@ -1,14 +1,16 @@
-<%= render 'insights_intro', school: @school %>
-<%= render 'schools/advice/out_of_hours/current_usage',
-           school: @school,
-           analysis_dates: @analysis_dates,
-           dashboard_alerts: @dashboard_alerts,
-           annual_usage_breakdown: @annual_usage_breakdown,
-           alert_classes: [AlertOutOfHoursElectricityUsage],
-           fuel_type: :electricity %>
-<%= render 'schools/advice/out_of_hours/comparison',
-           school: @school,
-           benchmarked_usage: @benchmarked_usage,
-           analysis_dates: @analysis_dates,
-           well_managed_percent: @well_managed_percent,
-           fuel_type: :electricity %>
+<% cache [@school.latest_content, I18n.locale], expires_in: 4.hours do %>
+  <%= render 'insights_intro', school: @school %>
+  <%= render 'schools/advice/out_of_hours/current_usage',
+             school: @school,
+             analysis_dates: @analysis_dates,
+             dashboard_alerts: @dashboard_alerts,
+             annual_usage_breakdown: @out_of_hours_usage_service.annual_usage_breakdown,
+             alert_classes: [AlertOutOfHoursElectricityUsage],
+             fuel_type: :electricity %>
+  <%= render 'schools/advice/out_of_hours/comparison',
+             school: @school,
+             benchmarked_usage: @out_of_hours_usage_service.benchmarked_usage,
+             analysis_dates: @analysis_dates,
+             well_managed_percent: @out_of_hours_usage_service.benchmark_value(:benchmark_school),
+             fuel_type: :electricity %>
+<% end %>

--- a/app/views/schools/advice/electricity_out_of_hours/_insights_intro.html.erb
+++ b/app/views/schools/advice/electricity_out_of_hours/_insights_intro.html.erb
@@ -1,7 +1,7 @@
 <%= render PromptComponent.new(status: :none, icon: :lightbulb) do |c| %>
   <% c.with_link do
        link_to t('advice_pages.electricity_out_of_hours.insights.what_is_out_of_hours_usage_link'),
-               learn_more_school_advice_electricity_out_of_hours_path(@school)
+               learn_more_school_advice_electricity_out_of_hours_path(school)
      end %>
   <%= t('advice_pages.electricity_out_of_hours.insights.what_is_out_of_hours_usage_html') %>
 <% end %>

--- a/app/views/schools/advice/gas_out_of_hours/_analysis.html.erb
+++ b/app/views/schools/advice/gas_out_of_hours/_analysis.html.erb
@@ -1,51 +1,53 @@
-<p><%= t('advice_pages.gas_out_of_hours.analysis.summary') %></p>
-<ul>
-  <li>
-    <a href='#last_twelve_months'>
-      <% if @analysis_dates.one_years_data? %>
-        <%= t('advice_pages.gas_out_of_hours.analysis.last_twelve_months.title') %>
-      <% else %>
-        <%= t('advice_pages.gas_long_term.analysis.recent_trend.title') %>
-      <% end %>
-    </a>
-  </li>
-  <li>
-    <a href='#usage_by_day_of_week'>
-      <%= t('advice_pages.gas_out_of_hours.analysis.usage_by_day_of_week.title') %>
-    </a>
-  </li>
-  <% if show_holiday_usage_section?(@holiday_usage) %>
+<% cache [@school.latest_content, I18n.locale], expires_in: 4.hours do %>
+  <p><%= t('advice_pages.gas_out_of_hours.analysis.summary') %></p>
+  <ul>
     <li>
-      <a href='#holiday-usage'>
-        <%= t('advice_pages.gas_out_of_hours.analysis.holiday_usage.title') %>
+      <a href='#last_twelve_months'>
+        <% if @analysis_dates.one_years_data? %>
+          <%= t('advice_pages.gas_out_of_hours.analysis.last_twelve_months.title') %>
+        <% else %>
+          <%= t('advice_pages.gas_long_term.analysis.recent_trend.title') %>
+        <% end %>
       </a>
     </li>
-  <% end %>
-</ul>
+    <li>
+      <a href='#usage_by_day_of_week'>
+        <%= t('advice_pages.gas_out_of_hours.analysis.usage_by_day_of_week.title') %>
+      </a>
+    </li>
+    <% if show_holiday_usage_section?(@out_of_hours_usage_service.holiday_usage) %>
+      <li>
+        <a href='#holiday-usage'>
+          <%= t('advice_pages.gas_out_of_hours.analysis.holiday_usage.title') %>
+        </a>
+      </li>
+    <% end %>
+  </ul>
 
-<%= render 'schools/advice/out_of_hours/last_year',
-           analysis_dates: @analysis_dates,
-           meter_selection: @meter_selection,
-           usage_categories: @usage_categories,
-           annual_usage_breakdown: @annual_usage_breakdown,
-           fuel_type: :gas,
-           chart: :daytype_breakdown_gas_tolerant %>
+  <%= render 'schools/advice/out_of_hours/last_year',
+             analysis_dates: @analysis_dates,
+             meter_selection: @meter_selection,
+             usage_categories: @usage_categories,
+             annual_usage_breakdown: @out_of_hours_usage_service.annual_usage_breakdown,
+             fuel_type: :gas,
+             chart: :daytype_breakdown_gas_tolerant %>
 
-<%= render 'by_day',
-           school: @school,
-           analysis_dates: @analysis_dates,
-           meter_selection: @meter_selection,
-           annual_usage_breakdown: @annual_usage_breakdown %>
-
-<% if show_holiday_usage_section?(@holiday_usage) %>
-  <%= render 'schools/advice/out_of_hours/holidays',
+  <%= render 'by_day',
              school: @school,
              analysis_dates: @analysis_dates,
-             fuel_type: :gas,
-             dashboard_alerts: @dashboard_alerts,
-             alert_classes: [AlertGasHeatingHotWaterOnDuringHoliday, AlertPreviousHolidayComparisonGas,
-                             AlertPreviousYearHolidayComparisonGas],
-             full_chart: :alert_group_by_week_gas_14_months,
-             limited_chart: :management_dashboard_group_by_week_gas,
-             holiday_usage: @holiday_usage %>
+             meter_selection: @meter_selection,
+             annual_usage_breakdown: @out_of_hours_usage_service.annual_usage_breakdown %>
+
+  <% if show_holiday_usage_section?(@out_of_hours_usage_service.holiday_usage) %>
+    <%= render 'schools/advice/out_of_hours/holidays',
+               school: @school,
+               analysis_dates: @analysis_dates,
+               fuel_type: :gas,
+               dashboard_alerts: @dashboard_alerts,
+               alert_classes: [AlertGasHeatingHotWaterOnDuringHoliday, AlertPreviousHolidayComparisonGas,
+                               AlertPreviousYearHolidayComparisonGas],
+               full_chart: :alert_group_by_week_gas_14_months,
+               limited_chart: :management_dashboard_group_by_week_gas,
+               holiday_usage: @out_of_hours_usage_service.holiday_usage %>
+  <% end %>
 <% end %>

--- a/app/views/schools/advice/gas_out_of_hours/_insights.html.erb
+++ b/app/views/schools/advice/gas_out_of_hours/_insights.html.erb
@@ -1,14 +1,16 @@
-<%= render 'insights_intro', school: @school %>
-<%= render 'schools/advice/out_of_hours/current_usage',
-           school: @school,
-           analysis_dates: @analysis_dates,
-           dashboard_alerts: @dashboard_alerts,
-           annual_usage_breakdown: @annual_usage_breakdown,
-           alert_classes: [AlertOutOfHoursGasUsage],
-           fuel_type: :gas %>
-<%= render 'schools/advice/out_of_hours/comparison',
-           school: @school,
-           benchmarked_usage: @benchmarked_usage,
-           analysis_dates: @analysis_dates,
-           well_managed_percent: @well_managed_percent,
-           fuel_type: :gas %>
+<% cache [@school.latest_content, I18n.locale], expires_in: 4.hours do %>
+  <%= render 'insights_intro', school: @school %>
+  <%= render 'schools/advice/out_of_hours/current_usage',
+             school: @school,
+             analysis_dates: @analysis_dates,
+             dashboard_alerts: @dashboard_alerts,
+             annual_usage_breakdown: @out_of_hours_usage_service.annual_usage_breakdown,
+             alert_classes: [AlertOutOfHoursGasUsage],
+             fuel_type: :gas %>
+  <%= render 'schools/advice/out_of_hours/comparison',
+             school: @school,
+             benchmarked_usage: @out_of_hours_usage_service.benchmarked_usage,
+             analysis_dates: @analysis_dates,
+             well_managed_percent: @out_of_hours_usage_service.benchmark_value(:benchmark_school),
+             fuel_type: :gas %>
+<% end %>

--- a/app/views/schools/advice/gas_out_of_hours/_insights_intro.html.erb
+++ b/app/views/schools/advice/gas_out_of_hours/_insights_intro.html.erb
@@ -1,7 +1,7 @@
 <%= render PromptComponent.new(status: :none, icon: :lightbulb) do |c| %>
   <% c.with_link do
        link_to t('advice_pages.gas_out_of_hours.insights.what_is_out_of_hours_usage_link'),
-               learn_more_school_advice_gas_out_of_hours_path(@school)
+               learn_more_school_advice_gas_out_of_hours_path(school)
      end %>
   <%= t('advice_pages.gas_out_of_hours.insights.what_is_out_of_hours_usage_html') %>
 <% end %>


### PR DESCRIPTION
Adds template caching to the out of hours pages.

- Add OutOfHoursUsageService for use by the templates
- Refactor controller and templates to use the service
- Add caching to insights and analysis templates