### PR TITLE
Handle feedback from testing invoicing workflow

### DIFF
--- a/app/components/schools/utility_status_component.rb
+++ b/app/components/schools/utility_status_component.rb
@@ -7,15 +7,11 @@ module Schools
       @school = school
     end
 
-    def render?
-      @school.process_data && @school.configuration.present?
-    end
-
     private
 
     def utility_status
       return ['text-bg-danger', 'Not data visible'] unless @school.data_enabled
-      return ['text-bg-danger', 'No data'] if fuel_status.empty?
+      return ['text-bg-danger', 'No data'] if no_data?
 
       if fuel_status.values.all?(false)
         ['text-bg-danger', 'No recent data']
@@ -30,6 +26,12 @@ module Schools
       @fuel_status ||= @school.configuration.aggregate_meter_dates.transform_values do |dates|
         Date.parse(dates['end_date']) > 14.days.ago
       end
+    end
+
+    # Handles edge cases where school might not have yet been regenerated, has failed to regenerate
+    # or does not have any active meters.
+    def no_data?
+      !@school.process_data || @school.configuration.nil? || fuel_status.empty?
     end
   end
 end

--- a/app/services/commercial/licence_manager.rb
+++ b/app/services/commercial/licence_manager.rb
@@ -42,8 +42,9 @@ module Commercial
     def school_made_data_enabled
       licence = @school.licences.current.first
       return unless licence
+      return licence if licence.invoiced? # no changes once invoiced
 
-      if licence.contract.licence_period.to_sym == :custom
+      if update_dates?(licence)
         licence_dates = self.class.licence_dates(licence.contract)
         licence.start_date = licence_dates[:start_date]
         licence.end_date = licence_dates[:end_date]
@@ -79,6 +80,10 @@ module Commercial
         comments:,
         status: contract.confirmed? ? :confirmed : :provisional
       )
+    end
+
+    def update_dates?(licence)
+      licence.contract.custom? || licence.contract.pro_rata?
     end
   end
 end

--- a/app/views/admin/commercial/invoices/show.html.erb
+++ b/app/views/admin/commercial/invoices/show.html.erb
@@ -2,6 +2,7 @@
   <% header_nav.with_header title: @invoice.invoice_number %>
   <% header_nav.with_button 'Contract', admin_commercial_contract_path(@invoice.contract) %>
   <% header_nav.with_button 'All Invoices', admin_commercial_invoices_path %>
+  <% header_nav.with_button 'Pending Invoices', pending_invoicing_admin_commercial_contracts_path %>
 <% end %>
 
 <div class="row">

--- a/spec/components/schools/utility_status_component_spec.rb
+++ b/spec/components/schools/utility_status_component_spec.rb
@@ -9,22 +9,6 @@ RSpec.describe Schools::UtilityStatusComponent, type: :component do
     render_inline component
   end
 
-  context 'with no configuration' do
-    let(:school) do
-      school = create(:school, process_data: true)
-      school.configuration.destroy
-      school.reload
-    end
-
-    it { expect(component.render?).to be(false) }
-  end
-
-  context 'when not processing data' do
-    let(:school) { create(:school, process_data: false) }
-
-    it { expect(component.render?).to be(false) }
-  end
-
   context 'when not data enabled' do
     let(:school) { create(:school, :with_meter_dates, data_enabled: false) }
 
@@ -33,12 +17,32 @@ RSpec.describe Schools::UtilityStatusComponent, type: :component do
     it { expect(page).to have_text('Not data visible') }
   end
 
+  shared_examples 'with a no data message' do
+    it { expect(page).to have_css('span.text-bg-danger') }
+    it { expect(page).to have_text('No data') }
+  end
+
   context 'when data enabled' do
+    context 'with no configuration' do
+      let(:school) do
+        school = create(:school, process_data: true)
+        school.configuration.destroy
+        school.reload
+      end
+
+      it_behaves_like 'with a no data message'
+    end
+
+    context 'when not processing data' do
+      let(:school) { create(:school, process_data: false) }
+
+      it_behaves_like 'with a no data message'
+    end
+
     context 'with no meter dates' do
       let(:school) { create(:school) }
 
-      it { expect(page).to have_css('span.text-bg-danger') }
-      it { expect(page).to have_text('No data') }
+      it_behaves_like 'with a no data message'
     end
 
     context 'with single fuel type' do

--- a/spec/services/commercial/licence_manager_spec.rb
+++ b/spec/services/commercial/licence_manager_spec.rb
@@ -148,12 +148,32 @@ describe Commercial::LicenceManager do
                status: :confirmed)
       end
 
-      it 'updates the licence status only' do
-        expect(updated_licence).to have_attributes(
-          status: 'pending_invoice',
-          start_date: licence.start_date,
-          end_date: licence.end_date
-        )
+      context 'when invoice terms are full' do
+        it 'updates the licence status only' do
+          expect(updated_licence).to have_attributes(
+            status: 'pending_invoice',
+            start_date: licence.start_date,
+            end_date: licence.end_date
+          )
+        end
+      end
+
+      context 'when invoice terms are pro_rata' do
+        let!(:licence) do
+          create(:commercial_licence,
+                 school:,
+                 start_date: Time.zone.yesterday,
+                 contract: create(:commercial_contract, licence_period: :contract, invoice_terms: :pro_rata),
+                 status: :confirmed)
+        end
+
+        it 'updates the licence start date' do
+          expect(updated_licence).to have_attributes(
+            status: 'pending_invoice',
+            start_date: Time.zone.today,
+            end_date: licence.end_date
+          )
+        end
       end
 
       context 'when the status had already changed' do

--- a/spec/system/admin/commercial/manage_invoices_spec.rb
+++ b/spec/system/admin/commercial/manage_invoices_spec.rb
@@ -48,6 +48,9 @@ describe 'manage invoices', :include_application_helper do
       click_on invoice.invoice_number
     end
 
+    it { expect(page).to have_link('Pending Invoices', href: pending_invoicing_admin_commercial_contracts_path) }
+    it { expect(page).to have_link('All Invoices', href: admin_commercial_invoices_path) }
+
     context 'when viewing summary' do
       it { expect(page).to have_text(invoice.purchase_order_number) }
       it { expect(page).to have_text(invoice.date.to_fs(:es_short)) }


### PR DESCRIPTION
Changes how utility status component renders to catch some edge cases in the school status

Adds a link from invoice page to the pending invoice report

Fixes bugs in LicenceManager:

- should not update an invoiced licence
- should revise dates for non invoiced licences under a pro_rata contract (licence will start today if invoicing has started for the contract)