### PR TITLE
Create Audience Component

### DIFF
--- a/app/components/cms/audience_component.rb
+++ b/app/components/cms/audience_component.rb
@@ -1,0 +1,16 @@
+module Cms
+  class AudienceComponent < ApplicationComponent
+    def initialize(page:, current_user:, **kwargs)
+      super
+      @audience = page.audience.to_sym
+      @role = current_user&.role&.to_sym
+    end
+
+    def has_permission?
+      return true if @audience == :anyone
+      return true if @audience == :school_users && @role.present?
+      return true if @audience == :group_admins && @role == :group_admin
+      return @audience == :school_admins && [:school_onboarding, :school_admin, :group_admin, :admin].include?(@role)
+    end
+  end
+end

--- a/app/components/cms/audience_component/audience_component.html.erb
+++ b/app/components/cms/audience_component/audience_component.html.erb
@@ -1,0 +1,24 @@
+<%= tag.div id: id, class: classes do %>
+  <%= render PromptComponent.new(status: :none) do |c| %>
+    <% c.with_title { t('components.cms.audience.title') } %>
+    <p>
+    <%= t('components.cms.audience.message', audience: t("page.audience.#{@audience}")) %>
+    </p>
+    <% if @audience != :anyone %>
+        <% if @role.nil? %>
+            <p>
+              <%= t('components.cms.audience.not_logged_in_html', link: new_user_session_path) %>
+            </p>
+        <% else %>
+            <p>
+            <%= t('components.cms.audience.logged_in', role: t("role.#{@role}")) %>
+            </p>
+            <% unless has_permission? %>
+              <p>
+                <%= t('components.cms.audience.incorrect_permissions') %>
+              </p>
+            <% end %>
+        <% end %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/cms/pages/show.html.erb
+++ b/app/views/cms/pages/show.html.erb
@@ -23,10 +23,7 @@
     <div id="cms-page-body" class="col-md-5 col-lg-5 col-xl-7">
       <%= render 'cms/admin_buttons', content: @page, current_user: current_user %>
 
-      <%= render PromptComponent.new(status: :none) do |c| %>
-        <% c.with_title { 'Audience' } %>
-        <%= t("page.audience.#{@page.audience}") %>
-      <% end %>
+      <%= render Cms::AudienceComponent.new(page: @page, current_user: current_user) %>
 
       <% @sections.each do |section| %>
         <section id="<%= section.slug %>"

--- a/config/locales/models/lists.yml
+++ b/config/locales/models/lists.yml
@@ -40,11 +40,11 @@ en:
   role:
     admin: Admin
     analytics: Analytics
-    group_admin: Group Admin
+    group_admin: Group admin
     guest: Guest
     pupil: Pupil
-    school_admin: School Admin
-    school_onboarding: Onboarding
+    school_admin: School admin
+    school_onboarding: Onboarding admin
     staff: Staff
   staff_role:
     building_site_manager_or_caretaker: Building/site manager or caretaker

--- a/config/locales/models/page.yml
+++ b/config/locales/models/page.yml
@@ -2,7 +2,7 @@
 en:
   page:
     audience:
-      anyone: Anyone
-      group_admins: School group administrators
-      school_admins: School and group administrators
-      school_users: School users
+      anyone: anyone using the Energy Sparks website
+      group_admins: Group admins
+      school_admins: School and Group admins
+      school_users: all registered school users

--- a/config/locales/views/components/cms/audience.yml
+++ b/config/locales/views/components/cms/audience.yml
@@ -1,0 +1,10 @@
+---
+en:
+  components:
+    cms:
+      audience:
+        incorrect_permissions: You will not have permission to follow all of the instructions on this page.
+        logged_in: You are currently signed in as a %{role} user.
+        message: This page provides help for %{audience}.
+        not_logged_in_html: You will need to <a href="%{link}">sign-in</a> to follow the instructions on this page.
+        title: Audience

--- a/spec/components/cms/audience_component_spec.rb
+++ b/spec/components/cms/audience_component_spec.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Cms::AudienceComponent, :include_application_helper, :include_url_helpers, type: :component do
+  let(:current_user) { create(:school_admin) }
+  let(:audience) { :anyone }
+
+  let(:params) do
+    {
+      id: 'custom-id',
+      classes: 'extra-classes',
+      page: create(:page, :with_sections, audience: audience, sections_published: true, published: true),
+      current_user: current_user
+    }
+  end
+
+  let(:html) do
+    render_inline(described_class.new(**params))
+  end
+
+  context 'with base params' do
+    it_behaves_like 'an application component' do
+      let(:expected_classes) { params[:classes] }
+      let(:expected_id) { params[:id] }
+    end
+
+    it { expect(html).to have_content(I18n.t('components.cms.audience.title')) }
+
+    context 'when audience is anyone' do
+      it 'summarises the audience' do
+        expect(html).to have_content('This page provides help for anyone using the Energy Sparks website')
+      end
+    end
+
+    context 'when audience is school users' do
+      let(:audience) { :school_users }
+
+      it 'summarises the audience' do
+        expect(html).to have_content('This page provides help for all registered school users')
+      end
+
+      it 'confirms the user' do
+        expect(html).to have_content('You are currently signed in as a School admin')
+      end
+
+      context 'with no user' do
+        let(:current_user) { nil }
+
+        it 'prompts to login' do
+          expect(html).to have_link('sign-in', href: new_user_session_path)
+        end
+      end
+    end
+
+    context 'when audience is school admins' do
+      let(:audience) { :school_admins }
+
+      it 'summarises the audience' do
+        expect(html).to have_content('This page provides help for School and Group admins')
+      end
+
+      context 'with only staff user' do
+        let(:current_user) { create(:staff) }
+
+        it 'says they wont have permission' do
+          expect(html).to have_content('This page provides help for School and Group admins')
+        end
+      end
+    end
+
+    context 'when audience is group admins' do
+      let(:audience) { :group_admins }
+
+      it 'summarises the audience' do
+        expect(html).to have_content('This page provides help for Group admins')
+      end
+    end
+  end
+end

--- a/spec/system/cms/pages_spec.rb
+++ b/spec/system/cms/pages_spec.rb
@@ -10,6 +10,12 @@ describe 'view pages and sections' do
       let(:model) { cms_page }
     end
 
+    it 'has an audience section' do
+      within('div.cms-audience-component') do
+        expect(page).to have_content(I18n.t('components.cms.audience.title'))
+      end
+    end
+
     it 'displays the expected sections', if: sections do
       visible_sections.each do |cms_section|
         expect(page).to have_css("section.cms-page-section##{cms_section.slug}")


### PR DESCRIPTION
Create a component for populating the Audience section on the support pages

- describe the intended audience
- confirm if user needs to sign in or their current role
- warn if they don't have permissions to do everything on the page

