### PR TITLE
Revise licence summary component

### DIFF
--- a/app/components/commercial/licensing_summary_component.rb
+++ b/app/components/commercial/licensing_summary_component.rb
@@ -8,9 +8,12 @@ module Commercial
       RowComponent.new(**kwargs)
     }
 
-    def initialize(first_range: nil, second_range: nil, table_id: 'summary-table', **)
+    def initialize(first_range: nil, second_range: nil,
+                   labels: { first: 'Current Academic Year', second: nil },
+                   table_id: 'summary-table', **)
       super(**)
       @table_id = table_id
+      @labels = labels
       @first_range = first_range || Calendar.default_national.current_academic_year.then do |year|
         year.start_date..year.end_date
       end

--- a/app/components/commercial/licensing_summary_component.rb
+++ b/app/components/commercial/licensing_summary_component.rb
@@ -35,24 +35,16 @@ module Commercial
 
       private
 
-      def licensed_for_first_range
-        @licenced_for_first_range = @school.licensed_for_period(@first_range)
+      def licensed_for(range)
+        return nil unless range
+
+        @school.licensed_for_period(range)
       end
 
-      def contract_holder_for_first_range
-        @school.licences.for_period(@first_range).map { |x| x.contract_holder.name }
-      end
+      def contract_holder_for(range)
+        return nil unless range
 
-      def licensed_for_second_range
-        return nil unless @second_range
-
-        @licenced_for_second_range = @school.licensed_for_period(@second_range)
-      end
-
-      def contract_holder_for_second_range
-        return nil unless @second_range
-
-        @school.licences.for_period(@second_range).map { |x| x.contract_holder.name }
+        @school.licences.for_period(range).map { |x| x.contract_holder.name }
       end
     end
   end

--- a/app/components/commercial/licensing_summary_component.rb
+++ b/app/components/commercial/licensing_summary_component.rb
@@ -3,14 +3,18 @@
 module Commercial
   class LicensingSummaryComponent < ApplicationComponent
     renders_many :rows, lambda { |**kwargs|
-      kwargs[:date_range] = @date_range
+      kwargs[:first_range] = @first_range
+      kwargs[:second_range] = @second_range
       RowComponent.new(**kwargs)
     }
 
-    def initialize(date_range: nil, table_id: 'summary-table', **)
+    def initialize(first_range: nil, second_range: nil, table_id: 'summary-table', **)
       super(**)
       @table_id = table_id
-      @date_range = date_range || AcademicYear.current.then { |year| year.start_date..year.end_date }
+      @first_range = first_range || Calendar.default_national.current_academic_year.then do |year|
+        year.start_date..year.end_date
+      end
+      @second_range = second_range
     end
 
     class RowComponent < ViewComponent::Base
@@ -18,11 +22,34 @@ module Commercial
 
       renders_many :buttons
 
-      def initialize(school:, date_range:, id: "school-#{school.id}")
+      def initialize(school:, first_range:, second_range: nil, id: "school-#{school.id}")
         super()
         @id = id
         @school = school
-        @date_range = date_range
+        @first_range = first_range
+        @second_range = second_range
+      end
+
+      private
+
+      def licensed_for_first_range
+        @licenced_for_first_range = @school.licensed_for_period(@first_range)
+      end
+
+      def contract_holder_for_first_range
+        @school.licences.for_period(@first_range).map { |x| x.contract_holder.name }
+      end
+
+      def licensed_for_second_range
+        return nil unless @second_range
+
+        @licenced_for_second_range = @school.licensed_for_period(@second_range)
+      end
+
+      def contract_holder_for_second_range
+        return nil unless @second_range
+
+        @school.licences.for_period(@second_range).map { |x| x.contract_holder.name }
       end
     end
   end

--- a/app/components/commercial/licensing_summary_component/licensing_summary_component.html.erb
+++ b/app/components/commercial/licensing_summary_component/licensing_summary_component.html.erb
@@ -2,11 +2,21 @@
   <table id="<%= @table_id %>" class="table table-sorted table-sm advice-table">
     <thead>
       <tr>
+        <th></th>
+        <th colspan="2"><%= @labels[:first] %></th>
+        <% if @second_range.present? %>
+          <th colspan="2"><%= @labels[:second] %></th>
+        <% end %>
+        <th></th>
+      </tr>
+      <tr>
         <th>School</th>
-        <th>Licensed for First Range?</th>
-        <th>Funder for First Range</th>
-        <th>Licensed for Second Range?</th>
-        <th>Funder for Second Range</th>
+        <th>Licensed?</th>
+        <th>Funder</th>
+        <% if @second_range.present? %>
+          <th>Licensed?</th>
+          <th>Funder</th>
+        <% end %>
         <th></th>
       </tr>
     </thead>

--- a/app/components/commercial/licensing_summary_component/licensing_summary_component.html.erb
+++ b/app/components/commercial/licensing_summary_component/licensing_summary_component.html.erb
@@ -10,14 +10,14 @@
         <th></th>
       </tr>
       <tr>
-        <th>School</th>
-        <th>Licensed?</th>
-        <th>Funder</th>
+        <th class="col-3">School</th>
+        <th class="col-1">Licensed?</th>
+        <th class="col-2">Funder</th>
         <% if @second_range.present? %>
-          <th>Licensed?</th>
-          <th>Funder</th>
+          <th class="col-1">Licensed?</th>
+          <th class="col-2">Funder</th>
         <% end %>
-        <th></th>
+        <th class="col-2"></th>
       </tr>
     </thead>
     <tbody>

--- a/app/components/commercial/licensing_summary_component/licensing_summary_component.html.erb
+++ b/app/components/commercial/licensing_summary_component/licensing_summary_component.html.erb
@@ -3,10 +3,10 @@
     <thead>
       <tr>
         <th>School</th>
-        <th>Current Licence?</th>
-        <th>Current Funder</th>
-        <th>Future Funder</th>
-        <th>Licenced for Period?</th>
+        <th>Licensed for First Range?</th>
+        <th>Funder for First Range</th>
+        <th>Licensed for Second Range?</th>
+        <th>Funder for Second Range</th>
         <th></th>
       </tr>
     </thead>

--- a/app/components/commercial/licensing_summary_component/row_component.html.erb
+++ b/app/components/commercial/licensing_summary_component/row_component.html.erb
@@ -3,23 +3,23 @@
     <%= link_to school.name, school_path(school) %>
   </td>
   <td>
-    <%= render(Elements::BadgeComponent.new(licensed_for_first_range.to_s.humanize,
+    <%= render(Elements::BadgeComponent.new(licensed_for(@first_range).to_s.humanize,
                                             pill: true,
-                                            colour: helpers.period_badge_colour(licensed_for_first_range))) %>
+                                            colour: helpers.period_badge_colour(licensed_for(@first_range)))) %>
 
   </td>
   <td>
-    <%= contract_holder_for_first_range.join(',') %>
+    <%= contract_holder_for(@first_range).join(',') %>
   </td>
   <% if @second_range.present? %>
     <td>
-      <%= render(Elements::BadgeComponent.new(licensed_for_second_range.to_s.humanize,
+      <%= render(Elements::BadgeComponent.new(licensed_for(@second_range).to_s.humanize,
                                               pill: true,
-                                              colour: helpers.period_badge_colour(licensed_for_second_range))) %>
+                                              colour: helpers.period_badge_colour(licensed_for(@second_range)))) %>
 
     </td>
     <td>
-      <%= contract_holder_for_second_range.join(',') %>
+      <%= contract_holder_for(@second_range).join(',') %>
     </td>
   <% end %>
   <td>

--- a/app/components/commercial/licensing_summary_component/row_component.html.erb
+++ b/app/components/commercial/licensing_summary_component/row_component.html.erb
@@ -3,21 +3,24 @@
     <%= link_to school.name, school_path(school) %>
   </td>
   <td>
-    <%= helpers.checkmark(school.currently_licenced?) %>
-  </td>
-  <td>
-    <%= school.current_licence&.contract&.contract_holder&.name %>
-  </td>
-  <td id="future-funder-<%= school.id %>">
-    <%= school.default_contract_holder&.name || 'Self funding' %>
-  </td>
-  <td>
-    <% licenced_for = school.licenced_for_period(date_range) %>
-    <%= render(Elements::BadgeComponent.new(licenced_for.to_s.humanize,
+    <%= render(Elements::BadgeComponent.new(licensed_for_first_range.to_s.humanize,
                                             pill: true,
-                                            colour: helpers.period_badge_colour(licenced_for))) %>
+                                            colour: helpers.period_badge_colour(licensed_for_first_range))) %>
+
   </td>
-  <td class="d-flex gap-2">
+  <td>
+    <%= contract_holder_for_first_range.join(',') %>
+  </td>
+  <td>
+    <%= render(Elements::BadgeComponent.new(licensed_for_second_range.to_s.humanize,
+                                            pill: true,
+                                            colour: helpers.period_badge_colour(licensed_for_second_range))) %>
+
+  </td>
+  <td>
+    <%= contract_holder_for_second_range.join(',') %>
+  </td>
+  <td>
     <% buttons.each do |button| %>
       <%= button %>
     <% end %>

--- a/app/components/commercial/licensing_summary_component/row_component.html.erb
+++ b/app/components/commercial/licensing_summary_component/row_component.html.erb
@@ -11,15 +11,17 @@
   <td>
     <%= contract_holder_for_first_range.join(',') %>
   </td>
-  <td>
-    <%= render(Elements::BadgeComponent.new(licensed_for_second_range.to_s.humanize,
-                                            pill: true,
-                                            colour: helpers.period_badge_colour(licensed_for_second_range))) %>
+  <% if @second_range.present? %>
+    <td>
+      <%= render(Elements::BadgeComponent.new(licensed_for_second_range.to_s.humanize,
+                                              pill: true,
+                                              colour: helpers.period_badge_colour(licensed_for_second_range))) %>
 
-  </td>
-  <td>
-    <%= contract_holder_for_second_range.join(',') %>
-  </td>
+    </td>
+    <td>
+      <%= contract_holder_for_second_range.join(',') %>
+    </td>
+  <% end %>
   <td>
     <% buttons.each do |button| %>
       <%= button %>

--- a/app/components/forms/commercial/bulk_licence_editor_component/bulk_licence_editor_component.html.erb
+++ b/app/components/forms/commercial/bulk_licence_editor_component/bulk_licence_editor_component.html.erb
@@ -36,34 +36,30 @@
   <%= link_to 'Cancel', admin_commercial_contract_path(@contract), class: 'btn btn-secondary' %>
 
   <% if @additional_schools.any? %>
+    <h2>Add schools to contract</h2>
+    <p>
+      The following schools in this school group are not currently part of this contract.
+    </p>
+    <p>
+      The table identifies whether they are licensed for the current academic year and
+      the relevant contract holder(s) for the licence(s) for that period.
+    </p>
+    <p>
+      "Full" means they are already licensed. "Partial" means they a licence that covers part of this contracted period.
+      "No" means there are no licences for that period.
+    </p>
+    <p>
+      The table also indicates whether the school already has a licence for the period defined by the
+      contract start and end dates. This is presented similarly to the above.
+    </p>
+    <p>
+      Use the "<strong>Add Licence</strong>" button to add a licence for the school under this contract.
+    </p>
     <div class="mt-4 licence-editor-table-wrapper">
-      <h2>Add schools to contract</h2>
-      <p>
-        The following schools in this school group are not currently part of this contract. The table identifies whether
-        they are currently licensed, who their current and future funder is expected to be, and whether they have
-        any (future) licence that covers the period of this contact.
-      </p>
-      <p>
-        If a school has a current licence (valid for today) then the "<strong>Current Funder</strong>" column includes the name of
-        the contract holder for that licence. "<strong>Future Funder</strong>" indicates whether we are expecting the school to be
-        self-funded or covered by a MAT contract in future.
-      </p>
-
-      <p>
-        "<strong>Licensed for Period?</strong>" indicates whether school has any existing licences that cover the period of this contract.
-        "Full" means they are already licensed. "Partial" means they a licence that covers part of this contracted period.
-      </p>
-      <p>
-        Use the "<strong>Add Licence</strong>" button to add a licence for the school under this contract.
-      </p>
-      <p>
-        Use the "<strong>Make Self funded</strong> / <strong>Make MAT funded</strong>" toggle to set whether the school is expected to be
-        MAT or self-funded in future. If a school was self-funded and is going to be added to this contract, then change their status before
-        adding a licence.
-      </p>
       <%= render ::Commercial::LicensingSummaryComponent.new(
             table_id: "contract-#{@contract.id}-additional-schools-table",
-            second_range: @contract.as_range
+            second_range: @contract.as_range,
+            labels: { first: 'Current Academic Year', second: 'Contract Period' }
           ) do |c| %>
         <% @additional_schools.each do |school| %>
           <% c.with_row id: "additional-school-#{school.id}", school: school do |r| %>

--- a/app/components/forms/commercial/bulk_licence_editor_component/bulk_licence_editor_component.html.erb
+++ b/app/components/forms/commercial/bulk_licence_editor_component/bulk_licence_editor_component.html.erb
@@ -63,7 +63,7 @@
       </p>
       <%= render ::Commercial::LicensingSummaryComponent.new(
             table_id: "contract-#{@contract.id}-additional-schools-table",
-            date_range: @contract.as_range
+            second_range: @contract.as_range
           ) do |c| %>
         <% @additional_schools.each do |school| %>
           <% c.with_row id: "additional-school-#{school.id}", school: school do |r| %>
@@ -77,22 +77,10 @@
                             class: 'btn btn-sm btn-primary' %>
             <% end %>
             <% r.with_button do %>
-              <div id="self-funded-toggle-<%= school.id %>">
-                <% if school.self_funded_in_future? %>
-                  <%= button_to 'Make MAT funded',
-                                school_self_funded_path(school),
-                                method: :create,
-                                remote: true,
-                                class: 'btn btn-sm btn-secondary' %>
-                <% else %>
-                  <%= button_to 'Make Self funded',
-                                school_self_funded_path(school),
-                                method: :delete,
-                                remote: true,
-                                class: 'btn btn-sm btn-secondary' %>
-
-                <% end %>
-              </div>
+              <%= link_to 'View issues',
+                          admin_school_issues_path(school),
+                          target: '_new',
+                          class: 'btn btn-sm' %>
             <% end %>
           <% end %>
         <% end %>

--- a/app/components/forms/commercial/bulk_licence_editor_component/bulk_licence_editor_component.html.erb
+++ b/app/components/forms/commercial/bulk_licence_editor_component/bulk_licence_editor_component.html.erb
@@ -45,8 +45,8 @@
       the relevant contract holder(s) for the licence(s) for that period.
     </p>
     <p>
-      "Full" means they are already licensed. "Partial" means they a licence that covers part of this contracted period.
-      "No" means there are no licences for that period.
+      "Full" means they are already licensed. "Partial" means they have a licence that covers
+      part of this contracted period. "No" means there are no licences for that period.
     </p>
     <p>
       The table also indicates whether the school already has a licence for the period defined by the

--- a/app/components/forms/commercial/bulk_licence_editor_component/bulk_licence_editor_component.html.erb
+++ b/app/components/forms/commercial/bulk_licence_editor_component/bulk_licence_editor_component.html.erb
@@ -73,7 +73,13 @@
                             class: 'btn btn-sm btn-primary' %>
             <% end %>
             <% r.with_button do %>
-              <%= link_to 'View issues',
+              <%= link_to 'Licences',
+                          admin_school_licences_path(school),
+                          target: '_new',
+                          class: 'btn btn-sm' %>
+            <% end %>
+            <% r.with_button do %>
+              <%= link_to 'Issues',
                           admin_school_issues_path(school),
                           target: '_new',
                           class: 'btn btn-sm' %>

--- a/app/components/forms/commercial/bulk_licence_editor_component/bulk_licence_editor_component.scss
+++ b/app/components/forms/commercial/bulk_licence_editor_component/bulk_licence_editor_component.scss
@@ -5,6 +5,11 @@
     overflow-y: auto;
   }
 
+  .licence-editor-table-wrapper form.button_to {
+    display: inline-block !important;
+    white-space: nowrap;
+  }
+
   .licence-editor-table > thead > tr > th {
     background-color: $header-dark !important;
     border-bottom: 0;

--- a/app/controllers/admin/school_groups/licence_summaries_controller.rb
+++ b/app/controllers/admin/school_groups/licence_summaries_controller.rb
@@ -8,7 +8,13 @@ module Admin
       layout 'group_settings'
 
       def show
-        @academic_year = Calendar.default_national.current_academic_year
+        @current_year = Calendar.default_national.current_academic_year
+        @next_year = Calendar.default_national.current_academic_year.next_year
+        @selected_year = if params[:academic_year].present?
+                           AcademicYear.find(params.expect(:academic_year))
+                         else
+                           @current_year
+                         end
       end
     end
   end

--- a/app/controllers/admin/school_groups/licence_summaries_controller.rb
+++ b/app/controllers/admin/school_groups/licence_summaries_controller.rb
@@ -10,11 +10,6 @@ module Admin
       def show
         @current_year = Calendar.default_national.current_academic_year
         @next_year = Calendar.default_national.current_academic_year.next_year
-        @selected_year = if params[:academic_year].present?
-                           AcademicYear.find(params.expect(:academic_year))
-                         else
-                           @current_year
-                         end
       end
     end
   end

--- a/app/models/concerns/commercial/licence_holder.rb
+++ b/app/models/concerns/commercial/licence_holder.rb
@@ -32,7 +32,7 @@ module Commercial
     #   :no    – no licence overlaps the period at all
     #   :partial – some overlap, but not full coverage
     #   :full    – the entire period is covered by one or more licences
-    def licenced_for_period(period)
+    def licensed_for_period(period)
       # Collect all overlapping licence ranges
       overlapping = licences.filter_map do |licence|
         licence_range = (licence.start_date..licence.end_date)

--- a/app/models/concerns/temporal_range.rb
+++ b/app/models/concerns/temporal_range.rb
@@ -29,6 +29,14 @@ module TemporalRange
       where("#{table_name}.updated_at >= ? AND #{table_name}.updated_at > #{table_name}.created_at", updated_at)
     }
 
+    scope :for_period, lambda { |period|
+      where(
+        'start_date <= ? AND end_date >= ?',
+        period.end,
+        period.begin
+      ).by_start_date
+    }
+
     # Define in model, returning array of attributes
     def temporal_group_keys
       raise NotImplementedError

--- a/app/views/admin/commercial/licences/unlicensed.html.erb
+++ b/app/views/admin/commercial/licences/unlicensed.html.erb
@@ -46,10 +46,10 @@
                         <%= checkmark(school.licences.expired.any?) %>
                     </td>
                     <td class="text-end">
-                        <% licenced_for = school.licenced_for_period(@academic_year.start_date..@academic_year.end_date) %>
-                        <%= render(Elements::BadgeComponent.new(licenced_for.to_s.humanize,
+                        <% licensed_for = school.licensed_for_period(@academic_year.start_date..@academic_year.end_date) %>
+                        <%= render(Elements::BadgeComponent.new(licensed_for.to_s.humanize,
                                                                 pill: true,
-                                                                colour: period_badge_colour(licenced_for))) %>
+                                                                colour: period_badge_colour(licensed_for))) %>
                     </td>
                     <td class="text-end">
                         <%= link_to 'Licences', admin_school_licences_path(school), class: 'btn btn-sm' %>

--- a/app/views/admin/school_groups/licence_summaries/show.html.erb
+++ b/app/views/admin/school_groups/licence_summaries/show.html.erb
@@ -3,45 +3,44 @@
 <div class="row">
   <div class="col">
     <p>
-      This page provides a summary of the licensing situation for this group for the Academic Year
-      <%= nice_dates(@selected_year.start_date) %> - <%= nice_dates(@selected_year.end_date) %>
+      This page provides a summary of the licensing situation for this group for the current and next academic
+      years.
     </p>
     <p>
       The table below lists all schools in this group along with an indication of whether:
     </p>
     <ul>
-      <li>They have a current licence, valid for today</li>
-      <li>The contract holder for their current licence</li>
-      <li>Who is funding them in future (e.g. who is contract holder for their next licence?)</li>
-      <li>Whether their current licences cover the period of
-          <%= nice_dates(@selected_year.start_date) %> - <%= nice_dates(@selected_year.end_date) %>.
-          Full indicates their licences cover the entire year, Partial means that they are only funded
-          for part of the year.</li>
+      <li>For the current academic year
+          (<%= short_dates(@current_year.start_date) %> - <%= short_dates(@current_year.end_date) %>).
+          <ul>
+            <li>Whether they are licensed for that period</li>
+            <li>The contract holder(s) for those licences</li>
+          </ul>
+      </li>
+      <li>For the next academic year
+          (<%= short_dates(@next_year.start_date) %> - <%= short_dates(@next_year.end_date) %>).
+          <ul>
+            <li>Whether they are licensed for that period</li>
+            <li>The contract holder(s) for those licences</li>
+          </ul>
+      </li>
       <li>A link to the full licence history for the school</li>
     </ul>
-  </div>
-</div>
 
-<div class="row">
-  <div class="col">
-      <%= simple_form_for '', url: admin_school_group_licence_summaries_path(@school_group), method: 'GET',
-                              html: { class: 'form-inline' } do |f| %>
-        <%= f.select :academic_year,
-                     options_for_select([['Current Academic Year', @current_year.id],
-                                         ['Next Academic Year', @next_year.id]],
-                                        @selected_year.id),
-                     { include_blank: false },
-                     { class: 'form-control' } %>
-        <%= f.submit 'Update', class: 'btn btn-primary btn-sm ml-2' %>
-      <% end %>
+    <p>
+      "Full" indicates that their licences cover the entire year, "Partial" means that they are only funded
+      for part of that year.
+    </p>
+
   </div>
 </div>
 
 <div class="row">
   <div class="col">
     <%= render Commercial::LicensingSummaryComponent.new(
-          first_range: @selected_year.start_date..@selected_year.end_date,
-          second_range: @selected_year.next_year.start_date..@selected_year.next_year.end_date
+          first_range: @current_year.start_date..@current_year.end_date,
+          second_range: @next_year.start_date..@next_year.next_year.end_date,
+          labels: { first: @current_year.title, second: @next_year.title }
         ) do |c| %>
       <% @school_group.assigned_schools.by_name.each do |school| %>
         <% c.with_row school: school do |r| %>

--- a/app/views/admin/school_groups/licence_summaries/show.html.erb
+++ b/app/views/admin/school_groups/licence_summaries/show.html.erb
@@ -3,7 +3,8 @@
 <div class="row">
   <div class="col">
     <p>
-      This page provides a summary of the current licensing situation for this group.
+      This page provides a summary of the licensing situation for this group for the Academic Year
+      <%= nice_dates(@selected_year.start_date) %> - <%= nice_dates(@selected_year.end_date) %>
     </p>
     <p>
       The table below lists all schools in this group along with an indication of whether:
@@ -11,9 +12,9 @@
     <ul>
       <li>They have a current licence, valid for today</li>
       <li>The contract holder for their current licence</li>
-      <li>Who is expected to be funding them in future (will either be their group or themselves)</li>
-      <li>Whether their current licences cover the current academic year (
-          <%= nice_dates(@academic_year.end_date) %> - <%= nice_dates(@academic_year.start_date) %> ).
+      <li>Who is funding them in future (e.g. who is contract holder for their next licence?)</li>
+      <li>Whether their current licences cover the period of
+          <%= nice_dates(@selected_year.start_date) %> - <%= nice_dates(@selected_year.end_date) %>.
           Full indicates their licences cover the entire year, Partial means that they are only funded
           for part of the year.</li>
       <li>A link to the full licence history for the school</li>
@@ -23,13 +24,35 @@
 
 <div class="row">
   <div class="col">
+      <%= simple_form_for '', url: admin_school_group_licence_summaries_path(@school_group), method: 'GET',
+                              html: { class: 'form-inline' } do |f| %>
+        <%= f.select :academic_year,
+                     options_for_select([['Current Academic Year', @current_year.id],
+                                         ['Next Academic Year', @next_year.id]],
+                                        @selected_year.id),
+                     { include_blank: false },
+                     { class: 'form-control' } %>
+        <%= f.submit 'Update', class: 'btn btn-primary btn-sm ml-2' %>
+      <% end %>
+  </div>
+</div>
+
+<div class="row">
+  <div class="col">
     <%= render Commercial::LicensingSummaryComponent.new(
-          date_range: @academic_year.start_date..@academic_year.end_date
+          first_range: @selected_year.start_date..@selected_year.end_date,
+          second_range: @selected_year.next_year.start_date..@selected_year.next_year.end_date
         ) do |c| %>
       <% @school_group.assigned_schools.by_name.each do |school| %>
         <% c.with_row school: school do |r| %>
           <% r.with_button do %>
-            <%= link_to 'Licences', admin_school_licences_path(school) %>
+            <%= link_to 'Licences', admin_school_licences_path(school), class: 'btn btn-sm btn-primary' %>
+          <% end %>
+          <% r.with_button do %>
+            <%= link_to 'View issues',
+                        admin_school_issues_path(school),
+                        target: '_new',
+                        class: 'btn btn-sm' %>
           <% end %>
         <% end %>
       <% end %>

--- a/app/views/admin/school_groups/licence_summaries/show.html.erb
+++ b/app/views/admin/school_groups/licence_summaries/show.html.erb
@@ -48,7 +48,7 @@
             <%= link_to 'Licences', admin_school_licences_path(school), class: 'btn btn-sm btn-primary' %>
           <% end %>
           <% r.with_button do %>
-            <%= link_to 'View issues',
+            <%= link_to 'Issues',
                         admin_school_issues_path(school),
                         target: '_new',
                         class: 'btn btn-sm' %>

--- a/app/views/admin/school_groups/licence_summaries/show.html.erb
+++ b/app/views/admin/school_groups/licence_summaries/show.html.erb
@@ -39,7 +39,7 @@
   <div class="col">
     <%= render Commercial::LicensingSummaryComponent.new(
           first_range: @current_year.start_date..@current_year.end_date,
-          second_range: @next_year.start_date..@next_year.next_year.end_date,
+          second_range: @next_year.start_date..@next_year.end_date,
           labels: { first: @current_year.title, second: @next_year.title }
         ) do |c| %>
       <% @school_group.assigned_schools.by_name.each do |school| %>

--- a/spec/components/commercial/licensing_summary_component_spec.rb
+++ b/spec/components/commercial/licensing_summary_component_spec.rb
@@ -14,41 +14,80 @@ RSpec.describe Commercial::LicensingSummaryComponent, :include_application_helpe
 
   let(:date_range) { Date.new(2025, 9, 1)..Date.new(2026, 8, 31) }
 
-  before do
-    render_inline described_class.new(date_range:
-      date_range.begin..date_range.end,
-                                      id: 'custom-id',
-                                      classes: 'extra-classes') do |c|
-      c.with_row id: "custom-school-id-#{school.id}", school: school
+  context 'when showing a single range' do
+    before do
+      render_inline described_class.new(first_range:
+        date_range.begin..date_range.end,
+                                        id: 'custom-id',
+                                        classes: 'extra-classes') do |c|
+        c.with_row id: "custom-school-id-#{school.id}", school: school
+      end
+    end
+
+    it_behaves_like 'an application component' do
+      let(:expected_classes) { 'extra-classes' }
+      let(:expected_id) { 'custom-id' }
+      let(:html) { page }
+    end
+
+    it 'includes the school id' do
+      expect(page).to have_css("#custom-school-id-#{school.id}")
+    end
+
+    context 'when school has a current licence' do
+      it_behaves_like 'it contains the expected data table', sortable: true, aligned: false do
+        let(:table_id) { '#summary-table' }
+        let(:expected_header) do
+          [
+            ['', 'Current Academic Year', ''],
+            ['School', 'Licensed?', 'Funder', '']
+          ]
+        end
+        let(:expected_rows) do
+          [
+            [
+              school.name,
+              'Full',
+              licence.contract.contract_holder.name,
+              ''
+            ]
+          ]
+        end
+      end
     end
   end
 
-  it_behaves_like 'an application component' do
-    let(:expected_classes) { 'extra-classes' }
-    let(:expected_id) { 'custom-id' }
-    let(:html) { page }
-  end
+  context 'when showing two ranges' do
+    before do
+      create(:commercial_licence,
+             school:,
+             start_date: date_range.end + 1,
+             end_date: date_range.end + 30)
+      render_inline described_class.new(first_range: date_range.begin..date_range.end,
+                                        second_range: (date_range.end + 1)..(date_range.end + 364),
+                                        labels: { first: 'Current Year', second: 'Following Year' },
+                                        id: 'custom-id',
+                                        classes: 'extra-classes') do |c|
+        c.with_row id: "custom-school-id-#{school.id}", school: school
+      end
+    end
 
-  it 'includes the school id' do
-    expect(page).to have_css("#custom-school-id-#{school.id}")
-  end
-
-  context 'when school has a current licence' do
     it_behaves_like 'it contains the expected data table', sortable: true, aligned: false do
       let(:table_id) { '#summary-table' }
       let(:expected_header) do
         [
-          ['School', 'Current Licence?', 'Current Funder', 'Future Funder', 'Licenced for Period?', '']
+          ['', 'Current Year', 'Following Year', ''],
+          ['School', 'Licensed?', 'Funder', 'Licensed?', 'Funder', '']
         ]
       end
       let(:expected_rows) do
         [
           [
             school.name,
-            '',
-            licence.contract.contract_holder.name,
-            school.default_contract_holder&.name,
             'Full',
+            licence.contract.contract_holder.name,
+            'Partial',
+            school.licences.by_start_date.last.contract_holder.name,
             ''
           ]
         ]

--- a/spec/components/forms/commercial/bulk_licence_editor_component_spec.rb
+++ b/spec/components/forms/commercial/bulk_licence_editor_component_spec.rb
@@ -17,6 +17,9 @@ RSpec.describe Forms::Commercial::BulkLicenceEditorComponent, :include_applicati
   end
 
   before do
+    calendar = create(:calendar, :default_national)
+    create(:academic_year, calendar:)
+
     render_inline described_class.new(
       contract:,
       id: 'custom-id',
@@ -200,16 +203,20 @@ RSpec.describe Forms::Commercial::BulkLicenceEditorComponent, :include_applicati
 
         it { expect(page).to have_text('Add schools to contract') }
 
+        it { expect(page).to have_link('Issues', href: admin_school_issues_path(additional_school)) }
+        it { expect(page).to have_link('Licences', href: admin_school_licences_path(additional_school)) }
+
         it_behaves_like 'it contains the expected data table', sortable: true, aligned: false do
           let(:table_id) { "#contract-#{contract.id}-additional-schools-table" }
           let(:expected_header) do
             [
-              ['School', 'Current Licence?', 'Current Funder', 'Future Funder', 'Licenced for Period?', '']
+              ['', 'Current Academic Year', 'Contract Period', ''],
+              ['School', 'Licensed?', 'Funder', 'Licensed?', 'Funder', '']
             ]
           end
           let(:expected_rows) do
             [
-              [additional_school.name, '', '', 'Self funding', 'No', 'Add licence Make MAT funded']
+              [additional_school.name, 'No', '', 'No', '', 'Add licence Licences Issues']
             ]
           end
         end

--- a/spec/factories/calendars_factory.rb
+++ b/spec/factories/calendars_factory.rb
@@ -30,6 +30,11 @@ FactoryBot.define do
       calendar_type { :national }
     end
 
+    trait :default_national do
+      calendar_type { :national }
+      title { 'England and Wales' }
+    end
+
     # For creating a school calendar with associated regional and national calendars with academic years
     trait :for_school do
       calendar_type { :school }
@@ -42,11 +47,10 @@ FactoryBot.define do
       after(:create) do |calendar, evaluator|
         # Create the national calendar first, with years
         national_calendar = create(:calendar,
-          :with_academic_years,
-          calendar_type: :national,
-          previous_academic_year_count: evaluator.previous_academic_year_count,
-          academic_year_count: evaluator.academic_year_count
-        )
+                                   :with_academic_years,
+                                   calendar_type: :national,
+                                   previous_academic_year_count: evaluator.previous_academic_year_count,
+                                   academic_year_count: evaluator.academic_year_count)
         regional_calendar = create(:calendar, calendar_type: :regional, based_on: national_calendar)
 
         calendar.update!(based_on: regional_calendar)
@@ -91,7 +95,8 @@ FactoryBot.define do
         start_year = today.year - (today.month < 9 ? 2 : 1)
         end_year = today.year + 1
         (start_year..end_year).each do |year|
-          create(:academic_year, calendar: calendar, start_date: Date.new(year, 9, 1), end_date: Date.new(year + 1, 8, 31))
+          create(:academic_year, calendar: calendar, start_date: Date.new(year, 9, 1),
+                                 end_date: Date.new(year + 1, 8, 31))
         end
       end
     end

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -1429,24 +1429,24 @@ describe School do
       end
     end
 
-    describe '#licenced_for_period' do
+    describe '#licensed_for_period' do
       let(:start_date) { Date.new(2024, 1, 1) }
       let(:end_date)   { Date.new(2024, 1, 31) }
 
       it 'returns :no when no licences overlap' do
         create_licence(Date.new(2024, 3, 1), Date.new(2024, 3, 31))
-        expect(school.licenced_for_period(start_date..end_date)).to eq(:no)
+        expect(school.licensed_for_period(start_date..end_date)).to eq(:no)
       end
 
       it 'returns :partial when licences overlap but do not cover full period' do
         create_licence(Date.new(2024, 1, 10), Date.new(2024, 1, 20))
-        expect(school.licenced_for_period(start_date..end_date)).to eq(:partial)
+        expect(school.licensed_for_period(start_date..end_date)).to eq(:partial)
       end
 
       it 'returns :full when licences fully cover the period' do
         create_licence(Date.new(2023, 12, 1), Date.new(2024, 1, 15))
         create_licence(Date.new(2024, 1, 16), Date.new(2024, 2, 1))
-        expect(school.licenced_for_period(start_date..end_date)).to eq(:full)
+        expect(school.licensed_for_period(start_date..end_date)).to eq(:full)
       end
     end
   end

--- a/spec/system/admin/commercial/bulk_editing_contract_licences_spec.rb
+++ b/spec/system/admin/commercial/bulk_editing_contract_licences_spec.rb
@@ -17,12 +17,15 @@ describe 'bulk editing contract licences' do
   end
 
   before do
+    calendar = create(:calendar, :default_national)
+    create(:academic_year, calendar:)
+
     sign_in(user)
     visit admin_commercial_contract_path(contract)
     click_on('Manage All Licences')
   end
 
-  it { expect(page).to have_content("#{contract.name} Bulk Licence Editor") }
+  it { expect(page).to have_text("#{contract.name} Bulk Licence Editor") }
 
   def field_name(licence, name)
     "commercial_contract[licences_attributes][#{licence.id}][#{name}]"
@@ -39,13 +42,13 @@ describe 'bulk editing contract licences' do
       end
     end
 
-    it { expect(page).to have_content('Undo') }
+    it { expect(page).to have_text('Undo') }
 
     context 'when the changes are saved' do
       before { click_on 'Save changes' }
 
       it 'deletes the licence' do
-        expect(page).to have_content('Licences updated')
+        expect(page).to have_text('Licences updated')
         expect(Commercial::Licence.all).to eq([licence])
       end
     end
@@ -62,7 +65,7 @@ describe 'bulk editing contract licences' do
     end
 
     it 'updates the licence' do
-      expect(page).to have_content('Licences updated')
+      expect(page).to have_text('Licences updated')
       expect(licence_to_be_modified.reload).to have_attributes({
                                                                  school_specific_price: 200.0,
                                                                  status: 'confirmed',
@@ -88,18 +91,18 @@ describe 'bulk editing contract licences' do
 
       before { refresh }
 
-      it { expect(page).to have_content('Add schools to contract') }
+      it { expect(page).to have_text('Add schools to contract') }
 
       it 'lists the school' do
         within("#contract-#{contract.id}-additional-schools-table") do
-          expect(page).to have_content(additional_school.name)
-          expect(page).to have_link('View issues', href: admin_school_issues_path(additional_school))
+          expect(page).to have_text(additional_school.name)
+          expect(page).to have_link('Issues', href: admin_school_issues_path(additional_school))
         end
       end
 
       it 'does not show a licence for the school' do
         within("#contract-#{contract.id}-licence-table") do
-          expect(page).to have_no_content(additional_school.name)
+          expect(page).to have_no_text(additional_school.name)
         end
       end
 
@@ -115,7 +118,7 @@ describe 'bulk editing contract licences' do
 
         it 'updates the licence table to include the licence' do
           within("#contract-#{contract.id}-licence-table") do
-            expect(page).to have_content(additional_school.name)
+            expect(page).to have_text(additional_school.name)
           end
           expect(additional_school.reload.licences.count).to eq(1)
         end
@@ -130,7 +133,7 @@ describe 'bulk editing contract licences' do
           end
 
           it 'deletes the licence' do
-            expect(page).to have_content('Licences updated')
+            expect(page).to have_text('Licences updated')
             expect(additional_school.licences.reload).to be_empty
           end
         end
@@ -142,7 +145,7 @@ describe 'bulk editing contract licences' do
           end
 
           it 'updates the newly added licence' do
-            expect(page).to have_content('Licences updated')
+            expect(page).to have_text('Licences updated')
             expect(additional_school.licences.reload.last.comments).to eq('Some comments')
           end
         end

--- a/spec/system/admin/commercial/bulk_editing_contract_licences_spec.rb
+++ b/spec/system/admin/commercial/bulk_editing_contract_licences_spec.rb
@@ -93,6 +93,7 @@ describe 'bulk editing contract licences' do
       it 'lists the school' do
         within("#contract-#{contract.id}-additional-schools-table") do
           expect(page).to have_content(additional_school.name)
+          expect(page).to have_link('View issues', href: admin_school_issues_path(additional_school))
         end
       end
 
@@ -143,35 +144,6 @@ describe 'bulk editing contract licences' do
           it 'updates the newly added licence' do
             expect(page).to have_content('Licences updated')
             expect(additional_school.licences.reload.last.comments).to eq('Some comments')
-          end
-        end
-      end
-
-      context 'when toggling school funding status' do
-        before do
-          click_on 'Make Self funded'
-          within("#contract-#{contract.id}-additional-schools-table") do
-            find('tr', text: 'Self funding')
-          end
-        end
-
-        it 'toggles the button and text' do
-          within("#contract-#{contract.id}-additional-schools-table") do
-            find('tr', text: 'Make MAT funded')
-          end
-          expect(additional_school.reload.default_contract_holder).to be_nil
-        end
-
-        context 'when toggling back' do
-          before do
-            click_on 'Make MAT funded'
-            within("#contract-#{contract.id}-additional-schools-table") do
-              find('tr', text: 'Make Self funded')
-            end
-          end
-
-          it 'reverts the change' do
-            expect(additional_school.reload.default_contract_holder).to eq(contract.contract_holder)
           end
         end
       end

--- a/spec/system/admin/commercial/group_contracts_and_licences_spec.rb
+++ b/spec/system/admin/commercial/group_contracts_and_licences_spec.rb
@@ -8,7 +8,11 @@ describe 'group contracts and licences' do
 
   before do
     calendar = create(:national_calendar, title: 'England and Wales')
-    create(:academic_year, calendar:)
+    academic_year = create(:academic_year, calendar:)
+    create(:academic_year,
+           calendar:,
+           start_date: academic_year.end_date + 1.day,
+           end_date: academic_year.end_date + 12.months)
     sign_in(create(:admin))
     visit settings_school_group_path(school_group)
   end
@@ -17,7 +21,7 @@ describe 'group contracts and licences' do
     before { click_on 'Licence Summaries' }
 
     it { expect(page).to have_css('div.commercial-licensing-summary-component') }
-    it { expect(page).to have_content(licence.school.name) }
+    it { expect(page).to have_text(licence.school.name) }
     it { expect(page).to have_link('Licences', href: admin_school_licences_path(licence.school)) }
   end
 
@@ -27,6 +31,6 @@ describe 'group contracts and licences' do
     before { click_on 'Contracts' }
 
     it { expect(page).to have_css('div.commercial-contracts-component') }
-    it { expect(page).to have_content(contract.name) }
+    it { expect(page).to have_text(contract.name) }
   end
 end


### PR DESCRIPTION
Rework the `LicenceSummariesComponent` and pages that use it:

- [x] Rework layout of summary component so it can show summary of a single period or two periods (e.g. two academic years, or current year and a contract). Show summary of licensing and contract holder names for each period
- [x] Removing toggling of the `default_contract_holder` column from bulk editor
- [x] Add extra links to issues and licences