### PR TITLE
Fix timeline counts

### DIFF
--- a/app/controllers/timeline_controller.rb
+++ b/app/controllers/timeline_controller.rb
@@ -62,6 +62,6 @@ class TimelineController < ApplicationController
   end
 
   def observation_counts
-    @observation_counts ||= timelineable.observations.with_academic_year.counts_by_academic_year
+    @observation_counts ||= timelineable.observations.visible.with_academic_year.with_end_date.counts_by_academic_year
   end
 end

--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -50,11 +50,9 @@
 class Observation < ApplicationRecord
   include Description
   include Todos::Recording
-
   belongs_to :school
-
-  has_many   :temperature_recordings
-  has_many   :locations, through: :temperature_recordings
+  has_many :temperature_recordings
+  has_many :locations, through: :temperature_recordings
 
   belongs_to :programme, optional: true # to be removed when column is removed
   belongs_to :intervention_type, optional: true
@@ -108,8 +106,12 @@ class Observation < ApplicationRecord
     joins('JOIN academic_years ON observations.at BETWEEN academic_years.start_date AND academic_years.end_date')
   }
 
+  scope :with_end_date, ->(end_date = Time.current.end_of_day) {
+    where('observations.at <= LEAST(academic_years.end_date, ?)', end_date)
+  }
+
   scope :counts_by_academic_year, -> {
-    with_academic_year.group('academic_years.id').count
+    group('academic_years.id').count
   }
 
   has_rich_text :description


### PR DESCRIPTION
Noticed the counts in the left nav of the timeline was one out for a group. Realised the counting for the current year was up to the end of the year and not just today (as we are actually displaying). Also make sure we are counting only visible observations.