### PR TITLE
Change behaviour of group savings prompt component

### DIFF
--- a/app/components/dashboards/group_savings_prompt_component.rb
+++ b/app/components/dashboards/group_savings_prompt_component.rb
@@ -4,7 +4,7 @@ module Dashboards
 
     attr_reader :school_group, :priority_action, :savings, :metric
 
-    def initialize(school_group:, schools:, metric: [:kwh, :co2, :gbp].sample, **_kwargs)
+    def initialize(school_group:, schools:, metric: :gbp, **_kwargs)
       super
       @school_group = school_group
       @schools = schools

--- a/app/components/dashboards/group_savings_prompt_component/group_savings_prompt_component.html.erb
+++ b/app/components/dashboards/group_savings_prompt_component/group_savings_prompt_component.html.erb
@@ -1,36 +1,27 @@
 <%= tag.div id: id,
             class: class_names(classes,
-                               'p-4 d-flex flex-wrap align-items-center justify-content-between rounded-lg') do %>
-  <div>
-    <div class="row">
-      <div class="col">
-        <h2 id='prompt-title'>
-          <%= title %>
-        </h2>
-      </div>
-    </div>
-    <div class="row">
-      <div id="prompt-body" class="col">
-        <p>
-          <%= t("#{metric}_prompt_html",
-                scope: 'components.dashboards.group_savings_prompt',
-                schools: school_count,
-                fuel_type: fuel_type,
-                saving: saving) %>
-        </p>
-        <p>
-          <%= t('components.dashboards.group_savings_prompt.note') %>
-        </p>
-      </div>
-    </div>
-  </div>
-  <div>
-    <div class="row">
-      <div class="col d-flex justify-content-center align-items-center">
-        <%= link_to t('components.dashboards.group_savings_prompt.view_all_savings'),
+                               'p-4 rounded-lg') do %>
+
+  <div class="mb-md-0">
+    <h2 id="prompt-title"><%= title %></h2>
+    <p>
+      <%= t("#{metric}_prompt_html",
+            scope: 'components.dashboards.group_savings_prompt',
+            schools: school_count,
+            fuel_type: fuel_type,
+            saving: saving) %>
+    </p>
+
+    <div class="d-flex flex-column flex-xl-row justify-content-between align-items-xl-center align-items-md-left">
+      <p class="mb-xl-0">
+        <%= t('components.dashboards.group_savings_prompt.note') %>
+      </p>
+      <div class='flex-shrink-0 align-self-xl-end'>
+        <%= link_to t('components.dashboards.group_savings_prompt.view_all_potential_savings'),
                     priorities_school_group_advice_path(school_group),
-                    class: 'btn btn-primary mr-2' %>
+                    class: 'btn btn-primary' %>
       </div>
     </div>
   </div>
+
 <% end %>

--- a/app/views/school_groups/show.html.erb
+++ b/app/views/school_groups/show.html.erb
@@ -40,7 +40,8 @@
 
     <%= render Dashboards::GroupSavingsPromptComponent.new(
           school_group: @school_group,
-          schools: @schools
+          schools: @schools,
+          classes: 'mb-4'
         ) %>
 
     <%= render Dashboards::GroupInsightsComponent.new(

--- a/config/locales/views/components/dashboards/group_savings_prompt.yml
+++ b/config/locales/views/components/dashboards/group_savings_prompt.yml
@@ -7,4 +7,4 @@ en:
         gbp_prompt_html: Take action in <strong>%{schools}</strong> to decrease your %{fuel_type} costs over the next year by <strong>%{saving}</strong>.
         kwh_prompt_html: Take action in <strong>%{schools}</strong> to decrease your %{fuel_type} use over the next year by <strong>%{saving}</strong>.
         note: This is just one example of the potential savings we have identified across schools in this group
-        view_all_savings: View all savings
+        view_all_potential_savings: View all potential savings

--- a/spec/components/dashboards/group_savings_prompt_component_spec.rb
+++ b/spec/components/dashboards/group_savings_prompt_component_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Dashboards::GroupSavingsPromptComponent, :include_url_helpers, ty
     it { expect(html).to have_content('4,400 kWh') }
 
     it {
-      expect(html).to have_link(I18n.t('components.dashboards.group_savings_prompt.view_all_savings'),
+      expect(html).to have_link(I18n.t('components.dashboards.group_savings_prompt.view_all_potential_savings'),
                                    href: priorities_school_group_advice_path(school_group))
     }
 

--- a/spec/components/previews/dashboards/group_savings_prompt_component_preview.rb
+++ b/spec/components/previews/dashboards/group_savings_prompt_component_preview.rb
@@ -2,7 +2,7 @@ module Dashboards
   class GroupSavingsPromptComponentPreview < ViewComponent::Preview
     # @param slug select :group_options
     # @param metric select { choices: [kwh, gbp, co2] }
-    def example(slug: nil, metric: :kwh)
+    def example(slug: nil, metric: :gbp)
       school_group = slug ? SchoolGroup.find(slug) : SchoolGroup.with_active_schools.sample
       render(Dashboards::GroupSavingsPromptComponent.new(school_group: school_group, schools: school_group.schools.active, metric: metric))
     end

--- a/spec/system/school_groups/dashboard_spec.rb
+++ b/spec/system/school_groups/dashboard_spec.rb
@@ -44,10 +44,6 @@ describe 'School group dashboard page', :school_groups do
       end
     end
 
-    it 'shows priorities prompt' do
-      expect(page).to have_link(I18n.t('components.dashboards.group_savings_prompt.view_all_potential_savings'),
-                                href: priorities_school_group_advice_path(school_group))
-    end
 
     context 'with learn more / select school section' do
       it 'shows select school section' do
@@ -58,6 +54,11 @@ describe 'School group dashboard page', :school_groups do
         expect(page).to have_content I18n.t('components.dashboards.group_learn_more.advice.title')
         expect(page).to have_link(href: school_group_advice_path(school_group))
       end
+    end
+
+    it 'shows savings prompt' do
+      expect(page).to have_link(I18n.t('components.dashboards.group_savings_prompt.view_all_potential_savings'),
+                                href: priorities_school_group_advice_path(school_group))
     end
 
     it 'shows insights section' do

--- a/spec/system/school_groups/dashboard_spec.rb
+++ b/spec/system/school_groups/dashboard_spec.rb
@@ -30,6 +30,7 @@ describe 'School group dashboard page', :school_groups do
       within('div.layout-cards-page-header-component') do
         expect(page).to have_content(I18n.t('common.labels.welcome'))
       end
+
       within('div.layout-cards-page-header-component-callout-component') do
         expect(page).to have_content(I18n.t('school_count', count: school_group.schools.count))
         expect(page).to have_content(I18n.t(school_group.group_type, scope: 'school_groups.clusters.group_type'))
@@ -44,16 +45,25 @@ describe 'School group dashboard page', :school_groups do
     end
 
     it 'shows priorities prompt' do
-      expect(page).to have_link(I18n.t('components.dashboards.group_savings_prompt.view_all_savings'),
+      expect(page).to have_link(I18n.t('components.dashboards.group_savings_prompt.view_all_potential_savings'),
                                 href: priorities_school_group_advice_path(school_group))
+    end
+
+    context 'with learn more / select school section' do
+      it 'shows select school section' do
+        expect(page).to have_content I18n.t('components.dashboards.group_learn_more.schools.title')
+      end
+
+      it 'shows learn more section' do
+        expect(page).to have_content I18n.t('components.dashboards.group_learn_more.advice.title')
+        expect(page).to have_link(href: school_group_advice_path(school_group))
+      end
     end
 
     it 'shows insights section' do
       expect(page).to have_link(I18n.t('schools.show.view_more_alerts'),
                                 href: alerts_school_group_advice_path(school_group))
     end
-
-    it 'shows learn more/quick links'
 
     it 'displays the scoreboard summary' do
       expect(page).to have_content(I18n.t('components.scoreboards.group_summary.timeline.title'))


### PR DESCRIPTION
- [x] Don’t show a random metric, always show cost
- [x] Change button label to “View all potential savings”
- [x] Align button with last sentence