### PR TITLE
Improve contract and licensing forms

### DIFF
--- a/app/components/commercial/contracts_component/contracts_component.html.erb
+++ b/app/components/commercial/contracts_component/contracts_component.html.erb
@@ -10,6 +10,8 @@
           <th>Contract Holder</th>
         <% end %>
         <th>Product</th>
+        <th class="text-end">Period</th>
+        <th class="text-end">Terms</th>
         <th class="text-end">Start Date</th>
         <th class="text-end">End Date</th>
         <th class="text-end">Number of Schools</th>
@@ -28,6 +30,8 @@
             <td class="col-2"><%= contract.contract_holder.name %></td>
           <% end %>
           <td class="col-2"><%= link_to contract.product.name, admin_commercial_product_path(contract.product) %></td>
+          <td><%= contract.licence_period.humanize %></td>
+          <td><%= contract.invoice_terms.humanize %></td>
           <td data-order="<%= contract.start_date.iso8601 %>" class="text-end"><%= contract.start_date.to_fs(:es_short) %></td>
           <td data-order="<%= contract.end_date.iso8601 %>" class="text-end"><%= contract.end_date.to_fs(:es_short) %></td>
           <td class="text-end col-1"><%= contract.number_of_schools %></td>

--- a/app/components/forms/commercial/bulk_licence_editor_component/licence_row_component.html.erb
+++ b/app/components/forms/commercial/bulk_licence_editor_component/licence_row_component.html.erb
@@ -5,22 +5,31 @@
     <td><%= link_to licence.school.name, school_path(licence.school) %></td>
 
     <% if show_field?(:start_date) %>
-      <td class="col-2"><%= lf.input :start_date, as: :tempus_dominus_date, label: false %></td>
+      <td class="col-2">
+        <%= lf.input :start_date, as: :tempus_dominus_date, label: false, disabled: licence.invoiced? %>
+        </td>
     <% end %>
     <% if show_field?(:end_date) %>
-      <td class="col-2"><%= lf.input :end_date, as: :tempus_dominus_date, label: false %></td>
+      <td class="col-2">
+        <%= lf.input :end_date, as: :tempus_dominus_date, label: false, disabled: licence.invoiced? %>
+      </td>
     <% end %>
     <% if show_field?(:status) %>
-      <td class="col-2"><%= lf.input :status,
-                                     collection: helpers.collection_from_enum(Commercial::Licence.statuses),
-                                     include_blank: false,
-                                     label: false %></td>
+      <td class="col-2">
+        <%= lf.input :status,
+                     collection: helpers.collection_from_enum(Commercial::Licence.statuses),
+                     include_blank: false,
+                     label: false,
+                     disabled: licence.invoiced? %>
+      </td>
     <% end %>
     <% if show_field?(:school_specific_price) %>
-      <td class="col-1"><%= lf.input :school_specific_price,
-                                     as: :decimal,
-                                     input_html: { step: '0.01' },
-                                     label: false %></td>
+      <td class="col-1">
+        <%= lf.input :school_specific_price,
+                     as: :decimal,
+                     input_html: { step: '0.01' },
+                     label: false, disabled: licence.invoiced? %>
+      </td>
     <% end %>
 
     <% if show_field?(:invoice_reference) %>
@@ -31,7 +40,7 @@
       <%= button_tag 'Delete',
                      type: :button,
                      data: { target: licence.id },
-                     class: 'btn btn-sm btn-danger licence-toggle-delete' %>
+                     class: 'btn btn-sm btn-danger licence-toggle-delete', disabled: licence.invoiced? %>
     </td>
   </tr>
   <% if show_field?(:comments) %>

--- a/app/controllers/admin/commercial/contracts_controller.rb
+++ b/app/controllers/admin/commercial/contracts_controller.rb
@@ -64,11 +64,14 @@ module Admin
 
       def edit; end
 
-      def create
+      def create # rubocop:disable Metrics/AbcSize
         @contract = ::Commercial::Contract.build(contract_params.merge(created_by: current_user))
-        render :new and return unless @contract.save
+        unless @contract.save
+          @original = ::Commercial::Contract.find(params[:original_contract_id]) if params[:original_contract_id]
+          render :new and return
+        end
 
-        if params[:renew_licences] == '1'
+        if @contract.renew_licences?
           renew_licences(@contract)
           redirect_to(admin_commercial_contract_path(@contract),
                       notice: 'Contract and provisional licences have been created') # rubocop:disable Rails/I18nLocaleTexts
@@ -163,7 +166,8 @@ module Admin
       def contract_params
         params.expect(contract: %i[agreed_school_price comments contract_holder_id contract_holder_type
                                    end_date invoice_terms licence_period licence_years name
-                                   number_of_schools product_id purchase_order_number start_date status])
+                                   number_of_schools product_id purchase_order_number
+                                   renew_licences start_date status])
       end
     end
   end

--- a/app/controllers/admin/commercial/contracts_controller.rb
+++ b/app/controllers/admin/commercial/contracts_controller.rb
@@ -51,8 +51,6 @@ module Admin
       end
 
       def new
-        @title = new_model_form_title
-
         if renewal_request?
           @original = ::Commercial::Contract.find(params.expect(:original_contract_id))
           @contract = ::Commercial::Contract.as_renewal(@original)
@@ -61,6 +59,7 @@ module Admin
 
           @contract = build_contract
         end
+        @title = new_model_form_title
       end
 
       def edit; end
@@ -158,7 +157,7 @@ module Admin
       end
 
       def chosen_params
-        params.permit(:contract_holder_type, :contract_holder_id, :chosen_type)
+        params.permit(:contract_holder_type, :contract_holder_id, :original_contract_id, :chosen_type)
       end
 
       def contract_params

--- a/app/controllers/admin/commercial/contracts_controller.rb
+++ b/app/controllers/admin/commercial/contracts_controller.rb
@@ -2,8 +2,13 @@
 
 module Admin
   module Commercial
-    class ContractsController < AdminController
+    class ContractsController < AdminController # rubocop:disable Metrics/ClassLength
       ALLOWED_SCOPES = %w[current expired expiring future provisional recent].freeze
+      CONTRACT_DEFAULTS = {
+        'standard' => { licence_period: :contract, invoice_terms: :full },
+        'pro-rata' => { licence_period: :contract, invoice_terms: :pro_rata },
+        'custom' => { licence_period: :custom, invoice_terms: :full }
+      }.freeze
 
       load_and_authorize_resource :contract, class: 'Commercial::Contract'
 
@@ -38,15 +43,24 @@ module Admin
         @pricing = ::Commercial::ContractPriceCalculator.new(@contract)
       end
 
+      def choose
+        @chosen_params = {
+          contract_holder_id: params[:contract_holder_id],
+          contract_holder_type: params[:contract_holder_type]
+        }
+      end
+
       def new
-        @contract = if renewal_request?
-                      @original = ::Commercial::Contract.find(params[:original_contract_id])
-                      ::Commercial::Contract.as_renewal(@original)
-                    elsif contract_holder_request?
-                      ::Commercial::Contract.new(contract_holder: find_contract_holder)
-                    else
-                      ::Commercial::Contract.new(contract_holder_type: 'Funder')
-                    end
+        @title = new_model_form_title
+
+        if renewal_request?
+          @original = ::Commercial::Contract.find(params.expect(:original_contract_id))
+          @contract = ::Commercial::Contract.as_renewal(@original)
+        else
+          redirect_to choose_admin_commercial_contracts_path and return if chosen_params[:chosen_type].blank?
+
+          @contract = build_contract
+        end
       end
 
       def edit; end
@@ -100,31 +114,57 @@ module Admin
         @contracts = ::Commercial::Contract.filtered(scope, @date)
       end
 
+      def new_model_form_title
+        if renewal_request?
+          'Create renewed contract'
+        elsif contract_holder_request?
+          "Create a new #{chosen_params[:chosen_type]} contract for #{@contract.contract_holder.name}"
+        else
+          "Create new #{chosen_params[:chosen_type]} contract"
+        end
+      end
+
+      def build_contract
+        attributes = CONTRACT_DEFAULTS[chosen_params[:chosen_type]]
+
+        if contract_holder_request?
+          attributes[:contract_holder] = find_contract_holder
+        else
+          attributes[:contract_holder_type] = 'Funder'
+        end
+
+        ::Commercial::Contract.new(attributes)
+      end
+
       def renewal_request?
-        params[:original_contract_id].present?
+        chosen_params[:original_contract_id].present?
       end
 
       def contract_holder_request?
-        params[:contract_holder_id].present?
+        chosen_params[:contract_holder_id].present?
       end
 
       def find_contract_holder
         case params[:contract_holder_type]
-        when 'School'      then School.find(params[:contract_holder_id])
-        when 'SchoolGroup' then SchoolGroup.find(params[:contract_holder_id])
-        when 'Funder'      then Funder.find(params[:contract_holder_id])
+        when 'School'      then School.find(params.expect(:contract_holder_id))
+        when 'SchoolGroup' then SchoolGroup.find(params.expect(:contract_holder_id))
+        when 'Funder'      then Funder.find(params.expect(:contract_holder_id))
         end
       end
 
       def renew_licences(contract)
-        original_contract = ::Commercial::Contract.find(params[:original_contract_id])
+        original_contract = ::Commercial::Contract.find(params.expect(:original_contract_id))
         ::Commercial::ContractManager.new(contract).renew_licences(original_contract)
       end
 
+      def chosen_params
+        params.permit(:contract_holder_type, :contract_holder_id, :chosen_type)
+      end
+
       def contract_params
-        params.require(:contract).permit(:agreed_school_price, :comments, :contract_holder_id, :contract_holder_type,
-                                         :end_date, :invoice_terms, :licence_period, :licence_years, :name,
-                                         :number_of_schools, :product_id, :purchase_order_number, :start_date, :status)
+        params.expect(contract: %i[agreed_school_price comments contract_holder_id contract_holder_type
+                                   end_date invoice_terms licence_period licence_years name
+                                   number_of_schools product_id purchase_order_number start_date status])
       end
     end
   end

--- a/app/controllers/admin/commercial/contracts_controller.rb
+++ b/app/controllers/admin/commercial/contracts_controller.rb
@@ -71,7 +71,7 @@ module Admin
           render :new and return
         end
 
-        if @contract.renew_licences?
+        if @contract.update_licences?
           renew_licences(@contract)
           redirect_to(admin_commercial_contract_path(@contract),
                       notice: 'Contract and provisional licences have been created') # rubocop:disable Rails/I18nLocaleTexts
@@ -167,7 +167,7 @@ module Admin
         params.expect(contract: %i[agreed_school_price comments contract_holder_id contract_holder_type
                                    end_date invoice_terms licence_period licence_years name
                                    number_of_schools product_id purchase_order_number
-                                   renew_licences start_date status])
+                                   update_licences start_date status])
       end
     end
   end

--- a/app/models/commercial/contract.rb
+++ b/app/models/commercial/contract.rb
@@ -88,6 +88,12 @@ module Commercial
 
     accepts_nested_attributes_for :licences, allow_destroy: true
 
+    attr_accessor :renew_licences
+
+    def renew_licences?
+      ActiveModel::Type::Boolean.new.cast(renew_licences)
+    end
+
     def self.as_renewal(original)
       new(
         original.slice(
@@ -102,7 +108,8 @@ module Commercial
         ).merge(
           comments: "Renewed from #{original.name}",
           end_date: original.end_date.next_year,
-          start_date: original.end_date + 1.day
+          start_date: original.end_date + 1.day,
+          renew_licences: true
         )
       )
     end
@@ -130,14 +137,14 @@ module Commercial
     # Others cannot be changed once invoicing has started, e.g. agreed_school_price
     def editable_attributes
       fields = %i[comments name purchase_order_number number_of_schools updated_by_id]
-      fields += [:status] if provisional?
+      fields += %i[status] if provisional?
       fields += [:licence_years] if custom? && !invoiced?
-      fields += %i[agreed_school_price start_date end_date] unless invoiced?
+      fields += %i[agreed_school_price product_id start_date end_date] unless invoiced?
       fields
     end
 
     def cascade_updates_to_licences?
-      licences.exists? && saved_changes.keys.intersect?(%w[start_date end_date status])
+      licences.exists? && saved_changes.keys.intersect?(%w[start_date end_date status licence_years])
     end
 
     def as_range

--- a/app/models/commercial/contract.rb
+++ b/app/models/commercial/contract.rb
@@ -121,6 +121,7 @@ module Commercial
       !licences.invoiced.exists?
     end
 
+    # FIXME: might need revising
     def editable_attribute?(name)
       new_record? || editable_attributes.include?(name)
     end

--- a/app/models/commercial/contract.rb
+++ b/app/models/commercial/contract.rb
@@ -88,10 +88,10 @@ module Commercial
 
     accepts_nested_attributes_for :licences, allow_destroy: true
 
-    attr_accessor :renew_licences
+    attr_accessor :update_licences
 
-    def renew_licences?
-      ActiveModel::Type::Boolean.new.cast(renew_licences)
+    def update_licences?
+      ActiveModel::Type::Boolean.new.cast(update_licences)
     end
 
     def self.as_renewal(original)
@@ -109,7 +109,7 @@ module Commercial
           comments: "Renewed from #{original.name}",
           end_date: original.end_date.next_year,
           start_date: original.end_date + 1.day,
-          renew_licences: true
+          update_licences: true
         )
       )
     end
@@ -143,8 +143,11 @@ module Commercial
       fields
     end
 
+    # Indicate whether changes to the contract should trigger updates to existing licences. Based on
+    # user choice (:update_licences) and whether the saved changes indicate that an update is worthwhile.
     def cascade_updates_to_licences?
-      licences.exists? && saved_changes.keys.intersect?(%w[start_date end_date status licence_years])
+      update_licences? && licences.exists? && saved_changes.keys.intersect?(%w[start_date end_date status
+                                                                               licence_years])
     end
 
     def as_range

--- a/app/models/commercial/contract.rb
+++ b/app/models/commercial/contract.rb
@@ -121,7 +121,6 @@ module Commercial
       !licences.invoiced.exists?
     end
 
-    # FIXME: might need revising
     def editable_attribute?(name)
       new_record? || editable_attributes.include?(name)
     end
@@ -132,6 +131,7 @@ module Commercial
     def editable_attributes
       fields = %i[comments name purchase_order_number number_of_schools updated_by_id]
       fields += [:status] if provisional?
+      fields += [:licence_years] if custom? && !invoiced?
       fields += %i[agreed_school_price start_date end_date] unless invoiced?
       fields
     end

--- a/app/views/admin/commercial/contract_holder_contracts/_contracts.html.erb
+++ b/app/views/admin/commercial/contract_holder_contracts/_contracts.html.erb
@@ -1,8 +1,8 @@
 <div class="row">
   <div class="col">
     <p>
-      <%= link_to 'New contract', new_admin_commercial_contract_path(contract_holder_type: @contract_holder.class,
-                                                                     contract_holder_id: @contract_holder.id),
+      <%= link_to 'New contract', choose_admin_commercial_contracts_path(contract_holder_type: @contract_holder.class,
+                                                                         contract_holder_id: @contract_holder.id),
                   class: 'btn btn-primary btn-sm' %>
     </p>
   </div>

--- a/app/views/admin/commercial/contracts/_form.html.erb
+++ b/app/views/admin/commercial/contracts/_form.html.erb
@@ -16,33 +16,39 @@
 
 <div class="row">
   <div class="col">
-  <% if local_assigns[:original].present? %>
-    <p>
-      Creating a new contract for <strong><%= contract.contract_holder.name %></strong> based on
-      <strong><%= original.name %></strong>.
-      The form has been populated using the existing contractual details, including contract terms, length and
-      agreed pricing.
-    </p>
-    <p>
-      Provisional licences for all schools under <strong><%= original.name %></strong> will be added
-      by default (see option below). Additional schools can be added later.
-    </p>
-  <% elsif contract.new_record? && contract.contract_holder.present? %>
-    <p>
-      Create a new contract for <strong><%= contract.contract_holder.name %></strong>.
-    </p>
-  <% elsif contract.persisted? && contract.licences.invoiced.exists? %>
-    <p>
-      One or more licences associated with this contract have already been invoiced. Only limited changes can now
-      be made the contract itself.
-    </p>
-  <% elsif contract.persisted? %>
-    <p>
-      Any changes made to the start and end dates for this contract will be automatically applied to all licences,
-      overwriting any existing licence dates.
-    </p>
-  <% end %>
-</div>
+    <% if local_assigns[:original].present? %>
+      <%= render PromptComponent.new icon: 'circle-info', status: :neutral do %>
+        <p>
+          Creating a new contract for <strong><%= contract.contract_holder.name %></strong> based on
+          <strong><%= original.name %></strong>.
+          The form has been populated using the existing contractual details, including contract terms, length and
+          agreed pricing.
+        </p>
+        <p>
+          Provisional licences for all schools under <strong><%= original.name %></strong> will be added
+          by default (see option below). Additional schools can be added later.
+        </p>
+      <% end %>
+    <% elsif contract.new_record? && contract.contract_holder.present? %>
+      <p>
+        Create a new contract for <strong><%= contract.contract_holder.name %></strong>.
+      </p>
+    <% elsif contract.persisted? && contract.licences.invoiced.exists? %>
+      <%= render PromptComponent.new icon: 'circle-info', status: :neutral do %>
+        <p>
+          One or more licences associated with this contract have already been invoiced. Only limited changes can now
+          be made the contract itself.
+        </p>
+      <% end %>
+    <% elsif contract.persisted? %>
+      <%= render PromptComponent.new icon: 'circle-info', status: :negative do %>
+        <p>
+          Any changes made to the start and end dates for this contract will be automatically applied to any
+          licences that have not yet been invoiced, overwriting any existing licence dates.
+        </p>
+      <% end %>
+    <% end %>
+  </div>
 </div>
 
 <div class="row">

--- a/app/views/admin/commercial/contracts/_form.html.erb
+++ b/app/views/admin/commercial/contracts/_form.html.erb
@@ -43,8 +43,8 @@
     <% elsif contract.persisted? %>
       <%= render PromptComponent.new icon: 'circle-info', status: :negative do %>
         <p>
-          Any changes made to the start and end dates for this contract will be automatically applied to any
-          licences that have not yet been invoiced, overwriting any existing licence dates.
+          Any changes made to the start and end dates for this contract will be automatically applied to any licences
+          that have not yet been invoiced, overwriting any existing licence dates.
         </p>
       <% end %>
     <% end %>
@@ -101,17 +101,10 @@
                     collection: collection_from_enum(Commercial::Contract.statuses),
                     include_blank: false
           end %>
-      <%= if contract.editable_attribute?(:invoice_terms)
-            f.input :invoice_terms,
-                    collection: collection_from_enum(Commercial::Contract.invoice_terms),
-                    include_blank: false
-          end %>
-      <%= if contract.editable_attribute?(:licence_period)
-            f.input :licence_period,
-                    collection: collection_from_enum(Commercial::Contract.licence_periods),
-                    include_blank: false
-          end %>
-      <%= f.input :licence_years if contract.editable_attribute?(:licence_years) %>
+
+      <%= f.input :invoice_terms, as: :hidden %>
+      <%= f.input :licence_period, as: :hidden %>
+      <%= f.input :licence_years if contract.custom? && contract.editable_attribute?(:licence_years) %>
 
       <% if local_assigns[:original].present? %>
         <div class="form-group">

--- a/app/views/admin/commercial/contracts/_form.html.erb
+++ b/app/views/admin/commercial/contracts/_form.html.erb
@@ -43,8 +43,8 @@
     <% elsif contract.persisted? %>
       <%= render PromptComponent.new icon: 'circle-info', status: :negative do %>
         <p>
-          Any changes made to the start and end dates for this contract will be automatically applied to any licences
-          that have not yet been invoiced, overwriting any existing licence dates.
+          Any changes made to the start and end dates or licence years fields for this contract will be
+          automatically applied to any licences that have not yet been invoiced, overwriting any existing licence dates.
         </p>
       <% end %>
     <% end %>
@@ -63,7 +63,7 @@
       <%= f.input :name %>
       <%= f.input :comments %>
 
-      <% if contract.editable_attribute?(:product) %>
+      <% if contract.editable_attribute?(:product_id) %>
         <%= f.input :product_id,
                     collection: Commercial::Product.with_default_first,
                     include_blank: false %>
@@ -72,7 +72,7 @@
       <% if contract.contract_holder.present? %>
         <%= f.input :contract_holder_type, as: :hidden %>
         <%= f.input :contract_holder_id, as: :hidden %>
-      <% elsif contract.editable_attribute?(:contract_holder) %>
+      <% elsif contract.editable_attribute?(:contract_holder_id) %>
         <%= f.input :contract_holder_type,
                     as: :radio_buttons,
                     collection: Commercial::HasContractHolder::ALLOWED_HOLDERS.map(&:name).sort,
@@ -110,11 +110,12 @@
         <div class="form-group">
           <div class="form-check">
             <%= hidden_field_tag :original_contract_id, original.id %>
-            <%= check_box_tag 'renew_licences', '1', true, class: 'form-check-input' %>
+            <%= f.check_box :renew_licences, class: 'form-check-input' %>
 
-            <%= label_tag 'renew_licences',
-                          'Automatically add licences for all schools associated with the original contract?',
-                          class: 'form-check-label' %>
+            <%= f.label :renew_licences,
+                        'Automatically add licences for all schools associated with the original contract?',
+                        class: 'form-check-label' %>
+
           </div>
         </div>
       <% end %>

--- a/app/views/admin/commercial/contracts/_form.html.erb
+++ b/app/views/admin/commercial/contracts/_form.html.erb
@@ -105,20 +105,22 @@
       <%= f.input :invoice_terms, as: :hidden %>
       <%= f.input :licence_period, as: :hidden %>
       <%= f.input :licence_years if contract.custom? && contract.editable_attribute?(:licence_years) %>
+      <%= hidden_field_tag :original_contract_id, original.id if local_assigns[:original].present? %>
 
-      <% if local_assigns[:original].present? %>
-        <div class="form-group">
-          <div class="form-check">
-            <%= hidden_field_tag :original_contract_id, original.id %>
-            <%= f.check_box :renew_licences, class: 'form-check-input' %>
+      <div class="form-group">
+        <div class="form-check">
+          <%= f.check_box :update_licences, class: 'form-check-input' %>
 
-            <%= f.label :renew_licences,
-                        'Automatically add licences for all schools associated with the original contract?',
-                        class: 'form-check-label' %>
+          <% if local_assigns[:original].present? %>
+            <% label = 'Automatically add licences for all schools associated with the original contract?' %>
+          <% else %>
+            <% label = 'Automatically update existing licences based on changes?' %>
+          <% end %>
 
-          </div>
+          <%= f.label :update_licences, label, class: 'form-check-label' %>
+
         </div>
-      <% end %>
+      </div>
 
       <%= f.submit 'Save', class: 'btn btn-primary' %>
       <%= link_to 'Cancel', all_contracts_path, class: 'btn' %>

--- a/app/views/admin/commercial/contracts/_form.html.erb
+++ b/app/views/admin/commercial/contracts/_form.html.erb
@@ -21,30 +21,17 @@
         <p>
           Creating a new contract for <strong><%= contract.contract_holder.name %></strong> based on
           <strong><%= original.name %></strong>.
+        </p>
+        <p>
           The form has been populated using the existing contractual details, including contract terms, length and
           agreed pricing.
         </p>
-        <p>
-          Provisional licences for all schools under <strong><%= original.name %></strong> will be added
-          by default (see option below). Additional schools can be added later.
-        </p>
       <% end %>
-    <% elsif contract.new_record? && contract.contract_holder.present? %>
-      <p>
-        Create a new contract for <strong><%= contract.contract_holder.name %></strong>.
-      </p>
-    <% elsif contract.persisted? && contract.licences.invoiced.exists? %>
+    <% elsif contract.persisted? && contract.invoiced? %>
       <%= render PromptComponent.new icon: 'circle-info', status: :neutral do %>
         <p>
           One or more licences associated with this contract have already been invoiced. Only limited changes can now
           be made the contract itself.
-        </p>
-      <% end %>
-    <% elsif contract.persisted? %>
-      <%= render PromptComponent.new icon: 'circle-info', status: :negative do %>
-        <p>
-          Any changes made to the start and end dates or licence years fields for this contract will be
-          automatically applied to any licences that have not yet been invoiced, overwriting any existing licence dates.
         </p>
       <% end %>
     <% end %>
@@ -60,66 +47,100 @@
              end %>
     <%= simple_form_for(contract, as: :contract, url: url) do |f| %>
       <%= render 'shared/errors', subject: contract, subject_name: 'contract' %>
-      <%= f.input :name %>
-      <%= f.input :comments %>
 
-      <% if contract.editable_attribute?(:product_id) %>
-        <%= f.input :product_id,
-                    collection: Commercial::Product.with_default_first,
-                    include_blank: false %>
-      <% end %>
-
-      <% if contract.contract_holder.present? %>
-        <%= f.input :contract_holder_type, as: :hidden %>
-        <%= f.input :contract_holder_id, as: :hidden %>
-      <% elsif contract.editable_attribute?(:contract_holder_id) %>
-        <%= f.input :contract_holder_type,
-                    as: :radio_buttons,
-                    collection: Commercial::HasContractHolder::ALLOWED_HOLDERS.map(&:name).sort,
-                    include_blank: false,
-                    input_html: { class: 'contract-holder-type' } %>
-
-        <%= f.input :contract_holder_id,
-                    collection: [],
-                    include_blank: true,
-                    input_html: {
-                      class: 'contract-holder-select',
-                      data: { selected_id: contract.contract_holder_id }
-                    } %>
-      <% end %>
-
-      <%= f.input :number_of_schools if contract.editable_attribute?(:number_of_schools) %>
-      <%= f.input :purchase_order_number if contract.editable_attribute?(:purchase_order_number) %>
-
-      <%= f.input :start_date, as: :tempus_dominus_date if contract.editable_attribute?(:start_date) %>
-      <%= f.input :end_date, as: :tempus_dominus_date if contract.editable_attribute?(:end_date) %>
-
-      <%= f.input :agreed_school_price if contract.editable_attribute?(:agreed_school_price) %>
-
-      <%= if contract.editable_attribute?(:status)
-            f.input :status,
-                    collection: collection_from_enum(Commercial::Contract.statuses),
-                    include_blank: false
-          end %>
-
-      <%= f.input :invoice_terms, as: :hidden %>
-      <%= f.input :licence_period, as: :hidden %>
-      <%= f.input :licence_years if contract.custom? && contract.editable_attribute?(:licence_years) %>
       <%= hidden_field_tag :original_contract_id, original.id if local_assigns[:original].present? %>
 
-      <div class="form-group">
-        <div class="form-check">
-          <%= f.check_box :update_licences, class: 'form-check-input' %>
+      <div class="col-12 mb-4 bg-light rounded-2 pb-3">
+        <h3>Basic information</h3>
+        <%= f.input :name %>
+        <%= f.input :comments %>
+      </div>
 
+      <div class="col-12 mb-4 bg-light rounded-2 pb-3">
+        <h3>Commercial information</h3>
+        <% if contract.editable_attribute?(:product_id) %>
+          <%= f.input :product_id,
+                      collection: Commercial::Product.with_default_first,
+                      include_blank: false %>
+        <% end %>
+
+        <% if contract.contract_holder.present? %>
+          <%= f.input :contract_holder_type, as: :hidden %>
+          <%= f.input :contract_holder_id, as: :hidden %>
+        <% elsif contract.editable_attribute?(:contract_holder_id) %>
+          <%= f.input :contract_holder_type,
+                      as: :radio_buttons,
+                      collection: Commercial::HasContractHolder::ALLOWED_HOLDERS.map(&:name).sort,
+                      include_blank: false,
+                      input_html: { class: 'contract-holder-type' } %>
+
+          <%= f.input :contract_holder_id,
+                      collection: [],
+                      include_blank: true,
+                      input_html: {
+                        class: 'contract-holder-select',
+                        data: { selected_id: contract.contract_holder_id }
+                      } %>
+        <% end %>
+
+        <%= f.input :agreed_school_price if contract.editable_attribute?(:agreed_school_price) %>
+        <%= f.input :number_of_schools if contract.editable_attribute?(:number_of_schools) %>
+        <%= if contract.editable_attribute?(:status)
+              f.input :status,
+                      collection: collection_from_enum(Commercial::Contract.statuses),
+                      include_blank: false
+            end %>
+      </div>
+
+      <% unless contract.invoiced? %>
+        <div class="col-12 mb-4 bg-light rounded-2 pb-3">
+          <h3>Contract and licence terms</h3>
           <% if local_assigns[:original].present? %>
-            <% label = 'Automatically add licences for all schools associated with the original contract?' %>
-          <% else %>
-            <% label = 'Automatically update existing licences based on changes?' %>
+            <%= render PromptComponent.new icon: 'circle-info', status: :neutral do %>
+              <p>
+                Provisional licences for all schools under <strong><%= original.name %></strong> will be added
+                by default if the below option is checked. Additional schools can be added later.
+              </p>
+            <% end %>
+          <% end %>
+          <% if contract.persisted? %>
+            <%= render PromptComponent.new icon: 'circle-info', status: :negative do %>
+              <p>
+                Any changes made to the start and end dates or licence years fields for this contract will be
+                applied to any licences that have not yet been invoiced, if the below option is checked.
+              </p>
+              <p>
+                This will overwrite any existing licence dates.
+              </p>
+            <% end %>
           <% end %>
 
-          <%= f.label :update_licences, label, class: 'form-check-label' %>
+          <%= f.input :start_date, as: :tempus_dominus_date if contract.editable_attribute?(:start_date) %>
+          <%= f.input :end_date, as: :tempus_dominus_date if contract.editable_attribute?(:end_date) %>
 
+          <%= f.input :invoice_terms, as: :hidden %>
+          <%= f.input :licence_period, as: :hidden %>
+          <%= f.input :licence_years if contract.custom? && contract.editable_attribute?(:licence_years) %>
+
+          <div class="form-group">
+            <div class="form-check">
+              <%= f.check_box :update_licences, class: 'form-check-input' %>
+
+              <% if local_assigns[:original].present? %>
+                <% label = 'Automatically add licences for all schools associated with the original contract?' %>
+              <% else %>
+                <% label = 'Automatically update existing licences based on changes?' %>
+              <% end %>
+
+              <%= f.label :update_licences, label, class: 'form-check-label' %>
+            </div>
+          </div>
         </div>
+      <% end %>
+
+      <div class="col-12 mb-4 bg-light rounded-2 pb-3">
+        <h3>Invoicing</h3>
+        <%= f.input :purchase_order_number if contract.editable_attribute?(:purchase_order_number) %>
       </div>
 
       <%= f.submit 'Save', class: 'btn btn-primary' %>

--- a/app/views/admin/commercial/contracts/choose.html.erb
+++ b/app/views/admin/commercial/contracts/choose.html.erb
@@ -4,78 +4,74 @@
 <% end %>
 
 <div class="row">
-    <div class="col">
-        <h3>
-            Standard Contract
-        </h3>
-        <div id="standard" class="p-4 bg-grey-pale rounded">
-            <h4>
-                Full invoicing option
-            </h4>
-            <p>
-                All licences for the contract will have the same start and end dates as the contract.
-            </p>
-            <p>
-                The contract can have any length, e.g. 3 months, 1 year, 3 years, defined by its start and end date.
-            </p>
-            <p>
-                The system will scale the annual prices defined in the contract (and its product), as needed.
-            </p>
-            <p>
-                The contract holder will always be charged the full amount for each school regardless of when they
-                onboard / are added to the contract.
-            </p>
-            <%= link_to 'Create this type of contract',
-                        new_admin_commercial_contract_path(params: @chosen_params.merge(chosen_type: :standard)),
-                        class: 'btn btn-sm' %>
-        </div>
-        <div id="pro-rata" class="mt-4 p-4 bg-grey-pale rounded">
-            <h4>Pro Rata invoicing option</h4>
-            <p>
-                This option changes how licences are created.
-            </p>
-            <p>
-                When the pro rata option is created, any schools added to the contract after invoicing has begun will
-                have their licence begin on that day (e.g. day of onboarding). The licences will end on the contract end
-                date.
-            </p>
-            <p>
-                This allows contract holders to be charged for just the part of the contract period for those schools that
-                join late in the contract.
-            </p>
-            <p>
-                As above, the contract can have any length. Pricing will be prorated within the length of the contract
-            </p>
-            <%= link_to 'Create this type of contract',
-                        new_admin_commercial_contract_path(params: @chosen_params.merge(chosen_type: 'pro-rata')),
-                        class: 'btn btn-sm' %>
-        </div>
+  <div class="col">
+    <h3>Standard Contract</h3>
+    <div id="standard" class="p-4 bg-grey-pale rounded">
+      <h4>Full invoicing option</h4>
+      <p>
+        All licences for the contract will have the same start and end dates as the contract.
+      </p>
+      <p>
+        The contract can have any length, e.g. 3 months, 1 year, 3 years, defined by its start and end date.
+      </p>
+      <p>
+        The system will scale the annual prices defined in the contract (and its product), as needed.
+      </p>
+      <p>
+        The contract holder will always be charged the full amount for each school regardless of when they
+        onboard / are added to the contract.
+      </p>
+      <%= link_to 'Create this type of contract',
+                  new_admin_commercial_contract_path(params: @chosen_params.merge(chosen_type: :standard)),
+                  class: 'btn btn-sm' %>
     </div>
+    <div id="pro-rata" class="mt-4 p-4 bg-grey-pale rounded">
+      <h4>Pro Rata invoicing option</h4>
+      <p>
+        This option changes how licences are created.
+      </p>
+      <p>
+        When the pro rata option is created, any schools added to the contract after invoicing has begun will
+        have their licence begin on that day (e.g. day of onboarding). The licences will end on the contract end
+        date.
+      </p>
+      <p>
+        This allows contract holders to be charged for just the part of the contract period for those schools that
+        join late in the contract.
+      </p>
+      <p>
+        As above, the contract can have any length. Pricing will be prorated within the length of the contract
+      </p>
+      <%= link_to 'Create this type of contract',
+                  new_admin_commercial_contract_path(params: @chosen_params.merge(chosen_type: 'pro-rata')),
+                  class: 'btn btn-sm' %>
+    </div>
+  </div>
 </div>
 
 <div class="row mt-4">
-    <div class="col">
-        <h3>Custom Contract</h3>
-        <div id="custom" class="mt-4 p-4 bg-grey-pale rounded">
-            <p>
-                All licences for this contract type will have their own start and end dates.
-            </p>
-            <p>
-                Licences will start from when a school is added to the contract and run for a number of "licence years".
-            </p>
-            <p>
-                Licences will have their own date ranges and may extend beyond the date of the contract.
-            </p>
-            <p>
-                Licence years can be any length (e.g. 1, 2, 3 years) and may be fractional (e.g. 1.2, 1.5 years).
-            </p>
-            <p>
-                The system will scale the annual prices defined in the contract (and its product), as needed for the
-                length of the licensed period.
-            </p>
-            <%= link_to 'Create this type of contract',
-                        new_admin_commercial_contract_path(params: @chosen_params.merge(chosen_type: :custom)),
-                        class: 'btn btn-sm' %>
-        </div>
+  <div class="col">
+    <h3>Custom Contract</h3>
+    <div id="custom" class="mt-4 p-4 bg-grey-pale rounded">
+      <p>
+        All licences for this contract type will have their own start and end dates.
+      </p>
+      <p>
+        Licences will start from when a school is added to the contract and run for a number of "licence years".
+      </p>
+      <p>
+        Licences will have their own date ranges and may extend beyond the date of the contract.
+      </p>
+      <p>
+        Licence years can be any length (e.g. 1, 2, 3 years) and may be fractional (e.g. 1.2, 1.5 years).
+      </p>
+      <p>
+        The system will scale the annual prices defined in the contract (and its product), as needed for the
+        length of the licensed period.
+      </p>
+      <%= link_to 'Create this type of contract',
+                  new_admin_commercial_contract_path(params: @chosen_params.merge(chosen_type: :custom)),
+                  class: 'btn btn-sm' %>
     </div>
+  </div>
 </div>

--- a/app/views/admin/commercial/contracts/choose.html.erb
+++ b/app/views/admin/commercial/contracts/choose.html.erb
@@ -1,0 +1,81 @@
+<%= render Admin::HeaderNavComponent.new do |header_nav| %>
+  <% header_nav.with_header title: 'Choose Contract Type' %>
+  <% header_nav.with_button 'Contracts & Licensing', admin_commercial_path %>
+<% end %>
+
+<div class="row">
+    <div class="col">
+        <h3>
+            Standard Contract
+        </h3>
+        <div id="standard" class="p-4 bg-grey-pale rounded">
+            <h4>
+                Full invoicing option
+            </h4>
+            <p>
+                All licences for the contract will have the same start and end dates as the contract.
+            </p>
+            <p>
+                The contract can have any length, e.g. 3 months, 1 year, 3 years, defined by its start and end date.
+            </p>
+            <p>
+                The system will scale the annual prices defined in the contract (and its product), as needed.
+            </p>
+            <p>
+                The contract holder will always be charged the full amount for each school regardless of when they
+                onboard / are added to the contract.
+            </p>
+            <%= link_to 'Create this type of contract',
+                        new_admin_commercial_contract_path(params: @chosen_params.merge(chosen_type: :standard)),
+                        class: 'btn btn-sm' %>
+        </div>
+        <div id="pro-rata" class="mt-4 p-4 bg-grey-pale rounded">
+            <h4>Pro Rata invoicing option</h4>
+            <p>
+                This option changes how licences are created.
+            </p>
+            <p>
+                When the pro rata option is created, any schools added to the contract after invoicing has begun will
+                have their licence begin on that day (e.g. day of onboarding). The licences will end on the contract end
+                date.
+            </p>
+            <p>
+                This allows contract holders to be charged for just the part of the contract period for those schools that
+                join late in the contract.
+            </p>
+            <p>
+                As above, the contract can have any length. Pricing will be prorated within the length of the contract
+            </p>
+            <%= link_to 'Create this type of contract',
+                        new_admin_commercial_contract_path(params: @chosen_params.merge(chosen_type: 'pro-rata')),
+                        class: 'btn btn-sm' %>
+        </div>
+    </div>
+</div>
+
+<div class="row mt-4">
+    <div class="col">
+        <h3>Custom Contract</h3>
+        <div id="custom" class="mt-4 p-4 bg-grey-pale rounded">
+            <p>
+                All licences for this contract type will have their own start and end dates.
+            </p>
+            <p>
+                Licences will start from when a school is added to the contract and run for a number of "licence years".
+            </p>
+            <p>
+                Licences will have their own date ranges and may extend beyond the date of the contract.
+            </p>
+            <p>
+                Licence years can be any length (e.g. 1, 2, 3 years) and may be fractional (e.g. 1.2, 1.5 years).
+            </p>
+            <p>
+                The system will scale the annual prices defined in the contract (and its product), as needed for the
+                length of the licensed period.
+            </p>
+            <%= link_to 'Create this type of contract',
+                        new_admin_commercial_contract_path(params: @chosen_params.merge(chosen_type: :custom)),
+                        class: 'btn btn-sm' %>
+        </div>
+    </div>
+</div>

--- a/app/views/admin/commercial/contracts/licences/edit.html.erb
+++ b/app/views/admin/commercial/contracts/licences/edit.html.erb
@@ -13,7 +13,7 @@
       <strong>Note</strong> to make bulk changes to all licences, e.g. revising all start/end dates or marking them all as confirmed, then please
       <%= link_to 'edit the contract instead', edit_admin_commercial_contract_path(@contract) %>. This is simpler than changing all fields
       individually. This form is primarily intended to allow quick editing of school specific pricing and comments, addition and removal of
-      licences, etc
+      licences, etc.
     </p>
   </div>
 </div>

--- a/app/views/admin/commercial/contracts/new.html.erb
+++ b/app/views/admin/commercial/contracts/new.html.erb
@@ -1,4 +1,4 @@
 <%= render 'form',
            contract: @contract,
            original: @original,
-           title: @original.present? ? 'Create renewed contract' : 'Create new contract' %>
+           title: @title %>

--- a/app/views/admin/commercial/licences/_form.html.erb
+++ b/app/views/admin/commercial/licences/_form.html.erb
@@ -14,6 +14,12 @@
       <p>Create a new licence under the <strong><%= contract.name %></strong> contract.</p>
     </div>
   </div>
+<% elsif licence.invoiced? %>
+    <%= render PromptComponent.new icon: 'circle-info', status: :neutral do %>
+      <p>
+        This licence has been invoiced. Only limited changes can now be made
+      </p>
+    <% end %>
 <% elsif licence.persisted? %>
   <div class="row">
     <div class="col">
@@ -31,42 +37,68 @@
              end %>
     <%= simple_form_for(licence, as: :licence, url: url) do |f| %>
       <%= render 'shared/errors', subject: licence, subject_name: 'licence' %>
-      <% if local_assigns[:contract].present? %>
-        <%= f.input :contract_id, as: :hidden %>
-      <% else %>
-        <%= f.input :contract_id,
-                    collection: Commercial::Contract.all.by_name,
-                    include_blank: false,
-                    input_html: { class: 'select2' } %>
-      <% end %>
-      <% if licence.new_record? %>
-        <%= f.input :school_id,
-                    collection: School.visible.by_name,
-                    include_blank: false,
-                    input_html: { class: 'select2' } %>
-      <% else %>
-        <%= f.input :school_id, as: :hidden %>
-      <% end %>
-      <%= f.input :status, collection: collection_from_enum(Commercial::Licence.statuses), include_blank: false %>
 
-      <% if licence.dates_will_automatically_change? %>
-        <p>
-          The following dates will be automatically revised once the school becomes data visible to run for
-          <%= licence.contract.licence_years %> years from that day. Changes made here will be overwritten.
-        </p>
-      <% elsif licence.new_record? %>
-        <p>
-          Leave date fields empty to automatically create a licence starting from today and ending according to the
-          period defined in the contract.
-        </p>
+      <div class="col-12 mb-4 bg-light rounded-2 pb-3">
+        <h3>Basic information</h3>
+        <% if licence.new_record? %>
+          <%= f.input :school_id,
+                      collection: School.visible.by_name,
+                      include_blank: false,
+                      input_html: { class: 'select2' } %>
+        <% else %>
+          <%= f.input :school_id, as: :hidden %>
+        <% end %>
+
+        <%= f.input :comments %>
+      </div>
+
+      <% unless licence.invoiced? %>
+        <div class="col-12 mb-4 bg-light rounded-2 pb-3">
+          <h3>Commercial information</h3>
+          <% if local_assigns[:contract].present? %>
+            <%= f.input :contract_id, as: :hidden %>
+          <% else %>
+            <%= f.input :contract_id,
+                        collection: Commercial::Contract.all.by_name,
+                        include_blank: false,
+                        input_html: { class: 'select2' } %>
+          <% end %>
+          <%= f.input :school_specific_price %>
+          <%= f.input :status, collection: collection_from_enum(Commercial::Licence.statuses), include_blank: false %>
+        </div>
+
+        <div class="col-12 mb-4 bg-light rounded-2 pb-3">
+          <h3>Licence dates</h3>
+            <% if local_assigns[:contract].present? && licence.new_record? %>
+              <%= render PromptComponent.new icon: 'circle-info', status: :neutral do %>
+                <p>
+                  Leave the following fields blank to automatically populate the licence according to the terms of
+                  the <%= contract.name %> contract.
+                </p>
+              <% end %>
+            <% elsif licence.dates_will_automatically_change? %>
+              <%= render PromptComponent.new icon: 'circle-info', status: :neutral do %>
+                <p>
+                  The following dates will be automatically revised by the system once the school becomes data
+                  visible to run for <%= licence.contract.licence_years %> years from that day.
+                  Any changes made here will then be overwritten.
+                </p>
+              <% end %>
+            <% elsif licence.new_record? %>
+              <p>
+                Leave the following fields blank to automatically populate the licence for the period defined in the contract.
+              </p>
+            <% end %>
+
+            <%= f.input :start_date, as: :tempus_dominus_date %>
+            <%= f.input :end_date, as: :tempus_dominus_date %>
+        </div>
       <% end %>
 
-      <%= f.input :start_date, as: :tempus_dominus_date %>
-      <%= f.input :end_date, as: :tempus_dominus_date %>
-
-      <%= f.input :school_specific_price %>
-      <%= f.input :invoice_reference %>
-      <%= f.input :comments %>
+      <div class="col-12 mb-4 bg-light rounded-2 pb-3">
+        <h3>Invoicing information</h3>
+        <%= f.input :invoice_reference %>
+      </div>
 
       <%= f.submit 'Save', class: 'btn btn-primary' %>
       <%= link_to 'Cancel', admin_commercial_licences_path, class: 'btn' %>

--- a/app/views/admin/commercial/licences/show.html.erb
+++ b/app/views/admin/commercial/licences/show.html.erb
@@ -1,6 +1,6 @@
 <%= render Admin::HeaderNavComponent.new do |header_nav| %>
   <% header_nav.with_header title: @licence.school.name.to_s %>
-  <% header_nav.with_button 'All licences', admin_commercial_licences_path %>
+  <% header_nav.with_button 'All licences', polymorphic_path([:admin, @licence.contract]) %>
 <% end %>
 
 <div class="row">

--- a/app/views/admin/commercial/show.html.erb
+++ b/app/views/admin/commercial/show.html.erb
@@ -26,7 +26,7 @@
                 <li><%= link_to 'Funder allocation report', admin_reports_funder_allocations_path %></li>
             </ul>
             <div class="mt-auto text-end">
-                <%= link_to 'New contract', new_admin_commercial_contract_path,
+                <%= link_to 'New contract', choose_admin_commercial_contracts_path,
                             class: 'btn btn-sm btn-secondary' %>
             </div>
         </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -637,6 +637,7 @@ Rails.application.routes.draw do
     namespace :commercial do
       resources :contracts do
         get :contract_holder_options, on: :collection
+        get :choose, on: :collection
         resources :licences, controller: "contracts/licences" do
           collection do
             get :edit

--- a/spec/components/commercial/contracts_component_spec.rb
+++ b/spec/components/commercial/contracts_component_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Commercial::ContractsComponent, :include_application_helper, :inc
       classes: 'extra-classes',
       show_actions: false
     ) do |c|
-      c.with_header { 'Current Contracts'}
+      c.with_header { 'Current Contracts' }
     end
   end
 
@@ -24,13 +24,14 @@ RSpec.describe Commercial::ContractsComponent, :include_application_helper, :inc
   end
 
   context 'when rendering' do
-    it { expect(page).to have_content('Current Contracts') }
+    it { expect(page).to have_text('Current Contracts') }
 
     it_behaves_like 'it contains the expected data table', sortable: false, aligned: false do
       let(:table_id) { '#contracts-table' }
       let(:expected_header) do
         [
-          ['Name', 'Contract Holder', 'Product', 'Start Date', 'End Date', 'Number of Schools', 'Licensed Schools', 'Status']
+          ['Name', 'Contract Holder', 'Product', 'Period', 'Terms', 'Start Date', 'End Date', 'Number of Schools', 'Licensed Schools',
+           'Status']
         ]
       end
       let(:expected_rows) do
@@ -39,6 +40,8 @@ RSpec.describe Commercial::ContractsComponent, :include_application_helper, :inc
             contract.name,
             contract.contract_holder.name,
             contract.product.name,
+            contract.licence_period.humanize,
+            contract.invoice_terms.humanize,
             contract.start_date.to_fs(:es_short),
             contract.end_date.to_fs(:es_short),
             contract.number_of_schools.to_s,
@@ -64,7 +67,8 @@ RSpec.describe Commercial::ContractsComponent, :include_application_helper, :inc
         let(:table_id) { '#contracts-table' }
         let(:expected_header) do
           [
-            ['Name', 'Product', 'Start Date', 'End Date', 'Number of Schools', 'Licensed Schools', 'Status']
+            ['Name', 'Product', 'Period', 'Terms', 'Start Date', 'End Date', 'Number of Schools', 'Licensed Schools',
+             'Status']
           ]
         end
         let(:expected_rows) do
@@ -72,6 +76,8 @@ RSpec.describe Commercial::ContractsComponent, :include_application_helper, :inc
             [
               contract.name,
               contract.product.name,
+              contract.licence_period.humanize,
+              contract.invoice_terms.humanize,
               contract.start_date.to_fs(:es_short),
               contract.end_date.to_fs(:es_short),
               contract.number_of_schools.to_s,

--- a/spec/components/forms/commercial/bulk_licence_editor_component_spec.rb
+++ b/spec/components/forms/commercial/bulk_licence_editor_component_spec.rb
@@ -109,6 +109,22 @@ RSpec.describe Forms::Commercial::BulkLicenceEditorComponent, :include_applicati
           expect(main).to have_field(field_name(licence, :invoice_reference),
                                      with: 'INV-001')
         end
+
+        context 'with an invoiced licence' do # rubocop:disable RSpec/NestedGroups
+          let!(:licence) do
+            create(:commercial_licence,
+                   contract:,
+                   status: :invoiced)
+          end
+
+          it 'disables some of the fields' do
+            expect(main).to have_field(field_name(licence, :start_date), disabled: true)
+            expect(main).to have_field(field_name(licence, :end_date), disabled: true)
+            expect(main).to have_select(field_name(licence, :status), disabled: true)
+            expect(main).to have_field(field_name(licence, :school_specific_price), disabled: true)
+            expect(main).to have_field(field_name(licence, :invoice_reference), disabled: false)
+          end
+        end
       end
 
       context 'when populating the comments row' do
@@ -117,6 +133,18 @@ RSpec.describe Forms::Commercial::BulkLicenceEditorComponent, :include_applicati
         it 'renders the comments' do
           expect(comments).to have_field(field_name(licence, :comments),
                                          with: 'Some comments')
+        end
+
+        context 'with an invoiced licence' do # rubocop:disable RSpec/NestedGroups
+          let!(:licence) do
+            create(:commercial_licence,
+                   contract:,
+                   status: :invoiced)
+          end
+
+          it 'allows comments to be edited' do
+            expect(comments).to have_field(field_name(licence, :comments), disabled: false)
+          end
         end
       end
 
@@ -162,7 +190,7 @@ RSpec.describe Forms::Commercial::BulkLicenceEditorComponent, :include_applicati
       let!(:licence) { create(:commercial_licence, contract:, school:) }
 
       context 'when there are no additional schools' do
-        it { expect(page).to have_no_content('Add schools to contract') }
+        it { expect(page).to have_no_text('Add schools to contract') }
       end
 
       context 'when there are schools to show' do
@@ -170,7 +198,7 @@ RSpec.describe Forms::Commercial::BulkLicenceEditorComponent, :include_applicati
 
         let(:additional_schools) { [additional_school] }
 
-        it { expect(page).to have_content('Add schools to contract') }
+        it { expect(page).to have_text('Add schools to contract') }
 
         it_behaves_like 'it contains the expected data table', sortable: true, aligned: false do
           let(:table_id) { "#contract-#{contract.id}-additional-schools-table" }

--- a/spec/models/commercial/contract_spec.rb
+++ b/spec/models/commercial/contract_spec.rb
@@ -62,9 +62,9 @@ describe Commercial::Contract do
         end
 
         it 'prevents editing fields that are never editable' do
-          contract.product = create(:commercial_product)
+          contract.contract_holder = create(:funder)
           expect(contract).not_to be_valid
-          expect(contract.errors[:product_id]).to include(
+          expect(contract.errors[:contract_holder_id]).to include(
             'cannot be changed once the contract is in its current state'
           )
         end
@@ -114,8 +114,9 @@ describe Commercial::Contract do
       subject(:contract) { create(:commercial_contract, status: :provisional) }
 
       it 'has the expected fields' do
-        expect(contract.editable_attributes).to contain_exactly(:agreed_school_price, :comments, :end_date, :name,
-                                                                :number_of_schools, :purchase_order_number,
+        expect(contract.editable_attributes).to contain_exactly(:agreed_school_price, :comments, :end_date,
+                                                                :name, :number_of_schools,
+                                                                :product_id, :purchase_order_number,
                                                                 :start_date, :status, :updated_by_id)
       end
 
@@ -123,8 +124,9 @@ describe Commercial::Contract do
         subject(:contract) { create(:commercial_contract, status: :confirmed) }
 
         it 'has the expected fields' do
-          expect(contract.editable_attributes).to contain_exactly(:agreed_school_price, :comments, :end_date, :name,
-                                                                  :number_of_schools, :purchase_order_number,
+          expect(contract.editable_attributes).to contain_exactly(:agreed_school_price, :comments, :end_date,
+                                                                  :name, :number_of_schools,
+                                                                  :product_id, :purchase_order_number,
                                                                   :start_date, :updated_by_id)
         end
       end
@@ -146,8 +148,8 @@ describe Commercial::Contract do
 
       it 'has the expected fields' do
         expect(contract.editable_attributes).to contain_exactly(:agreed_school_price, :comments, :end_date,
-                                                                :licence_years, :name,
-                                                                :number_of_schools, :purchase_order_number,
+                                                                :licence_years, :name, :number_of_schools,
+                                                                :product_id, :purchase_order_number,
                                                                 :start_date, :status, :updated_by_id)
       end
 
@@ -156,8 +158,8 @@ describe Commercial::Contract do
 
         it 'has the expected fields' do
           expect(contract.editable_attributes).to contain_exactly(:agreed_school_price, :comments, :end_date,
-                                                                  :licence_years, :name,
-                                                                  :number_of_schools, :purchase_order_number,
+                                                                  :licence_years, :name, :number_of_schools,
+                                                                  :product_id, :purchase_order_number,
                                                                   :start_date, :updated_by_id)
         end
       end

--- a/spec/models/commercial/contract_spec.rb
+++ b/spec/models/commercial/contract_spec.rb
@@ -110,32 +110,67 @@ describe Commercial::Contract do
   end
 
   describe '#editable_fields' do
-    subject(:contract) { create(:commercial_contract, status: :provisional) }
-
-    it 'has the expected fields' do
-      expect(contract.editable_attributes).to contain_exactly(:agreed_school_price, :comments, :end_date, :name,
-                                                              :number_of_schools, :purchase_order_number,
-                                                              :start_date, :status, :updated_by_id)
-    end
-
-    context 'when confirmed' do
-      subject(:contract) { create(:commercial_contract, status: :confirmed) }
+    context 'with standard contract' do
+      subject(:contract) { create(:commercial_contract, status: :provisional) }
 
       it 'has the expected fields' do
         expect(contract.editable_attributes).to contain_exactly(:agreed_school_price, :comments, :end_date, :name,
                                                                 :number_of_schools, :purchase_order_number,
-                                                                :start_date, :updated_by_id)
+                                                                :start_date, :status, :updated_by_id)
+      end
+
+      context 'when confirmed' do
+        subject(:contract) { create(:commercial_contract, status: :confirmed) }
+
+        it 'has the expected fields' do
+          expect(contract.editable_attributes).to contain_exactly(:agreed_school_price, :comments, :end_date, :name,
+                                                                  :number_of_schools, :purchase_order_number,
+                                                                  :start_date, :updated_by_id)
+        end
+      end
+
+      context 'with invoiced licences' do
+        before do
+          create(:commercial_licence, contract:, status: :invoiced)
+        end
+
+        it 'has the expected fields' do
+          expect(contract.editable_attributes).to contain_exactly(:comments, :name, :number_of_schools,
+                                                                  :purchase_order_number, :status, :updated_by_id)
+        end
       end
     end
 
-    context 'with invoiced licences' do
-      before do
-        create(:commercial_licence, contract:, status: :invoiced)
-      end
+    context 'with custom contract' do
+      subject(:contract) { create(:commercial_contract, :custom, status: :provisional) }
 
       it 'has the expected fields' do
-        expect(contract.editable_attributes).to contain_exactly(:comments, :name, :number_of_schools,
-                                                                :purchase_order_number, :status, :updated_by_id)
+        expect(contract.editable_attributes).to contain_exactly(:agreed_school_price, :comments, :end_date,
+                                                                :licence_years, :name,
+                                                                :number_of_schools, :purchase_order_number,
+                                                                :start_date, :status, :updated_by_id)
+      end
+
+      context 'when confirmed' do
+        subject(:contract) { create(:commercial_contract, :custom, status: :confirmed) }
+
+        it 'has the expected fields' do
+          expect(contract.editable_attributes).to contain_exactly(:agreed_school_price, :comments, :end_date,
+                                                                  :licence_years, :name,
+                                                                  :number_of_schools, :purchase_order_number,
+                                                                  :start_date, :updated_by_id)
+        end
+      end
+
+      context 'with invoiced licences' do
+        before do
+          create(:commercial_licence, contract:, status: :invoiced)
+        end
+
+        it 'has the expected fields' do
+          expect(contract.editable_attributes).to contain_exactly(:comments, :name, :number_of_schools,
+                                                                  :purchase_order_number, :status, :updated_by_id)
+        end
       end
     end
   end

--- a/spec/system/admin/commercial/manage_contracts_spec.rb
+++ b/spec/system/admin/commercial/manage_contracts_spec.rb
@@ -21,6 +21,36 @@ shared_examples 'a filtered contract list' do
   end
 end
 
+shared_examples 'it shows the common contract fields' do
+  it { expect(page).to have_field('Name') }
+  it { expect(page).to have_field('Comments') }
+  it { expect(page).to have_field('Contract holder') }
+  it { expect(page).to have_field('Product') }
+end
+
+shared_examples 'it applies validation when creating a contract' do
+  context 'with invalid data' do
+    it { expect { click_on 'Save' }.not_to change(Commercial::Contract, :count) }
+
+    it 'displays errors' do
+      click_on 'Save'
+      expect(page).to have_text("Name can't be blank")
+    end
+  end
+end
+
+shared_examples 'it successfully creates a contract' do
+  it 'creates the model' do
+    expect(page).to have_text('Contract has been created')
+    expect(Commercial::Contract.last).to have_attributes(expected_attributes)
+  end
+
+  it 'does not create any licences' do
+    expect(page).to have_text('Contract has been created')
+    expect(Commercial::Contract.last.licences).to be_empty
+  end
+end
+
 describe 'manage contracts' do
   let(:user) { create(:admin) }
 
@@ -33,66 +63,173 @@ describe 'manage contracts' do
     let!(:product) { create(:commercial_product, :default_product) }
     let!(:funder) { create(:funder) }
 
-    before do
-      click_on 'New contract'
-    end
+    before { click_on 'New contract' }
 
-    it { expect(page).to have_field('Contract holder') }
-    it { expect(page).to have_field('Product') }
-
-    context 'with valid data', :js do
+    context 'when choosing a standard contract' do
       before do
-        fill_in 'Name', with: 'Custom contract'
-        fill_in 'Comments', with: 'Some notes'
-
-        select product.name, from: 'Product'
-        choose 'Funder'
-        select funder.name, from: 'Contract holder'
-
-        fill_in 'Number of schools', with: 100
-        fill_in 'Purchase order number', with: 'PO123'
-
-        set_date('#contract_start_date', '01/01/2026')
-        set_date('#contract_end_date', '31/12/2026')
-
-        fill_in 'Agreed school price', with: 525
-        select 'Full', from: 'Invoice terms'
-        select 'Custom', from: 'Licence period'
-        fill_in 'Licence years', with: 1.0
-
-        click_on 'Save'
+        within('div#standard') do
+          click_on 'Create this type of contract'
+        end
       end
 
-      it 'creates the model' do
-        expect(page).to have_text('Contract has been created')
-        expect(Commercial::Contract.last).to have_attributes(
-          name: 'Custom contract',
-          comments: 'Some notes',
-          product: product,
-          contract_holder: funder,
-          licence_period: 'custom',
-          licence_years: 1.0,
-          number_of_schools: 100,
-          purchase_order_number: 'PO123',
-          start_date: Date.new(2026, 1, 1),
-          end_date: Date.new(2026, 12, 31),
-          agreed_school_price: BigDecimal(525),
-          created_by: user
-        )
-      end
+      it { expect(page).to have_text('Create new standard contract') }
 
-      it 'does not create any licences' do
-        expect(page).to have_text('Contract has been created')
-        expect(Commercial::Contract.last.licences).to be_empty
+      it_behaves_like 'it shows the common contract fields'
+
+      it { expect(page).to have_no_field('Invoice terms') }
+      it { expect(page).to have_no_field('Licence period') }
+      it { expect(page).to have_no_field('Licence years') }
+
+      it_behaves_like 'it applies validation when creating a contract'
+
+      context 'with valid data', :js do
+        before do
+          fill_in 'Name', with: 'Standard contract'
+          fill_in 'Comments', with: 'Some notes'
+
+          select product.name, from: 'Product'
+          choose 'Funder'
+          select funder.name, from: 'Contract holder'
+
+          fill_in 'Number of schools', with: 100
+          fill_in 'Agreed school price', with: 525
+
+          set_date('#contract_start_date', '01/01/2026')
+          set_date('#contract_end_date', '31/12/2026')
+
+          click_on 'Save'
+        end
+
+        it_behaves_like 'it successfully creates a contract' do
+          let(:expected_attributes) do
+            {
+              name: 'Standard contract',
+              comments: 'Some notes',
+              product: product,
+              contract_holder: funder,
+              licence_period: 'contract',
+              invoice_terms: 'full',
+              number_of_schools: 100,
+              start_date: Date.new(2026, 1, 1),
+              end_date: Date.new(2026, 12, 31),
+              agreed_school_price: BigDecimal(525),
+              created_by: user
+            }
+          end
+        end
       end
     end
 
-    context 'with invalid data' do
-      it { expect { click_on 'Save' }.not_to change(Commercial::Contract, :count) }
+    context 'when choosing a pro_rata contract' do
+      before do
+        within('div#pro-rata') do
+          click_on 'Create this type of contract'
+        end
+      end
 
-      it 'displays errors' do
-        click_on 'Save'
-        expect(page).to have_text("Name can't be blank")
+      it { expect(page).to have_text('Create new pro-rata contract') }
+
+      it_behaves_like 'it shows the common contract fields'
+      it { expect(page).to have_no_field('Invoice terms') }
+      it { expect(page).to have_no_field('Licence period') }
+      it { expect(page).to have_no_field('Licence years') }
+
+      it_behaves_like 'it applies validation when creating a contract'
+
+      context 'with valid data', :js do
+        before do
+          fill_in 'Name', with: 'Pro-rata contract'
+          fill_in 'Comments', with: 'Some notes'
+
+          select product.name, from: 'Product'
+          choose 'Funder'
+          select funder.name, from: 'Contract holder'
+
+          fill_in 'Number of schools', with: 100
+          fill_in 'Agreed school price', with: 525
+
+          set_date('#contract_start_date', '01/01/2026')
+          set_date('#contract_end_date', '31/12/2026')
+
+          click_on 'Save'
+        end
+
+        it_behaves_like 'it successfully creates a contract' do
+          let(:expected_attributes) do
+            {
+              name: 'Pro-rata contract',
+              comments: 'Some notes',
+              product: product,
+              contract_holder: funder,
+              licence_period: 'contract',
+              invoice_terms: 'pro_rata',
+              number_of_schools: 100,
+              start_date: Date.new(2026, 1, 1),
+              end_date: Date.new(2026, 12, 31),
+              agreed_school_price: BigDecimal(525),
+              created_by: user
+            }
+          end
+        end
+      end
+    end
+
+    context 'when choosing a custom contract' do
+      before do
+        within('div#custom') do
+          click_on 'Create this type of contract'
+        end
+      end
+
+      it { expect(page).to have_text('Create new custom contract') }
+
+      it_behaves_like 'it shows the common contract fields'
+      it { expect(page).to have_no_field('Invoice terms') }
+      it { expect(page).to have_no_field('Licence period') }
+      it { expect(page).to have_field('Licence years') }
+
+      it_behaves_like 'it applies validation when creating a contract'
+
+      context 'with valid data', :js do
+        before do
+          fill_in 'Name', with: 'Custom contract'
+          fill_in 'Comments', with: 'Some notes'
+
+          select product.name, from: 'Product'
+          choose 'Funder'
+          select funder.name, from: 'Contract holder'
+
+          fill_in 'Number of schools', with: 100
+          fill_in 'Purchase order number', with: 'PO123'
+
+          set_date('#contract_start_date', '01/01/2026')
+          set_date('#contract_end_date', '31/12/2026')
+
+          fill_in 'Agreed school price', with: 525
+          fill_in 'Licence years', with: 2.0
+
+          click_on 'Save'
+        end
+
+        it_behaves_like 'it successfully creates a contract' do
+          let(:expected_attributes) do
+            {
+              name: 'Custom contract',
+              comments: 'Some notes',
+              product: product,
+              contract_holder: funder,
+              licence_period: 'custom',
+              invoice_terms: 'full',
+              licence_years: 2.0,
+              number_of_schools: 100,
+              purchase_order_number: 'PO123',
+              start_date: Date.new(2026, 1, 1),
+              end_date: Date.new(2026, 12, 31),
+              agreed_school_price: BigDecimal(525),
+              created_by: user
+            }
+          end
+        end
       end
     end
   end
@@ -104,10 +241,13 @@ describe 'manage contracts' do
     before do
       visit admin_school_group_contracts_path(contract_holder)
       click_on 'New contract'
+      within('div#custom') do
+        click_on 'Create this type of contract'
+      end
     end
 
     it 'initialises the form correctly' do
-      expect(page).to have_text("Create a new contract for #{contract_holder.name}")
+      expect(page).to have_text("Create a new custom contract for #{contract_holder.name}")
     end
 
     it { expect(page).to have_no_field('Contract holder') }
@@ -125,34 +265,28 @@ describe 'manage contracts' do
         set_date('#contract_end_date', '31/12/2026')
 
         fill_in 'Agreed school price', with: 525
-        select 'Full', from: 'Invoice terms'
-        select 'Custom', from: 'Licence period'
         fill_in 'Licence years', with: 1.0
 
         click_on 'Save'
       end
 
-      it 'creates the model' do
-        expect(page).to have_text('Contract has been created')
-        expect(Commercial::Contract.last).to have_attributes(
-          name: 'Custom contract',
-          comments: 'Some notes',
-          product: product,
-          contract_holder: contract_holder,
-          licence_period: 'custom',
-          licence_years: 1.0,
-          number_of_schools: 100,
-          purchase_order_number: 'PO123',
-          start_date: Date.new(2026, 1, 1),
-          end_date: Date.new(2026, 12, 31),
-          agreed_school_price: BigDecimal(525),
-          created_by: user
-        )
-      end
-
-      it 'does not create any licences' do
-        expect(page).to have_text('Contract has been created')
-        expect(Commercial::Contract.last.licences).to be_empty
+      it_behaves_like 'it successfully creates a contract' do
+        let(:expected_attributes) do
+          {
+            name: 'Custom contract',
+            comments: 'Some notes',
+            product: product,
+            contract_holder: contract_holder,
+            licence_period: 'custom',
+            licence_years: 1.0,
+            number_of_schools: 100,
+            purchase_order_number: 'PO123',
+            start_date: Date.new(2026, 1, 1),
+            end_date: Date.new(2026, 12, 31),
+            agreed_school_price: BigDecimal(525),
+            created_by: user
+          }
+        end
       end
     end
   end
@@ -172,7 +306,7 @@ describe 'manage contracts' do
 
       it {
         expect(page).to have_text(
-          'Any changes made to the start and end dates for this contract will be automatically applied to all licences'
+          'Any changes made to the start and end dates for this contract will be automatically applied to any licences'
         )
       }
 
@@ -297,7 +431,6 @@ describe 'manage contracts' do
              agreed_school_price: 600.0,
              invoice_terms: :full,
              licence_period: :contract,
-             licence_years: 2,
              number_of_schools: 100)
     end
 
@@ -317,9 +450,9 @@ describe 'manage contracts' do
 
       it { expect(page).to have_field('Agreed school price', with: contract.agreed_school_price) }
       it { expect(page).to have_field('Comments', with: "Renewed from #{contract.name}") }
-      it { expect(page).to have_select('Invoice terms', selected: 'Full') }
-      it { expect(page).to have_select('Licence period', selected: 'Contract') }
-      it { expect(page).to have_field('Licence years', with: '2.0') }
+      it { expect(page).to have_field('contract_invoice_terms', with: 'full', type: :hidden, visible: :all) }
+      it { expect(page).to have_field('contract_licence_period', with: 'contract', type: :hidden, visible: :all) }
+
       it { expect(page).to have_field('Number of schools', with: contract.number_of_schools) }
       it { expect(page).to have_select('Status', selected: 'Provisional') }
 
@@ -339,7 +472,6 @@ describe 'manage contracts' do
             product: contract.product,
             contract_holder: contract.contract_holder,
             licence_period: contract.licence_period,
-            licence_years: contract.licence_years,
             number_of_schools: contract.number_of_schools,
             start_date: contract.end_date + 1.day,
             end_date: contract.end_date.next_year,

--- a/spec/system/admin/commercial/manage_contracts_spec.rb
+++ b/spec/system/admin/commercial/manage_contracts_spec.rb
@@ -28,6 +28,12 @@ shared_examples 'it shows the common contract fields' do
   it { expect(page).to have_field('Product') }
 end
 
+shared_examples 'it shows the fields for a non-custom contract' do
+  it { expect(page).to have_no_field('Invoice terms') }
+  it { expect(page).to have_no_field('Licence period') }
+  it { expect(page).to have_no_field('Licence years') }
+end
+
 shared_examples 'it applies validation when creating a contract' do
   context 'with invalid data' do
     it { expect { click_on 'Save' }.not_to change(Commercial::Contract, :count) }
@@ -75,11 +81,7 @@ describe 'manage contracts' do
       it { expect(page).to have_text('Create new standard contract') }
 
       it_behaves_like 'it shows the common contract fields'
-
-      it { expect(page).to have_no_field('Invoice terms') }
-      it { expect(page).to have_no_field('Licence period') }
-      it { expect(page).to have_no_field('Licence years') }
-
+      it_behaves_like 'it shows the fields for a non-custom contract'
       it_behaves_like 'it applies validation when creating a contract'
 
       context 'with valid data', :js do
@@ -130,9 +132,7 @@ describe 'manage contracts' do
       it { expect(page).to have_text('Create new pro-rata contract') }
 
       it_behaves_like 'it shows the common contract fields'
-      it { expect(page).to have_no_field('Invoice terms') }
-      it { expect(page).to have_no_field('Licence period') }
-      it { expect(page).to have_no_field('Licence years') }
+      it_behaves_like 'it shows the fields for a non-custom contract'
 
       it_behaves_like 'it applies validation when creating a contract'
 
@@ -241,51 +241,156 @@ describe 'manage contracts' do
     before do
       visit admin_school_group_contracts_path(contract_holder)
       click_on 'New contract'
-      within('div#custom') do
-        click_on 'Create this type of contract'
-      end
     end
 
-    it 'initialises the form correctly' do
-      expect(page).to have_text("Create a new custom contract for #{contract_holder.name}")
-    end
-
-    it { expect(page).to have_no_field('Contract holder') }
-
-    context 'with valid data', :js do
+    context 'when choosing a standard contract' do
       before do
-        fill_in 'Name', with: 'Custom contract'
-        fill_in 'Comments', with: 'Some notes'
-
-        select product.name, from: 'Product'
-        fill_in 'Number of schools', with: 100
-        fill_in 'Purchase order number', with: 'PO123'
-
-        set_date('#contract_start_date', '01/01/2026')
-        set_date('#contract_end_date', '31/12/2026')
-
-        fill_in 'Agreed school price', with: 525
-        fill_in 'Licence years', with: 1.0
-
-        click_on 'Save'
+        within('div#standard') do
+          click_on 'Create this type of contract'
+        end
       end
 
-      it_behaves_like 'it successfully creates a contract' do
-        let(:expected_attributes) do
-          {
-            name: 'Custom contract',
-            comments: 'Some notes',
-            product: product,
-            contract_holder: contract_holder,
-            licence_period: 'custom',
-            licence_years: 1.0,
-            number_of_schools: 100,
-            purchase_order_number: 'PO123',
-            start_date: Date.new(2026, 1, 1),
-            end_date: Date.new(2026, 12, 31),
-            agreed_school_price: BigDecimal(525),
-            created_by: user
-          }
+      it 'initialises the form correctly' do
+        expect(page).to have_text("Create a new standard contract for #{contract_holder.name}")
+      end
+
+      it { expect(page).to have_no_field('Contract holder') }
+
+      it_behaves_like 'it shows the fields for a non-custom contract'
+
+      context 'with valid data', :js do
+        before do
+          fill_in 'Name', with: 'Standard contract'
+          fill_in 'Comments', with: 'Some notes'
+
+          select product.name, from: 'Product'
+          fill_in 'Number of schools', with: 100
+          fill_in 'Agreed school price', with: 525
+
+          set_date('#contract_start_date', '01/01/2026')
+          set_date('#contract_end_date', '31/12/2026')
+
+          click_on 'Save'
+        end
+
+        it_behaves_like 'it successfully creates a contract' do
+          let(:expected_attributes) do
+            {
+              name: 'Standard contract',
+              comments: 'Some notes',
+              product: product,
+              contract_holder: contract_holder,
+              licence_period: 'contract',
+              invoice_terms: 'full',
+              number_of_schools: 100,
+              start_date: Date.new(2026, 1, 1),
+              end_date: Date.new(2026, 12, 31),
+              agreed_school_price: BigDecimal(525),
+              created_by: user
+            }
+          end
+        end
+      end
+    end
+
+    context 'when choosing a pro_rata contract' do
+      before do
+        within('div#pro-rata') do
+          click_on 'Create this type of contract'
+        end
+      end
+
+      it {
+        expect(page).to have_text("Create a new pro-rata contract for #{contract_holder.name}")
+      }
+
+      it_behaves_like 'it shows the fields for a non-custom contract'
+      it_behaves_like 'it applies validation when creating a contract'
+
+      context 'with valid data', :js do
+        before do
+          fill_in 'Name', with: 'Pro-rata contract'
+          fill_in 'Comments', with: 'Some notes'
+
+          select product.name, from: 'Product'
+
+          fill_in 'Number of schools', with: 100
+          fill_in 'Agreed school price', with: 525
+
+          set_date('#contract_start_date', '01/01/2026')
+          set_date('#contract_end_date', '31/12/2026')
+
+          click_on 'Save'
+        end
+
+        it_behaves_like 'it successfully creates a contract' do
+          let(:expected_attributes) do
+            {
+              name: 'Pro-rata contract',
+              comments: 'Some notes',
+              product: product,
+              contract_holder: contract_holder,
+              licence_period: 'contract',
+              invoice_terms: 'pro_rata',
+              number_of_schools: 100,
+              start_date: Date.new(2026, 1, 1),
+              end_date: Date.new(2026, 12, 31),
+              agreed_school_price: BigDecimal(525),
+              created_by: user
+            }
+          end
+        end
+      end
+    end
+
+    context 'when choosing a custom contract' do
+      before do
+        within('div#custom') do
+          click_on 'Create this type of contract'
+        end
+      end
+
+      it 'initialises the form correctly' do
+        expect(page).to have_text("Create a new custom contract for #{contract_holder.name}")
+      end
+
+      it { expect(page).to have_no_field('Contract holder') }
+
+      context 'with valid data', :js do
+        before do
+          fill_in 'Name', with: 'Custom contract'
+          fill_in 'Comments', with: 'Some notes'
+
+          select product.name, from: 'Product'
+          fill_in 'Number of schools', with: 100
+          fill_in 'Purchase order number', with: 'PO123'
+
+          set_date('#contract_start_date', '01/01/2026')
+          set_date('#contract_end_date', '31/12/2026')
+
+          fill_in 'Agreed school price', with: 525
+          fill_in 'Licence years', with: 1.0
+
+          click_on 'Save'
+        end
+
+        it_behaves_like 'it successfully creates a contract' do
+          let(:expected_attributes) do
+            {
+              name: 'Custom contract',
+              comments: 'Some notes',
+              product: product,
+              contract_holder: contract_holder,
+              licence_period: 'custom',
+              licence_years: 1.0,
+              number_of_schools: 100,
+              purchase_order_number: 'PO123',
+              start_date: Date.new(2026, 1, 1),
+              end_date: Date.new(2026, 12, 31),
+              agreed_school_price: BigDecimal(525),
+              created_by: user
+            }
+          end
         end
       end
     end

--- a/spec/system/admin/commercial/manage_contracts_spec.rb
+++ b/spec/system/admin/commercial/manage_contracts_spec.rb
@@ -411,8 +411,8 @@ describe 'manage contracts' do
 
       it {
         expect(page).to have_text(
-          'Any changes made to the start and end dates or licence years fields for this contract will be ' \
-          'automatically applied to any licences'
+          'Any changes made to the start and end dates or licence years fields for this contract will be applied to ' \
+          'any licences that have not yet been invoiced'
         )
       }
 

--- a/spec/system/admin/commercial/manage_contracts_spec.rb
+++ b/spec/system/admin/commercial/manage_contracts_spec.rb
@@ -411,12 +411,13 @@ describe 'manage contracts' do
 
       it {
         expect(page).to have_text(
-          'Any changes made to the start and end dates for this contract will be automatically applied to any licences'
+          'Any changes made to the start and end dates or licence years fields for this contract will be ' \
+          'automatically applied to any licences'
         )
       }
 
       it { expect(page).to have_no_field('Contract holder') }
-      it { expect(page).to have_no_field('Product') }
+
       it { expect(page).to have_no_select('Invoice terms') }
       it { expect(page).to have_no_select('Licence period') }
       it { expect(page).to have_no_field('Licence years') }
@@ -598,7 +599,7 @@ describe 'manage contracts' do
 
         before do
           fill_in('Name', with: 'Renewed contract')
-          uncheck('renew_licences')
+          uncheck('contract_renew_licences')
           click_on 'Save'
         end
 
@@ -743,7 +744,8 @@ describe 'manage contracts' do
         let(:table_id) { '#contracts-table' }
         let(:expected_header) do
           [
-            ['Name', 'Product', 'Start Date', 'End Date', 'Number of Schools', 'Licensed Schools', 'Status', 'Actions']
+            ['Name', 'Product', 'Period', 'Terms', 'Start Date', 'End Date', 'Number of Schools', 'Licensed Schools',
+             'Status', 'Actions']
           ]
         end
         let(:expected_rows) do
@@ -751,6 +753,8 @@ describe 'manage contracts' do
             [
               contract.name,
               contract.product.name,
+              contract.licence_period.humanize,
+              contract.invoice_terms.humanize,
               contract.start_date.to_fs(:es_short),
               contract.end_date.to_fs(:es_short),
               contract.number_of_schools.to_s,

--- a/spec/system/admin/commercial/manage_contracts_spec.rb
+++ b/spec/system/admin/commercial/manage_contracts_spec.rb
@@ -467,6 +467,7 @@ describe 'manage contracts' do
           select 'Confirmed', from: 'Status'
           set_date('#contract_start_date', '01/01/2026')
           set_date('#contract_end_date', '31/12/2026')
+          check('contract_update_licences')
           click_on 'Save'
         end
 
@@ -478,6 +479,21 @@ describe 'manage contracts' do
             status: 'confirmed',
             updated_by: user
           )
+        end
+      end
+
+      context 'when making changes without cascading them to licences', :js do
+        before do
+          select 'Confirmed', from: 'Status'
+          set_date('#contract_start_date', '01/01/2026')
+          set_date('#contract_end_date', '31/12/2026')
+          click_on 'Save'
+        end
+
+        it 'updates the model' do
+          expect(page).to have_text('Contract has been updated')
+          original_attributes = licence.attributes
+          expect(licence.reload).to have_attributes(original_attributes)
         end
       end
     end
@@ -599,7 +615,7 @@ describe 'manage contracts' do
 
         before do
           fill_in('Name', with: 'Renewed contract')
-          uncheck('contract_renew_licences')
+          uncheck('contract_update_licences')
           click_on 'Save'
         end
 

--- a/spec/system/admin/commercial/manage_licences_spec.rb
+++ b/spec/system/admin/commercial/manage_licences_spec.rb
@@ -53,7 +53,7 @@ describe 'manage licences' do
       visit new_admin_commercial_licence_path
     end
 
-    it { expect(page).to have_text('Leave date fields empty to automatically create a licence starting from today') }
+    it { expect(page).to have_text('Leave the following fields blank ') }
 
     context 'with valid data', :js do
       before do
@@ -113,7 +113,7 @@ describe 'manage licences' do
       click_on('Add New Licence')
     end
 
-    it { expect(page).to have_text('Leave date fields empty to automatically create a licence starting from today') }
+    it { expect(page).to have_text('Leave the following fields blank to automatically populate the licence') }
     it { expect(page).to have_text("Create a new licence under the #{contract.name} contract.") }
 
     context 'with valid data', :js do
@@ -186,7 +186,7 @@ describe 'manage licences' do
       let!(:licence) { create(:commercial_licence, contract:, school:) }
 
       it 'includes a warning' do
-        expect(page).to have_text('Changes made here will be overwritten')
+        expect(page).to have_text('Any changes made here will then be overwritten.')
       end
     end
 
@@ -215,6 +215,18 @@ describe 'manage licences' do
           updated_by: user
         )
       end
+    end
+
+    context 'when licence is invoiced' do
+      let!(:licence) { create(:commercial_licence, status: :invoiced) }
+
+      it { expect(page).to have_text('This licence has been invoiced. Only limited changes can now be made') }
+
+      it { expect(page).to have_no_field('School specific price') }
+
+      it { expect(page).to have_no_field('Status') }
+      it { expect(page).to have_no_field('Start date') }
+      it { expect(page).to have_no_field('End date') }
     end
   end
 

--- a/spec/system/admin/manage_funders_spec.rb
+++ b/spec/system/admin/manage_funders_spec.rb
@@ -21,8 +21,8 @@ describe 'manage funders' do
         click_on 'Create'
       end
 
-      it { expect(page).to have_content('Funder was successfully created') }
-      it { expect(page).to have_content('My funder') }
+      it { expect(page).to have_text('Funder was successfully created') }
+      it { expect(page).to have_text('My funder') }
     end
 
     context 'with invalid data' do
@@ -30,7 +30,7 @@ describe 'manage funders' do
 
       it 'displays errors' do
         click_on 'Create'
-        expect(page).to have_content("Name can't be blank")
+        expect(page).to have_text("Name can't be blank")
       end
     end
   end
@@ -49,8 +49,8 @@ describe 'manage funders' do
         click_on 'Update'
       end
 
-      it { expect(page).to have_content('Funder was successfully updated') }
-      it { expect(page).to have_content(funder.reload.name) }
+      it { expect(page).to have_text('Funder was successfully updated') }
+      it { expect(page).to have_text(funder.reload.name) }
     end
   end
 
@@ -69,7 +69,7 @@ describe 'manage funders' do
         click_on 'Delete'
       end
 
-      it { expect(page).to have_content('Cannot delete record because dependent contracts exist') }
+      it { expect(page).to have_text('Cannot delete record because dependent contracts exist') }
     end
   end
 
@@ -97,7 +97,8 @@ describe 'manage funders' do
         let(:table_id) { '#contracts-table' }
         let(:expected_header) do
           [
-            ['Name', 'Product', 'Start Date', 'End Date', 'Number of Schools', 'Licensed Schools', 'Status', 'Actions']
+            ['Name', 'Product', 'Period', 'Terms', 'Start Date', 'End Date', 'Number of Schools', 'Licensed Schools',
+             'Status', 'Actions']
           ]
         end
         let(:expected_rows) do
@@ -105,6 +106,8 @@ describe 'manage funders' do
             [
               contract.name,
               contract.product.name,
+              contract.licence_period.humanize,
+              contract.invoice_terms.humanize,
               contract.start_date.to_fs(:es_short),
               contract.end_date.to_fs(:es_short),
               contract.number_of_schools.to_s,


### PR DESCRIPTION
Improves the contract and licence management forms to help better enforce different contract types and guide users to choosing right options.

## Contract Creation and Editing

- Adds a new "Choose type of contract" interstitial page when creating new contracts to allow user to choose the type of contract. This simplifies the following form avoiding problems with inconsistent configuration
- Rework the forms to better group together fields
- Change which fields can be edited to allow alteration of product and licence years fields until invoicing has begun
- Fix some issues with renewal workflow where validation failures could stop licences being created
- Make cascading of updates to licences optional
- Add better documentation and warnings to the form about impacts of changes
- Improve test coverage

## Licence Creation and Editing

- Improve layout of form and description of how dates will be created
- Disable editing of fields when a licence is invoiced, on both the main form and the bulk licence editor
