### PR TITLE
Sort consistently across comparisons

### DIFF
--- a/app/components/charts/group_dashboard_charts_component/group_dashboard_charts_component.html.erb
+++ b/app/components/charts/group_dashboard_charts_component/group_dashboard_charts_component.html.erb
@@ -38,7 +38,7 @@
                <% chart.with_footer do %>
                 <div class="text-right">
                   <%= link_to t('school_groups.priority_actions.view_analysis'),
-                              compare_path(group_dashboard: true,
+                              compare_path(group: true,
                                            benchmark: report,
                                            school_group_ids: [@school_group.id]) %>
                 </div>

--- a/app/controllers/comparisons/annual_energy_costs_per_floor_area_controller.rb
+++ b/app/controllers/comparisons/annual_energy_costs_per_floor_area_controller.rb
@@ -22,7 +22,7 @@ module Comparisons
 
     def load_data
       columns = [:one_year_electricity_per_floor_area_kwh, :one_year_gas_per_floor_area_kwh, :one_year_storage_heater_per_floor_area_kwh]
-      Comparison::AnnualEnergyCostsPerUnit.for_schools(@schools).where_any_present(columns).by_total(columns)
+      Comparison::AnnualEnergyCostsPerUnit.for_schools(@schools).where_any_present(columns).by_total(columns, 'DESC NULLS LAST')
     end
 
     def create_charts(results)

--- a/app/controllers/comparisons/annual_energy_costs_per_pupil_controller.rb
+++ b/app/controllers/comparisons/annual_energy_costs_per_pupil_controller.rb
@@ -22,7 +22,7 @@ module Comparisons
 
     def load_data
       columns = [:one_year_electricity_per_pupil_kwh, :one_year_gas_per_pupil_kwh, :one_year_storage_heater_per_pupil_kwh]
-      Comparison::AnnualEnergyCostsPerUnit.for_schools(@schools).where_any_present(columns).by_total(columns)
+      Comparison::AnnualEnergyCostsPerUnit.for_schools(@schools).where_any_present(columns).by_total(columns, 'DESC NULLS LAST')
     end
 
     def create_charts(results)

--- a/spec/components/charts/group_dashboard_charts_component_spec.rb
+++ b/spec/components/charts/group_dashboard_charts_component_spec.rb
@@ -72,5 +72,12 @@ RSpec.describe Charts::GroupDashboardChartsComponent, :include_url_helpers, type
                                                         format: :json)
       end
     end
+
+    it 'includes view analysis link' do
+      expect(html).to have_link(I18n.t('school_groups.priority_actions.view_analysis'),
+                                href: compare_path(group: true,
+                                             benchmark: comparisons.first,
+                                             school_group_ids: [school_group.id]))
+    end
   end
 end


### PR DESCRIPTION
Changes sort order on the annual cost per pupil and floor area comparisons to sort highest to lowest. Makes the ordering consistent across the annual comparisons and on the group dashboards.

Also fixes incorrect link to the comparison table. Parameter name had changed but was missed here. Added a spec to test this.