### PR TITLE
Remove entire day if all readings are negative

### DIFF
--- a/spec/services/aggregation/validate_amr_data_spec.rb
+++ b/spec/services/aggregation/validate_amr_data_spec.rb
@@ -116,7 +116,7 @@ describe Aggregation::ValidateAmrData, type: :service do
 
       context 'when there are no possible substitutes' do
         it 'falls back to other validations' do
-          reading, validator = modify_arbitrary_reading_and_validate(create_meter(kwh_data_x48: Array.new(48, -0.1)))
+          reading, = modify_arbitrary_reading_and_validate(create_meter(kwh_data_x48: Array.new(48, -0.1)))
           expect(reading.type).to eq('PROB') # small amount missing, so will be filled with PROB data
         end
       end

--- a/spec/services/aggregation/validate_amr_data_spec.rb
+++ b/spec/services/aggregation/validate_amr_data_spec.rb
@@ -102,6 +102,26 @@ describe Aggregation::ValidateAmrData, type: :service do
       expect(reading.substitute_date).to eq(Date.new(2025, 4, 27))
     end
 
+    context 'with entire day negative' do
+      context 'when there are possible substitutes' do
+        it 'substitutes the entire day' do
+          reading, = modify_arbitrary_reading_and_validate(create_meter) do |reading|
+            reading.kwh_data_x48[0..47] = Array.new(48, -0.1)
+          end
+          expect(reading.kwh_data_x48[0]).to eq(0.44)
+          expect(reading.type).to eq('RNEG')
+          expect(reading.substitute_date).to eq(Date.new(2025, 4, 27))
+        end
+      end
+
+      context 'when there are no possible substitutes' do
+        it 'falls back to other validations' do
+          reading, validator = modify_arbitrary_reading_and_validate(create_meter(kwh_data_x48: Array.new(48, -0.1)))
+          expect(reading.type).to eq('PROB') # small amount missing, so will be filled with PROB data
+        end
+      end
+    end
+
     %i[solar_pv exported_solar_pv].each do |type|
       it "doesn't correct #{type} meters" do
         kwh_data_x48 = Array.new(48, 0).tap { |a| a[24] = -1 }


### PR DESCRIPTION
A previous change to the validator [made here](https://github.com/Energy-Sparks/energy-sparks/pull/4543/files#diff-1a0f2510fb6b3b861ad7f07f0557f39c3ee002c4b9d061096abe28949003140aL595) changed the behaviour for handling days with partial or all missing readings.

Previously days with all or partial missing readings were removed from the AMRData then later substituted or interpolated. If the substitution failed then the day had already been removed, so it would later be substituted again, filled with PROB data or, for large amounts of missing reading, replaced with an LGAP reading. It would also mean that partial/missing readings would not be used for later substitutions.

With the current code the invalid readings are left in place.

I've restored the behaviour to fix an issue encountered on production: one solar electricity meter had all negative readings. Because the analytics couldn't substitute any of the data, we ended up leaving in dates with entirely null readings. This caused a transaction error on the `AmrValidatedReading` table.

With the current changes that particular meter will be truncated with an LGAP as all the data was readings. The later aggregation step fails but it's a bit clearer there's a meter data issue.

Note: I think this does mean that we might not preserve the status code for an original data issue in some cases. Not sure if there's a better approach though.