### PR TITLE
Minor navigation and UX improvements in contracts & licensing pages

### DIFF
--- a/app/components/commercial/range_funding_summary_component/range_funding_summary_component.text.erb
+++ b/app/components/commercial/range_funding_summary_component/range_funding_summary_component.text.erb
@@ -4,5 +4,6 @@
 <%- categorised_schools[category].sort_by(&:name).each do |school| %>
 <%= school.name %>
 <% end %>
+
   <% end %>
 <% end %>

--- a/app/controllers/admin/commercial/contracts_controller.rb
+++ b/app/controllers/admin/commercial/contracts_controller.rb
@@ -118,9 +118,10 @@ module Admin
 
       def destroy
         if @contract.destroy
-          redirect_to(admin_commercial_contracts_path, alert: 'Contract has been deleted')
+          redirect_back_or_to(admin_commercial_contracts_path, alert: 'Contract has been deleted')
         else
-          redirect_to(admin_commercial_contracts_path, alert: @contract.errors.full_messages.to_sentence)
+          redirect_to fallback_location: admin_commercial_contracts_path,
+                      alert: @contract.errors.full_messages.to_sentence
         end
       end
 
@@ -131,7 +132,7 @@ module Admin
         else
           notice = 'Unable to confirm contract'
         end
-        redirect_to(admin_commercial_contract_path(@contract), notice:)
+        redirect_back_or_to(admin_commercial_contract_path(@contract), notice:)
       end
 
       private

--- a/app/controllers/admin/commercial/contracts_controller.rb
+++ b/app/controllers/admin/commercial/contracts_controller.rb
@@ -120,8 +120,7 @@ module Admin
         if @contract.destroy
           redirect_back_or_to(admin_commercial_contracts_path, alert: 'Contract has been deleted')
         else
-          redirect_to fallback_location: admin_commercial_contracts_path,
-                      alert: @contract.errors.full_messages.to_sentence
+          redirect_back_or_to(admin_commercial_contracts_path, alert: @contract.errors.full_messages.to_sentence)
         end
       end
 

--- a/app/controllers/admin/commercial/licences_controller.rb
+++ b/app/controllers/admin/commercial/licences_controller.rb
@@ -64,9 +64,9 @@ module Admin::Commercial
     def destroy
       path = admin_commercial_contract_path(@licence.contract)
       if @licence.destroy
-        redirect_to(path, alert: 'Licence has been deleted')
+        redirect_back_or_to(path, alert: 'Licence has been deleted')
       else
-        redirect_to(path, alert: @licence.errors.full_messages.to_sentence)
+        redirect_back_or_to(path, alert: @licence.errors.full_messages.to_sentence)
       end
     end
 

--- a/app/controllers/admin/commercial/products_controller.rb
+++ b/app/controllers/admin/commercial/products_controller.rb
@@ -6,6 +6,9 @@ module Admin::Commercial
       @products = Commercial::Product.with_default_first
     end
 
+    def edit
+    end
+
     def create
       @product = Commercial::Product.build(product_params.merge(created_by: current_user))
       if @product.save
@@ -13,9 +16,6 @@ module Admin::Commercial
       else
         render :new
       end
-    end
-
-    def edit
     end
 
     def update
@@ -28,9 +28,9 @@ module Admin::Commercial
 
     def destroy
       if @product.destroy
-        redirect_to(admin_commercial_products_path, notice: 'Product has been deleted')
+        redirect_back_or_to(admin_commercial_products_path, notice: 'Product has been deleted')
       else
-        redirect_to(admin_commercial_products_path, alert: @product.errors.full_messages.to_sentence)
+        redirect_back_or_to(admin_commercial_products_path, alert: @product.errors.full_messages.to_sentence)
       end
     end
 
@@ -38,7 +38,7 @@ module Admin::Commercial
 
     def product_params
       params.require(:product).permit(:name, :comments, :default_product, :small_school_price, :large_school_price, :size_threshold, :mat_price,
-      :private_account_fee, :metering_fee)
+                                      :private_account_fee, :metering_fee)
     end
   end
 end

--- a/app/views/admin/commercial/contracts/show.html.erb
+++ b/app/views/admin/commercial/contracts/show.html.erb
@@ -2,7 +2,7 @@
   <% header_nav.with_header title: @contract.name %>
   <% header_nav.with_button 'Contract holder contracts',
                             polymorphic_path([:admin, @contract.contract_holder, :contracts]) %>
-  <% header_nav.with_button 'All contracts', current_admin_commercial_contracts_path %>
+  <% header_nav.with_button 'All contracts', admin_commercial_contracts_path %>
 <% end %>
 
 <div class="row">

--- a/app/views/admin/schools/licences/index.html.erb
+++ b/app/views/admin/schools/licences/index.html.erb
@@ -3,6 +3,17 @@
 
   <div class="row">
     <div class="col">
+      <p>
+        <%= link_to 'New contract',
+                    choose_admin_commercial_contracts_path(contract_holder_type: @school.class,
+                                                           contract_holder_id: @school.id),
+                    class: 'btn btn-primary btn-sm' %>
+      </p>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="col">
       <h3>Licences</h3>
       <p>The following table lists all current, historical and future licences held by <%= @school.name %>.</p>
     </div>

--- a/spec/system/admin/commercial/manage_contracts_spec.rb
+++ b/spec/system/admin/commercial/manage_contracts_spec.rb
@@ -713,7 +713,7 @@ describe 'manage contracts', :include_application_helper do
 
     it { expect(page).to have_text(contract.name) }
     it { expect(page).to have_text(contract.comments) }
-    it { expect(page).to have_link('All contracts', href: current_admin_commercial_contracts_path) }
+    it { expect(page).to have_link('All contracts', href: admin_commercial_contracts_path) }
 
     it do
       expect(page).to have_link('Contract holder contracts',


### PR DESCRIPTION
- [x] add link to new contract from school licences page
- [x] change link at top of contract page to actually go to "All Contracts"
- [x] add spacing in text version of licence summaries
- [x] add redirect back to licence and contract controllers when deleting/confirming