### PR TITLE
Impact reports: wording fixes

### DIFF
--- a/app/components/impact_reports/energy_efficiency/metrics_component/metrics_component.html.erb
+++ b/app/components/impact_reports/energy_efficiency/metrics_component/metrics_component.html.erb
@@ -9,12 +9,14 @@
       <% grid.with_stats_card do |card| %>
         <% key = metric.unit.nil? ? metric.metric_type : "#{metric.metric_type}.#{metric.unit}" %>
         <%= card.with_header title: impact_t("energy_efficiency.metric_types.#{key}.title",
-                                             fuel_type: t("advice_pages.fuel_type.#{metric.fuel_type}")) %>
+                                             fuel_type: t("advice_pages.fuel_type.#{metric.fuel_type}")).capitalize %>
         <%= card.with_figure(
               metric.unit ? format_unit(metric.value, metric.unit.to_sym, false) : number_with_delimiter(metric.value)
             ) %>
+
+        <% subtext_key = metric.metric_type == 'annual_saving' && metric.unit == 'co2' ? ".#{metric.fuel_type}" : '' %>
         <%= card.with_subtext do
-              impact_t("energy_efficiency.metric_types.#{key}.subtext",
+              impact_t("energy_efficiency.metric_types.#{key}.subtext#{subtext_key}",
                        count: metric.number_of_schools,
                        fuel_type: t("advice_pages.fuel_type.#{metric.fuel_type}"))
             end %>

--- a/app/components/impact_reports/overview/metrics_component.rb
+++ b/app/components/impact_reports/overview/metrics_component.rb
@@ -14,6 +14,7 @@ module ImpactReports
       end
 
       def enrollment_metrics
+        # return the first metric that has a value above zero
         %i[enrolling_schools enrolled_schools].find { |metric| overview(metric)&.nonzero? }
       end
     end

--- a/app/components/scoreboards/podium_component/podium_component.html.erb
+++ b/app/components/scoreboards/podium_component/podium_component.html.erb
@@ -8,6 +8,7 @@
               position_ordinal: podium.school_position.ordinal,
               scoreboard: podium.scoreboard.name,
               scoreboard_path: path_to_scoreboard,
+              highest_school_path: school_path(podium.high_to_low.first.school),
               national_position_ordinal: national_podium.school_position.ordinal,
               national_scoreboard_path: scoreboard_path(national_podium.scoreboard)) %>.
       <% else %>

--- a/app/components/scoreboards/podium_component/podium_component.html.erb
+++ b/app/components/scoreboards/podium_component/podium_component.html.erb
@@ -8,7 +8,6 @@
               position_ordinal: podium.school_position.ordinal,
               scoreboard: podium.scoreboard.name,
               scoreboard_path: path_to_scoreboard,
-              highest_school_path: school_path(podium.high_to_low.first.school),
               national_position_ordinal: national_podium.school_position.ordinal,
               national_scoreboard_path: scoreboard_path(national_podium.scoreboard)) %>.
       <% else %>

--- a/app/views/school_groups/impact/runs/show.html.erb
+++ b/app/views/school_groups/impact/runs/show.html.erb
@@ -17,6 +17,10 @@
       <%= render 'metrics', metrics: @run.metrics.overview %>
     </div>
     <h3>Displayed as</h3>
+    <p>
+      The report will always show schools, adult users and pupils. If there are any enrolling schools, that metric will be shown; otherwise, enrolled schools will be shown if available.
+    </p>
+
     <%= render ImpactReports::Overview::MetricsComponent.new(run: @run, classes: 'mt-4') %>
   <% end %>
   <%= grid.with_cell do |row| %>
@@ -27,11 +31,11 @@
     </div>
     <h3>Displayable metrics</h3>
     <p>
-      The live report takes the first 4 from the following list, excluding any under £<%= ImpactReport::Run.gbp_threshold %>
+      The report takes the first 4 from the following list, excluding any under £<%= ImpactReport::Run.gbp_threshold %>
       (<%= ImpactReport::Run.gbp_threshold_product.name %>: <%= ImpactReport::Run.gbp_threshold_price.to_s.humanize %>)
     </p>
     <p>
-      Energy efficiency metrics are ordered by unit (GBP, count, CO2) and then by descending value within each unit.
+      Energy efficiency metrics are arranged into cost savings, counts and carbon emissions, with metrics shown in descending order within each group.
     </p>
     <%= render ImpactReports::EnergyEfficiency::MetricsComponent.new(run: @run, max: nil, gbp_threshold: 0,
                                                                      classes: 'mt-4') %>
@@ -43,6 +47,9 @@
       <%= render 'metrics', metrics: @run.metrics.engagement %>
     </div>
     <h3>Displayed as</h3>
+    <p>
+      Only engagement metrics with a value greater than zero are displayed in the report.
+    </p>
     <%= render ImpactReports::Engagement::MetricsComponent.new(run: @run, classes: 'mt-4') %>
   <% end %>
   <%= grid.with_cell do |row| %>
@@ -52,10 +59,10 @@
       <%= render 'metrics', metrics: @run.metrics.potential_savings %>
     </div>
     <h3>Displayable metrics</h3>
-    <p>The live report takes the first 2 from the following list.</p>
+    <p>The report takes the first 2 from the following list.</p>
     <p>
       Potential savings metrics are arranged so that the highest electricity, gas and solar PV savings are shown first,
-      followed by the next highest for each fuel type and so on.
+      followed by the next highest for each fuel type and so on. Only metrics with a value greater than zero are included.
     </p>
     <%= render ImpactReports::PotentialSavings::MetricsComponent.new(run: @run, max: nil, classes: 'mt-4') %>
   <% end %>

--- a/config/locales/views/components/scoreboards/group_summary.yml
+++ b/config/locales/views/components/scoreboards/group_summary.yml
@@ -12,7 +12,7 @@ en:
             A coordinated programme can help engage schools across the group.
           </p>
         podium:
-          full_position_html: Your highest scoring school holds <strong>%{national_position_ordinal} place</strong> <a href='%{national_scoreboard_path}'>nationally</a>
+          full_position_html: Your <a href='%{highest_school_path}'>highest scoring school</a> holds <strong>%{national_position_ordinal} place</strong> <a href='%{national_scoreboard_path}'>nationally</a>
           no_points_this_year: Your schools have not yet scored any points this academic year
           scoreboard_position_html: Your highest scoring school is in <strong>%{position_ordinal} place</strong> among <a href='%{scoreboard_path}'>%{scoreboard} schools</a>
         timeline:

--- a/config/locales/views/components/scoreboards/group_summary.yml
+++ b/config/locales/views/components/scoreboards/group_summary.yml
@@ -12,7 +12,7 @@ en:
             A coordinated programme can help engage schools across the group.
           </p>
         podium:
-          full_position_html: Your highest scoring school is in <strong>%{position_ordinal} place</strong> among <a href='%{scoreboard_path}'>%{scoreboard} schools</a> and holds <strong>%{national_position_ordinal} place</strong> <a href='%{national_scoreboard_path}'>nationally</a>
+          full_position_html: Your highest scoring school holds <strong>%{national_position_ordinal} place</strong> <a href='%{national_scoreboard_path}'>nationally</a>
           no_points_this_year: Your schools have not yet scored any points this academic year
           scoreboard_position_html: Your highest scoring school is in <strong>%{position_ordinal} place</strong> among <a href='%{scoreboard_path}'>%{scoreboard} schools</a>
         timeline:

--- a/config/locales/views/components/scoreboards/group_summary.yml
+++ b/config/locales/views/components/scoreboards/group_summary.yml
@@ -12,7 +12,7 @@ en:
             A coordinated programme can help engage schools across the group.
           </p>
         podium:
-          full_position_html: Your <a href='%{highest_school_path}'>highest scoring school</a> holds <strong>%{national_position_ordinal} place</strong> <a href='%{national_scoreboard_path}'>nationally</a>
+          full_position_html: Your <a href='%{scoreboard_path}'>highest scoring school</a> holds <strong>%{national_position_ordinal} place</strong> <a href='%{national_scoreboard_path}'>nationally</a>
           no_points_this_year: Your schools have not yet scored any points this academic year
           scoreboard_position_html: Your highest scoring school is in <strong>%{position_ordinal} place</strong> among <a href='%{scoreboard_path}'>%{scoreboard} schools</a>
         timeline:

--- a/config/locales/views/school_groups/impact.yml
+++ b/config/locales/views/school_groups/impact.yml
@@ -11,9 +11,13 @@ en:
           annual_saving:
             co2:
               subtext:
-                one: Reduced emissions by reducing %{fuel_type} use in %{count} school in the last 12 months
-                other: Reduced emissions by reducing %{fuel_type} use in %{count} schools in the last 12 months
-              title: Reduced %{fuel_type} emissions
+                electricity:
+                  one: Reduced carbon emissions from electricity use in %{count} school in the last 12 months
+                  other: Reduced carbon emissions from electricity use in %{count} schools in the last 12 months
+                gas:
+                  one: Reduced carbon emissions by reducing gas use in %{count} school in the last 12 months
+                  other: Reduced carbon emissions by reducing gas use in %{count} schools in the last 12 months
+              title: Reduced carbon emissions from %{fuel_type}
             gbp:
               subtext:
                 one: Cost saving by reducing %{fuel_type} use in %{count} school in the last 12 months using current tariffs
@@ -21,10 +25,10 @@ en:
               title: Total %{fuel_type} savings
           baseload:
             subtext: Schools achieving a well managed or exemplar rating for managing electricity baseload
-            title: Baseload management
+            title: Good baseload management
           heating_control:
             subtext: Schools achieving a well managed or exemplar rating for heating control
-            title: Improved heating control
+            title: Good heating control
           holiday_previous:
             gbp:
               subtext:
@@ -36,7 +40,7 @@ en:
               subtext:
                 one: Cost saving by reducing %{fuel_type} use in %{count} school between the last holiday and same holiday in previous year using current tariffs
                 other: Cost saving by reducing %{fuel_type} use in %{count} schools between the last holiday and same holiday in previous year using current tariffs
-              title: Yearly holiday %{fuel_type} savings
+              title: Holiday %{fuel_type} savings compared to last year
           long_term:
             subtext: Schools achieving a well managed or exemplar rating for their %{fuel_type} use
             title: Reducing %{fuel_type} use
@@ -45,7 +49,7 @@ en:
             title: Reducing out of hours %{fuel_type} use
           targets:
             subtext: Schools with measurable progress against reducing their %{fuel_type} use
-            title: Energy saving targets
+            title: "%{fuel_type} saving targets"
         title: Energy Efficiency
       engagement:
         cards:
@@ -59,7 +63,7 @@ en:
             subtext: Points scored in the last 12 months in our energy saving competitions
             title: Points
           targets:
-            subtext: Number of active Energy Saving Targets set by schools in the group
+            subtext: Number of active energy saving targets set by schools in the group
             title: Current targets
         description: How are schools in this group engaging with the Energy Sparks education programme?
         featured:
@@ -84,7 +88,7 @@ en:
         title: "%{school_group} Impact Report"
       notes:
         comparisons_basis: Reductions in energy use are based on comparing use with the previous 12 month period (%{comparison_start} - %{comparison_end}).
-        cost_savings: Cost savings are based on the historical energy tariff data provided to us by the group and/or individual schools. Where not available we use a default charge.
+        cost_savings: Cost savings achieved are based on the current energy tariff data provided to us by the group and/or individual schools. Where not available we use a default charge.
         coverage: Energy Sparks may not have full coverage for all meters in schools, but school data is only made available for analysis where we have significant coverage. This means our figures may underestimate actual or potential savings.
         data_updated: The data on this page was last updated on %{date}.
         other_analysis: Other analysis, e.g. progress against energy targets is based on the latest available data at the point of analysis.
@@ -116,11 +120,11 @@ en:
               one: Of which %{count} has logged into the tool in the last 3 months
               other: Of which %{count} have logged into the tool in the last 3 months
               zero: Number of group and school users
-            title: Users
+            title: Adult users
         description: How many schools and users are enrolled in Energy Sparks from this group?
         title: Overview
       potential_savings:
-        description: What additional savings have we identified that can help these schools continue to reduce their energy bills and carbon emissions?
+        description: Further energy and carbon saving opportunities identified for these schools
         keys:
           baseload:
             one: By reducing %{fuel_type} baseload in %{count} school

--- a/spec/components/impact_reports/energy_efficiency/metrics_component_spec.rb
+++ b/spec/components/impact_reports/energy_efficiency/metrics_component_spec.rb
@@ -54,12 +54,12 @@ RSpec.describe ImpactReports::EnergyEfficiency::MetricsComponent, :include_appli
       }
     end
 
-    context 'with holiday_previous_year_gbp metric' do
+    context 'with holiday_previous_year metric' do
       let!(:metric_type) { :holiday_previous_year }
       let!(:metric) do
         create(:impact_report_metric, run:, metric_category:, metric_type:, fuel_type: :electricity, unit: :gbp)
       end
-      let(:card) { card_with_title('Yearly holiday electricity savings') }
+      let(:card) { card_with_title('Holiday electricity savings compared to last year') }
 
       before do
         render_inline(described_class.new(**params))
@@ -73,7 +73,7 @@ RSpec.describe ImpactReports::EnergyEfficiency::MetricsComponent, :include_appli
       }
     end
 
-    context 'with holiday_previous_gbp metric' do
+    context 'with holiday_previous metric' do
       let!(:metric_type) { :holiday_previous }
       let!(:metric) do
         create(:impact_report_metric, run:, metric_category:, metric_type:, fuel_type: :electricity, unit: :gbp)
@@ -92,12 +92,12 @@ RSpec.describe ImpactReports::EnergyEfficiency::MetricsComponent, :include_appli
       }
     end
 
-    context 'with annual_saving_co2 metric' do
+    context 'with annual_saving co2 metric' do
       let!(:metric_type) { :annual_saving }
       let!(:metric) do
         create(:impact_report_metric, run:, metric_category:, metric_type:, fuel_type: :gas, unit: :co2)
       end
-      let(:card) { card_with_title('Reduced gas emissions') }
+      let(:card) { card_with_title('Reduced carbon emissions from gas') }
 
       before do
         render_inline(described_class.new(**params))
@@ -106,8 +106,8 @@ RSpec.describe ImpactReports::EnergyEfficiency::MetricsComponent, :include_appli
       it { expect(card).to have_css('.figure', exact_text: "#{metric.value} kg CO2") }
 
       it {
-        expect(card).to have_text(impact_t("energy_efficiency.metric_types.#{metric_type}.co2.subtext",
-                                           fuel_type: 'gas', count: metric.number_of_schools))
+        expect(card).to have_text(impact_t("energy_efficiency.metric_types.#{metric_type}.co2.subtext.gas",
+                                           count: metric.number_of_schools))
       }
     end
 
@@ -116,7 +116,7 @@ RSpec.describe ImpactReports::EnergyEfficiency::MetricsComponent, :include_appli
       let!(:metric) do
         create(:impact_report_metric, run:, metric_category:, metric_type:, fuel_type: :gas)
       end
-      let(:card) { card_with_title('Energy saving targets') }
+      let(:card) { card_with_title('Gas saving targets') }
 
       before do
         render_inline(described_class.new(**params))

--- a/spec/components/impact_reports/overview/metrics_component_spec.rb
+++ b/spec/components/impact_reports/overview/metrics_component_spec.rb
@@ -36,10 +36,10 @@ RSpec.describe ImpactReports::Overview::MetricsComponent, :include_application_h
       end
     end
 
-    describe 'users card' do
+    describe 'Adult users card' do
       let(:card) { cards[1] }
 
-      it { expect(card).to have_text('Users') }
+      it { expect(card).to have_text('Adult users') }
       it { expect(card).to have_css('.figure', exact_text: run.overview(:users).value) }
 
       it do

--- a/spec/components/scoreboards/group_summary_component_spec.rb
+++ b/spec/components/scoreboards/group_summary_component_spec.rb
@@ -19,9 +19,8 @@ RSpec.describe Scoreboards::GroupSummaryComponent, :include_url_helpers, type: :
   end
 
   context 'when there are activities' do
-    let!(:school) { create(:school, :with_points, score_points: 50, school_group: school_group) }
-
     before do
+      create(:school, :with_points, score_points: 50, school_group: school_group)
       render_inline(described_class.new(**params))
     end
 
@@ -30,7 +29,7 @@ RSpec.describe Scoreboards::GroupSummaryComponent, :include_url_helpers, type: :
     it 'shows podium correctly' do
       podium = page.find('.scoreboards-podium-component')
       expect(podium).to have_text('Your highest scoring school holds 1st place nationally')
-      expect(podium).to have_link('highest scoring school', href: school_path(school))
+      expect(podium).to have_link('highest scoring school', href: scores_school_group_advice_path(school_group))
     end
 
     it 'links to scoreboard' do

--- a/spec/components/scoreboards/group_summary_component_spec.rb
+++ b/spec/components/scoreboards/group_summary_component_spec.rb
@@ -9,34 +9,35 @@ RSpec.describe Scoreboards::GroupSummaryComponent, :include_url_helpers, type: :
     { school_group: school_group, user: create(:admin) }
   end
 
-  subject(:html) do
+  before do
     render_inline(described_class.new(**params))
   end
 
   context 'when there are no activities in group' do
-    it { expect(html).to have_content(I18n.t('components.scoreboards.group_summary.podium.no_points_this_year'))}
-    it { expect(html).not_to have_css('.timeline-component')}
+    it { expect(page).to have_content(I18n.t('components.scoreboards.group_summary.podium.no_points_this_year'))}
+    it { expect(page).not_to have_css('.timeline-component')}
   end
 
   context 'when there are activities' do
+    let!(:school) { create(:school, :with_points, score_points: 50, school_group: school_group) }
+
     before do
-      create(:school, :with_points, score_points: 50, school_group: school_group)
-      html
+      render_inline(described_class.new(**params))
     end
 
-    it { expect(html).not_to have_content(I18n.t('components.scoreboards.group_summary.podium.no_points_this_year'))}
+    it { expect(page).not_to have_content(I18n.t('components.scoreboards.group_summary.podium.no_points_this_year'))}
 
     it 'shows podium correctly' do
       podium = page.find('.scoreboards-podium-component')
-      expect(podium).to have_text('Your highest scoring school')
-      expect(podium).to have_link(href: scores_school_group_advice_path(school_group))
+      expect(podium).to have_text('Your highest scoring school holds 1st place nationally')
+      expect(podium).to have_link('highest scoring school', href: school_path(school))
     end
 
     it 'links to scoreboard' do
-      expect(html).to have_link(I18n.t('components.scoreboard_summary.view_scoreboard'),
+      expect(page).to have_link(I18n.t('components.scoreboard_summary.view_scoreboard'),
                                 href: scores_school_group_advice_path(school_group))
     end
 
-    it { expect(html).to have_content(I18n.t('components.scoreboards.group_summary.timeline.title'))}
+    it { expect(page).to have_content(I18n.t('components.scoreboards.group_summary.timeline.title'))}
   end
 end


### PR DESCRIPTION
Completed Claudia's wording fixes.

Podium text changed from: Your highest scoring school is in 1st place among [Oasis Community Learning schools](https://energysparks.uk/school_groups/oasis-community-learning/advice/scores) and holds 2nd place [nationally](https://energysparks.uk/scoreboards/national).
Updated to: Your highest scoring school holds 2nd place [nationally](https://energysparks.uk/scoreboards/national).

I have also linked the text 'highest scoring school' to https://energysparks.uk/school_groups/oasis-community-learning/advice/scores . Is this ok, or would you rather it be a link to the school dashboard, or not at all?

Also these changes will also be shown on the group dashboard, presume this is right given Claudia's comment: "The highest scoring school will always be in 1st place on the group dashboard - there is no need to state the obvious!"