### PR TITLE
Fix join in unlicensed schools report

### DIFF
--- a/app/controllers/admin/commercial/licences_controller.rb
+++ b/app/controllers/admin/commercial/licences_controller.rb
@@ -20,8 +20,9 @@ module Admin::Commercial
 
     def unlicensed
       @academic_year = Calendar.default_national.current_academic_year
-      @schools = School.active.without_current_licence.joins(:school_groupings,
-                                                             school_groupings: :school_group).order('school_groups.name ASC')
+      @schools = School.active.without_current_licence.joins(
+        organisation_school_grouping: :school_group
+      ).order('school_groups.name ASC')
     end
 
     def new

--- a/spec/system/admin/commercial/manage_licences_spec.rb
+++ b/spec/system/admin/commercial/manage_licences_spec.rb
@@ -287,7 +287,11 @@ describe 'manage licences' do
   end
 
   context 'when viewing unlicensed schools' do
-    let!(:school) { create(:school, :with_trust) }
+    let!(:school) do
+      school = create(:school, :with_trust)
+      school.update(diocese: create(:school_group, :diocese))
+      school
+    end
 
     before do
       calendar = create(:national_calendar, title: 'England and Wales')


### PR DESCRIPTION
Unlicensed schools report was joining to all SchoolGroups (e.g. MAT, diocese, etc). Should have been joining to just the organisation group.

Fixed and added spec to ensure we're only getting one row per school.