### PR TITLE
Add format_price helper and use on commercial pages

### DIFF
--- a/app/components/commercial/price_breakdown_component/price_breakdown_component.html.erb
+++ b/app/components/commercial/price_breakdown_component/price_breakdown_component.html.erb
@@ -9,19 +9,19 @@
         <tbody>
             <tr>
             <td>Base Price</td>
-            <td><%= helpers.format_unit(@price.base_price, :£) %></td>
+            <td><%= helpers.format_price(@price.base_price) %></td>
             </tr>
             <tr>
             <td>Metering Fee</td>
-            <td><%= helpers.format_unit(@price.metering_fee, :£) %></td>
+            <td><%= helpers.format_price(@price.metering_fee) %></td>
             </tr>
             <tr>
             <td>Private Account Fee</td>
-            <td><%= helpers.format_unit(@price.private_account_fee, :£) %></td>
+            <td><%= helpers.format_price(@price.private_account_fee) %></td>
             </tr>
             <tr>
             <td>Total Price</td>
-            <td><%= helpers.format_unit(@price.total, :£) %></td>
+            <td><%= helpers.format_price(@price.total) %></td>
             </tr>
         </tbody>
     </table>

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -141,11 +141,11 @@ class HomeController < ApplicationController
     product = Commercial::Product.default_product
     return {} unless product
     {
-      small_school_price: format_unit(product.small_school_price, :£),
-      large_school_price: format_unit(product.large_school_price, :£),
-      mat_price: format_unit(product.mat_price, :£),
-      private_account_fee: format_unit(product.private_account_fee, :£),
-      metering_fee: format_unit(product.metering_fee, :£),
+      small_school_price: format_price(product.small_school_price, decimals: false),
+      large_school_price: format_price(product.large_school_price, decimals: false),
+      mat_price: format_price(product.mat_price, decimals: false),
+      private_account_fee: format_price(product.private_account_fee, decimals: false),
+      metering_fee: format_price(product.metering_fee, decimals: false),
       size_threshold: product.size_threshold
     }
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,6 +1,7 @@
 module ApplicationHelper
   include Pagy::Frontend
   include ActionView::Helpers::TagHelper
+  include ActionView::Helpers::NumberHelper
 
   def nice_date_times(datetime, options = {})
     return '' if datetime.nil?
@@ -263,6 +264,19 @@ module ApplicationHelper
     return school_time if school_time.blank?
 
     format('%04d', school_time).insert(2, ':')
+  end
+
+  def format_price(price, decimals: true)
+    raw = price.to_s
+    integer, decimal = raw.split('.')
+
+    formatted_int = ActiveSupport::NumberHelper.number_to_delimited(integer)
+
+    if decimals && decimal
+      "£#{formatted_int}.#{decimal}"
+    else
+      "£#{formatted_int}"
+    end
   end
 
   def table_headers_from_array(array)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -272,10 +272,13 @@ module ApplicationHelper
 
     formatted_int = ActiveSupport::NumberHelper.number_to_delimited(integer)
 
-    if decimals && decimal
-      "£#{formatted_int}.#{decimal}"
+    return "£#{formatted_int}" unless decimals
+
+    if decimal
+      padded = decimal.ljust(2, '0')
+      "£#{formatted_int}.#{padded}"
     else
-      "£#{formatted_int}"
+      "£#{formatted_int}.00"
     end
   end
 

--- a/app/views/admin/commercial/contracts/show.html.erb
+++ b/app/views/admin/commercial/contracts/show.html.erb
@@ -100,7 +100,7 @@
               Agreed School Price
             </dt>
             <dd class="col-7">
-              <%= format_unit(@contract.agreed_school_price, :£) %>
+              <%= format_price(@contract.agreed_school_price) %>
             </dd>
             <dt class="col-5">
               Purchase order number
@@ -129,19 +129,19 @@
             <tbody>
               <tr>
                 <td>Base price</td>
-                <td><%= format_unit(@pricing.totals.base_price, :£) %></td>
+                <td><%= format_price(@pricing.totals.base_price) %></td>
               </tr>
               <tr>
                 <td>Metering fees</td>
-                <td><%= format_unit(@pricing.totals.metering_fee, :£) %></td>
+                <td><%= format_price(@pricing.totals.metering_fee) %></td>
               </tr>
               <tr>
                 <td>Private account fees</td>
-                <td><%= format_unit(@pricing.totals.private_account_fee, :£) %></td>
+                <td><%= format_price(@pricing.totals.private_account_fee) %></td>
               </tr>
               <tr>
                 <td><strong>Total</strong></td>
-                <td><strong><%= format_unit(@pricing.totals.total, :£) %></strong></td>
+                <td><strong><%= format_price(@pricing.totals.total) %></strong></td>
               </tr>
             </tbody>
           </table>
@@ -223,16 +223,16 @@
             </td>
             <td><%= link_to school.name, school_path(school) %></td>
             <td data-sort="<%= pricing[:price].base_price %>">
-              <%= format_unit(pricing[:price].base_price, :£) %>
+              <%= format_price(pricing[:price].base_price) %>
             </td>
             <td data-sort="<%= pricing[:price].metering_fee %>">
-              <%= format_unit(pricing[:price].metering_fee, :£) %>
+              <%= format_price(pricing[:price].metering_fee) %>
             </td>
             <td data-sort="<%= pricing[:price].private_account_fee %>">
-              <%= format_unit(pricing[:price].private_account_fee, :£) %>
+              <%= format_price(pricing[:price].private_account_fee) %>
             </td>
             <td data-sort="<%= pricing[:price].total %>">
-              <%= format_unit(pricing[:price].total, :£) %>
+              <%= format_price(pricing[:price].total) %>
             </td>
           </tr>
         <% end %>
@@ -241,10 +241,10 @@
         <tr>
           <td></td>
           <td></td>
-          <td><strong><%= format_unit(@pricing.totals.base_price, :£) %></strong></td>
-          <td><strong><%= format_unit(@pricing.totals.metering_fee, :£) %></strong></td>
-          <td><strong><%= format_unit(@pricing.totals.private_account_fee, :£) %></strong></td>
-          <td><strong><%= format_unit(@pricing.totals.total, :£) %></strong></td>
+          <td><strong><%= format_price(@pricing.totals.base_price) %></strong></td>
+          <td><strong><%= format_price(@pricing.totals.metering_fee) %></strong></td>
+          <td><strong><%= format_price(@pricing.totals.private_account_fee) %></strong></td>
+          <td><strong><%= format_price(@pricing.totals.total) %></strong></td>
         </tr>
       </tfoot>
     </table>

--- a/app/views/admin/commercial/products/show.html.erb
+++ b/app/views/admin/commercial/products/show.html.erb
@@ -16,13 +16,13 @@
           Small school price
         </dt>
         <dd class="col-7">
-          <%= format_unit(@product.small_school_price, :£) %>
+          <%= format_price(@product.small_school_price) %>
         </dd>
         <dt class="col-5">
           Large school price
         </dt>
         <dd class="col-7">
-          <%= format_unit(@product.large_school_price, :£) %>
+          <%= format_price(@product.large_school_price) %>
         </dd>
         <dt class="col-5">
           School size threshold
@@ -34,19 +34,19 @@
           MAT price
         </dt>
         <dd class="col-7">
-          <%= format_unit(@product.mat_price, :£) %>
+          <%= format_price(@product.mat_price) %>
         </dd>
         <dt class="col-5">
           Private account fee (per year)
         </dt>
         <dd class="col-7">
-          <%= format_unit(@product.private_account_fee, :£) %>
+          <%= format_price(@product.private_account_fee) %>
         </dd>
         <dt class="col-5">
           Metering fee (per meter)
         </dt>
         <dd class="col-7">
-          <%= format_unit(@product.metering_fee, :£) %>
+          <%= format_price(@product.metering_fee) %>
         </dd>
         <dt class="col-5">
           Comments

--- a/spec/components/commercial/price_breakdown_component_spec.rb
+++ b/spec/components/commercial/price_breakdown_component_spec.rb
@@ -26,10 +26,10 @@ RSpec.describe Commercial::PriceBreakdownComponent, :include_application_helper,
     end
     let(:expected_rows) do
       [
-        ['Base Price', format_unit(100.0, :£, true, :ks2, :text)],
-        ['Metering Fee', format_unit(200.0, :£, true, :ks2, :text)],
-        ['Private Account Fee', format_unit(90.0, :£, true, :ks2, :text)],
-        ['Total Price', format_unit(390.0, :£, true, :ks2, :text)]
+        ['Base Price', format_price(100.0)],
+        ['Metering Fee', format_price(200.0)],
+        ['Private Account Fee', format_price(90.0)],
+        ['Total Price', format_price(390.0)]
       ]
     end
   end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -335,4 +335,29 @@ describe ApplicationHelper do
       end
     end
   end
+
+  describe '#format_price' do
+    it 'formats floats correctly' do
+      expect(helper.format_price(123.0)).to eq('£123.00')
+      expect(helper.format_price(1234.0)).to eq('£1,234.00')
+      expect(helper.format_price(1234.50)).to eq('£1,234.50')
+      expect(helper.format_price(1234.567)).to eq('£1,234.567')
+      expect(helper.format_price(0.0)).to eq('£0.00')
+    end
+
+    it 'formats integers correctly' do
+      expect(helper.format_price(1234)).to eq('£1,234.00')
+    end
+
+    it 'formats BigDecimals correctly' do
+      expect(helper.format_price(BigDecimal(123.0))).to eq('£123.00')
+    end
+
+    it 'formats floats correctly excluding decimals' do
+      expect(helper.format_price(123.0, decimals: false)).to eq('£123')
+      expect(helper.format_price(1234.0, decimals: false)).to eq('£1,234')
+      expect(helper.format_price(1234.50, decimals: false)).to eq('£1,234')
+      expect(helper.format_price(1234.567, decimals: false)).to eq('£1,234')
+    end
+  end
 end

--- a/spec/system/admin/commercial/manage_contracts_spec.rb
+++ b/spec/system/admin/commercial/manage_contracts_spec.rb
@@ -441,10 +441,10 @@ describe 'manage contracts' do
         end
         let(:expected_rows) do
           [
-            ['Base price', '£600.0'],
-            ['Metering fees', '£0.0'],
-            ['Private account fees', '£0.0'],
-            ['Total', '£600.0']
+            ['Base price', '£600.00'],
+            ['Metering fees', '£0.00'],
+            ['Private account fees', '£0.00'],
+            ['Total', '£600.00']
           ]
         end
       end
@@ -465,12 +465,12 @@ describe 'manage contracts' do
         end
         let(:expected_rows) do
           [
-            ['', contract.schools.first.name, '£600.0', '£0.0', '£0.0', '£600.0']
+            ['', contract.schools.first.name, '£600.00', '£0.00', '£0.00', '£600.00']
           ]
         end
         let(:expected_footer_rows) do
           [
-            ['', '', '£600.0', '£0.0', '£0.0', '£600.0']
+            ['', '', '£600.00', '£0.00', '£0.00', '£600.00']
           ]
         end
       end

--- a/spec/system/admin/commercial/manage_contracts_spec.rb
+++ b/spec/system/admin/commercial/manage_contracts_spec.rb
@@ -441,10 +441,10 @@ describe 'manage contracts' do
         end
         let(:expected_rows) do
           [
-            ['Base price', '£600'],
-            ['Metering fees', '0p'],
-            ['Private account fees', '0p'],
-            ['Total', '£600']
+            ['Base price', '£600.0'],
+            ['Metering fees', '£0.0'],
+            ['Private account fees', '£0.0'],
+            ['Total', '£600.0']
           ]
         end
       end
@@ -465,12 +465,12 @@ describe 'manage contracts' do
         end
         let(:expected_rows) do
           [
-            ['', contract.schools.first.name, '£600', '0p', '0p', '£600']
+            ['', contract.schools.first.name, '£600.0', '£0.0', '£0.0', '£600.0']
           ]
         end
         let(:expected_footer_rows) do
           [
-            ['', '', '£600', '0p', '0p', '£600']
+            ['', '', '£600.0', '£0.0', '£0.0', '£600.0']
           ]
         end
       end

--- a/spec/system/admin/commercial/pricing_spec.rb
+++ b/spec/system/admin/commercial/pricing_spec.rb
@@ -30,10 +30,10 @@ describe 'pricing calculator' do
         end
         let(:expected_rows) do
           [
-            ['Base Price', format_unit(product.small_school_price, :£, true, :ks2, :text)],
-            ['Metering Fee', format_unit(0.0, :£, true, :ks2, :text)],
-            ['Private Account Fee', format_unit(0.0, :£, true, :ks2, :text)],
-            ['Total Price', format_unit(product.small_school_price, :£, true, :ks2, :text)]
+            ['Base Price', format_price(product.small_school_price)],
+            ['Metering Fee', format_price(0.0)],
+            ['Private Account Fee', format_price(0.0)],
+            ['Total Price', format_price(product.small_school_price)]
           ]
         end
       end
@@ -65,10 +65,10 @@ describe 'pricing calculator' do
         end
         let(:expected_rows) do
           [
-            ['Base Price', format_unit(contract.agreed_school_price, :£, true, :ks2, :text)],
-            ['Metering Fee', format_unit(0.0, :£, true, :ks2, :text)],
-            ['Private Account Fee', format_unit(0.0, :£, true, :ks2, :text)],
-            ['Total Price', format_unit(contract.agreed_school_price, :£, true, :ks2, :text)]
+            ['Base Price', format_price(contract.agreed_school_price)],
+            ['Metering Fee', format_price(0.0)],
+            ['Private Account Fee', format_price(0.0)],
+            ['Total Price', format_price(contract.agreed_school_price)]
           ]
         end
       end

--- a/spec/system/admin/commercial/pricing_spec.rb
+++ b/spec/system/admin/commercial/pricing_spec.rb
@@ -1,8 +1,6 @@
 require 'rails_helper'
 
-describe 'pricing calculator' do
-  include AdvicePageHelper
-
+describe 'pricing calculator', :include_application_helper do
   let!(:product) { create(:commercial_product, default_product: true) }
 
   before do

--- a/spec/system/schools/licences_spec.rb
+++ b/spec/system/schools/licences_spec.rb
@@ -2,9 +2,7 @@
 
 require 'rails_helper'
 
-describe 'school licences' do
-  include AdvicePageHelper
-
+describe 'school licences', :include_application_helper do
   let(:user) { create(:admin) }
   let!(:school) { create(:school, :with_school_group, number_of_pupils: 100) }
   let!(:product) { create(:commercial_product, :default_product) }
@@ -31,10 +29,10 @@ describe 'school licences' do
     end
     let(:expected_rows) do
       [
-        ['Base Price', format_unit(product.small_school_price, :£, true, :ks2, :text)],
-        ['Metering Fee', format_unit(0.0, :£, true, :ks2, :text)],
-        ['Private Account Fee', format_unit(0.0, :£, true, :ks2, :text)],
-        ['Total Price', format_unit(product.small_school_price, :£, true, :ks2, :text)]
+        ['Base Price', format_price(product.small_school_price)],
+        ['Metering Fee', format_price(0.0)],
+        ['Private Account Fee', format_price(0.0)],
+        ['Total Price', format_price(product.small_school_price)]
       ]
     end
   end
@@ -48,10 +46,10 @@ describe 'school licences' do
     end
     let(:expected_rows) do
       [
-        ['Base Price', format_unit(product.small_school_price, :£, true, :ks2, :text)],
-        ['Metering Fee', format_unit(0.0, :£, true, :ks2, :text)],
-        ['Private Account Fee', format_unit(0.0, :£, true, :ks2, :text)],
-        ['Total Price', format_unit(product.small_school_price, :£, true, :ks2, :text)]
+        ['Base Price', format_price(product.small_school_price)],
+        ['Metering Fee', format_price(0.0)],
+        ['Private Account Fee', format_price(0.0)],
+        ['Total Price', format_price(product.small_school_price)]
       ]
     end
   end


### PR DESCRIPTION
Replace use of the FormatUnit helper when displaying product and contract pricing. The existing helper rounds to significant figures which isn't correct for driving invoicing, etc.

Added a custom helper to do the formatting rather than using `number_to_currency` as that doesn't handle the formatting options I needed. Thought it was better to have a single helper rather than have the public pricing page use different rules.