### PR TITLE
Add impact report links to group pages

### DIFF
--- a/app/components/dashboards/group_learn_more_component/group_learn_more_component.html.erb
+++ b/app/components/dashboards/group_learn_more_component/group_learn_more_component.html.erb
@@ -10,7 +10,7 @@
                       class: 'd-flex align-items-center justify-content-end' do |form| %>
             <%= form.select :school, options_for_select(schools.pluck(:name, :slug)),
                             { prompt: t('activity_types.show.select_school') }, class: 'form-control select2' %>
-            <%= form.submit t('common.labels.view'), class: 'btn btn-primary ml-2' %>
+            <%= form.submit t('common.labels.view'), class: 'btn btn-primary ms-2' %>
         <% end %>
       <% end %>
     <% end %>
@@ -20,7 +20,7 @@
         <%= feature.with_description { t('components.dashboards.group_learn_more.advice.intro') } %>
         <%= feature.with_button t('common.explore_energy_data'),
                                 school_group_advice_path(school_group),
-                                style: :primary, classes: 'ml-auto' %>
+                                style: :primary, classes: 'ms-auto' %>
       <% end %>
     <% else %>
       <% grid.with_feature_card(classes: 'data-disabled') do |feature| %>

--- a/app/components/impact_reports/base_component.rb
+++ b/app/components/impact_reports/base_component.rb
@@ -6,7 +6,7 @@ module ImpactReports
 
     def initialize(run: nil, school_group: nil, **)
       super(**)
-      @run = run
+      @run = run || school_group&.impact_report_runs&.latest
       @school_group = school_group || run&.school_group
       @config = @school_group.impact_report_configuration
     end

--- a/app/components/impact_reports/prompt_component.rb
+++ b/app/components/impact_reports/prompt_component.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module ImpactReports
+  class PromptComponent < ImpactReports::BaseComponent # rubocop:disable ViewComponent/PreferComposition
+    def render?
+      Flipper.enabled?(:impact_reporting, current_user) &&
+        @config&.visible? &&
+        @run&.enough_data?
+    end
+  end
+end

--- a/app/components/impact_reports/prompt_component/prompt_component.html.erb
+++ b/app/components/impact_reports/prompt_component/prompt_component.html.erb
@@ -1,0 +1,17 @@
+<%= tag.div id: id, class: classes do %>
+  <div class="mb-md-0">
+    <h2 id="prompt-title"><%= impact_t('prompt.title') %></h2>
+    <div class="d-flex flex-column flex-xl-row justify-content-between align-items-xl-center align-items-md-left">
+      <p class="mb-xl-0">
+        <%= impact_t('feature.description_html',
+                     count: @run.overview(:visible_schools).value,
+                     group_type: t(@school_group.group_type, scope: 'school_groups.clusters.group_type')) %>
+      </p>
+      <div class='flex-shrink-0 align-self-xl-end'>
+        <%= link_to impact_t('prompt.view_report'),
+                    school_group_impact_index_path(@school_group),
+                    class: 'btn btn-primary' %>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/app/components/impact_reports/prompt_component/prompt_component.html.erb
+++ b/app/components/impact_reports/prompt_component/prompt_component.html.erb
@@ -1,17 +1,20 @@
 <%= tag.div id: id, class: classes do %>
-  <div class="mb-md-0">
-    <h2 id="prompt-title"><%= impact_t('prompt.title') %></h2>
-    <div class="d-flex flex-column flex-xl-row justify-content-between align-items-xl-center align-items-md-left">
-      <p class="mb-xl-0">
-        <%= impact_t('feature.description_html',
-                     count: @run.overview(:visible_schools).value,
-                     group_type: t(@school_group.group_type, scope: 'school_groups.clusters.group_type')) %>
-      </p>
-      <div class='flex-shrink-0 align-self-xl-end'>
-        <%= link_to impact_t('prompt.view_report'),
-                    school_group_impact_index_path(@school_group),
-                    class: 'btn btn-primary' %>
+  <%= render Layout::Cards::FeatureComponent.new(theme: :pale,
+                                                 classes: 'p-4 rounded-lg mb-4',
+                                                 cell_classes: 'mb-4') do |feature| %>
+    <%= feature.with_header level: 2, title: impact_t('prompt.title') %>
+    <%= feature.with_block(classes: 'd-flex flex-column flex-xl-row align-items-xl-center') do %>
+      <div>
+        <%= impact_t(
+              'feature.description_html',
+              count: @run.overview(:visible_schools).value,
+              group_type: t(@school_group.group_type, scope: 'school_groups.clusters.group_type')
+            ) %>
       </div>
-    </div>
-  </div>
+
+      <%= link_to impact_t('prompt.view_report'),
+                  school_group_impact_index_path(@school_group),
+                  class: 'btn btn-primary mt-3 mt-xl-0 ml-xl-auto align-self-start text-nowrap mt-xl-auto' %>
+    <% end %>
+  <% end %>
 <% end %>

--- a/app/components/layout/cards/feature_component.rb
+++ b/app/components/layout/cards/feature_component.rb
@@ -3,37 +3,38 @@ module Layout
     class FeatureComponent < LayoutComponent
       attr_reader :size, :position
 
-      renders_one :header, ->(**kwargs) do
-        Elements::HeaderComponent.new(**{ level: header_size }.merge(kwargs))
-      end
-      renders_one :price, ->(**kwargs) do
+      renders_one :header, lambda { |**kwargs|
+        Elements::HeaderComponent.new(level: header_size, **kwargs)
+      }
+      renders_one :price, lambda { |**kwargs|
         Elements::PriceComponent.new(**merge_classes('', kwargs))
-      end
-      renders_many :tags, ->(*args, **kwargs) do
-        Elements::BadgeComponent.new(*args, **{ classes: 'fw-normal text-uppercase' }.merge(kwargs))
-      end
+      }
+      renders_many :tags, lambda { |*args, **kwargs|
+        Elements::BadgeComponent.new(*args, classes: 'fw-normal text-uppercase', **kwargs)
+      }
       renders_one :date, ->(date) { short_dates(date.to_s.to_date) }
       renders_one :datetime, ->(datetime) { nice_date_times(datetime.to_s.to_datetime) }
-      renders_one :author, ->(*args, **kwargs) do
+      renders_one :author, lambda { |*args, **kwargs|
         Elements::TagComponent.new(:a, *args, **merge_classes('', kwargs))
-      end
-      renders_one :description, ->(**kwargs) do
+      }
+      renders_one :description, lambda { |**kwargs|
         Elements::TagComponent.new(:div, **merge_classes('pt-2 pb-4', kwargs))
-      end
-      renders_many :buttons, ->(*args, **kwargs) do
-        Elements::ButtonComponent.new(*args, **merge_classes('mb-1 me-2', kwargs))
-      end
-      renders_many :links, ->(*args, **kwargs) do
+      }
+      renders_many :buttons, lambda { |*args, **kwargs|
+        Elements::ButtonComponent.new(*args,  classes: 'mb-1 me-2', **kwargs)
+      }
+      renders_many :links, lambda { |*args, **kwargs|
         Elements::TagComponent.new(:a, *args, **merge_classes('mb-1 mt-auto', kwargs))
-      end
-      renders_many :blocks, ->(**kwargs) do
+      }
+      renders_many :blocks, lambda { |**kwargs|
         Elements::TagComponent.new(:div, **merge_classes('mt-auto', kwargs))
-      end
+      }
 
       def initialize(size: :md, **_kwargs)
         super
         @size = size
         raise ArgumentError.new(self.class.size_error) unless self.class.sizes.key?(@size.to_sym)
+
         add_classes('d-flex flex-column')
       end
 
@@ -46,7 +47,7 @@ module Layout
       end
 
       def self.size_error
-        'Size must be: ' + self.sizes.keys.to_sentence(two_words_connector: ' or ')
+        'Size must be: ' + sizes.keys.to_sentence(two_words_connector: ' or ')
       end
     end
   end

--- a/app/views/school_groups/advice/show.html.erb
+++ b/app/views/school_groups/advice/show.html.erb
@@ -19,6 +19,8 @@
     <% end %>
   <% end %>
 
+  <%= render ImpactReports::PromptComponent.new(school_group: @school_group) %>
+
   <%= render Dashboards::GroupAdvicePageListComponent.new(
         id: 'detailed-analysis',
         school_group: @school_group,

--- a/app/views/school_groups/show.html.erb
+++ b/app/views/school_groups/show.html.erb
@@ -12,7 +12,7 @@
         <%= link_to t('school_groups.header.view_map'), map_school_group_path(@school_group) %>
       <% end %>
       <% callout.with_row do %>
-        <span class="badge badge-secondary">
+        <span class="badge text-bg-secondary">
           <%= t(@school_group.group_type, scope: 'school_groups.clusters.group_type') %>
         </span>
       <% end %>
@@ -55,6 +55,10 @@
         school_group: @school_group,
         schools: @schools,
         classes: 'mt-4'
+      ) %>
+
+  <%= render ImpactReports::PromptComponent.new(
+        school_group: @school_group
       ) %>
 
   <%= render Dashboards::GroupSavingsPromptComponent.new(

--- a/config/locales/views/school_groups/impact.yml
+++ b/config/locales/views/school_groups/impact.yml
@@ -141,3 +141,6 @@ en:
           electricity: Potential electricity savings
           gas: Potential gas savings
           solar_pv: Install solar panels
+      prompt:
+        title: Latest impact report
+        view_report: View impact report

--- a/spec/components/impact_reports/prompt_component_spec.rb
+++ b/spec/components/impact_reports/prompt_component_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ImpactReports::PromptComponent, :include_application_helper,
+               :include_url_helpers, type: :component do
+  include ActionView::Helpers::SanitizeHelper
+
+  let!(:school_group) { create(:school_group) }
+  let!(:run) { create(:impact_report_run, categories: %i[overview], school_group:) } # rubocop:disable RSpec/LetSetup
+  let!(:config) { create(:impact_report_configuration, school_group:, visible: true) } # rubocop:disable RSpec/LetSetup
+
+  context with_feature: :impact_reporting do
+    before do
+      render_inline(described_class.new(school_group: school_group))
+    end
+
+    it 'has a title' do
+      expect(page).to have_text 'Latest impact report'
+    end
+
+    it 'has a description' do
+      group_type = I18n.t(school_group.group_type, scope: 'school_groups.clusters.group_type')
+      expect(page).to have_text(strip_tags(
+                                  I18n.t('school_groups.impact.feature.description_html',
+                                         count: 2, group_type: group_type)
+                                ))
+    end
+
+    it 'has button' do
+      expect(page).to have_link('View impact report', href: school_group_impact_index_path(school_group))
+    end
+
+    context 'when report is not visible' do
+      let(:config) { create(:impact_report_configuration, school_group:, visible: false) }
+
+      it 'does not render' do
+        expect(rendered_content).to be_blank
+      end
+    end
+
+    context 'when not enough schools' do
+      let(:run) do
+        create(:impact_report_run, categories: %i[overview], school_group:, overview: { visible_schools: { value: 1 } })
+      end
+
+      it 'does not render' do
+        expect(rendered_content).to be_blank
+      end
+    end
+  end
+
+  context without_feature: :impact_reporting do
+    before do
+      render_inline(described_class.new(school_group: school_group))
+    end
+
+    it 'does not render' do
+      expect(rendered_content).to be_blank
+    end
+  end
+end

--- a/spec/components/previews/impact_reports/prompt_component_preview.rb
+++ b/spec/components/previews/impact_reports/prompt_component_preview.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module ImpactReports
+  class PromptComponentPreview < ::ViewComponent::Preview
+    # @param slug select :group_options
+    # @param bs5 toggle
+    def default(bs5: true, slug: nil) # rubocop:disable Lint/UnusedMethodArgument
+      school_group = slug ? SchoolGroup.find(slug) : SchoolGroup.with_active_schools.sample
+      render(ImpactReports::PromptComponent.new(run: school_group.impact_report_runs.latest))
+    end
+
+    private
+
+    def group_options
+      {
+        choices: SchoolGroup.with_active_schools.by_name.map { |g| [g.name, g.slug] }
+      }
+    end
+  end
+end

--- a/spec/support/shared_contexts/school_groups.rb
+++ b/spec/support/shared_contexts/school_groups.rb
@@ -1,6 +1,6 @@
 RSpec.shared_context 'school group recent usage' do
   before do
-    allow_any_instance_of(SchoolGroup).to receive(:fuel_types).and_return([:electricity, :gas, :storage_heaters])
+    allow_any_instance_of(SchoolGroup).to receive(:fuel_types).and_return(%i[electricity gas storage_heaters])
     electricity_changes = OpenStruct.new(
       change: '-16%',
       usage: '910',
@@ -44,7 +44,8 @@ RSpec.shared_context 'school group recent usage' do
       OpenStruct.new(
         electricity: OpenStruct.new(week: electricity_changes, month: electricity_changes, year: electricity_changes),
         gas: OpenStruct.new(week: gas_changes, month: gas_changes, year: gas_changes),
-        storage_heaters: OpenStruct.new(week: storage_heater_changes, month: storage_heater_changes, year: storage_heater_changes)
+        storage_heaters: OpenStruct.new(week: storage_heater_changes, month: storage_heater_changes,
+                                        year: storage_heater_changes)
       )
     end
   end
@@ -66,7 +67,7 @@ RSpec.shared_context 'school group priority actions' do
     create(
       :alert_type_rating_content_version,
       alert_type_rating: alert_type_rating,
-      management_priorities_title: 'Spending too much money on heating',
+      management_priorities_title: 'Spending too much money on heating'
     )
   end
   let(:saving) do
@@ -109,12 +110,21 @@ RSpec.shared_context 'school group current scores' do
       OpenStruct.new(
         with_points: OpenStruct.new(
           schools_with_positions: {
-           1 => [OpenStruct.new(name: 'School 1', sum_points: 20, school_group_cluster_name: 'My Cluster'), OpenStruct.new(name: 'School 2', sum_points: 20, school_group_cluster_name: 'Not set')],
-           2 => [OpenStruct.new(name: 'School 3', sum_points: 18, school_group_cluster_name: 'Not set')]
+            1 => [OpenStruct.new(name: 'School 1', sum_points: 20, school_group_cluster_name: 'My Cluster'),
+                  OpenStruct.new(name: 'School 2', sum_points: 20, school_group_cluster_name: 'Not set')],
+            2 => [OpenStruct.new(name: 'School 3', sum_points: 18, school_group_cluster_name: 'Not set')]
           }
-                     ),
-        without_points: [OpenStruct.new(name: 'School 4', school_group_cluster_name: 'Not set'), OpenStruct.new(name: 'School 5', school_group_cluster_name: 'Not set')]
+        ),
+        without_points: [OpenStruct.new(name: 'School 4', school_group_cluster_name: 'Not set'),
+                         OpenStruct.new(name: 'School 5', school_group_cluster_name: 'Not set')]
       )
     end
+  end
+end
+
+RSpec.shared_context 'with impact report' do
+  before do
+    create(:impact_report_run, categories: %i[overview], school_group:)
+    create(:impact_report_configuration, school_group:, visible: true)
   end
 end

--- a/spec/system/school_groups/advice/index_spec.rb
+++ b/spec/system/school_groups/advice/index_spec.rb
@@ -11,7 +11,7 @@ describe 'School group advice index page' do
           visit school_group_advice_path(school_group)
         end
 
-        it { expect(page).to have_no_content(message.message) }
+        it { expect(page).to have_no_text(message.message) }
       end
 
       context 'when signed in as a group user' do
@@ -20,13 +20,25 @@ describe 'School group advice index page' do
           visit school_group_advice_path(school_group)
         end
 
-        it { expect(page).to have_content(message.message) }
+        it { expect(page).to have_text(message.message) }
       end
     end
 
     it 'displays the charts' do
       within('div.charts-group-dashboard-charts-component') do
-        expect(page).to have_content(I18n.t('school_groups.show.energy_use.title'))
+        expect(page).to have_text(I18n.t('school_groups.show.energy_use.title'))
+      end
+    end
+
+    context 'when displaying impact prompt component', with_feature: :impact_reporting do
+      include_context 'with impact report'
+
+      before do
+        visit school_group_advice_path(school_group)
+      end
+
+      it 'shows impact report component' do
+        expect(page).to have_text 'Latest impact report'
       end
     end
   end

--- a/spec/system/school_groups/dashboard_spec.rb
+++ b/spec/system/school_groups/dashboard_spec.rb
@@ -84,6 +84,18 @@ describe 'School group dashboard page', :school_groups do
       end
     end
 
+    context 'when displaying impact prompt component', with_feature: :impact_reporting do
+      before do
+        create(:impact_report_run, categories: %i[overview], school_group:)
+        create(:impact_report_configuration, school_group:, visible: true)
+        visit school_group_path(school_group)
+      end
+
+      it 'shows impact report component' do
+        expect(page).to have_text 'Latest impact report'
+      end
+    end
+
     context 'when showing the savings and alerts section' do
       it 'shows savings prompt' do
         expect(page).to have_link(I18n.t('components.dashboards.group_savings_prompt.view_all_potential_savings'),

--- a/spec/system/school_groups/dashboard_spec.rb
+++ b/spec/system/school_groups/dashboard_spec.rb
@@ -85,9 +85,9 @@ describe 'School group dashboard page', :school_groups do
     end
 
     context 'when displaying impact prompt component', with_feature: :impact_reporting do
+      include_context 'with impact report'
+
       before do
-        create(:impact_report_run, categories: %i[overview], school_group:)
-        create(:impact_report_configuration, school_group:, visible: true)
         visit school_group_path(school_group)
       end
 


### PR DESCRIPTION
Displays the amount of schools from the impact report metrics rather than the latest visible schools count for group (so it matches report). Is this the right thing to do @ldodds?

Group dashboard:
<img width="1458" height="564" alt="image" src="https://github.com/user-attachments/assets/68166bbb-ed12-4f93-a40d-a4924d4caa61" />

Group advice index:
<img width="1458" height="633" alt="image" src="https://github.com/user-attachments/assets/1c9db334-dee6-4c27-bbf0-e747ec040b61" />
