### PR TITLE
Revise how self-funding status is handled

### DIFF
--- a/app/components/commercial/licences_component/licences_component.html.erb
+++ b/app/components/commercial/licences_component/licences_component.html.erb
@@ -63,7 +63,7 @@
           </td>
           <% if @show_renewal_data %>
             <td>
-              <% if licence.school.default_contract_holder_id == licence.school.id %>
+              <% if licence.school.default_contract_holder.nil? %>
                 Self funding
               <% else %>
                 MAT funded

--- a/app/components/commercial/licensing_summary_component/row_component.html.erb
+++ b/app/components/commercial/licensing_summary_component/row_component.html.erb
@@ -9,7 +9,7 @@
     <%= school.current_licence&.contract&.contract_holder&.name %>
   </td>
   <td>
-    <%= school.default_contract_holder&.name || school.name %>
+    <%= school.default_contract_holder&.name || 'Self funding' %>
   </td>
   <td>
     <% licenced_for = school.licenced_for_period(date_range) %>

--- a/app/components/commercial/licensing_summary_component/row_component.html.erb
+++ b/app/components/commercial/licensing_summary_component/row_component.html.erb
@@ -8,7 +8,7 @@
   <td>
     <%= school.current_licence&.contract&.contract_holder&.name %>
   </td>
-  <td>
+  <td id="future-funder-<%= school.id %>">
     <%= school.default_contract_holder&.name || 'Self funding' %>
   </td>
   <td>
@@ -17,7 +17,7 @@
                                             pill: true,
                                             colour: period_badge_colour(licenced_for))) %>
   </td>
-  <td>
+  <td class="d-flex gap-2">
     <% buttons.each do |button| %>
       <%= button %>
     <% end %>

--- a/app/components/commercial/licensing_summary_component/row_component.html.erb
+++ b/app/components/commercial/licensing_summary_component/row_component.html.erb
@@ -9,7 +9,7 @@
     <%= school.current_licence&.contract&.contract_holder&.name %>
   </td>
   <td>
-    <%= school.default_contract_holder&.name %>
+    <%= school.default_contract_holder&.name || school.name %>
   </td>
   <td>
     <% licenced_for = school.licenced_for_period(date_range) %>

--- a/app/components/forms/commercial/bulk_licence_editor_component/bulk_licence_editor_component.html.erb
+++ b/app/components/forms/commercial/bulk_licence_editor_component/bulk_licence_editor_component.html.erb
@@ -44,7 +44,22 @@
         any (future) licence that covers the period of this contact.
       </p>
       <p>
-        Use the "Add Licence" button to add a licence for the school under this contract.
+        If a school has a current licence (valid for today) then the "<strong>Current Funder</strong>" column includes the name of
+        the contract holder for that licence. "<strong>Future Funder</strong>" indicates whether we are expecting the school to be
+        self-funded or covered by a MAT contract in future.
+      </p>
+
+      <p>
+        "<strong>Licensed for Period?</strong>" indicates whether school has any existing licences that cover the period of this contract.
+        "Full" means they are already licensed. "Partial" means they a licence that covers part of this contracted period.
+      </p>
+      <p>
+        Use the "<strong>Add Licence</strong>" button to add a licence for the school under this contract.
+      </p>
+      <p>
+        Use the "<strong>Make Self funded</strong> / <strong>Make MAT funded</strong>" toggle to set whether the school is expected to be
+        MAT or self-funded in future. If a school was self-funded and is going to be added to this contract, then change their status before
+        adding a licence.
       </p>
       <%= render ::Commercial::LicensingSummaryComponent.new(
             table_id: "contract-#{@contract.id}-additional-schools-table",

--- a/app/components/forms/commercial/bulk_licence_editor_component/bulk_licence_editor_component.html.erb
+++ b/app/components/forms/commercial/bulk_licence_editor_component/bulk_licence_editor_component.html.erb
@@ -61,6 +61,24 @@
                             remote: true,
                             class: 'btn btn-sm btn-primary' %>
             <% end %>
+            <% r.with_button do %>
+              <div id="self-funded-toggle-<%= school.id %>">
+                <% if school.self_funded_in_future? %>
+                  <%= button_to 'Make MAT funded',
+                                school_self_funded_path(school),
+                                method: :create,
+                                remote: true,
+                                class: 'btn btn-sm btn-secondary' %>
+                <% else %>
+                  <%= button_to 'Make Self funded',
+                                school_self_funded_path(school),
+                                method: :delete,
+                                remote: true,
+                                class: 'btn btn-sm btn-secondary' %>
+
+                <% end %>
+              </div>
+            <% end %>
           <% end %>
         <% end %>
       <% end %>

--- a/app/controllers/schools/configuration_controller.rb
+++ b/app/controllers/schools/configuration_controller.rb
@@ -15,28 +15,26 @@ module Schools
         @school.school_group_id = grouping_attrs[:school_group_id]
       end
 
-      [:area_school_grouping_attributes, :diocese_school_grouping_attributes].each do |attributes|
-        if params[:school][attributes]
-          attrs = params[:school][attributes]
+      %i[area_school_grouping_attributes diocese_school_grouping_attributes].each do |attributes|
+        next unless params[:school][attributes]
 
-          if attrs[:school_group_id].blank?
-            case attributes
-            when :diocese_school_grouping_attributes
-              @school.diocese_school_grouping&.destroy
-            else
-              @school.area_school_grouping&.destroy
-            end
+        attrs = params[:school][attributes]
 
-            params[:school].delete(attributes)
-          end
+        next if attrs[:school_group_id].present?
+
+        case attributes
+        when :diocese_school_grouping_attributes
+          @school.diocese_school_grouping&.destroy
+        else
+          @school.area_school_grouping&.destroy
         end
+
+        params[:school].delete(attributes)
       end
 
       default_contract_holder_type = case school_params[:default_contract_holder_id]
                                      when '', nil
                                        nil
-                                     when @school.id
-                                       School
                                      else
                                        SchoolGroup
                                      end
@@ -45,7 +43,7 @@ module Schools
       redirect_to school_path(@school)
     end
 
-  private
+    private
 
     def set_school
       @school = School.friendly.find(params[:school_id])

--- a/app/controllers/schools/self_funded_controller.rb
+++ b/app/controllers/schools/self_funded_controller.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Schools
+  class SelfFundedController < ApplicationController
+    load_and_authorize_resource :school
+
+    def create
+      authorize! :change_self_funding, @school
+      @school.update!(default_contract_holder: @school.organisation_group)
+
+      respond_to do |format|
+        format.js
+        format.html do
+          redirect_back_or_to(school_path(@school),
+                              notice: "#{@school.name} is configured to be funded by their group in future")
+        end
+      end
+    end
+
+    def destroy
+      authorize! :change_self_funding, @school
+      @school.update!(default_contract_holder: nil)
+
+      respond_to do |format|
+        format.js
+        format.html do
+          redirect_back_or_to(school_path(@school), notice: "#{@school.name} is configured to be self-funded in future")
+        end
+      end
+    end
+  end
+end

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -331,7 +331,6 @@ class School < ApplicationRecord
 
   scope :unfunded, -> { where(schools: { funder_id: nil }) }
 
-
   scope :missing_alert_contacts, -> { where('schools.id NOT IN (SELECT distinct(school_id) from contacts)') }
 
   def self.with_energy_tariffs
@@ -976,6 +975,10 @@ class School < ApplicationRecord
     # 1 - "Nursery"
     # 6 - "16 plus"
     # 7 - "All-through"
+  end
+
+  def self_funded_in_future?
+    default_contract_holder.nil?
   end
 
   private

--- a/app/services/commercial/contract_importer.rb
+++ b/app/services/commercial/contract_importer.rb
@@ -38,9 +38,7 @@ module Commercial
       )
 
       # Self-funding
-      if contract_holder.is_a?(School)
-        contract_holder.update!(default_contract_holder: contract_holder)
-      end
+      contract_holder.update!(default_contract_holder: nil) if contract_holder.is_a?(School)
 
       contract
     end
@@ -54,7 +52,7 @@ module Commercial
       contract_holder = School.find_by_name(name)
       return contract_holder unless contract_holder.nil?
 
-      return SchoolGroup.find_by_name(name)
+      SchoolGroup.find_by_name(name)
     end
   end
 end

--- a/app/services/schools/funder_allocation_report_service.rb
+++ b/app/services/schools/funder_allocation_report_service.rb
@@ -116,7 +116,7 @@ module Schools
             solar_routes[1],
             solar_routes[2],
             current_contract&.contract_holder&.name,
-            school.default_contract_holder&.name || school.name,
+            school.default_contract_holder&.name || 'Self funding',
             current_contract&.start_date,
             current_contract&.end_date,
             current_licence&.start_date,

--- a/app/services/schools/funder_allocation_report_service.rb
+++ b/app/services/schools/funder_allocation_report_service.rb
@@ -65,11 +65,11 @@ module Schools
         active_and_archived_schools.each do |school|
           electricity_data_sources = school.all_data_sources(:electricity)
           gas_data_sources = school.all_data_sources(:gas)
-          solar_data_sources = school.all_data_sources([:solar_pv, :exported_solar_pv])
+          solar_data_sources = school.all_data_sources(%i[solar_pv exported_solar_pv])
 
           electricity_routes = school.all_procurement_routes(:electricity)
           gas_routes = school.all_procurement_routes(:gas)
-          solar_routes = school.all_procurement_routes([:solar_pv, :exported_solar_pv])
+          solar_routes = school.all_procurement_routes(%i[solar_pv exported_solar_pv])
 
           current_licence = school.licences.current.by_start_date.first
           current_contract = school.licences.current.by_start_date.first&.contract
@@ -116,7 +116,7 @@ module Schools
             solar_routes[1],
             solar_routes[2],
             current_contract&.contract_holder&.name,
-            school.default_contract_holder&.name,
+            school.default_contract_holder&.name || school.name,
             current_contract&.start_date,
             current_contract&.end_date,
             current_licence&.start_date,
@@ -134,15 +134,15 @@ module Schools
     private
 
     def country(school)
-      school.country.present? ? school.country.humanize : nil
+      school.country.presence&.humanize
     end
 
     def region(school)
-      school.region.present? ? school.region.humanize : nil
+      school.region.presence&.humanize
     end
 
     def local_authority_area(school)
-      school.local_authority_area_group.present? ? school.local_authority_area_group.name : nil
+      school.local_authority_area_group.presence&.name
     end
 
     def onboarding_completed(school)
@@ -160,12 +160,14 @@ module Schools
     def activities_this_academic_year(school)
       academic_year = academic_year(school)
       return 0 unless academic_year.present?
+
       school.activities.between(academic_year.start_date, academic_year.end_date).count
     end
 
     def actions_this_academic_year(school)
       academic_year = academic_year(school)
       return 0 unless academic_year.present?
+
       school.observations.intervention.between(academic_year.start_date, academic_year.end_date).count
     end
 
@@ -174,7 +176,7 @@ module Schools
     end
 
     def format_time(date)
-      date.present? ? date.iso8601 : nil
+      date.presence&.iso8601
     end
   end
 end

--- a/app/views/admin/commercial/contracts/licences/edit.html.erb
+++ b/app/views/admin/commercial/contracts/licences/edit.html.erb
@@ -9,6 +9,12 @@
       <%= link_to @contract.name, admin_commercial_contract_path(@contract) %> contract, allowing
       revisions of dates, status, school specific prices and comments.
     </p>
+    <p>
+      <strong>Note</strong> to make bulk changes to all licences, e.g. revising all start/end dates or marking them all as confirmed, then please
+      <%= link_to 'edit the contract instead', edit_admin_commercial_contract_path(@contract) %>. This is simpler than changing all fields
+      individually. This form is primarily intended to allow quick editing of school specific pricing and comments, addition and removal of
+      licences, etc
+    </p>
   </div>
 </div>
 

--- a/app/views/schools/configuration/_form.html.erb
+++ b/app/views/schools/configuration/_form.html.erb
@@ -111,7 +111,7 @@
     <div class="form-group col-md-12">
       <%= f.label :default_contract_holder_id, 'How will school be funded in future?' %>
       <%= f.select :default_contract_holder_id,
-                   options_for_select([['Self funding', school.id], ['MAT funded', school.organisation_group&.id]],
+                   options_for_select([['Self funding', nil], ['MAT funded', school.organisation_group&.id]],
                                       school.default_contract_holder_id),
                    { include_blank: true },
                    { class: 'form-control' } %>

--- a/app/views/schools/configuration/_form.html.erb
+++ b/app/views/schools/configuration/_form.html.erb
@@ -113,7 +113,7 @@
       <%= f.select :default_contract_holder_id,
                    options_for_select([['Self funding', nil], ['MAT funded', school.organisation_group&.id]],
                                       school.default_contract_holder_id),
-                   { include_blank: true },
+                   { include_blank: false },
                    { class: 'form-control' } %>
       <p class="small">Indicates whether we expect a school to be self-funded or funded by their MAT in future</p>
     </div>

--- a/app/views/schools/self_funded/_button.html.erb
+++ b/app/views/schools/self_funded/_button.html.erb
@@ -1,0 +1,13 @@
+<% if school.self_funded_in_future? %>
+    <%= button_to 'Make MAT funded',
+                  school_self_funded_path(school),
+                  method: :create,
+                  remote: true,
+                  class: 'btn btn-sm btn-secondary' %>
+<% else %>
+    <%= button_to 'Make Self funded',
+                  school_self_funded_path(school),
+                  method: :delete,
+                  remote: true,
+                  class: 'btn btn-sm btn-secondary' %>
+<% end %>

--- a/app/views/schools/self_funded/create.js.erb
+++ b/app/views/schools/self_funded/create.js.erb
@@ -1,0 +1,4 @@
+document.getElementById("future-funder-<%= @school.id %>").innerHTML =
+  `<%= @school.organisation_group.name %>`;
+document.getElementById("self-funded-toggle-<%= @school.id %>").innerHTML =
+  `<%= j render('schools/self_funded/button', school: @school) %>`;

--- a/app/views/schools/self_funded/destroy.js.erb
+++ b/app/views/schools/self_funded/destroy.js.erb
@@ -1,0 +1,3 @@
+document.getElementById("future-funder-<%= @school.id %>").innerHTML = 'Self funding';
+document.getElementById("self-funded-toggle-<%= @school.id %>").innerHTML =
+  `<%= j render('schools/self_funded/button', school: @school) %>`;

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -447,6 +447,7 @@ Rails.application.routes.draw do
       resource :public, only: %i[create destroy], controller: :public
       resource :data_processing, only: %i[create destroy], controller: :data_processing
       resource :data_enabled, only: %i[create destroy], controller: :data_enabled
+      resource :self_funded, only: %i[create destroy], controller: :self_funded
       resources :contacts
       resources :subscription_generation_runs, only: %i[index show]
       resources :alert_subscription_events, only: [:show]

--- a/spec/components/commercial/licences_component_spec.rb
+++ b/spec/components/commercial/licences_component_spec.rb
@@ -145,7 +145,7 @@ RSpec.describe Commercial::LicencesComponent, :include_application_helper, :incl
               licence.start_date.to_fs(:es_short),
               licence.end_date.to_fs(:es_short),
               licence.status.to_s.humanize,
-              'MAT funded'
+              'Self funding'
             ]
           ]
         end

--- a/spec/components/forms/commercial/bulk_licence_editor_component_spec.rb
+++ b/spec/components/forms/commercial/bulk_licence_editor_component_spec.rb
@@ -181,7 +181,7 @@ RSpec.describe Forms::Commercial::BulkLicenceEditorComponent, :include_applicati
           end
           let(:expected_rows) do
             [
-              [additional_school.name, '', '', 'Self funding', 'No', 'Add licence']
+              [additional_school.name, '', '', 'Self funding', 'No', 'Add licence Make MAT funded']
             ]
           end
         end

--- a/spec/components/forms/commercial/bulk_licence_editor_component_spec.rb
+++ b/spec/components/forms/commercial/bulk_licence_editor_component_spec.rb
@@ -181,7 +181,7 @@ RSpec.describe Forms::Commercial::BulkLicenceEditorComponent, :include_applicati
           end
           let(:expected_rows) do
             [
-              [additional_school.name, '', '', '', 'No', 'Add licence']
+              [additional_school.name, '', '', 'Self funding', 'No', 'Add licence']
             ]
           end
         end

--- a/spec/services/commercial/contract_importer_spec.rb
+++ b/spec/services/commercial/contract_importer_spec.rb
@@ -118,7 +118,7 @@ describe Commercial::ContractImporter do
           invoice_terms: 'pro_rata',
           agreed_school_price: 600.0
         )
-        expect(contract_holder.reload.default_contract_holder).to eq(contract_holder)
+        expect(contract_holder.reload.default_contract_holder).to be_nil
       end
     end
 

--- a/spec/services/schools/funder_allocation_report_service_spec.rb
+++ b/spec/services/schools/funder_allocation_report_service_spec.rb
@@ -158,7 +158,7 @@ RSpec.describe Schools::FunderAllocationReportService, type: :service do
         current_licence.contract.end_date,
         current_licence.start_date,
         current_licence.end_date,
-        current_licence.contract.product.name,
+        current_licence.contract.product.name
       ].join(',')
       expect(csv.lines[2].chomp).to eq [
         school_2.school_group.name,
@@ -202,7 +202,7 @@ RSpec.describe Schools::FunderAllocationReportService, type: :service do
         nil,
         nil,
         nil, # Current Contract Holder
-        nil,
+        'Self funding',
         nil,
         nil,
         nil,

--- a/spec/support/shared_examples/tables.rb
+++ b/spec/support/shared_examples/tables.rb
@@ -6,7 +6,7 @@ RSpec.shared_examples 'it contains the expected data table' do |sortable: true, 
   end
 
   it 'does not have sortable columns', unless: sortable do
-    expect(page).not_to have_css("#{table_id}.table-sorted")
+    expect(page).to have_no_css("#{table_id}.table-sorted")
   end
 
   it 'aligns the data cells correctly', if: aligned do
@@ -30,7 +30,7 @@ RSpec.shared_examples 'it contains the expected data table' do |sortable: true, 
   it 'has the expected rows', if: rows do
     body_rows = page.find("#{table_id} > tbody").find_all('tr')
     actual_rows = body_rows.map do |tr|
-      tr.find_all('td').map { |td| td.text.strip }
+      tr.find_all('td').map { |td| td.text.gsub(/\s+/, ' ').strip }
     end
 
     expect(actual_rows).to eq(expected_rows)

--- a/spec/system/admin/commercial/bulk_editing_contract_licences_spec.rb
+++ b/spec/system/admin/commercial/bulk_editing_contract_licences_spec.rb
@@ -146,6 +146,35 @@ describe 'bulk editing contract licences' do
           end
         end
       end
+
+      context 'when toggling school funding status' do
+        before do
+          click_on 'Make Self funded'
+          within("#contract-#{contract.id}-additional-schools-table") do
+            find('tr', text: 'Self funding')
+          end
+        end
+
+        it 'toggles the button and text' do
+          within("#contract-#{contract.id}-additional-schools-table") do
+            find('tr', text: 'Make MAT funded')
+          end
+          expect(additional_school.reload.default_contract_holder).to be_nil
+        end
+
+        context 'when toggling back' do
+          before do
+            click_on 'Make MAT funded'
+            within("#contract-#{contract.id}-additional-schools-table") do
+              find('tr', text: 'Make Self funded')
+            end
+          end
+
+          it 'reverts the change' do
+            expect(additional_school.reload.default_contract_holder).to eq(contract.contract_holder)
+          end
+        end
+      end
       # rubocop:enable RSpec/NestedGroups
     end
   end


### PR DESCRIPTION
We capture expected future funding source for a school in the `default_contract_holder` field. Currently this has a circular reference in the case of schools that will be self-funded in the future.

This PR removes the circularity by switching to use `nil` as the indicator that the school is self-funded. Otherwise the field will refer to their MAT (or possibly other sources in future).

Changes:

- Change the import to set field correctly
- Revise existing reports/components to display status correctly
- Update school configuration form
- Add a new controller to allow toggling of funding status and a button that does this from the bulk licence editing page
- Add some additional explanatory text to the forms