### PR TITLE
Include licence date range on invoice page

### DIFF
--- a/app/components/commercial/line_items_component/line_items_component.html.erb
+++ b/app/components/commercial/line_items_component/line_items_component.html.erb
@@ -4,6 +4,8 @@
       <tr>
         <th>School Group</th>
         <th>School</th>
+        <th>Start date</th>
+        <th>End date</th>
         <th>Private Account?</th>
         <th>Number of Meters</th>
         <th>Base price</th>
@@ -15,14 +17,20 @@
     <tbody>
       <% @invoice.line_items.each do |line_item| %>
         <tr>
-          <td><%= line_item.school&.school_group&.name %></td>
-          <td><%= line_item.school.name %></td>
-          <td><%= helpers.y_n line_item.private_account %></td>
-          <td><%= line_item.number_of_meters %></td>
-          <td><%= helpers.format_price line_item.value.base_price %></td>
-          <td><%= helpers.format_price line_item.value.metering_fee %></td>
-          <td><%= helpers.format_price line_item.value.private_account_fee %></td>
-          <td><%= helpers.format_price line_item.value.total %></td>
+          <td class="col-2"><%= line_item.school&.school_group&.name %></td>
+          <td class="col-2"><%= line_item.school.name %></td>
+          <td class="col-1" data-order="<%= line_item.licence.start_date.iso8601 %>">
+            <%= line_item.licence.start_date.to_fs(:es_short) %>
+          </td>
+          <td class="col-1" data-order="<%= line_item.licence.end_date.iso8601 %>">
+            <%= line_item.licence.end_date.to_fs(:es_short) %>
+          </td>
+          <td class="col-1"><%= helpers.y_n line_item.private_account %></td>
+          <td class="col-1"><%= line_item.number_of_meters %></td>
+          <td class="col-1"><%= helpers.format_price line_item.value.base_price %></td>
+          <td class="col-1"><%= helpers.format_price line_item.value.metering_fee %></td>
+          <td class="col-1"><%= helpers.format_price line_item.value.private_account_fee %></td>
+          <td class="col-1"><%= helpers.format_price line_item.value.total %></td>
         </tr>
       <% end %>
     </tbody>

--- a/app/components/commercial/line_items_component/line_items_component.html.erb
+++ b/app/components/commercial/line_items_component/line_items_component.html.erb
@@ -2,12 +2,17 @@
   <table id="invoice-<%= @invoice.id %>-line-items-table" class="table table-paged table-sm">
     <thead>
       <tr>
+        <th colspan="4">School</th>
+        <th class="text-center" colspan="2">Licence</th>
+        <th class="text-center" colspan="4">Fees</th>
+      </tr>
+      <tr>
         <th>School Group</th>
         <th>School</th>
-        <th>Start date</th>
-        <th>End date</th>
         <th>Private Account?</th>
         <th>Number of Meters</th>
+        <th>Start date</th>
+        <th>End date</th>
         <th>Base price</th>
         <th>Metering fee</th>
         <th>Private account fee</th>
@@ -19,14 +24,14 @@
         <tr>
           <td class="col-2"><%= line_item.school&.school_group&.name %></td>
           <td class="col-2"><%= line_item.school.name %></td>
+          <td class="col-1"><%= helpers.y_n line_item.private_account %></td>
+          <td class="col-1"><%= line_item.number_of_meters %></td>
           <td class="col-1" data-order="<%= line_item.licence.start_date.iso8601 %>">
             <%= line_item.licence.start_date.to_fs(:es_short) %>
           </td>
           <td class="col-1" data-order="<%= line_item.licence.end_date.iso8601 %>">
             <%= line_item.licence.end_date.to_fs(:es_short) %>
           </td>
-          <td class="col-1"><%= helpers.y_n line_item.private_account %></td>
-          <td class="col-1"><%= line_item.number_of_meters %></td>
           <td class="col-1"><%= helpers.format_price line_item.value.base_price %></td>
           <td class="col-1"><%= helpers.format_price line_item.value.metering_fee %></td>
           <td class="col-1"><%= helpers.format_price line_item.value.private_account_fee %></td>

--- a/spec/components/commercial/line_items_component_spec.rb
+++ b/spec/components/commercial/line_items_component_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Commercial::LineItemsComponent, :include_application_helper, :inc
       let(:table_id) { "#invoice-#{invoice.id}-line-items-table" }
       let(:expected_header) do
         [
-          ['School Group', 'School', 'Private Account?', 'Number of Meters',
+          ['School Group', 'School', 'Start date', 'End date', 'Private Account?', 'Number of Meters',
            'Base price', 'Metering fee', 'Private account fee', 'Total']
         ]
       end
@@ -24,6 +24,8 @@ RSpec.describe Commercial::LineItemsComponent, :include_application_helper, :inc
           [
             '',
             line_item.school.name,
+            line_item.licence.start_date.to_fs(:es_short),
+            line_item.licence.end_date.to_fs(:es_short),
             'No',
             '0',
             format_price(line_item.value.base_price),

--- a/spec/components/commercial/line_items_component_spec.rb
+++ b/spec/components/commercial/line_items_component_spec.rb
@@ -15,7 +15,8 @@ RSpec.describe Commercial::LineItemsComponent, :include_application_helper, :inc
       let(:table_id) { "#invoice-#{invoice.id}-line-items-table" }
       let(:expected_header) do
         [
-          ['School Group', 'School', 'Start date', 'End date', 'Private Account?', 'Number of Meters',
+          ['School', 'Licence', 'Fees'],
+          ['School Group', 'School', 'Private Account?', 'Number of Meters', 'Start date', 'End date',
            'Base price', 'Metering fee', 'Private account fee', 'Total']
         ]
       end
@@ -24,10 +25,10 @@ RSpec.describe Commercial::LineItemsComponent, :include_application_helper, :inc
           [
             '',
             line_item.school.name,
-            line_item.licence.start_date.to_fs(:es_short),
-            line_item.licence.end_date.to_fs(:es_short),
             'No',
             '0',
+            line_item.licence.start_date.to_fs(:es_short),
+            line_item.licence.end_date.to_fs(:es_short),
             format_price(line_item.value.base_price),
             format_price(line_item.value.metering_fee),
             format_price(line_item.value.private_account_fee),

--- a/spec/system/admin/commercial/manage_invoices_spec.rb
+++ b/spec/system/admin/commercial/manage_invoices_spec.rb
@@ -100,7 +100,7 @@ describe 'manage invoices', :include_application_helper do
         let(:table_id) { "#invoice-#{invoice.id}-line-items-table" }
         let(:expected_header) do
           [
-            ['School Group', 'School', 'Private Account?', 'Number of Meters',
+            ['School Group', 'School', 'Start date', 'End date', 'Private Account?', 'Number of Meters',
              'Base price', 'Metering fee', 'Private account fee', 'Total']
           ]
         end
@@ -109,6 +109,8 @@ describe 'manage invoices', :include_application_helper do
             [
               '',
               line_item.school.name,
+              line_item.licence.start_date.to_fs(:es_short),
+              line_item.licence.end_date.to_fs(:es_short),
               'No',
               '0',
               format_price(line_item.value.base_price),

--- a/spec/system/admin/commercial/manage_invoices_spec.rb
+++ b/spec/system/admin/commercial/manage_invoices_spec.rb
@@ -100,7 +100,8 @@ describe 'manage invoices', :include_application_helper do
         let(:table_id) { "#invoice-#{invoice.id}-line-items-table" }
         let(:expected_header) do
           [
-            ['School Group', 'School', 'Start date', 'End date', 'Private Account?', 'Number of Meters',
+            ['School', 'Licence', 'Fees'],
+            ['School Group', 'School', 'Private Account?', 'Number of Meters', 'Start date', 'End date',
              'Base price', 'Metering fee', 'Private account fee', 'Total']
           ]
         end
@@ -109,10 +110,10 @@ describe 'manage invoices', :include_application_helper do
             [
               '',
               line_item.school.name,
-              line_item.licence.start_date.to_fs(:es_short),
-              line_item.licence.end_date.to_fs(:es_short),
               'No',
               '0',
+              line_item.licence.start_date.to_fs(:es_short),
+              line_item.licence.end_date.to_fs(:es_short),
               format_price(line_item.value.base_price),
               format_price(line_item.value.metering_fee),
               format_price(line_item.value.private_account_fee),


### PR DESCRIPTION
Adds new columns and improves table header and spacing to make more readable.