### PR TITLE
Switch to pro_rata by default

### DIFF
--- a/app/models/commercial/contract.rb
+++ b/app/models/commercial/contract.rb
@@ -192,12 +192,12 @@ module Commercial
           :agreed_school_price,
           :contract_holder_type,
           :contract_holder_id,
-          :invoice_terms,
           :licence_period,
           :licence_years,
           :number_of_schools,
           :product
         ).merge(
+          invoice_terms: original.custom? ? :full : :pro_rata,
           comments: "Renewed from #{original.name}",
           end_date: original.end_date.next_year,
           start_date: original.end_date + 1.day,

--- a/lib/tasks/deployment/20260610134003_change_future_contracts_to_prorata.rake
+++ b/lib/tasks/deployment/20260610134003_change_future_contracts_to_prorata.rake
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+namespace :after_party do
+  desc 'Deployment task: change_future_contracts_to_prorata'
+  task change_future_contracts_to_prorata: :environment do
+    puts "Running deploy task 'change_future_contracts_to_prorata'"
+
+    Commercial::Contract.future
+                        .where(licence_period: :contract, invoice_terms: :full)
+                        .where(contract_holder: SchoolGroup.all).find_each do |c|
+      c.update_attribute!(:invoice_terms, :pro_rata)
+    end
+
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord
+      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+  end
+end

--- a/spec/models/commercial/contract_spec.rb
+++ b/spec/models/commercial/contract_spec.rb
@@ -202,6 +202,54 @@ describe Commercial::Contract do
         end_date: original.end_date.next_year
       )
     end
+
+    context 'when the original licence terms were pro_rata' do
+      let(:original) do
+        create(:commercial_contract,
+               licence_period: :contract,
+               invoice_terms: :pro_rata,
+               agreed_school_price: 450.0,
+               number_of_schools: 15)
+      end
+
+      it 'correctly populates the defaults' do
+        expect(renewed).to have_attributes(
+          agreed_school_price: original.agreed_school_price,
+          comments: "Renewed from #{original.name}",
+          contract_holder: original.contract_holder,
+          invoice_terms: 'pro_rata',
+          licence_period: original.licence_period,
+          number_of_schools: original.number_of_schools,
+          product: original.product,
+          start_date: original.end_date + 1.day,
+          end_date: original.end_date.next_year
+        )
+      end
+    end
+
+    context 'when the original licence terms were full' do
+      let(:original) do
+        create(:commercial_contract,
+               licence_period: :contract,
+               invoice_terms: :full,
+               agreed_school_price: 450.0,
+               number_of_schools: 15)
+      end
+
+      it 'switches to a pro-rata contract' do
+        expect(renewed).to have_attributes(
+          agreed_school_price: original.agreed_school_price,
+          comments: "Renewed from #{original.name}",
+          contract_holder: original.contract_holder,
+          invoice_terms: 'pro_rata',
+          licence_period: original.licence_period,
+          number_of_schools: original.number_of_schools,
+          product: original.product,
+          start_date: original.end_date + 1.day,
+          end_date: original.end_date.next_year
+        )
+      end
+    end
   end
 
   describe '.over_licensed' do

--- a/spec/system/admin/commercial/manage_contracts_spec.rb
+++ b/spec/system/admin/commercial/manage_contracts_spec.rb
@@ -579,7 +579,7 @@ describe 'manage contracts' do
 
       it { expect(page).to have_field('Agreed school price', with: contract.agreed_school_price) }
       it { expect(page).to have_field('Comments', with: "Renewed from #{contract.name}") }
-      it { expect(page).to have_field('contract_invoice_terms', with: 'full', type: :hidden, visible: :all) }
+      it { expect(page).to have_field('contract_invoice_terms', with: 'pro_rata', type: :hidden, visible: :all) }
       it { expect(page).to have_field('contract_licence_period', with: 'contract', type: :hidden, visible: :all) }
 
       it { expect(page).to have_field('Number of schools', with: contract.number_of_schools) }


### PR DESCRIPTION
When renewing a standard contract that is set to `invoice_terms` of `:full` we've decided to switch the terms to pro rata as it makes it easier to add additional schools to the renewed contract.

This PR has:

- an After Party task to revise some of the recently created future contracts to be pro rata
- change the defaults when creating a renewed contract