### PR TITLE
improvements for adding school admin

### DIFF
--- a/app/views/schools/users/new.html.erb
+++ b/app/views/schools/users/new.html.erb
@@ -2,6 +2,7 @@
 <%= simple_form_for @user, url: school_users_path(@school) do |f| %>
   <%= f.hidden_field :role %>
   <% if @user.role == 'school_admin' && !@new_school_admin && !params.key?(:new_user_form) %>
+    <p><%= t('schools.users.new.introduction_admin') %></p>
     <%= f.input :email %>
     <%= f.submit t('common.labels.continue'), class: 'btn btn-rounded' %>
   <% else %>

--- a/config/locales/views/schools/schools.yml
+++ b/config/locales/views/schools/schools.yml
@@ -756,6 +756,7 @@ en:
       new:
         create_account: Create account
         introduction: New users will be sent an email to confirm their account and will then be asked to set a password for their account before it can be accessed
+        introduction_admin: Enter the email of an existing admin to add them to this school, or provide a new email to create a new admin account
         title: Add %{user_role} account
     your_school_estates:
       edit:


### PR DESCRIPTION
feels like the dual functionality would do with explanation text, also wonder
- should there be validation to check the user is already a school admin (perhaps in the same group?) or how does this overlap with the staff make school admin button
- perhaps could do with an additional confirmation step when adding an existing user