### PR TITLE
Exclude capital investment opportunities in data enabled email

### DIFF
--- a/app/mailers/onboarding_mailer2025.rb
+++ b/app/mailers/onboarding_mailer2025.rb
@@ -16,7 +16,7 @@ class OnboardingMailer2025 < OnboardingMailer
     @title = @school.name
     @user = params[:user]
     management_priorities = @school.latest_management_priorities(exclude_capital: true)
-    @top_priority = Schools::Priorities.by_average_one_year_saving(management_priorities).first
+    @top_priority = Schools::Priorities.by_energy_saving(management_priorities).first
     make_bootstrap_mail(to: @user.email, subject: default_i18n_subject(school: @school.name, locale: locale_param))
   end
 
@@ -25,7 +25,8 @@ class OnboardingMailer2025 < OnboardingMailer
     @school = params[:school]
     @users = params[:users]
     @staff = params[:staff]
-    @top_priority = Schools::Priorities.by_average_one_year_saving(@school.latest_management_priorities).first
+    management_priorities = @school.latest_management_priorities(exclude_capital: true)
+    @top_priority = Schools::Priorities.by_energy_saving(management_priorities).first
     super
   end
 end

--- a/app/mailers/onboarding_mailer2025.rb
+++ b/app/mailers/onboarding_mailer2025.rb
@@ -15,7 +15,8 @@ class OnboardingMailer2025 < OnboardingMailer
     @school = params[:school]
     @title = @school.name
     @user = params[:user]
-    @top_priority = Schools::Priorities.by_average_one_year_saving(@school.latest_management_priorities).first
+    management_priorities = @school.latest_management_priorities(exclude_capital: true)
+    @top_priority = Schools::Priorities.by_average_one_year_saving(management_priorities).first
     make_bootstrap_mail(to: @user.email, subject: default_i18n_subject(school: @school.name, locale: locale_param))
   end
 

--- a/app/models/management_priority.rb
+++ b/app/models/management_priority.rb
@@ -35,6 +35,10 @@ class ManagementPriority < ApplicationRecord
   validates :priority, numericality: true
 
   scope :by_priority, -> { order(priority: :desc) }
+  # priorities that don't involve capital investment
+  scope :without_investment, -> do
+    joins(:alert, alert: :alert_type).where.not(alert_type: { class_name: ['AlertSolarPVBenefitEstimator', 'AlertHotWaterInsulationAdvice'] })
+  end
 
   # Returns an Array of OpenStruct
   def self.for_schools(schools)

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -551,7 +551,9 @@ class School < ApplicationRecord
 
   def latest_management_priorities(exclude_capital: false)
     if latest_content
-      exclude_capital ? latest_content.management_priorities.without_investment : latest_content.management_priorities
+      priorities = latest_content.management_priorities
+      priorities = priorities.without_investment if exclude_capital
+      priorities
     else
       ManagementPriority.none
     end

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -549,9 +549,9 @@ class School < ApplicationRecord
     @latest_management_priority_count ||= latest_management_priorities.count
   end
 
-  def latest_management_priorities
+  def latest_management_priorities(exclude_capital: false)
     if latest_content
-      latest_content.management_priorities
+      exclude_capital ? latest_content.management_priorities.without_investment : latest_content.management_priorities
     else
       ManagementPriority.none
     end

--- a/app/services/schools/priorities.rb
+++ b/app/services/schools/priorities.rb
@@ -30,6 +30,12 @@ module Schools
       end.reverse
     end
 
+    def self.by_energy_saving(priorities)
+      interpolate(priorities).sort_by do |priority|
+        priority.template_variables[:one_year_saving_kwh]
+      end
+    end
+
     private_class_method def self.money_to_i(val)
       val.gsub(/\D/, '').to_i
     end


### PR DESCRIPTION
Two of the management opportunities we might recommend to schools involve some capital investment: installing solar and lagging hot water pipes. Exclude these from the data enabled emails as we want them to focus on quick wins from behaviour change.

Also sort the opportunities presented here based on kWh reduction not cost, so they can see the biggest energy efficiency and carbon saving.