### PR TITLE
School page short-links

### DIFF
--- a/app/controllers/pupils/sessions_controller.rb
+++ b/app/controllers/pupils/sessions_controller.rb
@@ -20,7 +20,8 @@ module Pupils
       pupil = school.authenticate_pupil(password)
       if pupil
         sign_in(:user, pupil)
-        redirect_to pupils_school_path(school), notice: t('devise.sessions.new.signed_in_successfully')
+        redirect_path = stored_location_for(:user) || pupils_school_path(school)
+        redirect_to redirect_path, notice: t('devise.sessions.new.signed_in_successfully')
       else
         redirect_to new_user_session_path(role: 'pupil', school: school), alert: t('errors.messages.invalid_password')
       end

--- a/app/controllers/redirects_controller.rb
+++ b/app/controllers/redirects_controller.rb
@@ -1,0 +1,38 @@
+class RedirectsController < ApplicationController
+  skip_before_action :authenticate_user!
+
+  helper_method :school_redirect_path
+
+  def school_page_redirect
+    unless current_user.present?
+      store_location_for(:user, "/s/#{params[:path]}")
+      redirect_to new_user_session_path, notice: I18n.t('users.index.redirect') and return
+    end
+    user_role = current_user.role.to_sym
+    if user_role == :group_admin || (user_role == :school_admin && current_user.has_other_schools?)
+      @path = params[:path]
+      @schools = if current_user.group_admin?
+                   current_user.school_group.schools.visible.by_name
+                 else
+                   current_user.cluster_schools.visible.by_name
+                 end
+      render :choose_school, layout: 'dashboards'
+    else
+      school = user_role == :admin ? School.data_enabled.sample : current_user.school
+      redirect_to school_redirect_path(school, params[:path])
+    end
+  end
+
+  private
+
+  def school_redirect_path(school, path)
+    case path
+    when 'dashboard'
+      school_path(school)
+    when 'pupils'
+      pupils_school_path(school)
+    else
+      "/schools/#{school.slug}/#{path}"
+    end
+  end
+end

--- a/app/controllers/redirects_controller.rb
+++ b/app/controllers/redirects_controller.rb
@@ -32,7 +32,7 @@ class RedirectsController < ApplicationController
     when 'pupils'
       pupils_school_path(school)
     else
-      "/schools/#{school.slug}/#{path}"
+      "/schools/#{school.slug}/#{ActionController::Base.helpers.sanitize(path)}"
     end
   end
 end

--- a/app/views/redirects/choose_school.html.erb
+++ b/app/views/redirects/choose_school.html.erb
@@ -1,0 +1,28 @@
+<% content_for :page_title, t('redirects.choose_school.title') %>
+
+<% content_for :dashboard_header do %>
+  <div class="row" id="profile-header">
+    <div class="col">
+      <h1><%= t('redirects.choose_school.title') %></h1>
+    </div>
+  </div>
+<% end %>
+
+<div class="container">
+  <div class="row mt-4">
+    <div class="col">
+      <p><%= t('redirects.choose_school.intro') %>.</p>
+    </div>
+  </div>
+  <div class="row" id="my-school-list">
+    <div class="col">
+      <ul>
+        <% @schools.each do |school| %>
+          <li>
+            <%= link_to school.name, school_redirect_path(school, @path) %>
+          </li>
+        <% end %>
+      </ul>
+    </div>
+  </div>
+</div>

--- a/app/views/redirects/choose_school.html.erb
+++ b/app/views/redirects/choose_school.html.erb
@@ -8,8 +8,8 @@
   </div>
 <% end %>
 
-<div class="container">
-  <div class="row mt-4">
+<div class="container mt-4 mb-3">
+  <div class="row">
     <div class="col">
       <p><%= t('redirects.choose_school.intro') %>.</p>
     </div>

--- a/config/locales/views/home/home.yml
+++ b/config/locales/views/home/home.yml
@@ -103,6 +103,10 @@ en:
     title_html: Stay up to date&hellip;
   newsletters:
     title: Newsletters
+  redirects:
+    choose_school:
+      intro: You have followed a school-specific link. Choose one of your schools to continue
+      title: Choose a school to continue
   school_count:
     one: 1 school
     other: "%{count} schools"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -61,7 +61,7 @@ Rails.application.routes.draw do
 
   get 'cms/youtube_embed/:id', to: 'cms/youtube_embed#show'
 
-  get '/s/*path', to: 'redirects#school_page_redirect', as: :school_page_redirect
+  get '/user/school(/*path)', to: 'redirects#school_page_redirect', as: :school_page_redirect, constraints: { path: /.*/ }
 
   direct :cdn_link do |model, options|
     expires_in = options.delete(:expires_in) { ActiveStorage.urls_expire_in }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -61,6 +61,8 @@ Rails.application.routes.draw do
 
   get 'cms/youtube_embed/:id', to: 'cms/youtube_embed#show'
 
+  get '/s/*path', to: 'redirects#school_page_redirect', as: :school_page_redirect
+
   direct :cdn_link do |model, options|
     expires_in = options.delete(:expires_in) { ActiveStorage.urls_expire_in }
     asset_host = ENV.fetch('ASSET_HOST') { 'localhost:3000' }

--- a/spec/system/redirects_spec.rb
+++ b/spec/system/redirects_spec.rb
@@ -1,8 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe 'User account page and updates', :include_application_helper do
+  let(:base) { '/user/school' }
+
   context 'when visiting a school redirect' do
-    let(:path) { '/s/advice' }
+    let(:path) { "#{base}/advice" }
 
     context 'without a session' do
       let!(:school) { create(:school, :with_school_group) }
@@ -60,7 +62,7 @@ RSpec.describe 'User account page and updates', :include_application_helper do
       end
 
       context 'with dashboard redirect' do
-        let(:path) { '/s/dashboard' }
+        let(:path) { "#{base}/dashboard" }
 
         it 'has redirected' do
           expect(page).to have_current_path school_path(user.school), ignore_query: true
@@ -68,7 +70,7 @@ RSpec.describe 'User account page and updates', :include_application_helper do
       end
 
       context 'with pupil dashboard redirect' do
-        let(:path) { '/s/pupils' }
+        let(:path) { "#{base}/pupils" }
 
         it 'has redirected' do
           expect(page).to have_current_path pupils_school_path(user.school), ignore_query: true

--- a/spec/system/redirects_spec.rb
+++ b/spec/system/redirects_spec.rb
@@ -1,0 +1,138 @@
+require 'rails_helper'
+
+RSpec.describe 'User account page and updates', :include_application_helper do
+  context 'when visiting a school redirect' do
+    let(:path) { '/s/advice' }
+
+    context 'without a session' do
+      let!(:school) { create(:school, :with_school_group) }
+
+      before do
+        visit path
+      end
+
+      it_behaves_like 'the page requires a login'
+
+      context 'with a successful adult login' do
+        let!(:user) { create(:school_admin, password: 'thisismyuserpassword') }
+
+        before do
+          fill_in 'Email', with: user.email
+          fill_in 'Password', with: user.password
+          within '#staff' do
+            click_on 'Sign in'
+          end
+        end
+
+        it 'has redirected' do
+          expect(page).to have_current_path school_advice_path(user.school), ignore_query: true
+        end
+      end
+
+      context 'with a successful pupil login' do
+        let!(:user) { create(:pupil, school: school, pupil_password: 'thisismyuserpassword') }
+        let(:select_school) { "#{user.school.name} (#{user.school.school_group.name})" }
+
+        before do
+          within '#pupil' do
+            select select_school, from: 'Select your school'
+            fill_in 'Your pupil password', with: 'thisismyuserpassword'
+            click_on 'Sign in'
+          end
+        end
+
+        it 'has redirected' do
+          expect(page).to have_current_path school_advice_path(user.school), ignore_query: true
+        end
+      end
+    end
+
+    context 'when logged in as a staff user' do
+      let!(:user) { create(:staff) }
+
+      before do
+        sign_in(user)
+        visit path
+      end
+
+      it 'has redirected' do
+        expect(page).to have_current_path school_advice_path(user.school), ignore_query: true
+      end
+
+      context 'with dashboard redirect' do
+        let(:path) { '/s/dashboard' }
+
+        it 'has redirected' do
+          expect(page).to have_current_path school_path(user.school), ignore_query: true
+        end
+      end
+
+      context 'with pupil dashboard redirect' do
+        let(:path) { '/s/pupils' }
+
+        it 'has redirected' do
+          expect(page).to have_current_path pupils_school_path(user.school), ignore_query: true
+        end
+      end
+    end
+
+    context 'when logged in as a school admin user' do
+      let!(:user) { create(:school_admin) }
+
+      before do
+        sign_in(user)
+        visit path
+      end
+
+      it 'has redirected' do
+        expect(page).to have_current_path school_advice_path(user.school), ignore_query: true
+      end
+    end
+
+    context 'when logged in as an admin' do
+      let!(:user) { create(:admin) }
+      let!(:school) { create(:school) }
+
+      before do
+        sign_in(user)
+        visit path
+      end
+
+      it 'has redirected' do
+        expect(page).to have_current_path school_advice_path(school), ignore_query: true
+      end
+    end
+
+    context 'when logged in as a cluster admin user' do
+      let!(:user) { create(:school_admin, :with_cluster_schools) }
+
+      before do
+        sign_in(user)
+        visit path
+      end
+
+      it 'prompts user to choose' do
+        expect(page).to have_content(I18n.t('redirects.choose_school.title'))
+        expect(page).to have_content(I18n.t('redirects.choose_school.intro'))
+        expect(page).to have_link(user.cluster_schools.first.name,
+                                  href: school_advice_path(user.cluster_schools.first))
+      end
+    end
+
+    context 'when logged in as a group admin user' do
+      let!(:user) { create(:group_admin, school_group: create(:school_group, :with_active_schools)) }
+
+      before do
+        sign_in(user)
+        visit path
+      end
+
+      it 'prompts user to choose' do
+        expect(page).to have_content(I18n.t('redirects.choose_school.title'))
+        expect(page).to have_content(I18n.t('redirects.choose_school.intro'))
+        expect(page).to have_link(user.school_group.schools.first.name,
+                                  href: school_advice_path(user.school_group.schools.first))
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds a new set of short-links that attempts to redirect a user to the right location for their school. These are intended to be used from the new support pages, but might be used elsewhere (e.g. in newsletters).

The syntax is: `/s/:path`

If a user is logged in as a pupil or school user, we redirect them to the appropriate place. 

If `:path` is `dashboard` then we redirect to the school dashboard. If it is `pupils` we redirect to the pupil dashboard. Otherwise the path is assumed to be a school relative link. E.g. `/s/advice` would redirect to something like `/s/some-primary-school/advice`.

This allows all the school relative admin pages, advice, etc to be targeted.

If the user is not currently signed in, then they are prompted to login and are then redirected. Group admins or school admins linked to multiple schools will see an interstitial page where they can choose a school to visit. This seemed better than just failing, or picking an arbitrary school. 

Internal admins just get sent to a random data enabled school. Shows the links are working.

Happy to take suggestions for improving the design/text/etc. 

I've sanitized the path when it is used directly, but maybe there's other approaches? E.g. I wasn't sure if there was another way to generate the full range of routes using helpers, e.g. users, edit, advice, advice/baseload/analysis, etc.