### PR TITLE
Redesign newsletters page

### DIFF
--- a/app/controllers/admin/newsletters_controller.rb
+++ b/app/controllers/admin/newsletters_controller.rb
@@ -26,7 +26,7 @@ module Admin
 
     # POST /newsletters
     def create
-      @newsletter = Newsletter.new(newsletter_params)
+      @newsletter = Newsletter.new(newsletter_params.merge(created_by: current_user))
       if @newsletter.save
         redirect_to admin_newsletters_path, notice: 'Newsletter was successfully created.'
       else
@@ -36,7 +36,7 @@ module Admin
 
     # PATCH/PUT /newsletters/1
     def update
-      if @newsletter.update(newsletter_params)
+      if @newsletter.update(newsletter_params.merge(updated_by: current_user))
         redirect_to admin_newsletters_path, notice: 'Newsletter was successfully updated.'
       else
         render :edit

--- a/app/controllers/admin/newsletters_controller.rb
+++ b/app/controllers/admin/newsletters_controller.rb
@@ -52,7 +52,7 @@ module Admin
     private
 
     def newsletter_params
-      params.require(:newsletter).permit(:title, :url, :published_on, :image)
+      params.require(:newsletter).permit(:title, :url, :published_on, :published, :image)
     end
   end
 end

--- a/app/controllers/admin/newsletters_controller.rb
+++ b/app/controllers/admin/newsletters_controller.rb
@@ -1,6 +1,11 @@
 module Admin
   class NewslettersController < AdminController
+    include ImageResizer
+
     load_and_authorize_resource
+    before_action only: [:create, :update] do
+      resize_image(newsletter_params[:image])
+    end
 
     # GET /newsletters
     def index

--- a/app/controllers/case_studies_controller.rb
+++ b/app/controllers/case_studies_controller.rb
@@ -5,6 +5,7 @@ class CaseStudiesController < DownloadableController
 
   def index
     @case_studies = CaseStudy.published.order(:position)
+
     @show_images = @case_studies.without_images.none? || (params[:show_images] && current_user&.admin?)
 
     if params[:show_images] && current_user&.admin? # show case studies with images first

--- a/app/controllers/newsletters_controller.rb
+++ b/app/controllers/newsletters_controller.rb
@@ -1,6 +1,19 @@
 class NewslettersController < ApplicationController
   skip_before_action :authenticate_user!
+
+  layout :choose_layout
+
   def index
-    @newsletters = Newsletter.order(published_on: :desc)
+    @newsletters = Newsletter.published.order(published_on: :desc)
+  end
+
+  private
+
+  def choose_layout
+    if Flipper.enabled?(:new_newsletters_page, current_user)
+      'home'
+    else
+      'application'
+    end
   end
 end

--- a/app/models/case_study.rb
+++ b/app/models/case_study.rb
@@ -46,17 +46,10 @@ class CaseStudy < ApplicationRecord
   validates :image,
               content_type: ['image/png', 'image/jpeg'],
               dimension: { width: { min: 640, max: 1400 } } # betwen half and full container width size to be conservative
+  validates :image, presence: true, if: :publishing?
 
   validates :title_en, :file_en, presence: true
   validates :position, numericality: true, presence: true
-
-  def publishable?
-    image.attached?
-  end
-
-  def self.publishable_error_without
-    'without image'
-  end
 
   def tag_list
     return [] if tags.blank?

--- a/app/models/case_study.rb
+++ b/app/models/case_study.rb
@@ -41,7 +41,7 @@ class CaseStudy < ApplicationRecord
   translates :tags, type: :string, fallbacks: { cy: :en }
   translates :description, backend: :action_text
   t_has_one_attached :file
-  has_one_attached :image # assume this doesn't need to be translatable
+  has_one_attached :image
 
   validates :image,
               content_type: ['image/png', 'image/jpeg'],
@@ -49,6 +49,14 @@ class CaseStudy < ApplicationRecord
 
   validates :title_en, :file_en, presence: true
   validates :position, numericality: true, presence: true
+
+  def publishable?
+    image.attached?
+  end
+
+  def self.publishable_error_without
+    'without image'
+  end
 
   def tag_list
     return [] if tags.blank?

--- a/app/models/cms/category.rb
+++ b/app/models/cms/category.rb
@@ -33,6 +33,7 @@ module Cms
     translates :description, type: :string, fallbacks: { cy: :en }
 
     validates_presence_of :title, :description
+    validate :change_publication_status?, on: :update
 
     has_many :pages, class_name: 'Cms::Page', dependent: :restrict_with_error
 

--- a/app/models/cms/category.rb
+++ b/app/models/cms/category.rb
@@ -33,7 +33,6 @@ module Cms
     translates :description, type: :string, fallbacks: { cy: :en }
 
     validates_presence_of :title, :description
-    validate :change_publication_status?, on: :update
 
     has_many :pages, class_name: 'Cms::Page', dependent: :restrict_with_error
 

--- a/app/models/cms/page.rb
+++ b/app/models/cms/page.rb
@@ -38,7 +38,6 @@ module Cms
     enum(:audience, %w[anyone school_users school_admins group_admins].to_h { |v| [v, v] })
 
     validates_presence_of :title, :description
-    validate :change_publication_status?, on: :update
 
     belongs_to :category, class_name: 'Cms::Category'
     has_many :sections, class_name: 'Cms::Section', dependent: :nullify

--- a/app/models/concerns/publishable.rb
+++ b/app/models/concerns/publishable.rb
@@ -4,8 +4,6 @@ module Publishable
   included do
     scope :published, -> { where(published: true) }
     scope :tx_resources, -> { published.order(:id) }
-
-    validate :change_publication_status?, on: :update
   end
 
   def publishable?
@@ -14,10 +12,14 @@ module Publishable
 
   private
 
+  def publishing?
+    published_changed?(from: false, to: true)
+  end
+
   # only allow changing publication status if we're unpublishing something
   # or if its publishable
   def change_publication_status?
-    if published_changed?(from: false, to: true) && !publishable?
+    if publishing? && !publishable?
       message = "Cannot publish #{self.class.name.demodulize.to_s.downcase} "
       message += self.class.publishable_error_without
       errors.add(:published, message)

--- a/app/models/concerns/publishable.rb
+++ b/app/models/concerns/publishable.rb
@@ -4,6 +4,8 @@ module Publishable
   included do
     scope :published, -> { where(published: true) }
     scope :tx_resources, -> { published.order(:id) }
+
+    validate :change_publication_status?, on: :update
   end
 
   def publishable?

--- a/app/models/newsletter.rb
+++ b/app/models/newsletter.rb
@@ -37,5 +37,5 @@ class Newsletter < ApplicationRecord
   validates :image, presence: true, if: :publishing?
   validates :image,
     content_type: ['image/png', 'image/jpeg'],
-    dimension: { width: { min: 300, max: 1400 } } # betwen 300 (existing images) and full container width size to be conservative
+    dimension: { width: { min: 640, max: 1400 } } # betwen 640 and full container width size to be conservative
 end

--- a/app/models/newsletter.rb
+++ b/app/models/newsletter.rb
@@ -34,15 +34,8 @@ class Newsletter < ApplicationRecord
   has_one_attached :image
 
   validates_presence_of :title, :url, :published_on
+  validates :image, presence: true, if: :publishing?
   validates :image,
     content_type: ['image/png', 'image/jpeg'],
     dimension: { width: { min: 300, max: 1400 } } # betwen 300 (existing images) and full container width size to be conservative
-
-  def publishable?
-    image.attached?
-  end
-
-  def self.publishable_error_without
-    'without image'
-  end
 end

--- a/app/models/newsletter.rb
+++ b/app/models/newsletter.rb
@@ -2,16 +2,47 @@
 #
 # Table name: newsletters
 #
-#  created_at   :datetime         not null
-#  id           :bigint(8)        not null, primary key
-#  published_on :date             not null
-#  title        :text             not null
-#  updated_at   :datetime         not null
-#  url          :text             not null
+#  created_at    :datetime         not null
+#  created_by_id :bigint(8)
+#  id            :bigint(8)        not null, primary key
+#  published     :boolean          default(FALSE), not null
+#  published_on  :date             not null
+#  title         :text             not null
+#  updated_at    :datetime         not null
+#  updated_by_id :bigint(8)
+#  url           :text             not null
+#
+# Indexes
+#
+#  index_newsletters_on_created_by_id  (created_by_id)
+#  index_newsletters_on_updated_by_id  (updated_by_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (created_by_id => users.id) ON DELETE => nullify
+#  fk_rails_...  (updated_by_id => users.id) ON DELETE => nullify
 #
 
 class Newsletter < ApplicationRecord
+  include Publishable
+  include Trackable
+
+  scope :without_images, -> {
+    left_outer_joins(:image_attachment).where(active_storage_attachments: { id: nil })
+  }
+
   has_one_attached :image
 
   validates_presence_of :title, :url, :published_on
+  validates :image,
+    content_type: ['image/png', 'image/jpeg'],
+    dimension: { width: { min: 300, max: 1400 } } # betwen 300 (existing images) and full container width size to be conservative
+
+  def publishable?
+    image.attached?
+  end
+
+  def self.publishable_error_without
+    'without image'
+  end
 end

--- a/app/views/admin/case_studies/_form.html.erb
+++ b/app/views/admin/case_studies/_form.html.erb
@@ -27,7 +27,7 @@
           <% else %>
             No image attached
           <% end %>
-          <%= f.input :image, class: 'form-control' %>
+          <%= f.input :image, as: :file, label: 'Image', hint: 'Must be PNG or JPG' %>
         </div>
         <%= render 'admin/shared/locale_tabs', f: f, field: :file do |locale| %>
           <%= f.input t_field(:file, locale), label: CaseStudy.human_attribute_name(:file) %>
@@ -37,7 +37,7 @@
     </div>
     <div class="mt-2">
       <%= f.input :published, as: :boolean %>
-      <%= f.submit 'Save case study', class: 'btn btn-primary btn-small' %>
+      <%= f.submit 'Save', class: 'btn btn-primary btn-small' %>
       <%= link_to 'Back', admin_case_studies_path, class: 'btn btn-secondary btn-small' %>
     </div>
   <% end %>

--- a/app/views/admin/cms/categories/index.html.erb
+++ b/app/views/admin/cms/categories/index.html.erb
@@ -23,7 +23,7 @@
         <tr>
           <th><%= render IconComponent.new(name: category.icon) if category.icon %></th>
           <td><%= link_to category.title, edit_admin_cms_category_path(category) %></td>
-          <td><%= fa_icon(category.published? ? 'check-circle text-success' : 'times-circle text-danger') %></td>
+          <td><%= checkmark category.published? %></td>
           <td><%= category.pages.published.count %> / <%= category.pages.count %></td>
           <td>
             <%= link_to 'Edit', edit_admin_cms_category_path(category), class: 'btn' %>

--- a/app/views/admin/cms/pages/index.html.erb
+++ b/app/views/admin/cms/pages/index.html.erb
@@ -25,7 +25,7 @@
           <td><%= link_to page.category.title, edit_admin_cms_category_path(page) %></td>
           <td><%= link_to page.title, edit_admin_cms_page_path(page) %></td>
           <td><%= t("page.audience.#{page.audience}") %></td>
-          <td><%= fa_icon(page.published? ? 'check-circle text-success' : 'times-circle text-danger') %></td>
+          <td><%= checkmark page.published? %></td>
           <td><%= page.sections.published.count %> / <%= page.sections.count %></td>
           <td>
             <%= link_to 'Edit', edit_admin_cms_page_path(page), class: 'btn' %>

--- a/app/views/admin/cms/sections/index.html.erb
+++ b/app/views/admin/cms/sections/index.html.erb
@@ -25,7 +25,7 @@
                   end %></td>
           <td><%= link_to section.page.title, edit_admin_cms_page_path(section.page) if section.page %></td>
           <td><%= link_to section.title, edit_admin_cms_section_path(section) %></td>
-          <td><%= fa_icon(section.published? ? 'check-circle text-success' : 'times-circle text-danger') %></td>
+          <td><%= checkmark section.published? %></td>
           <td>
             <%= link_to 'Edit', edit_admin_cms_section_path(section), class: 'btn' %>
             <%= link_to 'View', category_page_path(section.page.category,

--- a/app/views/admin/newsletters/_form.html.erb
+++ b/app/views/admin/newsletters/_form.html.erb
@@ -16,9 +16,11 @@
             <% else %>
               No image attached
             <% end %>
-            <%= f.input :image, class: 'form-control' %>
-          </div>          <%= f.input :published, as: :boolean %>
-          <%= f.button :submit %>
+            <%= f.input :image, as: :file, label: 'Image', hint: 'Must be PNG or JPG' %>
+          </div>
+          <%= f.input :published, as: :boolean %>
+          <%= f.submit 'Save', class: 'btn btn-primary btn-small' %>
+          <%= link_to 'Back', admin_newsletters_path, class: 'btn btn-secondary btn-small' %>
       </div>
       <div class="col-6">
         <h4>Change history</h4>

--- a/app/views/admin/newsletters/_form.html.erb
+++ b/app/views/admin/newsletters/_form.html.erb
@@ -1,7 +1,29 @@
-<%= simple_form_for([:admin, @newsletter]) do |f| %>
-  <%= f.input :title, as: :string %>
-  <%= f.input :url, as: :string %>
-  <%= f.input :published_on, as: :tempus_dominus_date, default_date: Date.today, input_html: { class: "form-control form-control-lg" } %>
-  <%= f.input :image, hint: "Please use an image with a width of 300 pixels and a height of 200 pixels" %>
-  <%= f.button :submit %>
-<% end %>
+<div class="border rounded bg-light p-4">
+  <%= simple_form_for([:admin, @newsletter]) do |f| %>
+    <div class="row">
+      <div class="col-6">
+          <%= f.input :title, as: :string %>
+          <%= f.input :url, as: :string %>
+          <%= f.input :published_on, as: :tempus_dominus_date,
+                                     default_date: Time.zone.today,
+                                     input_html: { class: 'form-control form-control-lg' } %>
+          <div class='pb-3'>
+            <% if @newsletter.image.attached? && @newsletter.image.persisted? %>
+              <div class="mt-2">
+                <p>Current Image:</p>
+                <%= image_tag @newsletter.image, class: 'img-thumbnail' %>
+              </div>
+            <% else %>
+              No image attached
+            <% end %>
+            <%= f.input :image, class: 'form-control' %>
+          </div>          <%= f.input :published, as: :boolean %>
+          <%= f.button :submit %>
+      </div>
+      <div class="col-6">
+        <h4>Change history</h4>
+        <%= render 'admin/cms/change_history', model: @newsletter %>
+      </div>
+    </div>
+  <% end %>
+</div>

--- a/app/views/admin/newsletters/_title_and_navigation.html.erb
+++ b/app/views/admin/newsletters/_title_and_navigation.html.erb
@@ -1,0 +1,5 @@
+<%= render Admin::HeaderNavComponent.new do |header_nav| %>
+  <% header_nav.with_header title: title %>
+  <% header_nav.with_button 'New', new_admin_newsletter_path %>
+  <% header_nav.with_button 'Newsletters', admin_newsletters_path %>
+<% end %>

--- a/app/views/admin/newsletters/edit.html.erb
+++ b/app/views/admin/newsletters/edit.html.erb
@@ -1,4 +1,3 @@
-<h1>Editing Newsletter</h1>
-<p><%= link_to 'All newsletters', admin_newsletters_path %></p>
+<%= render 'title_and_navigation', title: 'Newsletters: edit' %>
 
 <%= render 'form', newsletter: @newsletter %>

--- a/app/views/admin/newsletters/index.html.erb
+++ b/app/views/admin/newsletters/index.html.erb
@@ -8,6 +8,7 @@
       <th>Title</th>
       <th>URL</th>
       <th>Published on</th>
+      <th>Published?</th>
       <th>Image</th>
       <th colspan="3">Actions</th>
     </tr>
@@ -19,6 +20,7 @@
         <td><%= link_to newsletter.title, admin_newsletter_path(newsletter) %></td>
         <td><%= link_to newsletter.url, newsletter.url %></td>
         <td><%= nice_dates newsletter.published_on %></td>
+        <td><%= checkmark(newsletter.published) %></td>
         <td>
           <% if newsletter.image.attached? %>
             <%= image_tag newsletter.image.variant(resize_to_limit: [50, 50]) %>
@@ -28,7 +30,10 @@
         </td>
         <td>
           <%= link_to 'Edit', edit_admin_newsletter_path(newsletter), class: 'btn' %>
-          <%= link_to 'Delete', admin_newsletter_path(newsletter), method: :delete, data: { confirm: 'Are you sure?' }, class: 'btn' %>
+          <%= link_to 'Delete', admin_newsletter_path(newsletter),
+                      method: :delete,
+                      data: { confirm: 'Are you sure?' },
+                      class: 'btn' %>
         </td>
       </tr>
     <% end %>

--- a/app/views/admin/newsletters/index.html.erb
+++ b/app/views/admin/newsletters/index.html.erb
@@ -1,4 +1,4 @@
-<h1>Newsletters</h1>
+<%= render 'title_and_navigation', title: 'Newsletters' %>
 
 <% if @newsletters %>
 

--- a/app/views/admin/newsletters/new.html.erb
+++ b/app/views/admin/newsletters/new.html.erb
@@ -1,4 +1,3 @@
-<h1>New Newsletter</h1>
-<p><%= link_to 'All newsletters', admin_newsletters_path %></p>
+<%= render 'title_and_navigation', title: 'Newsletters: new' %>
 
 <%= render 'form', newsletter: @newsletter %>

--- a/app/views/admin/newsletters/show.html.erb
+++ b/app/views/admin/newsletters/show.html.erb
@@ -1,14 +1,16 @@
-<h1><%= @newsletter.title %></h1>
-
-<p><%= link_to 'All newsletters', admin_newsletters_path %></p>
-
+<%= render 'title_and_navigation', title: "Newsletters: #{@newsletter.title}" %>
 
 <dl>
+  <dt>Title</dt><dd><%= @newsletter.title %></dd>
   <dt>Url</dt><dd><%= link_to @newsletter.url, @newsletter.url %></dd>
   <dt>Published on</dt><dd><%= nice_dates @newsletter.published_on %></dd>
+  <dt>Published</dt><dd><%= checkmark(@newsletter.published) %></dd>
 </dl>
 
 <p><%= image_tag @newsletter.image %></p>
 
 <%= link_to 'Edit', edit_admin_newsletter_path(@newsletter), class: 'btn' %>
-<%= link_to 'Destroy', admin_newsletter_path(@newsletter), method: :delete, data: { confirm: 'Are you sure?' }, class: 'btn' %>
+<%= link_to 'Destroy', admin_newsletter_path(@newsletter),
+            method: :delete,
+            data: { confirm: 'Are you sure?' },
+            class: 'btn' %>

--- a/app/views/case_studies/index.html.erb
+++ b/app/views/case_studies/index.html.erb
@@ -30,7 +30,7 @@
               end %>
           <%= card.with_feature_card(
                 theme: :light, size: :sm,
-                classes: "p-4 rounded-bottom-xl #{'rounded-top-xl' if !case_study.image.attached? || !@show_images}"
+                classes: "p-4 rounded-xl #{'rounded-top-xl' unless case_study.image.attached? && @show_images}"
               ) do |feature| %>
             <% case_study.tag_list.each do |tag| %>
               <%= feature.with_tag(tag) %>

--- a/app/views/newsletters/index.html.erb
+++ b/app/views/newsletters/index.html.erb
@@ -1,36 +1,76 @@
 <% cache_unless current_user&.admin?, I18n.locale, expires_in: 1.hour do %>
   <% content_for :page_title, t('newsletters.title') %>
-  <div class="application container">
-    <div class="row">
-      <div class="col">
-        <h1 id="intro"><%= t('newsletters.title') %></h1>
-      </div>
+  <% if Flipper.enabled?(:new_newsletters_page) %>
+    <div class="container-fluid adult mb-5 py-5">
+      <%= render Layout::GridComponent.new(cols: 2, classes: 'container', feature: true, cell_classes: 'my-auto',
+                                           id: 'hero') do |grid| %>
+        <% grid.with_feature_card size: :xl do |feature| %>
+          <%= feature.with_header title: t('mailchimp.latest_news_title') %>
+          <%= feature.with_description { t('mailchimp.never_share_your_email_promise') } %>
+          <%= feature.with_button t('mailchimp.signup_now'), user_emails_path(current_user), style: :primary %>
+
+        <% end %>
+        <%= grid.with_image src: 'laptop.jpg' %>
+      <% end %>
     </div>
-    <% unless @newsletters.empty? %>
-      <% @newsletters.in_groups_of(4, nil).each do |group| %>
-        <div class="card-deck mb-4">
-          <% group.each do |newsletter| %>
-            <% if newsletter.nil? %>
-              <div class="card mb-3">
-                <div class="card-body">
-                  <h5 class="card-title"></h5>
-                </div>
-              </div>
-            <% else %>
-              <div class="card mb-3">
-                <% if newsletter.image.present? %>
-                  <%= image_tag newsletter.image %>
-                <% else %>
-                  <%= image_tag('stay-up-to-date/newsletter-placeholder.png', class: 'img-fluid') %>
-                <% end %>
-                <div class="card-body">
-                  <h5 class="card-title"><%= link_to newsletter.title, newsletter.url %></h5>
-                </div>
-              </div>
+
+    <div class="container mt-4">
+      <%= render Layout::GridComponent.new(
+            id: 'newsletters',
+            cols: 3,
+            classes: 'pb-4',
+            cell_classes: 'mb-4',
+            component_classes: 'h-100'
+          ) do |grid| %>
+
+        <% @newsletters.each do |newsletter| %>
+          <%= grid.with_card do |card| %>
+            <%= card.with_image(src: cdn_link_url(newsletter.image), rounded: :top) if newsletter.image.attached? %>
+            <%= card.with_feature_card(
+                  theme: :light, size: :sm,
+                  classes: 'p-4 rounded-bottom-xl'
+                ) do |feature| %>
+              <%= feature.with_header(title: newsletter.title) %>
+              <%= feature.with_date(newsletter.published_on) %>
+              <%= feature.with_link(href: newsletter.url) { t('newsletters.view_newsletter') } %>
             <% end %>
           <% end %>
-        </div>
+        <% end %>
       <% end %>
-    <% end %>
-  </div>
+    </div>
+  <% else %>
+    <div class="application container">
+      <div class="row">
+        <div class="col">
+          <h1 id="intro"><%= t('newsletters.title') %></h1>
+        </div>
+      </div>
+      <% unless @newsletters.empty? %>
+        <% @newsletters.in_groups_of(4, nil).each do |group| %>
+          <div class="card-deck mb-4">
+            <% group.each do |newsletter| %>
+              <% if newsletter.nil? %>
+                <div class="card mb-3">
+                  <div class="card-body">
+                    <h5 class="card-title"></h5>
+                  </div>
+                </div>
+              <% else %>
+                <div class="card mb-3">
+                  <% if newsletter.image.present? %>
+                    <%= image_tag newsletter.image %>
+                  <% else %>
+                    <%= image_tag('stay-up-to-date/newsletter-placeholder.png', class: 'img-fluid') %>
+                  <% end %>
+                  <div class="card-body">
+                    <h5 class="card-title"><%= link_to newsletter.title, newsletter.url %></h5>
+                  </div>
+                </div>
+              <% end %>
+            <% end %>
+          </div>
+        <% end %>
+      <% end %>
+    </div>
+  <% end %>
 <% end %>

--- a/config/locales/views/home/home.yml
+++ b/config/locales/views/home/home.yml
@@ -83,6 +83,7 @@ en:
     title_html: Stay up to date&hellip;
   newsletters:
     title: Newsletters
+    view_newsletter: View newsletter
   redirects:
     choose_school:
       intro: You have followed a school-specific link. Choose one of your schools to continue

--- a/db/migrate/20250711133624_add_published_to_newsletters.rb
+++ b/db/migrate/20250711133624_add_published_to_newsletters.rb
@@ -1,0 +1,17 @@
+class AddPublishedToNewsletters < ActiveRecord::Migration[7.2]
+  def up
+    add_column :newsletters, :published, :boolean, null: false, default: false
+
+    add_reference :newsletters, :created_by, foreign_key: { on_delete: :nullify, to_table: :users }
+    add_reference :newsletters, :updated_by, foreign_key: { on_delete: :nullify, to_table: :users }
+
+    Newsletter.update_all(published: true)
+  end
+
+  def down
+    remove_reference :newsletters, :updated_by
+    remove_reference :newsletters, :created_by
+
+    remove_column :newsletters, :published
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_07_03_154310) do
+ActiveRecord::Schema[7.2].define(version: 2025_07_11_133624) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pgcrypto"
@@ -1405,6 +1405,11 @@ ActiveRecord::Schema[7.2].define(version: 2025_07_03_154310) do
     t.date "published_on", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "published", default: false, null: false
+    t.bigint "created_by_id"
+    t.bigint "updated_by_id"
+    t.index ["created_by_id"], name: "index_newsletters_on_created_by_id"
+    t.index ["updated_by_id"], name: "index_newsletters_on_updated_by_id"
   end
 
   create_table "observations", force: :cascade do |t|
@@ -2273,6 +2278,8 @@ ActiveRecord::Schema[7.2].define(version: 2025_07_03_154310) do
   add_foreign_key "meters", "schools", on_delete: :cascade
   add_foreign_key "meters", "solar_edge_installations", on_delete: :cascade
   add_foreign_key "meters", "solis_cloud_installations", on_delete: :cascade
+  add_foreign_key "newsletters", "users", column: "created_by_id", on_delete: :nullify
+  add_foreign_key "newsletters", "users", column: "updated_by_id", on_delete: :nullify
   add_foreign_key "observations", "activities", on_delete: :nullify
   add_foreign_key "observations", "audits"
   add_foreign_key "observations", "intervention_types", on_delete: :restrict

--- a/spec/models/case_study_spec.rb
+++ b/spec/models/case_study_spec.rb
@@ -101,4 +101,13 @@ RSpec.describe CaseStudy, type: :model do
       end
     end
   end
+
+  context 'when attempting to publish with no image' do
+    let!(:case_study_no_image) { create(:case_study, image: nil, published: false) }
+
+    it 'raises' do
+      case_study_no_image.published = true
+      expect { case_study_no_image.save! }.to raise_error(ActiveRecord::RecordInvalid)
+    end
+  end
 end

--- a/spec/models/case_study_spec.rb
+++ b/spec/models/case_study_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe CaseStudy, type: :model do
 
     context 'when some case studies do not have images attached' do
       let!(:case_study_with_image) { create(:case_study, image: fixture_file_upload('spec/fixtures/images/laptop.jpg')) }
-      let!(:case_study_without_image) { create(:case_study, image: nil) }
+      let!(:case_study_without_image) { build(:case_study, image: nil).tap { |cs| cs.save(validate: false) } }
 
       it 'returns only case studies without images' do
         expect(CaseStudy.without_images).to match_array([case_study_without_image])
@@ -38,8 +38,8 @@ RSpec.describe CaseStudy, type: :model do
     end
 
     context 'when no case studies have images attached' do
-      let!(:case_study_without_image_1) { create(:case_study, image: nil) }
-      let!(:case_study_without_image_2) { create(:case_study, image: nil) }
+      let!(:case_study_without_image_1) { build(:case_study, image: nil).tap { |cs| cs.save(validate: false) } }
+      let!(:case_study_without_image_2) { build(:case_study, image: nil).tap { |cs| cs.save(validate: false) } }
 
       it 'returns all case studies' do
         expect(CaseStudy.without_images).to match_array([case_study_without_image_1, case_study_without_image_2])

--- a/spec/models/newsletter_spec.rb
+++ b/spec/models/newsletter_spec.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+
+RSpec.describe Newsletter, type: :model do
+  describe '.without_images' do
+    context 'when all newsletters have images attached' do
+      let!(:newsletters) { create_list(:newsletter, 2, image: fixture_file_upload('spec/fixtures/images/laptop.jpg')) }
+
+      it 'returns nothing' do
+        expect(Newsletter.without_images).to be_empty
+      end
+    end
+
+    context 'when some newsletters do not have images attached' do
+      let!(:newsletter_with_image) { create(:newsletter, image: fixture_file_upload('spec/fixtures/images/laptop.jpg')) }
+      let!(:newsletter_without_image) { create(:newsletter, image: nil) }
+
+      it 'returns only newsletters without images' do
+        expect(Newsletter.without_images).to contain_exactly(newsletter_without_image)
+      end
+    end
+
+    context 'when no newsletters have images attached' do
+      let!(:newsletters) { create_list(:newsletter, 2, image: nil) }
+
+      it 'returns all newsletters' do
+        expect(Newsletter.without_images).to match_array(newsletters)
+      end
+    end
+
+    context 'when there are no newsletters' do
+      it 'returns an empty ActiveRecord::Relation' do
+        expect(Newsletter.without_images).to be_empty
+      end
+    end
+  end
+
+  context 'when attempting to publish with no image' do
+    let!(:newsletter_no_image) { create(:newsletter, image: nil, published: false) }
+
+    it 'raises' do
+      newsletter_no_image.published = true
+      expect { newsletter_no_image.save! }.to raise_error(ActiveRecord::RecordInvalid)
+    end
+  end
+end

--- a/spec/system/admin/case_studies_spec.rb
+++ b/spec/system/admin/case_studies_spec.rb
@@ -116,7 +116,7 @@ RSpec.describe 'Admin case studies', type: :system do
           before do
             fill_in :case_study_title_en, with: ''
             attach_file 'Image', Rails.root.join('spec/fixtures/documents/fake-bill.pdf')
-            click_on 'Save case study'
+            click_on 'Save'
           end
 
           it { expect(page).to have_content("Title *\ncan't be blank") }
@@ -134,7 +134,7 @@ RSpec.describe 'Admin case studies', type: :system do
             fill_in :case_study_tags_en, with: 'en1, en2'
             uncheck :case_study_published
 
-            click_on 'Save case study'
+            click_on 'Save'
           end
 
           it { expect(page).to have_content('Updated title') }
@@ -157,7 +157,7 @@ RSpec.describe 'Admin case studies', type: :system do
         context 'with invalid attributes' do
           before do
             attach_file 'Image', Rails.root.join('spec/fixtures/documents/fake-bill.pdf')
-            click_on 'Save case study'
+            click_on 'Save'
           end
 
           it { expect(page).to have_content("Title *\ncan't be blank") }
@@ -167,7 +167,7 @@ RSpec.describe 'Admin case studies', type: :system do
         context 'when publishing without an image' do
           before do
             check :case_study_published
-            click_on 'Save case study'
+            click_on 'Save'
           end
 
           it { expect(page).to have_content('No image attached') }
@@ -184,7 +184,7 @@ RSpec.describe 'Admin case studies', type: :system do
             fill_in :case_study_tags_en, with: 'new, example'
             check :case_study_published
 
-            click_on 'Save case study'
+            click_on 'Save'
           end
 
           it 'shows the index page' do

--- a/spec/system/admin/case_studies_spec.rb
+++ b/spec/system/admin/case_studies_spec.rb
@@ -96,7 +96,7 @@ RSpec.describe 'Admin case studies', type: :system do
       end
 
       context 'when there is no image' do
-        let!(:case_study) { create(:case_study, image: nil) }
+        let!(:case_study) { create(:case_study, image: nil, published: false) }
 
         it 'shows the no image icon' do
           expect(page).to have_css('i.fa-triangle-exclamation')
@@ -162,6 +162,15 @@ RSpec.describe 'Admin case studies', type: :system do
 
           it { expect(page).to have_content("Title *\ncan't be blank") }
           it { expect(page).to have_content("Image\nhas an invalid content type (authorized content types are PNG, JPG)") }
+        end
+
+        context 'when publishing without an image' do
+          before do
+            check :case_study_published
+            click_on 'Save case study'
+          end
+
+          it { expect(page).to have_content('No image attached') }
         end
 
         context 'with valid attributes' do

--- a/spec/system/admin/newsletter_spec.rb
+++ b/spec/system/admin/newsletter_spec.rb
@@ -1,40 +1,116 @@
 require 'rails_helper'
 
-describe 'Newsletter managment', type: :system do
+RSpec.describe 'Admin newsletters', type: :system do
   let!(:admin) { create(:admin) }
 
-  describe 'managing' do
-    before do
-      sign_in(admin)
-      visit root_path
-      click_on 'Admin'
-      within '.application' do
-        click_on 'Newsletters'
+  describe 'when not logged in' do
+    context 'when visiting the index' do
+      before { visit admin_newsletters_path }
+
+      it 'does not authorise viewing' do
+        expect(page).to have_content('You need to sign in or sign up before continuing.')
       end
     end
 
-    it 'allows the user to create, edit and delete a newsletter type' do
-      url = 'https://sausage-dogs-and-draught-excluders.com'
-      title = 'Save energy with a sausage dog'
-      new_title = 'Save energy without a sausage dog'
+    context 'when creating a new newsletter' do
+      before { visit new_admin_newsletter_path }
 
-      click_on 'New Newsletter'
-      fill_in 'Title', with: title
-      click_on 'Create Newsletter'
-      expect(page).to have_content('blank')
-      fill_in 'Url', with: url
-      attach_file('Image', Rails.root + 'spec/fixtures/images/newsletter-placeholder.png')
-      click_on 'Create Newsletter'
-      expect(page).to have_content url
+      it 'does not authorise viewing' do
+        expect(page).to have_content('You need to sign in or sign up before continuing.')
+      end
+    end
+  end
 
-      click_on 'Edit'
-      fill_in 'Title', with: new_title
-      click_on 'Update Newsletter'
+  describe 'when logged in as admin' do
+    before { sign_in(admin) }
 
-      expect(page).to have_content new_title
+    context 'when viewing the index' do
+      before { visit admin_newsletters_path }
 
-      click_on 'Delete'
-      expect(page).to have_content('Newsletter was successfully destroyed.')
+      it { expect(page).to have_link('New') }
+    end
+
+    context 'when creating a newsletter' do
+      let(:url) { 'https://sausage-dogs-and-draught-excluders.com' }
+      let(:title) { 'Save energy with a sausage dog' }
+
+      before do
+        visit admin_newsletters_path
+        click_on 'New'
+      end
+
+      context 'with invalid attributes' do
+        before do
+          click_on 'Save'
+        end
+
+        it { expect(page).to have_content("Title *\ncan't be blank") }
+        it { expect(page).to have_content("Url *\ncan't be blank") }
+      end
+
+      context 'when publishing without an image' do
+        before do
+          check :newsletter_published
+          click_on 'Save'
+        end
+
+        it { expect(page).to have_content('No image attached') }
+      end
+
+      context 'with valid attributes' do
+        before do
+          fill_in 'Title', with: title
+          fill_in 'Url', with: url
+          attach_file 'Image', Rails.root.join('spec/fixtures/images/boiler.jpg')
+          fill_in 'Published on', with: Time.zone.today
+          check :newsletter_published
+
+          click_on 'Save'
+        end
+
+        it 'shows the newsletter details' do
+          expect(page).to have_content(title)
+          expect(page).to have_content(url)
+          expect(page).to have_content('Newsletter was successfully created.')
+        end
+      end
+    end
+
+    context 'when editing a newsletter' do
+      let!(:newsletter) do
+        create(:newsletter, title: 'Original Title', url: 'https://example.com', published_on: Time.zone.today)
+      end
+
+      before do
+        visit admin_newsletters_path
+        click_on 'Edit'
+      end
+
+      context 'with valid attributes' do
+        before do
+          fill_in 'Title', with: 'Updated Title'
+          click_on 'Save'
+        end
+
+        it { expect(page).to have_content('Updated Title') }
+        it { expect(page).to have_content('Newsletter was successfully updated.') }
+      end
+    end
+
+    context 'when deleting a newsletter' do
+      let!(:newsletter) do
+        create(:newsletter, title: 'Delete Me', url: 'https://example.com', published_on: Time.zone.today)
+      end
+
+      before do
+        visit admin_newsletters_path
+        click_on 'Delete'
+      end
+
+      it 'removes the newsletter' do
+        expect(page).to have_content('Newsletter was successfully destroyed.')
+        expect(page).not_to have_content('Delete Me')
+      end
     end
   end
 end

--- a/spec/system/case_studies_spec.rb
+++ b/spec/system/case_studies_spec.rb
@@ -113,7 +113,7 @@ RSpec.describe 'case_studies', :include_application_helper do
     end
 
     context 'when some case studies do not have images' do
-      let!(:case_study_without_image) { create(:case_study, image: nil) }
+      let!(:case_study_without_image) { build(:case_study, image: nil).tap { |cs| cs.save(validate: false) } }
 
       before do
         visit case_studies_path


### PR DESCRIPTION
* Added published flag and change history functionality to newsletter model and admin interfaces. Also changed newsletter and case studies to only be publishable if an image is present (hope this is ok, makes sense to me).
* Added better rpsec for newsletters. 

The titles can be quite inconsistent for newsletters:
Example 1: 2024/25 Term 1:4: Half term switch off reminder
Example 2: Tips for identifying and fixing lighting problems in your school - Getting the most out of Energy Sparks
Example 3: 2024/25 Term 2:2 LUPD

We either could do with changing some so they are consistent or the other option (which I've just thought of) is to add tags list like we do for case studies, for the '2024/25 Term 1:4' bit and then also have a more descriptive title.