### PR TITLE
Add warning messages when creating or updating licences causes overlaps

### DIFF
--- a/app/controllers/admin/commercial/licences_controller.rb
+++ b/app/controllers/admin/commercial/licences_controller.rb
@@ -41,7 +41,7 @@ module Admin::Commercial
     def edit
     end
 
-    def create
+    def create # rubocop:disable Metrics/AbcSize
       @licence = Commercial::Licence.build(licence_params.merge(created_by: current_user))
       if @licence.start_date.nil? && @licence.end_date.nil?
         @licence.assign_attributes(
@@ -49,7 +49,7 @@ module Admin::Commercial
         )
       end
       if @licence.save
-        redirect_to admin_commercial_contract_path(@licence.contract), notice: 'Licence has been created'
+        redirect_to admin_commercial_contract_path(@licence.contract), redirect_flash(@licence, 'created')
       else
         render :new
       end
@@ -57,7 +57,7 @@ module Admin::Commercial
 
     def update
       if @licence.update(licence_params.merge(updated_by: current_user))
-        redirect_to admin_commercial_contract_path(@licence.contract), notice: 'Licence has been updated'
+        redirect_to admin_commercial_contract_path(@licence.contract), redirect_flash(@licence, 'updated')
       else
         render :edit
       end
@@ -76,6 +76,14 @@ module Admin::Commercial
 
     def filter_params
       params.fetch(:filters, {})
+    end
+
+    def redirect_flash(licence, action)
+      if Commercial::Licence.overlapping.where(school_id: licence.school_id).any?
+        { alert: "Licence has been #{action}. But this school now has overlapping licences" }
+      else
+        { notice: "Licence has been #{action}" }
+      end
     end
 
     def load_licences(scope)

--- a/app/views/shared/page/_flash.html.erb
+++ b/app/views/shared/page/_flash.html.erb
@@ -1,5 +1,5 @@
 <% if flash.any? %>
   <% flash.each do |name, msg| %>
-    <%= content_tag(:div, msg, class: 'alert alert-info') %>
+    <%= content_tag(:div, msg, class: "alert #{name == 'alert' ? 'alert-warning' : 'alert-info'}") %>
   <% end %>
 <% end %>

--- a/spec/system/admin/commercial/manage_licences_spec.rb
+++ b/spec/system/admin/commercial/manage_licences_spec.rb
@@ -86,6 +86,20 @@ describe 'manage licences' do
       end
     end
 
+    context 'when school has an existing licence that overlap', :js do
+      before do
+        create(:commercial_licence, school:, start_date: Date.new(2026, 1, 1), end_date: Date.new(2026, 12, 31))
+        select contract.name, from: 'Contract'
+        select school.name, from: 'School'
+        select 'Confirmed', from: 'Status'
+        set_date('#licence_start_date', '01/01/2026')
+        set_date('#licence_end_date', '31/12/2026')
+        click_on 'Save'
+      end
+
+      it { expect(page).to have_text('Licence has been created. But this school now has overlapping licences') }
+    end
+
     context 'with no dates' do
       before do
         select contract.name, from: 'Contract'
@@ -219,6 +233,21 @@ describe 'manage licences' do
           updated_by: user
         )
       end
+    end
+
+    context 'when school has an existing licence that overlap', :js do
+      before do
+        create(:commercial_licence,
+               school: licence.school,
+               start_date: Date.new(2026, 1, 1),
+               end_date: Date.new(2026, 12, 31))
+        select 'Pending invoice', from: 'Status'
+        set_date('#licence_start_date', '01/01/2026')
+        set_date('#licence_end_date', '31/12/2026')
+        click_on 'Save'
+      end
+
+      it { expect(page).to have_text('Licence has been updated. But this school now has overlapping licences') }
     end
 
     context 'when licence is invoiced' do


### PR DESCRIPTION
Related to https://github.com/Energy-Sparks/energy-sparks/pull/5493.

Revised the flash messages when creating or updating a licence means we now have overlapping licences.

I've revised the flash partial for the site to properly show different alert colours for "alert" vs "notice". Tried for minimal change but this might affect other pages. Ideally we should have different flash message styling for notices, warnings and alerts.