### PR TITLE
Add import time index and change scope

### DIFF
--- a/app/controllers/admin/reports/amr_data_feed_import_logs_controller.rb
+++ b/app/controllers/admin/reports/amr_data_feed_import_logs_controller.rb
@@ -2,6 +2,7 @@ module Admin
   module Reports
     class AmrDataFeedImportLogsController < AdminController
       include Pagy::Backend
+
       before_action :set_log_counts
       SUMMARY_PERIOD_IN_DAYS = 30
 

--- a/app/models/amr_data_feed_import_log.rb
+++ b/app/models/amr_data_feed_import_log.rb
@@ -27,9 +27,7 @@ class AmrDataFeedImportLog < ApplicationRecord
 
   scope :errored,       -> { where.not(error_messages: nil) }
   scope :successful,    -> { where(error_messages: nil) }
-  scope :with_warnings, lambda {
-    where(id: AmrReadingWarning.select(:amr_data_feed_import_log_id))
-  }
+  scope :with_warnings, -> { where(id: AmrReadingWarning.select(:amr_data_feed_import_log_id)) }
 
   scope :since, ->(date) { where('import_time >= ?', date) }
 

--- a/app/models/amr_data_feed_import_log.rb
+++ b/app/models/amr_data_feed_import_log.rb
@@ -15,6 +15,7 @@
 # Indexes
 #
 #  index_amr_data_feed_import_logs_on_amr_data_feed_config_id  (amr_data_feed_config_id)
+#  index_amr_data_feed_import_logs_on_import_time              (import_time)
 #
 
 class AmrDataFeedImportLog < ApplicationRecord
@@ -26,8 +27,11 @@ class AmrDataFeedImportLog < ApplicationRecord
 
   scope :errored,       -> { where.not(error_messages: nil) }
   scope :successful,    -> { where(error_messages: nil) }
-  scope :with_warnings, -> { includes(:amr_reading_warnings).where.not(amr_reading_warnings: { id: nil }) }
-  scope :since,         ->(date) { where('import_time >= ?', date) }
+  scope :with_warnings, lambda {
+    where(id: AmrReadingWarning.select(:amr_data_feed_import_log_id))
+  }
+
+  scope :since, ->(date) { where('import_time >= ?', date) }
 
   def errors?
     error_messages.present?

--- a/db/migrate/20260414143128_import_log_indexes.rb
+++ b/db/migrate/20260414143128_import_log_indexes.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ImportLogIndexes < ActiveRecord::Migration[7.2]
+  def change
+    add_index :amr_data_feed_import_logs, :import_time
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_03_17_160827) do
+ActiveRecord::Schema[7.2].define(version: 2026_04_14_143128) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pgcrypto"
@@ -457,6 +457,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_03_17_160827) do
     t.integer "records_updated", default: 0, null: false
     t.text "error_messages"
     t.index ["amr_data_feed_config_id"], name: "index_amr_data_feed_import_logs_on_amr_data_feed_config_id"
+    t.index ["import_time"], name: "index_amr_data_feed_import_logs_on_import_time"
   end
 
   create_table "amr_data_feed_readings", force: :cascade do |t|


### PR DESCRIPTION
Small bit of tuning for the import log report:

- Add an index on import_time as we're filtering on that
- Change the `with_warnings` scope to be more efficient. 