### PR TITLE
Updated observation time when activity edited

### DIFF
--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -55,6 +55,8 @@ class Activity < ApplicationRecord
 
   has_rich_text :description
 
+  after_save :update_observation_time
+
   self.ignored_columns = %w(deprecated_description)
 
   def display_name
@@ -63,5 +65,9 @@ class Activity < ApplicationRecord
 
   def points
     observations.sum(:points)
+  end
+
+  def update_observation_time
+    observations.update_all(at: happened_on) if happened_on_previously_changed?
   end
 end

--- a/spec/system/activities_spec.rb
+++ b/spec/system/activities_spec.rb
@@ -114,6 +114,25 @@ describe 'viewing and recording activities' do
         refresh
       end
 
+      context 'when updating the activity' do
+        let(:updated_date) { Date.new(2025, 1, 1) }
+
+        before do
+          visit school_activity_path(school, activity)
+          click_on 'Edit'
+          fill_in :activity_happened_on, with: updated_date.strftime('%d/%m/%Y')
+          click_on 'Update activity'
+        end
+
+        it 'shows the updates' do
+          expect(page).to have_content(activity_type.name)
+          expect(page).to have_content(updated_date.strftime('%A, %d %B %Y'))
+          activity.reload
+          expect(activity.happened_on).to eq(updated_date)
+          expect(activity.observations.first.at).to eq(updated_date)
+        end
+      end
+
       context 'when school is data enabled' do
         it 'sees previous records' do
           expect(page).to have_content('Activity previously completed')


### PR DESCRIPTION
If a user corrects the date on a previously recorded activity, the system doesn't currently update the `.at` field of the link observation(s).

This PR adds a basic spec for the editing workflow and a callback on the model to ensure they stay in sync.