### PR TITLE
Allow filtering of contract and licence list by date

### DIFF
--- a/app/controllers/admin/commercial/contracts_controller.rb
+++ b/app/controllers/admin/commercial/contracts_controller.rb
@@ -89,10 +89,15 @@ module Admin
 
       private
 
+      def filter_params
+        params.fetch(:filters, {})
+      end
+
       def load_contracts(scope)
         raise ArgumentError unless ALLOWED_SCOPES.include?(scope)
 
-        @contracts = ::Commercial::Contract.send(scope).by_start_date
+        @date = filter_params[:date]
+        @contracts = ::Commercial::Contract.filtered(scope, @date)
       end
 
       def renewal_request?

--- a/app/controllers/admin/commercial/licences_controller.rb
+++ b/app/controllers/admin/commercial/licences_controller.rb
@@ -1,22 +1,20 @@
 module Admin::Commercial
   class LicencesController < AdminController
+    ALLOWED_SCOPES = %w[current expired expiring recent].freeze
+
     load_and_authorize_resource :licence, class: 'Commercial::Licence'
 
     def index
-      @expiry_date = filter_params[:expiry_date]
-      @expired_date = filter_params[:expired_date]
-      @recently_added_date = filter_params[:recently_added_date]
-      @recently_updated_date = filter_params[:recently_updated_date]
-
-      @school_group_id = filter_params[:school_group_id]
-      @tab = filter_params[:tab]
-
-      @expiring_licences = Commercial::Licence.filtered(:expiring, @expiry_date, @school_group_id)
-      @recently_expired_licences = Commercial::Licence.filtered(:recently_expired, @expired_date, @school_group_id)
-      @recent_licences = Commercial::Licence.filtered(:recent, @recently_added_date, @school_group_id)
-      @recently_updated_licences = Commercial::Licence.filtered(:recently_updated, @recently_updated_date,
-                                                                @school_group_id)
+      @licences = Commercial::Licence.all.by_start_date
     end
+
+    def current = load_licences(action_name)
+
+    def expired = load_licences(action_name)
+
+    def expiring = load_licences(action_name)
+
+    def recent = load_licences(action_name)
 
     def unlicensed
       @academic_year = Calendar.default_national.current_academic_year
@@ -71,15 +69,15 @@ module Admin::Commercial
     private
 
     def filter_params
-      last_month = (Time.zone.today - 1.month).beginning_of_month
-      params.fetch(:filters, {}).with_defaults(
-        expiry_date: (Time.zone.today + 1.month).end_of_month,
-        expired_date: last_month,
-        recently_added_date: last_month,
-        recently_updated_date: last_month,
-        school_group_id: nil,
-        tab: 'expiring'
-      )
+      params.fetch(:filters, {})
+    end
+
+    def load_licences(scope)
+      raise ArgumentError unless ALLOWED_SCOPES.include?(scope)
+
+      @date = filter_params[:date]
+      @school_group_id = filter_params[:school_group_id]
+      @licences = ::Commercial::Licence.filtered(scope, @date, @school_group_id)
     end
 
     def licence_params

--- a/app/models/commercial/contract.rb
+++ b/app/models/commercial/contract.rb
@@ -106,6 +106,12 @@ module Commercial
       )
     end
 
+    def self.filtered(scope_name, date = nil)
+      date = Date.parse(date) if date.present? && date.is_a?(String)
+      scope = date.present? ? public_send(scope_name, date) : public_send(scope_name)
+      scope.includes(:contract_holder, :product).by_start_date
+    end
+
     def status_colour
       STATUS_COLOUR[status.to_sym]
     end

--- a/app/models/commercial/licence.rb
+++ b/app/models/commercial/licence.rb
@@ -62,11 +62,11 @@ module Commercial
 
     enum :status, LICENCE_STATUS
 
-    validates_presence_of :start_date, :end_date
+    validates :start_date, :end_date, presence: true
 
-    def self.filtered(scope_name, date = Time.zone.today, school_group_id = nil)
-      date = Date.parse(date) if date.is_a?(String)
-      scope = public_send(scope_name, date)
+    def self.filtered(scope_name, date = nil, school_group_id = nil)
+      date = Date.parse(date) if date.present? && date.is_a?(String)
+      scope = date.present? ? public_send(scope_name, date) : public_send(scope_name)
 
       if school_group_id.present?
         scope = scope.joins(school: :school_groupings)

--- a/app/models/concerns/temporal_range.rb
+++ b/app/models/concerns/temporal_range.rb
@@ -13,7 +13,7 @@ module TemporalRange
     }
 
     scope :expiring, lambda { |end_date = (Time.zone.today + 1.month).end_of_month|
-      where("#{table_name}.end_date <= ?", end_date)
+      where("#{table_name}.end_date >= CURRENT_DATE and #{table_name}.end_date <= ?", end_date)
     }
 
     scope :expired, lambda { |today = Time.zone.today|
@@ -24,8 +24,8 @@ module TemporalRange
       where("#{table_name}.end_date >= ? and #{table_name}.end_date < ?", end_date, Time.zone.today)
     }
 
-    scope :recent, lambda { |updated_at = (Time.zone.today - 1.month).beginning_of_month|
-      where("#{table_name}.created_at >= ?", updated_at)
+    scope :recent, lambda { |created_at = (Time.zone.today - 1.month).beginning_of_month|
+      where("#{table_name}.created_at >= ?", created_at)
     }
 
     scope :recently_updated, lambda { |updated_at = (Time.zone.today - 1.month).beginning_of_month|

--- a/app/views/admin/commercial/contracts/_contract_list.html.erb
+++ b/app/views/admin/commercial/contracts/_contract_list.html.erb
@@ -11,6 +11,22 @@
   </div>
 </div>
 
+<% if local_assigns[:date_label] %>
+  <div class="row mb-4">
+    <div class="col">
+      <%= simple_form_for :filters, url: path, method: 'GET', html: { class: 'form-inline' } do |f| %>
+        <%= f.input :date,
+                    as: :tempus_dominus_date,
+                    default_date: @date,
+                    label: date_label,
+                    label_html: { class: 'd-block mr-2' },
+                    required: false %>
+        <%= f.submit 'Filter', class: 'btn btn-primary btn-sm ml-auto' %>
+      <% end %>
+    </div>
+  </div>
+<% end %>
+
 <div class="row">
   <div class="col">
     <%= render Commercial::ContractsComponent.new(contracts: contracts) %>

--- a/app/views/admin/commercial/contracts/_contract_list.html.erb
+++ b/app/views/admin/commercial/contracts/_contract_list.html.erb
@@ -21,7 +21,7 @@
                     label: date_label,
                     label_html: { class: 'd-block mr-2' },
                     required: false %>
-        <%= f.submit 'Filter', class: 'btn btn-primary btn-sm ml-auto' %>
+        <%= f.submit 'Filter', class: 'btn btn-primary btn-sm ms-auto' %>
       <% end %>
     </div>
   </div>

--- a/app/views/admin/commercial/contracts/current.html.erb
+++ b/app/views/admin/commercial/contracts/current.html.erb
@@ -1,4 +1,4 @@
 <%= render 'contract_list',
            title: 'Current Contracts',
            contracts: @contracts,
-           description: 'This page lists all current contracts' %>
+           description: 'This page lists all currently valid contracts' %>

--- a/app/views/admin/commercial/contracts/expired.html.erb
+++ b/app/views/admin/commercial/contracts/expired.html.erb
@@ -1,4 +1,6 @@
 <%= render 'contract_list',
            title: 'Expired Contracts',
            contracts: @contracts,
+           date_label: 'Show contracts that expired before this date',
+           path: expired_admin_commercial_contracts_path,
            description: 'This page lists all expired contracts' %>

--- a/app/views/admin/commercial/contracts/expiring.html.erb
+++ b/app/views/admin/commercial/contracts/expiring.html.erb
@@ -1,4 +1,6 @@
 <%= render 'contract_list',
            title: 'Expiring Contracts',
            contracts: @contracts,
-           description: 'This page lists all contracts that are expiring in the next month.' %>
+           date_label: 'Show contracts that will be expired by this date',
+           path: expiring_admin_commercial_contracts_path,
+           description: 'This page lists all contracts that will shortly be expiring.' %>

--- a/app/views/admin/commercial/contracts/future.html.erb
+++ b/app/views/admin/commercial/contracts/future.html.erb
@@ -1,4 +1,6 @@
 <%= render 'contract_list',
            title: 'Future Contracts',
            contracts: @contracts,
+           date_label: 'Show contracts starting after this date',
+           path: future_admin_commercial_contracts_path,
            description: 'This page lists all contracts set to start on a future date.' %>

--- a/app/views/admin/commercial/contracts/recent.html.erb
+++ b/app/views/admin/commercial/contracts/recent.html.erb
@@ -1,4 +1,6 @@
 <%= render 'contract_list',
            title: 'Recently Added Contracts',
            contracts: @contracts,
-           description: 'This page lists all contracts added in the last 30 days.' %>
+           date_label: 'Show contracts that were added since this date',
+           path: recent_admin_commercial_contracts_path,
+           description: 'This page lists recently added contracts (30 days by default).' %>

--- a/app/views/admin/commercial/licences/_filters.html.erb
+++ b/app/views/admin/commercial/licences/_filters.html.erb
@@ -7,7 +7,6 @@
             include_blank: 'All school groups',
             label_html: { class: 'd-block mr-2' },
             required: false %>
-
   <%= f.input :date,
               as: :tempus_dominus_date,
               default_date: date,

--- a/app/views/admin/commercial/licences/_filters.html.erb
+++ b/app/views/admin/commercial/licences/_filters.html.erb
@@ -1,5 +1,4 @@
-<%= simple_form_for :filters, url: admin_commercial_licences_path, method: 'GET', html: { class: 'form-inline' } do |f| %>
-<%= f.input :tab, as: :hidden, input_html: { value: tab } %>
+<%= simple_form_for :filters, url: path, method: 'GET', html: { class: 'form-inline' } do |f| %>
 <%= f.input :school_group_id,
             collection: SchoolGroup.organisation_groups.with_active_schools.by_name,
             value_method: :id,
@@ -9,7 +8,7 @@
             label_html: { class: 'd-block mr-2' },
             required: false %>
 
-  <%= f.input field_name,
+  <%= f.input :date,
               as: :tempus_dominus_date,
               default_date: date,
               label: date_label,
@@ -17,4 +16,3 @@
               required: false %>
   <%= f.submit 'Filter', class: 'btn btn-primary btn-sm ml-auto' %>
 <% end %>
-<hr>

--- a/app/views/admin/commercial/licences/_filters.html.erb
+++ b/app/views/admin/commercial/licences/_filters.html.erb
@@ -13,5 +13,5 @@
               label: date_label,
               label_html: { class: 'd-block ml-2 mr-2' },
               required: false %>
-  <%= f.submit 'Filter', class: 'btn btn-primary btn-sm ml-auto' %>
+  <%= f.submit 'Filter', class: 'btn btn-primary btn-sm ms-auto' %>
 <% end %>

--- a/app/views/admin/commercial/licences/_licence_list.html.erb
+++ b/app/views/admin/commercial/licences/_licence_list.html.erb
@@ -1,0 +1,26 @@
+<%= render Admin::HeaderNavComponent.new do |header_nav| %>
+  <% header_nav.with_header title: title %>
+  <% header_nav.with_button 'Contracts & Licensing', admin_commercial_path %>
+<% end %>
+
+<div class="row">
+  <div class="col">
+    <p>
+        <%= description %>
+    </p>
+  </div>
+</div>
+
+<% if local_assigns[:date_label] %>
+  <div class="row mb-4">
+    <div class="col">
+        <%= render 'filters', path:, date_label:, date:, school_group_id: %>
+    </div>
+  </div>
+<% end %>
+
+<div class="row">
+  <div class="col">
+    <%= render Commercial::LicencesComponent.new(licences: licences) %>
+  </div>
+</div>

--- a/app/views/admin/commercial/licences/current.html.erb
+++ b/app/views/admin/commercial/licences/current.html.erb
@@ -1,0 +1,4 @@
+<%= render 'licence_list',
+           title: 'Current Licences',
+           description: 'This page shows all currently valid licences in the system',
+           licences: @licences %>

--- a/app/views/admin/commercial/licences/expired.html.erb
+++ b/app/views/admin/commercial/licences/expired.html.erb
@@ -2,7 +2,7 @@
            title: 'Expired Licences',
            description: 'This page lists all expired licences.',
            licences: @licences,
-           date_label: 'Show licences that expired before this date',
+           date_label: 'Show licences expired before this date',
            path: expired_admin_commercial_licences_path,
            date: @date,
            school_group_id: @school_group_id %>

--- a/app/views/admin/commercial/licences/expired.html.erb
+++ b/app/views/admin/commercial/licences/expired.html.erb
@@ -1,0 +1,8 @@
+<%= render 'licence_list',
+           title: 'Expired Licences',
+           description: 'This page lists all expired licences.',
+           licences: @licences,
+           date_label: 'Show licences that expired before this date',
+           path: expired_admin_commercial_licences_path,
+           date: @date,
+           school_group_id: @school_group_id %>

--- a/app/views/admin/commercial/licences/expiring.html.erb
+++ b/app/views/admin/commercial/licences/expiring.html.erb
@@ -1,0 +1,8 @@
+<%= render 'licence_list',
+           title: 'Expiring Licences',
+           description: 'This page lists all licences that will shortly be expiring.',
+           licences: @licences,
+           date_label: 'Show licences that will be expired by this date',
+           path: expiring_admin_commercial_licences_path,
+           date: @date,
+           school_group_id: @school_group_id %>

--- a/app/views/admin/commercial/licences/expiring.html.erb
+++ b/app/views/admin/commercial/licences/expiring.html.erb
@@ -2,7 +2,7 @@
            title: 'Expiring Licences',
            description: 'This page lists all licences that will shortly be expiring.',
            licences: @licences,
-           date_label: 'Show licences that will be expired by this date',
+           date_label: 'Show licences that will expire by this date',
            path: expiring_admin_commercial_licences_path,
            date: @date,
            school_group_id: @school_group_id %>

--- a/app/views/admin/commercial/licences/index.html.erb
+++ b/app/views/admin/commercial/licences/index.html.erb
@@ -1,46 +1,6 @@
-<%= render Admin::HeaderNavComponent.new do |header_nav| %>
-  <% header_nav.with_header title: 'Licence overview' %>
-<% end %>
-
-<div class="row">
-  <div class="col-12">
-    <%= render TabsComponent.new do |component| %>
-      <% component.with_tab(name: 'expiring', label: 'Expiring', active: @tab == 'expiring') do %>
-        <%= render 'filters', tab: 'expiring',
-                              school_group_id: @school_group_id,
-                              date_label: 'Show licences expiring by',
-                              field_name: :expiry_date,
-                              date: @expiry_date %>
-
-        <%= render Commercial::LicencesComponent.new(licences: @expiring_licences, show_renewal_data: true) %>
-      <% end %>
-      <% component.with_tab(name: 'recently-expired', label: 'Recently Expired', active: @tab == 'recently-expired') do %>
-        <%= render 'filters', tab: 'recently-expired',
-                              school_group_id: @school_group_id,
-                              date_label: 'Show licences that have expired since',
-                              field_name: :expired_date,
-                              date: @expired_date %>
-
-        <%= render Commercial::LicencesComponent.new(licences: @recently_expired_licences) %>
-      <% end %>
-      <% component.with_tab(name: 'recent', label: 'Recently Added', active: @tab == 'recent') do %>
-        <%= render 'filters', tab: 'recent',
-                              school_group_id: @school_group_id,
-                              date_label: 'Show licences created since',
-                              field_name: :recently_added_date,
-                              date: @recently_added_date %>
-
-        <%= render Commercial::LicencesComponent.new(licences: @recent_licences) %>
-      <% end %>
-      <% component.with_tab(name: 'recently-updated', label: 'Recently Updated', active: @tab == 'recently-updated') do %>
-        <%= render 'filters', tab: 'recently-updated',
-                              school_group_id: @school_group_id,
-                              date_label: 'Show licences updated since',
-                              field_name: :recently_updated_date,
-                              date: @recently_updated_date %>
-
-        <%= render Commercial::LicencesComponent.new(licences: @recently_updated_licences) %>
-      <% end %>
-    <% end %>
-  </div>
-</div>
+<%= render 'licence_list',
+           title: 'All Licences',
+           description: 'This page shows all licences in the system',
+           licences: @licences,
+           date: @date,
+           school_group_id: @school_group_id %>

--- a/app/views/admin/commercial/licences/recent.html.erb
+++ b/app/views/admin/commercial/licences/recent.html.erb
@@ -1,0 +1,8 @@
+<%= render 'licence_list',
+           title: 'Recently Added Licences',
+           description: 'This page lists recently added licences (30 days by default).',
+           licences: @licences,
+           date_label: 'Show licences that were added since this date',
+           path: recent_admin_commercial_licences_path,
+           date: @date,
+           school_group_id: @school_group_id %>

--- a/app/views/admin/commercial/licences/recent.html.erb
+++ b/app/views/admin/commercial/licences/recent.html.erb
@@ -2,7 +2,7 @@
            title: 'Recently Added Licences',
            description: 'This page lists recently added licences (30 days by default).',
            licences: @licences,
-           date_label: 'Show licences that were added since this date',
+           date_label: 'Show licences added since this date',
            path: recent_admin_commercial_licences_path,
            date: @date,
            school_group_id: @school_group_id %>

--- a/app/views/admin/commercial/show.html.erb
+++ b/app/views/admin/commercial/show.html.erb
@@ -37,19 +37,11 @@
             <ul>
                 <li>Licences
                     <ul>
-                        <li>
-                          <%= link_to 'Expiring Licences', admin_commercial_licences_path(anchor: 'expiring') %>
-                        </li>
-                        <li>
-                          <%= link_to 'Expired Licences', admin_commercial_licences_path(anchor: 'recently-expired') %>
-                        </li>
-                        <li>
-                          <%= link_to 'Recently Added Licences', admin_commercial_licences_path(anchor: 'recent') %>
-                        </li>
-                        <li>
-                            <%= link_to 'Recently updated Licences',
-                                        admin_commercial_licences_path(anchor: 'recently-updated') %>
-                        </li>
+                        <li><%= link_to 'Current Licences', current_admin_commercial_licences_path %></li>
+                        <li><%= link_to 'Expiring Licences', expiring_admin_commercial_licences_path %></li>
+                        <li><%= link_to 'Expired Licences', expired_admin_commercial_licences_path %></li>
+                        <li><%= link_to 'Recently Added Licences', recent_admin_commercial_licences_path %></li>
+                        <li><%= link_to 'All Licences', admin_commercial_licences_path %></li>
                     </ul>
                 </li>
                 <li>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -655,6 +655,10 @@ Rails.application.routes.draw do
       end
       resources :licences do
         collection do
+          get :current
+          get :expired
+          get :expiring
+          get :recent
           get :unlicensed
         end
       end

--- a/spec/system/admin/commercial/manage_contracts_spec.rb
+++ b/spec/system/admin/commercial/manage_contracts_spec.rb
@@ -2,6 +2,25 @@
 
 require 'rails_helper'
 
+shared_examples 'a filtered contract list' do
+  let(:filter_date) { nil }
+
+  it { expect(page).to have_field(:date) }
+
+  context 'when applying a filter', :js do
+    before do
+      set_date('#filters_date', filter_date)
+      click_on 'Filter'
+    end
+
+    it 'filters the view' do
+      within('#contracts-table') do
+        expect(page).to have_no_text(filtered_contract.name)
+      end
+    end
+  end
+end
+
 describe 'manage contracts' do
   let(:user) { create(:admin) }
 
@@ -44,7 +63,7 @@ describe 'manage contracts' do
       end
 
       it 'creates the model' do
-        expect(page).to have_content('Contract has been created')
+        expect(page).to have_text('Contract has been created')
         expect(Commercial::Contract.last).to have_attributes(
           name: 'Custom contract',
           comments: 'Some notes',
@@ -62,7 +81,7 @@ describe 'manage contracts' do
       end
 
       it 'does not create any licences' do
-        expect(page).to have_content('Contract has been created')
+        expect(page).to have_text('Contract has been created')
         expect(Commercial::Contract.last.licences).to be_empty
       end
     end
@@ -72,7 +91,7 @@ describe 'manage contracts' do
 
       it 'displays errors' do
         click_on 'Save'
-        expect(page).to have_content("Name can't be blank")
+        expect(page).to have_text("Name can't be blank")
       end
     end
   end
@@ -87,7 +106,7 @@ describe 'manage contracts' do
     end
 
     it 'initialises the form correctly' do
-      expect(page).to have_content("Create a new contract for #{contract_holder.name}")
+      expect(page).to have_text("Create a new contract for #{contract_holder.name}")
     end
 
     it { expect(page).to have_no_field('Contract holder') }
@@ -112,7 +131,7 @@ describe 'manage contracts' do
       end
 
       it 'creates the model' do
-        expect(page).to have_content('Contract has been created')
+        expect(page).to have_text('Contract has been created')
         expect(Commercial::Contract.last).to have_attributes(
           name: 'Custom contract',
           comments: 'Some notes',
@@ -130,7 +149,7 @@ describe 'manage contracts' do
       end
 
       it 'does not create any licences' do
-        expect(page).to have_content('Contract has been created')
+        expect(page).to have_text('Contract has been created')
         expect(Commercial::Contract.last.licences).to be_empty
       end
     end
@@ -147,10 +166,10 @@ describe 'manage contracts' do
     context 'when the contract is editable' do
       before { click_on 'Edit' }
 
-      it { expect(page).to have_content(contract.name) }
+      it { expect(page).to have_text(contract.name) }
 
       it {
-        expect(page).to have_content(
+        expect(page).to have_text(
           'Any changes made to the start and end dates for this contract will be automatically applied to all licences'
         )
       }
@@ -175,7 +194,7 @@ describe 'manage contracts' do
         end
 
         it 'updates the model' do
-          expect(page).to have_content('Contract has been updated')
+          expect(page).to have_text('Contract has been updated')
           expect(contract.reload).to have_attributes(
             name: 'Custom contract',
             comments: 'Some notes',
@@ -210,7 +229,7 @@ describe 'manage contracts' do
         end
 
         it 'updates the model' do
-          expect(page).to have_content('Contract and licences have been updated')
+          expect(page).to have_text('Contract and licences have been updated')
           expect(licence.reload).to have_attributes(
             start_date: Date.new(2026, 1, 1),
             end_date: Date.new(2026, 12, 31),
@@ -227,10 +246,10 @@ describe 'manage contracts' do
         click_on 'Edit'
       end
 
-      it { expect(page).to have_content(contract.name) }
+      it { expect(page).to have_text(contract.name) }
 
       it {
-        expect(page).to have_content('One or more licences associated with this contract have already been invoiced')
+        expect(page).to have_text('One or more licences associated with this contract have already been invoiced')
       }
 
       it { expect(page).to have_no_field('Contract holder') }
@@ -311,7 +330,7 @@ describe 'manage contracts' do
         end
 
         it 'creates the contract' do
-          expect(page).to have_content('Contract and provisional licences have been created')
+          expect(page).to have_text('Contract and provisional licences have been created')
           expect(renewed_contract).to have_attributes(
             name: 'Renewed contract',
             comments: "Renewed from #{contract.name}",
@@ -328,7 +347,7 @@ describe 'manage contracts' do
         end
 
         it 'creates the licences' do
-          expect(page).to have_content('Contract and provisional licences have been created')
+          expect(page).to have_text('Contract and provisional licences have been created')
           expect(renewed_contract.licences.count).to eq(1)
           expect(renewed_contract.licences.first.school).to eq(original_licence.school)
           expect(renewed_contract.licences.first.school_specific_price).to eq(original_licence.school_specific_price)
@@ -345,7 +364,7 @@ describe 'manage contracts' do
         end
 
         it 'does not create the licences' do
-          expect(page).to have_content('Contract has been created')
+          expect(page).to have_text('Contract has been created')
           expect(renewed_contract.licences.count).to eq(0)
         end
       end
@@ -365,8 +384,8 @@ describe 'manage contracts' do
 
     it { expect(page).to have_css('#metadata') }
 
-    it { expect(page).to have_content(contract.name) }
-    it { expect(page).to have_content(contract.comments) }
+    it { expect(page).to have_text(contract.name) }
+    it { expect(page).to have_text(contract.comments) }
 
     context 'when viewing terms' do
       it {
@@ -374,17 +393,17 @@ describe 'manage contracts' do
                                   href: polymorphic_path([:admin, contract.contract_holder, :contracts]))
       }
 
-      it { expect(page).to have_content(contract.contract_holder_type) }
-      it { expect(page).to have_content(contract.product.name) }
-      it { expect(page).to have_content(contract.start_date.to_fs(:es_short)) }
-      it { expect(page).to have_content(contract.end_date.to_fs(:es_short)) }
-      it { expect(page).to have_content(contract.status.humanize) }
-      it { expect(page).to have_content(contract.invoice_terms.humanize) }
-      it { expect(page).to have_content(contract.licence_period.humanize) }
-      it { expect(page).to have_content(contract.licence_years) }
-      it { expect(page).to have_content(contract.number_of_schools) }
-      it { expect(page).to have_content(FormatUnit.format(:£, contract.agreed_school_price)) }
-      it { expect(page).to have_content(contract.comments) }
+      it { expect(page).to have_text(contract.contract_holder_type) }
+      it { expect(page).to have_text(contract.product.name) }
+      it { expect(page).to have_text(contract.start_date.to_fs(:es_short)) }
+      it { expect(page).to have_text(contract.end_date.to_fs(:es_short)) }
+      it { expect(page).to have_text(contract.status.humanize) }
+      it { expect(page).to have_text(contract.invoice_terms.humanize) }
+      it { expect(page).to have_text(contract.licence_period.humanize) }
+      it { expect(page).to have_text(contract.licence_years) }
+      it { expect(page).to have_text(contract.number_of_schools) }
+      it { expect(page).to have_text(FormatUnit.format(:£, contract.agreed_school_price)) }
+      it { expect(page).to have_text(contract.comments) }
     end
 
     context 'when viewing licence summary' do
@@ -479,7 +498,7 @@ describe 'manage contracts' do
     context 'when navigating to contract holder page' do
       before { click_on 'All contracts' }
 
-      it { expect(page).to have_content("#{contract.contract_holder.name} Contracts") }
+      it { expect(page).to have_text("#{contract.contract_holder.name} Contracts") }
 
       it_behaves_like 'it contains the expected data table', sortable: false, aligned: false do
         let(:table_id) { '#contracts-table' }
@@ -512,9 +531,11 @@ describe 'manage contracts' do
 
       before { click_on 'Current Contracts' }
 
+      it { expect(page).to have_no_field(:date) }
+
       it 'shows the contract' do
         within('#contracts-table') do
-          expect(page).to have_content(contract.name)
+          expect(page).to have_text(contract.name)
         end
       end
     end
@@ -526,20 +547,30 @@ describe 'manage contracts' do
 
       it 'shows the contract' do
         within('#contracts-table') do
-          expect(page).to have_content(contract.name)
+          expect(page).to have_text(contract.name)
         end
+      end
+
+      it_behaves_like 'a filtered contract list' do
+        let(:filter_date) { (contract.end_date - 1).strftime('%d/%m/%Y') }
+        let(:filtered_contract) { contract }
       end
     end
 
     context 'with expiring' do
-      let!(:contract) { create(:commercial_contract, end_date: Time.zone.today + 1) }
+      let!(:contract) { create(:commercial_contract, end_date: Time.zone.tomorrow) }
 
       before { click_on 'Expiring Contracts' }
 
       it 'shows the contract' do
         within('#contracts-table') do
-          expect(page).to have_content(contract.name)
+          expect(page).to have_text(contract.name)
         end
+      end
+
+      it_behaves_like 'a filtered contract list' do
+        let(:filter_date) { Time.zone.yesterday.strftime('%d/%m/%Y') }
+        let(:filtered_contract) { contract }
       end
     end
 
@@ -550,8 +581,13 @@ describe 'manage contracts' do
 
       it 'shows the contract' do
         within('#contracts-table') do
-          expect(page).to have_content(contract.name)
+          expect(page).to have_text(contract.name)
         end
+      end
+
+      it_behaves_like 'a filtered contract list' do
+        let(:filter_date) { Time.zone.tomorrow.strftime('%d/%m/%Y') }
+        let(:filtered_contract) { contract }
       end
     end
 
@@ -560,9 +596,11 @@ describe 'manage contracts' do
 
       before { click_on 'Provisional Contracts' }
 
+      it { expect(page).to have_no_field(:date) }
+
       it 'shows the contract' do
         within('#contracts-table') do
-          expect(page).to have_content(contract.name)
+          expect(page).to have_text(contract.name)
         end
       end
     end
@@ -574,8 +612,13 @@ describe 'manage contracts' do
 
       it 'shows the contract' do
         within('#contracts-table') do
-          expect(page).to have_content(contract.name)
+          expect(page).to have_text(contract.name)
         end
+      end
+
+      it_behaves_like 'a filtered contract list' do
+        let(:filter_date) { (contract.start_date + 1).strftime('%d/%m/%Y') }
+        let(:filtered_contract) { contract }
       end
     end
   end

--- a/spec/system/admin/commercial/manage_licences_spec.rb
+++ b/spec/system/admin/commercial/manage_licences_spec.rb
@@ -17,7 +17,7 @@ describe 'manage licences' do
       visit new_admin_commercial_licence_path
     end
 
-    it { expect(page).to have_content('Leave date fields empty to automatically create a licence starting from today') }
+    it { expect(page).to have_text('Leave date fields empty to automatically create a licence starting from today') }
 
     context 'with valid data', :js do
       before do
@@ -33,7 +33,7 @@ describe 'manage licences' do
       end
 
       it 'creates the licence' do
-        expect(page).to have_content('Licence has been created')
+        expect(page).to have_text('Licence has been created')
         expect(Commercial::Licence.last).to have_attributes(
           contract:,
           school:,
@@ -56,7 +56,7 @@ describe 'manage licences' do
       end
 
       it 'creates the licence' do
-        expect(page).to have_content('Licence has been created')
+        expect(page).to have_text('Licence has been created')
         expect(Commercial::Licence.last).to have_attributes(
           contract:,
           school:,
@@ -77,8 +77,8 @@ describe 'manage licences' do
       click_on('Add New Licence')
     end
 
-    it { expect(page).to have_content('Leave date fields empty to automatically create a licence starting from today') }
-    it { expect(page).to have_content("Create a new licence under the #{contract.name} contract.") }
+    it { expect(page).to have_text('Leave date fields empty to automatically create a licence starting from today') }
+    it { expect(page).to have_text("Create a new licence under the #{contract.name} contract.") }
 
     context 'with valid data', :js do
       before do
@@ -93,7 +93,7 @@ describe 'manage licences' do
       end
 
       it 'creates the model' do
-        expect(page).to have_content('Licence has been created')
+        expect(page).to have_text('Licence has been created')
         expect(Commercial::Licence.last).to have_attributes(
           contract:,
           school:,
@@ -115,7 +115,7 @@ describe 'manage licences' do
       end
 
       it 'creates the licence' do
-        expect(page).to have_content('Licence has been created')
+        expect(page).to have_text('Licence has been created')
         expect(Commercial::Licence.last).to have_attributes(
           contract:,
           school:,
@@ -138,10 +138,10 @@ describe 'manage licences' do
       end
     end
 
-    it { expect(page).to have_content(licence.contract.name) }
+    it { expect(page).to have_text(licence.contract.name) }
 
     it {
-      expect(page).to have_content("Update the licence for #{licence.school.name} under the #{licence.contract.name} contract.")
+      expect(page).to have_text("Update the licence for #{licence.school.name} under the #{licence.contract.name} contract.")
     }
 
     context 'when dates may change' do
@@ -150,7 +150,7 @@ describe 'manage licences' do
       let!(:licence) { create(:commercial_licence, contract:, school:) }
 
       it 'includes a warning' do
-        expect(page).to have_content('Changes made here will be overwritten')
+        expect(page).to have_text('Changes made here will be overwritten')
       end
     end
 
@@ -166,7 +166,7 @@ describe 'manage licences' do
       end
 
       it 'updates the model' do
-        expect(page).to have_content('Licence has been updated')
+        expect(page).to have_text('Licence has been updated')
         expect(licence.reload).to have_attributes(
           contract: licence.contract,
           start_date: Date.new(2026, 1, 1),
@@ -202,85 +202,77 @@ describe 'manage licences' do
 
     it { expect(page).to have_css('#metadata') }
 
-    it { expect(page).to have_content(licence.status.to_s.humanize) }
-    it { expect(page).to have_content(licence.school.name) }
-    it { expect(page).to have_content(licence.contract.name) }
-    it { expect(page).to have_content(licence.contract.product.name) }
-    it { expect(page).to have_content(licence.start_date.to_fs(:es_short)) }
-    it { expect(page).to have_content(licence.end_date.to_fs(:es_short)) }
-    it { expect(page).to have_content(licence.comments) }
+    it { expect(page).to have_text(licence.status.to_s.humanize) }
+    it { expect(page).to have_text(licence.school.name) }
+    it { expect(page).to have_text(licence.contract.name) }
+    it { expect(page).to have_text(licence.contract.product.name) }
+    it { expect(page).to have_text(licence.start_date.to_fs(:es_short)) }
+    it { expect(page).to have_text(licence.end_date.to_fs(:es_short)) }
+    it { expect(page).to have_text(licence.comments) }
   end
 
-  context 'when viewing licence index' do
+  context 'when viewing licence lists' do
     let!(:school_group) { create(:school_group) }
     let!(:school) { create(:school, :with_school_grouping, group: school_group) }
 
-    let!(:expiring_in_a_week) { create(:commercial_licence, end_date: Time.zone.today + 7, school: school) }
-    let!(:expiring_in_a_month) do
-      create(:commercial_licence, created_at: Time.zone.yesterday, updated_at: Time.zone.today,
-                                  end_date: Time.zone.today + 30)
-    end
-    let!(:expired) { create(:commercial_licence, :expired) }
+    context 'with current' do
+      let!(:licence) { create(:commercial_licence, school:) }
 
-    before { visit admin_commercial_licences_path }
+      before { click_on 'Current Licences' }
 
-    it { expect(page).to have_content('Expiring') }
+      it { expect(page).to have_no_field(:date) }
 
-    it 'shows expiring licences' do
-      within('#expiring') do
-        expect(page).to have_link(href: admin_commercial_licence_path(expiring_in_a_week.id))
-        expect(page).to have_link(href: admin_commercial_licence_path(expiring_in_a_month.id))
-      end
-    end
-
-    it 'shows recent licences' do
-      within('#recent') do
-        expect(page).to have_link(href: admin_commercial_licence_path(expiring_in_a_week.id))
-        expect(page).to have_link(href: admin_commercial_licence_path(expiring_in_a_month.id))
-      end
-    end
-
-    it 'shows expired licences' do
-      within('#recently-expired') do
-        expect(page).to have_link(href: admin_commercial_licence_path(expired.id))
-      end
-    end
-
-    it 'shows recently updated licences' do
-      within('#recently-updated') do
-        expect(page).to have_link(href: admin_commercial_licence_path(expiring_in_a_month.id))
-      end
-    end
-
-    context 'when filtering by school group' do
-      before do
-        within('#expiring') do
-          select(school_group.name, from: 'School group')
-          fill_in(:filters_expiry_date, with: (Time.zone.today + 30.days).iso8601)
-          click_on('Filter')
-        end
-      end
-
-      it 'shows the filtered expiring licences' do
-        within('#expiring') do
-          expect(page).to have_link(href: admin_commercial_licence_path(expiring_in_a_week.id))
-          expect(page).to have_no_link(href: admin_commercial_licence_path(expiring_in_a_month.id))
+      it 'shows the licence' do
+        within('#licences-table') do
+          expect(page).to have_link(href: admin_commercial_licence_path(licence.id))
         end
       end
     end
 
-    context 'when filtering by just date' do
-      before do
-        within('#expiring') do
-          fill_in(:filters_expiry_date, with: (Time.zone.today + 10.days).iso8601)
-          click_on('Filter')
+    context 'with expired' do
+      let!(:licence) { create(:commercial_licence, :expired, school:) }
+
+      before { click_on 'Expired Licences' }
+
+      it 'shows the licence' do
+        within('#licences-table') do
+          expect(page).to have_link(href: admin_commercial_licence_path(licence.id))
         end
       end
+    end
 
-      it 'shows the filtered expiring licences' do
-        within('#expiring') do
-          expect(page).to have_link(href: admin_commercial_licence_path(expiring_in_a_week.id))
-          expect(page).to have_no_link(href: admin_commercial_licence_path(expiring_in_a_month.id))
+    context 'with expiring' do
+      let!(:licence) { create(:commercial_licence, end_date: Time.zone.today + 7, school:) }
+
+      before { click_on 'Expiring Licences' }
+
+      it 'shows the licence' do
+        within('#licences-table') do
+          expect(page).to have_link(href: admin_commercial_licence_path(licence.id))
+        end
+      end
+    end
+
+    context 'with recent' do
+      let!(:licence) { create(:commercial_licence, school:) }
+
+      before { click_on 'Recently Added Licences' }
+
+      it 'shows the licence' do
+        within('#licences-table') do
+          expect(page).to have_link(href: admin_commercial_licence_path(licence.id))
+        end
+      end
+    end
+
+    context 'with all' do
+      let!(:licence) { create(:commercial_licence, school:) }
+
+      before { click_on 'All Licences' }
+
+      it 'shows the licence' do
+        within('#licences-table') do
+          expect(page).to have_link(href: admin_commercial_licence_path(licence.id))
         end
       end
     end

--- a/spec/system/admin/commercial/manage_licences_spec.rb
+++ b/spec/system/admin/commercial/manage_licences_spec.rb
@@ -1,5 +1,41 @@
 require 'rails_helper'
 
+shared_examples 'a licence list filtered by date' do
+  let(:filter_date) { nil }
+
+  it { expect(page).to have_field(:date) }
+
+  context 'when applying the filter', :js do
+    before do
+      set_date('#filters_date', filter_date)
+      click_on 'Filter'
+    end
+
+    it 'filters the view' do
+      within('#licences-table') do
+        expect(page).to have_no_link(href: admin_commercial_licence_path(filtered_licence.id))
+      end
+    end
+  end
+end
+
+shared_examples 'a licence list filtered by school group' do
+  it { expect(page).to have_field('School group') }
+
+  context 'when applying the filter' do
+    before do
+      select(filter_group.name, from: 'School group')
+      click_on 'Filter'
+    end
+
+    it 'filters the view' do
+      within('#licences-table') do
+        expect(page).to have_no_link(href: admin_commercial_licence_path(filtered_licence.id))
+      end
+    end
+  end
+end
+
 describe 'manage licences' do
   let(:user) { create(:admin) }
   let!(:school) { create(:school, :with_school_group) }
@@ -213,6 +249,8 @@ describe 'manage licences' do
 
   context 'when viewing licence lists' do
     let!(:school_group) { create(:school_group) }
+    let!(:filter_group) { create(:school_group, :with_active_schools) }
+
     let!(:school) { create(:school, :with_school_grouping, group: school_group) }
 
     context 'with current' do
@@ -221,6 +259,7 @@ describe 'manage licences' do
       before { click_on 'Current Licences' }
 
       it { expect(page).to have_no_field(:date) }
+      it { expect(page).to have_no_field(:school_group_id) }
 
       it 'shows the licence' do
         within('#licences-table') do
@@ -239,6 +278,15 @@ describe 'manage licences' do
           expect(page).to have_link(href: admin_commercial_licence_path(licence.id))
         end
       end
+
+      it_behaves_like 'a licence list filtered by date' do
+        let(:filter_date) { (licence.end_date - 1).strftime('%d/%m/%Y') }
+        let(:filtered_licence) { licence }
+      end
+
+      it_behaves_like 'a licence list filtered by school group' do
+        let(:filtered_licence) { licence }
+      end
     end
 
     context 'with expiring' do
@@ -250,6 +298,15 @@ describe 'manage licences' do
         within('#licences-table') do
           expect(page).to have_link(href: admin_commercial_licence_path(licence.id))
         end
+      end
+
+      it_behaves_like 'a licence list filtered by date' do
+        let(:filter_date) { Time.zone.yesterday.strftime('%d/%m/%Y') }
+        let(:filtered_licence) { licence }
+      end
+
+      it_behaves_like 'a licence list filtered by school group' do
+        let(:filtered_licence) { licence }
       end
     end
 
@@ -263,12 +320,23 @@ describe 'manage licences' do
           expect(page).to have_link(href: admin_commercial_licence_path(licence.id))
         end
       end
+
+      it_behaves_like 'a licence list filtered by date' do
+        let(:filter_date) { Time.zone.tomorrow.strftime('%d/%m/%Y') }
+        let(:filtered_licence) { licence }
+      end
+
+      it_behaves_like 'a licence list filtered by school group' do
+        let(:filtered_licence) { licence }
+      end
     end
 
     context 'with all' do
       let!(:licence) { create(:commercial_licence, school:) }
 
       before { click_on 'All Licences' }
+
+      it { expect(page).to have_no_field(:date) }
 
       it 'shows the licence' do
         within('#licences-table') do


### PR DESCRIPTION
Updated the lists of Contracts linked from /admin/commercial to include date filters for lists where this would be useful (e.g. expired, expiring)

Revise the list of Licences linked from same page to use the same style of presentation as the Contracts (controller actions, rather than tabbed view). 

This will make it easier to add more lists later, optimise the individual pages and add additional filters if needed.
