### PR TITLE
Add caching to admin dashboards

### DIFF
--- a/app/helpers/admin_dashboard_helper.rb
+++ b/app/helpers/admin_dashboard_helper.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module AdminDashboardHelper
+  def prompt_cache_timestamp(user)
+    user.owned_issues.maximum(:updated_at).to_i
+  end
+end

--- a/app/views/admin/dashboards/show.html.erb
+++ b/app/views/admin/dashboards/show.html.erb
@@ -1,4 +1,11 @@
 <% content_for :title, "#{@dashboard_user&.display_name}'s Admin Dashboard" %>
 
-<%= render Admin::QuickLinksComponent.new(user: @dashboard_user, classes: 'mt-1') %>
-<%= render Admin::DashboardPromptComponent.new(user: @dashboard_user, classes: 'mt-1') %>
+<%= cache([:admin_quick_links_component, @dashboard_user.id],
+          expires_in: 2.hours) do %>
+  <%= render Admin::QuickLinksComponent.new(user: @dashboard_user, classes: 'mt-1') %>
+<% end %>
+
+<%= cache([:admin_dashboard_prompt_component, @dashboard_user.id],
+          expires_in: 30.minutes) do %>
+  <%= render Admin::DashboardPromptComponent.new(user: @dashboard_user, classes: 'mt-1') %>
+<% end %>

--- a/app/views/admin/dashboards/show.html.erb
+++ b/app/views/admin/dashboards/show.html.erb
@@ -1,11 +1,12 @@
 <% content_for :title, "#{@dashboard_user&.display_name}'s Admin Dashboard" %>
 
-<%= cache([:admin_quick_links_component, @dashboard_user.id],
+<%= cache({ title: :admin_quick_links_component, user: @dashboard_user.id },
           expires_in: 2.hours) do %>
   <%= render Admin::QuickLinksComponent.new(user: @dashboard_user, classes: 'mt-1') %>
 <% end %>
 
-<%= cache([:admin_dashboard_prompt_component, @dashboard_user.id],
-          expires_in: 30.minutes) do %>
+<%= cache({ title: :admin_dashboard_prompt_component, user: @dashboard_user.id,
+            timestamp: prompt_cache_timestamp(@dashboard_user) },
+          expires_in: 20.minutes) do %>
   <%= render Admin::DashboardPromptComponent.new(user: @dashboard_user, classes: 'mt-1') %>
 <% end %>


### PR DESCRIPTION
Adds caching to the quick link and prompt components rendering on the dashboard homepage. Prompts have a timestamp for when the last issue was updated