### PR TITLE
Error generating meter monthly summaries

### DIFF
--- a/app/models/meter_monthly_summary.rb
+++ b/app/models/meter_monthly_summary.rb
@@ -105,12 +105,12 @@ class MeterMonthlySummary < ApplicationRecord
       :incomplete
     else
       types = month_readings.to_set(&:type)
-      if %w[ORIG SOLN].to_set.superset?(types)
+      if %w[ORIG SOLN SOL0].to_set.superset?(types)
         :actual
+      elsif types.intersect?(%w[PROB ZMDR E0H1])
+        :incomplete
       elsif types.intersect?(%w[SOLR SOLO SOLE BKPV])
         :estimated
-      elsif types.intersect?(%w[PROB SOL0 ZMDR E0H1])
-        :incomplete
       else
         raise "unknown #{types} - #{month_start} #{month_readings}"
       end


### PR DESCRIPTION
add for `'E0H1' => { name: 'Missing electricity - holiday set to zero' }`

Wonder if would be best to default to :incomplete