### PR TITLE
Fix bar chart labels

### DIFF
--- a/app/assets/javascripts/common_chart_options.js.erb
+++ b/app/assets/javascripts/common_chart_options.js.erb
@@ -156,8 +156,8 @@ function barColumnLine(chartData, highchartsChart, seriesData, chartConfig, $cha
     }
 
     highchartsChart.update({
-      chart: { inverted: true, marginLeft: 200, marginRight: 100 },
-      xAxis: [{ labels: { reserveSpace: true, align: 'left', style: { textOverflow: 'none' } } }],
+      chart: { inverted: true, marginRight: 100 },
+      xAxis: [{ labels: { reserveSpace: true, align: 'right' } }],
       yAxis: [{ reversedStacks: false, stackLabels: { style: { fontWeight: 'bold',  color: '<%= Colours.chart_dark_blue %>' } } }],
       plotOptions: { bar: { tooltip: { headerFormat: '<b>{series.name}</b><br>', pointFormat: orderedPointFormat(yAxisLabel) } } }
     });

--- a/app/components/charts/group_dashboard_charts_component/group_dashboard_charts_component.html.erb
+++ b/app/components/charts/group_dashboard_charts_component/group_dashboard_charts_component.html.erb
@@ -33,7 +33,9 @@
              aria-labelledby="<%= report.key %>-tab">
 
              <div id="chart_wrapper_<%= report.key %>" class="chart-wrapper">
-               <div id="<%= report.key %>-chart" class="analysis-chart tabbed <%= report.key %>-analysis-chart"
+               <div id="<%= report.key %>-chart"
+                    style="height: <%= [18 * school_group.visible_schools_count, 700].max %>px;"
+                    class="analysis-chart tabbed <%= report.key %>-analysis-chart"
                     data-autoload-chart="<%= index.zero? %>"
                     data-chart-config="<%= chart_config_json(report) %>">
                </div>


### PR DESCRIPTION
A better fix for labelling issues on comparison charts where there are a lot of long school names.

Current:

<img width="741" height="609" alt="Screenshot from 2025-08-22 19-25-44" src="https://github.com/user-attachments/assets/e833af89-b992-4be4-8db1-cf68f3c8c22e" />

Fixed;

<img width="741" height="609" alt="Screenshot from 2025-08-22 19-25-55" src="https://github.com/user-attachments/assets/75dcb245-eb73-4285-b75d-c01294380eb9" />

Just removes the hard-coded left margin on the bar charts which was stopping `reserveSpace` from working correctly. Have checked other charts and there's no other side-effects so safe to go with this I think.

I reverted to a right aligment to help with readability. I'd tried left alignment previous to allow space for wrapping, but that's no longer needed.

I've added a bit of extra height to increase spacing, but not sure it's adding much value here. Goal is to have these charts be readable but not too high on the group dashboards.