### PR TITLE
Fix for incorrect url parameters

### DIFF
--- a/app/controllers/pupils/analysis_controller.rb
+++ b/app/controllers/pupils/analysis_controller.rb
@@ -24,6 +24,7 @@ module Pupils
     def fuel_type
       fuel_type = params[:category]
       fuel_type = 'solar' if fuel_type == 'solar_pv'
+      fuel_type = 'storage_heaters' if ['storage heaters', 'storage_heater'].include?(fuel_type)
       fuel_type
     end
 


### PR DESCRIPTION
Possibly crawlers accessing links as “storage+heaters” rather than “storage_heaters”. I don’t believe we publish the former as links anywhere. But fixing to reduce noise in rollbar