### PR TITLE
Baseload anomaly report for admins

### DIFF
--- a/app/controllers/admin/reports/baseload_anomaly_controller.rb
+++ b/app/controllers/admin/reports/baseload_anomaly_controller.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Admin
+  module Reports
+    class BaseloadAnomalyController < AdminController
+      def index
+        @anomalies = Report::BaseloadAnomaly.all.with_meter_school_and_group.default_order
+      end
+    end
+  end
+end

--- a/app/jobs/daily_regeneration_on_finish_job.rb
+++ b/app/jobs/daily_regeneration_on_finish_job.rb
@@ -8,7 +8,8 @@ class DailyRegenerationOnFinishJob < ApplicationJob
   end
 
   def perform(*)
-    Comparison::View.descendants.each do |view_class|
+    views = Comparison::View.descendants + [Report::BaseloadAnomaly]
+    views.each do |view_class|
       view_class.refresh
     rescue StandardError => e
       EnergySparks::Log.exception(e, job: :daily_regeneration_on_finish, view_class: view_class.name)

--- a/app/models/report/baseload_anomaly.rb
+++ b/app/models/report/baseload_anomaly.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: report_baseload_anomalies
+#
+#  id                    :bigint(8)
+#  meter_id              :bigint(8)
+#  previous_day_baseload :decimal(, )
+#  reading_date          :date
+#  today_baseload        :decimal(, )
+#
+# Indexes
+#
+#  index_report_baseload_anomalies_on_id  (id) UNIQUE
+#
+module Report
+  class BaseloadAnomaly < ApplicationRecord
+    self.table_name_prefix = 'report_'
+
+    belongs_to :meter
+    scope :with_meter_school_and_group, -> { includes(:meter, meter: [:school, { school: :school_group }]) }
+
+    scope :default_order, -> { order(:meter_id, :reading_date) }
+
+    def readonly?
+      true
+    end
+
+    def self.refresh
+      Scenic.database.refresh_materialized_view(table_name, concurrently: true, cascade: false)
+    end
+  end
+end

--- a/app/views/admin/reports/baseload_anomaly/index.html.erb
+++ b/app/views/admin/reports/baseload_anomaly/index.html.erb
@@ -1,0 +1,36 @@
+<%= render 'admin/reports/title', title: 'Baseload Anomaly' %>
+
+<div class="row">
+  <table class="table table-sorted">
+    <thead>
+    <tr>
+      <th>School Group</th>
+      <th>School</th>
+      <th>Meter</th>
+      <th>Reading date</th>
+      <th>Baseload (kw)</th>
+      <th>Previous baseload day (kwh)</th>
+      <th></th>
+    </tr>
+    </thead>
+    <tbody>
+      <% @anomalies.each do |anomaly| %>
+        <tr>
+          <td><%= link_to(anomaly.meter.school.school_group.name, school_group_path(anomaly.meter.school.school_group)) %></td>
+          <td><%= link_to(anomaly.meter.school.name, school_path(anomaly.meter.school)) %></td>
+          <td>
+            <%= link_to(anomaly.meter.display_name,
+                        school_meter_path(anomaly.meter.school, anomaly.meter)) %>
+          </td>
+          <td><%= anomaly.reading_date %></td>
+          <td><%= FormatEnergyUnit.format(:kw, anomaly.today_baseload.to_f, :html, false, true, :benchmark) %></td>
+          <td><%= FormatEnergyUnit.format(:kw, anomaly.previous_day_baseload.to_f, :html, false, true, :benchmark) %></td>
+          <td>
+            <%= link_to('Baseload chart',
+                        analysis_school_advice_baseload_path(anomaly.meter.school, anchor: 'meter-charts')) %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -735,6 +735,7 @@ Rails.application.routes.draw do
       resources :heating_types, only: [:index]
       resources :manual_reads, only: [:index]
       resources :perse_meter, only: [:index]
+      resources :baseload_anomaly, only: [:index]
       resource :unvalidated_readings, only: [:show]
       resource :funder_allocations, only: [:show] do
         post :deliver

--- a/db/migrate/20250523084317_create_report_baseload_anomalies.rb
+++ b/db/migrate/20250523084317_create_report_baseload_anomalies.rb
@@ -1,0 +1,6 @@
+class CreateReportBaseloadAnomalies < ActiveRecord::Migration[7.2]
+  def change
+    create_view :report_baseload_anomalies, materialized: true
+    add_index :report_baseload_anomalies, :id, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_04_30_093955) do
+ActiveRecord::Schema[7.2].define(version: 2025_05_23_084317) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pgcrypto"
@@ -4118,5 +4118,66 @@ ActiveRecord::Schema[7.2].define(version: 2025_04_30_093955) do
        LEFT JOIN gas ON ((latest_runs.id = gas.alert_generation_run_id)));
   SQL
   add_index "comparison_heating_in_warm_weathers", ["school_id"], name: "index_comparison_heating_in_warm_weathers_on_school_id", unique: true
+
+  create_view "report_baseload_anomalies", materialized: true, sql_definition: <<-SQL
+      WITH unnested_readings_with_index AS (
+           SELECT amr.id,
+              amr.meter_id,
+              amr.reading_date,
+              (EXISTS ( SELECT 1
+                     FROM meter_attributes ma
+                    WHERE ((ma.meter_id = amr.meter_id) AND (((ma.attribute_type)::text = 'solar_pv_mpan_meter_mapping'::text) OR ((ma.attribute_type)::text = 'solar_pv'::text)) AND (ma.deleted_by_id IS NULL) AND (ma.replaced_by_id IS NULL)))) AS has_solar,
+              (t.val * 2.0) AS val_kw,
+              t.ordinality AS index
+             FROM ((amr_validated_readings amr
+               JOIN meters m ON ((amr.meter_id = m.id)))
+               CROSS JOIN LATERAL unnest(amr.kwh_data_x48) WITH ORDINALITY t(val, ordinality))
+            WHERE ((amr.reading_date >= (CURRENT_DATE - 'P31D'::interval)) AND (m.meter_type = 0) AND (m.active = true))
+          ), unnested_readings_with_index_and_ranking AS (
+           SELECT unnested_readings_with_index.id,
+              unnested_readings_with_index.meter_id,
+              unnested_readings_with_index.reading_date,
+              unnested_readings_with_index.has_solar,
+              unnested_readings_with_index.val_kw,
+              unnested_readings_with_index.index,
+              row_number() OVER (PARTITION BY unnested_readings_with_index.meter_id, unnested_readings_with_index.reading_date ORDER BY unnested_readings_with_index.val_kw) AS ranking
+             FROM unnested_readings_with_index
+          ), daily_baseload AS (
+           SELECT unnested_readings_with_index_and_ranking.id,
+              unnested_readings_with_index_and_ranking.meter_id,
+              unnested_readings_with_index_and_ranking.reading_date,
+                  CASE
+                      WHEN unnested_readings_with_index_and_ranking.has_solar THEN avg(
+                      CASE
+                          WHEN (((unnested_readings_with_index_and_ranking.index >= 1) AND (unnested_readings_with_index_and_ranking.index <= 4)) OR ((unnested_readings_with_index_and_ranking.index >= 45) AND (unnested_readings_with_index_and_ranking.index <= 48))) THEN unnested_readings_with_index_and_ranking.val_kw
+                          ELSE NULL::numeric
+                      END)
+                      ELSE avg(
+                      CASE
+                          WHEN (unnested_readings_with_index_and_ranking.ranking <= 8) THEN unnested_readings_with_index_and_ranking.val_kw
+                          ELSE NULL::numeric
+                      END)
+                  END AS selected_avg
+             FROM unnested_readings_with_index_and_ranking
+            GROUP BY unnested_readings_with_index_and_ranking.id, unnested_readings_with_index_and_ranking.meter_id, unnested_readings_with_index_and_ranking.reading_date, unnested_readings_with_index_and_ranking.has_solar
+          ), last_two_days_baseload AS (
+           SELECT t1.id,
+              t1.meter_id,
+              t1.reading_date,
+              t1.selected_avg AS today_baseload,
+              t2.selected_avg AS previous_day_baseload
+             FROM (daily_baseload t1
+               LEFT JOIN daily_baseload t2 ON (((t1.meter_id = t2.meter_id) AND (t1.reading_date = (t2.reading_date + 'P1D'::interval)))))
+            WHERE (t1.reading_date >= (CURRENT_DATE - 'P30D'::interval))
+          )
+   SELECT last_two_days_baseload.id,
+      last_two_days_baseload.meter_id,
+      last_two_days_baseload.reading_date,
+      last_two_days_baseload.today_baseload,
+      last_two_days_baseload.previous_day_baseload
+     FROM last_two_days_baseload
+    WHERE ((last_two_days_baseload.previous_day_baseload IS NOT NULL) AND (last_two_days_baseload.previous_day_baseload > 0.5) AND (((last_two_days_baseload.today_baseload >= (0)::numeric) AND (last_two_days_baseload.today_baseload < 0.01)) OR (last_two_days_baseload.previous_day_baseload >= (last_two_days_baseload.today_baseload * (5)::numeric))));
+  SQL
+  add_index "report_baseload_anomalies", ["id"], name: "index_report_baseload_anomalies_on_id", unique: true
 
 end

--- a/db/views/report_baseload_anomalies_v01.sql
+++ b/db/views/report_baseload_anomalies_v01.sql
@@ -1,0 +1,131 @@
+-- This query is used to find data issues by looking for anomalies in validated electricity meter readings
+--
+-- Anomalies are defined as sudden changes in baseload, e.g. a large daily change or drop to zero.
+-- This type of anomaly can be used to identify meter data issues or the installation of a solar array
+--
+-- The query does all of the baseload calculations from the underlying half-hourly data, applying alternate
+-- rules depending on whether the meter is associated with solar panels (with either metered or estimated data)
+--
+-- The query is built from four CTEs that build on each other to fetch and calculate the baseload with the
+-- final comparison done in the SELECT query at the end
+--
+-- It returns the id of the amr_validated_reading with the anomalous reading, along with the meter_id, reading_date
+-- and the calculated baseload for that and the previous day.
+--
+-- The SQL is commented, but to summarise:
+--
+-- unnested_readings_with_index -
+--   selects the amr_validated_readings, unnesting the 48 half-hourly readings so there is a row
+--   per reading, it includes the index of the reading in the original array
+--
+-- unnested_readings_with_index_and_ranking
+--   calculates an additional index for each half-hourly reading, lowest first. Either the original
+--   array index or this order is used when calculating the baseload
+--
+-- daily_baseload
+--   calculates the baseload, switching between two different methods depending on whether the
+--   meter has a solar array
+--
+-- last_two_days_baseload
+--   brings together each days readings with the day before
+--
+-- The final SELECT statement then selects from with_prev_day to identify the anomalies.
+--
+-- An anomaly is: a drop to near zero (0.0--0.01), where the previous day is not a negligible value. Or there has
+-- just been a large drop in baseload (change by x5)
+
+-- Join the amr_validated_readings to the meters table
+WITH unnested_readings_with_index AS (
+  SELECT
+    amr.id AS id,
+    amr.meter_id,
+    amr.reading_date,
+    -- creates a flag to indicate whether there is a solar array associated with the meter
+    EXISTS (
+      SELECT 1 FROM meter_attributes ma
+      WHERE ma.meter_id = amr.meter_id
+        AND (ma.attribute_type = 'solar_pv_mpan_meter_mapping' OR ma.attribute_type = 'solar_pv')
+        AND ma.deleted_by_id IS NULL
+        AND ma.replaced_by_id IS NULL
+    ) AS has_solar,
+    -- Convert kWh to kW
+    t.val * 2.0 AS val_kw,
+    -- original array index
+    t.ordinality AS index
+  FROM
+    amr_validated_readings amr
+    JOIN meters m ON amr.meter_id = m.id
+    -- the cross join lateral joins the amr_validated_readings to each of their kwh readings
+    -- the values are unnested with their index in the original array
+    CROSS JOIN LATERAL unnest(amr.kwh_data_x48) WITH ORDINALITY AS t(val, ordinality)
+  WHERE
+    -- include previous day
+    amr.reading_date >= CURRENT_DATE - INTERVAL '31 days'
+     -- active electricity meters
+    AND m.meter_type = 0
+    AND m.active = true
+),
+unnested_readings_with_index_and_ranking AS (
+  SELECT
+    id,
+    meter_id,
+    reading_date,
+    has_solar,
+    val_kw,
+    index,
+    -- allows us to order the values by size, not just original index
+    -- calculating this here seems to be more efficient than doing a self-join on the unnested_readings
+    ROW_NUMBER() OVER (PARTITION BY meter_id, reading_date ORDER BY val_kw ASC) AS ranking
+  FROM unnested_readings_with_index
+),
+daily_baseload AS (
+  SELECT
+    id,
+    meter_id,
+    reading_date,
+    -- either calculate baseload from readings around midnight (if there are solar panels)
+    -- or take lowest 8 half-hourly periods
+    CASE
+      WHEN has_solar
+        THEN AVG(CASE WHEN index BETWEEN 1 AND 4 OR index BETWEEN 45 AND 48 THEN val_kw END)
+      ELSE
+        AVG(CASE WHEN ranking <= 8 THEN val_kw END)
+    END AS selected_avg
+  FROM unnested_readings_with_index_and_ranking
+  GROUP BY id, meter_id, reading_date, has_solar
+),
+last_two_days_baseload AS (
+  SELECT
+    t1.id,
+    t1.meter_id,
+    t1.reading_date,
+    t1.selected_avg AS today_baseload,
+    t2.selected_avg AS previous_day_baseload
+  FROM
+    daily_baseload t1
+    LEFT JOIN daily_baseload t2
+      ON t1.meter_id = t2.meter_id
+      AND t1.reading_date = t2.reading_date + INTERVAL '1 day'
+  WHERE
+    t1.reading_date >= CURRENT_DATE - INTERVAL '30 days'
+)
+SELECT
+  id,
+  meter_id,
+  reading_date,
+  today_baseload,
+  previous_day_baseload
+FROM
+  last_two_days_baseload
+WHERE
+  previous_day_baseload IS NOT NULL
+  -- ignore if there is low use for the meter, e.g. if usage is always low or intermittent
+  -- also ignores where the previous day usage was zero
+  AND previous_day_baseload > 0.5
+  AND (
+    -- look for drops to near zero, not precisely zero
+    (today_baseload >= 0 AND today_baseload < 0.01)
+    OR
+    -- look for large drops of any kind
+    (previous_day_baseload >= today_baseload * 5)
+  );

--- a/spec/models/report/baseload_anomaly_spec.rb
+++ b/spec/models/report/baseload_anomaly_spec.rb
@@ -1,0 +1,128 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Report::BaseloadAnomaly do
+  subject(:anomaly) { described_class.first }
+
+  let(:meter) { create(:electricity_meter) }
+
+  let(:reading_date) { Date.yesterday }
+
+  let(:previous_day_readings) { Array.new(48, 10.0) }
+  let(:current_day_readings) { Array.new(48, 0.0) }
+
+  before do
+    create(:amr_validated_reading, meter: meter, reading_date: reading_date - 1, kwh_data_x48: previous_day_readings)
+    create(:amr_validated_reading, meter: meter, reading_date: reading_date, kwh_data_x48: current_day_readings)
+    described_class.refresh
+  end
+
+  def assert_result(anomaly, previous_date_average_baseload = nil, current_date_average_baseload = 0.0)
+    expect(anomaly.meter).to eq(meter)
+    expect(anomaly.reading_date).to eq(reading_date)
+    # FIXME
+    expect(anomaly.previous_day_baseload).to be_within(0.0000001).of(previous_date_average_baseload) if previous_date_average_baseload
+    expect(anomaly.today_baseload).to be_within(0.0000001).of(current_date_average_baseload)
+  end
+
+  context 'when identifying drops in baseload' do
+    context 'with a large drop to zero' do
+      it 'produces a result' do
+        assert_result(anomaly, 20.0, 0.0)
+      end
+    end
+
+    context 'with a large drop to near zero' do
+      let(:current_day_readings) { Array.new(48, 0.004) }
+
+      it 'produces a result' do
+        assert_result(anomaly, 20.0, 0.008)
+      end
+    end
+
+    context 'with a large drop but not to zero' do
+      let(:current_day_readings) { Array.new(48, 1.0) }
+
+      it 'produces a result' do
+        assert_result(anomaly, 20.0, 2.0)
+      end
+    end
+
+    context 'with a small drop to zero' do
+      let(:previous_day_readings) { Array.new(48, 0.24) }
+
+      it 'does not produce a result' do
+        expect(anomaly).to be_nil
+      end
+    end
+
+    context 'when both days are zero' do
+      let(:previous_day_readings) { Array.new(48, 0.0) }
+
+      it 'does not produce a result' do
+        expect(anomaly).to be_nil
+      end
+    end
+  end
+
+  context 'when filtering readings' do
+    let(:meter) { create(:gas_meter) }
+
+    it 'only includes electricity meters' do
+      expect(anomaly).to be_nil
+    end
+
+    context 'when filtering by date' do
+      let(:analysis_date) { Time.zone.today - 30.days }
+
+      it 'only includes readings from last 30 days' do
+        expect(anomaly).to be_nil
+      end
+    end
+  end
+
+  context 'when calculating baseload' do
+    # first 2 and last 2 hours are 0.2, rest are 0.1
+    let(:current_day_readings) { Array.new(4, 0.2) + Array.new(40, 0.1) + Array.new(4, 0.2) }
+
+    context 'when meter has no solar' do
+      it 'calculates the statistical baseload correctly' do
+        expect(anomaly.today_baseload).to be_within(0.0000001).of(0.2)
+      end
+    end
+
+    context 'when meter has estimated solar' do
+      before do
+        create(:solar_pv_attribute, meter: meter)
+        described_class.refresh
+      end
+
+      it 'calculates the overnight baseload correctly' do
+        expect(anomaly.today_baseload).to be_within(0.0000001).of(0.4)
+      end
+    end
+
+    context 'when meter has metered solar' do
+      before do
+        create(:solar_pv_mpan_meter_mapping, meter: meter)
+        described_class.refresh
+      end
+
+      it 'calculates the overnight baseload correctly' do
+        expect(anomaly.today_baseload).to be_within(0.0000001).of(0.4)
+      end
+    end
+
+    context 'when meter has deleted solar_pv attribute' do
+      before do
+        create(:solar_pv_attribute, meter: meter, deleted_by: create(:admin))
+        described_class.refresh
+      end
+
+      it 'calculates the statistical baseload correctly' do
+        expect(anomaly.today_baseload).to be_within(0.0000001).of(0.2)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Initial version, likely to get reworked following feedback and review against live data.

Creates an admin report that tries to identifies data anomalies by looking for sudden changes in baseload. These are usually attributable to problems with the underlying meter data that need correction or the installation of solar panels which we don't yet have configured.

The report uses a fairly complex query, built up of a series of CTEs that collectively push all the calculations into the database. The appropriate baseload calculations are done depending on whether the meters are already associated with solar panels.

I've commented the query and added specs to test all of the important filtering and calculation its doing.

This approach seems workable here as we're looking at the meter level readings. It also avoids having to add more overhead to the daily regeneration run for each school. We might be able to use this pattern for other meter level reports.

The UX is likely to get reworked to provide more of a summary, e.g. which meters have problems. This is a more detailed view for testing. We might also tweak the date window and the thresholds.

TODO:

- [ ] add a spec for the report
- [ ] revise the view so that it links to the main baseload chart if a school only has a single electricity meter
 