### PR TITLE
Add more flexibility when editing and renewing contracts

### DIFF
--- a/app/components/commercial/contracts_component/contracts_component.html.erb
+++ b/app/components/commercial/contracts_component/contracts_component.html.erb
@@ -48,7 +48,7 @@
               <%= link_to 'Edit', edit_admin_commercial_contract_path(contract),
                           class: 'btn btn-secondary btn-sm' %>
               <%= unless contract.future?
-                    link_to 'Renew', new_admin_commercial_contract_path(original_contract_id: contract.id),
+                    link_to 'Renew', renew_admin_commercial_contracts_path(original_contract_id: contract.id),
                             class: 'btn btn-secondary btn-sm'
                   end %>
               <% unless contract.confirmed? %>

--- a/app/controllers/admin/commercial/contracts_controller.rb
+++ b/app/controllers/admin/commercial/contracts_controller.rb
@@ -62,10 +62,19 @@ module Admin
         }
       end
 
+      def renew
+        @original = ::Commercial::Contract.find(params.expect(:original_contract_id))
+        @chosen_params = {
+          contract_holder_id: params[:contract_holder_id],
+          contract_holder_type: params[:contract_holder_type],
+          original_contract_id: params[:original_contract_id]
+        }
+      end
+
       def new
         if renewal_request?
           @original = ::Commercial::Contract.find(params.expect(:original_contract_id))
-          @contract = ::Commercial::Contract.as_renewal(@original)
+          @contract = ::Commercial::Contract.as_renewal(@original, chosen_type: params.expect(:chosen_type)&.to_sym)
         else
           redirect_to choose_admin_commercial_contracts_path and return if chosen_params[:chosen_type].blank?
 

--- a/app/controllers/admin/commercial/contracts_controller.rb
+++ b/app/controllers/admin/commercial/contracts_controller.rb
@@ -74,7 +74,7 @@ module Admin
       def new
         if renewal_request?
           @original = ::Commercial::Contract.find(params.expect(:original_contract_id))
-          @contract = ::Commercial::Contract.as_renewal(@original, chosen_type: params.expect(:chosen_type)&.to_sym)
+          @contract = ::Commercial::Contract.as_renewal(@original, chosen_type: params.expect(:chosen_type).to_sym)
         else
           redirect_to choose_admin_commercial_contracts_path and return if chosen_params[:chosen_type].blank?
 

--- a/app/models/commercial/contract.rb
+++ b/app/models/commercial/contract.rb
@@ -200,20 +200,19 @@ module Commercial
 
     def self.temporal_group_keys = %i[contract_holder_id contract_holder_type]
 
-    def self.as_renewal(original, chosen_type: :contract)
+    def self.as_renewal(original, chosen_type: nil)
       renewed_attributes = {
         comments: "Renewed from #{original.name}",
         end_date: original.end_date.next_year,
         start_date: original.end_date + 1.day,
-        update_licences: true
+        update_licences: true,
+        licence_period: :contract,
+        invoice_terms: :pro_rata
       }
 
       if chosen_type == :custom
         renewed_attributes[:licence_period] = :custom
         renewed_attributes[:invoice_terms] = :full
-      else
-        renewed_attributes[:licence_period] = :contract
-        renewed_attributes[:invoice_terms] = :pro_rata
       end
 
       new(

--- a/app/models/commercial/contract.rb
+++ b/app/models/commercial/contract.rb
@@ -200,22 +200,32 @@ module Commercial
 
     def self.temporal_group_keys = %i[contract_holder_id contract_holder_type]
 
-    def self.as_renewal(original)
+    def self.as_renewal(original, chosen_type: :contract)
+      renewed_attributes = {
+        comments: "Renewed from #{original.name}",
+        end_date: original.end_date.next_year,
+        start_date: original.end_date + 1.day,
+        update_licences: true
+      }
+
+      if chosen_type == :custom
+        renewed_attributes[:licence_period] = :custom
+        renewed_attributes[:invoice_terms] = :full
+      else
+        renewed_attributes[:licence_period] = :contract
+        renewed_attributes[:invoice_terms] = :pro_rata
+      end
+
       new(
         original.slice(
           :agreed_school_price,
           :contract_holder_type,
           :contract_holder_id,
-          :licence_period,
           :licence_years,
           :number_of_schools,
           :product
         ).merge(
-          invoice_terms: original.custom? ? :full : :pro_rata,
-          comments: "Renewed from #{original.name}",
-          end_date: original.end_date.next_year,
-          start_date: original.end_date + 1.day,
-          update_licences: true
+          renewed_attributes
         )
       )
     end

--- a/app/models/commercial/contract.rb
+++ b/app/models/commercial/contract.rb
@@ -245,6 +245,7 @@ module Commercial
       fields = %i[comments name purchase_order_number number_of_schools updated_by_id]
       fields += %i[status] if provisional?
       fields += [:licence_years] if custom? && !invoiced?
+      fields += [:invoice_terms] if contract? && !invoiced?
       fields += %i[agreed_school_price product_id start_date end_date] unless invoiced?
       fields
     end

--- a/app/views/admin/commercial/contracts/_form.html.erb
+++ b/app/views/admin/commercial/contracts/_form.html.erb
@@ -26,6 +26,12 @@
           The form has been populated using the existing contractual details, including contract terms, length and
           agreed pricing.
         </p>
+        <% if @contract.licence_period != @original.licence_period %>
+          <p>
+            <strong>Note</strong> based on the chosen option the licence period has been changed to
+            <%= @contract.licence_period.to_s.humanize %>
+          </p>
+        <% end %>
       <% end %>
     <% elsif contract.persisted? && contract.invoiced? %>
       <%= render PromptComponent.new icon: 'circle-info', status: :neutral do %>

--- a/app/views/admin/commercial/contracts/_form.html.erb
+++ b/app/views/admin/commercial/contracts/_form.html.erb
@@ -124,7 +124,14 @@
           <%= f.input :start_date, as: :tempus_dominus_date if contract.editable_attribute?(:start_date) %>
           <%= f.input :end_date, as: :tempus_dominus_date if contract.editable_attribute?(:end_date) %>
 
-          <%= f.input :invoice_terms, as: :hidden %>
+          <% if contract.editable_attribute?(:invoice_terms) && !contract.custom? %>
+            <%= f.input :invoice_terms,
+                        collection: collection_from_enum(Commercial::Contract.invoice_terms),
+                        include_blank: false %>
+          <% else %>
+            <%= f.input :invoice_terms, as: :hidden %>
+          <% end %>
+
           <%= f.input :licence_period, as: :hidden %>
           <%= if contract.custom? && contract.editable_attribute?(:licence_years)
                 f.input :licence_years, hint: 'Length of custom licence in years. E.g. 1.0, 2.0, 3.0, 1.2, 1.5, etc'

--- a/app/views/admin/commercial/contracts/renew.html.erb
+++ b/app/views/admin/commercial/contracts/renew.html.erb
@@ -1,0 +1,65 @@
+<%= render Admin::HeaderNavComponent.new do |header_nav| %>
+  <% header_nav.with_header title: 'Choose Renewed Contract Type' %>
+  <% header_nav.with_button 'Contracts & Licensing', admin_commercial_path %>
+<% end %>
+
+<div class="row">
+  <div class="col">
+    <h3>Renew as Standard Contract</h3>
+    <div id="standard" class="p-4 bg-grey-pale rounded">
+      <% unless @original.custom? %>
+        <p>
+          <strong>Keep the same type as the original contract</strong>
+        </p>
+      <% end %>
+      <p>
+         Renew as a standard contract. By default the contract will be renewed for pro rata invoicing, but this
+         can be changed on the following page.
+      </p>
+      <p>
+        With pro rata invoicing any schools added to the contract after invoicing has begun will
+        have their licence begin on that day (e.g. day of onboarding). The licences will end on the contract end
+        date.
+      </p>
+      <p>
+        This allows contract holders to be charged for just the part of the contract period for those schools that
+        join late in the contract.
+      </p>
+      <%= link_to 'Renew contract',
+                  new_admin_commercial_contract_path(params: @chosen_params.merge(chosen_type: :pro_rata)),
+                  class: 'btn btn-sm' %>
+    </div>
+  </div>
+</div>
+
+<div class="row mt-4">
+  <div class="col">
+    <h3>Renew as Custom Contract</h3>
+    <div id="custom" class="mt-4 p-4 bg-grey-pale rounded">
+      <% if @original.custom? %>
+        <p>
+          <strong>Keep the same type as the original contract</strong>
+        </p>
+      <% end %>
+      <p>
+        All licences for this contract type will have their own start and end dates.
+      </p>
+      <p>
+        Licences will start from when a school is added to the contract and run for a number of "licence years".
+      </p>
+      <p>
+        Licences will have their own date ranges and may extend beyond the date of the contract.
+      </p>
+      <p>
+        Licence years can be any length (e.g. 1, 2, 3 years) and may be fractional (e.g. 1.2, 1.5 years).
+      </p>
+      <p>
+        The system will scale the annual prices defined in the contract (and its product), as needed for the
+        length of the licensed period.
+      </p>
+      <%= link_to 'Renew contract',
+                  new_admin_commercial_contract_path(params: @chosen_params.merge(chosen_type: :custom)),
+                  class: 'btn btn-sm' %>
+    </div>
+  </div>
+</div>

--- a/app/views/admin/commercial/contracts/show.html.erb
+++ b/app/views/admin/commercial/contracts/show.html.erb
@@ -20,7 +20,7 @@
                   class: 'btn btn-secondary btn-sm' %>
 
       <%= unless @contract.future?
-            link_to 'Renew', new_admin_commercial_contract_path(original_contract_id: @contract.id),
+            link_to 'Renew', renew_admin_commercial_contracts_path(original_contract_id: @contract.id),
                     class: 'btn btn-secondary btn-sm'
           end %>
       <%= if @contract.licences.pending_invoice.any?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -653,6 +653,7 @@ Rails.application.routes.draw do
 
         get :contract_holder_options, on: :collection
         get :choose, on: :collection
+        get :renew, on: :collection
         resources :invoices, controller: 'contracts/invoices', only: %i[new create] do
           get :raise_invoice, on: :collection
         end

--- a/spec/models/commercial/contract_spec.rb
+++ b/spec/models/commercial/contract_spec.rb
@@ -199,32 +199,62 @@ describe Commercial::Contract do
   end
 
   describe '#as_renewal' do
-    subject(:renewed) { described_class.as_renewal(original) }
+    context 'when renewing as a custom contract' do
+      subject(:renewed) { described_class.as_renewal(original, chosen_type: :custom) }
 
-    let(:original) do
-      create(:commercial_contract,
-             :custom,
-             agreed_school_price: 450.0,
-             licence_years: 2.0,
-             number_of_schools: 15)
+      let(:original) do
+        create(:commercial_contract,
+               :custom,
+               agreed_school_price: 450.0,
+               licence_years: 2.0,
+               number_of_schools: 15)
+      end
+
+      it 'correctly populates the new contract' do
+        expect(renewed).to have_attributes(
+          agreed_school_price: original.agreed_school_price,
+          comments: "Renewed from #{original.name}",
+          contract_holder: original.contract_holder,
+          invoice_terms: original.invoice_terms,
+          licence_period: original.licence_period,
+          licence_years: original.licence_years,
+          number_of_schools: original.number_of_schools,
+          product: original.product,
+          start_date: original.end_date + 1.day,
+          end_date: original.end_date.next_year
+        )
+      end
+
+      context 'when switching type' do
+        let(:original) do
+          create(:commercial_contract,
+                 licence_period: :contract,
+                 invoice_terms: :pro_rata,
+                 agreed_school_price: 450.0,
+                 licence_years: 2.0,
+                 number_of_schools: 15)
+        end
+
+        it 'correctly switches the contract options' do
+          expect(renewed).to have_attributes(
+            agreed_school_price: original.agreed_school_price,
+            comments: "Renewed from #{original.name}",
+            contract_holder: original.contract_holder,
+            invoice_terms: 'full',
+            licence_period: 'custom',
+            licence_years: original.licence_years,
+            number_of_schools: original.number_of_schools,
+            product: original.product,
+            start_date: original.end_date + 1.day,
+            end_date: original.end_date.next_year
+          )
+        end
+      end
     end
 
-    it 'correctly populates the defaults' do
-      expect(renewed).to have_attributes(
-        agreed_school_price: original.agreed_school_price,
-        comments: "Renewed from #{original.name}",
-        contract_holder: original.contract_holder,
-        invoice_terms: original.invoice_terms,
-        licence_period: original.licence_period,
-        licence_years: original.licence_years,
-        number_of_schools: original.number_of_schools,
-        product: original.product,
-        start_date: original.end_date + 1.day,
-        end_date: original.end_date.next_year
-      )
-    end
+    context 'when renewing as a standard contract' do
+      subject(:renewed) { described_class.as_renewal(original, chosen_type: :pro_rata) }
 
-    context 'when the original licence terms were pro_rata' do
       let(:original) do
         create(:commercial_contract,
                licence_period: :contract,
@@ -233,7 +263,7 @@ describe Commercial::Contract do
                number_of_schools: 15)
       end
 
-      it 'correctly populates the defaults' do
+      it 'correctly populates the new contract' do
         expect(renewed).to have_attributes(
           agreed_school_price: original.agreed_school_price,
           comments: "Renewed from #{original.name}",
@@ -246,29 +276,54 @@ describe Commercial::Contract do
           end_date: original.end_date.next_year
         )
       end
-    end
 
-    context 'when the original licence terms were full' do
-      let(:original) do
-        create(:commercial_contract,
-               licence_period: :contract,
-               invoice_terms: :full,
-               agreed_school_price: 450.0,
-               number_of_schools: 15)
+      context 'when the original licence terms were full' do
+        let(:original) do
+          create(:commercial_contract,
+                 licence_period: :contract,
+                 invoice_terms: :full,
+                 agreed_school_price: 450.0,
+                 number_of_schools: 15)
+        end
+
+        it 'switches to a pro-rata contract' do
+          expect(renewed).to have_attributes(
+            agreed_school_price: original.agreed_school_price,
+            comments: "Renewed from #{original.name}",
+            contract_holder: original.contract_holder,
+            invoice_terms: 'pro_rata',
+            licence_period: original.licence_period,
+            number_of_schools: original.number_of_schools,
+            product: original.product,
+            start_date: original.end_date + 1.day,
+            end_date: original.end_date.next_year
+          )
+        end
       end
 
-      it 'switches to a pro-rata contract' do
-        expect(renewed).to have_attributes(
-          agreed_school_price: original.agreed_school_price,
-          comments: "Renewed from #{original.name}",
-          contract_holder: original.contract_holder,
-          invoice_terms: 'pro_rata',
-          licence_period: original.licence_period,
-          number_of_schools: original.number_of_schools,
-          product: original.product,
-          start_date: original.end_date + 1.day,
-          end_date: original.end_date.next_year
-        )
+      context 'when switching type' do
+        let(:original) do
+          create(:commercial_contract,
+                 :custom,
+                 agreed_school_price: 450.0,
+                 licence_years: 2.0,
+                 number_of_schools: 15)
+        end
+
+        it 'correctly switches the contract options' do
+          expect(renewed).to have_attributes(
+            agreed_school_price: original.agreed_school_price,
+            comments: "Renewed from #{original.name}",
+            contract_holder: original.contract_holder,
+            invoice_terms: 'pro_rata',
+            licence_period: 'contract',
+            licence_years: original.licence_years,
+            number_of_schools: original.number_of_schools,
+            product: original.product,
+            start_date: original.end_date + 1.day,
+            end_date: original.end_date.next_year
+          )
+        end
       end
     end
   end

--- a/spec/models/commercial/contract_spec.rb
+++ b/spec/models/commercial/contract_spec.rb
@@ -134,6 +134,7 @@ describe Commercial::Contract do
 
       it 'has the expected fields' do
         expect(contract.editable_attributes).to contain_exactly(:agreed_school_price, :comments, :end_date,
+                                                                :invoice_terms,
                                                                 :name, :number_of_schools,
                                                                 :product_id, :purchase_order_number,
                                                                 :start_date, :status, :updated_by_id)
@@ -144,6 +145,7 @@ describe Commercial::Contract do
 
         it 'has the expected fields' do
           expect(contract.editable_attributes).to contain_exactly(:agreed_school_price, :comments, :end_date,
+                                                                  :invoice_terms,
                                                                   :name, :number_of_schools,
                                                                   :product_id, :purchase_order_number,
                                                                   :start_date, :updated_by_id)

--- a/spec/system/admin/commercial/manage_contracts_spec.rb
+++ b/spec/system/admin/commercial/manage_contracts_spec.rb
@@ -601,63 +601,99 @@ describe 'manage contracts', :include_application_helper do
       click_on 'All contracts'
     end
 
-    context 'when visiting the pre-populated form', :js do
+    context 'when choosing to renew' do
       before { click_on 'Renew' }
 
-      it { expect(page).to have_field('Agreed school price', with: contract.agreed_school_price) }
-      it { expect(page).to have_field('Comments', with: "Renewed from #{contract.name}") }
+      it { expect(page).to have_text('Choose Renewed Contract Type') }
 
-      it { expect(page).to have_select('Invoice terms', selected: 'Pro rata') } # this is default for renewed
-      it { expect(page).to have_field('contract_licence_period', with: 'contract', type: :hidden, visible: :all) }
-
-      it { expect(page).to have_field('Number of schools', with: contract.number_of_schools) }
-      it { expect(page).to have_select('Status', selected: 'Provisional') }
-
-      context 'when submitting with defaults' do
-        subject(:renewed_contract) { contract.contract_holder.contracts.by_start_date.last }
-
-        before do
-          fill_in('Name', with: 'Renewed contract')
-          click_on 'Save'
-        end
-
-        it 'creates the contract' do
-          expect(page).to have_text('Contract and provisional licences have been created')
-          expect(renewed_contract).to have_attributes(
-            name: 'Renewed contract',
-            comments: "Renewed from #{contract.name}",
-            product: contract.product,
-            contract_holder: contract.contract_holder,
-            licence_period: contract.licence_period,
-            number_of_schools: contract.number_of_schools,
-            start_date: contract.end_date + 1.day,
-            end_date: contract.end_date.next_year,
-            agreed_school_price: contract.agreed_school_price,
-            created_by: user
-          )
-        end
-
-        it 'creates the licences' do
-          expect(page).to have_text('Contract and provisional licences have been created')
-          expect(renewed_contract.licences.count).to eq(1)
-          expect(renewed_contract.licences.first.school).to eq(original_licence.school)
-          expect(renewed_contract.licences.first.school_specific_price).to eq(original_licence.school_specific_price)
+      it 'indicates the original type' do
+        within('div#standard') do
+          expect(page).to have_text('Keep the same type as the original contract')
         end
       end
 
-      context 'when choosing not to add licences' do
-        subject(:renewed_contract) { contract.contract_holder.contracts.by_start_date.last }
-
+      context 'when renewing as a standard contract', :js do
         before do
-          fill_in('Name', with: 'Renewed contract')
-          uncheck('contract_update_licences')
-          click_on 'Save'
+          within('div#standard') do
+            click_on 'Renew contract'
+          end
         end
 
-        it 'does not create the licences' do
-          expect(page).to have_text('Contract has been created')
-          expect(renewed_contract.licences.count).to eq(0)
+        it { expect(page).to have_field('Agreed school price', with: contract.agreed_school_price) }
+        it { expect(page).to have_field('Comments', with: "Renewed from #{contract.name}") }
+
+        it { expect(page).to have_select('Invoice terms', selected: 'Pro rata') } # this is default for renewed
+        it { expect(page).to have_field('contract_licence_period', with: 'contract', type: :hidden, visible: :all) }
+
+        it { expect(page).to have_field('Number of schools', with: contract.number_of_schools) }
+        it { expect(page).to have_select('Status', selected: 'Provisional') }
+
+        context 'when submitting with defaults' do # rubocop:disable RSpec/NestedGroups
+          subject(:renewed_contract) { contract.contract_holder.contracts.by_start_date.last }
+
+          before do
+            fill_in('Name', with: 'Renewed contract')
+            click_on 'Save'
+          end
+
+          it 'creates the contract' do
+            expect(page).to have_text('Contract and provisional licences have been created')
+            expect(renewed_contract).to have_attributes(
+              name: 'Renewed contract',
+              comments: "Renewed from #{contract.name}",
+              product: contract.product,
+              contract_holder: contract.contract_holder,
+              licence_period: contract.licence_period,
+              number_of_schools: contract.number_of_schools,
+              start_date: contract.end_date + 1.day,
+              end_date: contract.end_date.next_year,
+              agreed_school_price: contract.agreed_school_price,
+              created_by: user
+            )
+          end
+
+          it 'creates the licences' do
+            expect(page).to have_text('Contract and provisional licences have been created')
+            expect(renewed_contract.licences.count).to eq(1)
+            expect(renewed_contract.licences.first.school).to eq(original_licence.school)
+            expect(renewed_contract.licences.first.school_specific_price).to eq(original_licence.school_specific_price)
+          end
         end
+
+        context 'when choosing not to add licences' do # rubocop:disable RSpec/NestedGroups
+          subject(:renewed_contract) { contract.contract_holder.contracts.by_start_date.last }
+
+          before do
+            fill_in('Name', with: 'Renewed contract')
+            uncheck('contract_update_licences')
+            click_on 'Save'
+          end
+
+          it 'does not create the licences' do
+            expect(page).to have_text('Contract has been created')
+            expect(renewed_contract.licences.count).to eq(0)
+          end
+        end
+      end
+
+      context 'when renewing as a custom contract', :js do
+        before do
+          within('div#custom') do
+            click_on 'Renew contract'
+          end
+        end
+
+        it { expect(page).to have_text('based on the chosen option the licence period has been changed') }
+
+        it { expect(page).to have_field('Agreed school price', with: contract.agreed_school_price) }
+        it { expect(page).to have_field('Comments', with: "Renewed from #{contract.name}") }
+
+        it { expect(page).to have_field('contract_invoice_terms', with: 'full', type: :hidden, visible: :all) }
+
+        it { expect(page).to have_field('contract_licence_period', with: 'custom', type: :hidden, visible: :all) }
+
+        it { expect(page).to have_field('Number of schools', with: contract.number_of_schools) }
+        it { expect(page).to have_select('Status', selected: 'Provisional') }
       end
     end
   end

--- a/spec/system/admin/commercial/manage_contracts_spec.rb
+++ b/spec/system/admin/commercial/manage_contracts_spec.rb
@@ -29,9 +29,16 @@ shared_examples 'it shows the common contract fields' do
 end
 
 shared_examples 'it shows the fields for a non-custom contract' do
-  it { expect(page).to have_no_field('Invoice terms') }
   it { expect(page).to have_no_field('Licence period') }
   it { expect(page).to have_no_field('Licence years') }
+end
+
+shared_examples 'it does not allow choosing invoice terms' do
+  it { expect(page).to have_no_field('Invoice terms') }
+end
+
+shared_examples 'it allows choosing invoice terms' do
+  it { expect(page).to have_field('Invoice terms') }
 end
 
 shared_examples 'it applies validation when creating a contract' do
@@ -81,6 +88,7 @@ describe 'manage contracts', :include_application_helper do
       it { expect(page).to have_text('Create new standard contract') }
 
       it_behaves_like 'it shows the common contract fields'
+      it_behaves_like 'it allows choosing invoice terms'
       it_behaves_like 'it shows the fields for a non-custom contract'
       it_behaves_like 'it applies validation when creating a contract'
 
@@ -139,6 +147,7 @@ describe 'manage contracts', :include_application_helper do
       it { expect(page).to have_text('Create new pro-rata contract') }
 
       it_behaves_like 'it shows the common contract fields'
+      it_behaves_like 'it allows choosing invoice terms'
       it_behaves_like 'it shows the fields for a non-custom contract'
 
       it_behaves_like 'it applies validation when creating a contract'
@@ -191,10 +200,10 @@ describe 'manage contracts', :include_application_helper do
       it { expect(page).to have_text('Create new custom contract') }
 
       it_behaves_like 'it shows the common contract fields'
-      it { expect(page).to have_no_field('Invoice terms') }
       it { expect(page).to have_no_field('Licence period') }
       it { expect(page).to have_field('Licence years') }
 
+      it_behaves_like 'it does not allow choosing invoice terms'
       it_behaves_like 'it applies validation when creating a contract'
 
       context 'with valid data', :js do
@@ -264,6 +273,7 @@ describe 'manage contracts', :include_application_helper do
       it { expect(page).to have_no_field('Contract holder') }
 
       it_behaves_like 'it shows the fields for a non-custom contract'
+      it_behaves_like 'it allows choosing invoice terms'
 
       context 'with valid data', :js do
         before do
@@ -312,6 +322,7 @@ describe 'manage contracts', :include_application_helper do
       }
 
       it_behaves_like 'it shows the fields for a non-custom contract'
+      it_behaves_like 'it allows choosing invoice terms'
       it_behaves_like 'it applies validation when creating a contract'
 
       context 'with valid data', :js do
@@ -363,6 +374,8 @@ describe 'manage contracts', :include_application_helper do
 
       it { expect(page).to have_no_field('Contract holder') }
 
+      it_behaves_like 'it does not allow choosing invoice terms'
+
       context 'with valid data', :js do
         before do
           fill_in 'Name', with: 'Custom contract'
@@ -404,7 +417,7 @@ describe 'manage contracts', :include_application_helper do
   end
 
   context 'when updating an existing contract' do
-    let!(:contract) { create(:commercial_contract, contract_holder: funder) }
+    let!(:contract) { create(:commercial_contract, licence_period: :contract, contract_holder: funder) }
     let!(:funder) { create(:funder) }
 
     before do
@@ -425,9 +438,10 @@ describe 'manage contracts', :include_application_helper do
 
       it { expect(page).to have_no_field('Contract holder') }
 
-      it { expect(page).to have_no_select('Invoice terms') }
       it { expect(page).to have_no_select('Licence period') }
       it { expect(page).to have_no_field('Licence years') }
+
+      it_behaves_like 'it allows choosing invoice terms'
 
       context 'with valid data', :js do
         before do
@@ -462,6 +476,17 @@ describe 'manage contracts', :include_application_helper do
           expect(contract.reload.licences).to be_empty
         end
       end
+    end
+
+    context 'when the licence period is custom' do
+      let!(:contract) { create(:commercial_contract, :custom, contract_holder: funder) }
+
+      before { click_on 'Edit' }
+
+      it { expect(page).to have_text(contract.name) }
+      it { expect(page).to have_no_field('Contract holder') }
+
+      it_behaves_like 'it does not allow choosing invoice terms'
     end
 
     context 'when there are licences' do
@@ -519,7 +544,9 @@ describe 'manage contracts', :include_application_helper do
 
       it { expect(page).to have_no_field('Contract holder') }
       it { expect(page).to have_no_field('Product') }
-      it { expect(page).to have_no_select('Invoice terms') }
+
+      it_behaves_like 'it does not allow choosing invoice terms'
+
       it { expect(page).to have_no_select('Licence period') }
       it { expect(page).to have_no_field('Licence years') }
     end
@@ -579,7 +606,8 @@ describe 'manage contracts', :include_application_helper do
 
       it { expect(page).to have_field('Agreed school price', with: contract.agreed_school_price) }
       it { expect(page).to have_field('Comments', with: "Renewed from #{contract.name}") }
-      it { expect(page).to have_field('contract_invoice_terms', with: 'pro_rata', type: :hidden, visible: :all) }
+
+      it { expect(page).to have_select('Invoice terms', selected: 'Pro rata') } # this is default for renewed
       it { expect(page).to have_field('contract_licence_period', with: 'contract', type: :hidden, visible: :all) }
 
       it { expect(page).to have_field('Number of schools', with: contract.number_of_schools) }


### PR DESCRIPTION
Further changes to the contract renewal workflow.

Invoice terms (full, pro_rata) can now be edited on standard contracts until they've been invoiced. The invoice terms can also be altered during renewal, if needed, but the defaults remain as 'pro_rata' for this contract type.

Allows changing from a custom to a standard contract, or vice versa when renewing a contract. This is handled by adding a new interstitial page so the user can confirm the choice of what contract type to create for the renewal. This is primarily there to allow for custom contracts to be changed to a more standard pro rata based contract.