### PR TITLE
Add secr to advice page nav plus a few other fixes

### DIFF
--- a/app/components/page_nav_component.rb
+++ b/app/components/page_nav_component.rb
@@ -75,14 +75,14 @@ class PageNavComponent < ApplicationComponent
   class ItemComponent < ViewComponent::Base
     attr_reader :name, :href, :match_controller, :classes
 
-    def initialize(name:, href:, note: nil, match_controller: false, selected: false, classes: nil, **kwargs)
+    def initialize(name:, href:, note: nil, match_controller: false, selected: false, visible: true, classes: nil)
       @name = name
       @note = note
       @href = href
       @match_controller = match_controller
       @selected = selected
+      @visible = visible
       @classes = classes
-      @if = kwargs.fetch(:if) { true }
     end
 
     def current_controller?(href)
@@ -98,11 +98,13 @@ class PageNavComponent < ApplicationComponent
       kwargs[:class] += " #{classes}" if classes
       kwargs[:class] += ' current' if current_item?(href) || @selected
       note = @note.nil? ? '' : content_tag(:span, @note, class: 'nav-toggle-icons')
-      link_to(content_tag(:span, name, class: 'nav-text') + note, href, kwargs)
+      tag.li(class: 'nav-item') do
+        link_to(content_tag(:span, name, class: 'nav-text') + note, href, kwargs)
+      end
     end
 
     def render?
-      name && @if
+      name && @visible
     end
   end
 

--- a/app/components/page_nav_component.rb
+++ b/app/components/page_nav_component.rb
@@ -1,33 +1,33 @@
 # frozen_string_literal: true
 
-class PageNavComponent < ViewComponent::Base
-  renders_many :sections, ->(**args) do
-    args[:options] ||= {}
-    args[:options] = options.merge(args[:options])
-    SectionComponent.new(**args)
+class PageNavComponent < ApplicationComponent
+  renders_many :sections, ->(**kwargs) do
+    kwargs[:options] ||= {}
+    kwargs[:options] = options.merge(kwargs[:options])
+    SectionComponent.new(**kwargs)
   end
 
   attr_reader :name, :icon, :classes, :href, :options
 
   def initialize(name: 'Menu', icon: 'home', href:, classes: nil, options: {})
+    super(classes: classes)
     @name = name
     @icon = icon
-    @classes = classes
     @href = href
     @options = options
   end
 
   def header
-    args = { class: 'nav-link header' }
-    args[:class] += " #{classes}" if classes
+    kwargs = { class: 'nav-link header' }
+    kwargs[:class] += " #{classes}" if classes
     text = icon.nil? ? name : helpers.text_with_icon(name, icon)
-    link_to(text, href, args)
+    link_to(text, href, kwargs)
   end
 
   class SectionComponent < ViewComponent::Base
-    renders_many :items, ->(**args) do
-      args[:match_controller] ||= options[:match_controller]
-      PageNavComponent::ItemComponent.new(**args)
+    renders_many :items, ->(**kwargs) do
+      kwargs[:match_controller] ||= options[:match_controller]
+      PageNavComponent::ItemComponent.new(**kwargs)
     end
 
     attr_reader :name, :icon, :visible, :classes, :options
@@ -75,13 +75,14 @@ class PageNavComponent < ViewComponent::Base
   class ItemComponent < ViewComponent::Base
     attr_reader :name, :href, :match_controller, :classes
 
-    def initialize(name:, href:, note: nil, match_controller: false, selected: false, classes: nil)
+    def initialize(name:, href:, note: nil, match_controller: false, selected: false, classes: nil, **kwargs)
       @name = name
       @note = note
       @href = href
       @match_controller = match_controller
       @selected = selected
       @classes = classes
+      @if = kwargs.fetch(:if) { true }
     end
 
     def current_controller?(href)
@@ -93,15 +94,15 @@ class PageNavComponent < ViewComponent::Base
     end
 
     def call
-      args = { class: 'nav-link item' }
-      args[:class] += " #{classes}" if classes
-      args[:class] += ' current' if current_item?(href) || @selected
+      kwargs = { class: 'nav-link item' }
+      kwargs[:class] += " #{classes}" if classes
+      kwargs[:class] += ' current' if current_item?(href) || @selected
       note = @note.nil? ? '' : content_tag(:span, @note, class: 'nav-toggle-icons')
-      link_to(content_tag(:span, name, class: 'nav-text') + note, href, args)
+      link_to(content_tag(:span, name, class: 'nav-text') + note, href, kwargs)
     end
 
     def render?
-      name
+      name && @if
     end
   end
 
@@ -122,8 +123,8 @@ class PageNavComponent < ViewComponent::Base
     end
 
     def call
-      args = { class: "nav-link d-md-none d-#{display}", 'data-toggle': 'collapse', 'data-target': "##{id}" }
-      link_to(icon, '', args)
+      kwargs = { class: "nav-link d-md-none d-#{display}", 'data-toggle': 'collapse', 'data-target': "##{id}" }
+      link_to(icon, '', kwargs)
     end
   end
 end

--- a/app/components/page_nav_component/page_nav_component.html.erb
+++ b/app/components/page_nav_component/page_nav_component.html.erb
@@ -8,9 +8,7 @@
           <div class="<%= class_names('collapse', { show: section.expanded? }) %>" id="<%= section.id %>" aria-expanded="false">
             <ul class="flex-column pl-0">
               <% section.items.each do |item| %>
-                <li class="nav-item">
-                  <%= item %>
-                </li>
+                <%= item %>
               <% end %>
             </ul>
           </div>

--- a/app/components/page_nav_component/page_nav_component.html.erb
+++ b/app/components/page_nav_component/page_nav_component.html.erb
@@ -1,4 +1,4 @@
-<%= tag.div id: 'page-nav', class: class_names(classes, 'page-nav-component collapse d-md-flex') do %>
+<%= tag.div id: 'page-nav', class: class_names(classes, 'collapse d-md-flex') do %>
   <ul class="nav flex-column flex-nowrap w-100">
     <li class="nav-item"><%= header %></li>
     <% sections.each do |section| %>

--- a/app/components/page_nav_component/page_nav_component.html.erb
+++ b/app/components/page_nav_component/page_nav_component.html.erb
@@ -1,4 +1,4 @@
-<%= tag.div id: 'page-nav', class: class_names(classes, 'collapse d-md-flex') do %>
+<%= tag.div id: 'page-nav', class: class_names(classes, 'collapse d-md-flex mb-2') do %>
   <ul class="nav flex-column flex-nowrap w-100">
     <li class="nav-item"><%= header %></li>
     <% sections.each do |section| %>

--- a/app/components/page_nav_component/page_nav_component.scss
+++ b/app/components/page_nav_component/page_nav_component.scss
@@ -19,7 +19,13 @@
     }
 
     &.current {
-      font-weight: bold;
+      font-weight: bold !important;
+    }
+
+    &:not(.section-link) {
+      &:hover, &.current {
+        border-radius: $border-radius;
+      }
     }
   }
 
@@ -42,26 +48,21 @@
       font-weight: $default-font-weight;
 
       &:hover, &.current {
-        border-radius: $border-radius;
         background-color: map-get($tones, "light");
-      }
-
-      &.current {
-        font-weight: bold !important;
       }
     }
 
     a.#{$fuel}-section {
       font-weight: $font-weight-semibold;
 
-      &:hover {
-        background-color: transparent;
-      }
-
       i.fuel {  // icon colour for fuel icon
         color: map-get($tones, "dark");
       }
     }
+  }
+
+  a.nav-link.toggler {
+    background-color: transparent;
   }
 
   a.nav-link.generic-item {
@@ -70,21 +71,12 @@
     font-weight: $default-font-weight;
 
     &:hover, &.current {
-      border-radius: $border-radius;
       background-color: $teal-light;
-    }
-
-    &.current {
-      font-weight: bold !important;
     }
   }
 
   a.generic-section {
     font-weight: $font-weight-semibold;
-
-    &:hover {
-      background-color: transparent;
-    }
 
     i.fuel {
       color: $teal-dark;

--- a/app/controllers/school_groups/secr_controller.rb
+++ b/app/controllers/school_groups/secr_controller.rb
@@ -3,7 +3,7 @@
 module SchoolGroups
   class SecrController < BaseController
     def index
-      raise CanCan::AccessDenied unless current_user.admin? || current_user.group_admin?
+      raise CanCan::AccessDenied unless can?(:update_settings, @school_group)
 
       build_breadcrumbs([name: I18n.t('school_groups.sub_nav.secr_report')])
       @last_two_academic_year_periods = Periods::FixedAcademicYear.enumerator(

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -77,6 +77,7 @@
 # But also used to control access to school group page with data.
 # :update_settings - can use manage settings (chart prefs, clusters) for school group. But also used to gate
 # access to viewing clusters on school group dashboard. Also used to decide whether to show sub navbar on some pages
+# Used to control access to SECR report page too
 #
 # METERS
 #

--- a/app/views/school_groups/advice/shared/_nav.html.erb
+++ b/app/views/school_groups/advice/shared/_nav.html.erb
@@ -27,10 +27,15 @@
                    classes: 'section-link') %>
   <% end %>
   <% c.with_section(name: t('school_groups.titles.reports'),
-                    icon: 'magnifying-glass-chart') do |s| %>
+                    icon: 'magnifying-glass-chart',
+                    options: { match_controller: false }) do |s| %>
     <% s.with_item(name: t('school_groups.titles.charts'),
                    href: charts_school_group_advice_path(school_group),
                    classes: 'small') %>
+    <% s.with_item(name: t('school_groups.titles.secr'),
+                   href: school_group_secr_index_path(school_group),
+                   classes: 'small',
+                   if: current_user.admin? || current_user.group_admin?) %>
   <% end %>
   <% c.with_section(name: t('advice_pages.nav.sections.electricity'),
                     icon: fuel_type_icon(:electricity), classes: 'electric-section',

--- a/app/views/school_groups/advice/shared/_nav.html.erb
+++ b/app/views/school_groups/advice/shared/_nav.html.erb
@@ -35,7 +35,7 @@
     <% s.with_item(name: t('school_groups.titles.secr'),
                    href: school_group_secr_index_path(school_group),
                    classes: 'small',
-                   visible: can?(:show_management_dash, school_group)) %>
+                   visible: can?(:update_settings, school_group)) %>
   <% end %>
   <% c.with_section(name: t('advice_pages.nav.sections.electricity'),
                     icon: fuel_type_icon(:electricity), classes: 'electric-section',

--- a/app/views/school_groups/advice/shared/_nav.html.erb
+++ b/app/views/school_groups/advice/shared/_nav.html.erb
@@ -35,7 +35,7 @@
     <% s.with_item(name: t('school_groups.titles.secr'),
                    href: school_group_secr_index_path(school_group),
                    classes: 'small',
-                   visible: current_user&.admin? || current_user&.group_admin? && can?(:read, school_group)) %>
+                   visible: can?(:show_management_dash, school_group)) %>
   <% end %>
   <% c.with_section(name: t('advice_pages.nav.sections.electricity'),
                     icon: fuel_type_icon(:electricity), classes: 'electric-section',

--- a/app/views/school_groups/advice/shared/_nav.html.erb
+++ b/app/views/school_groups/advice/shared/_nav.html.erb
@@ -35,7 +35,7 @@
     <% s.with_item(name: t('school_groups.titles.secr'),
                    href: school_group_secr_index_path(school_group),
                    classes: 'small',
-                   if: current_user.admin? || current_user.group_admin?) %>
+                   visible: current_user&.admin? || current_user&.group_admin? && can?(:read, school_group)) %>
   <% end %>
   <% c.with_section(name: t('advice_pages.nav.sections.electricity'),
                     icon: fuel_type_icon(:electricity), classes: 'electric-section',

--- a/config/locales/views/school_groups/school_groups.yml
+++ b/config/locales/views/school_groups/school_groups.yml
@@ -396,5 +396,5 @@ en:
       priority_actions: Priority Actions
       recent_usage: Recent Usage
       reports: Reports
-      secr: SECR
+      secr: SECR report
       show: Group Dashboard

--- a/config/locales/views/school_groups/school_groups.yml
+++ b/config/locales/views/school_groups/school_groups.yml
@@ -396,4 +396,5 @@ en:
       priority_actions: Priority Actions
       recent_usage: Recent Usage
       reports: Reports
+      secr: SECR
       show: Group Dashboard

--- a/spec/components/page_nav_component_spec.rb
+++ b/spec/components/page_nav_component_spec.rb
@@ -131,14 +131,14 @@ RSpec.describe PageNavComponent, type: :component do
         it { expect(list_item).to have_css('.current') }
       end
 
-      context 'with if set to false for the item' do
-        let(:item_params) { all_item_params.update(href: '/schools/new', if: false)}
+      context 'with visible set to false for the item' do
+        let(:item_params) { all_item_params.update(href: '/schools/new', visible: false)}
 
         it { expect(list_item).not_to have_link('Item Name') }
       end
 
-      context 'with if set to true for the item' do
-        let(:item_params) { all_item_params.update(href: '/schools/new', if: true)}
+      context 'with visible set to true for the item' do
+        let(:item_params) { all_item_params.update(href: '/schools/new', visible: true)}
 
         it { expect(list_item).to have_link('Item Name') }
       end

--- a/spec/components/page_nav_component_spec.rb
+++ b/spec/components/page_nav_component_spec.rb
@@ -131,6 +131,17 @@ RSpec.describe PageNavComponent, type: :component do
         it { expect(list_item).to have_css('.current') }
       end
 
+      context 'with if set to false for the item' do
+        let(:item_params) { all_item_params.update(href: '/schools/new', if: false)}
+
+        it { expect(list_item).not_to have_link('Item Name') }
+      end
+
+      context 'with if set to true for the item' do
+        let(:item_params) { all_item_params.update(href: '/schools/new', if: true)}
+
+        it { expect(list_item).to have_link('Item Name') }
+      end
 
       context 'with match_controller page nav option set to true' do
         let(:header_params) { all_header_params.update(options: { match_controller: true }) }

--- a/spec/support/shared_examples/school_groups.rb
+++ b/spec/support/shared_examples/school_groups.rb
@@ -421,3 +421,13 @@ RSpec.shared_examples 'schools are filtered by permissions' do |admin: false, sc
     end
   end
 end
+
+RSpec.shared_examples 'a group advice page secr nav link' do |display: true|
+  it "#{display ? 'shows' : "doesn't show"} secr nav link" do
+    if display
+      expect(page).to have_link('SECR report', href: school_group_secr_index_path(school_group))
+    else
+      expect(page).to have_no_link('SECR report', href: school_group_secr_index_path(school_group))
+    end
+  end
+end

--- a/spec/system/school_groups/advice/index_spec.rb
+++ b/spec/system/school_groups/advice/index_spec.rb
@@ -48,6 +48,7 @@ describe 'School group advice index page' do
     end
 
     it_behaves_like 'schools are filtered by permissions'
+    it_behaves_like 'a group advice page secr nav link', display: false
   end
 
   context 'when logged in as group admin' do
@@ -57,5 +58,16 @@ describe 'School group advice index page' do
     end
 
     it_behaves_like 'schools are filtered by permissions', admin: true
+    it_behaves_like 'a group advice page secr nav link', display: true
+  end
+
+  context 'when logged in as group admin for a different group' do
+    before do
+      sign_in(create(:group_admin, school_group: create(:school_group)))
+      visit school_group_advice_path(school_group)
+    end
+
+    it_behaves_like 'schools are filtered by permissions', admin: false
+    it_behaves_like 'a group advice page secr nav link', display: false
   end
 end

--- a/spec/system/school_groups/secr_spec.rb
+++ b/spec/system/school_groups/secr_spec.rb
@@ -33,7 +33,16 @@ describe 'School group SECR' do
       it { expect(page).to have_content('You need to sign in or sign up before continuing') }
     end
 
-    context 'when signed in' do
+    context 'when signed in as a different group admin' do
+      before do
+        sign_in(create(:group_admin, school_group: create(:school_group)))
+        visit school_group_secr_index_path(school_group)
+      end
+
+      it { expect(page).to have_content('You are not authorized to access this page.') }
+    end
+
+    context 'when signed in as a group admin in the same group' do
       before do
         sign_in(create(:group_admin, school_group: school_group))
         visit school_group_secr_index_path(school_group)


### PR DESCRIPTION
Adds SECR report link to group advice nav.

I am a bit confused about permissions. Should a group admin from a group be able to see another group's secr link and report? I think all school group admins can see any secr report at the moment for any school group. Currently am using can? (:show_management_dash) for the link which only allows group admins to see their own but not sure this is right @ldodds ?

Made some other nav changes while I was there - the nav was highlighting Energy use charts when on any of the top items. i.e.
<img width="259" height="465" alt="Screenshot 2025-09-25 at 18 11 38" src="https://github.com/user-attachments/assets/8305a7cc-4ef6-4831-989d-f25e023fd346" />
 For the report section (i.e. a non fuel type section) the current and hover was not rounded (like the fuel type ones were). The section header had a grey hover when the fuel sections didn't. Just made them consistent, hope that's ok.
Also added the ability to show/hide an item based on a boolean (i.e. if visible variable is positive, it will show)

