### PR TITLE
View all school groups buttons

### DIFF
--- a/app/views/admin/school_groups/index.html.erb
+++ b/app/views/admin/school_groups/index.html.erb
@@ -8,15 +8,31 @@
 
 <div class="row">
   <div class="col-12 d-flex justify-content-between">
-    <div>
-      <% if @organisation_group %>
-        <%= link_to 'New school group', new_admin_school_group_path, class: 'btn btn-sm btn-primary' %>
-      <% elsif @group_type == 'project' %>
+    <% if @organisation_group %>
+      <div>
+          <%= link_to 'New school group', new_admin_school_group_path, class: 'btn btn-sm btn-primary' %>
+      </div>
+      <% if @dashboard_user %>
+        <div>
+          <%= link_to 'View all groups',
+                      admin_school_groups_path,
+                      class: 'btn btn-secondary btn-sm' %>
+        </div>
+      <% end %>
+    <% elsif @group_type == 'project' %>
+      <div>
         <%= link_to "New #{t(@group_type, scope: 'school_groups.clusters.group_type')} group",
                     new_admin_school_group_path(group_type: @group_type),
                     class: 'btn btn-sm btn-primary' %>
+      </div>
+      <% if @dashboard_user %>
+        <div>
+          <%= link_to 'View all groups',
+                      admin_school_groups_path(group_type: @group_type),
+                      class: 'btn btn-secondary btn-sm' %>
+        </div>
       <% end %>
-    </div>
+    <% end %>
     <div>
       <%= link_to 'Download as CSV',
                   admin_school_groups_path(format: :csv, group_type: @organisation_group ? nil : @group_type.to_sym),

--- a/spec/system/admin/dashboards_spec.rb
+++ b/spec/system/admin/dashboards_spec.rb
@@ -71,6 +71,7 @@ RSpec.describe 'Admin dashboard' do
 
           it 'links to the school groups page' do
             expect(page).to have_current_path("/admin/dashboards/#{user.id}/school_groups")
+            expect(page).to have_link('View all groups', href: admin_school_groups_path)
           end
 
           it 'displays school groups belonging to the user' do
@@ -92,6 +93,7 @@ RSpec.describe 'Admin dashboard' do
 
           it 'links to the project groups page' do
             expect(page).to have_current_path("/admin/dashboards/#{user.id}/school_groups?group_type=project")
+            expect(page).to have_link('View all groups', href: admin_school_groups_path(group_type: 'project'))
           end
 
           it 'displays project groups belonging to the user' do


### PR DESCRIPTION
Simply adds 'View all groups' buttons to 'my project groups' and 'my school groups' pages.