### PR TITLE
Ensure dates used for filtering licences are always Date objects

### DIFF
--- a/app/models/commercial/licence.rb
+++ b/app/models/commercial/licence.rb
@@ -65,6 +65,7 @@ module Commercial
     validates_presence_of :start_date, :end_date
 
     def self.filtered(scope_name, date = Time.zone.today, school_group_id = nil)
+      date = Date.parse(date) if date.is_a?(String)
       scope = public_send(scope_name, date)
 
       if school_group_id.present?

--- a/spec/models/commercial/licence_spec.rb
+++ b/spec/models/commercial/licence_spec.rb
@@ -84,6 +84,12 @@ describe Commercial::Licence do
 
         it { expect(licences).to contain_exactly(licence_school_a) }
       end
+
+      context 'with String parameter' do
+        subject(:licences) { described_class.filtered(:current, Time.zone.today.strftime('%d/%m/%Y')) }
+
+        it { expect(licences).to contain_exactly(licence_school_a) }
+      end
     end
 
     context 'with :expiring' do


### PR DESCRIPTION
Fixes issue with Postgres having a US default datestyle so not handling parsing of dates in UK format.

I've applied the fix to the method doing the filtering. We obviously need some specs on the UX too but I'm going to rework the UI in a follow up PR to remove the tabs and make it more consistent with the contract interface in https://github.com/Energy-Sparks/energy-sparks/pull/5198

