### PR TITLE
Bulk load meter data

### DIFF
--- a/app/services/amr/analytics_meter_collection_factory.rb
+++ b/app/services/amr/analytics_meter_collection_factory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Amr
   class AnalyticsMeterCollectionFactory
     def initialize(active_record_school, meter_collection_class = MeterCollectionFactory)
@@ -21,7 +23,8 @@ module Amr
 
     def validated_data
       heat_meters = @active_record_school.meters_with_validated_readings(:gas)
-      electricity_meters = @active_record_school.meters_with_validated_readings([:electricity, :solar_pv, :exported_solar_pv])
+      electricity_meters = @active_record_school.meters_with_validated_readings(%i[electricity solar_pv
+                                                                                   exported_solar_pv])
       data(AnalyticsValidatedAmrDataFactory, heat_meters, electricity_meters)
     end
 

--- a/app/services/amr/analytics_meter_collection_factory.rb
+++ b/app/services/amr/analytics_meter_collection_factory.rb
@@ -12,8 +12,8 @@ module Amr
     end
 
     def unvalidated_data
-      heat_meters = @active_record_school.meters_with_readings(:gas)
-      electricity_meters = @active_record_school.meters_with_readings(Meter.non_gas_meter_types)
+      heat_meters = @active_record_school.meters_with_readings(:gas).includes(:meter_attributes)
+      electricity_meters = @active_record_school.meters_with_readings(Meter.non_gas_meter_types).includes(:meter_attributes)
       data(AnalyticsUnvalidatedAmrDataFactory, heat_meters, electricity_meters)
     end
 
@@ -22,9 +22,9 @@ module Amr
     end
 
     def validated_data
-      heat_meters = @active_record_school.meters_with_validated_readings(:gas)
+      heat_meters = @active_record_school.meters_with_validated_readings(:gas).includes(:meter_attributes)
       electricity_meters = @active_record_school.meters_with_validated_readings(%i[electricity solar_pv
-                                                                                   exported_solar_pv])
+                                                                                   exported_solar_pv]).includes(:meter_attributes)
       data(AnalyticsValidatedAmrDataFactory, heat_meters, electricity_meters)
     end
 

--- a/app/services/amr/analytics_meter_factory.rb
+++ b/app/services/amr/analytics_meter_factory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'dashboard'
 
 module Amr
@@ -8,13 +10,13 @@ module Amr
 
     def build(readings)
       {
-        readings:           readings,
-        type:               @active_record_meter.meter_type.to_sym,
-        identifier:         @active_record_meter.mpan_mprn,
-        name:               @active_record_meter.name,
-        external_meter_id:  @active_record_meter.id,
-        dcc_meter:          @active_record_meter.dcc_meter?,
-        attributes:         all_attributes
+        readings: readings,
+        type: @active_record_meter.meter_type.to_sym,
+        identifier: @active_record_meter.mpan_mprn,
+        name: @active_record_meter.name,
+        external_meter_id: @active_record_meter.id,
+        dcc_meter: @active_record_meter.dcc_meter?,
+        attributes: all_attributes
       }
     end
 

--- a/app/services/amr/analytics_unvalidated_amr_data_factory.rb
+++ b/app/services/amr/analytics_unvalidated_amr_data_factory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'dashboard'
 
 module Amr
@@ -6,6 +8,7 @@ module Amr
       @heat_meters = heat_meters
       @electricity_meters = electricity_meters
       @feed_configs = load_configs
+      @all_readings_by_meter = load_all_readings
     end
 
     def build
@@ -20,17 +23,40 @@ module Amr
       meters
     end
 
-  private
+    private
 
     # load just the data we need to convert data formats and enforce missing readings limit
     def load_configs
       AmrDataFeedConfig.select(:id, :date_format, :row_per_reading, :missing_readings_limit).index_by(&:id)
     end
 
+    def all_meter_ids
+      (@heat_meters + @electricity_meters).map(&:id)
+    end
+
+    def load_all_readings
+      rows = AmrDataFeedReading
+             .joins(:meter)
+             .where(meters: { id: all_meter_ids })
+             .order('amr_data_feed_readings.created_at ASC')
+             .pluck(
+               'meters.id',
+               'amr_data_feed_readings.amr_data_feed_config_id',
+               'amr_data_feed_readings.reading_date',
+               'amr_data_feed_readings.created_at',
+               'amr_data_feed_readings.readings'
+             )
+
+      rows.group_by { |meter_id, *_| meter_id }
+    end
+
+    def readings_for_meter(active_record_meter)
+      @all_readings_by_meter[active_record_meter.id] || []
+    end
+
     def build_meter_data(active_record_meter)
-      readings = AmrDataFeedReading.order(created_at: :asc)
-        .where(meter_id: active_record_meter.id)
-        .pluck(:amr_data_feed_config_id, :reading_date, :created_at, :readings).map do |reading|
+      readings = readings_for_meter(active_record_meter).map do |(_, config_id, reading_date, created_at, values)|
+        reading = [config_id, reading_date, created_at, values]
         reading_if_valid(active_record_meter.mpan_mprn, reading)
       end
 
@@ -39,8 +65,10 @@ module Amr
 
     def reading_if_valid(meter_id, reading)
       return if reading_invalid?(reading)
-      reading_date = date_from_string_using_date_format(reading,)
+
+      reading_date = date_from_string_using_date_format(reading)
       return if reading_date.nil?
+
       OneDayAMRReading.new(
         meter_id,
         reading_date,

--- a/app/services/amr/analytics_validated_amr_data_factory.rb
+++ b/app/services/amr/analytics_validated_amr_data_factory.rb
@@ -1,19 +1,39 @@
+# frozen_string_literal: true
+
 require 'dashboard'
 
 module Amr
   class AnalyticsValidatedAmrDataFactory < AnalyticsUnvalidatedAmrDataFactory
     private
 
+    # override parent method to load validated readings instead
+    def load_all_readings
+      rows = AmrValidatedReading
+             .joins(:meter)
+             .where(meters: { id: all_meter_ids })
+             .order('amr_validated_readings.reading_date ASC')
+             .pluck(
+               'meters.id',
+               'amr_validated_readings.reading_date',
+               'amr_validated_readings.status',
+               'amr_validated_readings.substitute_date',
+               'amr_validated_readings.upload_datetime',
+               'amr_validated_readings.kwh_data_x48'
+             )
+
+      rows.group_by { |meter_id, *_| meter_id }
+    end
+
     def build_meter_data(active_record_meter)
-      validated_reading_array = AmrValidatedReading.where(meter_id: active_record_meter.id).pluck(:reading_date, :status, :substitute_date, :upload_datetime, :kwh_data_x48)
-      readings = validated_reading_array.map do |reading|
+      raw_readings = readings_for_meter(active_record_meter)
+      readings = raw_readings.map do |(_, reading_date, status, substitute_date, upload_datetime, kwh_data_x48)|
         OneDayAMRReading.new(
           active_record_meter.mpan_mprn,
-          reading[0],
-          reading[1],
-          reading[2],
-          reading[3],
-          reading[4].map(&:to_f)
+          reading_date,
+          status,
+          substitute_date,
+          upload_datetime,
+          kwh_data_x48.map(&:to_f)
         )
       end
       Amr::AnalyticsMeterFactory.new(active_record_meter).build(readings)

--- a/spec/services/amr/analytics_unvalidated_amr_data_factory_spec.rb
+++ b/spec/services/amr/analytics_unvalidated_amr_data_factory_spec.rb
@@ -1,6 +1,8 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
-module Amr
+module Amr # rubocop:disable Metrics/ModuleLength
   describe AnalyticsUnvalidatedAmrDataFactory do
     subject(:factory) { described_class.new(heat_meters: [g_meter], electricity_meters: [e_meter]) }
 
@@ -17,7 +19,10 @@ module Amr
         expect(first_electricity_meter[:identifier]).to eq e_meter.mpan_mprn
         expect(first_electricity_meter[:dcc_meter]).to be false
         expect(first_electricity_meter[:readings].size).to eq 2
-        expect(first_electricity_meter[:readings].map(&:kwh_data_x48)).to match_array(e_meter.amr_data_feed_readings.map { |reading| reading.readings.map(&:to_f) })
+        expected_readings = e_meter.amr_data_feed_readings.map do |reading|
+          reading.readings.map(&:to_f)
+        end
+        expect(first_electricity_meter[:readings].map(&:kwh_data_x48)).to match_array(expected_readings)
       end
 
       it 'creates gas meters' do
@@ -25,8 +30,10 @@ module Amr
 
         expect(first_gas_meter[:identifier]).to eq g_meter.mpan_mprn
         expect(first_gas_meter[:dcc_meter]).to be true
-        expect(first_gas_meter[:readings].first.date).to eq Date.parse(g_meter.amr_data_feed_readings.first.reading_date)
-        expect(first_gas_meter[:readings].first.kwh_data_x48).to eq g_meter.amr_data_feed_readings.first.readings.map(&:to_f)
+        expected_date = g_meter.amr_data_feed_readings.first.reading_date
+        expect(first_gas_meter[:readings].first.date).to eq Date.parse(expected_date)
+        expected_readings = g_meter.amr_data_feed_readings.first.readings.map(&:to_f)
+        expect(first_gas_meter[:readings].first.kwh_data_x48).to eq expected_readings
       end
     end
 
@@ -80,7 +87,9 @@ module Amr
       end
 
       context 'with partial readings for day' do
-        let(:amr_data_feed_config) { create(:amr_data_feed_config, row_per_reading: false, missing_readings_limit: nil) }
+        let(:amr_data_feed_config) do
+          create(:amr_data_feed_config, row_per_reading: false, missing_readings_limit: nil)
+        end
 
         before do
           create(:amr_data_feed_reading,
@@ -102,7 +111,9 @@ module Amr
 
         context 'with a missing_readings_limit' do
           context 'when above the threshold' do
-            let(:amr_data_feed_config) { create(:amr_data_feed_config, row_per_reading: true, missing_readings_limit: 3) }
+            let(:amr_data_feed_config) do
+              create(:amr_data_feed_config, row_per_reading: true, missing_readings_limit: 3)
+            end
 
             it 'rejects the day' do
               expect(e_meter.amr_data_feed_readings.count).to be 3
@@ -111,7 +122,9 @@ module Amr
           end
 
           context 'when below the threshold' do
-            let(:amr_data_feed_config) { create(:amr_data_feed_config, row_per_reading: true, missing_readings_limit: 47) }
+            let(:amr_data_feed_config) do
+              create(:amr_data_feed_config, row_per_reading: true, missing_readings_limit: 47)
+            end
 
             it 'converts nil to 0.0' do
               expect(amr_data[:electricity_meters].last[:readings].last.kwh_data_x48[0]).to be 1.23

--- a/spec/services/amr/analytics_unvalidated_amr_data_factory_spec.rb
+++ b/spec/services/amr/analytics_unvalidated_amr_data_factory_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-module Amr # rubocop:disable Metrics/ModuleLength
+module Amr
   describe AnalyticsUnvalidatedAmrDataFactory do
     subject(:factory) { described_class.new(heat_meters: [g_meter], electricity_meters: [e_meter]) }
 

--- a/spec/services/amr/analytics_validated_amr_data_factory_spec.rb
+++ b/spec/services/amr/analytics_validated_amr_data_factory_spec.rb
@@ -1,31 +1,38 @@
+# frozen_string_literal: true
+
 require 'dashboard'
 require 'rails_helper'
 
 module Amr
   describe AnalyticsValidatedAmrDataFactory do
-    let(:school_name) { 'Active school' }
-    let!(:school)     { create(:school, :with_school_group, name: school_name) }
-    let!(:config)     { create(:amr_data_feed_config) }
-    let!(:e_meter)    { create(:electricity_meter_with_validated_reading_dates, start_date: Date.parse('01/06/2019'), end_date: Date.parse('02/06/2019'), school: school) }
-    let!(:g_meter)    { create(:gas_meter_with_validated_reading_dates, start_date: Date.parse('01/06/2019'), end_date: Date.parse('02/06/2019'), school: school) }
+    let!(:school)     { create(:school, :with_school_group) }
+    let!(:e_meter)    do
+      create(:electricity_meter_with_validated_reading_dates, start_date: Date.parse('01/06/2019'),
+                                                              end_date: Date.parse('02/06/2019'), school:)
+    end
+    let!(:g_meter) do
+      create(:gas_meter_with_validated_reading_dates, start_date: Date.parse('01/06/2019'),
+                                                      end_date: Date.parse('02/06/2019'), school:)
+    end
 
-    it 'builds an Validated meter collection' do
-      amr_data = AnalyticsValidatedAmrDataFactory.new(heat_meters: [g_meter], electricity_meters: [e_meter]).build
+    subject(:amr_data) { described_class.new(heat_meters: [g_meter], electricity_meters: [e_meter]).build }
 
+    it 'builds the electricity meters' do
       expect(e_meter.amr_validated_readings.count).to be 2
-
       first_electricity_meter = amr_data[:electricity_meters].first
-
       expect(first_electricity_meter[:identifier]).to eq e_meter.mpan_mprn
       expect(first_electricity_meter[:readings].size).to eq 2
       expect(first_electricity_meter[:readings].first.date).to eq e_meter.amr_validated_readings.first.reading_date
-      expect(first_electricity_meter[:readings].first.kwh_data_x48).to eq e_meter.amr_validated_readings.first.kwh_data_x48.map(&:to_f)
+      expected_readings = e_meter.amr_validated_readings.first.kwh_data_x48.map(&:to_f)
+      expect(first_electricity_meter[:readings].first.kwh_data_x48).to eq expected_readings
+    end
 
+    it 'builds the gas meters' do
       first_gas_meter = amr_data[:heat_meters].first
-
       expect(first_gas_meter[:identifier]).to eq g_meter.mpan_mprn
       expect(first_gas_meter[:readings].first.date).to eq g_meter.amr_validated_readings.first.reading_date
-      expect(first_gas_meter[:readings].first.kwh_data_x48).to eq g_meter.amr_validated_readings.first.kwh_data_x48.map(&:to_f)
+      expected_readings = g_meter.amr_validated_readings.first.kwh_data_x48.map(&:to_f)
+      expect(first_gas_meter[:readings].first.kwh_data_x48).to eq expected_readings
     end
   end
 end


### PR DESCRIPTION
Currently the unvalidated and validated meter factories run one query per meter to load in the required readings.

PR changes the code to load all meter data in a single query, then construct the meters from the pre-loaded readings. Reduces the number of SQL queries for schools with lots of meters.

Also adds `.includes(:meter_attributes)` to the scopes that load the meters to avoid N+1 queries when fetching attributes. Some meters may have a lot of corrections.