### PR TITLE
Remove old links to teachers and pupils pages

### DIFF
--- a/app/views/activity_categories/index.html.erb
+++ b/app/views/activity_categories/index.html.erb
@@ -12,8 +12,7 @@
 
 <div class="row">
   <div class="col-sm-6">
-    <p><%= t('activity_categories.introduction_1_html', for_teachers_path: for_teachers_path,
-                                                        for_pupils_path: for_pupils_path) %></p>
+    <p><%= t('activity_categories.introduction_1_html') %></p>
     <p><%= t('activity_categories.introduction_2_html', count: @activity_count) %></p>
   </div>
   <div class="col-sm-6">

--- a/app/views/home/contact.html.erb
+++ b/app/views/home/contact.html.erb
@@ -42,7 +42,7 @@
     <div class="col-md-8">
       <p><%= t('contact.further_information.in_the_meantime') %>:</p>
       <ul>
-        <li><%= t('contact.further_information.read_html', for_teachers_path: for_teachers_path) %></li>
+        <li><%= t('contact.further_information.read_html', product_path: product_path) %></li>
         <li><%= t('contact.further_information.learn_html', enrol_path: enrol_path) %></li>
         <li><%= t('contact.further_information.discover_html', datasets_path: datasets_path) %></li>
       </ul>

--- a/config/locales/cy/views/activity_categories/activity_categories.yml
+++ b/config/locales/cy/views/activity_categories/activity_categories.yml
@@ -1,6 +1,6 @@
 cy:
   activity_categories:
-    introduction_1_html: Mae Sbarcynni yn darparu cefnogaeth helaeth i <a href='%{for_teachers_path}'>athrawon</a> a <a href='%{for_pupils_path}'>disgyblion</a> wrth ddysgu am ynni a newid hinsawdd o fewn cyd-destun eich ysgol eich hun.
+    introduction_1_html: Mae Sbarcynni yn darparu cefnogaeth helaeth i athrawon a disgyblion wrth ddysgu am ynni a newid hinsawdd o fewn cyd-destun eich ysgol eich hun.
     introduction_2_html:
       one: Defnyddiwch y dolenni isod i archwilio <strong>%{count}</strong> gweithgaredd sydd ar gael yn rhwydd.
       two: Defnyddiwch y dolenni isod i archwilio <strong>%{count}</strong> o weithgareddau sydd ar gael yn rhwydd.

--- a/config/locales/cy/views/home/contact.yml
+++ b/config/locales/cy/views/home/contact.yml
@@ -4,7 +4,7 @@ cy:
       discover_html: Darganfod pa <a href='%{datasets_path}'>ddata agored</a> rydym yn eu defnyddio yn y gwasanaeth
       in_the_meantime: Yn y cyfamser gallwch
       learn_html: Dysgu sut i <a href='%{enrol_path}'>gofrestru eich ysgol</a>
-      read_html: Darllen <a href='%{for_teachers_path}'>am Sbarcynni</a> a nodau'r prosiect
+      read_html: Darllen <a href='%{product_path}'>am Sbarcynni</a> a nodau'r prosiect
       title: Gwybodaeth Bellach
     problem_reporting:
       content_1: Os ydych yn adrodd am broblem gyda'r gwasanaeth, ceisiwch gynnwys cymaint o fanylion â phosib yn eich e-bost, gan gynnwys pa borwr gwe a system weithredu rydych yn ei ddefnyddio, URL (cyfeiriad) y dudalen a phryd y cawsoch y broblem

--- a/config/locales/views/activity_categories/activity_categories.yml
+++ b/config/locales/views/activity_categories/activity_categories.yml
@@ -1,7 +1,7 @@
 ---
 en:
   activity_categories:
-    introduction_1_html: Energy Sparks provides extensive support to <a href='%{for_teachers_path}'>teachers</a> and <a href='%{for_pupils_path}'>pupils</a> when learning about energy and climate change within the context of your own school.
+    introduction_1_html: Energy Sparks provides extensive support to teachers and pupils when learning about energy and climate change within the context of your own school.
     introduction_2_html:
       one: Use the links below to explore <strong>%{count}</strong> freely available activity.
       other: Use the links below to explore <strong>%{count}</strong> freely available activities.

--- a/config/locales/views/home/contact.yml
+++ b/config/locales/views/home/contact.yml
@@ -5,7 +5,7 @@ en:
       discover_html: Discover what <a href='%{datasets_path}'>open data</a> we use in the service
       in_the_meantime: In the meantime you can
       learn_html: Learn how to <a href='%{enrol_path}'>enrol your school</a>
-      read_html: Read <a href='%{for_teachers_path}'>about Energy Sparks</a> and the goals of the project
+      read_html: Read <a href='%{product_path}'>about Energy Sparks</a> and the goals of the project
       title: Further Information
     problem_reporting:
       content_1: If you are reporting a problem with the service, please try to include as much detail in your email as possible, including which web browser and operating system you are using, the URL (address) of the page and when you experienced the problem

--- a/config/sitemap.rb
+++ b/config/sitemap.rb
@@ -7,10 +7,6 @@ if ENV.key?('GENERATE_SITEMAP')
     # Home controller stuff
     add root_path
 
-    add for_teachers_path
-    add for_pupils_path
-    add for_management_path
-    add for_teachers_path
     add home_page_path
     add contact_path
     add enrol_path


### PR DESCRIPTION
Removed some links to old pages on the activity categories and contact page. Both pages need a redesign so for now I've just removed the old links.