### PR TITLE
Allow blank option in form

### DIFF
--- a/app/views/schools/configuration/_form.html.erb
+++ b/app/views/schools/configuration/_form.html.erb
@@ -75,7 +75,7 @@
                      'title',
                      @school&.solar_pv_tuos_area&.id
                    ),
-                   {},
+                   { include_blank: true },
                    { class: 'form-control' } %>
     </div>
   </div>


### PR DESCRIPTION
Was trying to diagnose a problem with a school not have solar data area. Turns out the form doesn't allow blanks so it was looking like the area was first on the list, rather than empty.

Adding a blank option so its clear if the area is missing (which shouldn't happen in practice).