### PR TITLE
Fix support page searching and results

### DIFF
--- a/app/components/cms/search_results_component/search_results_component.html.erb
+++ b/app/components/cms/search_results_component/search_results_component.html.erb
@@ -32,8 +32,8 @@
             </div>
             <div class="row">
               <div class="col-md-12">
-                <span class="bg-teal-medium text-blue-very-dark text-uppercase mb-3 badge badge-primary">
-                  <%= section.page.category.title %>
+                <span class="bg-blue-very-dark text-white text-uppercase mb-3 badge badge-primary">
+                  <%= link_to section.page.category.title, category_path(section.page.category) %>
                 </span>
                 <% unless section.published %>
                   <span class="text-uppercase mb-3 badge badge-warning">

--- a/app/components/cms/search_results_component/search_results_component.scss
+++ b/app/components/cms/search_results_component/search_results_component.scss
@@ -9,6 +9,14 @@
     .badge {
       font-size: $f9;
       padding: 6px 14px;
+
+      a {
+        text-decoration: none;
+      }
+
+      a:visited {
+        color: white;
+      }
     }
   }
 

--- a/app/models/concerns/searchable.rb
+++ b/app/models/concerns/searchable.rb
@@ -10,7 +10,7 @@ module Searchable
     def search(query:, locale: :en, show_all: false)
       sql = ActiveRecord::Base.sanitize_sql_array(build_translated_search_sql(query:, locale:, show_all:))
       select("#{table_name}.*, search_results.rank, search_results.headline").joins(sql)
-                                                         .order('search_results.rank', "#{table_name}.id")
+                                                         .order('search_results.rank desc', "#{table_name}.id")
     end
 
     private
@@ -39,7 +39,8 @@ module Searchable
                 coalesce(rich_texts.body_field_text::text, '') ||
                 coalesce(mobility_strings.metadata_fields_text::text, '')
               ),
-              websearch_to_tsquery('#{dictionary}', #{search})
+              websearch_to_tsquery('#{dictionary}', #{search}),
+              'MaxFragments=1'
             ) AS headline
           FROM "#{table_name}"
           LEFT OUTER JOIN (

--- a/spec/models/cms/section_spec.rb
+++ b/spec/models/cms/section_spec.rb
@@ -22,6 +22,16 @@ describe Cms::Section do
       expect(results).to be_empty
     end
 
+    context 'when ranking results' do
+      let(:query) { 'Lorem' }
+
+      it 'returns in expected order' do
+        ranked_lower = create(:section, title: 'Lorem ipsum', published: true)
+        ranked_higher = create(:section, title: 'Lorem lorem ipsum. Ipsum Lorem. Lorem', published: true)
+        expect(results.first).to eq(ranked_higher)
+      end
+    end
+
     context 'when searching for unpublished' do
       let(:show_all) { true }
 


### PR DESCRIPTION
Fixes issue in `Searchable`, results should be in descending rank. Also adds the [`MaxFragments`](https://www.postgresql.org/docs/current/textsearch-controls.html#TEXTSEARCH-HEADLINE) parameter to the `ts_headline` function to improve snippets -- this seems better at producing longer snippets with whole sentences.

Minor improvements in the styling in the results so that the category badges are blue.
