### PR TITLE
Add school summary component

### DIFF
--- a/app/components/commercial/contract_school_summary_component.rb
+++ b/app/components/commercial/contract_school_summary_component.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Commercial
+  class ContractSchoolSummaryComponent < ApplicationComponent
+    def initialize(contract:, table_id: 'contract-school-summary-table', **)
+      super(**)
+      @contract = contract
+      @table_id = table_id
+    end
+
+    def render?
+      !@contract.contract_holder.is_a?(School)
+    end
+
+    private
+
+    def over_licensed?
+      @contract.schools.count > @contract.number_of_schools
+    end
+  end
+end

--- a/app/components/commercial/contract_school_summary_component/contract_school_summary_component.html.erb
+++ b/app/components/commercial/contract_school_summary_component/contract_school_summary_component.html.erb
@@ -1,0 +1,67 @@
+<%= tag.div id: id, class: classes do %>
+  <table id='<%= @table_id %>' class="table table-sm">
+    <% if @contract.contract_holder.is_a?(Funder) %>
+      <thead>
+        <tr>
+          <th>Category</th>
+          <th>Licensed</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>Visible</td>
+          <td class='<%= class_names('text-danger' => over_licensed?) %>'>
+            <%= @contract.schools.visible.count %>
+          </td>
+        </tr>
+        <tr>
+          <td>Data Visible</td>
+          <td class='<%= class_names('text-danger' => over_licensed?) %>'>
+            <%= @contract.schools.visible.data_enabled.count %>
+          </td>
+        </tr>
+        <tr>
+          <td>Onboarding</td>
+          <td class='<%= class_names('text-danger' => over_licensed?) %>'>
+            <%= @contract.school_onboardings.incomplete.count %>
+          </td>
+        </tr>
+      </tbody>
+    <% else %>
+      <thead>
+        <tr>
+          <th>Category</th>
+          <th>Licensed</th>
+          <th>In Group</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>Visible</td>
+          <td class='<%= class_names('text-danger' => over_licensed?) %>'>
+            <%= @contract.schools.where(id: @contract.contract_holder.assigned_schools.visible).count %>
+            </td>
+          <td>
+            <%= @contract.contract_holder.assigned_schools.visible.count %>
+          </td>
+        </tr>
+        <tr>
+          <td>Data Visible</td>
+          <td class='<%= class_names('text-danger' => over_licensed?) %>'>
+            <%= @contract.schools.where(id: @contract.contract_holder.assigned_schools.visible.data_enabled).count %>
+          </td>
+          <td><%= @contract.contract_holder.assigned_schools.visible.data_enabled.count %></td>
+        </tr>
+        <tr>
+          <td>Onboarding</td>
+          <td class='<%= class_names('text-danger' => over_licensed?) %>'>
+            <%= @contract.school_onboardings.incomplete.count %>
+          </td>
+          <td>
+            <%= @contract.contract_holder.onboardings_for_group.incomplete.count %>
+          </td>
+        </tr>
+      </tbody>
+    <% end %>
+  </table>
+<% end %>

--- a/app/components/commercial/contract_school_summary_component/contract_school_summary_component.html.erb
+++ b/app/components/commercial/contract_school_summary_component/contract_school_summary_component.html.erb
@@ -17,7 +17,7 @@
         <tr>
           <td>Data Visible</td>
           <td class='<%= class_names('text-danger' => over_licensed?) %>'>
-            <%= @contract.schools.visible.data_enabled.count %>
+            <%= @contract.schools.data_visible.count %>
           </td>
         </tr>
         <tr>
@@ -48,9 +48,9 @@
         <tr>
           <td>Data Visible</td>
           <td class='<%= class_names('text-danger' => over_licensed?) %>'>
-            <%= @contract.schools.where(id: @contract.contract_holder.assigned_schools.visible.data_enabled).count %>
+            <%= @contract.schools.where(id: @contract.contract_holder.assigned_schools.data_visible).count %>
           </td>
-          <td><%= @contract.contract_holder.assigned_schools.visible.data_enabled.count %></td>
+          <td><%= @contract.contract_holder.assigned_schools.data_visible.count %></td>
         </tr>
         <tr>
           <td>Onboarding</td>

--- a/app/views/admin/commercial/contracts/show.html.erb
+++ b/app/views/admin/commercial/contracts/show.html.erb
@@ -157,6 +157,12 @@
         </div>
       <% end %>
       <%= grid.with_block do %>
+        <% unless @contract.contract_holder.is_a?(School) %>
+          <h3>School Summary</h3>
+          <div id="contract-holder-schools" class="rounded-2 bg-light pt-3 pb-3 px-4 flex-fill">
+            <%= render Commercial::ContractSchoolSummaryComponent.new(contract: @contract) %>
+          </div>
+        <% end %>
         <h3>Licence Summary</h3>
         <div id="licence-summary" class="rounded-2 bg-light pt-3 pb-3 px-4 flex-fill">
           <table id='licence-summary-table' class="table table-sm">

--- a/spec/components/commercial/contract_school_summary_component_spec.rb
+++ b/spec/components/commercial/contract_school_summary_component_spec.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Commercial::ContractSchoolSummaryComponent, :include_application_helper, :include_url_helpers,
+               type: :component do
+  subject(:component) { described_class.new(contract:) }
+
+  context 'with a School' do
+    subject(:component) do
+      described_class.new(contract: create(:commercial_contract, contract_holder: create(:school)))
+    end
+
+    it { expect(component.render?).to be(false) }
+  end
+
+  context 'with a Funder' do
+    let!(:contract) { create(:commercial_contract, contract_holder: create(:funder)) }
+
+    before do
+      create(:commercial_licence, contract:, school: create(:school, data_enabled: false))
+      3.times do
+        create(:commercial_licence, contract:, school: create(:school, data_enabled: true))
+      end
+      create(:school_onboarding, contract:)
+      render_inline component
+    end
+
+    it { expect(component.render?).to be(true) }
+
+    it_behaves_like 'it contains the expected data table', sortable: false, aligned: false do
+      let(:table_id) { '#contract-school-summary-table' }
+      let(:expected_header) do
+        [
+          %w[Category Licensed]
+        ]
+      end
+      let(:expected_rows) do
+        [
+          ['Visible', '4'],
+          ['Data Visible', '3'],
+          ['Onboarding', '1']
+        ]
+      end
+    end
+  end
+
+  context 'with a School Group' do
+    let(:school_group) { create(:school_group) }
+    let!(:contract) { create(:commercial_contract, contract_holder: school_group) }
+
+    before do
+      create(:commercial_licence, contract:, school: create(:school, school_group:, data_enabled: false))
+      3.times do
+        create(:commercial_licence, contract:, school: create(:school, school_group:, data_enabled: true))
+      end
+      create(:school_onboarding, school_group:, contract:)
+
+      create(:school_onboarding, school_group:)
+      create(:school, school_group:, data_enabled: false)
+      render_inline component
+    end
+
+    it { expect(component.render?).to be(true) }
+
+    it_behaves_like 'it contains the expected data table', sortable: false, aligned: false do
+      let(:table_id) { '#contract-school-summary-table' }
+      let(:expected_header) do
+        [
+          ['Category', 'Licensed', 'In Group']
+        ]
+      end
+      let(:expected_rows) do
+        [
+          ['Visible', '4', '5'],
+          ['Data Visible', '3', '3'],
+          ['Onboarding', '1', '2']
+        ]
+      end
+    end
+  end
+end

--- a/spec/components/previews/commercial/contract_school_summary_component_preview.rb
+++ b/spec/components/previews/commercial/contract_school_summary_component_preview.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Commercial
+  class ContractSchoolSummaryComponentPreview < ViewComponent::Preview
+    # @param id select :contract_options
+    def example(id: nil)
+      contract = id ? ::Commercial::Contract.find(id) : ::Commercial::Contract.current.sample(1).first
+
+      render Commercial::ContractSchoolSummaryComponent.new(contract:)
+    end
+
+    private
+
+    def contract_options
+      {
+        choices: ::Commercial::Contract.current.by_name.pluck(:name, :id)
+      }
+    end
+  end
+end


### PR DESCRIPTION
Add a new component to summarise status of schools associated with a contract. Shows different tables for contracts held by Funders vs School Groups.

For Funders we just display status of schools associated with the contract. For School Groups we also show the number of schools in the group to highlight how many are licensed via this contract.