### PR TITLE
Allow meter attributes to be restored

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -63,3 +63,7 @@ ViewComponent/MissingPreview:
   PreviewPaths:
     - spec/components/previews
     - spec/components/previews/commercial
+
+Rails/I18nLocaleTexts:
+  Exclude:
+    - 'app/controllers/admin/**/*'

--- a/app/controllers/admin/global_meter_attributes_controller.rb
+++ b/app/controllers/admin/global_meter_attributes_controller.rb
@@ -43,15 +43,22 @@ module Admin
     def update
       meter_attribute = GlobalMeterAttribute.find(params[:id])
       authorize! :edit, @meter_attribute
-      new_attribute = GlobalMeterAttribute.create!(
-        attribute_type: meter_attribute.attribute_type,
-        reason: params[:attribute][:reason],
-        input_data: params[:attribute][:root],
-        meter_types: params[:attribute][:meter_types],
-        created_by: current_user
-      )
-      meter_attribute.update!(replaced_by: new_attribute)
-      redirect_to admin_global_meter_attributes_path
+      if params[:restore]
+        meter_attribute.deleted_by = nil
+        meter_attribute.save(validate: false)
+        notice = 'Meter attribute successfully restored'
+      else
+        new_attribute = GlobalMeterAttribute.create!(
+          attribute_type: meter_attribute.attribute_type,
+          reason: params[:attribute][:reason],
+          input_data: params[:attribute][:root],
+          meter_types: params[:attribute][:meter_types],
+          created_by: current_user
+        )
+        meter_attribute.update!(replaced_by: new_attribute)
+        notice = 'Meter attribute successfully updated'
+      end
+      redirect_to admin_global_meter_attributes_path, notice: notice
     rescue => e
       redirect_back fallback_location: admin_global_meter_attributes_path, notice: e.message
     end

--- a/app/controllers/admin/school_groups/meter_attributes_controller.rb
+++ b/app/controllers/admin/school_groups/meter_attributes_controller.rb
@@ -44,15 +44,22 @@ module Admin
       def update
         meter_attribute = @school_group.meter_attributes.find(params[:id])
         authorize! :edit, @meter_attribute
-        new_attribute = @school_group.meter_attributes.create!(
-          attribute_type: meter_attribute.attribute_type,
-          reason: params[:attribute][:reason],
-          input_data: params[:attribute][:root],
-          meter_types: params[:attribute][:meter_types],
-          created_by: current_user
-        )
-        meter_attribute.update!(replaced_by: new_attribute)
-        redirect_to admin_school_group_meter_attributes_path(@school_group)
+        if params[:restore]
+          meter_attribute.deleted_by = nil
+          meter_attribute.save(validate: false)
+          notice = 'Meter attribute successfully restored'
+        else
+          new_attribute = @school_group.meter_attributes.create!(
+            attribute_type: meter_attribute.attribute_type,
+            reason: params[:attribute][:reason],
+            input_data: params[:attribute][:root],
+            meter_types: params[:attribute][:meter_types],
+            created_by: current_user
+          )
+          meter_attribute.update!(replaced_by: new_attribute)
+          notice = 'Meter attribute successfully updated'
+        end
+        redirect_to admin_school_group_meter_attributes_path(@school_group), notice: notice
       rescue => e
         redirect_back fallback_location: admin_school_group_meter_attributes_path(@school_group), notice: e.message
       end
@@ -62,7 +69,8 @@ module Admin
         authorize! :delete, meter_attribute
         meter_attribute.deleted_by = current_user
         meter_attribute.save(validate: false)
-        redirect_to admin_school_group_meter_attributes_path(@school_group)
+        redirect_to admin_school_group_meter_attributes_path(@school_group),
+                    notice: 'Meter attribute successfully deleted'
       rescue => e
         redirect_back fallback_location: admin_school_group_meter_attributes_path(@school_group), notice: e.message
       end

--- a/app/controllers/admin/schools/meter_attributes_controller.rb
+++ b/app/controllers/admin/schools/meter_attributes_controller.rb
@@ -41,21 +41,33 @@ module Admin
 
       def update
         service = Meters::MeterAttributeManager.new(@school)
-        attribute = service.update!(
-          params[:id],
-          params[:attribute][:root],
-          params[:attribute][:reason],
-          current_user
-        )
-        redirect_to admin_school_single_meter_attribute_path(@school, attribute.meter)
+        if params[:restore]
+          service.restore!(
+            params[:id]
+          )
+
+          redirect_to admin_school_meter_attributes_path(@school), notice: 'Meter attribute successfully restored'
+        else
+          attribute = service.update!(
+            params[:id],
+            params[:attribute][:root],
+            params[:attribute][:reason],
+            current_user
+          )
+          redirect_to admin_school_single_meter_attribute_path(@school, attribute.meter)
+        end
       rescue => e
-        redirect_back fallback_location: edit_admin_school_meter_attribute_path(@school, meter_attribute), notice: e.message
+        if params[:restore]
+          redirect_back fallback_location: admin_school_meter_attributes_path(@school), notice: e.message
+        else
+          redirect_back fallback_location: edit_admin_school_meter_attribute_path(@school, meter_attribute), notice: e.message
+        end
       end
 
       def destroy
         service = Meters::MeterAttributeManager.new(@school)
         attribute = service.delete!(params[:id], current_user)
-        redirect_to admin_school_single_meter_attribute_path(@school, attribute.meter)
+        redirect_to admin_school_single_meter_attribute_path(@school, attribute.meter), notice: 'Meter attribute successfully deleted'
       rescue => e
         redirect_back fallback_location: admin_school_meter_attributes_path(@school), notice: e.message
       end

--- a/app/controllers/admin/schools/school_attributes_controller.rb
+++ b/app/controllers/admin/schools/school_attributes_controller.rb
@@ -41,15 +41,22 @@ module Admin
 
       def update
         meter_attribute = @school.meter_attributes.find(params[:id])
-        new_attribute = @school.meter_attributes.create!(
-          attribute_type: meter_attribute.attribute_type,
-          reason: params[:attribute][:reason],
-          input_data: params[:attribute][:root],
-          meter_types: params[:attribute][:meter_types],
-          created_by: current_user
-        )
-        meter_attribute.update!(replaced_by: new_attribute)
-        redirect_to admin_school_school_attributes_path(@school)
+        if params[:restore]
+          meter_attribute.deleted_by = nil
+          meter_attribute.save(validate: false)
+          notice = 'Meter attribute successfully restored'
+        else
+          new_attribute = @school.meter_attributes.create!(
+            attribute_type: meter_attribute.attribute_type,
+            reason: params[:attribute][:reason],
+            input_data: params[:attribute][:root],
+            meter_types: params[:attribute][:meter_types],
+            created_by: current_user
+          )
+          meter_attribute.update!(replaced_by: new_attribute)
+          notice = 'Meter attribute successfully updated'
+        end
+        redirect_to admin_school_school_attributes_path(@school), notice: notice
       rescue => e
         redirect_back fallback_location: admin_school_school_attributes_path(@school), notice: e.message
       end
@@ -57,7 +64,7 @@ module Admin
       def destroy
         meter_attribute = @school.meter_attributes.find(params[:id])
         meter_attribute.update!(deleted_by: current_user)
-        redirect_to admin_school_school_attributes_path(@school)
+        redirect_to admin_school_school_attributes_path(@school), notice: 'Meter attribute successfully deleted'
       end
     end
   end

--- a/app/services/meters/meter_attribute_manager.rb
+++ b/app/services/meters/meter_attribute_manager.rb
@@ -39,5 +39,12 @@ module Meters
       broadcast(:meter_attribute_deleted, attribute)
       attribute
     end
+
+    def restore!(attribute_id)
+      attribute = MeterAttribute.find(attribute_id)
+      attribute.deleted_by = nil
+      attribute.save(validate: false)
+      attribute
+    end
   end
 end

--- a/app/views/admin/global_meter_attributes/index.html.erb
+++ b/app/views/admin/global_meter_attributes/index.html.erb
@@ -22,6 +22,8 @@
         <%= render 'admin/schools/school_attributes/meter_attribute', meter_attribute: meter_attribute do %>
           <div class="btn-group">
             <%= link_to 'History', admin_global_meter_attribute_path(meter_attribute), class: 'btn btn-sm' %>
+            <%= link_to 'Restore', admin_global_meter_attribute_path(meter_attribute, restore: true),
+                        method: :put, class: 'btn btn-sm' %>
           </div>
         <% end %>
       <% end %>

--- a/app/views/admin/school_groups/meter_attributes/index.html.erb
+++ b/app/views/admin/school_groups/meter_attributes/index.html.erb
@@ -26,6 +26,9 @@
           <div class="btn-group">
             <%= link_to 'History', admin_school_group_meter_attribute_path(@school_group, meter_attribute),
                         class: 'btn btn-sm' %>
+            <%= link_to 'Restore',
+                        admin_school_group_meter_attribute_path(@school_group, meter_attribute, restore: true),
+                        method: :put, class: 'btn btn-sm' %>
           </div>
         <% end %>
       <% end %>

--- a/app/views/admin/schools/meter_attributes/_deleted_attributes_table.html.erb
+++ b/app/views/admin/schools/meter_attributes/_deleted_attributes_table.html.erb
@@ -3,7 +3,9 @@
     <tr scope="row">
       <th>
         <%= link_to school_meter_path(meter.school, meter) do %>
-          <%= fa_icon(fuel_type_icon(meter.meter_type)) %> <%= meter.mpan_mprn %> <%= "(#{meter.name})" unless meter.name.blank? %>
+          <% if meter.name.present? %>
+            <%= fa_icon(fuel_type_icon(meter.meter_type)) %> <%= meter.mpan_mprn %> <%= "(#{meter.name})" %>
+          <% end %>
         <% end %>
       </th>
       <th></th>
@@ -13,7 +15,13 @@
     <% meter.meter_attributes.deleted.each do |meter_attribute| %>
       <%= render 'shared/meter_attributes/print_meter_attribute', meter_attribute: meter_attribute do %>
         <div class="btn-group">
-          <%= link_to 'History', admin_school_meter_attribute_path(school, meter_attribute), class: 'btn btn-sm' if can?(:show, meter_attribute) %>
+          <% if can?(:show, meter_attribute) %>
+            <%= link_to 'History', admin_school_meter_attribute_path(school, meter_attribute), class: 'btn btn-sm' %>
+          <% end %>
+          <% if can?(:update, meter_attribute) %>
+            <%= link_to 'Restore', admin_school_meter_attribute_path(school, meter_attribute, restore: true),
+                        method: :put, class: 'btn btn-sm' %>
+          <% end %>
         </div>
       <% end %>
     <% end %>

--- a/app/views/admin/schools/school_attributes/index.html.erb
+++ b/app/views/admin/schools/school_attributes/index.html.erb
@@ -70,6 +70,8 @@
         <%= render 'meter_attribute', meter_attribute: meter_attribute do %>
           <div class="btn-group">
             <%= link_to 'History', admin_school_school_attribute_path(@school, meter_attribute), class: 'btn btn-sm' %>
+            <%= link_to 'Restore', admin_school_school_attribute_path(@school, meter_attribute, restore: true),
+                        method: :put, class: 'btn btn-sm' %>
           </div>
         <% end %>
       <% end %>

--- a/spec/system/admin/meter_attributes_spec.rb
+++ b/spec/system/admin/meter_attributes_spec.rb
@@ -57,7 +57,6 @@ RSpec.describe 'meter attribute management', :meters, type: :system do
       end
     end
 
-
     it 'is able to display a form for all meter attributes' do
       visit admin_school_single_meter_attribute_path(school, gas_meter)
       options = find('#type').all('option').collect(&:text)
@@ -70,42 +69,96 @@ RSpec.describe 'meter attribute management', :meters, type: :system do
       end
     end
 
-    it 'allow the admin to manage the meter attributes' do
-      visit school_path(school)
-      click_on 'Meter attributes'
-      select 'Heating model', from: 'type'
-      click_on 'New attribute'
-
-      fill_in 'Max summer daily heating kwh', with: 800
-
-      click_on 'Create'
-
-      expect(gas_meter.meter_attributes.size).to eq(1)
-      attribute = gas_meter.meter_attributes.first
-      expect { attribute.to_analytics }.not_to raise_error
-      expect(attribute.to_analytics.to_s).to include('800')
-
-
-      within '#database-meter-attributes' do
-        click_on 'Edit'
+    describe 'managing meter attributes' do
+      before do
+        visit school_path(school)
+        click_on 'Meter attributes'
       end
 
-      fill_in 'Max summer daily heating kwh', with: 200
+      context 'when creating an attribute' do
+        let(:attribute) { gas_meter.meter_attributes.first }
 
-      click_on 'Update'
+        before do
+          select 'Heating model', from: 'type'
+          click_on 'New attribute'
+          fill_in 'Max summer daily heating kwh', with: 800
+          click_on 'Create'
+        end
 
-      gas_meter.reload
-      new_attribute = gas_meter.meter_attributes.active.first
-      expect(new_attribute.to_analytics.to_s).to include('200')
-      attribute.reload
-      expect(attribute.replaced_by).to eq(new_attribute)
-
-      within '#database-meter-attributes' do
-        click_on 'Delete'
+        it 'allows creation of an attribute' do
+          expect(gas_meter.meter_attributes.size).to eq(1)
+          expect { attribute.to_analytics }.not_to raise_error
+          expect(attribute.to_analytics.to_s).to include('800')
+        end
       end
-      expect(gas_meter.meter_attributes.active.size).to eq(0)
-      new_attribute.reload
-      expect(new_attribute.deleted_by).to eq(admin)
+
+      context 'when editing an attribute' do
+        let!(:meter_attribute) do
+          create(:meter_attribute, attribute_type: 'heating_model',
+                                   input_data: { max_summer_daily_heating_kwh: 300 }, meter: gas_meter)
+        end
+
+        let(:new_attribute) { gas_meter.meter_attributes.active.first }
+
+        before do
+          refresh
+          within '#database-meter-attributes' do
+            click_on 'Edit'
+          end
+          fill_in 'Max summer daily heating kwh', with: 200
+          click_on 'Update'
+          gas_meter.reload
+        end
+
+        it 'allows editing of an attribute' do
+          meter_attribute.reload
+          expect(new_attribute.to_analytics.to_s).to include('200')
+          expect(meter_attribute.replaced_by).to eq(new_attribute)
+        end
+      end
+
+      context 'when deleting an attribute' do
+        let!(:meter_attribute) do
+          create(:meter_attribute, attribute_type: 'heating_model',
+                                   input_data: { max_summer_daily_heating_kwh: 300 }, meter: gas_meter)
+        end
+
+        before do
+          refresh
+          within '#database-meter-attributes' do
+            click_on 'Delete'
+          end
+        end
+
+        it 'allows deletion of an attribute' do
+          expect(gas_meter.meter_attributes.active.size).to eq(0)
+          meter_attribute.reload
+          expect(meter_attribute.deleted_by).to eq(admin)
+        end
+      end
+
+      context 'when restoring an attribute' do
+        let!(:meter_attribute) do
+          create(:meter_attribute, attribute_type: 'heating_model',
+                                   input_data: { max_summer_daily_heating_kwh: 300 }, meter: gas_meter)
+        end
+
+        before do
+          refresh
+          within '#database-meter-attributes' do
+            click_on 'Delete'
+          end
+          within '#deleted-meter-attributes-content' do
+            click_on 'Restore'
+          end
+        end
+
+        it 'allows restoration of an attribute' do
+          expect(gas_meter.meter_attributes.active.size).to eq(1)
+          meter_attribute.reload
+          expect(meter_attribute.deleted_by).to be_nil
+        end
+      end
     end
 
     it 'allows creating and editing of an attribute with nested TimeOfDay values' do
@@ -172,116 +225,273 @@ RSpec.describe 'meter attribute management', :meters, type: :system do
       })
     end
 
-    it 'allow the admin to manage school meter attributes' do
-      visit school_path(school)
-      click_on 'Meter attributes'
-      click_on 'School-wide attributes'
-      select 'Meter > Energy Use', from: 'type'
-      click_on 'New attribute'
-
-      check 'gas'
-      select 'hotwater_only', from: 'attribute_root'
-
-      click_on 'Create'
-
-      expect(school.meter_attributes.size).to eq(1)
-      attribute = school.meter_attributes.first
-      expect { attribute.to_analytics }.not_to raise_error
-      expect(attribute.to_analytics.to_s).to include('hotwater_only')
-
-
-      click_on 'Edit'
-
-      select 'kitchen_only', from: 'attribute_root'
-
-      click_on 'Update'
-
-      school.reload
-      new_attribute = school.meter_attributes.active.first
-      expect(new_attribute.to_analytics.to_s).to include('kitchen_only')
-      attribute.reload
-      expect(attribute.replaced_by).to eq(new_attribute)
-
-      click_on 'Delete'
-      expect(school.meter_attributes.active.size).to eq(0)
-      new_attribute.reload
-      expect(new_attribute.deleted_by).to eq(admin)
-    end
-
-    it 'allow the admin to manage school group meter attributes' do
-      visit root_path
-      click_on 'Manage'
-      click_on 'Admin'
-      click_on 'School Groups'
-      within 'table' do
-        click_on 'Manage'
+    describe 'managing school meter attributes' do
+      before do
+        visit school_path(school)
+        click_on 'Meter attributes'
+        click_on 'School-wide attributes'
       end
-      click_on 'Meter attributes'
 
-      select 'Meter > Energy Use', from: 'type'
-      click_on 'New attribute'
+      context 'when creating an attribute' do
+        let(:attribute) { school.meter_attributes.first }
 
-      check 'gas'
-      select 'hotwater_only', from: 'attribute_root'
+        before do
+          select 'Meter > Energy Use', from: 'type'
+          click_on 'New attribute'
+          check 'gas'
+          select 'hotwater_only', from: 'attribute_root'
+          click_on 'Create'
+        end
 
-      click_on 'Create'
+        it 'allows the creation of an attribute' do
+          expect(school.meter_attributes.size).to eq(1)
+          expect { attribute.to_analytics }.not_to raise_error
+          expect(attribute.to_analytics.to_s).to include('hotwater_only')
+        end
+      end
 
-      expect(school_group.meter_attributes.size).to eq(1)
-      attribute = school_group.meter_attributes.active.first
-      expect(attribute.selected_meter_types).to eq([:gas])
+      context 'when editing an attribute' do
+        let!(:school_meter_attribute) do
+          create(:school_meter_attribute, attribute_type: 'function_switch',
+                                          input_data: 'heating_only', school:)
+        end
 
-      click_on 'Edit'
+        let(:new_attribute) { school.meter_attributes.active.first }
 
-      check 'electricity'
-      uncheck 'gas'
+        before do
+          refresh
+          within '#database-group-meter-attributes-content' do
+            click_on 'Edit'
+          end
+          select 'kitchen_only', from: 'attribute_root'
+          click_on 'Update'
+          school.reload
+        end
 
-      click_on 'Update'
+        it 'allows editing an attribute' do
+          expect(new_attribute.to_analytics.to_s).to include('kitchen_only')
+          school_meter_attribute.reload
+          expect(school_meter_attribute.replaced_by).to eq(new_attribute)
+        end
+      end
 
-      school_group.reload
-      new_attribute = school_group.meter_attributes.active.first
-      expect(new_attribute.selected_meter_types).to eq([:electricity])
-      attribute.reload
-      expect(attribute.replaced_by).to eq(new_attribute)
+      context 'when deleting an attribute' do
+        let!(:school_meter_attribute) do
+          create(:school_meter_attribute, attribute_type: 'function_switch',
+                                          input_data: 'heating_only', school:)
+        end
 
-      click_on 'Delete'
-      expect(school_group.meter_attributes.active.size).to eq(0)
-      new_attribute.reload
-      expect(new_attribute.deleted_by).to eq(admin)
+        before do
+          refresh
+          within '#database-group-meter-attributes-content' do
+            click_on 'Delete'
+          end
+        end
+
+        it 'allows the deletion of an attribute' do
+          expect(school.meter_attributes.active.size).to eq(0)
+          school_meter_attribute.reload
+          expect(school_meter_attribute.deleted_by).to eq(admin)
+        end
+      end
+
+      context 'when restoring an attribute' do
+        let!(:school_meter_attribute) do
+          create(:school_meter_attribute, attribute_type: 'function_switch',
+                                          input_data: 'heating_only', school:)
+        end
+
+        before do
+          refresh
+          within '#database-group-meter-attributes-content' do
+            click_on 'Delete'
+          end
+          within '#deleted-group-meter-attributes-content' do
+            click_on 'Restore'
+          end
+        end
+
+        it 'allows restoration of an attribute' do
+          expect(school.meter_attributes.active.size).to eq(1)
+          school_meter_attribute.reload
+          expect(school_meter_attribute.deleted_by).to be_nil
+        end
+      end
     end
 
-    it 'allow the admin to manage global meter attributes' do
-      visit root_path
-      click_on 'Manage'
-      click_on 'Admin'
-      click_on 'Global Meter Attributes'
-      select 'Meter > Energy Use', from: 'type'
-      click_on 'New attribute'
+    describe 'managing school group meter attributes' do
+      let(:attribute) { school_group.meter_attributes.active.first }
 
-      check 'gas'
-      select 'hotwater_only', from: 'attribute_root'
+      before do
+        visit root_path
+        click_on 'Manage'
+        click_on 'Admin Home'
+        click_on 'School Groups'
+        within 'table' do
+          click_on 'Manage'
+        end
+        click_on 'Meter attributes'
+      end
 
-      click_on 'Create'
+      context 'when creating an attribute' do
+        before do
+          select 'Meter > Energy Use', from: 'type'
+          click_on 'New attribute'
+          check 'gas'
+          select 'hotwater_only', from: 'attribute_root'
+          click_on 'Create'
+        end
 
-      expect(GlobalMeterAttribute.count).to eq(1)
-      attribute = GlobalMeterAttribute.first
-      expect { attribute.to_analytics }.not_to raise_error
+        it 'allows the creation of an attribute' do
+          expect(school_group.meter_attributes.size).to eq(1)
+          expect(attribute.selected_meter_types).to eq([:gas])
+        end
+      end
 
-      click_on 'Edit'
+      context 'when editing an attribute' do
+        let!(:school_group_meter_attribute) do
+          create(:school_group_meter_attribute, attribute_type: 'function_switch',
+                                                input_data: 'hotwater_only', school_group:)
+        end
+        let(:new_attribute) { school_group.meter_attributes.active.first }
 
-      check 'electricity'
-      uncheck 'gas'
+        before do
+          refresh
+          click_on 'Edit'
+          check 'electricity'
+          uncheck 'gas'
+          click_on 'Update'
+          school_group.reload
+        end
 
-      click_on 'Update'
+        it 'allows editing of an attibute' do
+          expect(new_attribute.selected_meter_types).to eq([:electricity])
+          school_group_meter_attribute.reload
+          expect(school_group_meter_attribute.replaced_by).to eq(new_attribute)
+        end
+      end
 
-      new_attribute = GlobalMeterAttribute.active.first
-      expect(new_attribute.selected_meter_types).to eq([:electricity])
-      attribute.reload
-      expect(attribute.replaced_by).to eq(new_attribute)
+      context 'when deleting an attribute' do
+        let!(:school_group_meter_attribute) do
+          create(:school_group_meter_attribute, attribute_type: 'function_switch',
+                                                input_data: 'hotwater_only', school_group:)
+        end
 
-      click_on 'Delete'
-      expect(GlobalMeterAttribute.active.count).to eq(0)
-      new_attribute.reload
-      expect(new_attribute.deleted_by).to eq(admin)
+        before do
+          refresh
+          click_on 'Delete'
+        end
+
+        it 'allows deletion of an attribute' do
+          expect(school_group.meter_attributes.active.size).to eq(0)
+          school_group_meter_attribute.reload
+          expect(school_group_meter_attribute.deleted_by).to eq(admin)
+        end
+      end
+
+      context 'when restoring an attribute' do
+        let!(:school_group_meter_attribute) do
+          create(:school_group_meter_attribute, attribute_type: 'function_switch',
+                                                input_data: 'hotwater_only', school_group:)
+        end
+
+        before do
+          refresh
+          click_on 'Delete'
+          click_on 'Restore'
+        end
+
+        it 'allows restoration of an attribute' do
+          expect(school_group.meter_attributes.active.size).to eq(1)
+          school_group_meter_attribute.reload
+          expect(school_group_meter_attribute.deleted_by).to be_nil
+        end
+      end
+    end
+
+    describe 'managing global meter attributes' do
+      before do
+        visit root_path
+        click_on 'Manage'
+        click_on 'Admin Home'
+        click_on 'Global Meter Attributes'
+      end
+
+      context 'when creating an attribute' do
+        let(:attribute) { GlobalMeterAttribute.first }
+
+        before do
+          select 'Meter > Energy Use', from: 'type'
+          click_on 'New attribute'
+          check 'gas'
+          select 'hotwater_only', from: 'attribute_root'
+          click_on 'Create'
+        end
+
+        it 'allows creation of an attribute' do
+          expect(GlobalMeterAttribute.count).to eq(1)
+          expect { attribute.to_analytics }.not_to raise_error
+        end
+      end
+
+      context 'when editing an attribute' do
+        let!(:global_meter_attribute) do
+          create(:global_meter_attribute, attribute_type: 'function_switch',
+                                          input_data: 'hotwater_only')
+        end
+        let(:new_attribute) { GlobalMeterAttribute.active.first }
+
+        before do
+          refresh
+          click_on 'Edit'
+          check 'electricity'
+          uncheck 'gas'
+          click_on 'Update'
+        end
+
+        it 'allows editing of an attribute' do
+          expect(new_attribute.selected_meter_types).to eq([:electricity])
+          global_meter_attribute.reload
+          expect(global_meter_attribute.replaced_by).to eq(new_attribute)
+        end
+      end
+
+      context 'when deleting an attribute' do
+        let!(:global_meter_attribute) do
+          create(:global_meter_attribute, attribute_type: 'function_switch',
+                                          input_data: 'hotwater_only')
+        end
+
+        before do
+          refresh
+          click_on 'Delete'
+        end
+
+        it 'allows deletion of an attribute' do
+          expect(GlobalMeterAttribute.active.count).to eq(0)
+          global_meter_attribute.reload
+          expect(global_meter_attribute.deleted_by).to eq(admin)
+        end
+      end
+
+      context 'when restoring an attribute' do
+        let!(:global_meter_attribute) do
+          create(:global_meter_attribute, attribute_type: 'function_switch',
+                                          input_data: 'hotwater_only')
+        end
+
+        before do
+          refresh
+          click_on 'Delete'
+          click_on 'Restore'
+        end
+
+        it 'allows restoration of an attribute' do
+          expect(GlobalMeterAttribute.active.count).to eq(1)
+          global_meter_attribute.reload
+          expect(global_meter_attribute.deleted_by).to be_nil
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Adds a restore option to all deleted meter attribute across the site, removing their 'deleted_by'. Note that this currently does not change anything else about the attribute, such as updated_by etc - let me know if we want anything else about the attribute changing too