### PR TITLE
Remove exception handler in Low Carbon Hub Downloader

### DIFF
--- a/app/services/solar/low_carbon_hub_downloader.rb
+++ b/app/services/solar/low_carbon_hub_downloader.rb
@@ -21,15 +21,6 @@ module Solar
         @start_date,
         @end_date
       )
-    rescue => e
-      Rollbar.error(
-        e,
-        installation_id: @low_carbon_hub_installation.id,
-        school_id: @low_carbon_hub_installation.school_id,
-        start_date: @start_date,
-        end_date: @end_date,
-        installation_latest_electricity_reading: @low_carbon_hub_installation.latest_electricity_reading
-      )
     end
   end
 end


### PR DESCRIPTION
There are was an API outage in the Low Carbon Hub api today. We ended up with multiple errors in Rollbar:

- one triggered by a failure to parse the response (it was HTML, not JSON) which was logged in the downloader
- a second error triggered by the upserter code continuing to run with a nil response from the downloader

There's already an exception handler in BaseDownloadAndUpsert which captures and logs unhandled exceptions. So there's no need for one in the downloader.

Avoids getting a flurry of additional unrelated errors when there's an API problem.