### PR TITLE
Fix regent config

### DIFF
--- a/lib/tasks/deployment/20250709140550_fix_regent_config.rake
+++ b/lib/tasks/deployment/20250709140550_fix_regent_config.rake
@@ -1,0 +1,30 @@
+namespace :after_party do
+  desc 'Deployment task: fix_regent_config'
+  task fix_regent_config: :environment do
+    puts "Running deploy task 'fix_regent_config'"
+
+    AmrDataFeedConfig.where(identifier: 'energy-assets-regent').update(
+      enabled: false,
+      description: 'Energy Assets Regent Old',
+      identifier: 'energy-assets-regent-old',
+      notes: 'Removed due to data format issues'
+    )
+
+    AmrDataFeedConfig.find_or_create_by!(identifier: 'energy-assets-regent') do |config|
+      config.assign_attributes(
+        description: 'Energy Assets Regent',
+        number_of_header_rows: 1,
+        mpan_mprn_field: 'MPRN',
+        reading_date_field: 'Date',
+        date_format: '%d/%m/%y',
+        header_example: 'UtilityType,MPRN,SerialNum,Unit,Date,Reading,00:00,00:30,01:00,01:30,02:00,02:30,03:00,03:30,04:00,04:30,05:00,05:30,06:00,06:30,07:00,07:30,08:00,08:30,09:00,09:30,10:00,10:30,11:00,11:30,12:00,12:30,13:00,13:30,14:00,14:30,15:00,15:30,16:00,16:30,17:00,17:30,18:00,18:30,19:00,19:30,20:00,20:30,21:00,21:30,22:00,22:30,23:00,23:30',
+        reading_fields: '00:00,00:30,01:00,01:30,02:00,02:30,03:00,03:30,04:00,04:30,05:00,05:30,06:00,06:30,07:00,07:30,08:00,08:30,09:00,09:30,10:00,10:30,11:00,11:30,12:00,12:30,13:00,13:30,14:00,14:30,15:00,15:30,16:00,16:30,17:00,17:30,18:00,18:30,19:00,19:30,20:00,20:30,21:00,21:30,22:00,22:30,23:00,23:30'.split(',')
+      )
+    end
+
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord
+      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+  end
+end


### PR DESCRIPTION
Fix issue with config created in https://github.com/Energy-Sparks/energy-sparks/pull/4515.

Files provided as examples had been opened and saved in Excel so date formats had changed. Should be 2 year date.

As some data has been loaded i've renamed and disabled the old config and created a new one with same identifier.