### PR TITLE
Changed target to blank tab

### DIFF
--- a/app/components/admin/quick_links_component/quick_links_component.html.erb
+++ b/app/components/admin/quick_links_component/quick_links_component.html.erb
@@ -15,7 +15,7 @@
             <% else %>
               <%= form.search_field :query, id: card[:name], class: 'form-control' %>
             <% end %>
-            <%= form.submit card[:submit], class: 'btn btn-sm btn-primary ml-2' %>
+            <%= form.submit card[:submit], formtarget: '_blank', class: 'btn btn-sm btn-primary ml-2' %>
           <% end %>
         <% end %>
       <% end %>


### PR DESCRIPTION
Makes the quick links open in a new tab - used '_blank' rather than '_new' so that each link opens a new tab if multiple are clicked