### PR TITLE
Selectable Charts

### DIFF
--- a/app/assets/javascripts/select.js
+++ b/app/assets/javascripts/select.js
@@ -2,6 +2,8 @@
 
 $(document).ready(function() {
 
+  $.fn.select2.defaults.set("sorter", function(datas) { return datas.filter((data) => !data.element.hidden); });
+
   $('select.form-control.select2').select2({theme: 'bootstrap'});
 
   // Switch on select2 after cocoon insert. Needed for todos

--- a/app/assets/javascripts/usage_charts.js
+++ b/app/assets/javascripts/usage_charts.js
@@ -5,7 +5,6 @@ $(document).ready(function() {
   //they should have already made any changes to the form we're using, so this just updates
   //the explanation and then triggers the data load
   function updateChart(chartDiv) {
-
     var chartContainer = $(chartDiv).find('.usage-chart').first();
     var chartConfig = chartContainer.data('chart-config');
 
@@ -20,6 +19,16 @@ $(document).ready(function() {
         // will either be name of a sub meter type or undefined
         chartConfig.sub_meter = definitions[1];
       }
+    }
+
+    const chart_type = $(chartDiv).find("select[name='chart_selection_chart_type']").val();
+    if (chart_type) {
+      chartConfig.type = chart_type;
+    }
+
+    const school_id = $(chartDiv).find("select[name='chart_selection_school_id']").val();
+    if (school_id) {
+      chartConfig.jsonUrl = `/schools/${school_id}/chart.json`;
     }
 
     updateMeterSpecificChartState(chartDiv, chartConfig);
@@ -112,6 +121,29 @@ $(document).ready(function() {
     });
   }
 
+  function setSelectorState(fuel_type, chartDiv) {
+    const chartSelector = chartDiv.find("select[name='chart_selection_chart_type']").first();
+    const chartOptions = chartSelector.find("option");
+
+    var firstOption = null;
+    $(chartOptions).each(function(index, option) {
+      option_fuel_type = $(option).data('fuel_type');
+      if (option_fuel_type == fuel_type) {
+        if (firstOption == null) {
+          firstOption = $(option).val();
+        }
+        option.disabled = false;
+        option.hidden = false;
+      } else {
+        option.disabled = true;
+        option.hidden = true;
+      }
+    });
+
+    chartSelector.val(firstOption);
+    chartSelector.select2({theme: 'bootstrap'});
+  }
+
   function initChart(chartDiv) {
 
     var supply = $(chartDiv).find("input[name='supply']").val();
@@ -148,7 +180,7 @@ $(document).ready(function() {
     var chartConfig = chartContainer.data('chart-config');
     setupAxisControls(chartContainer[0], chartConfig);
     setupAnalysisControls(chartContainer[0], chartConfig);
-
+    setSelectorState('electricity', $(chartDiv)); // FIXME select first option in fuel type options
     updateChart(chartDiv);
   }
 
@@ -162,6 +194,18 @@ $(document).ready(function() {
   $(document).on('change', "select[name='meter']", function() {
     logEvent('meter', '');
     updateChart($(this).closest('.charts'));
+  });
+
+  $(document).on('change', "select[name='chart_selection_school_id'], select[name='chart_selection_chart_type']", function() {
+    const chartDiv = $(this).closest('.charts');
+    updateChart(chartDiv);
+  });
+
+  $(document).on('change', "input[name='chart_selection_fuel_type']", function() {
+    const fuel_type = $(this).data('fuel_type');
+    const chartDiv = $(this).closest('.charts');
+    setSelectorState(fuel_type, chartDiv);
+    updateChart(chartDiv);
   });
 
 });

--- a/app/components/charts/selectable_school_charts_component.rb
+++ b/app/components/charts/selectable_school_charts_component.rb
@@ -1,0 +1,18 @@
+module Charts
+  # A list of schools that can be seen by user
+  # A list of possible charts
+  #
+  # Filtering if fuel_type doesn't apply?, e.g. no storage heater charts
+  # Grouping based on categories of school, e.g. High baseload
+  # How to supply title/subtitle translation keys and parameters
+  class SelectableSchoolChartsComponent < ApplicationComponent
+    attr_reader :schools, :charts
+
+    def initialize(schools:, charts:, fuel_types:, **_kwargs)
+      super
+      @schools = schools
+      @charts = charts
+      @fuel_types = fuel_types
+    end
+  end
+end

--- a/app/components/charts/selectable_school_charts_component/selectable_school_charts_component.html.erb
+++ b/app/components/charts/selectable_school_charts_component/selectable_school_charts_component.html.erb
@@ -1,0 +1,79 @@
+<div class="row">
+  <div class="col">
+    <div class="charts">
+    <%= render ChartComponent.new chart_type: :management_dashboard_group_by_week_electricity,
+                                  axis_controls: true,
+                                  analysis_controls: true,
+                                  html_class: 'usage-chart',
+                                  school: @schools.first do |c| %>
+      <% c.with_header do %>
+        <%= form_tag '', method: 'GET', id: 'chart-filter', class: 'form' do |f| %>
+          <%= hidden_field_tag :configuration,
+                               nil,
+                               data: {
+                                 configuration:
+                                  helpers.create_chart_config(@schools.first,
+                                                              :management_dashboard_group_by_week_electricity)
+                               } %>
+
+          <div class="form-row">
+            <div class="form-group col-md-12">
+              <span class="text-align-center mr-1">
+                <%= t('components.selectable_school_charts_component.chart_selection_fuel_type') %>
+              </span>
+              <% @fuel_types.each_with_index do |fuel_type, index| %>
+                <div class="custom-control custom-radio custom-control-inline">
+                  <input type="radio"
+                         name="chart_selection_fuel_type"
+                         id="chart_selection_fuel_type-<%= fuel_type %>"
+                         data-fuel_type="<%= fuel_type %>"
+                         class="custom-control-input"
+                         <%= 'checked' if index.zero? %>>
+                  <label class="custom-control-label"
+                         for="chart_selection_fuel_type-<%= fuel_type %>"
+                         data-toggle="tooltip"
+                         data-placement="top"
+                         title="Change fuel type to <%= fuel_type %>">
+                         <%= t(fuel_type, scope: 'common') %>
+                  </label>
+                </div>
+              <% end %>
+            </div>
+          </div>
+          <div class="form-row">
+            <div class="form-group col-md-12">
+              <%= label_tag :chart_selection_chart_type,
+                            t('components.selectable_school_charts_component.chart_selection_chart_type') %>
+
+              <select id="chart_selection_chart_type" name="chart_selection_chart_type" class='form-control select2'>
+                <% @charts.each do |fuel_type, chart_config| %>
+                  <% next unless @fuel_types.include?(fuel_type) %>
+                  <% chart_config.each do |chart_type, config| %>
+                    <option value="<%= chart_type %>"
+                            data-fuel_type="<%= fuel_type %>"
+                            <%= 'disabled hidden' unless fuel_type == :electricity %>>
+                            <%= config[:label] %>
+                    </option>
+                  <% end %>
+                <% end %>
+              </select>
+            </div>
+          </div>
+
+          <div class="form-row">
+            <div class="form-group col-md-12">
+              <%= label_tag :chart_selection_school_id,
+                            t('components.selectable_school_charts_component.chart_selection_school_id') %>
+              <%= select_tag :chart_selection_school_id,
+                             options_from_collection_for_select(@schools, :slug, :name, @schools.first.slug),
+                             include_blank: false,
+                             class: 'form-control select2' %>
+            </div>
+          </div>
+
+        <% end %>
+      <% end %>
+    <% end %>
+    </div>
+  </div>
+</div>

--- a/app/services/aggregation/validate_amr_data.rb
+++ b/app/services/aggregation/validate_amr_data.rb
@@ -39,6 +39,8 @@ module Aggregation
       logger.debug "Meter data from #{@meter.amr_data.start_date} to #{@meter.amr_data.end_date}"
       logger.debug "DCC Meter #{@meter.dcc_meter}"
 
+      binding.irb if @meter.meter_type == :gas
+
       if debug_analysis
         assess_null_data # does nothing, count not used?
         Rails.logger.debug { "Before validation #{missing_data} missing items of data" }

--- a/config/locales/views/components/charts/selectable_school_charts_component.yml
+++ b/config/locales/views/components/charts/selectable_school_charts_component.yml
@@ -1,0 +1,7 @@
+---
+en:
+  components:
+    selectable_school_charts_component:
+      chart_selection_chart_type: Choose chart
+      chart_selection_fuel_type: Change fuel type
+      chart_selection_school_id: Choose school

--- a/spec/components/previews/charts/selectable_school_charts_component_preview.rb
+++ b/spec/components/previews/charts/selectable_school_charts_component_preview.rb
@@ -1,0 +1,57 @@
+module Charts
+  class SelectableSchoolChartsComponentPreview < ViewComponent::Preview
+    def example
+      schools = School.data_enabled.by_name
+
+      safe_charts = {
+        electricity: {
+          baseload: {
+            label: 'Baseload'
+          },
+          baseload_lastyear: {
+            label: 'Baseload last year'
+          },
+          baseload_versus_benchmarks: {
+            label: 'Baseload vs benchmarks'
+          },
+          management_dashboard_group_by_week_electricity: {
+            label: 'Group by week electricity'
+          },
+          group_by_week_electricity_meter_breakdown_one_year: {
+            label: 'Group by week electricity, meter breakdown'
+          },
+          daytype_breakdown_electricity_tolerant: {
+            label: 'Electricity use out of hours'
+          },
+          electricity_by_day_of_week_tolerant: {
+            label: 'Out of hours electricity use by day of week'
+          }
+        },
+        gas: {
+          management_dashboard_group_by_week_gas: {
+            label: 'Group by week gas'
+          },
+          group_by_week_gas_meter_breakdown_one_year: {
+            label: 'Group by week gas, meter breakdown'
+          },
+          daytype_breakdown_gas_tolerant: {
+            label: 'Gas use out of hours'
+          },
+          gas_by_day_of_week_tolerant: {
+            label: 'Out of hours gas use by day of week'
+          }
+        },
+        solar_pv: {
+          management_dashboard_group_by_month_solar_pv: {
+            label: 'Solar generation and use by month'
+          }
+        }
+      }
+
+      fuel_types = [:electricity, :gas, :solar_pv]
+
+      component = Charts::SelectableSchoolChartsComponent.new(schools:, fuel_types:, charts: safe_charts)
+      render(component)
+    end
+  end
+end


### PR DESCRIPTION
New component that can be configured to allow a user to choose between different charts and schools then see the results on the same page.

Intended to be the basis for the new group charts page to allow group admins to quickly check charts for individual schools

- [ ] Better preview
- [ ] Chart titles and subtitles
- [ ] Dynamic links to relevant school analysis page
- [ ] Defaults from page parameters
- [ ] Disabling schools based on fuel type configuration
- [ ] Specs for component
- [ ] Page that includes component
- [ ] Tidy JS to use less JQuery
- [ ] Rename 'usage-charts` to something else?
- [ ] Chart footnotes not working
- [ ] configuration field has hard-coded chart name, specify default elsewhere?
- [ ] setSelectorState has hard-coded electricity param
- [ ] Put safe set of charts somewhere.