### PR TITLE
Add links to group advice pages from group alerts

### DIFF
--- a/app/components/dashboards/group_alerts_component.rb
+++ b/app/components/dashboards/group_alerts_component.rb
@@ -2,6 +2,7 @@ module Dashboards
   # FIXME should use PromptList directly, and pass through additional prompts if possible.
   class GroupAlertsComponent < ApplicationComponent
     ALERT_GROUPS = %w[priority change benchmarking advice].freeze # specific order
+    GROUP_ADVICE_PAGES = %w[baseload electricity_long_term electricity_out_of_hours gas_long_term gas_out_of_hours heating_control].freeze
 
     attr_reader :school_group, :limit
 
@@ -60,6 +61,11 @@ module Dashboards
 
     def summarised_alerts
       @summarised_alerts ||= SchoolGroups::Alerts.new(@schools).summarise
+    end
+
+    def advice_link?(alert_type)
+      return false unless alert_type.advice_page
+      GROUP_ADVICE_PAGES.include?(alert_type.advice_page.key)
     end
 
     private

--- a/app/components/dashboards/group_alerts_component/group_alerts_component.html.erb
+++ b/app/components/dashboards/group_alerts_component/group_alerts_component.html.erb
@@ -26,6 +26,12 @@
                 fuel_type: alert_content.alert_type.fuel_type,
                 status: status_for_alert_colour(alert_content.colour)
               ) do |prompt| %>
+              <% if advice_link?(alert_content.alert_type) %>
+                <% prompt.with_link do %>
+                  <%= link_to t('schools.show.find_out_more'),
+                              helpers.advice_page_path(school_group, alert_content.advice_page, :analysis) %>
+                <% end %>
+              <% end %>
               <%= alert_content.group_dashboard_title %>
           <% end %>
         <% end %>
@@ -38,6 +44,12 @@
             fuel_type: alert_content.alert_type.fuel_type,
             status: status_for_alert_colour(alert_content.colour)
           ) do |prompt| %>
+          <% if advice_link?(alert_content.alert_type) %>
+            <% prompt.with_link do %>
+              <%= link_to t('schools.show.find_out_more'),
+                          helpers.advice_page_path(school_group, alert_content.advice_page, :analysis) %>
+            <% end %>
+          <% end %>
           <%= alert_content.group_dashboard_title %>
       <% end %>
     <% end %>

--- a/spec/components/dashboards/group_alerts_component_spec.rb
+++ b/spec/components/dashboards/group_alerts_component_spec.rb
@@ -32,6 +32,34 @@ RSpec.describe Dashboards::GroupAlertsComponent, :include_application_helper, :i
   end
 
 
+  shared_examples 'it links to advice pages' do
+    context 'when the alert has an advice page' do
+      context 'when there is no group advice page' do
+        it 'does not link' do
+          expect(html).not_to have_link(I18n.t('schools.show.find_out_more'))
+        end
+      end
+
+      context 'when there is non-matching advice page' do
+        let(:alert_type) { create(:alert_type, group: :benchmarking, advice_page: create(:advice_page)) }
+
+        it 'does not link' do
+          expect(html).not_to have_link(I18n.t('schools.show.find_out_more'))
+        end
+      end
+
+      context 'when there is a group advice page' do
+        let(:advice_page) { create(:advice_page, key: :baseload) }
+        let(:alert_type) { create(:alert_type, group: :benchmarking, advice_page:) }
+
+        it 'includes a link' do
+          expect(html).to have_link(I18n.t('schools.show.find_out_more'),
+                                    href: polymorphic_path([:analysis, school_group, :advice, advice_page.key.to_sym]))
+        end
+      end
+    end
+  end
+
   context 'when there are alerts to display' do
     before do
       school_group.schools.each do |school|
@@ -65,16 +93,22 @@ RSpec.describe Dashboards::GroupAlertsComponent, :include_application_helper, :i
       end
     end
 
+    it_behaves_like 'it links to advice pages'
+
     context 'when showing groups' do
       let(:params) do
         {
           id: 'custom-id',
           classes: 'extra-classes',
-          school_group: school_group
+          school_group: school_group,
+          grouped: true
         }
       end
 
+      it_behaves_like 'it links to advice pages'
+
       it 'shows the group headings' do
+        expect(html).to have_css('#benchmarking-alerts')
         within('#benchmarking-alerts') do
           expect(html).to have_content(content_version.group_dashboard_title.to_plain_text)
           expect(html).to have_content(I18n.t('advice_pages.alerts.groups.benchmarking'))


### PR DESCRIPTION
<img width="688" height="289" alt="Screenshot from 2025-09-25 12-07-35" src="https://github.com/user-attachments/assets/fcd36e97-098f-4015-b341-cdc44c6f4dce" />

Adds "Find our more" links to group dashboard alerts where the `AlertType` is related to one of the group advice pages (Baseload, Heating Control, or the long term or out of hours pages).

Note: you can only see this if you have group alerts configured locally, but it's just adding a standard link as shown above.

We might be able to do more sophisticated linking, e.g. to comparison reports or charts in future updates, but its not clear yet which alert types will be switched on as group alerts. This helps to ensure there's a link for the majority of alerts.