### PR TITLE
Optimising loading of alerts content for group advice

### DIFF
--- a/app/models/alert.rb
+++ b/app/models/alert.rb
@@ -119,10 +119,12 @@ class Alert < ApplicationRecord
   end
 
   def self.summarised_alerts(schools:)
+    list_of_ids = schools.map(&:id).join(',')
     query = <<-SQL.squish
       WITH latest_runs AS (
         SELECT DISTINCT ON (school_id) id
         FROM alert_generation_runs
+        WHERE school_id IN (#{list_of_ids})
         ORDER BY school_id, created_at DESC
       )
       SELECT
@@ -146,7 +148,7 @@ class Alert < ApplicationRecord
           one_year_saving_kwh FLOAT,
           time_of_year_relevance FLOAT
         )
-      WHERE schools.id IN (#{schools.map(&:id).join(',')})
+      WHERE schools.id IN (#{list_of_ids})
       AND
        average_one_year_saving_gbp IS NOT NULL
       AND

--- a/app/models/alert.rb
+++ b/app/models/alert.rb
@@ -120,41 +120,40 @@ class Alert < ApplicationRecord
 
   def self.summarised_alerts(schools:)
     query = <<-SQL.squish
+      WITH latest_runs AS (
+        SELECT DISTINCT ON (school_id) id
+        FROM alert_generation_runs
+        ORDER BY school_id, created_at DESC
+      )
       SELECT
-        alert_types.id AS alert_type_id,
+        alerts.alert_type_id AS alert_type_id,
         alert_type_ratings.id AS alert_type_rating_id,
-        count(alerts.school_id) AS number_of_schools,
-        sum(var.one_year_saving_kwh) AS total_one_year_saving_kwh,
-        sum(var.average_one_year_saving_gbp) AS total_average_one_year_saving_gbp,
-        sum(var.one_year_saving_co2) AS total_one_year_saving_co2,
-        sum(alerts.rating) / count(alerts.school_id)::float AS average_rating,
-        min(var.time_of_year_relevance) AS time_of_year_relevance
+        COUNT(alerts.school_id) AS number_of_schools,
+        SUM(var.one_year_saving_kwh) AS total_one_year_saving_kwh,
+        SUM(var.average_one_year_saving_gbp) AS total_average_one_year_saving_gbp,
+        SUM(var.one_year_saving_co2) AS total_one_year_saving_co2,
+        SUM(alerts.rating) / COUNT(alerts.school_id)::float AS average_rating,
+        MIN(var.time_of_year_relevance) AS time_of_year_relevance
       FROM alerts
-        JOIN alert_types ON alerts.alert_type_id = alert_types.id
-        JOIN alert_type_ratings ON alert_type_ratings.alert_type_id = alert_types.id
-        JOIN (
-          SELECT DISTINCT ON (school_id) id
-          FROM alert_generation_runs
-          ORDER BY school_id, created_at DESC
-        ) latest_runs ON alerts.alert_generation_run_id = latest_runs.id,
+        JOIN schools ON alerts.school_id = schools.id
+        JOIN latest_runs ON alerts.alert_generation_run_id = latest_runs.id
+        JOIN alert_type_ratings ON alert_type_ratings.alert_type_id = alerts.alert_type_id
+          AND alerts.rating BETWEEN alert_type_ratings.rating_from AND alert_type_ratings.rating_to
+          AND alert_type_ratings.group_dashboard_alert_active = TRUE,
         JSONB_TO_RECORD(alerts.variables) AS var(
-          average_one_year_saving_gbp float,
-          one_year_saving_co2 float,
-          one_year_saving_kwh float,
-          time_of_year_relevance float
+          average_one_year_saving_gbp FLOAT,
+          one_year_saving_co2 FLOAT,
+          one_year_saving_kwh FLOAT,
+          time_of_year_relevance FLOAT
         )
-      WHERE alerts.school_id IN (#{schools.map(&:id).join(',')})
-      AND
-       alert_type_ratings.group_dashboard_alert_active = true
-      AND
-       alerts.rating BETWEEN alert_type_ratings.rating_from AND alert_type_ratings.rating_to
+      WHERE schools.id IN (#{schools.map(&:id).join(',')})
       AND
        average_one_year_saving_gbp IS NOT NULL
       AND
        one_year_saving_co2 IS NOT NULL
       AND
        one_year_saving_kwh IS NOT NULL
-      GROUP BY alert_types.id, alert_type_ratings.id;
+      GROUP BY alerts.alert_type_id, alert_type_ratings.id;
     SQL
     sanitized_query = ActiveRecord::Base.sanitize_sql_array(query)
     Alert.connection.select_all(sanitized_query).map do |row|

--- a/app/models/management_priority.rb
+++ b/app/models/management_priority.rb
@@ -40,7 +40,6 @@ class ManagementPriority < ApplicationRecord
     joins(:alert, alert: :alert_type).where.not(alert_type: { class_name: ['AlertSolarPVBenefitEstimator', 'AlertHotWaterInsulationAdvice'] })
   end
 
-
   # Returns an Array of OpenStruct
   def self.for_schools(schools)
     query = <<-SQL.squish

--- a/app/services/school_groups/priority_actions.rb
+++ b/app/services/school_groups/priority_actions.rb
@@ -103,11 +103,11 @@ module SchoolGroups
     # ManagementPriority record. These are all the ratings that school might be graded
     # against
     def alert_type_ratings
-      @alert_type_ratings = AlertTypeRating.management_priorities_title
+      @alert_type_ratings ||= AlertTypeRating.management_priorities_title
     end
 
     def priorities
-      @priorities = ManagementPriority.for_schools(@schools)
+      @priorities ||= ManagementPriority.for_schools(@schools)
     end
   end
 end


### PR DESCRIPTION
- [x] Improve loading of summarised alerts for dashboard, recent alerts pages and navbar counts
- [x] Improve loading of priority actions for dashboard, priority actions page and navbar counts

The EXPLAIN ANALYZE for the `Alert.summarise_alerts` query is faster with the new query which optimises the JOINS and pulls out latest_runs into a CTE with is also filtered.

The results for `ManagementPriority.for_schools` is also slightly faster. Again switches to use a CTE but also uses `JOIN LATERAL ... ON TRUE` to only parse json for the rows being returned.