### PR TITLE
Improve layout of page nav component with longer items

### DIFF
--- a/app/components/page_nav_component.rb
+++ b/app/components/page_nav_component.rb
@@ -47,7 +47,7 @@ class PageNavComponent < ViewComponent::Base
     end
 
     def link_text
-      helpers.text_with_icon(name, icon, class: 'fuel fa-fw') + content_tag(:span, helpers.toggler, class: 'float-right')
+      helpers.text_with_icon(content_tag(:span, name, class: 'nav-text'), icon, class: 'fuel fa-fw') + content_tag(:span, helpers.toggler, class: 'nav-toggle-icons')
     end
 
     def expanded?
@@ -74,8 +74,9 @@ class PageNavComponent < ViewComponent::Base
   class ItemComponent < ViewComponent::Base
     attr_reader :name, :href, :match_controller, :classes
 
-    def initialize(name:, href:, classes: nil, match_controller: false)
+    def initialize(name:, href:, note: nil, classes: nil, match_controller: false)
       @name = name
+      @note = note
       @href = href
       @match_controller = match_controller
       @classes = classes
@@ -93,7 +94,8 @@ class PageNavComponent < ViewComponent::Base
       args = { class: 'nav-link item' }
       args[:class] += " #{classes}" if classes
       args[:class] += ' current' if current_item?(href)
-      link_to(name, href, args)
+      note = @note.nil? ? '' : content_tag(:span, @note, class: 'nav-toggle-icons')
+      link_to(content_tag(:span, name, class: 'nav-text') + note, href, args)
     end
 
     def render?

--- a/app/components/page_nav_component/page_nav_component.scss
+++ b/app/components/page_nav_component/page_nav_component.scss
@@ -4,6 +4,8 @@
   }
 
   a.nav-link {
+    display: flex;
+    align-items: center;
     font-family: $header-font-family;
     color: $blue-very-dark;
     font-weight: $font-weight-semibold;
@@ -15,6 +17,14 @@
     &.current {
       font-weight: bold;
     }
+  }
+
+  a.nav-link i.fuel {
+    margin-right: 0.5em;
+  }
+
+  a.nav-link .nav-toggle-icons {
+    margin-left: auto; //pushes to the right by using up all remaining space as margin
   }
 
   li.section {

--- a/app/views/schools/advice/_nav.html.erb
+++ b/app/views/schools/advice/_nav.html.erb
@@ -3,13 +3,15 @@
                                 options: { match_controller: true }) do |c| %>
   <% c.with_section toggler: false, visible: school.latest_adult_dashboard_alert_count&.positive?,
                     options: { match_controller: false } do |s| %>
-    <% s.with_item(name: "#{t('advice_pages.index.alerts.title')} (#{school.latest_adult_dashboard_alert_count})",
+    <% s.with_item(name: t('advice_pages.index.alerts.title'),
+                   note: "(#{school.latest_adult_dashboard_alert_count})",
                    href: alerts_school_advice_path(school), classes: 'section-link') %>
   <% end %>
   <% c.with_section toggler: false,
                     visible: school.latest_management_priority_count&.positive?,
                     options: { match_controller: false }  do |s| %>
-    <% s.with_item(name: "#{t('advice_pages.index.priorities.title')} (#{school.latest_management_priority_count})",
+    <% s.with_item(name: t('advice_pages.index.priorities.title'),
+                   note: "(#{school.latest_management_priority_count})",
                    href: priorities_school_advice_path(school),
                    classes: 'section-link') %>
   <% end %>

--- a/spec/components/page_nav_component_spec.rb
+++ b/spec/components/page_nav_component_spec.rb
@@ -53,11 +53,13 @@ RSpec.describe PageNavComponent, type: :component do
       it { expect(list_item).to have_css('i.fa-bolt') }
       it { expect(list_item).to have_css('.bg-section') }
       it { expect(list_item).to have_css('.nav-link') }
+      it { expect(list_item).to have_css('.nav-text') }
       it { expect(list_item).to have_css('.toggler') }
+      it { expect(list_item).to have_css('.nav-toggle-icons') }
       it { expect(page_nav).to have_css('.page-nav-component') } # css based on this
     end
 
-    context 'with toggling for section' do
+    context 'without toggling for section' do
       let(:section_params) { { name: 'Section Name', toggler: false, visible: true, classes: 'bg-section' } }
 
       it { expect(list_item).not_to have_css('.toggler') }
@@ -100,8 +102,16 @@ RSpec.describe PageNavComponent, type: :component do
       subject(:list_item) { list_items[2] }
 
       it { expect(list_item).to have_css('.nav-link') }
+      it { expect(list_item).to have_css('.nav-text') }
       it { expect(list_item).to have_link('Item Name', href: '/schools/index') }
       it { expect(list_item).to have_css('.current') }
+
+      context 'with note on item' do
+        let(:item_params) { all_item_params.update(note: '(X)') }
+
+        it { expect(list_item).to have_css('.nav-toggle-icons') }
+        it { expect(list_item).to have_content('(X)') }
+      end
 
       context 'with match_controller set to false (default)' do
         let(:item_params) { all_item_params.update(href: '/schools/new')}

--- a/spec/system/schools/advice_pages/advice_page_index_spec.rb
+++ b/spec/system/schools/advice_pages/advice_page_index_spec.rb
@@ -169,13 +169,15 @@ RSpec.describe 'advice pages', :include_application_helper, type: :system do
       end
 
       it {
-        expect(page).to have_link("#{I18n.t('advice_pages.index.alerts.title')} (2)",
-                                     href: alerts_school_advice_path(school))
+        expect(page).to have_link(I18n.t('advice_pages.index.alerts.title'),
+                                  href: alerts_school_advice_path(school))
       }
+
+      it { expect(page).to have_content('(2)') }
 
       context 'it shows the alerts' do
         before do
-          click_on "#{I18n.t('advice_pages.index.alerts.title')} (2)"
+          click_on I18n.t('advice_pages.index.alerts.title')
         end
 
         it 'displays the alert group' do
@@ -196,13 +198,15 @@ RSpec.describe 'advice pages', :include_application_helper, type: :system do
       end
 
       it {
-        expect(page).to have_link("#{I18n.t('advice_pages.index.priorities.title')} (2)",
-                                     href: priorities_school_advice_path(school))
+        expect(page).to have_link(I18n.t('advice_pages.index.priorities.title'),
+                                  href: priorities_school_advice_path(school))
       }
+
+      it { expect(page).to have_content('(2)') }
 
       context 'it shows the priorities' do
         before do
-          click_on "#{I18n.t('advice_pages.index.priorities.title')} (2)"
+          click_on I18n.t('advice_pages.index.priorities.title')
         end
 
         it 'displays English alert text' do


### PR DESCRIPTION
The PageNavComponent has some styling issues:

<img width="338" height="92" alt="Screenshot from 2025-07-31 10-17-42" src="https://github.com/user-attachments/assets/f87e2c15-5961-4af8-a806-372216ab5fa0" />
<img width="237" height="90" alt="Screenshot from 2025-07-31 10-18-13" src="https://github.com/user-attachments/assets/edae7a98-833e-4b93-b4c4-766e80fafa44" />

Fix the styling by refactoring the HTML slightly to add spans for labels and toggle icons and then use flex box to layout the content.

Also updated the component so that items can have a "note" which will allow some text to be put into the same location as the toggle icons. Switched the advice navbar to use this so that the recent alert and opportunities counts are laid out better.

<img width="318" height="281" alt="Screenshot from 2025-07-31 11-48-42" src="https://github.com/user-attachments/assets/624fc661-1c0f-42ea-92f2-4ac06f75b00b" />
<img width="233" height="447" alt="Screenshot from 2025-07-31 11-49-15" src="https://github.com/user-attachments/assets/1e38eaef-065a-480b-b3c0-1294fb58c6bf" />

