### PR TITLE
Ensure licences for existing schools have correct default status

### DIFF
--- a/app/models/commercial/licence.rb
+++ b/app/models/commercial/licence.rb
@@ -43,6 +43,8 @@ module Commercial
     delegate :product, to: :contract
     delegate :contract_holder, to: :contract
 
+    before_save :move_to_pending_if_school_data_enabled
+
     LICENCE_STATUS = {
       provisional: 'provisional',
       confirmed: 'confirmed',
@@ -108,6 +110,12 @@ module Commercial
 
     def destroy_error_message
       'Cannot delete an invoiced licence'
+    end
+
+    def move_to_pending_if_school_data_enabled
+      return if pending_invoice? || invoiced?
+
+      self.status = 'pending_invoice' if contract.confirmed? && school.data_enabled?
     end
   end
 end

--- a/app/services/commercial/contract_manager.rb
+++ b/app/services/commercial/contract_manager.rb
@@ -43,12 +43,7 @@ module Commercial
     def update_licence_statuses
       # update status for those that have not already advanced
       @contract.licences.where.not(status: %i[pending_invoice invoiced]).find_each do |licence|
-        status = if @contract.confirmed? && licence.school.data_enabled?
-                   :pending_invoice
-                 else
-                   @contract.status
-                 end
-        licence.update!(status:)
+        licence.update!(status: @contract.status)
       end
     end
   end

--- a/app/services/commercial/contract_manager.rb
+++ b/app/services/commercial/contract_manager.rb
@@ -43,7 +43,12 @@ module Commercial
     def update_licence_statuses
       # update status for those that have not already advanced
       @contract.licences.where.not(status: %i[pending_invoice invoiced]).find_each do |licence|
-        licence.update!(status: @contract.status)
+        status = if @contract.confirmed? && licence.school.data_enabled?
+                   :pending_invoice
+                 else
+                   @contract.status
+                 end
+        licence.update!(status:)
       end
     end
   end

--- a/app/services/commercial/licence_manager.rb
+++ b/app/services/commercial/licence_manager.rb
@@ -78,7 +78,7 @@ module Commercial
         end_date: licence_dates[:end_date],
         school_specific_price:,
         comments:,
-        status: contract.confirmed? ? :confirmed : :provisional
+        status: contract.status
       )
     end
 

--- a/lib/tasks/deployment/20260709173551_fix_licence_status.rake
+++ b/lib/tasks/deployment/20260709173551_fix_licence_status.rake
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+namespace :after_party do
+  desc 'Deployment task: fix_licence_status'
+  task fix_licence_status: :environment do
+    puts "Running deploy task 'fix_licence_status'"
+
+    # Find confirmed contracts and licences where the school is data enabled and set the
+    # licence to be 'pending_invoice'. Corrects for an existing bug where this status should
+    # have been used already.
+    Commercial::Licence
+      .joins(:contract, :school)
+      .where(commercial_contracts: { status: 'confirmed' })
+      .merge(School.where(data_enabled: true))
+      .update_all(status: 'pending_invoice') # rubocop:disable Rails/SkipsModelValidations
+
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord
+      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+  end
+end

--- a/lib/tasks/deployment/20260709173551_fix_licence_status.rake
+++ b/lib/tasks/deployment/20260709173551_fix_licence_status.rake
@@ -10,6 +10,7 @@ namespace :after_party do
     # have been used already.
     Commercial::Licence
       .joins(:contract, :school)
+      .where('start_date > ?', Time.zone.today)
       .where(commercial_contracts: { status: 'confirmed' })
       .merge(School.where(data_enabled: true))
       .update_all(status: 'pending_invoice') # rubocop:disable Rails/SkipsModelValidations

--- a/lib/tasks/deployment/20260709173551_fix_licence_status.rake
+++ b/lib/tasks/deployment/20260709173551_fix_licence_status.rake
@@ -10,7 +10,7 @@ namespace :after_party do
     # have been used already.
     Commercial::Licence
       .joins(:contract, :school)
-      .where('start_date > ?', Time.zone.today)
+      .where(start_date: Time.zone.today..)
       .where(commercial_contracts: { status: 'confirmed' })
       .merge(School.where(data_enabled: true))
       .update_all(status: 'pending_invoice') # rubocop:disable Rails/SkipsModelValidations

--- a/spec/services/commercial/contract_manager_spec.rb
+++ b/spec/services/commercial/contract_manager_spec.rb
@@ -38,7 +38,13 @@ describe Commercial::ContractManager do
     end
 
     context 'with provisional licences' do
-      let!(:licence) { create(:commercial_licence, contract:, status: :provisional, start_date: 1.year.ago) }
+      let!(:licence) do
+        create(:commercial_licence,
+               contract:,
+               school: create(:school, data_enabled: false),
+               status: :provisional,
+               start_date: 1.year.ago)
+      end
 
       before { service.cascade_updates_to_licences }
 
@@ -48,6 +54,24 @@ describe Commercial::ContractManager do
           start_date: contract.start_date,
           status: 'confirmed'
         )
+      end
+
+      context 'when school is data enabled' do
+        let!(:licence) do
+          create(:commercial_licence,
+                 contract:,
+                 school: create(:school, data_enabled: true),
+                 status: :provisional,
+                 start_date: 1.year.ago)
+        end
+
+        it 'updates the licence' do
+          expect(licence.reload).to have_attributes(
+            updated_by: admin,
+            start_date: contract.start_date,
+            status: 'pending_invoice'
+          )
+        end
       end
     end
   end

--- a/spec/services/commercial/licence_manager_spec.rb
+++ b/spec/services/commercial/licence_manager_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 describe Commercial::LicenceManager do
-  let(:school) { create(:school) }
+  let(:school) { create(:school, data_enabled: false) }
 
   let(:service) { described_class.new(school) }
 
@@ -89,6 +89,20 @@ describe Commercial::LicenceManager do
                                            })
       end
 
+      context 'when school is data enabled' do
+        let(:school) { create(:school, data_enabled: true) }
+
+        it 'creates a licence that is pending invoicing' do
+          expect(licence).to have_attributes({
+                                               contract:,
+                                               school:,
+                                               status: 'pending_invoice',
+                                               start_date: Time.zone.today,
+                                               end_date: contract.end_date
+                                             })
+        end
+      end
+
       context 'when the contract is not confirmed' do
         let!(:contract) { create(:commercial_contract, status: :provisional, licence_period: :contract) }
 
@@ -117,6 +131,20 @@ describe Commercial::LicenceManager do
                                              start_date: Time.zone.today,
                                              end_date: Time.zone.today + 364.days
                                            })
+      end
+
+      context 'when school is data enabled' do
+        let(:school) { create(:school, data_enabled: true) }
+
+        it 'creates a licence that is pending invoicing' do
+          expect(licence).to have_attributes({
+                                               contract:,
+                                               school:,
+                                               status: 'pending_invoice',
+                                               start_date: Time.zone.today,
+                                               end_date: Time.zone.today + 364.days
+                                             })
+        end
       end
 
       context 'when there is a fractional licence_years period' do

--- a/spec/system/admin/commercial/manage_contracts_spec.rb
+++ b/spec/system/admin/commercial/manage_contracts_spec.rb
@@ -543,7 +543,7 @@ describe 'manage contracts', :include_application_helper do
     end
 
     context 'when there are licences' do
-      let!(:licence) { create(:commercial_licence, contract:) }
+      let!(:licence) { create(:commercial_licence, contract:, school: create(:school, data_enabled: false)) }
 
       before { click_on 'Edit' }
 
@@ -969,7 +969,7 @@ describe 'manage contracts', :include_application_helper do
       end
 
       context 'when there are licences' do
-        let!(:licence) { create(:commercial_licence, contract:) }
+        let!(:licence) { create(:commercial_licence, contract:, school: create(:school, data_enabled: false)) }
 
         it 'confirms the licences' do
           click_on 'Confirm'

--- a/spec/system/admin/commercial/manage_licences_spec.rb
+++ b/spec/system/admin/commercial/manage_licences_spec.rb
@@ -144,6 +144,25 @@ describe 'manage licences' do
           created_by: user
         )
       end
+
+      context 'when the contract is confirmed and school is data enabled' do
+        let!(:contract) { create(:commercial_contract, status: :confirmed) }
+
+        it 'creates the model' do
+          expect(page).to have_text('Licence has been created')
+          expect(Commercial::Licence.last).to have_attributes(
+            contract:,
+            school:,
+            start_date: Date.new(2026, 1, 1),
+            end_date: Date.new(2026, 12, 31),
+            status: 'pending_invoice',
+            invoice_reference: 'INV-001',
+            school_specific_price: 250.0,
+            comments: 'my comments',
+            created_by: user
+          )
+        end
+      end
     end
 
     context 'with no dates' do
@@ -196,7 +215,7 @@ describe 'manage licences' do
 
     context 'with valid data', :js do
       before do
-        select 'Pending invoice', from: 'Status'
+        select 'Confirmed', from: 'Status'
         set_date('#licence_start_date', '01/01/2026')
         set_date('#licence_end_date', '31/12/2026')
         fill_in 'Invoice reference', with: 'INV-001'
@@ -211,13 +230,36 @@ describe 'manage licences' do
           contract: licence.contract,
           start_date: Date.new(2026, 1, 1),
           end_date: Date.new(2026, 12, 31),
-          status: 'pending_invoice',
+          status: 'confirmed',
           invoice_reference: 'INV-001',
           school_specific_price: 250.0,
           comments: 'my comments',
           created_by: licence.created_by,
           updated_by: user
         )
+      end
+
+      context 'with confirmed contract for data enabled school' do
+        let!(:licence) do
+          create(:commercial_licence,
+                 contract: create(:commercial_contract, status: :confirmed),
+                 school: create(:school, data_enabled: true))
+        end
+
+        it 'updates the model' do
+          expect(page).to have_text('Licence has been updated')
+          expect(licence.reload).to have_attributes(
+            contract: licence.contract,
+            start_date: Date.new(2026, 1, 1),
+            end_date: Date.new(2026, 12, 31),
+            status: 'pending_invoice',
+            invoice_reference: 'INV-001',
+            school_specific_price: 250.0,
+            comments: 'my comments',
+            created_by: licence.created_by,
+            updated_by: user
+          )
+        end
       end
     end
 


### PR DESCRIPTION
Licences move from provisional to confirmed, then pending invoice and finally invoiced.

Licences for schools that are data enabled, should have a pending invoice status if their contract is confirmed. This is currently applied if a school is onboard and then made data enabled. But there's a bug where this isn't happening correctly for renewed/future licences.

- [x] Ensure that when contracts are confirmed that licences are updated to pending invoice if school is already data enabled
- [x] Ensure that when licence is added for a school, via the licence form, it has the right status
- [x] Ensure that when licence is added for a school, via the bulk licence editor, it has the right status
- [x] Add migration to fix status of existing licences for renewed contracts.