### PR TITLE
Add not_provisional scope

### DIFF
--- a/app/models/commercial/licence.rb
+++ b/app/models/commercial/licence.rb
@@ -80,6 +80,8 @@ module Commercial
            .by_start_date
     end
 
+    scope :not_provisional, -> { where.not(status: :provisional) }
+
     # Calculate duration ignoring leap years
     def self.licence_period_days(period_start, period_end)
       real_days = (period_end - period_start).to_i + 1

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -985,7 +985,7 @@ class School < ApplicationRecord
     year = Calendar.default_national&.current_academic_year&.next_year
     return nil unless year
 
-    future_licences = licences.confirmed.for_period(year.start_date..year.end_date)
+    future_licences = licences.not_provisional.for_period(year.start_date..year.end_date)
     summarise_contract_holder(future_licences.first&.contract_holder)
   end
 

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -1541,6 +1541,21 @@ describe School do
       it { expect(name).to eq(contract_holder.name) }
     end
 
+    context 'with invoiced funder licence' do
+      let(:contract_holder) { create(:funder) }
+
+      before do
+        create(:commercial_licence,
+               school:,
+               contract: create(:commercial_contract, contract_holder:),
+               status: :invoiced,
+               start_date: next_academic_year.start_date,
+               end_date: next_academic_year.end_date)
+      end
+
+      it { expect(name).to eq(contract_holder.name) }
+    end
+
     context 'with unconfirmed funder licence' do
       let(:contract_holder) { create(:funder) }
 


### PR DESCRIPTION
Tweaks the scope used to find future funder so its looking for any non provisional licence, not just confirmed.