### PR TITLE
Fixed supplier email report failure

### DIFF
--- a/app/controllers/admin/suppliers_controller.rb
+++ b/app/controllers/admin/suppliers_controller.rb
@@ -13,7 +13,7 @@ module Admin
     def show; end
 
     def deliver
-      @supplier = Supplier.find(params.expect(:supplier_id))
+      @supplier = Supplier.find(params.expect(:id))
       SendSupplierReportJob.perform_later(to: current_user.email, supplier_id: @supplier.id)
       redirect_back_or_to admin_supplier_path(@supplier), notice: "Supplier report for #{@supplier.name}
                                                                   requested to be sent to #{current_user.email}"


### PR DESCRIPTION
Replaced 'supplier_id' with just 'id' in params search