### PR TITLE
Fix escaping issue

### DIFF
--- a/app/services/csv_downloader.rb
+++ b/app/services/csv_downloader.rb
@@ -8,7 +8,7 @@ module CsvDownloader
       s.puts csv_header
       conn.copy_data "COPY (#{sql_query}) TO STDOUT WITH CSV;" do
         while (row = conn.get_copy_data)
-          s.puts row.tr('"', '').tr('{', '').tr('}', '').chomp.to_s
+          s.puts row.gsub(/"\{([^}]*)\}"/, '\1').chomp.to_s
         end
       end
       s.string

--- a/spec/system/admin/school_groups/managing_group_spec.rb
+++ b/spec/system/admin/school_groups/managing_group_spec.rb
@@ -13,11 +13,11 @@ RSpec.describe 'Managing a school group', :include_application_helper, :school_g
 
   shared_examples 'a group admin page header' do
     it 'has the expected title' do
-      expect(page).to have_content(school_group.name)
+      expect(page).to have_text(school_group.name)
     end
 
     it 'identifies the group type' do
-      expect(page).to have_content(school_group.group_type.humanize)
+      expect(page).to have_text(school_group.group_type.humanize)
     end
 
     context "when clicking on 'All school groups'" do
@@ -27,7 +27,7 @@ RSpec.describe 'Managing a school group', :include_application_helper, :school_g
     end
 
     it 'displays pupils in active schools count' do
-      expect(page).to have_content("Pupils in active schools: #{school_group.assigned_schools.visible.filter_map(&:number_of_pupils).sum}")
+      expect(page).to have_text("Pupils in active schools: #{school_group.assigned_schools.visible.filter_map(&:number_of_pupils).sum}")
     end
   end
 
@@ -53,10 +53,12 @@ RSpec.describe 'Managing a school group', :include_application_helper, :school_g
     it 'lists issue in tab' do
       within id do
         expect(page).to have_link(issue.title, href: polymorphic_path([:admin, issue.issueable, issue]))
-        expect(page).to have_content issue.issueable.name
-        expect(page).to have_content issue.fuel_type.capitalize
-        expect(page).to have_content nice_date_times_today(issue.updated_at)
-        expect(page).to have_link('Edit', href: edit_polymorphic_path([:admin, issue], redirect_back: admin_school_group_path(school_group)))
+        expect(page).to have_text issue.issueable.name
+        expect(page).to have_text issue.fuel_type.capitalize
+        expect(page).to have_text nice_date_times_today(issue.updated_at)
+        expect(page).to have_link('Edit',
+                                  href: edit_polymorphic_path([:admin, issue],
+                                                              redirect_back: admin_school_group_path(school_group)))
         expect(page).to have_css("i[class*='fa-thumbtack']")
       end
     end
@@ -74,7 +76,7 @@ RSpec.describe 'Managing a school group', :include_application_helper, :school_g
       end
 
       it 'displays a count of school group issues' do
-        expect(page).to have_content 'Group issues 1'
+        expect(page).to have_text 'Group issues 1'
       end
 
       it_behaves_like 'an issue listed in a tab', '#school-group-issues'
@@ -86,7 +88,7 @@ RSpec.describe 'Managing a school group', :include_application_helper, :school_g
         visit admin_school_group_path(school_group)
       end
 
-      it { expect(page).to have_content("No school group issues for #{school_group.name}") }
+      it { expect(page).to have_text("No school group issues for #{school_group.name}") }
 
       it_behaves_like 'buttons for creating issues or notes'
     end
@@ -104,7 +106,7 @@ RSpec.describe 'Managing a school group', :include_application_helper, :school_g
       end
 
       it 'displays a count of school group issues' do
-        expect(page).to have_content 'Group notes 1'
+        expect(page).to have_text 'Group notes 1'
       end
 
       it_behaves_like 'an issue listed in a tab', '#school-group-notes'
@@ -116,7 +118,7 @@ RSpec.describe 'Managing a school group', :include_application_helper, :school_g
         visit admin_school_group_path(school_group)
       end
 
-      it { expect(page).to have_content("No school group notes for #{school_group.name}") }
+      it { expect(page).to have_text("No school group notes for #{school_group.name}") }
 
       it_behaves_like 'buttons for creating issues or notes'
     end
@@ -128,31 +130,37 @@ RSpec.describe 'Managing a school group', :include_application_helper, :school_g
         create(:issue, issue_type: :issue, status: :open, updated_by: admin, issueable: school, fuel_type: :gas,
                        pinned: true)
       end
-      let!(:inactive_school_issue) { create :issue, issue_type: :issue, status: :open, issueable: create(:school, school_group: school_group, active: false) }
+      let!(:inactive_school_issue) do
+        create(:issue, issue_type: :issue, status: :open,
+                       issueable: create(:school, school_group: school_group, active: false))
+      end
 
       before do
         visit admin_school_group_path(school_group)
       end
 
       it 'displays a count of school issues' do
-        expect(page).to have_content 'School issues 1'
+        expect(page).to have_text 'School issues 1'
       end
 
       it 'does not show issues for inactive schools' do
-        expect(page).not_to have_content inactive_school_issue.title
+        expect(page).to have_no_text inactive_school_issue.title
       end
 
       it_behaves_like 'an issue listed in a tab', '#school-issues'
     end
 
     context 'when there are no active issues' do
-      let!(:inactive_school_issue) { create :issue, issue_type: :issue, status: :open, issueable: create(:school, school_group: school_group, active: false) }
+      let!(:inactive_school_issue) do
+        create(:issue, issue_type: :issue, status: :open,
+                       issueable: create(:school, school_group: school_group, active: false))
+      end
 
       before do
         visit admin_school_group_path(school_group)
       end
 
-      it { expect(page).to have_content("No school issues for #{school_group.name}") }
+      it { expect(page).to have_text("No school issues for #{school_group.name}") }
     end
   end
 
@@ -162,31 +170,37 @@ RSpec.describe 'Managing a school group', :include_application_helper, :school_g
         create(:issue, issue_type: :note, status: :open, updated_by: admin, issueable: school, fuel_type: :gas,
                        pinned: true)
       end
-      let!(:inactive_school_issue) { create :issue, issue_type: :note, status: :open, issueable: create(:school, school_group: school_group, active: false) }
+      let!(:inactive_school_issue) do
+        create(:issue, issue_type: :note, status: :open,
+                       issueable: create(:school, school_group: school_group, active: false))
+      end
 
       before do
         visit admin_school_group_path(school_group)
       end
 
       it 'displays a count of school notes' do
-        expect(page).to have_content 'School notes 1'
+        expect(page).to have_text 'School notes 1'
       end
 
       it 'does not show notes for inactive schools' do
-        expect(page).not_to have_content inactive_school_issue.title
+        expect(page).to have_no_text inactive_school_issue.title
       end
 
       it_behaves_like 'an issue listed in a tab', '#school-notes'
     end
 
     context 'when there are no active notes' do
-      let!(:inactive_school_note) { create :issue, issue_type: :note, status: :open, issueable: create(:school, school_group: school_group, active: false) }
+      let!(:inactive_school_note) do
+        create(:issue, issue_type: :note, status: :open,
+                       issueable: create(:school, school_group: school_group, active: false))
+      end
 
       before do
         visit admin_school_group_path(school_group)
       end
 
-      it { expect(page).to have_content("No school notes for #{school_group.name}") }
+      it { expect(page).to have_text("No school notes for #{school_group.name}") }
     end
   end
 
@@ -197,7 +211,12 @@ RSpec.describe 'Managing a school group', :include_application_helper, :school_g
 
     it { expect(page).to have_link('View', href: school_group_path(school_group)) }
     it { expect(page).to have_link('Edit', href: edit_admin_school_group_path(school_group)) }
-    it { expect(page).to have_link(I18n.t('school_groups.titles.school_status'), href: school_group_status_index_path(school_group)) }
+
+    it {
+      expect(page).to have_link(I18n.t('school_groups.titles.school_status'),
+                                href: school_group_status_index_path(school_group))
+    }
+
     it { expect(page).to have_link('Manage users', href: admin_school_group_users_path(school_group)) }
     it { expect(page).to have_link('Manage partners', href: admin_school_group_partners_path(school_group)) }
     it { expect(page).to have_link('Delete', href: admin_school_group_path(school_group)) }
@@ -234,7 +253,7 @@ RSpec.describe 'Managing a school group', :include_application_helper, :school_g
       context "when clicking 'Delete'" do
         before { click_on 'Delete' }
 
-        it { expect(page).to have_content('There are no School groups') }
+        it { expect(page).to have_text('There are no School groups') }
       end
     end
 
@@ -366,12 +385,13 @@ RSpec.describe 'Managing a school group', :include_application_helper, :school_g
       end
 
       def expected_csv(meter, reading)
+        school_name = CSV.generate_line([meter.school.name]).strip
         'School Name,School Id,Mpan Mprn,Meter Type,Reading Date,One Day Total kWh,Status,Substitute Date,' \
-        '00:30,01:00,01:30,02:00,02:30,03:00,03:30,04:00,04:30,05:00,05:30,06:00,06:30,07:00,07:30,08:00,' \
-        '08:30,09:00,09:30,10:00,10:30,11:00,11:30,12:00,12:30,13:00,13:30,14:00,14:30,15:00,15:30,16:00,' \
-        "16:30,17:00,17:30,18:00,18:30,19:00,19:30,20:00,20:30,21:00,21:30,22:00,22:30,23:00,23:30,00:00\n" \
-        "#{meter.school.name},#{meter.school.id},#{meter.mpan_mprn},Electricity,#{Date.yesterday.iso8601},139.0," \
-        "ORIG,,#{([reading] * 48).join(',')}\n"
+          '00:30,01:00,01:30,02:00,02:30,03:00,03:30,04:00,04:30,05:00,05:30,06:00,06:30,07:00,07:30,08:00,' \
+          '08:30,09:00,09:30,10:00,10:30,11:00,11:30,12:00,12:30,13:00,13:30,14:00,14:30,15:00,15:30,16:00,' \
+          "16:30,17:00,17:30,18:00,18:30,19:00,19:30,20:00,20:30,21:00,21:30,22:00,22:30,23:00,23:30,00:00\n" \
+          "#{school_name},#{meter.school.id},#{meter.mpan_mprn},Electricity,#{Date.yesterday.iso8601},139.0," \
+          "ORIG,,#{([reading] * 48).join(',')}\n"
       end
 
       let(:meter) { create(:electricity_meter, school:) }
@@ -439,30 +459,32 @@ RSpec.describe 'Managing a school group', :include_application_helper, :school_g
     it_behaves_like 'a basic button panel'
 
     context 'with only a basic button panel' do
-      it { expect(page).not_to have_link('Meter attributes') }
-      it { expect(page).not_to have_link('Manage tariffs') }
-      it { expect(page).not_to have_link('Meter updates') }
-      it { expect(page).not_to have_link('Chart updates') }
+      it { expect(page).to have_no_link('Meter attributes') }
+      it { expect(page).to have_no_link('Manage tariffs') }
+      it { expect(page).to have_no_link('Meter updates') }
+      it { expect(page).to have_no_link('Chart updates') }
     end
 
     describe 'School counts by school type panel' do
       School.school_types.each_key do |school_type|
         context "when showing active #{school_type} schools" do
           before do
-            create(:school, :with_project, :with_school_group, school_type: school_type, group: school_group, active: true)
+            create(:school, :with_project, :with_school_group, school_type: school_type, group: school_group,
+                                                               active: true)
             visit admin_school_group_path(school_group)
           end
 
-          it { expect(page).to have_content("#{school_type.humanize} 1") }
+          it { expect(page).to have_text("#{school_type.humanize} 1") }
         end
 
         context "when showing inactive #{school_type} schools" do
           before do
-            create(:school, :with_project, :with_school_group, school_type: school_type, group: school_group, active: false)
+            create(:school, :with_project, :with_school_group, school_type: school_type, group: school_group,
+                                                               active: false)
             visit admin_school_group_path(school_group)
           end
 
-          it { expect(page).to have_content("#{school_type.humanize} 0") }
+          it { expect(page).to have_text("#{school_type.humanize} 0") }
         end
       end
     end
@@ -516,7 +538,9 @@ RSpec.describe 'Managing a school group', :include_application_helper, :school_g
 
       context 'when there are active non visible schools' do
         it_behaves_like 'an Active schools tab' do
-          let(:school) { create(:school, :with_project, :with_school_group, active: true, visible: false, group: school_group) }
+          let(:school) do
+            create(:school, :with_project, :with_school_group, active: true, visible: false, group: school_group)
+          end
         end
       end
 
@@ -530,7 +554,7 @@ RSpec.describe 'Managing a school group', :include_application_helper, :school_g
         it "doesn't show school active tab" do
           within '#active' do
             expect(page).to have_no_link(school.name)
-            expect(page).to have_content("No active schools for #{school_group.name}.")
+            expect(page).to have_text("No active schools for #{school_group.name}.")
           end
         end
       end
@@ -539,7 +563,8 @@ RSpec.describe 'Managing a school group', :include_application_helper, :school_g
     describe 'Removed schools tab' do
       context 'when there are inactive schools' do
         let!(:school) do
-          create(:school, :with_project, :with_school_group, active: false, removal_date: Time.zone.now, group: school_group)
+          create(:school, :with_project, :with_school_group, active: false, removal_date: Time.zone.now,
+                                                             group: school_group)
         end
 
         before do
@@ -549,7 +574,7 @@ RSpec.describe 'Managing a school group', :include_application_helper, :school_g
         it 'lists school in removed tab' do
           within '#removed' do
             expect(page).to have_link(school.name, href: school_path(school))
-            expect(page).to have_content(nice_dates(school.removal_date))
+            expect(page).to have_text(nice_dates(school.removal_date))
             expect(page).to have_link('Meters')
           end
         end
@@ -567,14 +592,22 @@ RSpec.describe 'Managing a school group', :include_application_helper, :school_g
         it "doesn't show school in removed tab" do
           within '#removed' do
             expect(page).to have_no_link(school.name)
-            expect(page).to have_content("No removed schools for #{school_group.name}.")
+            expect(page).to have_text("No removed schools for #{school_group.name}.")
           end
         end
       end
     end
 
     it_behaves_like 'a meter data export can be requested' do
-      let(:school) { create(:school, :with_project, :with_school_group, group: school_group) }
+      let(:school) do
+        create(:school, :with_project, :with_school_group, group: school_group)
+      end
+    end
+
+    it_behaves_like 'a meter data export can be requested' do
+      let(:school) do
+        create(:school, :with_project, :with_school_group, group: school_group, name: 'A School, Here')
+      end
     end
   end
 
@@ -590,30 +623,32 @@ RSpec.describe 'Managing a school group', :include_application_helper, :school_g
     it_behaves_like 'a basic button panel'
 
     context 'with only a basic button panel' do
-      it { expect(page).not_to have_link('Meter attributes') }
-      it { expect(page).not_to have_link('Manage tariffs') }
-      it { expect(page).not_to have_link('Meter updates') }
-      it { expect(page).not_to have_link('Chart updates') }
+      it { expect(page).to have_no_link('Meter attributes') }
+      it { expect(page).to have_no_link('Manage tariffs') }
+      it { expect(page).to have_no_link('Meter updates') }
+      it { expect(page).to have_no_link('Chart updates') }
     end
 
     describe 'School counts by school type panel' do
       School.school_types.each_key do |school_type|
         context "when showing active #{school_type} schools" do
           before do
-            create(:school, :with_diocese, :with_school_group, school_type: school_type, group: school_group, active: true)
+            create(:school, :with_diocese, :with_school_group, school_type: school_type, group: school_group,
+                                                               active: true)
             visit admin_school_group_path(school_group)
           end
 
-          it { expect(page).to have_content("#{school_type.humanize} 1") }
+          it { expect(page).to have_text("#{school_type.humanize} 1") }
         end
 
         context "when showing inactive #{school_type} schools" do
           before do
-            create(:school, :with_diocese, :with_school_group, school_type: school_type, group: school_group, active: false)
+            create(:school, :with_diocese, :with_school_group, school_type: school_type, group: school_group,
+                                                               active: false)
             visit admin_school_group_path(school_group)
           end
 
-          it { expect(page).to have_content("#{school_type.humanize} 0") }
+          it { expect(page).to have_text("#{school_type.humanize} 0") }
         end
       end
     end
@@ -656,7 +691,9 @@ RSpec.describe 'Managing a school group', :include_application_helper, :school_g
 
       context 'when there are active non visible schools' do
         it_behaves_like 'an Active schools tab' do
-          let(:school) { create(:school, :with_diocese, :with_school_group, active: true, visible: false, group: school_group) }
+          let(:school) do
+            create(:school, :with_diocese, :with_school_group, active: true, visible: false, group: school_group)
+          end
         end
       end
 
@@ -670,7 +707,7 @@ RSpec.describe 'Managing a school group', :include_application_helper, :school_g
         it "doesn't show school active tab" do
           within '#active' do
             expect(page).to have_no_link(school.name)
-            expect(page).to have_content("No active schools for #{school_group.name}.")
+            expect(page).to have_text("No active schools for #{school_group.name}.")
           end
         end
       end
@@ -679,7 +716,8 @@ RSpec.describe 'Managing a school group', :include_application_helper, :school_g
     describe 'Removed schools tab' do
       context 'when there are inactive schools' do
         let!(:school) do
-          create(:school, :with_diocese, :with_school_group, active: false, removal_date: Time.zone.now, group: school_group)
+          create(:school, :with_diocese, :with_school_group, active: false, removal_date: Time.zone.now,
+                                                             group: school_group)
         end
 
         before do
@@ -689,7 +727,7 @@ RSpec.describe 'Managing a school group', :include_application_helper, :school_g
         it 'lists school in removed tab' do
           within '#removed' do
             expect(page).to have_link(school.name, href: school_path(school))
-            expect(page).to have_content(nice_dates(school.removal_date))
+            expect(page).to have_text(nice_dates(school.removal_date))
             expect(page).to have_link('Meters')
           end
         end
@@ -707,7 +745,7 @@ RSpec.describe 'Managing a school group', :include_application_helper, :school_g
         it "doesn't show school in removed tab" do
           within '#removed' do
             expect(page).to have_no_link(school.name)
-            expect(page).to have_content("No removed schools for #{school_group.name}.")
+            expect(page).to have_text("No removed schools for #{school_group.name}.")
           end
         end
       end
@@ -728,7 +766,9 @@ RSpec.describe 'Managing a school group', :include_application_helper, :school_g
     it_behaves_like 'a group admin page header'
 
     describe 'with an issues admin' do
-      let!(:school_group) { create(:school_group, group_type: :multi_academy_trust, default_issues_admin_user: issues_admin) }
+      let!(:school_group) do
+        create(:school_group, group_type: :multi_academy_trust, default_issues_admin_user: issues_admin)
+      end
       let(:issues_link) { polymorphic_path([:admin, Issue], user: issues_admin) }
 
       before do
@@ -764,11 +804,11 @@ RSpec.describe 'Managing a school group', :include_application_helper, :school_g
         visit admin_school_group_path(school_group)
       end
 
-      it { expect(page).to have_content('Active 1') }
-      it { expect(page).to have_content('Active (with data visible) 1') }
-      it { expect(page).to have_content('Invisible 1') }
-      it { expect(page).to have_content('Onboarding 1') }
-      it { expect(page).to have_content('Removed 1') }
+      it { expect(page).to have_text('Active 1') }
+      it { expect(page).to have_text('Active (with data visible) 1') }
+      it { expect(page).to have_text('Invisible 1') }
+      it { expect(page).to have_text('Onboarding 1') }
+      it { expect(page).to have_text('Removed 1') }
     end
 
     describe 'School counts by school type panel' do
@@ -779,7 +819,7 @@ RSpec.describe 'Managing a school group', :include_application_helper, :school_g
             visit admin_school_group_path(school_group)
           end
 
-          it { expect(page).to have_content("#{school_type.humanize} 1") }
+          it { expect(page).to have_text("#{school_type.humanize} 1") }
         end
 
         context "when showing inactive #{school_type} schools" do
@@ -788,7 +828,7 @@ RSpec.describe 'Managing a school group', :include_application_helper, :school_g
             visit admin_school_group_path(school_group)
           end
 
-          it { expect(page).to have_content("#{school_type.humanize} 0") }
+          it { expect(page).to have_text("#{school_type.humanize} 0") }
         end
       end
     end
@@ -860,7 +900,7 @@ RSpec.describe 'Managing a school group', :include_application_helper, :school_g
         it "doesn't show school active tab" do
           within '#active' do
             expect(page).to have_no_link(school.name)
-            expect(page).to have_content("No active schools for #{school_group.name}.")
+            expect(page).to have_text("No active schools for #{school_group.name}.")
           end
         end
       end
@@ -874,13 +914,16 @@ RSpec.describe 'Managing a school group', :include_application_helper, :school_g
         visit admin_school_group_path(school_group)
       end
 
-      it { expect(page).to have_link('New School Onboarding', href: new_admin_school_onboarding_path(school_group_id: school_group.id)) }
+      it {
+        expect(page).to have_link('New School Onboarding',
+                                  href: new_admin_school_onboarding_path(school_group_id: school_group.id))
+      }
 
       context 'when using the new onboarding link' do
         before { click_on('New School Onboarding') }
 
         it 'autofills the school group name' do
-          expect(page).to have_content(school_group.name)
+          expect(page).to have_text(school_group.name)
         end
       end
 
@@ -891,7 +934,7 @@ RSpec.describe 'Managing a school group', :include_application_helper, :school_g
 
         it 'displays a message' do
           within '#onboarding' do
-            expect(page).to have_content("No schools currently onboarding for #{school_group.name}.")
+            expect(page).to have_text("No schools currently onboarding for #{school_group.name}.")
           end
         end
       end
@@ -927,7 +970,7 @@ RSpec.describe 'Managing a school group', :include_application_helper, :school_g
         it 'lists school in removed tab' do
           within '#removed' do
             expect(page).to have_link(school.name, href: school_path(school))
-            expect(page).to have_content(nice_dates(school.removal_date))
+            expect(page).to have_text(nice_dates(school.removal_date))
             expect(page).to have_link('Meters')
           end
         end
@@ -943,7 +986,7 @@ RSpec.describe 'Managing a school group', :include_application_helper, :school_g
         it "doesn't show school in removed tab" do
           within '#removed' do
             expect(page).to have_no_link(school.name)
-            expect(page).to have_content("No removed schools for #{school_group.name}.")
+            expect(page).to have_text("No removed schools for #{school_group.name}.")
           end
         end
       end


### PR DESCRIPTION
The CSVDownloader class which streams readings from Postgres has a quoting issue when processing school names that contain commas. This PR fixes that to ensure that the school group meter data exports are correctly formatted.

Key changes are to CSVDownloader and an extra spec in manage_groups_spec.rb. 