### PR TITLE
Allow future contracts to be selected in onboarding configuration

### DIFF
--- a/app/models/concerns/temporal_range.rb
+++ b/app/models/concerns/temporal_range.rb
@@ -11,6 +11,8 @@ module TemporalRange
 
     scope :future, ->(today = Time.zone.today) { where("#{table_name}.start_date > ?", today) }
 
+    scope :current_and_future, ->(today = Time.zone.today) { where("#{table_name}.end_date >= ?", today) }
+
     scope :expiring, lambda { |end_date = (Time.zone.today + 1.month).end_of_month|
       where("#{table_name}.end_date >= CURRENT_DATE and #{table_name}.end_date <= ?", end_date)
     }

--- a/app/views/admin/school_onboardings/configuration/edit.html.erb
+++ b/app/views/admin/school_onboardings/configuration/edit.html.erb
@@ -88,9 +88,9 @@
     <div class="form-group col-md-12">
       <%= f.label :contract_id %>
       <%= f.select :contract_id,
-                   options_for_select(Commercial::Contract.current.by_name.pluck(:name, :id),
+                   options_for_select(Commercial::Contract.current_and_future.by_name.pluck(:name, :id),
                                       @school_onboarding.contract_id),
-                   { include_blank: true }, { class: 'form-control' } %>
+                   { include_blank: true }, { class: 'form-control select2' } %>
       <p class="small">
         Which contract will this school be using when it completes onboarding?
         Self-fundeds school will not have a contract until they have completed onboarding.

--- a/spec/system/admin/school_onboarding_spec.rb
+++ b/spec/system/admin/school_onboarding_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe 'onboarding', :schools do
   let!(:diocese) { create(:school_group, group_type: :diocese) }
   let!(:local_authority_area) { create(:school_group, group_type: :local_authority_area) }
   let!(:funder) { create(:funder) }
-  let!(:contract) { create(:commercial_contract) }
+  let!(:contract) { create(:commercial_contract, :future) }
 
   let(:last_email) { ActionMailer::Base.deliveries.last }
 
@@ -69,7 +69,7 @@ RSpec.describe 'onboarding', :schools do
 
         it { expect(page).to have_select('Data Sharing', selected: 'Public') }
         it { expect(page).to have_select('Funder', options: [''] + Funder.all.by_name.map(&:name)) }
-        it { expect(page).to have_select('Contract', options: [''] + Commercial::Contract.current.by_name.map(&:name)) }
+        it { expect(page).to have_select('Contract', options: [''] + Commercial::Contract.current_and_future.by_name.map(&:name)) }
 
         it {
           expect(page).to have_select('Project Group', options: [''] + SchoolGroup.project_groups.by_name.map(&:name))


### PR DESCRIPTION
Change scope used to populate the select box.

Change field to be a `select2` so it's easier to find contracts in a long list.