### PR TITLE
Change meters for admin user to include all meters

### DIFF
--- a/app/controllers/admin/reports/admin_user_meter_report_controller.rb
+++ b/app/controllers/admin/reports/admin_user_meter_report_controller.rb
@@ -14,6 +14,7 @@ module Admin
       end
 
       def results
+        params[:active] ||= 'true'
         unless params.key?(:school_group) || params.key?(:admin)
           params[:admin] = current_user.id
           return nil
@@ -21,8 +22,12 @@ module Admin
         filtered_meters
       end
 
+      def columns
+        super.insert(7, Column.new(:active, ->(meter) { meter.active }))
+      end
+
       def filtered_meters
-        Meter.active
+        Meter.then { |scope| filter_by_active(scope) }
              .joins(:school)
              .includes(:school, { school: :school_group })
              .then { |scope| filter_by_admin(scope) }
@@ -40,6 +45,12 @@ module Admin
 
       def filter_by_school_group(scope)
         filter(scope, params[:school_group]) { scope.where(schools: { school_group_id: params[:school_group] }) }
+      end
+
+      def filter_by_active(scope)
+        return scope if params[:active] == 'all'
+
+        filter(scope, params[:active]) { scope.where(active: params[:active]) }
       end
 
       def filter(scope, condition)

--- a/app/views/admin/reports/admin_user_meter_report/_extra_filters.html.erb
+++ b/app/views/admin/reports/admin_user_meter_report/_extra_filters.html.erb
@@ -1,0 +1,23 @@
+<span class="nowrap">
+  <%= label_tag :meter_type, nil, class: 'small' %>
+  <%= select_tag :meter_type,
+                 options_for_select(Meter.meter_types.to_a, params[:meter_type]),
+                 include_blank: 'Any Meter Type',
+                 class: 'form-control-sm' %>
+</span>
+<span class="nowrap">
+  <%= label_tag :admin_meter_status, nil, class: 'small' %>
+  <%= select_tag :admin_meter_status,
+                 options_from_collection_for_select(
+                   AdminMeterStatus.include_in_inactive_meter_report.by_label, :id, :label, params[:admin_meter_status]
+                 ),
+                 include_blank: 'Any Meter Status',
+                 class: 'form-control-sm' %>
+</span>
+<span class="nowrap">
+  <%= label_tag :active, nil, class: 'small' %>
+  <%= select_tag :active,
+                 options_for_select([%w[Active true], %w[Inactive false], %w[All all]],
+                                    params[:active].presence || 'true'),
+                 class: 'form-control-sm' %>
+</span>

--- a/spec/system/admin/reports/admin_user_meter_report_spec.rb
+++ b/spec/system/admin/reports/admin_user_meter_report_spec.rb
@@ -14,12 +14,12 @@ describe 'admin user meter report' do
   it_behaves_like 'it contains the expected data table', aligned: false do
     let(:table_id) { '.advice-table' }
     let(:expected_header) do
-      [['School Group', 'Admin', 'School', 'Meter', 'Meter Name', 'Meter Type', 'Meter System', 'Data Source',
+      [['School Group', 'Admin', 'School', 'Meter', 'Meter Name', 'Meter Type', 'Meter System', 'Active', 'Data Source',
         'Procurement Route', 'Meter Status', 'Manual Reads', 'Last Validated Date', 'Issues & Notes']]
     end
     let(:expected_rows) do
-      [[school.school_group.name, 'Admin', school.name, meter.mpan_mprn.to_s, meter.name, '', 'NHH AMR', '', '', '',
-        'N', '', '']]
+      [[school.school_group.name, 'Admin', school.name, meter.mpan_mprn.to_s, meter.name, '', 'NHH AMR',
+        meter.active.to_s, '', '', '', 'N', '', '']]
     end
   end
 
@@ -28,10 +28,10 @@ describe 'admin user meter report' do
 
     it 'has the correct CSV' do
       expect(CSV.parse(page.body)).to eq(
-        [['School Group', 'Admin', 'School', 'Meter', 'Meter Name', 'Meter Type', 'Meter System', 'Data Source',
-          'Procurement Route', 'Meter Status', 'Manual Reads', 'Last Validated Date', 'Issues', 'Notes'],
+        [['School Group', 'Admin', 'School', 'Meter', 'Meter Name', 'Meter Type', 'Meter System', 'Active',
+          'Data Source', 'Procurement Route', 'Meter Status', 'Manual Reads', 'Last Validated Date', 'Issues', 'Notes'],
          [school.school_group.name, 'Admin', school.name, meter.mpan_mprn.to_s, meter.name, 'gas', 'NHH AMR',
-          nil, nil, nil, 'N', nil, '0', '0']]
+          meter.active.to_s, nil, nil, nil, 'N', nil, '0', '0']]
       )
     end
   end


### PR DESCRIPTION
Adds an 'active' filter to this report so that users can view active, inactive or all meters. Defaults to active