### PR TITLE
Check for consent to collect and store data on making data visible, not visible

### DIFF
--- a/app/services/school_creator.rb
+++ b/app/services/school_creator.rb
@@ -40,7 +40,6 @@ class SchoolCreator
   end
 
   def make_visible!
-    raise Error.new('School cannot be made visible as we dont have a record of consent') unless @school.consent_grants.any?
     @school.update!(visible: true)
     if onboarding_service.should_complete_onboarding?(@school)
       users = @school.users.reject(&:pupil?)
@@ -52,6 +51,7 @@ class SchoolCreator
 
   def make_data_enabled!
     raise Error.new('School must be visible before enabling data') unless @school.visible
+    raise Error.new('School cannot be made visible as we dont have a record of consent') unless @school.consent_grants.any?
     @school.update!(data_enabled: true)
     @school.update!(activation_date: Time.zone.today) unless @school.activation_date.present?
     onboarding_service.record_event(@school.school_onboarding, :onboarding_data_enabled)

--- a/app/services/school_creator.rb
+++ b/app/services/school_creator.rb
@@ -51,7 +51,7 @@ class SchoolCreator
 
   def make_data_enabled!
     raise Error.new('School must be visible before enabling data') unless @school.visible
-    raise Error.new('School cannot be made visible as we dont have a record of consent') unless @school.consent_grants.any?
+    raise Error.new('School cannot be made data visible as we dont have a record of consent') unless @school.consent_grants.any?
     @school.update!(data_enabled: true)
     @school.update!(activation_date: Time.zone.today) unless @school.activation_date.present?
     onboarding_service.record_event(@school.school_onboarding, :onboarding_data_enabled)

--- a/spec/factories/schools_factory.rb
+++ b/spec/factories/schools_factory.rb
@@ -24,6 +24,12 @@ FactoryBot.define do
       name { 'test school'}
     end
 
+    trait :with_consent do
+      after(:create) do |school, _evaluator|
+        create(:consent_grant, school:)
+      end
+    end
+
     trait :with_school_group do
       after(:create) do |school, _evaluator|
         school.update(school_group: create(:school_group))

--- a/spec/services/school_creator_spec.rb
+++ b/spec/services/school_creator_spec.rb
@@ -124,45 +124,57 @@ describe SchoolCreator, :schools, type: :service do
     let(:school) { create(:school, data_enabled: false, visible:) }
     let!(:school_onboarding) { create(:school_onboarding, school:) }
 
-    it 'broadcasts message' do
-      expect do
-        service.make_data_enabled!
-      end.to broadcast(:school_made_data_enabled)
-    end
-
-    it 'updates data enabled status' do
-      service.make_data_enabled!
-      expect(school.data_enabled).to be_truthy
-    end
-
-    it 'records event' do
-      service.make_data_enabled!
-      expect(school).to have_school_onboarding_event(:onboarding_data_enabled)
-    end
-
-    it 'records activation date' do
-      service.make_data_enabled!
-      school.reload
-      expect(school.activation_date).to eq(Time.zone.today)
-    end
-
-    context 'when there is an activation date' do
-      let(:school) { create(:school, data_enabled: false, visible:, activation_date: Time.zone.today - 1) }
-
-      it 'does not change the activation date' do
-        service.make_data_enabled!
-        school.reload
-        expect(school.activation_date).to eq(Time.zone.today - 1)
-      end
-    end
-
-    context 'where the school is not visible' do
-      let(:visible) { false }
-
+    context 'without consent granted' do
       it 'rejects call' do
         expect do
           service.make_data_enabled!
         end.to raise_error SchoolCreator::Error
+      end
+    end
+
+    context 'with consent granted' do
+      let!(:consent_grant) { create(:consent_grant, school:) }
+
+      it 'broadcasts message' do
+        expect do
+          service.make_data_enabled!
+        end.to broadcast(:school_made_data_enabled)
+      end
+
+      it 'updates data enabled status' do
+        service.make_data_enabled!
+        expect(school.data_enabled).to be_truthy
+      end
+
+      it 'records event' do
+        service.make_data_enabled!
+        expect(school).to have_school_onboarding_event(:onboarding_data_enabled)
+      end
+
+      it 'records activation date' do
+        service.make_data_enabled!
+        school.reload
+        expect(school.activation_date).to eq(Time.zone.today)
+      end
+
+      context 'when there is an activation date' do
+        let(:school) { create(:school, data_enabled: false, visible:, activation_date: Time.zone.today - 1) }
+
+        it 'does not change the activation date' do
+          service.make_data_enabled!
+          school.reload
+          expect(school.activation_date).to eq(Time.zone.today - 1)
+        end
+      end
+
+      context 'where the school is not visible' do
+        let(:visible) { false }
+
+        it 'rejects call' do
+          expect do
+            service.make_data_enabled!
+          end.to raise_error SchoolCreator::Error
+        end
       end
     end
   end
@@ -173,7 +185,6 @@ describe SchoolCreator, :schools, type: :service do
     context 'where the school has not been created via the onboarding process' do
       let!(:school_admin) { create(:school_admin, school:) }
       let!(:staff) { create(:staff, school:) }
-      let!(:consent_grant) { create(:consent_grant, school:) }
 
       before do
         expect do
@@ -189,7 +200,6 @@ describe SchoolCreator, :schools, type: :service do
     context 'where the school has been created as part of the onboarding process' do
       let(:onboarding_user) { create(:onboarding_user) }
       let!(:school_onboarding) { create(:school_onboarding, school:, created_user: onboarding_user) }
-      let!(:consent_grant) { create(:consent_grant, school:) }
 
       it 'sets visibility' do
         service.make_visible!

--- a/spec/services/school_creator_spec.rb
+++ b/spec/services/school_creator_spec.rb
@@ -121,10 +121,11 @@ describe SchoolCreator, :schools, type: :service do
 
   describe 'make_data_enabled!' do
     let(:visible) { true }
-    let(:school) { create(:school, data_enabled: false, visible:) }
     let!(:school_onboarding) { create(:school_onboarding, school:) }
 
     context 'without consent granted' do
+      let(:school) { create(:school, data_enabled: false, visible:) }
+
       it 'rejects call' do
         expect do
           service.make_data_enabled!
@@ -133,7 +134,7 @@ describe SchoolCreator, :schools, type: :service do
     end
 
     context 'with consent granted' do
-      let!(:consent_grant) { create(:consent_grant, school:) }
+      let(:school) { create(:school, :with_consent, data_enabled: false, visible:) }
 
       it 'broadcasts message' do
         expect do
@@ -158,7 +159,7 @@ describe SchoolCreator, :schools, type: :service do
       end
 
       context 'when there is an activation date' do
-        let(:school) { create(:school, data_enabled: false, visible:, activation_date: Time.zone.today - 1) }
+        let(:school) { create(:school, :with_consent, data_enabled: false, visible:, activation_date: Time.zone.today - 1) }
 
         it 'does not change the activation date' do
           service.make_data_enabled!

--- a/spec/support/shared_examples/admin_school_group_onboardings.rb
+++ b/spec/support/shared_examples/admin_school_group_onboardings.rb
@@ -28,18 +28,6 @@ RSpec.shared_examples 'admin school group onboardings' do
           it { expect(onboarding.school).not_to be_visible }
           it { expect(onboarding).to be_incomplete }
 
-          context 'without consents' do
-            before do
-              @back = current_path
-              click_button 'Make selected visible'
-            end
-
-            it { expect(page).to have_current_path(@back) }
-            it { expect(page).to have_content('School cannot be made visible as we dont have a record of consent') }
-            it { expect(page).to have_no_content('schools made visible') }
-            it { expect(onboarding.reload.school).not_to be_visible }
-          end
-
           context 'with consent' do
             before do
               Wisper.clear

--- a/spec/system/school_onboarding_spec.rb
+++ b/spec/system/school_onboarding_spec.rb
@@ -452,6 +452,7 @@ RSpec.describe 'onboarding', :schools do
 
           context 'when school is later set as data enabled' do
             it 'sends data enabled emails' do
+              create(:consent_grant, school: school)
               school.update(visible: true)
               click_on 'Complete setup', match: :first
               SchoolCreator.new(school).make_data_enabled!

--- a/spec/system/schools/dashboard/manage_school_spec.rb
+++ b/spec/system/schools/dashboard/manage_school_spec.rb
@@ -144,8 +144,7 @@ RSpec.describe 'manage school', type: :system do
         expect(school.data_sharing_within_group?).to be true
       end
 
-      it 'allows toggling visibility if consent granted' do
-        create :consent_grant, school: school
+      it 'allows toggling visibility' do
         visit school_path(school)
         click_on('Visible')
         school.reload
@@ -153,18 +152,6 @@ RSpec.describe 'manage school', type: :system do
         click_on('Visible')
         school.reload
         expect(school).to be_visible
-      end
-
-      it 'disallows toggling visibility if no consent' do
-        expect(school.consent_up_to_date?).to be false
-        visit school_path(school)
-        click_on('Visible')
-        school.reload
-        expect(school).not_to be_visible
-        click_on('Visible')
-        expect(page).to have_content('School cannot be made visible as we dont have a record of consent')
-        school.reload
-        expect(school).not_to be_visible
       end
 
       it 'allows toggling of data processing' do
@@ -192,6 +179,7 @@ RSpec.describe 'manage school', type: :system do
       end
 
       it 'allows toggling of data enabled via the review page' do
+        create(:consent_grant, school: school)
         visit school_path(school)
         click_on('Data visible')
         school.reload


### PR DESCRIPTION
Changes where we apply the assertion that we have consent to collect and store data to when the school is made data visible, rather than visible. Otherwise school users cannot login to grant consent.

Works around an issue for schools that joined before the current workflow and we don't have a consent document stored in the database (just elsewhere).