### PR TITLE
Fix count in awaiting activations

### DIFF
--- a/app/components/admin/dashboard_prompt_component.rb
+++ b/app/components/admin/dashboard_prompt_component.rb
@@ -32,6 +32,8 @@ module Admin
       ]
     end
 
+    private
+
     def prompt_for_issues_overdue?
       true unless overdue_issues_count.nil? || overdue_issues_count.zero?
     end
@@ -61,8 +63,10 @@ module Admin
     end
 
     def school_activations_count
-      @school_activations_count ||= SchoolGroup.organisation_groups.where(default_issues_admin_user: user).by_name
-                                               .count(&:has_schools_awaiting_activation?)
+      @school_activations_count ||= School.joins(:organisation_group)
+                                          .where(organisation_group: { default_issues_admin_user: user })
+                                          .awaiting_activation
+                                          .count
     end
 
     def lagging_data_sources_count
@@ -77,8 +81,6 @@ module Admin
                                                              .stopped_feeds
                                                              .count
     end
-
-    private
 
     def add_prompt(list:, status:, icon:, check: true, id: nil, link: nil, path: nil) # rubocop:disable Metrics/ParameterLists
       return unless check

--- a/app/components/admin/dashboard_prompt_component.rb
+++ b/app/components/admin/dashboard_prompt_component.rb
@@ -27,7 +27,7 @@ module Admin
           link: 'View Issues', path: admin_dashboard_issues_path(dashboard_id: @user, user: @user),
           content: "You have #{weekly_issues_count} issues due for review in the next week" },
         { id: 'school-activation', check: prompt_for_school_activation?, status: :neutral, icon: 'school',
-          link: 'View Activations', path: admin_activations_path,
+          link: 'View Activations', path: admin_dashboard_activations_path(dashboard_id: @user),
           content: "You have #{school_activations_count} schools awaiting activation" }
       ]
     end

--- a/spec/components/admin/dashboard_prompt_component_spec.rb
+++ b/spec/components/admin/dashboard_prompt_component_spec.rb
@@ -10,54 +10,62 @@ RSpec.describe Admin::DashboardPromptComponent, :include_url_helpers, type: :com
   let(:user) { create(:admin) }
 
   context 'when rendering' do
-    let(:html) do
-      render_inline(component)
-    end
-
     describe 'overdue issues prompt' do
       context 'when there are no overdue issues' do
+        before do
+          render_inline(component)
+        end
+
         it 'does not display the overdue issues prompt' do
-          expect(html).to have_no_css('#overdue-issues')
+          expect(page).to have_no_text('issues overdue for review')
         end
       end
 
       context 'when there are overdue issues' do
         before do
           create_list(:issue, 2, owned_by: user, review_date: Date.current - 2)
+          render_inline(component)
         end
 
         it 'displays the overdue issues prompt' do
-          expect(html).to have_css('#overdue-issues')
-          expect(html).to have_text('You have 2 issues overdue for review')
-          expect(html).to have_link('View Issues', href: admin_dashboard_issues_path(dashboard_id: user, user: user.id))
+          expect(page).to have_text('You have 2 issues overdue for review')
+          expect(page).to have_link('View Issues', href: admin_dashboard_issues_path(dashboard_id: user, user: user.id))
         end
       end
     end
 
     describe 'weekly issues prompt' do
       context 'when there are no issues due in the coming week' do
+        before do
+          render_inline(component)
+        end
+
         it 'does not display the weekly issues prompt' do
-          expect(html).to have_no_css('#weekly-issues')
+          expect(page).to have_no_text('review in the next week')
         end
       end
 
       context 'when there are issues due in the coming week' do
         before do
           create_list(:issue, 2, owned_by: user, review_date: Date.current + 2)
+          render_inline(component)
         end
 
         it 'displays the weekly issues prompt' do
-          expect(html).to have_css('#weekly-issues')
-          expect(html).to have_text('You have 2 issues due for review in the next week')
-          expect(html).to have_link('View Issues', href: admin_dashboard_issues_path(dashboard_id: user, user: user.id))
+          expect(page).to have_text('You have 2 issues due for review in the next week')
+          expect(page).to have_link('View Issues', href: admin_dashboard_issues_path(dashboard_id: user, user: user.id))
         end
       end
     end
 
     describe 'school activation prompt' do
       context 'when no schools are awaiting activation' do
+        before do
+          render_inline(component)
+        end
+
         it 'does not display the school activation prompt' do
-          expect(html).to have_no_css('#school-activation')
+          expect(page).to have_no_text('schools awaiting activation')
         end
       end
 
@@ -65,20 +73,24 @@ RSpec.describe Admin::DashboardPromptComponent, :include_url_helpers, type: :com
         before do
           create(:school, school_group: create(:school_group, default_issues_admin_user: user), active: true,
                           visible: false, data_enabled: false)
+          render_inline(component)
         end
 
         it 'displays the school activation prompt' do
-          expect(html).to have_css('#school-activation')
-          expect(html).to have_text('You have 1 schools awaiting activation')
-          expect(html).to have_link('Activations', href: admin_activations_path)
+          expect(page).to have_text('You have 1 schools awaiting activation')
+          expect(page).to have_link('Activations', href: admin_dashboard_activations_path(dashboard_id: user))
         end
       end
     end
 
     describe 'lagging data source prompt' do
       context 'when there are no lagging data sources' do
+        before do
+          render_inline(component)
+        end
+
         it 'does not display the lagging data sources prompt' do
-          expect(html).to have_no_css('#lagging-data-sources')
+          expect(page).to have_no_text('lagging data sources')
         end
       end
 
@@ -86,20 +98,24 @@ RSpec.describe Admin::DashboardPromptComponent, :include_url_helpers, type: :com
         before do
           create(:gas_meter_with_validated_reading_dates, end_date: 11.days.ago,
                                                           data_source: create(:data_source, owned_by: user))
+          render_inline(component)
         end
 
         it 'displays the lagging data sources prompt' do
-          expect(html).to have_css('#lagging-data-sources')
-          expect(html).to have_text('You have 1 lagging data sources')
-          expect(html).to have_link('View Data Sources', href: admin_dashboard_data_sources_path(dashboard_id: user))
+          expect(page).to have_text('You have 1 lagging data sources')
+          expect(page).to have_link('View Data Sources', href: admin_dashboard_data_sources_path(dashboard_id: user))
         end
       end
     end
 
     describe 'missing data feeds prompt' do
       context 'when there are no data feeds with missing data' do
+        before do
+          render_inline(component)
+        end
+
         it 'does not display the missing data feeds prompt' do
-          expect(html).to have_no_css('#missing-data-feeds')
+          expect(page).to have_no_text('configurations with missing data')
         end
       end
 
@@ -113,12 +129,12 @@ RSpec.describe Admin::DashboardPromptComponent, :include_url_helpers, type: :com
             reading_date: 4.days.ago,
             updated_at: 4.days.ago
           )
+          render_inline(component)
         end
 
         it 'displays the missing data feeds prompt' do
-          expect(html).to have_css('#missing-data-feeds')
-          expect(html).to have_text('You have 1 amr data feed configurations with missing data')
-          expect(html).to have_link('View AMR Data Feed Configurations',
+          expect(page).to have_text('You have 1 amr data feed configurations with missing data')
+          expect(page).to have_link('View AMR Data Feed Configurations',
                                     href: admin_dashboard_amr_data_feed_configs_path(dashboard_id: user))
         end
       end

--- a/spec/components/navigation/admin_dashboard_component_spec.rb
+++ b/spec/components/navigation/admin_dashboard_component_spec.rb
@@ -14,37 +14,37 @@ RSpec.describe Navigation::AdminDashboardComponent, :include_url_helpers, type: 
   end
 
   context 'when rendering' do
-    let(:html) do
+    before do
       render_inline(component)
     end
 
-    it { expect(html).to have_link('Dashboard Home', href: admin_dashboard_path(current_user)) }
+    it { expect(page).to have_link('Dashboard Home', href: admin_dashboard_path(current_user)) }
 
     describe 'my x links' do
       it 'has the correct links' do
-        expect(html).to have_link('My School Groups',
+        expect(page).to have_link('My School Groups',
                                   href: admin_dashboard_school_groups_path(current_user))
-        expect(html).to have_link('My Project Groups',
+        expect(page).to have_link('My Project Groups',
                                   href: admin_dashboard_school_groups_path(current_user, group_type: 'project'))
-        expect(html).to have_link('My Data Sources',
+        expect(page).to have_link('My Data Sources',
                                   href: admin_dashboard_data_sources_path(current_user))
-        expect(html).to have_link('My Data Feeds',
+        expect(page).to have_link('My Data Feeds',
                                   href: admin_dashboard_amr_data_feed_configs_path(current_user))
-        expect(html).to have_link('My Issues',
+        expect(page).to have_link('My Issues',
                                   href: admin_dashboard_issues_path(current_user))
       end
 
       describe 'my_schools section' do
         it 'has the correct links' do
-          expect(html).to have_link('Onboarding',
+          expect(page).to have_link('Onboarding',
                                     href: admin_dashboard_school_onboardings_path(current_user))
-          expect(html).to have_link('Awaiting activation',
+          expect(page).to have_link('Awaiting activation',
                                     href: admin_dashboard_activations_path(current_user))
-          expect(html).to have_link('Recently onboarded',
+          expect(page).to have_link('Recently onboarded',
                                     href: completed_admin_dashboard_school_onboardings_path(current_user))
-          expect(html).to have_link('Recent activities',
+          expect(page).to have_link('Recent activities',
                                     href: admin_dashboard_activities_path(current_user))
-          expect(html).to have_link('Recent actions',
+          expect(page).to have_link('Recent actions',
                                     href: admin_dashboard_interventions_path(current_user))
         end
       end


### PR DESCRIPTION
Fixes the query in awaiting activations to show the number of schools awaiting activations rather than the number of school groups with schools awaiting activation