### PR TITLE
Fix blank columns in suppliers import

### DIFF
--- a/app/services/meters/supplier_data_source_status_importer.rb
+++ b/app/services/meters/supplier_data_source_status_importer.rb
@@ -4,22 +4,62 @@ require 'csv'
 
 module Meters
   class SupplierDataSourceStatusImporter
-    def import(data) # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity
+    def import(data)
       meter = Meter.find_by(mpan_mprn: data[:meter])
       return if meter.blank?
 
-      data_source = DataSource.find_by(name: data[:data_source])
-      meter.update!(data_source:) if data_source.present?
+      updated_data = {
+        data_source: find_data_source(data, meter),
+        supplier: find_supplier(data, meter),
+        status: find_status(data, meter)
+      }
 
-      supplier = Supplier.find_by(name: data[:supplier])
-      meter.update!(supplier:) if supplier.present?
-
-      status = AdminMeterStatus.find_by(label: data[:status])
-      if status.present? || (status.blank? && meter.admin_meter_status&.label == 'Manual Request')
-        meter.update!(admin_meter_status: status)
-      end
+      meter.update!(data_source: updated_data[:data_source], supplier: updated_data[:supplier],
+                    admin_meter_status: updated_data[:status])
 
       meter
+    end
+
+    def find_data_source(data, meter)
+      if data[:data_source].blank?
+        nil
+      else
+        new_data_source = DataSource.find_by(name: data[:data_source])
+        if new_data_source.present?
+          new_data_source
+        else
+          warn "Cannot find data source with name #{data[:data_source]} for meter #{data[:meter]}"
+          meter.data_source
+        end
+      end
+    end
+
+    def find_supplier(data, meter)
+      if data[:supplier].blank?
+        nil
+      else
+        new_supplier = Supplier.find_by(name: data[:supplier])
+        if new_supplier.present?
+          new_supplier
+        else
+          warn "Cannot find supplier with name #{data[:supplier]} for meter #{data[:meter]}"
+          meter.supplier
+        end
+      end
+    end
+
+    def find_status(data, meter)
+      if data[:status].blank?
+        nil
+      else
+        new_status = AdminMeterStatus.find_by(name: data[:status])
+        if new_status.present?
+          new_status
+        else
+          warn "Cannot find meter status with name #{data[:status]} for meter #{data[:meter]}"
+          meter.admin_meter_status
+        end
+      end
     end
   end
 end

--- a/app/services/meters/supplier_data_source_status_importer.rb
+++ b/app/services/meters/supplier_data_source_status_importer.rb
@@ -4,29 +4,22 @@ require 'csv'
 
 module Meters
   class SupplierDataSourceStatusImporter
-    def import(data) # rubocop:disable Metrics/AbcSize
+    def import(data) # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity
       meter = Meter.find_by(mpan_mprn: data[:meter])
-      if meter.present?
-        data_source = DataSource.find_by(name: data[:data_source])
-        if data_source.blank?
-          warn "Can't find data source with name #{data[:data_source]}"
-          return
-        end
-        supplier = Supplier.find_by(name: data[:supplier])
-        if supplier.blank?
-          warn "Can't find supplier with name #{data[:supplier]}"
-          return
-        end
-        status = AdminMeterStatus.find_by(label: data[:status])
-        if status.blank?
-          return unless meter.admin_meter_status.label == 'Manual Request'
+      return if meter.blank?
 
-          warn 'This meter has status Manual Request: replacing with blank'
-        end
-        meter.update!(data_source:, supplier:, admin_meter_status: status)
-      else
-        warn "Can't find meter with mpan_mprn #{data[:meter]}"
+      data_source = DataSource.find_by(name: data[:data_source])
+      meter.update!(data_source:) if data_source.present?
+
+      supplier = Supplier.find_by(name: data[:supplier])
+      meter.update!(supplier:) if supplier.present?
+
+      status = AdminMeterStatus.find_by(label: data[:status])
+      if status.present? || (status.blank? && meter.admin_meter_status&.label == 'Manual Request')
+        meter.update!(admin_meter_status: status)
       end
+
+      meter
     end
   end
 end

--- a/lib/tasks/meters/import_suppliers_data_sources_and_statuses.rake
+++ b/lib/tasks/meters/import_suppliers_data_sources_and_statuses.rake
@@ -13,7 +13,7 @@ namespace :meters do
                                 supplier: row['Supplier'],
                                 status: row['Updated Meter Status']
                               })
-      puts "Unable to import meter #{row['Meter']}" if meter.blank?
+      puts "Could not find meter #{row['Meter']}" if meter.blank?
     rescue => e # rubocop:disable Style/RescueStandardError
       puts row['Meter']
       puts e


### PR DESCRIPTION
Allows for blank fields in data source suppliers and meter status - and will still update the meter with the other fields if 1 of its fields is left blank