### PR TITLE
Fix sorting and display issues on stacked comparison charts

### DIFF
--- a/app/components/charts/comparison_chart_component.rb
+++ b/app/components/charts/comparison_chart_component.rb
@@ -8,11 +8,13 @@ module Charts
     renders_one :subtitle
     renders_one :introduction
 
-    def initialize(x_axis:, x_data:, y_axis_label:, **_kwargs)
+    def initialize(x_axis:, x_data:, y_axis_label:, x_min_value: nil, x_max_value: nil, **_kwargs)
       super
       @x_axis = x_axis
       @x_data = x_data
       @y_axis_label = y_axis_label
+      @x_min_value = x_min_value
+      @x_max_value = x_max_value
     end
 
     def height
@@ -44,6 +46,8 @@ module Charts
         x_axis: @x_axis,
         x_data: @x_data,
         y_axis_label: @y_axis_label,
+        x_min_value: @x_min_value,
+        x_max_value: @x_max_value,
         chart1_type: :bar,
         chart1_subtype: :stacked
       }

--- a/app/controllers/comparisons/change_in_electricity_since_last_year_controller.rb
+++ b/app/controllers/comparisons/change_in_electricity_since_last_year_controller.rb
@@ -27,7 +27,9 @@ module Comparisons
       calculation = lambda do |result|
         percent_change(result.previous_year_electricity_kwh, result.current_year_electricity_kwh) * 100.0
       end
-      [create_calculated_chart(results, calculation, 'change_in_kwh_pct', 'percent')]
+      [
+        Charts::ComparisonChartData.new(results).create_calculated_chart(calculation, 'change_in_kwh_pct', 'percent')
+      ]
     end
   end
 end

--- a/app/controllers/comparisons/shared/change_in_consumption_controller.rb
+++ b/app/controllers/comparisons/shared/change_in_consumption_controller.rb
@@ -22,7 +22,7 @@ module Comparisons
       end
 
       def create_charts(results)
-        create_single_number_chart(results, :difference_percent, 100.0, 'change_pct', 'percent')
+        create_single_number_chart(results, :difference_percent, 100.0, 'change_pct', 'percent', x_max_value: 100.0)
       end
 
       def load_data

--- a/app/services/charts/comparison_chart_data.rb
+++ b/app/services/charts/comparison_chart_data.rb
@@ -1,0 +1,68 @@
+module Charts
+  # Service for producing data structured suitable for use via the ComparisonChartComponent or ChartComponent
+  class ComparisonChartData
+    def initialize(results,
+                   column_heading_keys: 'analytics.benchmarking.configuration.column_headings',
+                   y_axis_keys: 'chart_configuration.y_axis_label_name',
+                   x_min_value: nil,
+                   x_max_value: nil)
+      @results = results
+      @column_heading_keys = column_heading_keys
+      @y_axis_keys = y_axis_keys
+      @min_max_values = { x_min_value:, x_max_value: }.compact
+    end
+
+    def create_chart(metric_to_translation_key, multiplier, y_axis_label)
+      schools, chart_data = schools_and_chart_data do |chart_data, result|
+        result.slice(*metric_to_translation_key.keys).each do |metric, value|
+          value = value_or_nil(value)
+
+          # for a percentage metric we'd multiply * 100.0
+          # for converting from kW to W 1000.0
+          value *= multiplier unless value.nil? || multiplier.nil?
+          (chart_data[metric] ||= []) << value
+        end
+      end
+
+      chart_data.transform_keys! { |key| column_heading(metric_to_translation_key[key.to_sym]) }
+
+      chart_hash(schools, chart_data, y_axis_label)
+    end
+
+    def create_calculated_chart(lambda, series_name, y_axis_label)
+      schools, chart_data = schools_and_chart_data do |chart_data, result|
+        value = lambda.call(result)
+        (chart_data[column_heading(series_name)] ||= []) << value_or_nil(value)
+      end
+      chart_hash(schools, chart_data, y_axis_label)
+    end
+
+    private
+
+    def schools_and_chart_data
+      schools = []
+      chart_data = {}
+      @results.each do |result|
+        schools << result.school.name
+        yield(chart_data, result)
+      end
+      return schools, chart_data
+    end
+
+    def chart_hash(schools, chart_data, y_axis_label)
+      { id: :comparison,
+        x_axis: schools,
+        x_data: chart_data, # x is the vertical axis by default for stacked charts in Highcharts
+        y_axis_label: I18n.t("#{@y_axis_keys}.#{y_axis_label}") }.merge(@min_max_values)
+    end
+
+    def column_heading(series_name)
+      I18n.t("#{@column_heading_keys}.#{series_name}")
+    end
+
+    def value_or_nil(value)
+      return nil if value.nil? || value.respond_to?(:nan?) && (value.nan? || value.infinite?)
+      value
+    end
+  end
+end

--- a/spec/services/charts/comparison_chart_data_spec.rb
+++ b/spec/services/charts/comparison_chart_data_spec.rb
@@ -104,7 +104,7 @@ describe Charts::ComparisonChartData do
       end
 
       it 'adds the min and max data keys' do
-        expect(chart_hash.slice(:x_min_value, :x_max_value)).to eq({ x_min_value: 0, x_max_value: 100.0 })
+        expect(chart_hash).to include(x_min_value: 0, x_max_value: 100.0)
       end
     end
   end
@@ -126,6 +126,21 @@ describe Charts::ComparisonChartData do
 
     it 'produces the expected x_data' do
       expect(chart_hash[:x_data][expected_series_name]).to eq([100.0, 100.0])
+    end
+
+    context 'when school has NaN or infinite value' do
+      let(:results) do
+        [
+          create_result(schools.first, { one_year_electricity_per_pupil_kwh: Float::INFINITY }),
+          create_result(schools.last, { one_year_electricity_per_pupil_kwh: Float::NAN })
+        ]
+      end
+
+      it_behaves_like 'a chart hash'
+
+      it 'produces the expected x_data' do
+        expect(chart_hash[:x_data][expected_series_name]).to eq([nil, nil])
+      end
     end
 
     context 'when a school has missing data' do

--- a/spec/services/charts/comparison_chart_data_spec.rb
+++ b/spec/services/charts/comparison_chart_data_spec.rb
@@ -1,0 +1,146 @@
+require 'rails_helper'
+
+describe Charts::ComparisonChartData do
+  let(:service) { described_class.new(results) }
+
+  let(:schools) { create_list(:school, 2) }
+
+  let(:results) do
+    schools.map do |school|
+      create_result(school, { one_year_electricity_per_pupil_kwh: 1.0 })
+    end
+  end
+
+  def create_result(school, fields)
+    result = ActiveSupport::OrderedOptions.new
+    result[:school] = school
+    fields.each do |keyword, value|
+      result[keyword] = value
+    end
+    result
+  end
+
+  def expected_series_name(name = :last_year_electricity_kwh_pupil)
+    I18n.t(name, scope: 'analytics.benchmarking.configuration.column_headings')
+  end
+
+  RSpec.shared_examples 'a chart hash' do
+    it 'includes the expected keys' do
+      expect(chart_hash.keys).to contain_exactly(:id, :x_axis, :x_data, :y_axis_label)
+    end
+
+    it 'includes all schools in x_axis, in order' do
+      expect(chart_hash[:x_axis]).to contain_exactly(schools.first.name, schools.last.name)
+    end
+
+    it 'translated the y_axis_label' do
+      expect(chart_hash[:y_axis_label]).to eq(I18n.t(y_axis_label,
+                                              scope: 'chart_configuration.y_axis_label_name'))
+    end
+  end
+
+  describe '.create_chart' do
+    subject(:chart_hash) do
+      service.create_chart(
+        { one_year_electricity_per_pupil_kwh: :last_year_electricity_kwh_pupil },
+        multiplier,
+        y_axis_label
+      )
+    end
+
+    let(:multiplier) { nil }
+    let(:y_axis_label) { :kwh }
+
+    context 'with no multiplier' do
+      it_behaves_like 'a chart hash'
+      it 'produces the expected x_data' do
+        expect(chart_hash[:x_data][expected_series_name]).to eq([1.0, 1.0])
+      end
+    end
+
+    context 'when a multiplier is provided' do
+      let(:multiplier) { 100.0 }
+
+      it_behaves_like 'a chart hash'
+
+      it 'produces the expected x_data' do
+        expect(chart_hash[:x_data][expected_series_name]).to eq([100.0, 100.0])
+      end
+    end
+
+    context 'when a school has missing data' do
+      let(:results) do
+        [
+          create_result(schools.first, { one_year_electricity_per_pupil_kwh: 1.0 }),
+          create_result(schools.last, { one_year_electricity_per_pupil_kwh: nil })
+        ]
+      end
+
+      it_behaves_like 'a chart hash'
+
+      it 'produces the expected x_data' do
+        expect(chart_hash[:x_data][expected_series_name]).to eq([1.0, nil])
+      end
+    end
+
+    context 'when school has NaN or infinite value' do
+      let(:results) do
+        [
+          create_result(schools.first, { one_year_electricity_per_pupil_kwh: Float::INFINITY }),
+          create_result(schools.last, { one_year_electricity_per_pupil_kwh: Float::NAN })
+        ]
+      end
+
+      it_behaves_like 'a chart hash'
+
+      it 'produces the expected x_data' do
+        expect(chart_hash[:x_data][expected_series_name]).to eq([nil, nil])
+      end
+    end
+
+    context 'with min and max values' do
+      let(:service) do
+        described_class.new(results, x_min_value: 0, x_max_value: 100.0)
+      end
+
+      it 'adds the min and max data keys' do
+        expect(chart_hash.slice(:x_min_value, :x_max_value)).to eq({ x_min_value: 0, x_max_value: 100.0 })
+      end
+    end
+  end
+
+  describe '.create_calculated_chart' do
+    subject(:chart_hash) do
+      service.create_calculated_chart(calculation, :last_year_electricity_kwh_pupil, y_axis_label)
+    end
+
+    let(:calculation) do
+      lambda do |result|
+        result[:one_year_electricity_per_pupil_kwh].nil? ? nil : result[:one_year_electricity_per_pupil_kwh] * 100.0
+      end
+    end
+
+    let(:y_axis_label) { :kwh }
+
+    it_behaves_like 'a chart hash'
+
+    it 'produces the expected x_data' do
+      expect(chart_hash[:x_data][expected_series_name]).to eq([100.0, 100.0])
+    end
+
+    context 'when a school has missing data' do
+      let(:results) do
+        [
+          create_result(schools.first, { one_year_electricity_per_pupil_kwh: 1.0 }),
+          create_result(schools.last, { one_year_electricity_per_pupil_kwh: nil })
+        ]
+      end
+
+      it_behaves_like 'a chart hash'
+
+      it 'produces the expected x_data' do
+        expect(chart_hash[:x_data][expected_series_name]).to eq([100.0, nil])
+      end
+    end
+  end
+end


### PR DESCRIPTION
There's a severe bug with the stacked comparison charts.

If the chart has multiple series and a school doesn't have a value for that series, then the chart does not display correctly. The values for the series end up shifting, so the chart isn't displaying the actual values for the school.

Manifests as:

- missing series for a school (because value is shifted to a previous school)
- incorrect sorting on chart (again, because the values are shifted)

This PR extracts the code that formats the chart data and adds specs. It fixes this bug and also addresses another display issue.

Sometimes the % change between holidays is very large (e.g. little or no usage during holiday, then sudden increase when gas is turned on). The old comparison reports used a `x_min_value` and `x_max_value` configuration to force the % change charts to have 100% as maximum. This wasn't carried over when we rebuilt the comparison reports. I've implemented support for it and used it to enforce a max of 100% on the holiday comparison charts.