### PR TITLE
Change how HTTP -> HTTPS redirection is handled

### DIFF
--- a/.ebextensions/listener-ssl-rule.config
+++ b/.ebextensions/listener-ssl-rule.config
@@ -1,0 +1,40 @@
+###################################################################################################
+#### Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+####
+#### Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file
+#### except in compliance with the License. A copy of the License is located at
+####
+####     http://aws.amazon.com/apache2.0/
+####
+#### or in the "license" file accompanying this file. This file is distributed on an "AS IS"
+#### BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#### License for the specific language governing permissions and limitations under the License.
+###################################################################################################
+
+###################################################################################################
+#### This configuration file modifies the default port 80 listener attached to an Application Load Balancer
+#### to automatically redirect incoming connections on HTTP to HTTPS.
+#### This will not work with an environment using the load balancer type Classic or Network.
+#### A prerequisite is that the 443 listener has already been created.
+#### Please use the below link for more information about creating an Application Load Balancer on
+#### the Elastic Beanstalk console.
+#### https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/environments-cfg-alb.html#environments-cfg-alb-console
+###################################################################################################
+
+Resources:
+ AWSEBV2LoadBalancerListener:
+  Type: AWS::ElasticLoadBalancingV2::Listener
+  Properties:
+    LoadBalancerArn:
+      Ref: AWSEBV2LoadBalancer
+    Port: 80
+    Protocol: HTTP
+    DefaultActions:
+      - Type: redirect
+        RedirectConfig:
+          Host: "#{host}"
+          Path: "/#{path}"
+          Port: "443"
+          Protocol: "HTTPS"
+          Query: "#{query}"
+          StatusCode: "HTTP_301"

--- a/.ebextensions/listener-ssl-rule.config
+++ b/.ebextensions/listener-ssl-rule.config
@@ -21,6 +21,7 @@
 #### https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/environments-cfg-alb.html#environments-cfg-alb-console
 ###################################################################################################
 
+#### From: https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/configuring-https-httpredirect.html
 Resources:
  AWSEBV2LoadBalancerListener:
   Type: AWS::ElasticLoadBalancingV2::Listener


### PR DESCRIPTION
We currently rely on `config.force_ssl = true` to redirect HTTP to HTTPS. 

Reviewing crawler traffic this week shows that we're seeing repeated requests for the same resource that:

- `GET http://www.energysparks.uk/*`. This triggers redirect in nginx to bare domain
- `GET http://energysparks.uk/*`. This triggers Rails to redirect to SSL
- A request for the actual resource

The Rails redirect is handled by middleware. This means we're using a Puma worker thread and it seems like a db connection will be created (up to the pool limit). This ends up consuming memory on the database until the connection is recovered. This contributes to low memory warnings during spikes in crawler traffic.

The PR changes how we do SSL redirections to handle it in the Load Balancer instead. Avoids requests hitting the application server and consuming resources.

May not make a huge difference in overall resource usage but its a better approach than what we're using now.

I've left `config.force_ssl = true` in place as a final fall-back, but we could consider removing that in future.

```
$ curl -I http://test.energysparks.uk
HTTP/1.1 301 Moved Permanently
Server: awselb/2.0
Date: Wed, 06 May 2026 12:16:13 GMT
Content-Type: text/html
Content-Length: 134
Connection: keep-alive
Location: https://test.energysparks.uk:443/
```
