### PR TITLE
Add blank to geographic area dropdown

### DIFF
--- a/app/views/schools/configuration/_form.html.erb
+++ b/app/views/schools/configuration/_form.html.erb
@@ -170,7 +170,7 @@
                    options_for_select(
                      LocalAuthorityArea.all.order(name: :asc).pluck(:name, :id), school.local_authority_area_id
                    ),
-                   { include_blank: false },
+                   { include_blank: true },
                    { class: 'form-control' } %>
       <small class="form-text text-muted">Local authority areas cover the whole of England, Wales and Scotland</small>
     </div>

--- a/spec/system/admin/school_configuration_spec.rb
+++ b/spec/system/admin/school_configuration_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe 'editing school configuration', type: :system do
         before do
           school.update_attribute(:local_authority_area_group, area)
           refresh
-          select '', from: 'Local Authority Area'
+          select '', from: 'Local Authority Area Group'
           click_on('Update configuration')
         end
 


### PR DESCRIPTION
Changes includes blank to true for the local authority area on the school configuration. Temporary measure