### PR TITLE
Additional group caching changes

### DIFF
--- a/app/controllers/concerns/school_group_advice.rb
+++ b/app/controllers/concerns/school_group_advice.rb
@@ -6,7 +6,7 @@ module SchoolGroupAdvice
   end
 
   def set_counts
-    @priority_action_count = SchoolGroups::PriorityActions.new(@schools).priority_action_count
-    @alert_count = SchoolGroups::Alerts.new(@schools).summarise.count
+    @priority_actions_service = SchoolGroups::PriorityActions.new(@schools)
+    @alerts_service = SchoolGroups::Alerts.new(@schools)
   end
 end

--- a/app/controllers/school_groups/advice_controller.rb
+++ b/app/controllers/school_groups/advice_controller.rb
@@ -1,6 +1,7 @@
 module SchoolGroups
   class AdviceController < SchoolGroups::Advice::BaseController
     MODAL_ID = 'analysis-footnotes'.freeze
+    CACHE_TIME = 4.hours
 
     include Scoring
     include Promptable

--- a/app/helpers/school_groups_helper.rb
+++ b/app/helpers/school_groups_helper.rb
@@ -43,4 +43,11 @@ module SchoolGroupsHelper
   def secr_format_number(number)
     number_with_delimiter(number.round(2))
   end
+
+  # Cache (and use cached) pages if the list of schools for the current user
+  # all have public sharing. If not, then their list is bespoke to them so
+  # dont cache the content.
+  def can_cache_group_advice?(schools)
+    schools.all?(&:data_sharing_public?)
+  end
 end

--- a/app/helpers/school_groups_helper.rb
+++ b/app/helpers/school_groups_helper.rb
@@ -50,4 +50,8 @@ module SchoolGroupsHelper
   def can_cache_group_advice?(schools)
     schools.all?(&:data_sharing_public?)
   end
+
+  def group_advice_cache_key(school_group, additional = nil)
+    [school_group.most_recent_content_generation_run, *additional, I18n.locale]
+  end
 end

--- a/app/services/school_groups/alerts.rb
+++ b/app/services/school_groups/alerts.rb
@@ -7,7 +7,7 @@ module SchoolGroups
     # Summarise alerts being shown across schools in the group, exclude any that aren't
     # curerntly relevant for the group dashboard
     def summarise
-      summarised_alerts.reject do |alert|
+      @summarise ||= summarised_alerts.reject do |alert|
         content = alert.alert_type_rating.current_content
 
         !content.meets_timings?(scope: :group_dashboard_alert, today: Time.zone.today) ||

--- a/app/services/school_groups/priority_actions.rb
+++ b/app/services/school_groups/priority_actions.rb
@@ -6,7 +6,7 @@ module SchoolGroups
     end
 
     def priority_action_count
-      priority_actions.keys.count
+      @priority_action_count ||= priority_actions.keys.count
     end
 
     # returns a hash of alert_type_rating to a list of ManagementPriority

--- a/app/views/comparisons/base/index.html.erb
+++ b/app/views/comparisons/base/index.html.erb
@@ -14,7 +14,9 @@
     </div>
     <div id='group-advice-page-content' class="col-md-9 col-lg-9 col-xl-10">
       <div class="mt-2">
-        <% cache [@school_group.most_recent_content_generation_run, @report, I18n.locale], expires_in: 4.hours do %>
+        <% cache_if can_cache_group_advice?(@schools),
+                    [@school_group.most_recent_content_generation_run, @report, I18n.locale],
+                    expires_in: 4.hours do %>
           <%= render 'report' %>
         <% end %>
       </div>

--- a/app/views/comparisons/base/index.html.erb
+++ b/app/views/comparisons/base/index.html.erb
@@ -16,7 +16,7 @@
       <div class="mt-2">
         <% cache_if can_cache_group_advice?(@schools),
                     group_advice_cache_key(@school_group, @report),
-                    expires_in: 4.hours do %>
+                    expires_in: SchoolGroups::AdviceController::CACHE_TIME do %>
           <%= render 'report' %>
         <% end %>
       </div>

--- a/app/views/comparisons/base/index.html.erb
+++ b/app/views/comparisons/base/index.html.erb
@@ -15,7 +15,7 @@
     <div id='group-advice-page-content' class="col-md-9 col-lg-9 col-xl-10">
       <div class="mt-2">
         <% cache_if can_cache_group_advice?(@schools),
-                    [@school_group.most_recent_content_generation_run, @report, I18n.locale],
+                    group_advice_cache_key(@school_group, @report),
                     expires_in: 4.hours do %>
           <%= render 'report' %>
         <% end %>

--- a/app/views/school_groups/advice/alerts.html.erb
+++ b/app/views/school_groups/advice/alerts.html.erb
@@ -1,20 +1,6 @@
-<% content_for :page_title, "#{t('school_groups.advice.alerts.title')} | #{@school_group.name}" %>
-
-<% content_for :dashboard_header do %>
-  <%= render Layout::Cards::PageHeaderComponent.new(
-        title: t('school_groups.advice.alerts.title'),
-        subtitle: t('school_groups.advice.alerts.subtitle_html')
-      ) %>
+<%= render 'school_groups/advice/shared/advice_page',
+           page_title: t('school_groups.advice.alerts.title'),
+           page_subtitle: t('school_groups.advice.alerts.subtitle_html'),
+           school_group: @school_group do %>
+  <%= render Dashboards::GroupAlertsComponent.new(school_group: @school_group, grouped: true) %>
 <% end %>
-
-<div class="container">
-  <div class="row mt-2">
-    <div id='group-advice-page-nav' class="col-md-3 col-lg-3 col-xl-2 advice-page-nav">
-      <%= render 'school_groups/advice/shared/nav', school_group: @school_group %>
-    </div>
-    <div id='group-advice-page-content' class="col-md-9 col-lg-9 col-xl-10">
-      <%= render Dashboards::GroupAlertsComponent.new(school_group: @school_group,
-                                                      grouped: true) %>
-    </div>
-  </div>
-</div>

--- a/app/views/school_groups/advice/base/analysis.html.erb
+++ b/app/views/school_groups/advice/base/analysis.html.erb
@@ -8,7 +8,7 @@
   <div class="mt-4" id="<%= @advice_page_key %>-<%= @tab %>">
     <div class="mt-4" id="<%= @advice_page_key %>-<%= @tab %>">
       <% cache_if can_cache_group_advice?(@schools),
-                  [@school_group.most_recent_content_generation_run, @advice_page.key, I18n.locale],
+                  group_advice_cache_key(@school_group, @advice_page.key),
                   expires_in: 4.hours do %>
         <%= render 'analysis', school_group: @school_group %>
       <% end %>

--- a/app/views/school_groups/advice/base/analysis.html.erb
+++ b/app/views/school_groups/advice/base/analysis.html.erb
@@ -9,7 +9,7 @@
     <div class="mt-4" id="<%= @advice_page_key %>-<%= @tab %>">
       <% cache_if can_cache_group_advice?(@schools),
                   group_advice_cache_key(@school_group, @advice_page.key),
-                  expires_in: 4.hours do %>
+                  expires_in: SchoolGroups::AdviceController::CACHE_TIME do %>
         <%= render 'analysis', school_group: @school_group %>
       <% end %>
     </div>

--- a/app/views/school_groups/advice/base/analysis.html.erb
+++ b/app/views/school_groups/advice/base/analysis.html.erb
@@ -1,31 +1,20 @@
-<% content_for :page_title, "#{@page_title} | #{@school_group.name}" %>
-
-<% content_for :dashboard_header do %>
-  <%= render Layout::Cards::PageHeaderComponent.new(title: @page_title, subtitle: @page_subtitle) %>
-<% end %>
-
-<div class="container">
-  <div class="row mt-2">
-    <div id='group-advice-page-nav' class="col-md-3 col-lg-3 col-xl-2 advice-page-nav">
-      <%= render 'school_groups/advice/shared/nav', school_group: @school_group %>
-    </div>
-    <div id='group-advice-page-content' class="col-md-9 col-lg-9 col-xl-10 advice-page-tabs">
-      <%= render 'school_groups/advice/shared/advice_tabs',
-                 school_group: @school_group,
-                 advice_page: @advice_page,
-                 tab: @tab %>
-
-      <div class="mt-4" id="<%= @advice_page_key %>-<%= @tab %>">
-        <% cache_if can_cache_group_advice?(@schools),
-                    [@school_group.most_recent_content_generation_run, @advice_page.key, I18n.locale],
-                    expires_in: 4.hours do %>
-          <%= render 'analysis', school_group: @school_group %>
-        <% end %>
-      </div>
+<%= render 'school_groups/advice/shared/advice_page',
+           page_title: "#{@page_title} | #{@school_group.name}",
+           school_group: @school_group do %>
+  <%= render 'school_groups/advice/shared/advice_tabs',
+             school_group: @school_group,
+             advice_page: @advice_page,
+             tab: @tab %>
+  <div class="mt-4" id="<%= @advice_page_key %>-<%= @tab %>">
+    <div class="mt-4" id="<%= @advice_page_key %>-<%= @tab %>">
+      <% cache_if can_cache_group_advice?(@schools),
+                  [@school_group.most_recent_content_generation_run, @advice_page.key, I18n.locale],
+                  expires_in: 4.hours do %>
+        <%= render 'analysis', school_group: @school_group %>
+      <% end %>
     </div>
   </div>
-</div>
-
+<% end %>
 <%= render 'school_groups/advice/shared/analysis_footnotes',
            school_group: @school_group,
            schools: @schools,

--- a/app/views/school_groups/advice/base/analysis.html.erb
+++ b/app/views/school_groups/advice/base/analysis.html.erb
@@ -16,9 +16,9 @@
                  tab: @tab %>
 
       <div class="mt-4" id="<%= @advice_page_key %>-<%= @tab %>">
-        <% cache [@school_group.most_recent_content_generation_run,
-                  @advice_page.key,
-                  I18n.locale], expires_in: 4.hours do %>
+        <% cache_if can_cache_group_advice?(@schools),
+                    [@school_group.most_recent_content_generation_run, @advice_page.key, I18n.locale],
+                    expires_in: 4.hours do %>
           <%= render 'analysis', school_group: @school_group %>
         <% end %>
       </div>

--- a/app/views/school_groups/advice/base/insights.html.erb
+++ b/app/views/school_groups/advice/base/insights.html.erb
@@ -7,7 +7,7 @@
              tab: @tab %>
   <div class="mt-4" id="<%= @advice_page_key %>-<%= @tab %>">
     <% cache_if can_cache_group_advice?(@schools),
-                [@school_group.most_recent_content_generation_run, @advice_page.key, I18n.locale],
+                group_advice_cache_key(@school_group, @advice_page.key),
                 expires_in: 4.hours do %>
       <%= render 'insights', school_group: @school_group %>
     <% end %>

--- a/app/views/school_groups/advice/base/insights.html.erb
+++ b/app/views/school_groups/advice/base/insights.html.erb
@@ -16,9 +16,9 @@
                  tab: @tab %>
 
       <div class="mt-4" id="<%= @advice_page_key %>-<%= @tab %>">
-        <% cache [@school_group.most_recent_content_generation_run,
-                  @advice_page.key,
-                  I18n.locale], expires_in: 4.hours do %>
+        <% cache_if can_cache_group_advice?(@schools),
+                    [@school_group.most_recent_content_generation_run, @advice_page.key, I18n.locale],
+                    expires_in: 4.hours do %>
           <%= render 'insights', school_group: @school_group %>
         <% end %>
       </div>

--- a/app/views/school_groups/advice/base/insights.html.erb
+++ b/app/views/school_groups/advice/base/insights.html.erb
@@ -8,7 +8,7 @@
   <div class="mt-4" id="<%= @advice_page_key %>-<%= @tab %>">
     <% cache_if can_cache_group_advice?(@schools),
                 group_advice_cache_key(@school_group, @advice_page.key),
-                expires_in: 4.hours do %>
+                expires_in: SchoolGroups::AdviceController::CACHE_TIME do %>
       <%= render 'insights', school_group: @school_group %>
     <% end %>
   </div>

--- a/app/views/school_groups/advice/base/insights.html.erb
+++ b/app/views/school_groups/advice/base/insights.html.erb
@@ -1,27 +1,15 @@
-<% content_for :page_title, "#{@page_title} | #{@school_group.name}" %>
-
-<% content_for :dashboard_header do %>
-  <%= render Layout::Cards::PageHeaderComponent.new(title: @page_title, subtitle: @page_subtitle) %>
-<% end %>
-
-<div class="container">
-  <div class="row mt-2">
-    <div id='group-advice-page-nav' class="col-md-3 col-lg-3 col-xl-2 advice-page-nav">
-      <%= render 'school_groups/advice/shared/nav', school_group: @school_group %>
-    </div>
-    <div id='group-advice-page-content' class="col-md-9 col-lg-9 col-xl-10 advice-page-tabs">
-      <%= render 'school_groups/advice/shared/advice_tabs',
-                 school_group: @school_group,
-                 advice_page: @advice_page,
-                 tab: @tab %>
-
-      <div class="mt-4" id="<%= @advice_page_key %>-<%= @tab %>">
-        <% cache_if can_cache_group_advice?(@schools),
-                    [@school_group.most_recent_content_generation_run, @advice_page.key, I18n.locale],
-                    expires_in: 4.hours do %>
-          <%= render 'insights', school_group: @school_group %>
-        <% end %>
-      </div>
-    </div>
+<%= render 'school_groups/advice/shared/advice_page',
+           page_title: "#{@page_title} | #{@school_group.name}",
+           school_group: @school_group do %>
+  <%= render 'school_groups/advice/shared/advice_tabs',
+             school_group: @school_group,
+             advice_page: @advice_page,
+             tab: @tab %>
+  <div class="mt-4" id="<%= @advice_page_key %>-<%= @tab %>">
+    <% cache_if can_cache_group_advice?(@schools),
+                [@school_group.most_recent_content_generation_run, @advice_page.key, I18n.locale],
+                expires_in: 4.hours do %>
+      <%= render 'insights', school_group: @school_group %>
+    <% end %>
   </div>
-</div>
+<% end %>

--- a/app/views/school_groups/advice/charts.html.erb
+++ b/app/views/school_groups/advice/charts.html.erb
@@ -1,35 +1,22 @@
-<% content_for :page_title, t('school_groups.advice.charts.title', name: @school_group.name) %>
-
-<% content_for :dashboard_header do %>
-  <%= render Layout::Cards::PageHeaderComponent.new(
-        title: t('school_groups.advice.charts.title', name: @school_group.name)
-      ) %>
+<%= render 'school_groups/advice/shared/advice_page',
+           page_title: t('school_groups.advice.charts.title', name: @school_group.name),
+           school_group: @school_group do %>
+  <p>
+    <%= t('school_groups.advice.charts.introduction') %>.
+  <p>
+  <%= render Charts::SelectableSchoolChartsComponent.new(schools: @schools,
+                                                         fuel_types: @fuel_types,
+                                                         charts: @charts,
+                                                         defaults: {
+                                                           fuel_type: @default_fuel_type,
+                                                           chart_type: @default_chart_type,
+                                                           school: @default_school
+                                                         }) do |c| %>
+     <% c.with_chart_footer do %>
+       <%= render 'school_groups/advice/shared/analysis_footnotes_link' %>
+     <% end %>
+  <% end %>
 <% end %>
-
-<div class="container">
-  <div class="row mt-2">
-    <div id='group-advice-page-nav' class="col-md-3 col-lg-3 col-xl-2 advice-page-nav">
-      <%= render 'school_groups/advice/shared/nav', school_group: @school_group %>
-    </div>
-    <div id='group-advice-page-content' class="col-md-9 col-lg-9 col-xl-10">
-      <p>
-        <%= t('school_groups.advice.charts.introduction') %>.
-      <p>
-      <%= render Charts::SelectableSchoolChartsComponent.new(schools: @schools,
-                                                             fuel_types: @fuel_types,
-                                                             charts: @charts,
-                                                             defaults: {
-                                                               fuel_type: @default_fuel_type,
-                                                               chart_type: @default_chart_type,
-                                                               school: @default_school
-                                                             }) do |c| %>
-         <% c.with_chart_footer do %>
-           <%= render 'school_groups/advice/shared/analysis_footnotes_link' %>
-         <% end %>
-      <% end %>
-    </div>
-  </div>
-</div>
 <%= render 'school_groups/advice/shared/analysis_footnotes',
            school_group: @school_group,
            schools: @schools,

--- a/app/views/school_groups/advice/comparison_reports.html.erb
+++ b/app/views/school_groups/advice/comparison_reports.html.erb
@@ -1,161 +1,148 @@
-<% content_for :page_title, t('school_groups.advice.comparison_reports.title', name: @school_group.name) %>
-
-<% content_for :dashboard_header do %>
-  <%= render Layout::Cards::PageHeaderComponent.new(
-        title: t('school_groups.advice.comparison_reports.title', name: @school_group.name)
-      ) %>
-<% end %>
-
-<div class="container">
-  <div class="row mt-2">
-    <div id='group-advice-page-nav' class="col-md-3 col-lg-3 col-xl-2 advice-page-nav">
-      <%= render 'school_groups/advice/shared/nav', school_group: @school_group %>
-    </div>
-    <div id='group-advice-page-content' class="col-md-9 col-lg-9 col-xl-10">
-      <div class="row">
-        <div class="col-12">
-          <h3><%= t('school_groups.advice.comparison_reports.page_heading') %></h3>
-          <p><%= t('school_groups.advice.comparison_reports.introduction') %></p>
-        </div>
-      </div>
-
-      <% i18n_scope = 'school_groups.advice.comparison_reports.links' %>
-
-      <%= render Layout::GridComponent.new(id: 'report-grid',
-                                           cols: 2,
-                                           cell_classes: 'mb-4 pb-2',
-                                           component_classes: %w[h-100 p-4 bg-light rounded]) do |grid| %>
-        <% grid.with_block do %>
-          <h4><%= t('school_groups.advice.comparison_reports.lists.long_term') %></h4>
-          <%= render SchoolGroups::ComparisonReportListComponent.new(school_group: @school_group,
-                                                                     fuel_types: @fuel_types) do |list| %>
-            <% list.with_fuel_types t(:annual_change, scope: i18n_scope), reports: {
-                 electricity: :change_in_electricity_since_last_year,
-                 gas: :change_in_gas_since_last_year,
-                 storage_heaters: :change_in_storage_heaters_since_last_year
-               } %>
-            <% list.with_fuel_types t(:savings_potential, scope: i18n_scope), reports: {
-                 electricity: { report: :annual_electricity_costs_per_pupil,
-                                label: t(:electricity_per_pupil,
-                                         scope: i18n_scope) },
-                 gas: { report: :annual_heating_costs_per_floor_area,
-                        label: t(:gas_per_floor_area, scope: i18n_scope) }
-               } %>
-            <% list.with_fuel_types t(:progress, scope: i18n_scope), reports: {
-                 electricity: :electricity_targets,
-                 gas: :gas_targets
-               } %>
-          <% end %>
-        <% end %>
-        <% grid.with_block do %>
-          <h4><%= t('school_groups.advice.comparison_reports.lists.out_of_hours') %></h4>
-          <%= render SchoolGroups::ComparisonReportListComponent.new(school_group: @school_group,
-                                                                     fuel_types: @fuel_types) do |list| %>
-            <% list.with_fuel_types t(:annual, scope: i18n_scope), reports: {
-                 electricity: :annual_electricity_out_of_hours_use,
-                 gas: :annual_gas_out_of_hours_use,
-                 storage_heaters: :annual_storage_heater_out_of_hours_use
-               } %>
-            <% list.with_fuel_types t(:annual_change,
-                                      scope: i18n_scope), reports: {
-                                        electricity: :change_in_electricity_since_last_year,
-                                        gas: :change_in_gas_since_last_year,
-                                        storage_heaters: :change_in_storage_heaters_since_last_year
-                                      } %>
-            <% list.with_fuel_types t(:last_two_holidays,
-                                      scope: i18n_scope), reports: {
-                                        electricity: :change_in_electricity_holiday_consumption_previous_holiday,
-                                        gas: :change_in_gas_holiday_consumption_previous_holiday
-                                      } %>
-            <% list.with_fuel_types t(:same_holiday,
-                                      scope: i18n_scope), reports: {
-                                        electricity: :change_in_electricity_holiday_consumption_previous_years_holiday,
-                                        gas: :change_in_gas_holiday_consumption_previous_years_holiday
-                                      } %>
-            <% list.with_fuel_types t(:current_holiday,
-                                      scope: i18n_scope), reports: {
-                                        electricity: :electricity_consumption_during_holiday,
-                                        gas: :gas_consumption_during_holiday,
-                                        storage_heaters: :storage_heater_consumption_during_holiday
-                                      } %>
-            <% list.with_link t(:upcoming_holiday, scope: i18n_scope),
-                              report: :holiday_usage_last_year %>
-          <% end %>
-        <% end %>
-        <% grid.with_block do %>
-          <h4><%= t('school_groups.advice.comparison_reports.lists.baseload') %></h4>
-          <%= render SchoolGroups::ComparisonReportListComponent.new(school_group: @school_group,
-                                                                     fuel_types: @fuel_types) do |list| %>
-            <% list.with_link t(:baseload_per_pupil, scope: i18n_scope),
-                              report: :baseload_per_pupil,
-                              fuel_type: :electricity %>
-            <% list.with_link t(:recent_baseload, scope: i18n_scope),
-                              report: :recent_change_in_baseload,
-                              fuel_type: :electricity %>
-            <% list.with_link t(:peak_use, scope: i18n_scope),
-                              report: :electricity_peak_kw_per_pupil,
-                              fuel_type: :electricity %>
-            <% list.with_named t(:baseload_variation, scope: i18n_scope),
-                               fuel_type: :electricity,
-                               reports: {
-                                 seasonal_baseload_variation:
-                                  t(:seasonal, scope: i18n_scope),
-                                 weekday_baseload_variation:
-                                  t(:weekday, scope: i18n_scope)
-                               } %>
-          <% end %>
-        <% end if @fuel_types.include?(:electricity) %>
-        <% grid.with_block do %>
-          <h4><%= t('school_groups.advice.comparison_reports.lists.heating') %></h4>
-          <%= render SchoolGroups::ComparisonReportListComponent.new(school_group: @school_group,
-                                                                     fuel_types: @fuel_types) do |list| %>
-            <% list.with_link t(:change_thermostat, scope: i18n_scope),
-                              report: :thermostat_sensitivity,
-                              fuel_type: :gas %>
-            <% list.with_link t(:heating_times, scope: i18n_scope),
-                              report: :heating_coming_on_too_early,
-                              fuel_type: :gas %>
-            <% list.with_link t(:warm_weather, scope: i18n_scope),
-                              report: :heating_in_warm_weather,
-                              fuel_type: :gas %>
-            <% list.with_link t(:thermostatic_control, scope: i18n_scope),
-                              report: :thermostatic_control,
-                              fuel_type: :gas %>
-            <% list.with_link t(:heating_hot_water, scope: i18n_scope),
-                              report: :heating_vs_hot_water,
-                              fuel_type: :gas %>
-            <% list.with_link t(:hot_water_efficiency,
-                                scope: i18n_scope),
-                              report: :hot_water_efficiency,
-                              fuel_type: :gas %>
-          <% end %>
-        <% end if @fuel_types.include?(:gas) %>
-        <% grid.with_block do %>
-          <h4><%= t('school_groups.advice.comparison_reports.lists.total') %></h4>
-          <%= render SchoolGroups::ComparisonReportListComponent.new(school_group: @school_group,
-                                                                     fuel_types: @fuel_types) do |list| %>
-            <% list.with_link t(:annual_energy, scope: i18n_scope),
-                              report: :annual_energy_use %>
-            <% list.with_named t(:annual_energy, scope: i18n_scope), reports: {
-                 annual_energy_costs_per_pupil: t(:per_pupil, scope: i18n_scope),
-                 annual_energy_costs_per_floor_area: t(:per_floor_area,
-                                                       scope: i18n_scope)
-               } %>
-          <% end %>
-        <% end %>
-        <% grid.with_block do %>
-          <h4><%= t('school_groups.advice.comparison_reports.lists.solar') %></h4>
-          <%= render SchoolGroups::ComparisonReportListComponent.new(school_group: @school_group,
-                                                                     fuel_types: @fuel_types) do |list| %>
-            <% list.with_link t(:solar_benefit, scope: i18n_scope),
-                              report: :solar_pv_benefit_estimate %>
-            <% list.with_link t(:solar_generation, scope: i18n_scope),
-                              report: :solar_generation_summary %>
-            <% list.with_link t(:solar_change, scope: i18n_scope),
-                              report: :change_in_solar_pv_since_last_year %>
-          <% end %>
-        <% end if @fuel_types.include?(:solar_pv) %>
-      <% end %>
+<%= render 'school_groups/advice/shared/advice_page',
+           page_title: t('school_groups.advice.comparison_reports.title', name: @school_group.name),
+           school_group: @school_group do %>
+  <div class="row">
+    <div class="col-12">
+      <h3><%= t('school_groups.advice.comparison_reports.page_heading') %></h3>
+      <p><%= t('school_groups.advice.comparison_reports.introduction') %></p>
     </div>
   </div>
-</div>
+
+  <% i18n_scope = 'school_groups.advice.comparison_reports.links' %>
+
+  <%= render Layout::GridComponent.new(id: 'report-grid',
+                                       cols: 2,
+                                       cell_classes: 'mb-4 pb-2',
+                                       component_classes: %w[h-100 p-4 bg-light rounded]) do |grid| %>
+    <% grid.with_block do %>
+      <h4><%= t('school_groups.advice.comparison_reports.lists.long_term') %></h4>
+      <%= render SchoolGroups::ComparisonReportListComponent.new(school_group: @school_group,
+                                                                 fuel_types: @fuel_types) do |list| %>
+        <% list.with_fuel_types t(:annual_change, scope: i18n_scope), reports: {
+             electricity: :change_in_electricity_since_last_year,
+             gas: :change_in_gas_since_last_year,
+             storage_heaters: :change_in_storage_heaters_since_last_year
+           } %>
+        <% list.with_fuel_types t(:savings_potential, scope: i18n_scope), reports: {
+             electricity: { report: :annual_electricity_costs_per_pupil,
+                            label: t(:electricity_per_pupil,
+                                     scope: i18n_scope) },
+             gas: { report: :annual_heating_costs_per_floor_area,
+                    label: t(:gas_per_floor_area, scope: i18n_scope) }
+           } %>
+        <% list.with_fuel_types t(:progress, scope: i18n_scope), reports: {
+             electricity: :electricity_targets,
+             gas: :gas_targets
+           } %>
+      <% end %>
+    <% end %>
+    <% grid.with_block do %>
+      <h4><%= t('school_groups.advice.comparison_reports.lists.out_of_hours') %></h4>
+      <%= render SchoolGroups::ComparisonReportListComponent.new(school_group: @school_group,
+                                                                 fuel_types: @fuel_types) do |list| %>
+        <% list.with_fuel_types t(:annual, scope: i18n_scope), reports: {
+             electricity: :annual_electricity_out_of_hours_use,
+             gas: :annual_gas_out_of_hours_use,
+             storage_heaters: :annual_storage_heater_out_of_hours_use
+           } %>
+        <% list.with_fuel_types t(:annual_change,
+                                  scope: i18n_scope), reports: {
+                                    electricity: :change_in_electricity_since_last_year,
+                                    gas: :change_in_gas_since_last_year,
+                                    storage_heaters: :change_in_storage_heaters_since_last_year
+                                  } %>
+        <% list.with_fuel_types t(:last_two_holidays,
+                                  scope: i18n_scope), reports: {
+                                    electricity: :change_in_electricity_holiday_consumption_previous_holiday,
+                                    gas: :change_in_gas_holiday_consumption_previous_holiday
+                                  } %>
+        <% list.with_fuel_types t(:same_holiday,
+                                  scope: i18n_scope), reports: {
+                                    electricity: :change_in_electricity_holiday_consumption_previous_years_holiday,
+                                    gas: :change_in_gas_holiday_consumption_previous_years_holiday
+                                  } %>
+        <% list.with_fuel_types t(:current_holiday,
+                                  scope: i18n_scope), reports: {
+                                    electricity: :electricity_consumption_during_holiday,
+                                    gas: :gas_consumption_during_holiday,
+                                    storage_heaters: :storage_heater_consumption_during_holiday
+                                  } %>
+        <% list.with_link t(:upcoming_holiday, scope: i18n_scope),
+                          report: :holiday_usage_last_year %>
+      <% end %>
+    <% end %>
+    <% grid.with_block do %>
+      <h4><%= t('school_groups.advice.comparison_reports.lists.baseload') %></h4>
+      <%= render SchoolGroups::ComparisonReportListComponent.new(school_group: @school_group,
+                                                                 fuel_types: @fuel_types) do |list| %>
+        <% list.with_link t(:baseload_per_pupil, scope: i18n_scope),
+                          report: :baseload_per_pupil,
+                          fuel_type: :electricity %>
+        <% list.with_link t(:recent_baseload, scope: i18n_scope),
+                          report: :recent_change_in_baseload,
+                          fuel_type: :electricity %>
+        <% list.with_link t(:peak_use, scope: i18n_scope),
+                          report: :electricity_peak_kw_per_pupil,
+                          fuel_type: :electricity %>
+        <% list.with_named t(:baseload_variation, scope: i18n_scope),
+                           fuel_type: :electricity,
+                           reports: {
+                             seasonal_baseload_variation:
+                              t(:seasonal, scope: i18n_scope),
+                             weekday_baseload_variation:
+                              t(:weekday, scope: i18n_scope)
+                           } %>
+      <% end %>
+    <% end if @fuel_types.include?(:electricity) %>
+    <% grid.with_block do %>
+      <h4><%= t('school_groups.advice.comparison_reports.lists.heating') %></h4>
+      <%= render SchoolGroups::ComparisonReportListComponent.new(school_group: @school_group,
+                                                                 fuel_types: @fuel_types) do |list| %>
+        <% list.with_link t(:change_thermostat, scope: i18n_scope),
+                          report: :thermostat_sensitivity,
+                          fuel_type: :gas %>
+        <% list.with_link t(:heating_times, scope: i18n_scope),
+                          report: :heating_coming_on_too_early,
+                          fuel_type: :gas %>
+        <% list.with_link t(:warm_weather, scope: i18n_scope),
+                          report: :heating_in_warm_weather,
+                          fuel_type: :gas %>
+        <% list.with_link t(:thermostatic_control, scope: i18n_scope),
+                          report: :thermostatic_control,
+                          fuel_type: :gas %>
+        <% list.with_link t(:heating_hot_water, scope: i18n_scope),
+                          report: :heating_vs_hot_water,
+                          fuel_type: :gas %>
+        <% list.with_link t(:hot_water_efficiency,
+                            scope: i18n_scope),
+                          report: :hot_water_efficiency,
+                          fuel_type: :gas %>
+      <% end %>
+    <% end if @fuel_types.include?(:gas) %>
+    <% grid.with_block do %>
+      <h4><%= t('school_groups.advice.comparison_reports.lists.total') %></h4>
+      <%= render SchoolGroups::ComparisonReportListComponent.new(school_group: @school_group,
+                                                                 fuel_types: @fuel_types) do |list| %>
+        <% list.with_link t(:annual_energy, scope: i18n_scope),
+                          report: :annual_energy_use %>
+        <% list.with_named t(:annual_energy, scope: i18n_scope), reports: {
+             annual_energy_costs_per_pupil: t(:per_pupil, scope: i18n_scope),
+             annual_energy_costs_per_floor_area: t(:per_floor_area,
+                                                   scope: i18n_scope)
+           } %>
+      <% end %>
+    <% end %>
+    <% grid.with_block do %>
+      <h4><%= t('school_groups.advice.comparison_reports.lists.solar') %></h4>
+      <%= render SchoolGroups::ComparisonReportListComponent.new(school_group: @school_group,
+                                                                 fuel_types: @fuel_types) do |list| %>
+        <% list.with_link t(:solar_benefit, scope: i18n_scope),
+                          report: :solar_pv_benefit_estimate %>
+        <% list.with_link t(:solar_generation, scope: i18n_scope),
+                          report: :solar_generation_summary %>
+        <% list.with_link t(:solar_change, scope: i18n_scope),
+                          report: :change_in_solar_pv_since_last_year %>
+      <% end %>
+    <% end if @fuel_types.include?(:solar_pv) %>
+  <% end %>
+<% end %>

--- a/app/views/school_groups/advice/priorities.html.erb
+++ b/app/views/school_groups/advice/priorities.html.erb
@@ -8,7 +8,7 @@
 
   <% cache_if can_cache_group_advice?(@schools),
               group_advice_cache_key(@school_group),
-              expires_in: 4.hours do %>
+              expires_in: SchoolGroups::AdviceController::CACHE_TIME do %>
     <%= render 'school_groups/advice/priority_table',
                school_group: @school_group,
                path: [:priorities, @school_group, :advice],

--- a/app/views/school_groups/advice/priorities.html.erb
+++ b/app/views/school_groups/advice/priorities.html.erb
@@ -18,7 +18,9 @@
         <%= t('advice_pages.index.priorities.table_title') %>
       </h2>
 
-      <% cache [@school_group.most_recent_content_generation_run, I18n.locale], expires_in: 4.hours do %>
+      <% cache_if can_cache_group_advice?(@schools),
+                  [@school_group.most_recent_content_generation_run, I18n.locale],
+                  expires_in: 4.hours do %>
         <%= render 'school_groups/advice/priority_table',
                    school_group: @school_group,
                    path: [:priorities, @school_group, :advice],

--- a/app/views/school_groups/advice/priorities.html.erb
+++ b/app/views/school_groups/advice/priorities.html.erb
@@ -1,32 +1,18 @@
-<% content_for :page_title, "#{t('school_groups.advice.priorities.title')} | #{@school_group.name}" %>
+<%= render 'school_groups/advice/shared/advice_page',
+           page_title: t('school_groups.advice.priorities.title'),
+           school_group: @school_group do %>
+  <%= render 'school_groups/advice/shared/message', school_group: @school_group %>
+  <h2>
+    <%= t('advice_pages.index.priorities.table_title') %>
+  </h2>
 
-<% content_for :dashboard_header do %>
-  <%= render Layout::Cards::PageHeaderComponent.new(
-        title: t('school_groups.advice.priorities.title')
-      ) %>
+  <% cache_if can_cache_group_advice?(@schools),
+              [@school_group.most_recent_content_generation_run, I18n.locale],
+              expires_in: 4.hours do %>
+    <%= render 'school_groups/advice/priority_table',
+               school_group: @school_group,
+               path: [:priorities, @school_group, :advice],
+               priority_actions: @priority_actions,
+               total_savings: @total_savings %>
+  <% end %>
 <% end %>
-
-<div class="container">
-  <div class="row mt-2">
-    <div id='group-advice-page-nav' class="col-md-3 col-lg-3 col-xl-2">
-      <%= render 'school_groups/advice/shared/nav', school_group: @school_group %>
-    </div>
-    <div id='group-advice-page-content' class="col-md-9 col-lg-9 col-xl-10">
-      <%= render 'school_groups/advice/shared/message', school_group: @school_group %>
-
-      <h2>
-        <%= t('advice_pages.index.priorities.table_title') %>
-      </h2>
-
-      <% cache_if can_cache_group_advice?(@schools),
-                  [@school_group.most_recent_content_generation_run, I18n.locale],
-                  expires_in: 4.hours do %>
-        <%= render 'school_groups/advice/priority_table',
-                   school_group: @school_group,
-                   path: [:priorities, @school_group, :advice],
-                   priority_actions: @priority_actions,
-                   total_savings: @total_savings %>
-      <% end %>
-    </div>
-  </div>
-</div>

--- a/app/views/school_groups/advice/priorities.html.erb
+++ b/app/views/school_groups/advice/priorities.html.erb
@@ -7,7 +7,7 @@
   </h2>
 
   <% cache_if can_cache_group_advice?(@schools),
-              [@school_group.most_recent_content_generation_run, I18n.locale],
+              group_advice_cache_key(@school_group),
               expires_in: 4.hours do %>
     <%= render 'school_groups/advice/priority_table',
                school_group: @school_group,

--- a/app/views/school_groups/advice/scores.html.erb
+++ b/app/views/school_groups/advice/scores.html.erb
@@ -1,23 +1,10 @@
-<% content_for :page_title, t('school_groups.advice.scores.title', name: @school_group.name) %>
-
-<% content_for :dashboard_header do %>
-  <%= render Layout::Cards::PageHeaderComponent.new(
-        title: t('school_groups.advice.scores.title', name: @school_group.name)
-      ) %>
+<%= render 'school_groups/advice/shared/advice_page',
+           page_title: t('school_groups.advice.scores.title', name: @school_group.name),
+           school_group: @school_group do %>
+  <%= render 'school_groups/advice/scoreboard',
+             school_group: @school_group,
+             academic_year: @academic_year,
+             current_year: @current_year,
+             scored_schools: @scored_schools,
+             path: [:scores, @school_group, :advice] %>
 <% end %>
-
-<div class="container">
-  <div class="row mt-2">
-    <div id='group-advice-page-nav' class="col-md-3 col-lg-3 col-xl-2 advice-page-nav">
-      <%= render 'school_groups/advice/shared/nav', school_group: @school_group %>
-    </div>
-    <div id='group-advice-page-content' class="col-md-9 col-lg-9 col-xl-10">
-      <%= render 'school_groups/advice/scoreboard',
-                 school_group: @school_group,
-                 academic_year: @academic_year,
-                 current_year: @current_year,
-                 scored_schools: @scored_schools,
-                 path: [:scores, @school_group, :advice] %>
-    </div>
-  </div>
-</div>

--- a/app/views/school_groups/advice/shared/_advice_page.html.erb
+++ b/app/views/school_groups/advice/shared/_advice_page.html.erb
@@ -1,0 +1,16 @@
+<% content_for :page_title, page_title %>
+
+<% content_for :dashboard_header do %>
+  <%= render Layout::Cards::PageHeaderComponent.new(title: page_title, subtitle: local_assigns[:page_subtitle]) %>
+<% end %>
+
+<div class="container">
+  <div class="row mt-2">
+    <div id='group-advice-page-nav' class="col-md-3 col-lg-3 col-xl-2 advice-page-nav">
+      <%= render 'school_groups/advice/shared/nav', school_group: school_group %>
+    </div>
+    <div id='group-advice-page-content' class="col-md-9 col-lg-9 col-xl-10 advice-page-tabs">
+      <%= yield %>
+    </div>
+  </div>
+</div>

--- a/app/views/school_groups/advice/shared/_nav.html.erb
+++ b/app/views/school_groups/advice/shared/_nav.html.erb
@@ -1,20 +1,21 @@
 <%= render PageNavComponent.new(name: t('advice_pages.nav.overview'),
                                 icon: nil, href: school_group_advice_path(school_group),
                                 options: { match_controller: true }) do |c| %>
+
   <% c.with_section id: 'nav-section-alerts',
                     toggler: false,
-                    visible: @alert_count.positive?,
+                    visible: @alerts_service.summarise.count.positive?,
                     options: { match_controller: false } do |s| %>
     <% s.with_item(name: t('advice_pages.index.alerts.title'),
-                   note: "(#{@alert_count})",
+                   note: "(#{@alerts_service.summarise.count})",
                    href: alerts_school_group_advice_path(school_group), classes: 'section-link') %>
   <% end %>
   <% c.with_section id: 'nav-section-priorities',
                     toggler: false,
-                    visible: @priority_action_count.positive?,
+                    visible: @priority_actions_service.priority_action_count.positive?,
                     options: { match_controller: false }  do |s| %>
     <% s.with_item(name: t('advice_pages.index.priorities.title'),
-                   note: "(#{@priority_action_count})",
+                   note: "(#{@priority_actions_service.priority_action_count})",
                    href: priorities_school_group_advice_path(school_group),
                    classes: 'section-link') %>
   <% end %>

--- a/app/views/school_groups/advice/show.html.erb
+++ b/app/views/school_groups/advice/show.html.erb
@@ -9,7 +9,7 @@
 
   <% cache_if can_cache_group_advice?(@schools),
               group_advice_cache_key(@school_group, [params[:metric] || :change]),
-              expires_in: 4.hours do %>
+              expires_in: SchoolGroups::AdviceController::CACHE_TIME do %>
     <%= render Dashboards::GroupEnergySummaryComponent.new(
           school_group: @school_group,
           schools: @schools,

--- a/app/views/school_groups/advice/show.html.erb
+++ b/app/views/school_groups/advice/show.html.erb
@@ -8,7 +8,7 @@
   <%= render 'school_groups/advice/shared/message', school_group: @school_group %>
 
   <% cache_if can_cache_group_advice?(@schools),
-              [@school_group.most_recent_content_generation_run, params[:metric] || :change, I18n.locale],
+              group_advice_cache_key(@school_group, [params[:metric] || :change]),
               expires_in: 4.hours do %>
     <%= render Dashboards::GroupEnergySummaryComponent.new(
           school_group: @school_group,

--- a/app/views/school_groups/advice/show.html.erb
+++ b/app/views/school_groups/advice/show.html.erb
@@ -18,7 +18,9 @@
       </h2>
       <%= render 'school_groups/advice/shared/message', school_group: @school_group %>
 
-      <% cache [@school_group.most_recent_content_generation_run, params[:metric], I18n.locale], expires_in: 4.hours do %>
+      <% cache_if can_cache_group_advice?(@schools),
+                  [@school_group.most_recent_content_generation_run, params[:metric] || :change, I18n.locale],
+                  expires_in: 4.hours do %>
         <%= render Dashboards::GroupEnergySummaryComponent.new(
               school_group: @school_group,
               schools: @schools,

--- a/app/views/school_groups/advice/show.html.erb
+++ b/app/views/school_groups/advice/show.html.erb
@@ -1,47 +1,34 @@
-<% content_for :page_title, "#{t('advice_pages.index.title')} | #{@school_group.name}" %>
+<%= render 'school_groups/advice/shared/advice_page',
+           page_title: t('school_groups.advice.show.title'),
+           school_group: @school_group,
+           page_subtitle: t('school_groups.advice.show.subtitle_html') do %>
+  <h2>
+    <%= t('school_groups.advice.show.recent_energy_use.title') %>
+  </h2>
+  <%= render 'school_groups/advice/shared/message', school_group: @school_group %>
 
-<% content_for :dashboard_header do %>
-  <%= render Layout::Cards::PageHeaderComponent.new(
-        title: t('school_groups.advice.show.title'),
-        subtitle: t('school_groups.advice.show.subtitle_html')
-      ) %>
-<% end %>
-
-<div class="container">
-  <div class="row mt-2">
-    <div id="group-advice-page-nav" class="col-md-3 col-lg-3 col-xl-2 advice-page-nav">
-      <%= render 'school_groups/advice/shared/nav', school_group: @school_group %>
-    </div>
-    <div id='group-advice-page-content' class="col-md-9 col-lg-9 col-xl-10">
-      <h2>
-        <%= t('school_groups.advice.show.recent_energy_use.title') %>
-      </h2>
-      <%= render 'school_groups/advice/shared/message', school_group: @school_group %>
-
-      <% cache_if can_cache_group_advice?(@schools),
-                  [@school_group.most_recent_content_generation_run, params[:metric] || :change, I18n.locale],
-                  expires_in: 4.hours do %>
-        <%= render Dashboards::GroupEnergySummaryComponent.new(
-              school_group: @school_group,
-              schools: @schools,
-              fuel_types: @fuel_types,
-              metric: params[:metric],
-              classes: 'mt-2',
-              show_clusters: can?(:update_settings, @school_group)
-            ) do |summary| %>
-            <% summary.with_modal_link do %>
-              <%= render 'school_groups/advice/shared/analysis_footnotes_link' %>
-            <% end %>
-            <% summary.with_footer do %>
-              <%= render 'school_groups/advice/shared/analysis_footnotes',
-                         school_group: @school_group,
-                         schools: @schools,
-                         fuel_types: @fuel_types,
-                         extra_notes:
-                          t('school_groups.advice_pages.how_have_we_analysed_your_data.summary_table_notes_html') %>
-            <% end %>
+  <% cache_if can_cache_group_advice?(@schools),
+              [@school_group.most_recent_content_generation_run, params[:metric] || :change, I18n.locale],
+              expires_in: 4.hours do %>
+    <%= render Dashboards::GroupEnergySummaryComponent.new(
+          school_group: @school_group,
+          schools: @schools,
+          fuel_types: @fuel_types,
+          metric: params[:metric],
+          classes: 'mt-2',
+          show_clusters: can?(:update_settings, @school_group)
+        ) do |summary| %>
+        <% summary.with_modal_link do %>
+          <%= render 'school_groups/advice/shared/analysis_footnotes_link' %>
         <% end %>
-      <% end %>
-    </div>
-  </div>
-</div>
+        <% summary.with_footer do %>
+          <%= render 'school_groups/advice/shared/analysis_footnotes',
+                     school_group: @school_group,
+                     schools: @schools,
+                     fuel_types: @fuel_types,
+                     extra_notes:
+                      t('school_groups.advice_pages.how_have_we_analysed_your_data.summary_table_notes_html') %>
+        <% end %>
+    <% end %>
+  <% end %>
+<% end %>


### PR DESCRIPTION
- Switch to cache_if for groups. to ensure we're not caching content for `data_sharing_private` or `data_sharing_within_group` schools. Uses new helper
- Extract partial for group advice pages
- Add helper for building cache key for consistency