### PR TITLE
Fix bug in admin meter report csv

### DIFF
--- a/app/views/admin/reports/base_meter_reports/_report_filters.html.erb
+++ b/app/views/admin/reports/base_meter_reports/_report_filters.html.erb
@@ -24,12 +24,12 @@
       <div class="d-flex justify-content-between">
         <%= submit_tag 'Filter', class: 'btn btn-sm' %>
         <% unless defined? no_csv %>
-          <%= link_to 'CSV',
+          <%= link_to 'CSV for below table',
                       url_for(
                         controller: controller_path,
                         action: :index,
                         only_path: true,
-                        **params.permit(:school_group, :admin, :meter_type).merge(format: :csv)
+                        **params.permit(:school_group, :admin, :meter_type, :active).merge(format: :csv)
                       ),
                       class: 'ml-2 btn btn-sm' %>
           <% end %>

--- a/spec/system/admin/reports/admin_user_meter_report_spec.rb
+++ b/spec/system/admin/reports/admin_user_meter_report_spec.rb
@@ -50,4 +50,16 @@ describe 'admin user meter report' do
 
     it_behaves_like 'it has the correct CSV'
   end
+
+  context 'with inactive filter' do
+    let!(:meter) { create(:gas_meter, school:, active: false, name: 'Inactive Meter') }
+    let!(:before) do
+      sign_in school.school_group.default_issues_admin_user
+      visit admin_reports_admin_user_meter_report_index_path
+      select 'Inactive', from: 'Active'
+      click_on 'Filter'
+    end
+
+    it_behaves_like 'it has the correct CSV'
+  end
 end


### PR DESCRIPTION
Ensures that inactive meters appear in the csv downloads when filtered to 'inactive' or 'all'