### PR TITLE
Fix text on engagement featured school component

### DIFF
--- a/app/components/impact_reports/engagement/featured_school_component.rb
+++ b/app/components/impact_reports/engagement/featured_school_component.rb
@@ -24,30 +24,36 @@ module ImpactReports
       end
 
       def default_description
-        impact_t('engagement.featured.description',
+        key = if activity_count.zero?
+                'actions'
+              else
+                action_count.zero? ? 'activities' : 'both'
+              end
+
+        impact_t("engagement.featured.description.#{key}",
                  school: school.name,
-                 activities: activity_count,
-                 actions: action_count)
+                 activities: impact_t('engagement.featured.activities', count: activity_count),
+                 actions: impact_t('engagement.featured.actions', count: action_count))
       end
 
-      def today
-        @today ||= Time.zone.today
+      def now
+        @now ||= Time.zone.now
       end
 
       def twelve_months_ago
-        @twelve_months_ago ||= today - 12.months
+        @twelve_months_ago ||= now - 12.months
       end
 
       def activity_count
         @activity_count ||= school.activities
-                                  .between(twelve_months_ago, today)
+                                  .between(twelve_months_ago, now)
                                   .count
       end
 
       def action_count
         @action_count ||= school.observations
                                 .intervention
-                                .between(twelve_months_ago, today)
+                                .between(twelve_months_ago, now)
                                 .count
       end
 

--- a/app/components/impact_reports/engagement/featured_school_component.rb
+++ b/app/components/impact_reports/engagement/featured_school_component.rb
@@ -30,6 +30,10 @@ module ImpactReports
                 action_count.zero? ? 'activities' : 'both'
               end
 
+        # i18n-tasks-use t('school_groups.impact.engagement.featured.description.actions')
+        # i18n-tasks-use t('school_groups.impact.engagement.featured.description.activities')
+        # i18n-tasks-use t('school_groups.impact.engagement.featured.description.both')
+
         impact_t("engagement.featured.description.#{key}",
                  school: school.name,
                  activities: impact_t('engagement.featured.activities', count: activity_count),

--- a/app/components/scoreboards/podium_component.rb
+++ b/app/components/scoreboards/podium_component.rb
@@ -2,9 +2,9 @@
 
 module Scoreboards
   class PodiumComponent < ApplicationComponent
-    attr_reader :podium, :id, :user, :i18n_scope
+    attr_reader :podium, :i18n_scope
 
-    def initialize(podium: nil, classes: nil, id: nil, user: nil, path_to_scoreboard: nil, i18n_scope: 'components.podium', **_kwargs)
+    def initialize(podium: nil, user: nil, path_to_scoreboard: nil, i18n_scope: 'components.podium', **_kwargs)
       super
       @podium = podium
       @user = user
@@ -14,6 +14,10 @@ module Scoreboards
 
     def path_to_scoreboard
       @path_to_scoreboard || scoreboard_path(podium.scoreboard)
+    end
+
+    def path_to_school(school)
+      controller_path == 'pupils/schools' ? pupils_school_path(school) : school_path(school)
     end
 
     def school

--- a/app/components/scoreboards/podium_component/podium_component.html.erb
+++ b/app/components/scoreboards/podium_component/podium_component.html.erb
@@ -56,13 +56,14 @@
     </div>
     <div class="row border-top grey">
       <% podium.low_to_high.each do |position| %>
-        <div class="col-4 text-center px-3 small">
-          <% if podium.current_school?(position) %>
+        <% current = podium.current_school?(position) %>
+        <%= tag.div class: class_names('col-4 text-center px-3 small', current && 'fw-bold') do %>
+          <% if helpers.current_school == position.school %>
             <%= position.school.name %>
           <% else %>
-            <%= link_to position.school.name, pupils_school_path(position.school) %>
+            <%= link_to position.school.name, path_to_school(position.school) %>
           <% end %>
-        </div>
+        <% end %>
       <% end %>
     </div>
   <% end %>

--- a/config/locales/views/school_groups/impact.yml
+++ b/config/locales/views/school_groups/impact.yml
@@ -60,7 +60,16 @@ en:
             title: Current targets
         description: How are schools in this group engaging with the Energy Sparks education programme?
         featured:
-          description: "%{school} is currently the most active school in this group, having recorded %{activities} pupil activities and %{actions} adult actions in the last 12 months"
+          actions:
+            one: "%{count} adult action"
+            other: "%{count} adult actions"
+          activities:
+            one: "%{count} pupil activity"
+            other: "%{count} pupil activities"
+          description:
+            actions: "%{school} is currently the most active school in this group, having recorded %{actions} in the last 12 months"
+            activities: "%{school} is currently the most active school in this group, having recorded %{activities} in the last 12 months"
+            both: "%{school} is currently the most active school in this group, having recorded %{activities} and %{actions} in the last 12 months"
           title: Featured school
         looking_for_more_detail: Looking for more detail?
         title: Engagement

--- a/spec/components/impact_reports/engagement/featured_school_component_spec.rb
+++ b/spec/components/impact_reports/engagement/featured_school_component_spec.rb
@@ -8,20 +8,47 @@ RSpec.describe ImpactReports::Engagement::FeaturedSchoolComponent, :include_appl
   let!(:config) { create(:impact_report_configuration, school_group: school_group) }
   let(:school) { create(:school, :with_school_group, school_group: school_group) }
 
-  before do
-    create_list(:observation, 3, :activity, school: school)
-    school.reload
-  end
-
   context 'without override' do
-    before do
-      render_inline(described_class.new(school_group: school_group))
+    context 'with activities and actions' do
+      before do
+        create_list(:activity, 2, school: school)
+        create_list(:observation, 2, :intervention, school: school)
+        render_inline(described_class.new(school_group: school_group))
+      end
+
+      it { expect(page).to have_css('#engagement-featured') }
+      it { expect(page).to have_text('Featured school') }
+      it { expect(page).to have_text(school.name) }
+      it { expect(page).to have_text('2 pupil activities and 2 adult actions in the last 12 months') }
+      it { expect(page).to have_link('View dashboard', href: school_path(school)) }
+      it { expect(page).to have_css('.bg-white.p-4.rounded-3') }
     end
 
-    it { expect(page).to have_css('#engagement-featured') }
-    it { expect(page).to have_text(school.name) }
-    it { expect(page).to have_link('View dashboard', href: school_path(school)) }
-    it { expect(page).to have_css('.bg-white.p-4.rounded-3') }
+    context 'with a single action and no activities recorded' do
+      before do
+        create_list(:observation, 1, :intervention, school: school)
+        render_inline(described_class.new(school_group: school_group))
+      end
+
+      it { expect(page).to have_text('recorded 1 adult action in the last 12 months') }
+    end
+
+    context 'with a single activity and no actions recorded' do
+      before do
+        create_list(:activity, 1, school: school)
+        render_inline(described_class.new(school_group: school_group))
+      end
+
+      it { expect(page).to have_text('recorded 1 pupil activity in the last 12 months') }
+    end
+
+    context 'with no points' do
+      before do
+        render_inline(described_class.new(school_group: school_group))
+      end
+
+      it { expect(rendered_content).to be_blank }
+    end
   end
 
   context 'with override' do
@@ -46,6 +73,8 @@ RSpec.describe ImpactReports::Engagement::FeaturedSchoolComponent, :include_appl
     let(:override_school) { create(:school, school_group: school_group) }
 
     before do
+      create_list(:observation, 1, :intervention, school: school)
+
       config.update(
         engagement_school: override_school,
         engagement_school_expiry_date: 1.day.ago
@@ -66,7 +95,7 @@ RSpec.describe ImpactReports::Engagement::FeaturedSchoolComponent, :include_appl
     end
 
     it 'does not render' do
-      expect(render_inline(described_class.new(school_group: school_group)).to_html).to be_blank
+      expect(rendered_content).to be_blank
     end
   end
 end


### PR DESCRIPTION
In summary, this now does the following:
* Changes the left text on the engagement featured default school - it no longer shows zero activity or action counts. Also handles singular counts better.
* In response to Leigh's reply below, made the following podium changes:
  * Now links to current school shown on podium (if not already on that page) and makes it bold
  * Links schools to adult dashboard, unless on the pupil dashboard page.
  
Keeping text below so Leigh's reply makes sense:

---

What I currently have (what it defaulted to when changed to using the school scoreboard):
<img width="680" height="462" alt="image" src="https://github.com/user-attachments/assets/ac48bc99-ed7a-4ddf-8e55-191bccd5cd13" />

Becca asked for:
`Your highest scoring school is in X place among the x region and holds X place nationally.
`
Do we want it to be:
`Your highest scoring school is in 5th place on the South-West England scoreboard and holds 38th place nationally.
`

What is the preferred text @ldodds ? Thanks

A few other questions (could be done in a different card):
* The links at the bottom of the podium to the schools, always go to the pupil dashboard. Do we think this is still right? Or should the links be to be to the adult dashboards by default and then to pupil dashboards when on a pupil dashboard?
* The highest scoring school at the bottom does not have a link to the school. Think this would be useful to add in (certainly when not on the same school dashboard). Maybe could make the link bold to distinguish it from the other two.
* Do we want to also update the podium on the school group dashboard to have the same text?