### PR TITLE
Improve school picker when adding a new licence to a contract

### DIFF
--- a/app/assets/stylesheets/_activities.scss
+++ b/app/assets/stylesheets/_activities.scss
@@ -29,6 +29,10 @@
   border-top: 5px solid $grey-dark;
 }
 
+.select2-results__options {
+  max-height: 300px !important;
+}
+
 img.activity-card-img {
   min-height: 150px;
   max-height: 150px;

--- a/app/controllers/admin/commercial/licences_controller.rb
+++ b/app/controllers/admin/commercial/licences_controller.rb
@@ -30,9 +30,11 @@ module Admin::Commercial
     def new
       if params[:contract_id]
         @contract = Commercial::Contract.find(params[:contract_id])
+        @schools = @contract.candidate_schools
         @licence = Commercial::Licence.new(contract: @contract)
       else
         @licence = Commercial::Licence.new
+        @schools = School.visible.by_name
       end
     end
 

--- a/app/models/commercial/contract.rb
+++ b/app/models/commercial/contract.rb
@@ -235,6 +235,18 @@ module Commercial
       scope.includes(:contract_holder, :product).by_start_date
     end
 
+    # list of schools that might be added to this contract
+    def candidate_schools
+      return [] if contract_holder.is_a?(School)
+
+      scope = if contract_holder.is_a?(Funder)
+                School.visible.by_name
+              else
+                contract_holder.assigned_schools.visible.by_name
+              end
+      scope.where.not(id: schools)
+    end
+
     def status_colour
       STATUS_COLOUR[status.to_sym]
     end

--- a/app/views/admin/commercial/contracts/show.html.erb
+++ b/app/views/admin/commercial/contracts/show.html.erb
@@ -16,8 +16,11 @@
                     method: :post,
                     class: 'btn btn-warning btn-sm'
           end %>
-      <%= link_to 'Manage All Licences', edit_admin_commercial_contract_licences_path(@contract),
-                  class: 'btn btn-secondary btn-sm' %>
+      <%= unless @contract.contract_holder.is_a?(School)
+            link_to 'Manage All Licences',
+                    edit_admin_commercial_contract_licences_path(@contract),
+                    class: 'btn btn-secondary btn-sm'
+          end %>
 
       <%= unless @contract.future?
             link_to 'Renew', renew_admin_commercial_contracts_path(original_contract_id: @contract.id),
@@ -28,10 +31,16 @@
                     raise_invoice_admin_commercial_contract_invoices_path(@contract),
                     class: 'btn btn-secondary btn-sm'
           end %>
-      <%= link_to 'Add New Licence', new_admin_commercial_licence_path(contract_id: @contract.id),
-                  class: 'btn btn-secondary btn-sm' %>
-      <%= link_to 'Calculate Price', admin_commercial_pricing_path(pricing: { contract_id: @contract.id }),
-                  class: 'btn btn-secondary btn-sm' %>
+      <%= unless @contract.contract_holder.is_a?(School)
+            link_to 'Add New Licence',
+                    new_admin_commercial_licence_path(contract_id: @contract.id),
+                    class: 'btn btn-secondary btn-sm'
+          end %>
+      <%= unless @contract.contract_holder.is_a?(School)
+            link_to 'Calculate Price',
+                    admin_commercial_pricing_path(pricing: { contract_id: @contract.id }),
+                    class: 'btn btn-secondary btn-sm'
+          end %>
       <%= render(Forms::DeleteButtonComponent.new(admin_commercial_contract_path(@contract), resource: @contract)) %>
     </p>
   </div>

--- a/app/views/admin/commercial/licences/_form.html.erb
+++ b/app/views/admin/commercial/licences/_form.html.erb
@@ -42,7 +42,7 @@
         <h3>Basic information</h3>
         <% if licence.new_record? %>
           <%= f.input :school_id,
-                      collection: School.visible.by_name,
+                      collection: @schools,
                       include_blank: false,
                       input_html: { class: 'select2' } %>
         <% else %>

--- a/spec/factories/commercial/contracts.rb
+++ b/spec/factories/commercial/contracts.rb
@@ -29,6 +29,10 @@ FactoryBot.define do
       contract_holder { association :school_group }
     end
 
+    trait :with_funder do
+      contract_holder { association :funder }
+    end
+
     trait :expired do
       start_date { Time.zone.today - 1.year }
       end_date { Time.zone.yesterday }

--- a/spec/models/commercial/contract_spec.rb
+++ b/spec/models/commercial/contract_spec.rb
@@ -492,4 +492,47 @@ describe Commercial::Contract do
       expect(described_class.pending_invoicing).to contain_exactly(funder_contract)
     end
   end
+
+  describe '#candidate_schools' do
+    context 'with School' do
+      let!(:contract) { create(:commercial_contract, :with_school) }
+
+      it { expect(contract.candidate_schools).to eq([]) }
+    end
+
+    context 'with Funder' do
+      let!(:school) { create(:school) }
+      let!(:contract) { create(:commercial_contract, :with_funder) }
+
+      it { expect(contract.candidate_schools).to eq([school]) }
+
+      context 'with an already licensed school' do
+        let!(:school) { create(:school) }
+
+        before do
+          create(:commercial_licence, contract:)
+        end
+
+        it { expect(contract.candidate_schools).to eq([school]) }
+      end
+    end
+
+    context 'with SchoolGroup' do
+      let!(:school_group) { create(:school_group, :with_active_schools) }
+      let!(:contract) { create(:commercial_contract, contract_holder: school_group) }
+
+      it { expect(contract.candidate_schools).to eq(school_group.assigned_schools.by_name) }
+
+      context 'with an already licensed school' do
+        let!(:school_group) { create(:school_group) }
+        let!(:school) { create(:school, school_group:) }
+
+        before do
+          create(:commercial_licence, contract:, school: create(:school, school_group:))
+        end
+
+        it { expect(contract.candidate_schools).to eq([school]) }
+      end
+    end
+  end
 end

--- a/spec/system/admin/commercial/manage_contracts_spec.rb
+++ b/spec/system/admin/commercial/manage_contracts_spec.rb
@@ -886,6 +886,16 @@ describe 'manage contracts', :include_application_helper do
         end
       end
     end
+
+    context 'with a School contract' do
+      let!(:contract) do
+        create(:commercial_contract, :with_school)
+      end
+
+      it { expect(page).to have_no_link('Add New Licence') }
+      it { expect(page).to have_no_link('Manage All Licences') }
+      it { expect(page).to have_no_link('Calculate Price') }
+    end
   end
 
   context 'when confirming a contract' do


### PR DESCRIPTION
Revises the size of the `.select2` component results window to show more results. Component doesn't have an option for this so setting CSS. This would be a site-wide change which I think is safer as I think the only place we use this with users is on the compare schools page.

Otherwise changes the list of schools shown on the form for adding a new licence to be:

- Any school in the the system, if contract holder is a Funder
- Any school that is part of the group, if contract holder is a School
- Empty for school contract holders

The list also now excludes any schools that are already licensed under the contract.

PR also tidies the options on the contract page, removing links that are only relevant to Funder or School Group contracts.