### PR TITLE
Update admin meter statuses

### DIFF
--- a/lib/tasks/deployment/20260513142043_update_admin_meter_statuses.rake
+++ b/lib/tasks/deployment/20260513142043_update_admin_meter_statuses.rake
@@ -23,7 +23,7 @@ namespace :after_party do
     # 18 => 'Meter no longer required'
 
     # TO
-    # 19 => 'Not required'
+    # 19 => 'Not required' (or 'Data not required' if working with older database)
 
     Meter.where(admin_meter_statuses_id: 18)
          .update(admin_meter_statuses_id: 19)

--- a/lib/tasks/deployment/20260513142043_update_admin_meter_statuses.rake
+++ b/lib/tasks/deployment/20260513142043_update_admin_meter_statuses.rake
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+namespace :after_party do
+  desc 'Deployment task: update_admin_meter_statuses'
+  task update_admin_meter_statuses: :environment do
+    puts "Running deploy task 'update_admin_meter_statuses'"
+
+    # FROM
+    # 1  => 'Comms issue - requires site visit'
+    # 2  => 'Comms issue - site visit planned'
+    # 17 => 'Comms issue - under investigation'
+    # 16 => 'Meter issue - action required by Energy Sparks'
+    # 13 => 'Meter issue - action required by school/MAT/Council'
+    # 14 => 'Meter issue - action required by supplier/procurement/MOP'
+
+    # TO
+    # 11 => 'Meter issue raised'
+
+    Meter.where(admin_meter_statuses_id: [1, 2, 17, 16, 13, 14])
+         .update(admin_meter_statuses_id: 11)
+
+    # FROM
+    # 18 => 'Meter no longer required'
+
+    # TO
+    # 19 => 'Not required'
+
+    Meter.where(admin_meter_statuses_id: 18)
+         .update(admin_meter_statuses_id: 19)
+
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord
+      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+  end
+end


### PR DESCRIPTION
An after party task which changes:

Meters with statuses 'Comms issue - requires site visit', 'Comms issue - site visit planned', 'Comms issue - under investigation',  'Meter issue - action required by Energy Sparks', 'Meter issue - action required by school/MAT/Council', and 'Meter issue - action required by supplier/procurement/MOP' to have status 'Meter issue raised'

And meters with status 'Meter no longer required' to have status 'Not required'