### PR TITLE
Add admin link to impact reports config interface

### DIFF
--- a/app/views/admin/index.html.erb
+++ b/app/views/admin/index.html.erb
@@ -23,6 +23,7 @@
       <% SchoolGroup::RESTRICTED_GROUP_TYPES.sort.each do |group_type| %>
         <li><%= link_to "Manage #{group_type.to_s.humanize} Groups", admin_school_groups_path(group_type:) %></li>
       <% end %>
+      <li><%= link_to 'Manage Impact Reports', admin_impact_reports_path %></li>
     </ul>
 
     <h2>Schools and and scoreboards</h2>


### PR DESCRIPTION
In the call we talked about putting it in /admin/reports but it's more of an admin page in my head? Definitely something with school group context, but not sure it goes with the other items in there. What do you think @ldodds? 

<img width="545" height="635" alt="image" src="https://github.com/user-attachments/assets/3798d45d-d940-4316-a1fd-c3769154a480" />

Alternative in the reports index, not sure it's right where it is here either.
<img width="545" height="635" alt="image" src="https://github.com/user-attachments/assets/3d8c05f7-59cd-474c-b944-7ef883a89da2" />
