### PR TITLE
Add contracts to school onboarding page

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -9,7 +9,11 @@ module ApplicationHelper
     if options[:localtime] && Rails.application.config.display_timezone
       datetime = datetime.in_time_zone(Rails.application.config.display_timezone)
     end
-    "#{nice_dates(datetime)} #{nice_times_only(datetime)}"
+    if options[:short_date]
+      "#{short_dates(datetime)} #{nice_times_only(datetime)}"
+    else
+      "#{nice_dates(datetime)} #{nice_times_only(datetime)}"
+    end
   end
 
   def nice_times_only(datetime)

--- a/app/views/admin/school_groups/_onboarding_schools.html.erb
+++ b/app/views/admin/school_groups/_onboarding_schools.html.erb
@@ -1,10 +1,11 @@
 <%= simple_form_for school_group, html: { class: 'form-group', method: 'post' } do |f| %>
-  <table class="table table-sorted" style="width:100%">
+  <table class="table table-sm" style="width:100%">
     <thead>
       <tr>
-        <th class="no-sort"><%= check_box_tag "check-all-#{school_group.id}", false, false, { class: 'check-all' } %></th>
+        <th><%= check_box_tag "check-all-#{school_group.id}", false, false, { class: 'check-all' } %></th>
         <th>School</th>
         <th>Funder</th>
+        <th>Contract</th>
         <th>Contact email</th>
         <th>Invite sent</th>
         <th>Last event</th>
@@ -17,18 +18,25 @@
           <td>
             <%= f.check_box :school_onboarding_ids, { multiple: true, checked: false }, onboarding.id, nil %>
           </td>
-          <td><%= link_to onboarding.school_name, onboarding_path(onboarding) %></td>
-          <td><%= onboarding&.school&.funder&.name || onboarding&.funder&.name %></td>
-          <td class="wrap">
-            <%= onboarding.contact_email %>
+          <td class="col-2"><%= link_to onboarding.school_name, onboarding_path(onboarding) %></td>
+          <td class="col-1"><%= onboarding&.school&.funder&.name || onboarding&.funder&.name %></td>
+          <td class="col-1">
+            <% if onboarding.contract %>
+              <%= link_to onboarding.contract.name, admin_commercial_contract_path(onboarding.contract) %>
+            <% end %>
+          </td>
+          <td class="col-2">
+            <%= email_with_wbr(onboarding.contact_email) %>
             <%= if onboarding.has_only_sent_email_or_reminder?
                   link_to fa_icon('edit'),
                           edit_admin_school_onboarding_email_path(onboarding), class: '', title: 'Change email address'
                 end %>
           </td>
-          <td class="nowrap" data-order="<%= onboarding.started_on %>"><%= nice_date_times(onboarding.started_on) %></td>
-          <td class="nowrap" data-order="<%= onboarding.events.maximum(:created_at) %>">
-            <%= nice_date_times(onboarding.events.maximum(:created_at)) %><br>
+          <td class="col-2">
+            <%= nice_date_times(onboarding.started_on, short_date: true) %>
+          </td>
+          <td class="col-2">
+            <%= nice_date_times(onboarding.events.maximum(:created_at), short_date: true) %><br>
             <span class="badge text-bg-secondary">
               <%= SchoolOnboardingEvent.events.key(onboarding.events.maximum(:event)).try(:humanize) %>
             </span>
@@ -42,8 +50,9 @@
                  issues = onboarding.issues
                end %>
             <%= link_to issue_type_icons(issues, label: 'Issues'), issues_path, class: 'btn btn-default btn-sm' %>
-            <%= link_to 'Send reminder email', admin_school_onboarding_reminder_path(onboarding),
+            <%= link_to 'Send reminder', admin_school_onboarding_reminder_path(onboarding),
                         class: 'btn btn-default btn-sm', method: :post %>
+            <br>
             <% if onboarding.school && onboarding.school.consent_grants.any? %>
               <%= link_to 'Make visible',
                           school_visibility_path(onboarding.school),
@@ -63,8 +72,10 @@
   <%= hidden_field_tag :anchor, anchor %>
   <%= f.button :submit, 'Make selected visible',
                data: { confirm: 'Are you sure?' },
+               class: 'btn btn-sm',
                formaction: make_visible_admin_school_group_school_onboardings_path(school_group) %>
   <%= f.button :submit, 'Send reminders to selected',
                data: { confirm: 'Are you sure?' },
+               class: 'btn btn-sm',
                formaction: reminders_admin_school_group_school_onboardings_url(school_group) %>
 <% end %>

--- a/app/views/admin/school_onboardings/index.html.erb
+++ b/app/views/admin/school_onboardings/index.html.erb
@@ -2,26 +2,28 @@
   <% content_for :title do %>
       <%= "School Onboardings for #{@dashboard_user.display_name}'s Groups" %>
   <% end %>
-      <%= link_to 'All Onboardings', admin_school_onboardings_path, class: 'btn' %>
+      <%= link_to 'All Onboardings', admin_school_onboardings_path, class: 'btn btn-sm' %>
 <% else %>
   <h1>School onboardings currently in progress</h1>
 <% end %>
 
-<%= link_to 'New School Onboarding', new_admin_school_onboarding_path, class: 'btn' %>
-<%= link_to 'Download as CSV', admin_school_onboardings_path(format: :csv), class: 'btn' %>
+<%= link_to 'New School Onboarding', new_admin_school_onboarding_path, class: 'btn btn-sm' %>
+<%= link_to 'Download as CSV', admin_school_onboardings_path(format: :csv), class: 'btn btn-sm' %>
 
-<div class="mt-4">
-  <p>
-    Quick links:
-  </p>
-  <ul>
-  <% @school_groups.each do |school_group| %>
-    <% if school_group.school_onboardings.incomplete.any? %>
-      <li><%= link_to school_group.name, "##{school_group.slug}" %></li>
+<% unless @dashboard_user %>
+  <div class="mt-4">
+    <p>
+      Quick links:
+    </p>
+    <ul>
+    <% @school_groups.each do |school_group| %>
+      <% if school_group.school_onboardings.incomplete.any? %>
+        <li><%= link_to school_group.name, "##{school_group.slug}" %></li>
+      <% end %>
     <% end %>
-  <% end %>
-  </ul>
-</div>
+    </ul>
+  </div>
+<% end %>
 
 <% @school_groups.each do |school_group| %>
   <% next unless school_group.school_onboardings.incomplete.any? %>
@@ -36,7 +38,7 @@
       <%= link_to '#' do %>
         <%= t('common.back_to_top') %>
         <i class="fa fa-arrow-up" data-toggle="tooltip" title="<%= t('common.back_to_top') %>"></i>
-      <% end %>
+      <% end unless @dashboard_user %>
     </div>
   </div>
 
@@ -46,7 +48,7 @@
     </div>
     <div>
       <%= link_to 'Download as CSV', admin_school_group_school_onboardings_path(school_group, format: :csv),
-                  class: 'btn' %>
+                  class: 'btn btn-sm' %>
     </div>
   </div>
 

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -45,7 +45,8 @@ describe ApplicationHelper do
 
     it 'shows the last time as user signed in' do
       last_sign_in_at = DateTime.new(2001, 2, 3, 4, 5, 6)
-      expect(display_last_signed_in_as(build(:user, last_sign_in_at: last_sign_in_at))).to eq last_sign_in_at.strftime('%d/%m/%Y %H:%M')
+      expect(display_last_signed_in_as(build(:user,
+                                             last_sign_in_at: last_sign_in_at))).to eq last_sign_in_at.strftime('%d/%m/%Y %H:%M')
     end
   end
 
@@ -153,8 +154,14 @@ describe ApplicationHelper do
       end
     end
 
+    context 'when short_dates is true' do
+      subject { nice_date_times(utc_date_time, short_date: true) }
+
+      it { expect(subject).to eql("#{short_dates(utc_date_time)} #{nice_times_only(utc_date_time)}") }
+    end
+
     context 'when date is nil' do
-      subject {nice_date_times(nil)}
+      subject { nice_date_times(nil) }
 
       it { expect(nice_date_times(nil)).to be_blank }
     end
@@ -236,7 +243,8 @@ describe ApplicationHelper do
       times = (start_of_the_day..end_of_the_day).step(30.minutes)
       times = times.map { |time| helper.nice_times_only(Time.zone.at(time)) }
       expect(times).to eq(
-        ['00:00', '00:30', '01:00', '01:30', '02:00', '02:30', '03:00', '03:30', '04:00', '04:30', '05:00', '05:30', '06:00', '06:30', '07:00', '07:30', '08:00', '08:30', '09:00', '09:30', '10:00', '10:30', '11:00', '11:30', '12:00', '12:30', '13:00', '13:30', '14:00', '14:30', '15:00', '15:30', '16:00', '16:30', '17:00', '17:30', '18:00', '18:30', '19:00', '19:30', '20:00', '20:30', '21:00', '21:30', '22:00', '22:30', '23:00', '23:30']
+        ['00:00', '00:30', '01:00', '01:30', '02:00', '02:30', '03:00', '03:30', '04:00', '04:30', '05:00', '05:30',
+         '06:00', '06:30', '07:00', '07:30', '08:00', '08:30', '09:00', '09:30', '10:00', '10:30', '11:00', '11:30', '12:00', '12:30', '13:00', '13:30', '14:00', '14:30', '15:00', '15:30', '16:00', '16:30', '17:00', '17:30', '18:00', '18:30', '19:00', '19:30', '20:00', '20:30', '21:00', '21:30', '22:00', '22:30', '23:00', '23:30']
       )
     end
   end

--- a/spec/system/admin/school_onboarding_spec.rb
+++ b/spec/system/admin/school_onboarding_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe 'onboarding', :schools do
 
   let!(:project_group) { create(:school_group, group_type: :project) }
   let!(:diocese) { create(:school_group, group_type: :diocese) }
-  let!(:local_authority_area) { create(:school_group, group_type: :local_authority_area)}
+  let!(:local_authority_area) { create(:school_group, group_type: :local_authority_area) }
   let!(:funder) { create(:funder) }
   let!(:contract) { create(:commercial_contract) }
 
@@ -54,12 +54,14 @@ RSpec.describe 'onboarding', :schools do
         click_on 'New School Onboarding'
       end
 
-      it { expect(page).to have_select('School Group', options: [''] + SchoolGroup.organisation_groups.by_name.map(&:name)) }
+      it {
+        expect(page).to have_select('School Group', options: [''] + SchoolGroup.organisation_groups.by_name.map(&:name))
+      }
 
       context 'when completing the first form' do
         before do
           fill_in 'School name', with: school_name
-          fill_in 'URN', with: 100000
+          fill_in 'URN', with: 100_000
           fill_in 'Contact email', with: 'oldfield@test.com'
           select school_group.name, from: 'School Group'
           click_on 'Next'
@@ -68,7 +70,11 @@ RSpec.describe 'onboarding', :schools do
         it { expect(page).to have_select('Data Sharing', selected: 'Public') }
         it { expect(page).to have_select('Funder', options: [''] + Funder.all.by_name.map(&:name)) }
         it { expect(page).to have_select('Contract', options: [''] + Commercial::Contract.current.by_name.map(&:name)) }
-        it { expect(page).to have_select('Project Group', options: [''] + SchoolGroup.project_groups.by_name.map(&:name)) }
+
+        it {
+          expect(page).to have_select('Project Group', options: [''] + SchoolGroup.project_groups.by_name.map(&:name))
+        }
+
         it { expect(page).to have_select('Template calendar', selected: template_calendar.title) }
         it { expect(page).to have_select('Weather Station', selected: weather_station.title) }
         it { expect(page).to have_select('Scoreboard', selected: scoreboard.name) }
@@ -86,8 +92,8 @@ RSpec.describe 'onboarding', :schools do
             click_on 'Next'
           end
 
-          it { expect(page).to have_content(school_name) }
-          it { expect(page).to have_content('oldfield@test.com') }
+          it { expect(page).to have_text(school_name) }
+          it { expect(page).to have_text('oldfield@test.com') }
 
           context 'when the setup is done' do
             subject(:onboarding) { SchoolOnboarding.first }
@@ -102,7 +108,9 @@ RSpec.describe 'onboarding', :schools do
             it { expect(onboarding.diocese).to eq(diocese) }
             it { expect(onboarding.local_authority_area).to eq(local_authority_area) }
             it { expect(onboarding.funder).to eq(funder) }
-            it { expect(onboarding.contract).to eq(contract)}
+            it { expect(onboarding.contract).to eq(contract) }
+
+            it { expect(page).to have_link(contract.name, href: admin_commercial_contract_path(contract)) }
 
             it 'has sent an email' do
               expect(last_email.subject).to include('Set up your school on Energy Sparks')
@@ -118,7 +126,7 @@ RSpec.describe 'onboarding', :schools do
 
       before do
         click_on 'Manage school onboarding'
-        click_on 'Send reminder email'
+        click_on 'Send reminder'
       end
 
       it { expect(last_email.subject).to include("Don't forget to set up your school on Energy Sparks") }
@@ -165,7 +173,7 @@ RSpec.describe 'onboarding', :schools do
       it { expect(onboarding.default_chart_preference).to eq 'cost' }
       it { expect(onboarding.country).to eq 'scotland' }
       it { expect(onboarding.funder).to eq(funder) }
-      it { expect(onboarding.contract).to eq(contract)}
+      it { expect(onboarding.contract).to eq(contract) }
 
       context 'when revisiting the forms' do
         before do
@@ -214,7 +222,7 @@ RSpec.describe 'onboarding', :schools do
         click_on 'Manage school onboarding'
         click_on 'Make visible'
 
-        expect(page).to have_content('School onboardings')
+        expect(page).to have_text('School onboardings')
 
         school_onboarding.reload
         expect(school_onboarding).to be_complete
@@ -262,9 +270,9 @@ RSpec.describe 'onboarding', :schools do
           expect(header).to match(/^attachment/)
           expect(header).to match(/filename="#{Admin::SchoolOnboardingsController::INCOMPLETE_ONBOARDING_SCHOOLS_FILE_NAME}"/o)
 
-          expect(page.source).to have_content 'Email sent'
-          expect(page.source).to have_content onboarding.school_name
-          expect(page.source).to have_content onboarding.contact_email
+          expect(page.source).to have_text 'Email sent'
+          expect(page.source).to have_text onboarding.school_name
+          expect(page.source).to have_text onboarding.contact_email
         end
       end
 
@@ -279,11 +287,11 @@ RSpec.describe 'onboarding', :schools do
           header = page.response_headers['Content-Disposition']
           expect(header).to match(/^attachment/)
           expect(header).to match(/filename="#{onboarding.school_group.slug}-onboarding-schools.csv"/)
-          expect(page.source).to have_content 'Email sent'
-          expect(page.source).to have_content 'In progress'
-          expect(page.source).to have_content onboarding.school_name
-          expect(page.source).to have_content onboarding.contact_email
-          expect(page.source).to have_content 'Manual school'
+          expect(page.source).to have_text 'Email sent'
+          expect(page.source).to have_text 'In progress'
+          expect(page.source).to have_text onboarding.school_name
+          expect(page.source).to have_text onboarding.contact_email
+          expect(page.source).to have_text 'Manual school'
         end
       end
     end
@@ -306,8 +314,8 @@ RSpec.describe 'onboarding', :schools do
         let(:email_address) { '' }
 
         it "doesn't save" do
-          expect(page).to have_content("Contact email *\ncan't be blank")
-          expect(page).to have_content('Change email address')
+          expect(page).to have_text("Contact email *\ncan't be blank")
+          expect(page).to have_text('Change email address')
         end
       end
 
@@ -315,8 +323,8 @@ RSpec.describe 'onboarding', :schools do
         let(:email_address) { 'different_address@email.com' }
 
         it 'saves' do
-          expect(page).to have_content('School onboardings currently in progress')
-          expect(page).to have_content(email_address)
+          expect(page).to have_text('School onboardings currently in progress')
+          expect(page).to have_text(email_address)
         end
 
         it 'sends email' do
@@ -360,9 +368,9 @@ RSpec.describe 'onboarding', :schools do
       end
 
       it 'shows recently onboarded schools' do
-        expect(page).to have_content 'Schools recently onboarded'
+        expect(page).to have_text 'Schools recently onboarded'
         click_on onboarding.school_name
-        expect(page).to have_content(onboarding.school.name)
+        expect(page).to have_text(onboarding.school.name)
       end
     end
   end


### PR DESCRIPTION
Adds a link to the contract associated with the school onboarding. This will shortly replace the Funder field.

Also tidied the page a bit to:

- shorten the dates
- reduce white space in tables
- remove sorting (tables aren't large enough to warrant it?)
- reduce size of buttons
- hide the quick links on the admin dashboard view
