### PR TITLE
Add columns to smart meter email

### DIFF
--- a/app/views/dcc_mailer/dcc_meter_status_email.html.erb
+++ b/app/views/dcc_mailer/dcc_meter_status_email.html.erb
@@ -5,9 +5,11 @@
 <table style="width: 100%; margin: 20px">
   <thead>
   <tr>
+    <th>School Group</th>
+    <th>Admin</th>
     <th>School</th>
     <th>Meter</th>
-    <th>Type</th>
+    <th>Type</th>#
     <th>DCC Type</th>
     <th>Checked at</th>
   </tr>
@@ -15,6 +17,10 @@
   <tbody>
   <% @meters.each do |meter| %>
     <tr>
+      <td>
+        <%= link_to meter.school&.school_group&.name, admin_school_groups_url(meter.school) if meter.school.school_group %>
+      </td>
+      <td><%= meter.school&.school_group&.default_issues_admin_user&.name %></td>
       <td><%= link_to meter.school.name, school_meters_url(meter.school) %></td>
       <td><%= link_to meter.mpan_mprn, school_meter_url(meter.school, meter) %></td>
       <td><%= meter.meter_type %></td>

--- a/app/views/dcc_mailer/dcc_meter_status_email.html.erb
+++ b/app/views/dcc_mailer/dcc_meter_status_email.html.erb
@@ -9,7 +9,7 @@
     <th>Admin</th>
     <th>School</th>
     <th>Meter</th>
-    <th>Type</th>#
+    <th>Type</th>
     <th>DCC Type</th>
     <th>Checked at</th>
   </tr>

--- a/spec/factories/school_groups_factory.rb
+++ b/spec/factories/school_groups_factory.rb
@@ -1,6 +1,7 @@
 FactoryBot.define do
   factory :school_group do
     sequence(:name) {|n| "School group #{n}"}
+    default_issues_admin_user { create(:admin) }
     public { true }
 
     trait :with_default_scoreboard do

--- a/spec/factories/schools_factory.rb
+++ b/spec/factories/schools_factory.rb
@@ -25,8 +25,12 @@ FactoryBot.define do
     end
 
     trait :with_school_group do
-      after(:create) do |school, _evaluator|
-        school.update(school_group: create(:school_group))
+      transient do
+        default_issues_admin_user { create(:admin) }
+      end
+
+      after(:create) do |school, evaluator|
+        school.update(school_group: create(:school_group, default_issues_admin_user: evaluator.default_issues_admin_user))
       end
     end
 

--- a/spec/mailers/dcc_mailer_spec.rb
+++ b/spec/mailers/dcc_mailer_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe DccMailer do
-  let(:school_1)    { create(:school, name: 'Big School') }
-  let(:school_2)    { create(:school, name: 'Little School') }
+  let(:school_1)    { create(:school, :with_school_group, name: 'Big School') }
+  let(:school_2)    { create(:school, :with_school_group, name: 'Little School') }
   let(:meter_1)     { create(:electricity_meter, dcc_meter: :smets2, school: school_1) }
   let(:meter_2)     { create(:electricity_meter, dcc_meter: :no, school: school_2) }
   let(:meter_ids)   { [meter_1.id, meter_2.id] }
@@ -13,10 +13,16 @@ RSpec.describe DccMailer do
       expect(ActionMailer::Base.deliveries.count).to be 1
       email = ActionMailer::Base.deliveries.last
       expect(email.subject).to eql 'New smart meters found'
+      expect(email.html_part.decoded).to include(school_1.school_group.name)
+      expect(email.html_part.decoded).to include(school_1.school_group.default_issues_admin_user.name)
+      expect(email.html_part.decoded).to include(meter_1.school.name)
       expect(email.html_part.decoded).to include(meter_1.mpan_mprn.to_s)
-      expect(email.html_part.decoded).to include('Big School')
+
+      expect(email.html_part.decoded).to include(school_2.school_group.name)
+      expect(email.html_part.decoded).to include(school_2.school_group.default_issues_admin_user.name)
+      expect(email.html_part.decoded).to include(meter_1.school.name)
       expect(email.html_part.decoded).to include(meter_2.mpan_mprn.to_s)
-      expect(email.html_part.decoded).to include('Little School')
+
       expect(email.html_part.decoded).to include('SMETS2')
     end
   end

--- a/spec/services/confirmation_reminder_spec.rb
+++ b/spec/services/confirmation_reminder_spec.rb
@@ -9,7 +9,6 @@ describe ConfirmationReminder do
 
   shared_examples 'it ignores sending emails' do
     it 'does not send at any time' do
-      expect(User.count).to eq(1)
       expect { described_class.send }.to(not_change { ActionMailer::Base.deliveries.count })
       travel_to(now + 7.days)
       expect { described_class.send }.to(not_change { ActionMailer::Base.deliveries.count })

--- a/spec/services/mailchimp/csv_exporter_spec.rb
+++ b/spec/services/mailchimp/csv_exporter_spec.rb
@@ -91,7 +91,7 @@ describe Mailchimp::CsvExporter do
     end
 
     context 'with a school admin' do
-      let!(:school) { create(:school, :with_school_group, :with_scoreboard, :with_local_authority, region: :east_midlands, percentage_free_school_meals: 35) }
+      let!(:school) { create(:school, :with_school_group, :with_scoreboard, :with_local_authority, default_issues_admin_user: nil, region: :east_midlands, percentage_free_school_meals: 35) }
       let!(:user) { create(:school_admin, school: school) }
 
       it 'matches the contact' do
@@ -171,7 +171,7 @@ describe Mailchimp::CsvExporter do
       end
 
       context 'with archived school' do
-        let!(:school) { create(:school, :with_school_group, :with_scoreboard, :with_local_authority, :archived, region: :east_midlands) }
+        let!(:school) { create(:school, :with_school_group, :with_scoreboard, :with_local_authority, :archived, default_issues_admin_user: nil, region: :east_midlands) }
 
         it 'uses correct status' do
           expect(contact.school_status).to eq 'Archived'
@@ -207,14 +207,14 @@ describe Mailchimp::CsvExporter do
     end
 
     context 'with a group admin' do
-      let!(:user) { create(:group_admin, school_group: create(:school_group, :with_default_scoreboard)) }
+      let!(:user) { create(:group_admin, school_group: create(:school_group, :with_default_scoreboard, default_issues_admin_user: nil)) }
 
       it_behaves_like 'it correctly creates a contact', group_admin: true
       it_behaves_like 'it adds interests correctly'
 
       context 'when subscribed to alerts' do
         let!(:user) do
-          school_group = create(:school_group, :with_default_scoreboard, :with_active_schools)
+          school_group = create(:school_group, :with_default_scoreboard, :with_active_schools, default_issues_admin_user: nil)
           user = create(:group_admin, school_group: school_group)
           user.contacts << create(:contact_with_name_email_phone, school: school_group.schools.first)
           user
@@ -227,7 +227,7 @@ describe Mailchimp::CsvExporter do
     end
 
     context 'with a cluster admin' do
-      let!(:school) { create(:school, :with_scoreboard, :with_local_authority, region: :east_midlands, percentage_free_school_meals: 35, school_group: create(:school_group, :with_default_scoreboard)) }
+      let!(:school) { create(:school, :with_scoreboard, :with_local_authority, region: :east_midlands, percentage_free_school_meals: 35, school_group: create(:school_group, :with_default_scoreboard, default_issues_admin_user: nil)) }
       let!(:user) { create(:school_admin, :with_cluster_schools, school: school) }
 
       it_behaves_like 'it correctly creates a contact', school_user: false, cluster_admin: true
@@ -297,7 +297,7 @@ describe Mailchimp::CsvExporter do
     let(:contact) { service.new_nonsubscribed.first }
 
     context 'with a school admin' do
-      let!(:school) { create(:school, :with_school_group, :with_scoreboard, :with_local_authority, region: :east_midlands, percentage_free_school_meals: 35) }
+      let!(:school) { create(:school, :with_school_group, :with_scoreboard, :with_local_authority, region: :east_midlands, default_issues_admin_user: nil, percentage_free_school_meals: 35) }
       let!(:user) { create(:school_admin, school: school) }
 
       before do
@@ -324,7 +324,7 @@ describe Mailchimp::CsvExporter do
     end
 
     context 'with a group admin' do
-      let!(:user) { create(:group_admin, school_group: create(:school_group, :with_default_scoreboard)) }
+      let!(:user) { create(:group_admin, school_group: create(:school_group, :with_default_scoreboard, default_issues_admin_user: nil)) }
 
       before do
         service.perform
@@ -383,7 +383,7 @@ describe Mailchimp::CsvExporter do
   end
 
   context 'when there is a mixture of user types' do
-    let!(:school_group) { create(:school_group, :with_default_scoreboard) }
+    let!(:school_group) { create(:school_group, :with_default_scoreboard, default_issues_admin_user: nil) }
     let!(:school) { create(:school, :with_scoreboard, :with_local_authority, region: :east_midlands, percentage_free_school_meals: 35, school_group: school_group) }
     let!(:school_admin) { create(:school_admin, school: school) }
     let!(:group_admin) { create(:group_admin, school_group: school_group) }

--- a/spec/system/admin/reports/engaged_schools_report_spec.rb
+++ b/spec/system/admin/reports/engaged_schools_report_spec.rb
@@ -26,7 +26,7 @@ describe 'Engaged Schools Report', :aggregate_failures do
       [['School Group', 'School', 'School Type', 'Funder', 'Country', 'Active', 'Data Visible', 'Admin',
         'Activities', 'Actions', 'Programmes', 'Target?', 'Transport Survey?', 'Temperatures?', 'Audit?',
         'Active Users', 'Last Visit'],
-       [school.school_group.name, school.name, 'Primary', '', school.country.humanize, 'Y', 'Y', '',
+       [school.school_group.name, school.name, 'Primary', '', school.country.humanize, 'Y', 'Y', 'Admin',
         activities.to_s, '0', '0', 'N', 'N', 'N', 'N',
         '1', last_sign_in.iso8601]]
     )

--- a/spec/system/admin/reports/mailchimp_status_spec.rb
+++ b/spec/system/admin/reports/mailchimp_status_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 describe 'Mailchimp Status Report' do
   before do
     create_list(:school_admin, 3, mailchimp_status: :subscribed, mailchimp_updated_at: 1.day.ago)
-    create_list(:group_admin, 2, mailchimp_status: :unsubscribed, mailchimp_updated_at: 6.days.ago)
+    create_list(:group_admin, 2, school_group: create(:school_group, default_issues_admin_user: nil), mailchimp_status: :unsubscribed, mailchimp_updated_at: 6.days.ago)
     create(:school_admin, mailchimp_status: :subscribed, mailchimp_updated_at: 8.days.ago)
     create(:school_admin, :skip_confirmed, confirmed_at: nil, mailchimp_status: :subscribed)
     create(:school_admin)

--- a/spec/system/admin/reports/manual_reads_spec.rb
+++ b/spec/system/admin/reports/manual_reads_spec.rb
@@ -15,7 +15,7 @@ describe 'Manual Reads Report' do
     expect(all('tr').map { |tr| tr.all('th, td').map(&:text) }).to \
       eq([['Group Name', 'School Name', 'Group Owner', 'MPAN', 'Meter Type', 'Data Source', 'Last Validated Date',
            'Issues & Notes'],
-          [meter.school.school_group.name, meter.school.name, '', meter.mpan_mprn.to_s, 'gas', '', '', '']])
+          [meter.school.school_group.name, meter.school.name, 'Admin', meter.mpan_mprn.to_s, 'gas', '', '', '']])
   end
 
   it 'allows csv download' do
@@ -23,6 +23,6 @@ describe 'Manual Reads Report' do
     expect(page.response_headers['content-type']).to eq('text/csv')
     expect(body).to \
       eq("Group Name,School Name,Group Owner,MPAN,Meter Type,Data Source,Last Validated Date,Issues,Notes\n" \
-         "#{meter.school.school_group.name},#{meter.school.name},,#{meter.mpan_mprn},gas,,,0,0\n")
+         "#{meter.school.school_group.name},#{meter.school.name},Admin,#{meter.mpan_mprn},gas,,,0,0\n")
   end
 end

--- a/spec/system/admin/school_groups_spec.rb
+++ b/spec/system/admin/school_groups_spec.rb
@@ -477,7 +477,7 @@ RSpec.describe 'school groups', :school_groups, type: :system, include_applicati
     end
 
     describe 'Editing a school group' do
-      let!(:school_group) { create(:school_group, name: 'BANES', public: true) }
+      let!(:school_group) { create(:school_group, name: 'BANES', public: true, default_issues_admin_user: nil) }
 
       before do
         click_on 'Manage School Groups'

--- a/spec/system/school_groups_spec.rb
+++ b/spec/system/school_groups_spec.rb
@@ -459,7 +459,7 @@ describe 'school groups', :school_groups, type: :system do
 
   context 'when logged in as the group admin' do
     let!(:user)           { create(:group_admin, school_group: school_group) }
-    let!(:school_group2)  { create(:school_group) }
+    let!(:school_group2)  { create(:school_group, default_issues_admin_user: nil) }
 
     before do
       sign_in(user)
@@ -502,7 +502,7 @@ describe 'school groups', :school_groups, type: :system do
 
   context 'when logged in as an admin' do
     let!(:user)           { create(:admin) }
-    let!(:school_group2)  { create(:school_group) }
+    let!(:school_group2)  { create(:school_group, default_issues_admin_user: nil) }
 
     before do
       sign_in(user)
@@ -555,7 +555,7 @@ describe 'school groups', :school_groups, type: :system do
   end
 
   context 'when logged in as a group admin for a different group' do
-    let!(:user) { create(:group_admin, school_group: create(:school_group)) }
+    let!(:user) { create(:group_admin, school_group: create(:school_group, default_issues_admin_user: nil)) }
 
     before do
       sign_in(user)

--- a/spec/system/school_groups_spec.rb
+++ b/spec/system/school_groups_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe 'school groups', :school_groups, type: :system do
-  let!(:school_group) { create(:school_group, public: public, default_template_calendar: create(:template_calendar, :with_previous_and_next_academic_years)) }
+  let!(:school_group) { create(:school_group, public: public, default_issues_admin_user: nil, default_template_calendar: create(:template_calendar, :with_previous_and_next_academic_years)) }
   let(:public) { true }
 
   let!(:user)                  { create(:user) }


### PR DESCRIPTION
Add the school group and admin name to the email.

Changed the school group factory so that by default it has an admin user, as that matches real data more closely. As a result i needed to update some specs.