### PR TITLE
Handle SolarEdge Pending Site Status

### DIFF
--- a/lib/data_feeds/solar_edge_api.rb
+++ b/lib/data_feeds/solar_edge_api.rb
@@ -33,10 +33,8 @@ module DataFeeds
     end
 
     def site_start_end_dates(site_id)
-      dates = get_data("/site/#{site_id}/dataPeriod")
-      start_date = Date.parse(dates['dataPeriod']['startDate']) if dates['dataPeriod']['startDate']
-      end_date = Date.parse(dates['dataPeriod']['endDate']) if dates['dataPeriod']['endDate']
-      [start_date, end_date]
+      period = get_data("/site/#{site_id}/dataPeriod").fetch('dataPeriod', {})
+      %w[startDate endDate].map { |key| Date.parse(period[key]) if period[key] }
     end
 
     # Used by application code

--- a/lib/data_feeds/solar_edge_api.rb
+++ b/lib/data_feeds/solar_edge_api.rb
@@ -10,6 +10,7 @@ module DataFeeds
     class NotFound < StandardError; end
     class NotAllowed < StandardError; end
     class NotAuthorised < StandardError; end
+    class SiteStatusIssue < StandardError; end
 
     BASE_URL = 'https://monitoringapi.solaredge.com'
     # Maximum number of days that can be requested for 15 minute period data
@@ -33,7 +34,9 @@ module DataFeeds
 
     def site_start_end_dates(site_id)
       dates = get_data("/site/#{site_id}/dataPeriod")
-      [Date.parse(dates['dataPeriod']['startDate']), Date.parse(dates['dataPeriod']['endDate'])]
+      start_date = Date.parse(dates['dataPeriod']['startDate']) if dates['dataPeriod']['startDate']
+      end_date = Date.parse(dates['dataPeriod']['endDate']) if dates['dataPeriod']['endDate']
+      [start_date, end_date]
     end
 
     # Used by application code
@@ -178,6 +181,9 @@ module DataFeeds
 
     def dates(meter_id, start_date, end_date)
       sd, ed = site_start_end_dates(meter_id) if start_date.nil? || end_date.nil?
+
+      raise SiteStatusIssue, 'Site has incomplete Data Period. Is site still in pending status?' if sd.nil? || ed.nil?
+
       start_date = sd if start_date.nil?
       end_date   = ed if end_date.nil?
       [start_date, end_date]

--- a/spec/lib/data_feeds/solar_edge_api_spec.rb
+++ b/spec/lib/data_feeds/solar_edge_api_spec.rb
@@ -16,6 +16,42 @@ describe DataFeeds::SolarEdgeApi do
     allow(Faraday).to receive(:get).with(expected_url, expected_params, headers).and_return(response)
   end
 
+  describe '#site_start_end_dates' do
+    let(:expected_url) { "#{DataFeeds::SolarEdgeApi::BASE_URL}/site/#{site_id}/dataPeriod" }
+    let(:expected_params) { { api_key: } }
+    let(:site_id) { 123 }
+
+    context 'with valid dates' do
+      let(:body) do
+        {
+          dataPeriod: {
+            startDate: '2025-01-01',
+            endDate: '2026-05-11'
+          }
+        }
+      end
+
+      it 'returns data' do
+        expect(client.site_start_end_dates(site_id)).to eql [Date.new(2025, 1, 1), Date.new(2026, 5, 11)]
+      end
+    end
+
+    context 'when site is still in Pending status' do
+      let(:body) do
+        {
+          dataPeriod: {
+            startDate: nil,
+            endDate: '2026-05-11'
+          }
+        }
+      end
+
+      it 'returns data' do
+        expect(client.site_start_end_dates(site_id)).to eql [nil, Date.new(2026, 5, 11)]
+      end
+    end
+  end
+
   # minimal test of HTTP response handling behaviour
   describe '#site_details' do
     let(:expected_url) { "#{DataFeeds::SolarEdgeApi::BASE_URL}/sites/list" }


### PR DESCRIPTION
When a SolarEdge site is still in "Pending" status the data period API call will return a nil for data from which data is available.

This PR:

- ensures that nil dates are parsed correctly, allowing the site details to be properly read and stored (this allows admins to view the site status)
- cause the API client to raise an exception if there is an incomplete data period. This stops us from attempting to load data when there isn't any available

Added a spec for the parsing behaviour. There's already specs in calling code to ensure that exceptions are caught and logged correctly.