### PR TITLE
Impact reports: reorder energy efficiency metrics

### DIFF
--- a/app/assets/stylesheets/_bootstrap-overrides.scss
+++ b/app/assets/stylesheets/_bootstrap-overrides.scss
@@ -27,6 +27,8 @@ $carousel-control-prev-icon-bg: url("data:image/svg+xml,<svg xmlns='http://www.w
 $carousel-control-next-icon-bg: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' fill='#{$carousel-control-color}' width='8' height='8' viewBox='0 0 8 8'><path d='M2.75 0l-1.5 1.5 2.5 2.5-2.5 2.5 1.5 1.5 4-4-4-4z'/></svg>") !default;
 
 $form-check-input-checked-bg-color: darken($teal-dark, 5%); // darkened slightly to match input accent color (base.scss)
+$table-bg: unset;
+$table-color: unset;
 
 // To match our BS4 badges. Leave out for now. Prefer new BS5 settings
 // $badge-padding-y: .25em; // BS5 default is .35em

--- a/app/components/impact_reports/base_component.rb
+++ b/app/components/impact_reports/base_component.rb
@@ -6,7 +6,7 @@ module ImpactReports
 
     def initialize(run: nil, school_group: nil, **)
       super(**)
-      @run = run || school_group&.impact_report_runs&.latest
+      @run = run || school_group&.latest_impact_report_run
       @school_group = school_group || run&.school_group
       @config = @school_group.impact_report_configuration
     end

--- a/app/controllers/school_groups/impact/configurations_controller.rb
+++ b/app/controllers/school_groups/impact/configurations_controller.rb
@@ -30,7 +30,7 @@ module SchoolGroups
 
       def fetch_config_and_run
         @configuration = @school_group.impact_report_configuration || @school_group.build_impact_report_configuration
-        @run = @school_group.impact_report_runs.latest
+        @run = @school_group.latest_impact_report_run
       end
 
       def configuration_params

--- a/app/controllers/school_groups/impact/runs_controller.rb
+++ b/app/controllers/school_groups/impact/runs_controller.rb
@@ -11,11 +11,11 @@ module SchoolGroups
                                         through_association: :impact_report_runs, include: :metrics
 
       def index
-        @runs = @runs.order(run_date: :desc)
+        @runs = @runs.latest_first
       end
 
       def latest
-        @run = @runs.latest
+        @run = @runs.latest_first.first
         render :show
       end
     end

--- a/app/controllers/school_groups/impact_controller.rb
+++ b/app/controllers/school_groups/impact_controller.rb
@@ -20,7 +20,7 @@ module SchoolGroups
 
     def load_data
       @config = @school_group.impact_report_configuration
-      @run = @school_group.impact_report_runs.latest
+      @run = @school_group.latest_impact_report_run
     end
 
     def breadcrumbs
@@ -44,7 +44,7 @@ module SchoolGroups
     end
 
     def redirect_not_enough_data
-      return if @run.enough_data?
+      return if @run&.enough_data?
 
       redirect_to(school_group_path(@school_group),
                   alert: I18n.t('advice_pages.index.show.not_available'))

--- a/app/models/impact_report/metric.rb
+++ b/app/models/impact_report/metric.rb
@@ -48,13 +48,14 @@ module ImpactReport
       energy_efficiency
       engagement
       potential_savings
-      footnote
     ].freeze
     enum :metric_category, enum_map(METRIC_CATEGORIES).freeze
 
     GENERATOR = SchoolGroups::ImpactReport::Generator
     private_constant :GENERATOR
+
     OVERVIEW_METRICS = GENERATOR::Overview::METRICS
+
     ENERGY_EFFICIENCY_GENERATORS = [
       GENERATOR::AnnualSaving,
       GENERATOR::Benchmark,
@@ -63,20 +64,23 @@ module ImpactReport
       GENERATOR::OutOfHours
     ].freeze
     private_constant :ENERGY_EFFICIENCY_GENERATORS
+
     ENERGY_EFFICIENCY_METRICS = (
       %i[total_savings] + # not sure we need this now. Remove from DB too?
       ENERGY_EFFICIENCY_GENERATORS.flat_map { |type| type::METRICS }
     ).freeze
+
     ENGAGEMENT_METRICS = GENERATOR::Engagement::METRICS
+
     POTENTIAL_SAVINGS_METRICS = GENERATOR::PotentialSavings::METRICS
-    FOOTNOTE_METRICS = %i[].freeze
+
     METRIC_TYPES = (
       OVERVIEW_METRICS +
       ENGAGEMENT_METRICS +
       ENERGY_EFFICIENCY_METRICS +
-      POTENTIAL_SAVINGS_METRICS +
-      FOOTNOTE_METRICS
+      POTENTIAL_SAVINGS_METRICS
     ).uniq.freeze # uniq because targets is found in engagement and potential_savings
+
     enum :metric_type, enum_map(METRIC_TYPES).freeze, suffix: :metric
 
     def self.categories

--- a/app/models/impact_report/run.rb
+++ b/app/models/impact_report/run.rb
@@ -27,7 +27,6 @@ module ImpactReport
     has_many :metrics, class_name: 'ImpactReport::Metric', inverse_of: :run, dependent: :destroy
 
     scope :latest_first, -> { order(run_date: :desc, created_at: :desc) }
-    scope :latest, -> { includes(:metrics).latest_first.first }
 
     INDEXED_CATEGORIES = %w[overview engagement].freeze
     private_constant :INDEXED_CATEGORIES

--- a/app/models/impact_report/run.rb
+++ b/app/models/impact_report/run.rb
@@ -20,7 +20,7 @@
 #
 
 module ImpactReport
-  class Run < ApplicationRecord
+  class Run < ApplicationRecord # rubocop:disable Metrics/ClassLength
     self.table_name = 'impact_report_runs'
 
     belongs_to :school_group
@@ -29,17 +29,14 @@ module ImpactReport
     scope :latest_first, -> { order(run_date: :desc, created_at: :desc) }
     scope :latest, -> { includes(:metrics).latest_first.first }
 
-    SUPPORTED_ENERGY_EFFICIENCY_METRICS = [
-      %w[annual_saving gbp],
-      %w[holiday_previous_year gbp],
-      %w[holiday_previous gbp],
-      %w[annual_saving co2],
-      ['targets', nil],
-      ['out_of_hours', nil],
-      ['long_term', nil],
-      ['baseload', nil],
-      ['heating_control', nil]
-    ].freeze
+    INDEXED_CATEGORIES = %w[overview engagement].freeze
+    private_constant :INDEXED_CATEGORIES
+
+    SUPPORTED_ENERGY_EFFICIENCY_METRICS = {
+      gbp: %w[annual_saving holiday_previous_year holiday_previous],
+      count: %w[targets out_of_hours long_term baseload heating_control],
+      co2: %w[annual_saving]
+    }.freeze
     private_constant :SUPPORTED_ENERGY_EFFICIENCY_METRICS
 
     def end_date
@@ -64,84 +61,94 @@ module ImpactReport
       end
     end
 
-    # e.g. overview(:active_users)
     def overview(metric_type)
-      by_category(:overview).dig(metric_type.to_s, nil)
+      metrics_index['overview']&.[](metric_type.to_s)
     end
 
-    # e.g. engagement(:points)
     def engagement(metric_type)
-      by_category(:engagement).dig(metric_type.to_s, nil)
+      metrics_index['engagement']&.[](metric_type.to_s)
+    end
+
+    def energy_efficiency(gbp_threshold: self.class.gbp_threshold)
+      unit_order = SUPPORTED_ENERGY_EFFICIENCY_METRICS.keys
+
+      metrics
+        .filter { |metric| displayable_energy_efficiency_metric?(metric, gbp_threshold) }
+        .sort_by do |metric|
+          [
+            unit_order.index(metric.unit&.to_sym || :count),
+            -metric.value.to_f
+          ]
+        end
     end
 
     def potential_savings
       fuel_order = %w[electricity gas solar_pv]
-      fuel_order.filter_map { |fuel| sorted_potential_savings(fuel) }
-                .then do |groups|
-                  groups.map(&:size).max.to_i.times.flat_map do |i|
-                    groups.filter_map { |g| g[i] }
-                  end
-                end
-    end
+      grouped = grouped_potential_savings
+      max_size = grouped.values.map(&:size).max || 0
 
-    def energy_efficiency(gbp_threshold: self.class.gbp_threshold)
-      fuel_order = %w[gas electricity]
-      unit_order = %w[gbp co2 kwh]
-      metrics.filter { |metric| displayable_energy_efficiency_metric?(metric, gbp_threshold) }.sort_by do |metric|
-        [SUPPORTED_ENERGY_EFFICIENCY_METRICS.index([metric.metric_type, metric.unit]),
-         unit_order.index(metric.unit),
-         fuel_order.index(metric.fuel_type)]
+      (0...max_size).flat_map do |i|
+        fuel_order.filter_map do |fuel_type|
+          grouped[fuel_type]&.[](i)
+        end
       end
     end
 
     class << self
+      def gbp_threshold_product
+        Commercial::Product.default_product
+      end
+
+      def gbp_threshold_price
+        :large_school_price
+      end
+
       def gbp_threshold
-        Commercial::Product.default_product.try(:large_school_price).to_i
+        gbp_threshold_product.try(gbp_threshold_price).to_i
       end
     end
 
     private
 
-    def by_category(category)
-      metrics_index[category.to_s] || {}
-    end
-
     def metrics_index
       @metrics_index ||= metrics.each_with_object({}) do |metric, hash|
-        hash[metric.metric_category] ||= {}
-
-        if metric.metric_category == 'potential_savings'
-          store_potential_savings_metric(hash, metric)
-        else
-          store_metric(hash, metric)
+        if INDEXED_CATEGORIES.include?(metric.metric_category)
+          hash[metric.metric_category] ||= {}
+          hash[metric.metric_category][metric.metric_type] ||= metric
         end
       end
     end
 
-    def store_potential_savings_metric(hash, metric)
-      return if metric.unit.present? && metric.unit != :gbp
-
-      (hash[metric.metric_category][metric.fuel_type] ||= []) << metric
-    end
-
-    def store_metric(hash, metric)
-      (hash[metric.metric_category][metric.metric_type] ||= {})[metric.fuel_type] = metric
-    end
-
-    def sorted_potential_savings(fuel)
-      by_category(:potential_savings)
-        .to_h
-        .fetch(fuel) { [] }
-        .select(&:nonzero?)
-        .sort_by { |m| -m.value }
-        .presence
+    # Displayable potential savings metrics grouped by fuel type, highest value first
+    def grouped_potential_savings
+      @grouped_potential_savings ||=
+        metrics
+        .filter { |metric| displayable_potential_savings_metric?(metric) }
+        .group_by(&:fuel_type)
+        .transform_values do |metrics|
+          metrics.sort_by do |metric|
+            -metric.value.to_f
+          end
+        end
     end
 
     def displayable_energy_efficiency_metric?(metric, gbp_threshold)
       metric.metric_category == 'energy_efficiency' &&
-        SUPPORTED_ENERGY_EFFICIENCY_METRICS.include?([metric.metric_type, metric.unit]) &&
+        supported_energy_efficiency_metric?(metric) &&
         metric.nonzero? &&
         (metric.unit != 'gbp' || metric.value > gbp_threshold)
+    end
+
+    def supported_energy_efficiency_metric?(metric)
+      unit = metric.unit&.to_sym || :count
+
+      SUPPORTED_ENERGY_EFFICIENCY_METRICS
+        .fetch(unit) { [] }
+        .include?(metric.metric_type)
+    end
+
+    def displayable_potential_savings_metric?(metric)
+      metric.metric_category == 'potential_savings' && metric.nonzero?
     end
   end
 end

--- a/app/models/impact_report/run.rb
+++ b/app/models/impact_report/run.rb
@@ -96,7 +96,7 @@ module ImpactReport
 
     class << self
       def gbp_threshold
-        @gbp_threshold ||= Commercial::Product.default_product.try(:large_school_price).to_i
+        Commercial::Product.default_product.try(:large_school_price).to_i
       end
     end
 

--- a/app/models/school_group.rb
+++ b/app/models/school_group.rb
@@ -83,6 +83,7 @@ class SchoolGroup < ApplicationRecord
 
   has_one :impact_report_configuration, class_name: 'ImpactReport::Configuration', dependent: :destroy
   has_many :impact_report_runs, class_name: 'ImpactReport::Run', dependent: :destroy
+  has_one :latest_impact_report_run, -> { latest_first.includes(:metrics) }, class_name: 'ImpactReport::Run'
 
   has_many :observations, through: :assigned_schools
   has_many :case_studies, as: :organisation, dependent: :nullify

--- a/app/services/school_groups/impact_report/generator/potential_savings.rb
+++ b/app/services/school_groups/impact_report/generator/potential_savings.rb
@@ -32,6 +32,7 @@ module SchoolGroups
             number_of_schools = actions[alert]&.schools&.count
             metric.merge(value: actions[alert]&.average_one_year_saving_gbp || 0,
                          number_of_schools: number_of_schools || 0,
+                         unit: :gbp,
                          enough_data: number_of_schools.present?)
           end
         end

--- a/app/views/school_groups/impact/runs/_metrics.html.erb
+++ b/app/views/school_groups/impact/runs/_metrics.html.erb
@@ -1,9 +1,9 @@
 <% show_fuel_type = metrics.any?(&:fuel_type) %>
 <% show_unit = metrics.any?(&:unit) %>
-<table class="table table-sm">
+<table class="table table-sm table-sorted">
   <thead>
     <tr>
-      <th></th>
+      <th class='no-sort'></th>
       <% if show_fuel_type %>
         <th>Fuel</th>
       <% end %>

--- a/app/views/school_groups/impact/runs/_metrics.html.erb
+++ b/app/views/school_groups/impact/runs/_metrics.html.erb
@@ -1,21 +1,48 @@
-  <table class="table table-sm bg-light">
-    <thead>
-      <tr>
-        <th>Type</th>
+<% show_fuel_type = metrics.any?(&:fuel_type) %>
+<% show_unit = metrics.any?(&:unit) %>
+<table class="table table-sm">
+  <thead>
+    <tr>
+      <th></th>
+      <% if show_fuel_type %>
         <th>Fuel</th>
-        <th>Enough data</th>
-        <th>Number of schools</th>
-        <th>Value</th>
-      </tr>
-    </thead>
-    <tbody>
-      <% metrics.each do |metric| %>
-        <tr>
-          <td><%= metric.metric_type %></td>
-          <td><%= metric.fuel_type %></td>
-          <td><%= metric.enough_data? ? 'Yes' : 'No' %></td>
-          <td><%= metric.number_of_schools %></td>
-          <td><%= metric.value %></td>
-        </tr>
       <% end %>
-  </table>
+      <th>Metric type</th>
+      <% if show_unit %>
+        <th>Unit</th>
+      <% end %>
+      <th>Schools</th>
+      <th>Value</th>
+      <th class='text-end'>Created</th>
+    </tr>
+  </thead>
+  <tbody>
+    <% metrics.each do |metric| %>
+      <tr class="<%= 'text-muted bg-light' unless metric.enough_data? %>">
+        <td>
+          <span data-bs-toggle="tooltip" title="<%= metric.enough_data? ? 'Enough data' : 'Not enough data' %>">
+            <%= checkmark(metric.enough_data?, off_class: 'text-muted') %>
+          </span>
+        </td>
+        <% if show_fuel_type %>
+          <td>
+            <%= fa_icon(fuel_type_icon(metric.fuel_type)) %>
+            <%= " #{metric.fuel_type&.capitalize || ''}" %>
+          </td>
+        <% end %>
+        <td><%= metric.metric_type %></td>
+        <% if show_unit %>
+          <td><%= metric.unit %></td>
+        <% end %>
+        <td><%= metric.number_of_schools %></td>
+        <td><%= metric.value %></td>
+        <td class='text-end'><%= metric.created_at.to_fs(:es_data) %></td>
+      </tr>
+    <% end %>
+</table>
+<% unless show_fuel_type && show_unit %>
+  Columns with no data:
+  <span class='text-muted'>
+    <%= [('fuel type' unless show_fuel_type), ('unit' unless show_unit)].compact.join(', ') %>
+    </span>
+<% end %>

--- a/app/views/school_groups/impact/runs/show.html.erb
+++ b/app/views/school_groups/impact/runs/show.html.erb
@@ -12,15 +12,19 @@
 <%= render Layout::GridComponent.new(cols: 1, cell_classes: 'mb-2 rounded-2 px-3 bg-light') do |grid| %>
   <%= grid.with_cell do |row| %>
     <h2>Overview</h2>
-    <h3>Metrics</h3>
-    <%= render 'metrics', metrics: @run.metrics.overview %>
+    <div class='bg-white px-3 pb-3 mb-2 rounded-2'>
+      <h3>Metrics</h3>
+      <%= render 'metrics', metrics: @run.metrics.overview %>
+    </div>
     <h3>Displayed as</h3>
     <%= render ImpactReports::Overview::MetricsComponent.new(run: @run, classes: 'mt-4') %>
   <% end %>
   <%= grid.with_cell do |row| %>
     <h2>Energy efficiency</h2>
-    <h3>Metrics</h3>
-    <%= render 'metrics', metrics: @run.metrics.energy_efficiency %>
+    <div class='bg-white px-3 pb-3 mb-2 rounded-2'>
+      <h3>Metrics</h3>
+      <%= render 'metrics', metrics: @run.metrics.energy_efficiency %>
+    </div>
     <h3>Displayable metrics</h3>
     <p>The live report takes the first 4 from the following list, excluding any GBP metrics under £<%= ImpactReport::Run.gbp_threshold %> (default product - large school cost)</p>
 
@@ -29,15 +33,19 @@
   <% end %>
   <%= grid.with_cell do |row| %>
     <h2>Engagement</h2>
-    <h3>Metrics</h3>
-    <%= render 'metrics', metrics: @run.metrics.engagement %>
+    <div class='bg-white px-3 pb-3 mb-2 rounded-2'>
+      <h3>Metrics</h3>
+      <%= render 'metrics', metrics: @run.metrics.engagement %>
+    </div>
     <h3>Displayed as</h3>
     <%= render ImpactReports::Engagement::MetricsComponent.new(run: @run, classes: 'mt-4') %>
   <% end %>
   <%= grid.with_cell do |row| %>
     <h2>Potential savings</h2>
-    <h3>Metrics</h3>
-    <%= render 'metrics', metrics: @run.metrics.potential_savings %>
+    <div class='bg-white px-3 pb-3 mb-2 rounded-2'>
+      <h3>Metrics</h3>
+      <%= render 'metrics', metrics: @run.metrics.potential_savings %>
+    </div>
     <h3>Displayable metrics</h3>
     <p>The live report takes the first 2 from the following list</p>
     <%= render ImpactReports::PotentialSavings::MetricsComponent.new(run: @run, max: nil, classes: 'mt-4') %>

--- a/app/views/school_groups/impact/runs/show.html.erb
+++ b/app/views/school_groups/impact/runs/show.html.erb
@@ -26,7 +26,10 @@
       <%= render 'metrics', metrics: @run.metrics.energy_efficiency %>
     </div>
     <h3>Displayable metrics</h3>
-    <p>The live report takes the first 4 from the following list, excluding any GBP metrics under £<%= ImpactReport::Run.gbp_threshold %> (default product - large school cost)</p>
+    <p>
+      The live report takes the first 4 from the following list, excluding any under £<%= ImpactReport::Run.gbp_threshold %>
+      (<%= ImpactReport::Run.gbp_threshold_product.name %>: <%= ImpactReport::Run.gbp_threshold_price.to_s.humanize %>)
+    </p>
 
     <%= render ImpactReports::EnergyEfficiency::MetricsComponent.new(run: @run, max: nil, gbp_threshold: 0,
                                                                      classes: 'mt-4') %>

--- a/app/views/school_groups/impact/runs/show.html.erb
+++ b/app/views/school_groups/impact/runs/show.html.erb
@@ -30,7 +30,9 @@
       The live report takes the first 4 from the following list, excluding any under £<%= ImpactReport::Run.gbp_threshold %>
       (<%= ImpactReport::Run.gbp_threshold_product.name %>: <%= ImpactReport::Run.gbp_threshold_price.to_s.humanize %>)
     </p>
-
+    <p>
+      Energy efficiency metrics are ordered by unit (GBP, count, CO2) and then by descending value within each unit.
+    </p>
     <%= render ImpactReports::EnergyEfficiency::MetricsComponent.new(run: @run, max: nil, gbp_threshold: 0,
                                                                      classes: 'mt-4') %>
   <% end %>
@@ -50,7 +52,11 @@
       <%= render 'metrics', metrics: @run.metrics.potential_savings %>
     </div>
     <h3>Displayable metrics</h3>
-    <p>The live report takes the first 2 from the following list</p>
+    <p>The live report takes the first 2 from the following list.</p>
+    <p>
+      Potential savings metrics are arranged so that the highest electricity, gas and solar PV savings are shown first,
+      followed by the next highest for each fuel type and so on.
+    </p>
     <%= render ImpactReports::PotentialSavings::MetricsComponent.new(run: @run, max: nil, classes: 'mt-4') %>
   <% end %>
 <% end %>

--- a/config/initializers/date_formats.rb
+++ b/config/initializers/date_formats.rb
@@ -1,6 +1,7 @@
 Time::DATE_FORMATS[:es_short]   = lambda { |date_time| I18n.l(date_time, format: '%d %b %Y') }
 Time::DATE_FORMATS[:es_compact] = lambda { |date_time| I18n.l(date_time, format: '%d/%m/%Y %H:%M') }
 Time::DATE_FORMATS[:es_full]    = lambda { |date_time| I18n.l(date_time, format: "%a #{date_time.day.ordinalize} %b %Y") }
+Time::DATE_FORMATS[:es_data]    = lambda { |date_time| I18n.l(date_time, format: '%d/%m/%Y %H:%M:%S') }
 Date::DATE_FORMATS[:es_short]   = lambda { |date| I18n.l(date, format: '%d %b %Y') }
 Date::DATE_FORMATS[:es_compact] = lambda { |date| I18n.l(date, format: '%d/%m/%Y') }
 Date::DATE_FORMATS[:es_full]    = lambda { |date| I18n.l(date, format: "%a #{date.day.ordinalize} %b %Y") }

--- a/db/migrate/20260611074722_remove_footnote_from_metric_category.rb
+++ b/db/migrate/20260611074722_remove_footnote_from_metric_category.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class RemoveFootnoteFromMetricCategory < ActiveRecord::Migration[8.1]
+  def up
+    execute <<~SQL.squish
+      ALTER TYPE impact_report_metric_categories
+      RENAME TO impact_report_metric_categories_old;
+    SQL
+
+    create_enum :impact_report_metric_categories, %w[
+      overview
+      energy_efficiency
+      engagement
+      potential_savings
+    ]
+
+    change_column :impact_report_metrics, :metric_category, :enum,
+                  enum_type: :impact_report_metric_categories,
+                  using: 'metric_category::text::impact_report_metric_categories'
+
+    drop_enum :impact_report_metric_categories_old
+  end
+
+  def down
+    add_enum_value :impact_report_metric_categories, 'footnotes'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_09_162552) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_11_074722) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pg_catalog.plpgsql"
@@ -29,7 +29,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_09_162552) do
   create_enum "dcc_meter", ["no", "smets2", "other"]
   create_enum "gas_unit", ["kwh", "m3", "ft3", "hcf"]
   create_enum "half_hourly_labelling", ["start", "end"]
-  create_enum "impact_report_metric_categories", ["overview", "energy_efficiency", "engagement", "potential_savings", "footnotes"]
+  create_enum "impact_report_metric_categories", ["overview", "energy_efficiency", "engagement", "potential_savings"]
   create_enum "impact_report_metric_types", ["visible_schools", "data_visible_schools", "users", "active_users", "pupils", "enrolled_schools", "enrolling_schools", "activities", "actions", "points", "targets", "total_savings", "baseload_gbp", "baseload_co2", "baseload_kwh", "out_of_hours_gbp", "out_of_hours_co2", "out_of_hours_kwh", "peak_gbp", "peak_co2", "peak_kwh", "use_gbp", "use_co2", "use_kwh", "heating_down_gbp", "heating_down_co2", "heating_down_kwh", "heating_early_gbp", "heating_early_co2", "heating_early_kwh", "heating_off_gbp", "heating_off_co2", "heating_off_kwh", "insulate_pipes_gbp", "insulate_pipes_co2", "insulate_pipes_kwh", "thermostatic_control_gbp", "thermostatic_control_co2", "thermostatic_control_kwh", "solar_panels_gbp", "solar_panels_co2", "solar_panels_kwh", "annual_saving_gbp", "annual_saving_co2", "annual_saving_kwh", "out_of_hours_exemplar", "out_of_hours_well_managed", "long_term_exemplar", "long_term_well_managed", "baseload_exemplar", "baseload_well_managed", "heating_control_exemplar", "heating_control_well_managed", "holiday_previous_gbp", "holiday_previous_kwh", "holiday_previous_year_gbp", "holiday_previous_year_kwh", "out_of_hours", "long_term", "baseload", "heating_control", "peak", "use", "heating_down", "heating_early", "heating_off", "insulate_pipes", "thermostatic_control", "solar_panels", "holiday_previous", "holiday_previous_year", "annual_saving"]
   create_enum "impact_report_metric_units", ["kwh", "co2", "gbp"]
   create_enum "licence_status", ["provisional", "confirmed", "pending_invoice", "invoiced"]

--- a/spec/components/previews/impact_reports/energy_efficiency/metrics_component_preview.rb
+++ b/spec/components/previews/impact_reports/energy_efficiency/metrics_component_preview.rb
@@ -7,7 +7,7 @@ module ImpactReports
       # @param bs5 toggle
       def default(bs5: true, slug: nil) # rubocop:disable Lint/UnusedMethodArgument
         school_group = slug ? SchoolGroup.find(slug) : SchoolGroup.with_active_schools.sample
-        render(ImpactReports::EnergyEfficiency::MetricsComponent.new(run: school_group.impact_report_runs.latest))
+        render(ImpactReports::EnergyEfficiency::MetricsComponent.new(run: school_group.latest_impact_report_run))
       end
 
       private

--- a/spec/components/previews/impact_reports/engagement/metrics_component_preview.rb
+++ b/spec/components/previews/impact_reports/engagement/metrics_component_preview.rb
@@ -7,7 +7,7 @@ module ImpactReports
       # @param bs5 toggle
       def default(bs5: true, slug: nil) # rubocop:disable Lint/UnusedMethodArgument
         school_group = slug ? SchoolGroup.find(slug) : SchoolGroup.with_active_schools.sample
-        render(ImpactReports::Engagement::MetricsComponent.new(run: school_group.impact_report_runs.latest))
+        render(ImpactReports::Engagement::MetricsComponent.new(run: school_group.latest_impact_report_run))
       end
 
       private

--- a/spec/components/previews/impact_reports/overview/metrics_component_preview.rb
+++ b/spec/components/previews/impact_reports/overview/metrics_component_preview.rb
@@ -7,7 +7,7 @@ module ImpactReports
       # @param bs5 toggle
       def default(bs5: true, slug: nil) # rubocop:disable Lint/UnusedMethodArgument
         school_group = slug ? SchoolGroup.find(slug) : SchoolGroup.with_active_schools.sample
-        render(ImpactReports::Overview::MetricsComponent.new(run: school_group.impact_report_runs.latest))
+        render(ImpactReports::Overview::MetricsComponent.new(run: school_group.latest_impact_report_run))
       end
 
       private

--- a/spec/components/previews/impact_reports/potential_savings/metrics_component_preview.rb
+++ b/spec/components/previews/impact_reports/potential_savings/metrics_component_preview.rb
@@ -7,7 +7,7 @@ module ImpactReports
       # @param bs5 toggle
       def default(bs5: true, slug: nil) # rubocop:disable Lint/UnusedMethodArgument
         school_group = slug ? SchoolGroup.find(slug) : SchoolGroup.with_active_schools.sample
-        render(ImpactReports::PotentialSavings::MetricsComponent.new(run: school_group.impact_report_runs.latest))
+        render(ImpactReports::PotentialSavings::MetricsComponent.new(run: school_group.latest_impact_report_run))
       end
 
       private

--- a/spec/models/impact_report/run_spec.rb
+++ b/spec/models/impact_report/run_spec.rb
@@ -243,8 +243,11 @@ describe ImpactReport::Run do
 
     context 'when filtering metrics' do
       before do
+        # below threshold of 200
         create(:impact_report_metric, run:, metric_category:, metric_type: :annual_saving,
                                       fuel_type: :electricity, unit: :gbp, value: 45)
+
+        # enough data is false
         create(:impact_report_metric, run:, metric_category:, metric_type: :annual_saving,
                                       fuel_type: :gas, unit: :co2, enough_data: false)
       end

--- a/spec/models/impact_report/run_spec.rb
+++ b/spec/models/impact_report/run_spec.rb
@@ -28,24 +28,8 @@ describe ImpactReport::Run do
     end
   end
 
-  describe '.latest' do
+  describe '.latest_first' do
     subject(:run) { described_class.latest }
-
-    context 'with runs on different days' do
-      let!(:latest_run) { create(:impact_report_run, run_date: 1.day.ago) }
-
-      before do
-        create(:impact_report_run, run_date: 2.days.ago)
-      end
-
-      it 'returns the run with the most recent run_date' do
-        expect(run).to eq(latest_run)
-      end
-
-      it 'includes metrics' do
-        expect(run.association(:metrics)).to be_loaded
-      end
-    end
 
     context 'when there are two runs on the same day' do
       let(:today) { Time.zone.today }
@@ -53,9 +37,8 @@ describe ImpactReport::Run do
       let!(:first_run) { create(:impact_report_run, run_date: today, created_at: today + 1.hour) }
       let!(:latest_run) { create(:impact_report_run, run_date: today, created_at: today + 2.hours) }
 
-      it 'returns the latest created run' do
+      it 'returns the latest created run first' do
         expect(described_class.latest_first).to eq([latest_run, first_run])
-        expect(run).to eq(latest_run)
       end
     end
   end

--- a/spec/models/impact_report/run_spec.rb
+++ b/spec/models/impact_report/run_spec.rb
@@ -213,8 +213,8 @@ describe ImpactReport::Run do
     let(:metric_category) { :energy_efficiency }
     let(:run) { create(:impact_report_run) }
 
-    context 'with all metrics' do
-      let!(:metrics) do
+    context 'with all supported metrics' do
+      before do
         [create_metric(:annual_saving, :gas, 300, :gbp), create_metric(:annual_saving, :electricity, 400, :gbp),
          create_metric(:holiday_previous_year, :gas, 4500, :gbp),
          create_metric(:holiday_previous_year, :electricity, 500, :gbp),
@@ -227,17 +227,31 @@ describe ImpactReport::Run do
          create_metric(:heating_control, :gas, 8)]
       end
 
-      it 'returns metrics in configured order, gas first, then electricity' do
-        expect(energy_efficiency).to eq(metrics)
-      end
-    end
+      it 'orders metrics by unit group and value descending' do # rubocop:disable RSpec/ExampleLength
+        expect(
+          energy_efficiency.map { |m| [m.metric_type, m.unit, m.value] }
+        ).to eq(
+          [
+            ['holiday_previous_year', 'gbp', 4500],
+            ['holiday_previous', 'gbp', 4500],
+            ['holiday_previous_year', 'gbp', 500],
+            ['holiday_previous', 'gbp', 500],
+            ['annual_saving', 'gbp', 400],
+            ['annual_saving', 'gbp', 300],
 
-    context 'with just gas metrics' do
-      let!(:annual_saving_gbp_gas) { create_metric(:annual_saving, :gas, 300, :gbp) }
-      let!(:annual_saving_co2_gas) { create_metric(:annual_saving, :gas, 500, :co2) }
+            ['targets', nil, 12],
+            ['heating_control', nil, 8],
+            ['baseload', nil, 5],
+            ['long_term', nil, 4],
+            ['out_of_hours', nil, 3],
+            ['out_of_hours', nil, 2],
+            ['long_term', nil, 2],
+            ['targets', nil, 1],
 
-      it 'returns metrics in configured order, gas first, then electricity' do
-        expect(energy_efficiency).to eq([annual_saving_gbp_gas, annual_saving_co2_gas])
+            ['annual_saving', 'co2', 600],
+            ['annual_saving', 'co2', 500]
+          ]
+        )
       end
     end
 
@@ -297,28 +311,16 @@ describe ImpactReport::Run do
              metric_type: 'points')
     end
 
-    let!(:baseload) do
-      create(:impact_report_metric,
-             run: run,
-             fuel_type: 'electricity',
-             metric_category: 'potential_savings',
-             metric_type: 'baseload')
-    end
-
     it 'memoizes the index' do
       expect(index).to equal(run.send(:metrics_index))
     end
 
     it 'stores overview metrics in a hash' do
-      expect(index['overview']['active_users'][nil]).to equal(active_users)
+      expect(index['overview']['active_users']).to equal(active_users)
     end
 
     it 'stores engagemement metrics in a hash' do
-      expect(index['engagement']['points'][nil]).to equal(points)
-    end
-
-    it 'stores potential savings metrics in an array' do
-      expect(index['potential_savings']['electricity']).to eq([baseload])
+      expect(index['engagement']['points']).to equal(points)
     end
   end
 end

--- a/spec/services/school_groups/impact_report/generator/potential_savings_spec.rb
+++ b/spec/services/school_groups/impact_report/generator/potential_savings_spec.rb
@@ -18,8 +18,11 @@ RSpec.describe SchoolGroups::ImpactReport::Generator::PotentialSavings do
 
   describe '#metrics' do
     def metric(metric_type, fuel_type = :electricity, **)
-      { enough_data: false, metric_category: :potential_savings, metric_type:, fuel_type:, number_of_schools: 0,
-        value: 0 }.merge(**)
+      {
+        enough_data: false, metric_category: :potential_savings,
+        metric_type:, fuel_type:, number_of_schools: 0, unit: :gbp,
+        value: 0
+      }.merge(**)
     end
 
     it 'has the right metrics' do

--- a/spec/tasks/school_groups/generate_impact_reports_spec.rb
+++ b/spec/tasks/school_groups/generate_impact_reports_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe 'school_groups:generate_impact_reports' do # rubocop:disable RSpe
                      users: 1,
                      visible_schools: 1 },
          engagement: { actions: 1, activities: 1, points: 65, targets: 1 },
-         potential_savings: { gas_use: 1000 },
+         potential_savings: { gas_use_gbp: 1000 },
          energy_efficiency: { electricity_annual_saving_co2: 400,
                               electricity_annual_saving_kwh: 500,
                               electricity_annual_saving_gbp: 800 } }]


### PR DESCRIPTION
* Reorders energy efficiency metrics as discussed (I hope I have it right!)

Also:
* Adds unit of :gbp to potential savings metrics when they generated, to align with others.
* Removes footnotes from metric category enum, as is no longer needed
* Tidies up admin interface a bit
* Fixes an error that was happening if there was no latest run for a group

I think it might be useful / more efficient to add the visible_schools count directly to run model by the way, as it's being used on pages where we don't need all the metrics to check if there is enough data to display the report. Just a thought.
