### PR TITLE
Warn about overlapping licences on contract page

### DIFF
--- a/app/controllers/admin/commercial/contracts_controller.rb
+++ b/app/controllers/admin/commercial/contracts_controller.rb
@@ -53,6 +53,7 @@ module Admin
 
       def show
         @pricing = ::Commercial::ContractPriceCalculator.new(@contract)
+        @overlapping_licences = ::Commercial::Licence.overlapping.where(contract_id: @contract.id)
       end
 
       def choose

--- a/app/views/admin/commercial/contracts/show.html.erb
+++ b/app/views/admin/commercial/contracts/show.html.erb
@@ -222,6 +222,12 @@
     <p>
       The following table includes all licences for this contract sorted by start date.
     </p>
+    <% if @overlapping_licences.any? %>
+      <%= render PromptComponent.new(id: 'overlapping-licences', status: :negative, icon: 'calendar-xmark') do |p| %>
+        <% p.with_link { link_to 'Overlapping licences', overlapping_admin_commercial_licences_path } %>
+        <%= "#{@overlapping_licences.count} of these licences overlap with licences from other contracts" %>
+      <% end %>
+    <% end %>
     <%= render Commercial::LicencesComponent.new(id: 'licences',
                                                  licences: @contract.licences.by_start_date,
                                                  show_contract: false,

--- a/spec/system/admin/commercial/manage_contracts_spec.rb
+++ b/spec/system/admin/commercial/manage_contracts_spec.rb
@@ -914,6 +914,27 @@ describe 'manage contracts', :include_application_helper do
       end
     end
 
+    context 'when viewing licences' do
+      before do
+        create(:commercial_licence, status: :confirmed, contract:)
+        refresh
+      end
+
+      it { expect(page).to have_css('#licences') }
+      it { expect(page).to have_no_link('Overlapping licences', href: overlapping_admin_commercial_licences_path) }
+
+      context 'with an overlapping licence' do
+        before do
+          existing = contract.licences.last
+          create(:commercial_licence, school: existing.school, start_date: existing.start_date)
+          refresh
+        end
+
+        it { expect(page).to have_link('Overlapping licences', href: overlapping_admin_commercial_licences_path) }
+        it { expect(page).to have_text('1 of these licences overlap with licences from other contracts') }
+      end
+    end
+
     context 'when viewing invoices' do
       let!(:invoice) { create(:commercial_invoice, contract:) }
 


### PR DESCRIPTION
Add prompt to warn about overlaps with link to full report.