### PR TITLE
Create components for group dashboard insights

### DIFF
--- a/app/components/dashboards/group_insights_component.rb
+++ b/app/components/dashboards/group_insights_component.rb
@@ -1,0 +1,11 @@
+module Dashboards
+  class GroupInsightsComponent < ApplicationComponent
+    attr_reader :school_group, :user
+
+    def initialize(school_group:, user:, **kwargs)
+      super
+      @school_group = school_group
+      @user = user
+    end
+  end
+end

--- a/app/components/dashboards/group_insights_component/group_insights_component.html.erb
+++ b/app/components/dashboards/group_insights_component/group_insights_component.html.erb
@@ -1,0 +1,18 @@
+<%= tag.div id: id, class: classes do %>
+  <div class="row">
+    <div class="col-12">
+      <h2 id="<%= id %>" class="scrollable-title"><%= t('components.dashboard_insights.title') %></h2>
+    </div>
+  </div>
+
+  <div class="row">
+    <%# split to 2 column view on larger screens if we are displaying alerts %>
+    <div class="col-12 col-lg-6">
+      <h3><%= t('components.dashboard_insights.reminders.title') %></h3>
+    </div>
+
+    <div class="col-12 col-lg-6">
+      <h3><%= t('advice_pages.index.alerts.title') %></h3>
+    </div>
+  </div>
+<% end %>

--- a/spec/components/dashboards/group_insights_component_spec.rb
+++ b/spec/components/dashboards/group_insights_component_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe GroupInsightsComponent, :include_application_helper, :include_url_helpers, type: :component do
+  it 'tests the functionality'
+end

--- a/spec/components/previews/dashboards/group_insights_component_preview.rb
+++ b/spec/components/previews/dashboards/group_insights_component_preview.rb
@@ -1,0 +1,18 @@
+module Dashboards
+  class GroupInsightsComponentPreview < ViewComponent::Preview
+    def example(slug: nil)
+      school_group = slug ? SchoolGroup.find(slug) : SchoolGroup.with_active_schools.sample
+      user = User.group_admin.last
+      component = Dashboards::GroupInsightsComponent.new(school_group: school_group, user: user)
+      render(component)
+    end
+
+    private
+
+    def group_options
+      {
+        choices: SchoolGroup.with_active_schools.by_name.map { |g| [g.name, g.slug] }
+      }
+    end
+  end
+end


### PR DESCRIPTION

Reminders
- [ ] The group dashboard message added by us
- [ ] X schools in this group are still onboarding (there will be a new page for group admins to review in progress onboarding), or not yet started
- [ ] X schools in the group are not fully setup, e.g. are missing school admins
- [ ] Reminder about engagement if none or low % of schools in group are engaging
- [ ] Reminder to add clusters if they've not already
- [ ] Reminder for a logged in group admin to join training if they've recently registered
- [ ] Reminder to add/update group tariffs
- [ ] schools that don't have alerts?
- [ ] schools where there have been large increases / reductions in gas or electricity usage in comparison with the previous week
- [ ] schools with large increases / reductions in their baseload
 
Alerts
- [ ] The standard "Impending holiday" alert, based on the group calendar if they have one
- [ ] Their custom report is ready to review
- [ ] Prompt to review the gas and electricity use in last holiday comparison reports once a holiday is over
- [ ] Alert that X schools have changed classification, e.g. X schools are now Well Managed for baseload, Y schools are now Exemplar.
- [ ] X schools currently have an alert about baseload increases, etc. So just flagging up which alerts are being shown across schools in the group
