### PR TITLE
Sort out the priority numbering for case studies

### DIFF
--- a/app/views/admin/case_studies/_form.html.erb
+++ b/app/views/admin/case_studies/_form.html.erb
@@ -16,6 +16,7 @@
             <%= f.rich_text_area t_field(:description, locale), label: CaseStudy.human_attribute_name(:description) %>
           </div>
         <% end %>
+        <%= f.input :position %>
       </div>
       <div class="col-6">
         <div class='pb-3'>

--- a/app/views/case_studies/index.html.erb
+++ b/app/views/case_studies/index.html.erb
@@ -30,7 +30,7 @@
               end %>
           <%= card.with_feature_card(
                 theme: :light, size: :sm,
-                classes: "p-4 rounded-xl #{'rounded-top-xl' unless case_study.image.attached? && @show_images}"
+                classes: "p-4 rounded-bottom-xl #{'rounded-top-xl' unless case_study.image.attached? && @show_images}"
               ) do |feature| %>
             <% case_study.tag_list.each do |tag| %>
               <%= feature.with_tag(tag) %>

--- a/spec/system/admin/case_studies_spec.rb
+++ b/spec/system/admin/case_studies_spec.rb
@@ -132,14 +132,15 @@ RSpec.describe 'Admin case studies', type: :system do
             attach_file 'Image', Rails.root.join('spec/fixtures/images/boiler.jpg')
             attach_file(:case_study_file_en, Rails.root.join('spec/fixtures/documents/fake-bill.pdf'))
             fill_in :case_study_tags_en, with: 'en1, en2'
+            fill_in 'Position', with: 3
             uncheck :case_study_published
-
             click_on 'Save'
           end
 
           it { expect(page).to have_content('Updated title') }
           it { expect(page).to have_content('Updated description') }
           it { expect(page).to have_content('en1 en2') }
+          it { expect(page).to have_content('3') }
           it { expect(page).to have_content('Case study was successfully updated.') }
 
           it 'resizes images to 1400px width max' do
@@ -182,8 +183,8 @@ RSpec.describe 'Admin case studies', type: :system do
             attach_file 'Image', Rails.root.join('spec/fixtures/images/boiler.jpg')
             attach_file(:case_study_file_en, Rails.root.join('spec/fixtures/documents/fake-bill.pdf'))
             fill_in :case_study_tags_en, with: 'new, example'
+            fill_in 'Position', with: 7
             check :case_study_published
-
             click_on 'Save'
           end
 
@@ -194,6 +195,7 @@ RSpec.describe 'Admin case studies', type: :system do
           it { expect(page).to have_content('New Case Study Title') }
           it { expect(page).to have_content('This is a new case study description.') }
           it { expect(page).to have_content('new example') }
+          it { expect(page).to have_content('7') }
           it { expect(page).to have_content('Case study was successfully created.') }
 
           it 'resizes images to 1400px width max' do


### PR DESCRIPTION
* Adds missing position field to case studies admin interface
* Also sorts out the rounding used for the text portion of a case study on the case studies index. Not sure what happened there as I'm sure it was right. It is currently like this on production:
<img width="459" height="309" alt="image" src="https://github.com/user-attachments/assets/71698ffa-6002-4eb4-8ae3-12875422c492" />
