### PR TITLE
Add task to download Get Information about Schools data

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -132,6 +132,7 @@ group :development, :test do
   gem 'guard-rspec', require: false
   gem 'guard-rubocop', require: false
   gem 'knapsack'
+  gem 'mechanize' # For GIAS data downloader
   gem 'rails-controller-testing'
   gem 'rspec-json_expectations'
   gem 'rspec-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -462,6 +462,19 @@ GEM
       rest-client (>= 1.6.7)
     marcel (1.0.4)
     matrix (0.4.2)
+    mechanize (2.14.0)
+      addressable (~> 2.8)
+      base64
+      domain_name (~> 0.5, >= 0.5.20190701)
+      http-cookie (~> 1.0, >= 1.0.3)
+      mime-types (~> 3.3)
+      net-http-digest_auth (~> 1.4, >= 1.4.1)
+      net-http-persistent (>= 2.5.2, < 5.0.dev)
+      nkf
+      nokogiri (~> 1.11, >= 1.11.2)
+      rubyntlm (~> 0.6, >= 0.6.3)
+      webrick (~> 1.7)
+      webrobots (~> 0.1.2)
     memory_profiler (1.1.0)
     method_source (1.1.0)
     mime-types (3.6.2)
@@ -492,6 +505,9 @@ GEM
     nenv (0.3.0)
     net-http (0.6.0)
       uri
+    net-http-digest_auth (1.4.1)
+    net-http-persistent (4.0.6)
+      connection_pool (~> 2.2, >= 2.2.4)
     net-imap (0.5.6)
       date
       net-protocol
@@ -734,6 +750,8 @@ GEM
     ruby_parser (3.21.1)
       racc (~> 1.5)
       sexp_processor (~> 4.16)
+    rubyntlm (0.6.5)
+      base64
     rubyvis (0.7.0)
     rubyzip (2.4.1)
     sanitize (7.0.0)
@@ -851,6 +869,8 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
+    webrick (1.9.1)
+    webrobots (0.1.2)
     websocket (1.2.11)
     websocket-driver (0.7.7)
       base64
@@ -930,6 +950,7 @@ DEPENDENCIES
   lograge
   lookbook
   mailgun_rails
+  mechanize
   mobility (~> 1.3.2)
   mobility-actiontext (~> 1.1.1)
   momentjs-rails

--- a/lib/tasks/schools/download_gias_data.rake
+++ b/lib/tasks/schools/download_gias_data.rake
@@ -17,7 +17,7 @@ namespace :school do
 
       # After being redirected, auto refresh on an interval until the download form appears
       puts 'Submitted form, waiting for download'
-      get_download agent
+      get_download(agent, args)
     rescue => e
       warn e
       EnergySparks::Log.exception(e, {})
@@ -25,7 +25,7 @@ namespace :school do
   end
 end
 
-def get_download(agent)
+def get_download(agent, args)
   attempt = 0
   loop do
     sleep 3

--- a/lib/tasks/schools/download_gias_data.rake
+++ b/lib/tasks/schools/download_gias_data.rake
@@ -2,7 +2,7 @@ namespace :school do
   desc 'Download establishment data from get-information-schools.service.gov.uk'
   task :download_gias_data, [:refresh_attempts, :path] => :environment do |_t, args|
     begin
-      args.with_defaults(:refresh_attempts => 5, :path => 'tmp/gias_download.zip')
+      args.with_defaults(refresh_attempts: 5, path: 'tmp/gias_download.zip')
 
       agent = Mechanize.new
       agent.request_headers = { 'User-agent' => 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36 Edg/138.0.0.0' } # page returns a 403 error if the agent doesn't have a user agent header
@@ -10,10 +10,10 @@ namespace :school do
       url = 'http://get-information-schools.service.gov.uk/Downloads'
       puts "Getting page from #{url}"
       agent.get(url)
-      form = agent.page.form_with(:action => '/Downloads/Collate')
-      form.checkboxes_with(:id => 'establishment-fields-csv-checkbox').first.checked = true
-      form.checkboxes_with(:id => 'establishment-links-csv-checkbox').first.checked = true
-      form.click_button(form.buttons_with(:id => 'download-selected-files-button').first)
+      form = agent.page.form_with(action: '/Downloads/Collate')
+      form.checkboxes_with(id: 'establishment-fields-csv-checkbox').first.checked = true
+      form.checkboxes_with(id: 'establishment-links-csv-checkbox').first.checked = true
+      form.click_button(form.buttons_with(id: 'download-selected-files-button').first)
 
       # After being redirected, auto refresh on an interval until the download form appears
       puts 'Submitted form, waiting for download'
@@ -30,9 +30,9 @@ def get_download(agent, args)
   loop do
     sleep 3
     puts 'Refreshing...'
-    form = agent.get(agent.page.uri).form_with(:action => '/Downloads/Download/Extract')
+    form = agent.get(agent.page.uri).form_with(action: '/Downloads/Download/Extract')
     if form != nil
-      file = form.click_button(form.buttons_with(:id => 'download-button').first)
+      file = form.click_button(form.buttons_with(id: 'download-button').first)
       file.save!(args[:path])
       puts "Successfully saved at #{args[:path]}"
       break

--- a/lib/tasks/schools/download_gias_data.rake
+++ b/lib/tasks/schools/download_gias_data.rake
@@ -1,0 +1,46 @@
+namespace :school do
+  desc 'Download establishment data from get-information-schools.service.gov.uk'
+  task :download_gias_data, [:refresh_attempts, :path] => :environment do |_t, args|
+    begin
+      args.with_defaults(:refresh_attempts => 5, :path => 'tmp/gias_download.zip')
+
+      agent = Mechanize.new
+      agent.request_headers = { 'User-agent' => 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36 Edg/138.0.0.0' } # page returns a 403 error if the agent doesn't have a user agent header
+
+      url = 'http://get-information-schools.service.gov.uk/Downloads'
+      puts "Getting page from #{url}"
+      agent.get(url)
+      form = agent.page.form_with(:action => '/Downloads/Collate')
+      form.checkboxes_with(:id => 'establishment-fields-csv-checkbox').first.checked = true
+      form.checkboxes_with(:id => 'establishment-links-csv-checkbox').first.checked = true
+      form.click_button(form.buttons_with(:id => 'download-selected-files-button').first)
+
+      # After being redirected, auto refresh on an interval until the download form appears
+      puts 'Submitted form, waiting for download'
+      get_download agent
+    rescue => e
+      warn e
+      EnergySparks::Log.exception(e, {})
+    end
+  end
+end
+
+def get_download(agent)
+  attempt = 0
+  loop do
+    sleep 3
+    puts 'Refreshing...'
+    form = agent.get(agent.page.uri).form_with(:action => '/Downloads/Download/Extract')
+    if form != nil
+      file = form.click_button(form.buttons_with(:id => 'download-button').first)
+      file.save!(args[:path])
+      puts "Successfully saved at #{args[:path]}"
+      break
+    end
+    attempt += 1
+    if attempt == args[:refresh_attempts].to_i
+      warn "Timed out after #{args[:refresh_attempts]} attempts"
+      break
+    end
+  end
+end


### PR DESCRIPTION
Add a Rake task (`school:download_gias_data`) to download data from gov.uk.

Downloads "establishment fields" and "establishment links" from https://get-information-schools.service.gov.uk/Downloads.

<img width="686" height="148" alt="image" src="https://github.com/user-attachments/assets/1aecaab4-303e-4c73-8c00-963cb16444c2" />
