### PR TITLE
Latest data received and out of date badge

### DIFF
--- a/app/models/amr_data_feed_config.rb
+++ b/app/models/amr_data_feed_config.rb
@@ -88,6 +88,10 @@ class AmrDataFeedConfig < ApplicationRecord
 
   BLANK_THRESHOLD = 1
 
+  def latest_reading_date
+    amr_data_feed_readings.maximum(:updated_at)
+  end
+
   def period_or_time_field
     return unless positional_index && reading_time_field.blank? && period_field.blank?
 

--- a/app/views/admin/amr_data_feed_configs/_overview_table.html.erb
+++ b/app/views/admin/amr_data_feed_configs/_overview_table.html.erb
@@ -12,13 +12,12 @@
   </thead>
   <tbody>
     <% configurations.each do |config| %>
-      <% date_time = config.amr_data_feed_readings.maximum(:updated_at) %>
       <tr>
         <td><%= link_to config.description, admin_amr_data_feed_config_path(config) %></td>
         <td class="no-wrap"><code><%= config.identifier %></code></td>
         <td><%= config.owned_by&.name %></td>
-        <td data-order="<%= date_time.iso8601 %>">
-          <%= nice_date_times(date_time) %>
+        <td data-order="<%= config.latest_reading_date&.iso8601 %>">
+          <%= nice_date_times(config.latest_reading_date) %>
         </td>
         <% if configurations.stopped_feeds.include?(config) %>
           <td>

--- a/app/views/admin/amr_data_feed_configs/_overview_table.html.erb
+++ b/app/views/admin/amr_data_feed_configs/_overview_table.html.erb
@@ -12,11 +12,14 @@
   </thead>
   <tbody>
     <% configurations.each do |config| %>
+      <% date_time = config.amr_data_feed_readings.maximum(:updated_at) %>
       <tr>
         <td><%= link_to config.description, admin_amr_data_feed_config_path(config) %></td>
         <td class="no-wrap"><code><%= config.identifier %></code></td>
         <td><%= config.owned_by&.name %></td>
-        <td><%= config.amr_data_feed_readings.maximum(:updated_at) %></td>
+        <td data-order="<%= date_time.iso8601 %>">
+          <%= nice_date_times(date_time) %>
+        </td>
         <% if configurations.stopped_feeds.include?(config) %>
           <td>
              <span class="badge rounded-pill bg-danger text-light">

--- a/app/views/admin/amr_data_feed_configs/_overview_table.html.erb
+++ b/app/views/admin/amr_data_feed_configs/_overview_table.html.erb
@@ -4,6 +4,8 @@
       <th>Description</th>
       <th>Identifier</th>
       <th>Owned by</th>
+      <th>Latest data recieved</th>
+      <th>Out of date</th>
       <th data-orderable="false">Notes</th>
       <th data-orderable="false">Actions</th>
     </tr>
@@ -14,6 +16,16 @@
         <td><%= link_to config.description, admin_amr_data_feed_config_path(config) %></td>
         <td class="no-wrap"><code><%= config.identifier %></code></td>
         <td><%= config.owned_by&.name %></td>
+        <td><%= config.amr_data_feed_readings.maximum(:updated_at) %></td>
+        <% if configurations.stopped_feeds.include?(config) %>
+          <td>
+             <span class="badge rounded-pill bg-danger text-light">
+                Out of Date
+              </span>
+          </td>
+        <% else %>
+          <td></td>
+        <% end %>
         <td><%= config.notes %></td>
         <td>
           <div class="btn-group btn-group-sm" role="group">

--- a/spec/system/admin/amr_data_feed_configs_spec.rb
+++ b/spec/system/admin/amr_data_feed_configs_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe AmrDataFeedConfig do
+describe AmrDataFeedConfig, :include_application_helper do
   let!(:admin)              { create(:admin) }
   let!(:config)             { create(:amr_data_feed_config, owned_by: admin) }
   let!(:disabled_config)    { create(:amr_data_feed_config, description: 'Disabled', enabled: false) }
@@ -45,7 +45,7 @@ describe AmrDataFeedConfig do
         expect(page).to have_content(config.identifier)
         expect(page).to have_content(config.notes.to_plain_text)
         expect(page).to have_content(config.owned_by.name)
-        expect(page).to have_content(reading.updated_at)
+        expect(page).to have_content(nice_date_times(reading.updated_at))
         expect(page).to have_content('Out of Date')
         expect(page).to have_link('Upload')
         expect(page).to have_link('Edit')

--- a/spec/system/admin/amr_data_feed_configs_spec.rb
+++ b/spec/system/admin/amr_data_feed_configs_spec.rb
@@ -14,6 +14,10 @@ describe AmrDataFeedConfig do
   end
 
   context 'when viewing list of amr data feed configurations' do
+    let!(:reading) do
+      create(:amr_data_feed_reading, amr_data_feed_config: config, reading_date: 12.days.ago, updated_at: 12.days.ago)
+    end
+
     before do
       click_on 'Manage'
       click_on 'Admin'
@@ -41,6 +45,8 @@ describe AmrDataFeedConfig do
         expect(page).to have_content(config.identifier)
         expect(page).to have_content(config.notes.to_plain_text)
         expect(page).to have_content(config.owned_by.name)
+        expect(page).to have_content(reading.updated_at)
+        expect(page).to have_content('Out of Date')
         expect(page).to have_link('Upload')
         expect(page).to have_link('Edit')
       end


### PR DESCRIPTION
Adds 'latest data recieved' and 'out of date' columns to amr data feed configs index page (and therefore also to dashboards)