### PR TITLE
Fix render? calls in group components

### DIFF
--- a/app/components/dashboards/group_alerts_component.rb
+++ b/app/components/dashboards/group_alerts_component.rb
@@ -56,6 +56,7 @@ module Dashboards
     end
 
     def render?
+      return false unless @schools.any?
       prompts? || summarised_alerts.any?
     end
 

--- a/app/components/dashboards/group_savings_prompt_component.rb
+++ b/app/components/dashboards/group_savings_prompt_component.rb
@@ -12,6 +12,7 @@ module Dashboards
     end
 
     def render?
+      return false unless @schools.any?
       total_savings.any?
     end
 


### PR DESCRIPTION
Components should not render if no data enabled schools. Check before calling methods that query the database.