### PR TITLE
change flipper to use memory cache

### DIFF
--- a/config/initializers/flipper.rb
+++ b/config/initializers/flipper.rb
@@ -5,14 +5,7 @@ Flipper.register(:admins) do |actor, _context|
 end
 
 Flipper.configure do |config|
-  config.adapter do
-    Flipper::Adapters::ActiveSupportCacheStore.new(
-      Flipper::Adapters::ActiveRecord.new,
-      Rails.cache,
-      5.minutes,
-      race_condition_ttl: 10
-    )
-  end
+  config.use Flipper::Adapters::ActiveSupportCacheStore, ActiveSupport::Cache::MemoryStore.new, 5.minutes
 end
 
 Rails.application.configure do


### PR DESCRIPTION
try to avoid rollbar ENOENT errors

config more per https://www.flippercloud.io/docs/adapters/active-support-cache-store

trying on test