### PR TITLE
Add links to meter downloads for group admins

### DIFF
--- a/app/views/schools/downloads/index.html.erb
+++ b/app/views/schools/downloads/index.html.erb
@@ -4,13 +4,15 @@
 
 <p><%= link_to t('schools.downloads.index.back_to_school_dashboard'), @school %></p>
 
-<p><%= link_to t('schools.downloads.index.download_meter_data_for_all_meters_combined'), school_meters_path(@school, format: :csv) %></p>
-
 <h2><%= t('schools.downloads.index.meters') %></h2>
+
+<p><%= link_to t('schools.downloads.index.download_meter_data_for_all_meters_combined'),
+               school_meters_path(@school, format: :csv) %></p>
+
 <p><%= t('schools.downloads.index.download_the_data_for_each_active_meter') %></p>
 <ul>
   <% @school.meters.active.order(:mpan_mprn).each do |meter| %>
-    <li><%= link_to icon_and_display_name(meter), school_meter_path(@school, meter, format: "csv")  %></li>
+    <li><%= link_to icon_and_display_name(meter), school_meter_path(@school, meter, format: 'csv') %></li>
   <% end %>
 </ul>
 
@@ -18,7 +20,8 @@
 <p><%= t('schools.downloads.index.download_the_data_for_each_inactive_meter') %></p>
 <ul>
   <% @school.meters.inactive.order(:mpan_mprn).each do |meter| %>
-    <li><%= link_to "#{fa_icon(fuel_type_icon(meter.meter_type))} #{meter.display_name}".html_safe, school_meter_path(@school, meter, format: "csv")  %></li>
+    <li><%= link_to "#{fa_icon(fuel_type_icon(meter.meter_type))} #{meter.display_name}".html_safe,
+                    school_meter_path(@school, meter, format: 'csv') %></li>
   <% end %>
 </ul>
 <% end %>
@@ -27,20 +30,24 @@
 <p><%= t('schools.downloads.index.email_contact_message_html') %>.</p>
 
 <% if can?(:read, :meter_collection_download) %>
-  <hr/>
+  <hr>
   <h4>Download YAML files</h4>
   <div class="other-actions mb-3">
-    <%= link_to t('schools.downloads.index.unvalidated_meter_data'), admin_school_unvalidated_amr_data_path(@school, format: :yaml), class: 'btn' %>
-    <%= link_to t('schools.downloads.index.validated_meter_data'), admin_school_validated_amr_data_path(@school, format: :yaml), class: 'btn' %>
-    <%= link_to t('schools.downloads.index.aggregated_meter_collection'), admin_school_aggregated_meter_collection_path(@school, format: :yaml), class: 'btn' %>
+    <%= link_to t('schools.downloads.index.unvalidated_meter_data'),
+                admin_school_unvalidated_amr_data_path(@school, format: :yaml), class: 'btn' %>
+    <%= link_to t('schools.downloads.index.validated_meter_data'),
+                admin_school_validated_amr_data_path(@school, format: :yaml), class: 'btn' %>
+    <%= link_to t('schools.downloads.index.aggregated_meter_collection'),
+                admin_school_aggregated_meter_collection_path(@school, format: :yaml), class: 'btn' %>
   </div>
-  <hr/>
+  <hr>
 
   <h4>Download CSV file</h4>
   <div class="other-actions mb-3">
-    <%= link_to t('schools.downloads.index.unvalidated_meter_data_as_csv'), admin_reports_amr_data_feed_readings_path(school_id: @school.id, format: :csv), class: 'btn' %>
+    <%= link_to t('schools.downloads.index.unvalidated_meter_data_as_csv'),
+                admin_reports_amr_data_feed_readings_path(school_id: @school.id, format: :csv), class: 'btn' %>
   </div>
-  <hr/>
+  <hr>
 
   <% if @school.dark_sky_area.present? %>
     <h3><%= t('schools.downloads.index.dark_sky_data') %></h3>
@@ -48,7 +55,9 @@
     <p><%= t('schools.downloads.index.darksky_product_message_html') %></p>
 
     <p>
-      <%= link_to t('schools.downloads.index.darksky_weather_data_csv_for_your_area', dark_sky_area_title: @school.dark_sky_area.title), data_feeds_dark_sky_temperature_readings_path(@school.dark_sky_area, format: "csv") %>
+      <%= link_to t('schools.downloads.index.darksky_weather_data_csv_for_your_area',
+                    dark_sky_area_title: @school.dark_sky_area.title),
+                  data_feeds_dark_sky_temperature_readings_path(@school.dark_sky_area, format: 'csv') %>
     </p>
   <% end %>
 
@@ -56,10 +65,13 @@
   <p><%= t('schools.downloads.index.we_use_sheffield_solar_pv_api_message_html') %></p>
 
   <p>
-    <%= link_to t('schools.downloads.index.solar_pv_data_csv_for_your_area', solar_pv_tuos_area_title: @school.solar_pv_tuos_area.title), data_feeds_solar_pv_tuos_readings_path(@school.solar_pv_tuos_area, format: "csv") %>
+    <%= link_to t('schools.downloads.index.solar_pv_data_csv_for_your_area',
+                  solar_pv_tuos_area_title: @school.solar_pv_tuos_area.title),
+                data_feeds_solar_pv_tuos_readings_path(@school.solar_pv_tuos_area, format: 'csv') %>
   </p>
 
   <h3><%= t('schools.downloads.index.carbon_intensity_data') %></h3>
-  <p><%= link_to t('schools.downloads.index.carbon_intensity_data_csv'), data_feeds_carbon_intensity_readings_path(format: "csv") %></p>
+  <p><%= link_to t('schools.downloads.index.carbon_intensity_data_csv'),
+                 data_feeds_carbon_intensity_readings_path(format: 'csv') %></p>
 
 <% end %>

--- a/app/views/schools/meters/_active_meters.html.erb
+++ b/app/views/schools/meters/_active_meters.html.erb
@@ -54,7 +54,7 @@
             <i class="fas fa-gear"></i>
           <% end %>
         <% end %>
-        <% if can?(:report_on, meter) && meter.amr_validated_readings.any? %>
+        <% if can?(:download_school_data, meter.school) && meter.amr_validated_readings.any? %>
           <%= link_to school_meter_path(@school, meter, format: 'csv'),
                       class: 'btn btn-secondary btn-sm', title: t('schools.meters.index.readings') do %>
             <i class="fas fa-file-download"></i>

--- a/app/views/schools/meters/index.html.erb
+++ b/app/views/schools/meters/index.html.erb
@@ -40,6 +40,10 @@
       <% end %>
     <% end %>
   </div>
+<% else %>
+  <div class="alert alert-secondary mb-2">
+    <%= link_to t('schools.meters.index.school_downloads'), school_downloads_path(@school), class: 'btn' %>
+  </div>
 <% end %>
 
 <% unless @invalid_mpan.empty? %>
@@ -127,7 +131,6 @@
       <%= render 'inactive_meters', inactive_meters: @inactive_pseudo_meters %>
     </tbody>
   <% end %>
-
 </table>
 </div>
 

--- a/spec/system/meter_management_spec.rb
+++ b/spec/system/meter_management_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.shared_examples_for 'a listed meter' do |admin: true|
+RSpec.shared_examples_for 'a listed meter' do |admin: true, staff: false|
   it 'displays list heading' do
     if meter.active
       expect(page).to have_content('Active meters')
@@ -11,13 +11,19 @@ RSpec.shared_examples_for 'a listed meter' do |admin: true|
     end
   end
 
-  it 'displays meter' do
+  it 'displays meter data' do
     expect(page).to have_content(meter.mpan_mprn)
     expect(page).to have_content(meter.name)
     expect(page).to have_content(short_dates(meter.first_validated_reading))
     expect(page).to have_content(short_dates(meter.last_validated_reading))
     expect(page).to have_content(meter.zero_reading_days.count)
     expect(page).to have_content(meter.gappy_validated_readings.count)
+  end
+
+  it 'displays meter links' do
+    if !staff && meter.active && meter.amr_validated_readings.any?
+      expect(page).to have_link(href: school_meter_path(meter.school, meter, format: 'csv'))
+    end
     if admin
       expect(page).to have_link('Issues')
       expect(page).to have_link(meter.data_source.name)
@@ -48,7 +54,7 @@ RSpec.describe 'meter management', :include_application_helper, :meters do
   include ActiveJob::TestHelper
 
   let(:school_name)     { 'Oldfield Park Infants' }
-  let!(:school)         { create_active_school(name: school_name) }
+  let!(:school)         { create_active_school(name: school_name, school_group: create(:school_group)) }
   let!(:admin)          { create(:admin) }
   let!(:teacher)        { create(:staff) }
   let!(:school_admin)   { create(:school_admin, school_id: school.id) }
@@ -161,6 +167,36 @@ RSpec.describe 'meter management', :include_application_helper, :meters do
     end
   end
 
+  context 'when a group admin' do
+    before do
+      sign_in(create(:group_admin, school_group: school.school_group))
+      visit root_path
+    end
+
+    context 'Manage meters page' do
+      before { visit school_meters_path(school) }
+
+      it_behaves_like 'admin dashboard messages', permitted: false
+
+      context 'Add meter form' do
+        it 'does not display admin only fields' do
+          expect(page).to have_no_content('Data source')
+        end
+      end
+
+      context 'listing meters' do
+        let!(:setup_data) { meter }
+
+        it_behaves_like 'a listed meter', admin: false do
+          let(:meter) { active_meter }
+        end
+        it_behaves_like 'a listed meter', admin: false do
+          let(:meter) { inactive_meter }
+        end
+      end
+    end
+  end
+
   context 'as teacher' do
     before do
       sign_in(teacher)
@@ -185,10 +221,10 @@ RSpec.describe 'meter management', :include_application_helper, :meters do
     context 'listing meters' do
       let(:setup_data) { meter }
 
-      it_behaves_like 'a listed meter', admin: false do
+      it_behaves_like 'a listed meter', admin: false, staff: true do
         let(:meter) { active_meter }
       end
-      it_behaves_like 'a listed meter', admin: false do
+      it_behaves_like 'a listed meter', admin: false, staff: true do
         let(:meter) { inactive_meter }
       end
     end


### PR DESCRIPTION
Group admins can access school meter data downloads, but there's no obvious link to the page currently.

PR:

- revises meter page to allow direct links to download data for all school users and group admins
- add link to school download page for all school users and group admins