### PR TITLE
Fix permissions for alert management

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -204,8 +204,7 @@ class Ability
         show_management_dash read start_programme read_restricted_analysis read_restricted_advice
       ], School, school_scope
 
-      can %i[create update destroy], Contact, user_id: user.id
-
+      can :manage, Contact, user_id: user.id
       can :manage, [EstimatedAnnualConsumption, SchoolTarget, Activity, Contact, Observation, TransportSurvey],
           related_school_scope
       can :manage, TransportSurvey::Response, transport_survey: related_school_scope
@@ -272,7 +271,7 @@ class Ability
         can :start_programme, School, id: user.school_id, visible: true
         can :crud, Programme, school: { id: user.school_id, visible: true }
         can :enable_alerts, User, id: user.id
-        can %i[create update destroy], Contact, user_id: user.id
+        can :manage, Contact, user_id: user.id
         can :manage, TransportSurvey, school: { id: user.school_id, visible: true }
         can :manage, TransportSurvey::Response, transport_survey: { school: { id: user.school_id, visible: true } }
       end

--- a/spec/system/users/alert_management_spec.rb
+++ b/spec/system/users/alert_management_spec.rb
@@ -69,6 +69,21 @@ RSpec.describe 'User alert management', :include_application_helper do
       end
     end
 
+    context 'with a staff user' do
+      let(:user) { create(:staff) }
+
+      before do
+        within('#profile-page-navigation') do
+          click_on(I18n.t('users.show.manage_alerts'))
+        end
+      end
+
+      it_behaves_like 'an account page with navigation'
+      it_behaves_like 'an alert management page' do
+        let(:schools) { [user.school] }
+      end
+    end
+
     context 'with a cluster admin' do
       let(:user) { create(:school_admin, :with_cluster_schools) }
 


### PR DESCRIPTION
Staff users cannot properly manage their own weekly alerts. Incorrect permissions in the ability and a gap in the specs.