### PR TITLE
 fix csv and user filtering on admin meters report 

### DIFF
--- a/app/controllers/admin/reports/admin_user_meter_report_controller.rb
+++ b/app/controllers/admin/reports/admin_user_meter_report_controller.rb
@@ -3,6 +3,11 @@
 module Admin
   module Reports
     class AdminUserMeterReportController < BaseImportReportsController
+      def index
+        params[:admin] = current_user.id unless params.key?(:admin)
+        super
+      end
+
       private
 
       def description
@@ -14,21 +19,30 @@ module Admin
       end
 
       def results
-        default_issues_admin_user = User.admin.find_by(id: params[:admin]) || User.admin.first
+        return nil if !params.key?(:school_group) && !params.key?(:admin)
+
         Meter.active
              .joins(:school)
              .includes(:school, { school: :school_group })
-             .where(schools: { school_groups: { default_issues_admin_user: } })
+             .then { |scope| filter_by_admin(scope) }
              .then { |scope| filter_by_meter_type(scope) }
              .then { |scope| filter_by_school_group(scope) }
       end
 
+      def filter_by_admin(scope)
+        filter(scope, params[:admin]) { scope.where(school_groups: { default_issues_admin_user_id: params[:admin] }) }
+      end
+
       def filter_by_meter_type(scope)
-        params[:meter_type].present? ? scope.where(meter_type: params[:meter_type]) : scope
+        filter(scope, params[:meter_type]) { scope.where(meter_type: params[:meter_type]) }
       end
 
       def filter_by_school_group(scope)
-        params[:school_group].present? ? scope.where(schools: { school_group_id: params[:school_group] }) : scope
+        filter(scope, params[:school_group]) { scope.where(schools: { school_group_id: params[:school_group] }) }
+      end
+
+      def filter(scope, condition)
+        condition.present? ? yield : scope
       end
 
       def container_class

--- a/app/controllers/admin/reports/admin_user_meter_report_controller.rb
+++ b/app/controllers/admin/reports/admin_user_meter_report_controller.rb
@@ -3,11 +3,6 @@
 module Admin
   module Reports
     class AdminUserMeterReportController < BaseImportReportsController
-      def index
-        params[:admin] = current_user.id unless params.key?(:admin)
-        super
-      end
-
       private
 
       def description
@@ -19,8 +14,14 @@ module Admin
       end
 
       def results
-        return nil if !params.key?(:school_group) && !params.key?(:admin)
+        unless params.key?(:school_group) || params.key?(:admin)
+          params[:admin] = current_user.id
+          return nil
+        end
+        filtered_meters
+      end
 
+      def filtered_meters
         Meter.active
              .joins(:school)
              .includes(:school, { school: :school_group })

--- a/app/controllers/admin/reports/base_meter_reports_controller.rb
+++ b/app/controllers/admin/reports/base_meter_reports_controller.rb
@@ -9,6 +9,7 @@ module Admin
       include Columns
       include ActionView::Helpers::UrlHelper
       include ApplicationHelper
+
       before_action :set_metadata
 
       layout 'admin_reports'
@@ -20,8 +21,7 @@ module Admin
             @columns = columns.filter(&:display_html)
           end
           format.csv do
-            send_data(csv_report(@columns, @results),
-                      filename: EnergySparks::Filenames.csv(controller_name))
+            send_data(csv_report(@columns, @results), filename: EnergySparks::Filenames.csv(controller_name))
           end
         end
       end

--- a/app/views/admin/reports/base_meter_reports/_report_filters.html.erb
+++ b/app/views/admin/reports/base_meter_reports/_report_filters.html.erb
@@ -29,7 +29,7 @@
                         controller: controller_path,
                         action: :index,
                         only_path: true,
-                        **params.permit(:school_group, :user, :meter_type).merge(format: :csv)
+                        **params.permit(:school_group, :admin, :meter_type).merge(format: :csv)
                       ),
                       class: 'ml-2 btn btn-sm' %>
           <% end %>

--- a/app/views/admin/reports/base_meter_reports/index.html.erb
+++ b/app/views/admin/reports/base_meter_reports/index.html.erb
@@ -7,7 +7,7 @@
   </div>
   <div class="d-flex justify-content-between align-items-center">
     <p>
-       <span class="badge badge-info">Updated <%= @frequency.to_s.humanize %> </span> <%= @description %>
+       <span class="badge text-bg-info">Updated <%= @frequency.to_s.humanize %> </span> <%= @description %>
     </p>
     <% if lookup_context.exists?('help', lookup_context.prefixes, true) %>
     <p>

--- a/app/views/admin/reports/base_meter_reports/index.html.erb
+++ b/app/views/admin/reports/base_meter_reports/index.html.erb
@@ -35,16 +35,22 @@
   <% end %>
 <% end %>
 
-<div class="row">
-  <div class="col">
-    <span class="float-right">
-      <%= @results.length %> Results
-    </span>
+<% if @results.nil? %>
+  <div class="text-center m-4">
+    Filter to display results
   </div>
-</div>
+<% else %>
+  <div class="row">
+    <div class="col">
+      <span class="float-right">
+        <%= @results.length %> Results
+      </span>
+    </div>
+  </div>
 
-<div class="row">
-  <div class="col">
-    <%= render 'admin/reports/column_table', columns: @columns, rows: @results %>
+  <div class="row">
+    <div class="col">
+      <%= render 'admin/reports/column_table', columns: @columns, rows: @results %>
+    </div>
   </div>
-</div>
+<% end %>

--- a/app/views/admin/reports/base_meter_reports/index.html.erb
+++ b/app/views/admin/reports/base_meter_reports/index.html.erb
@@ -42,7 +42,7 @@
 <% else %>
   <div class="row">
     <div class="col">
-      <span class="float-right">
+      <span class="float-end">
         <%= @results.length %> Results
       </span>
     </div>

--- a/spec/system/admin/reports/admin_user_meter_report_spec.rb
+++ b/spec/system/admin/reports/admin_user_meter_report_spec.rb
@@ -27,7 +27,6 @@ describe 'admin user meter report' do
     before { click_on 'CSV' }
 
     it 'has the correct CSV' do
-      # debugger
       expect(CSV.parse(page.body)).to eq(
         [['School Group', 'Admin', 'School', 'Meter', 'Meter Name', 'Meter Type', 'Meter System', 'Data Source',
           'Procurement Route', 'Meter Status', 'Manual Reads', 'Last Validated Date', 'Issues', 'Notes'],

--- a/spec/system/admin/reports/admin_user_meter_report_spec.rb
+++ b/spec/system/admin/reports/admin_user_meter_report_spec.rb
@@ -8,6 +8,7 @@ describe 'admin user meter report' do
   let!(:before) do
     sign_in school.school_group.default_issues_admin_user
     visit admin_reports_admin_user_meter_report_index_path
+    click_on 'Filter'
   end
 
   it_behaves_like 'it contains the expected data table', aligned: false do

--- a/spec/system/admin/reports/admin_user_meter_report_spec.rb
+++ b/spec/system/admin/reports/admin_user_meter_report_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'admin user meter report' do
+  let(:school) { create(:school, :with_school_group) }
+  let!(:meter) { create(:gas_meter, school:) }
+  let!(:before) do
+    sign_in school.school_group.default_issues_admin_user
+    visit admin_reports_admin_user_meter_report_index_path
+  end
+
+  it_behaves_like 'it contains the expected data table', aligned: false do
+    let(:table_id) { '.advice-table' }
+    let(:expected_header) do
+      [['School Group', 'Admin', 'School', 'Meter', 'Meter Name', 'Meter Type', 'Meter System', 'Data Source',
+        'Procurement Route', 'Meter Status', 'Manual Reads', 'Last Validated Date', 'Issues & Notes']]
+    end
+    let(:expected_rows) do
+      [[school.school_group.name, 'Admin', school.name, meter.mpan_mprn.to_s, meter.name, '', 'NHH AMR', '', '', '',
+        'N', '', '']]
+    end
+  end
+
+  RSpec.shared_examples 'it has the correct CSV' do
+    before { click_on 'CSV' }
+
+    it 'has the correct CSV' do
+      # debugger
+      expect(CSV.parse(page.body)).to eq(
+        [['School Group', 'Admin', 'School', 'Meter', 'Meter Name', 'Meter Type', 'Meter System', 'Data Source',
+          'Procurement Route', 'Meter Status', 'Manual Reads', 'Last Validated Date', 'Issues', 'Notes'],
+         [school.school_group.name, 'Admin', school.name, meter.mpan_mprn.to_s, meter.name, 'gas', 'NHH AMR',
+          nil, nil, nil, 'N', nil, '0', '0']]
+      )
+    end
+  end
+
+  it_behaves_like 'it has the correct CSV'
+
+  context 'with admin filter' do
+    let!(:before) do
+      admin = create(:admin, name: 'Another Admin')
+      create(:gas_meter, school: create(:school, :with_school_group, default_issues_admin_user: admin))
+      sign_in admin
+      visit admin_reports_admin_user_meter_report_index_path
+      select 'Admin', from: 'Admin', exact: true
+      click_on 'Filter'
+    end
+
+    it_behaves_like 'it has the correct CSV'
+  end
+end


### PR DESCRIPTION
- changes behaviour of the report (/admin/reports/admin_user_meter_report) so it will not load data until the filter button is pressed - as it seems quite slow - perhaps should be paginated in future - previously showed Claudia's meters by default
- allows filtering by school group for any admin
- fixes use of user parameter for csv download