### PR TITLE
Better handling of onboarding schools that have already had an ES account

### DIFF
--- a/app/controllers/admin/school_onboardings_controller.rb
+++ b/app/controllers/admin/school_onboardings_controller.rb
@@ -27,6 +27,16 @@ module Admin
     end
 
     def create
+      existing_school = School.find_by(urn: params[:school_onboarding][:urn])
+      if existing_school
+        flash.now[:alert] = view_context.safe_join(
+          [
+            'This URN is already in use by ',
+            view_context.link_to(existing_school.name, school_path(existing_school))
+          ]
+        )
+        return render :new
+      end
       @school_onboarding.populate_default_values(current_user)
       if @school_onboarding.save
         redirect_to edit_admin_school_onboarding_configuration_path(@school_onboarding)

--- a/spec/system/admin/school_onboarding_spec.rb
+++ b/spec/system/admin/school_onboarding_spec.rb
@@ -58,6 +58,26 @@ RSpec.describe 'onboarding', :schools do
         expect(page).to have_select('School Group', options: [''] + SchoolGroup.organisation_groups.by_name.map(&:name))
       }
 
+      context 'when using an existing URN' do # rubocop:disable RSpec/MultipleMemoizedHelpers
+        let!(:existing_school) { create(:school, urn: 12_345) }
+
+        before do
+          fill_in 'School name', with: 'Name'
+          fill_in 'URN', with: 12_345
+          fill_in 'Contact email', with: 'oldfield@test.com'
+          select school_group.name, from: 'School Group'
+          click_on 'Next'
+        end
+
+        it 'displays an error' do
+          expect(page).to have_text("This URN is already in use by #{existing_school.name}")
+        end
+
+        it 'links to the existing school' do
+          expect(page).to have_link(existing_school.name, href: school_path(existing_school))
+        end
+      end
+
       context 'when completing the first form' do
         before do
           fill_in 'School name', with: school_name


### PR DESCRIPTION
Displays previous school (if it exists) with supplied urn when filling out onboarding form