### PR TITLE
Add impact report link and tidy

### DIFF
--- a/app/controllers/school_groups/impact_controller.rb
+++ b/app/controllers/school_groups/impact_controller.rb
@@ -9,7 +9,6 @@ module SchoolGroups
     before_action :redirect_unless_feature_enabled
     before_action :load_data
     before_action :redirect_unless_authorised
-    before_action :fetch_impact_report
     before_action :redirect_unless_visible
     before_action :redirect_not_enough_data
     before_action :enable_prototype_page
@@ -19,11 +18,6 @@ module SchoolGroups
     skip_before_action :authenticate_user!
 
     private
-
-    def fetch_impact_report
-      # Eventually this will be replaced with an active record object or similar
-      @impact_report = SchoolGroups::ImpactReport.new(@school_group)
-    end
 
     def load_data
       @config = @school_group.impact_report_configuration
@@ -51,7 +45,7 @@ module SchoolGroups
     end
 
     def redirect_not_enough_data
-      return if @impact_report.visible_schools_count >= 2
+      return if @run.enough_data?
 
       redirect_to(school_group_path(@school_group),
                   alert: I18n.t('advice_pages.index.show.not_available'))

--- a/app/models/commercial/contract.rb
+++ b/app/models/commercial/contract.rb
@@ -37,6 +37,10 @@
 #  fk_rails_...  (created_by_id => users.id)
 #  fk_rails_...  (product_id => commercial_products.id)
 #  fk_rails_...  (updated_by_id => users.id)
+#
+#  fk_rails_...  (created_by_id => users.id)
+#  fk_rails_...  (product_id => commercial_products.id)
+#  fk_rails_...  (updated_by_id => users.id)
 module Commercial
   # rubocop:disable Metrics/ClassLength
   class Contract < ApplicationRecord

--- a/app/models/commercial/contract.rb
+++ b/app/models/commercial/contract.rb
@@ -37,10 +37,6 @@
 #  fk_rails_...  (created_by_id => users.id)
 #  fk_rails_...  (product_id => commercial_products.id)
 #  fk_rails_...  (updated_by_id => users.id)
-#
-#  fk_rails_...  (created_by_id => users.id)
-#  fk_rails_...  (product_id => commercial_products.id)
-#  fk_rails_...  (updated_by_id => users.id)
 module Commercial
   # rubocop:disable Metrics/ClassLength
   class Contract < ApplicationRecord

--- a/app/models/impact_report/run.rb
+++ b/app/models/impact_report/run.rb
@@ -47,8 +47,9 @@ module ImpactReport
     end
 
     def enough_data?
-      metric = overview(:visible_schools)
-      metric.present? && metric.available? && metric.value >= 2
+      overview(:visible_schools).then do |metric|
+        metric.present? && metric.available? && metric&.value.to_i >= 2
+      end
     end
 
     # e.g. overview(:active_users)

--- a/app/models/impact_report/run.rb
+++ b/app/models/impact_report/run.rb
@@ -46,14 +46,19 @@ module ImpactReport
       comparison_end_date - 364.days
     end
 
+    def enough_data?
+      metric = overview(:visible_schools)
+      metric.present? && metric.available? && metric.value >= 2
+    end
+
     # e.g. overview(:active_users)
     def overview(metric_type)
-      by_category(:overview)[metric_type.to_s][nil]
+      by_category(:overview).dig(metric_type.to_s, nil)
     end
 
     # e.g. engagement(:points)
     def engagement(metric_type)
-      by_category(:engagement)[metric_type.to_s][nil]
+      by_category(:engagement).dig(metric_type.to_s, nil)
     end
 
     def potential_savings

--- a/app/views/admin/impact_reports/_form.html.erb
+++ b/app/views/admin/impact_reports/_form.html.erb
@@ -2,7 +2,15 @@
   <%= simple_form_for(config, url: admin_impact_report_path(config.school_group), method: :patch) do |f| %>
     <%= render Layout::GridComponent.new(cols: 1, cell_classes: 'mb-2 bg-light rounded-2 px-3') do |grid| %>
       <%= grid.with_cell do |row| %>
-        <h2>General</h2>
+        <div class="d-flex justify-content-between align-items-center">
+          <h2 class="mb-0">General</h2>
+
+          <div class="d-flex gap-2">
+            <%= link_to 'All reports', admin_impact_reports_path, class: 'btn btn-secondary' %>
+            <%= link_to 'View report', school_group_impact_index_path(@school_group), class: 'btn btn-primary' %>
+          </div>
+        </div>
+        <p>Impact reports will only be available for groups with at least 2 visible schools and where either the user is an admin, or the report is set to visible.</p>
         <%= f.input :visible,
                     wrapper: :custom_boolean_switch,
                     label: 'Report visible',

--- a/app/views/admin/impact_reports/edit.html.erb
+++ b/app/views/admin/impact_reports/edit.html.erb
@@ -1,3 +1,4 @@
 <% content_for :page_title, "#{@school_group.name} Impact report settings" %>
 <% content_for :header_title, "#{@school_group.name} Impact report settings" %>
+
 <%= render 'form', config: @configuration, school_group: @school_group %>

--- a/app/views/admin/impact_reports/index.html.erb
+++ b/app/views/admin/impact_reports/index.html.erb
@@ -62,7 +62,7 @@
           <% end %>
         </td>
         <td class='text-center'><%= link_to 'Edit', edit_admin_impact_report_path(school_group),
-                                            class: 'btn btn-secondary' %>
+                                            class: 'btn btn-secondary btn-sm' %>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/school_groups/impact/index.html.erb
+++ b/app/views/school_groups/impact/index.html.erb
@@ -44,7 +44,7 @@
         <%= carousel.with_testimonial_card(testimonial: testimonial) %>
       <% end %>
     <% end %>
-    <%= if current_user&.admin?
+    <%= if current_user&.admin? && CaseStudy.for_school_group(@school_group).published.none?
           carousel.with_placeholder(
             'Please edit case studies and assign a school group or ' \
             'school to each one, then relevant ones will display here. Add more testimonials too if possible please.',

--- a/spec/factories/impact_report_runs.rb
+++ b/spec/factories/impact_report_runs.rb
@@ -27,7 +27,7 @@ FactoryBot.define do
             run: run,
             metric_category: category,
             metric_type: type,
-            value: 1,
+            value: 2,
             enough_data: true
           }
 

--- a/spec/models/impact_report/run_spec.rb
+++ b/spec/models/impact_report/run_spec.rb
@@ -46,6 +46,41 @@ describe ImpactReport::Run do
     end
   end
 
+  describe '#enough_data?' do
+    let(:run) { create(:impact_report_run) }
+
+    context 'when visible_schools is >= 2 and enough_data? is true' do
+      before do
+        create(:impact_report_metric, run:, metric_category: 'overview',
+                                      metric_type: 'visible_schools', value: 2, enough_data: true)
+      end
+
+      it { expect(run.enough_data?).to be(true) }
+    end
+
+    context 'when enough_data? is false' do
+      before do
+        create(:impact_report_metric, run:, metric_category: 'overview',
+                                      metric_type: 'visible_schools', value: 2, enough_data: false)
+      end
+
+      it { expect(run.enough_data?).to be(false) }
+    end
+
+    context 'when visible schools < 2' do
+      before do
+        create(:impact_report_metric, run:, metric_category: 'overview',
+                                      metric_type: 'visible_schools', value: 1, enough_data: true)
+      end
+
+      it { expect(run.enough_data?).to be(false) }
+    end
+
+    context 'when metric not present' do
+      it { expect(run.enough_data?).to be(false) }
+    end
+  end
+
   describe '#overview' do
     let(:run) { create(:impact_report_run) }
 

--- a/spec/system/admin/impact_reports_spec.rb
+++ b/spec/system/admin/impact_reports_spec.rb
@@ -3,15 +3,15 @@
 require 'rails_helper'
 
 RSpec.describe 'Admin impact report configuration' do
+  before do
+    Flipper.enable(:impact_reporting)
+  end
+
   let!(:admin) { create(:admin) }
   let!(:school_group) { create(:school_group, :with_active_schools, count: 2) }
   let!(:other_school_group) { create(:school_group, :diocese) }
   let(:school) { school_group.assigned_schools.first }
-
-  before do
-    Flipper.enable(:impact_reporting)
-    create(:impact_report_run, :with_metrics, school_group:)
-  end
+  let!(:run) { create(:impact_report_run, :with_metrics, school_group:) }
 
   describe 'when not logged in' do
     context 'when visiting the index' do
@@ -106,6 +106,9 @@ RSpec.describe 'Admin impact report configuration' do
       before do
         visit edit_admin_impact_report_path(school_group)
       end
+
+      it { expect(page).to have_link('View report', href: school_group_impact_index_path(school_group)) }
+      it { expect(page).to have_link('All reports', href: admin_impact_reports_path) }
 
       context 'when turning sections off' do
         before do
@@ -207,6 +210,17 @@ RSpec.describe 'Admin impact report configuration' do
 
           it 'does not show the report' do
             expect(page).to have_text('This feature is not available')
+          end
+        end
+
+        context 'when there are not enough visible schools' do
+          before do
+            run.metrics.overview.find_by(metric_type: 'visible_schools').update!(value: 1)
+            visit school_group_impact_index_path(school_group.reload)
+          end
+
+          it 'does not show the report' do
+            expect(page).to have_text('Not enough data')
           end
         end
       end

--- a/spec/system/school_groups/impact_spec.rb
+++ b/spec/system/school_groups/impact_spec.rb
@@ -7,18 +7,18 @@ RSpec.describe 'school group impact reports', :include_application_helper, :scho
 
   let!(:school_group) { create(:school_group, :with_active_schools, count: 2, public: true) }
   let!(:config) { create(:impact_report_configuration, school_group:, visible: true) }
+  let!(:impact_report) { create(:impact_report_run, :with_metrics, school_group:) } # rubocop:disable RSpec/LetSetup
 
   before do
     # so we can display a testimonial
     create(:testimonial, case_study: create(:case_study, organisation: school_group))
-    create(:impact_report_run, :with_metrics, school_group:)
   end
 
   describe 'Access control' do
     shared_examples 'an access controlled impact page' do |message: 'This feature is not available'|
       it 'redirects to school group dashboard' do
         expect(page).to have_current_path(school_group_path(school_group))
-        expect(page).to have_content(message)
+        expect(page).to have_text(message)
       end
     end
 
@@ -71,8 +71,10 @@ RSpec.describe 'school group impact reports', :include_application_helper, :scho
         end
       end
 
-      context 'when group has less than 2 schools' do
-        let!(:school_group) { create(:school_group, :with_active_schools, count: 1, public: true) }
+      context 'when group run has less than 2 visible schools' do
+        let!(:impact_report) do
+          create(:impact_report_run, :with_metrics, school_group:, overview: { visible_schools: { value: 1 } })
+        end
 
         it_behaves_like 'an access controlled impact page', message: 'Not enough data'
       end
@@ -100,25 +102,25 @@ RSpec.describe 'school group impact reports', :include_application_helper, :scho
       let(:header) { find_by_id('header-section') }
 
       it 'has the title' do
-        expect(header).to have_content("#{school_group.name} Impact Report")
+        expect(header).to have_text("#{school_group.name} Impact Report")
       end
 
       it 'has the description' do
         group_type = I18n.t(school_group.group_type, scope: 'school_groups.clusters.group_type')
-        expect(header).to have_content(strip_tags(
-                                         I18n.t('school_groups.impact.feature.description_html',
-                                                count: 1, group_type: group_type)
-                                       ))
+        expect(header).to have_text(strip_tags(
+                                      I18n.t('school_groups.impact.feature.description_html',
+                                             count: 2, group_type: group_type)
+                                    ))
       end
 
       it 'has the report generation date' do
-        expect(header).to have_content(strip_tags(I18n.t('common.last_updated_on_html',
-                                                         date: Time.zone.today.to_date.to_fs(:es_long))))
+        expect(header).to have_text(strip_tags(I18n.t('common.last_updated_on_html',
+                                                      date: Time.zone.today.to_date.to_fs(:es_long))))
       end
 
       it 'has the read more link' do
-        expect(header).to have_content(strip_tags(I18n.t('school_groups.impact.feature.read_more_html',
-                                                         href: '#notes')))
+        expect(header).to have_text(strip_tags(I18n.t('school_groups.impact.feature.read_more_html',
+                                                      href: '#notes')))
         expect(header).to have_link('Read more', href: '#notes')
       end
     end


### PR DESCRIPTION
- Adds link to report on config admin page.
- Also adds link to index of reports.
- Also tidies up a few other bits.

We probably also need a link in the group/settings left nav to the report and also in the manage group menu, but assume this is for another time.