### PR TITLE
Add component for producing a funding summary for a group

### DIFF
--- a/app/components/commercial/range_funding_summary_component.rb
+++ b/app/components/commercial/range_funding_summary_component.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+module Commercial
+  class RangeFundingSummaryComponent < ApplicationComponent
+    CATEGORIES = %i[funded group_funded partially_group_funded self_funded].freeze
+    def initialize(school_group:, range:, range_label: 'this period', **)
+      super(**)
+      @school_group = school_group
+      @range = range
+      @range_label = range_label
+    end
+
+    def render?
+      categorised_schools.any?
+    end
+
+    private
+
+    # List 1: schools that are fully or partially funded for range and where group is not a contract holder
+    # List 2: schools that are fully or partially funded for range and where group is sole contract holder
+    # List 3: schools that are fully or partially funded for range and where group is one of the contract holders
+    def categorised_schools
+      @categorised_schools =
+        licensed_schools
+        .group_by do |school|
+          contract_holders = school.licences.for_period(@range).map(&:contract_holder)
+
+          case contract_holders
+          in [^school]
+            :self_funded
+          in [^@school_group]
+            :group_funded
+          in [*, ^@school_group, *]
+            :partially_group_funded
+          else
+            :funded
+          end
+        end
+    end
+
+    def licensed_schools
+      @school_group.assigned_schools.visible.reject { |s| s.licensed_for_period(@range) == :no }
+    end
+
+    def category_description(category)
+      count = categorised_schools[category].size
+      case category
+      when :self_funded
+        "#{pluralize(count, 'school')} self funding"
+      when :funded
+        "#{pluralize(count, 'school')} with funding for the academic year"
+      when :partially_group_funded
+        "#{pluralize(count, 'school')} with fees due for part of the academic year"
+      else
+        "#{pluralize(count, 'school')} with fees due for the full academic year"
+      end
+    end
+  end
+end

--- a/app/components/commercial/range_funding_summary_component/range_funding_summary_component.html.erb
+++ b/app/components/commercial/range_funding_summary_component/range_funding_summary_component.html.erb
@@ -1,0 +1,12 @@
+<%= tag.div id: id, class: classes do %>
+<p>For <%= @range_label %> this group has:</p>
+  <ul>
+    <% CATEGORIES.each do |category| %>
+      <% if categorised_schools[category]&.any? %>
+        <li>
+          <%= categorised_schools[category].size %> <%= category.to_s.humanize.downcase %> schools
+        </li>
+      <% end %>
+    <% end %>
+  </ul>
+<% end %>

--- a/app/components/commercial/range_funding_summary_component/range_funding_summary_component.text.erb
+++ b/app/components/commercial/range_funding_summary_component/range_funding_summary_component.text.erb
@@ -1,0 +1,9 @@
+<% CATEGORIES.each do |category| %>
+  <% if categorised_schools[category]&.any? %>
+<%= category_description(category) %>
+<% categorised_schools[category].sort_by(&:name).each do |school| %>
+<%= school.name %>
+<% end %>
+
+  <% end %>
+<% end %>

--- a/app/components/commercial/range_funding_summary_component/range_funding_summary_component.text.erb
+++ b/app/components/commercial/range_funding_summary_component/range_funding_summary_component.text.erb
@@ -1,9 +1,8 @@
-<% CATEGORIES.each do |category| %>
-  <% if categorised_schools[category]&.any? %>
+<%- CATEGORIES.each do |category| %>
+  <%- if categorised_schools[category]&.any? %>
 <%= category_description(category) %>
-<% categorised_schools[category].sort_by(&:name).each do |school| %>
+<%- categorised_schools[category].sort_by(&:name).each do |school| %>
 <%= school.name %>
 <% end %>
-
   <% end %>
 <% end %>

--- a/app/controllers/admin/school_groups/licence_summaries_controller.rb
+++ b/app/controllers/admin/school_groups/licence_summaries_controller.rb
@@ -10,6 +10,18 @@ module Admin
       def show
         @current_year = Calendar.default_national.current_academic_year
         @next_year = Calendar.default_national.current_academic_year.next_year
+
+        respond_to do |format|
+          format.html { render :show }
+          format.text do
+            render(::Commercial::RangeFundingSummaryComponent.new(
+                     school_group: @school_group,
+                     range: @next_year.start_date..@next_year.end_date,
+                     range_label: 'next academic year'
+                   ),
+                   content_type: 'text/plain')
+          end
+        end
       end
     end
   end

--- a/app/views/admin/school_groups/licence_summaries/show.html.erb
+++ b/app/views/admin/school_groups/licence_summaries/show.html.erb
@@ -31,7 +31,19 @@
       "Full" indicates that their licences cover the entire year, "Partial" means that they are only funded
       for part of that year.
     </p>
+  </div>
+</div>
 
+<div class="row">
+  <div class="col">
+    <%= render Commercial::RangeFundingSummaryComponent.new(
+          school_group: @school_group,
+          range: @next_year.start_date..@next_year.end_date,
+          range_label: 'the next academic year'
+        ) %>
+    <%= link_to 'Emailable summary',
+                admin_school_group_licence_summaries_path(@school_group, format: :text),
+                class: 'btn btn-sm' %>
   </div>
 </div>
 

--- a/spec/components/commercial/range_funding_summary_component_spec.rb
+++ b/spec/components/commercial/range_funding_summary_component_spec.rb
@@ -1,0 +1,183 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Commercial::RangeFundingSummaryComponent, type: :component do
+  subject(:component) { described_class.new(school_group:, range:) }
+
+  let!(:school_group) { create(:school_group) }
+  let(:range) { Date.new(2025, 9, 1)..Date.new(2026, 8, 31) }
+
+  def create_licences_in_group(number, contract_holder)
+    create(:commercial_contract, contract_holder:).then do |contract|
+      number.times do
+        create(:commercial_licence,
+               contract:,
+               school: create(:school, school_group:),
+               start_date: range.begin + 1.month,
+               end_date: range.end)
+      end
+      contract
+    end
+  end
+
+  context 'when rendering as HTML' do
+    context 'with no licences' do
+      it { expect(component.render?).to be(false) }
+    end
+
+    context 'with only funded schools' do
+      before do
+        contract = create(:commercial_contract, contract_holder: create(:funder))
+        create(:commercial_licence,
+               contract:,
+               school: create(:school, school_group:),
+               start_date: range.begin,
+               end_date: range.end)
+        render_inline component
+      end
+
+      it { expect(page).to have_text('1 funded schools') }
+      it { expect(page).to have_no_text('partially group funded schools') }
+      it { expect(page).to have_no_text('group funded schools') }
+
+      context 'with a range label' do
+        subject(:component) { described_class.new(school_group:, range:, range_label: 'this academic year') }
+
+        it { expect(page).to have_text('For this academic year this group has:') }
+      end
+    end
+
+    context 'with self funded schools' do
+      before do
+        school = create(:school, school_group:)
+        contract = create(:commercial_contract, contract_holder: school)
+        create(:commercial_licence,
+               contract:,
+               school:,
+               start_date: range.begin,
+               end_date: range.end)
+        render_inline component
+      end
+
+      it { expect(page).to have_text('1 self funded schools') }
+    end
+
+    context 'with group funded schools' do
+      before do
+        contract = create(:commercial_contract, contract_holder: school_group)
+        create(:commercial_licence,
+               contract:,
+               school: create(:school, school_group:),
+               start_date: range.begin,
+               end_date: range.end)
+        render_inline component
+      end
+
+      it { expect(page).to have_text('1 group funded schools') }
+      it { expect(page).to have_no_text('partially group funded schools') }
+    end
+
+    context 'with partially group funded schools' do
+      before do
+        contract = create(:commercial_contract, contract_holder: school_group)
+        school = create(:school, school_group:)
+        create(:commercial_licence,
+               contract:,
+               school:,
+               start_date: range.begin + 1.month,
+               end_date: range.end)
+        create(:commercial_licence,
+               contract: create(:commercial_contract, contract_holder: create(:funder)),
+               school:,
+               start_date: range.begin,
+               end_date: range.begin + 1.month)
+        render_inline component
+      end
+
+      it { expect(page).to have_text('1 partially group funded schools') }
+    end
+
+    context 'with group funded schools for part year' do
+      before do
+        contract = create(:commercial_contract, contract_holder: school_group)
+        school = create(:school, school_group:)
+        create(:commercial_licence,
+               contract:,
+               school:,
+               start_date: range.begin,
+               end_date: range.begin + 1.month)
+        render_inline component
+      end
+
+      it { expect(page).to have_text('1 group funded schools') }
+    end
+
+    context 'with range of licences' do
+      before do
+        group_contract = create_licences_in_group(3, school_group)
+        funder_contract = create_licences_in_group(2, create(:funder))
+        school = create(:school, school_group:)
+        create(:commercial_licence,
+               contract: group_contract,
+               school:,
+               start_date: range.begin + 1.month,
+               end_date: range.end)
+        create(:commercial_licence,
+               contract: funder_contract,
+               school:,
+               start_date: range.begin,
+               end_date: range.begin + 1.month)
+        render_inline component
+      end
+
+      it { expect(page).to have_text('2 funded schools') }
+      it { expect(page).to have_text('3 group funded schools') }
+      it { expect(page).to have_text('1 partially group funded schools') }
+    end
+  end
+
+  context 'when rendering as text' do
+    let!(:group_contract) { create_licences_in_group(3, school_group) }
+    let!(:funder_contract) { create_licences_in_group(2, create(:funder)) }
+    let(:partially_funded_school) { create(:school, school_group:) }
+
+    before do
+      contract = create(:commercial_contract, contract_holder: school_group)
+      create(:commercial_licence,
+             contract:,
+             school: partially_funded_school,
+             start_date: range.begin + 1.month,
+             end_date: range.end)
+      create(:commercial_licence,
+             contract:,
+             school: partially_funded_school,
+             start_date: range.begin,
+             end_date: range.begin + 1.month)
+
+      with_format(:text) do
+        render_inline described_class.new(school_group:, range:)
+      end
+    end
+
+    it 'counts schools with funded places' do
+      expect(page).to have_text('2 schools with funding for the academic year')
+    end
+
+    it 'counts schools with group funded places' do
+      expect(page).to have_text('3 schools with fees due for the full academic year')
+    end
+
+    it 'counts schools with partially group funded places' do
+      expect(page).to have_text('1 school with fees due for part of the academic year')
+    end
+
+    it 'produces a list of group funded schools' do
+      expect(page).to have_text(group_contract.schools.sort_by(&:name).map(&:name).join("\n"))
+    end
+
+    it 'produces a list of funded schools' do
+      expect(page).to have_text(funder_contract.schools.sort_by(&:name).map(&:name).join("\n"))
+    end
+  end
+end

--- a/spec/components/previews/commercial/range_funding_summary_component_preview.rb
+++ b/spec/components/previews/commercial/range_funding_summary_component_preview.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Commercial
+  class RangeFundingSummaryComponentPreview < ViewComponent::Preview
+    # @param slug select :group_options
+    def example(slug: nil)
+      school_group = slug ? SchoolGroup.find(slug) : SchoolGroup.with_active_schools.first
+      academic_year = Calendar.default_national.current_academic_year
+
+      render Commercial::RangeFundingSummaryComponent.new(
+        school_group:,
+        range: academic_year.start_date..academic_year.end_date,
+        range_label: 'this academic year'
+      )
+    end
+
+    private
+
+    def group_options
+      {
+        choices: SchoolGroup.with_active_schools.by_name.map { |g| [g.name, g.slug] }
+      }
+    end
+  end
+end

--- a/spec/system/admin/commercial/group_contracts_and_licences_spec.rb
+++ b/spec/system/admin/commercial/group_contracts_and_licences_spec.rb
@@ -23,6 +23,11 @@ describe 'group contracts and licences' do
     it { expect(page).to have_css('div.commercial-licensing-summary-component') }
     it { expect(page).to have_text(licence.school.name) }
     it { expect(page).to have_link('Licences', href: admin_school_licences_path(licence.school)) }
+
+    it {
+      expect(page).to have_link('Emailable summary',
+                                href: admin_school_group_licence_summaries_path(school_group, format: :text))
+    }
   end
 
   context 'when visiting contracts' do


### PR DESCRIPTION
Adds a new component that is capable of producing a high-level summary of the funding situation in a group. This is used to provide a shorter summary on the group licensing summary page, like this:

<img width="341" height="142" alt="Screenshot from 2026-06-10 14-23-53" src="https://github.com/user-attachments/assets/ef5fd42e-4e6a-49ca-b073-61c02435d4f3" />

The component supports a text based template for producing a similar version of the text which also includes the names of each school, e.g:

```
2 schools with fees due for the full academic year
Avebury Boys' Academy
Avebury Girls' Academy

2 schools self funding
Southpark Primary Academy
Castle Rock Academy
```

The latter is provided to allow the text to be copied into email correspondence with groups during renewals.