### PR TITLE
Restyle recommendations component / start of restyling tasks

### DIFF
--- a/app/components/layout/cards/feature_component.rb
+++ b/app/components/layout/cards/feature_component.rb
@@ -30,7 +30,7 @@ module Layout
         Elements::TagComponent.new(:div, **merge_classes('mt-auto', kwargs))
       }
 
-      SIZES = { xl: 1, lg: 2, md: 3, sm: 4 }.freeze
+      SIZES = { xl: 1, lg: 2, md: 3, sm: 4, xs: 5 }.freeze
       private_constant :SIZES
       TAG_POSITIONS = %i[top bottom].freeze
       private_constant :TAG_POSITIONS

--- a/app/components/recommendations_component.rb
+++ b/app/components/recommendations_component.rb
@@ -3,52 +3,19 @@
 class RecommendationsComponent < ApplicationComponent
   attr_reader :title, :description, :limit, :limit_lg
 
-  renders_many :items, 'ItemComponent'
-
-  def initialize(title: nil, description: nil, recommendations: [], limit: 4, limit_lg: 3, **_kwargs)
+  def initialize(title: nil, description: nil, tasks: [], limit: 4, **_kwargs)
     super
     @title = title
     @description = description
     @limit = limit
-    @limit_lg = limit_lg
-    @recommendations = recommendations
+    @tasks = tasks
   end
 
-  # `#helpers` can't be used during initialization as it depends on the view context that only exists once a ViewComponent is passed to the Rails render pipeline.
-  def before_render
-    @recommendations.each do |recommendation|
-      with_item(name: recommendation.name, href: helpers.url_for(recommendation), image: recommendation.t_attached_or_default(:image))
-    end
-  end
-
-  def responsive_classes(index)
-    ' d-none d-xl-block' if index >= limit_lg # limit to limit_lg for screens less than XL
-  end
-
-  # this is for when we add activity key stages etc
-  def footer
-    false
+  def link_text(task)
+    task.public_type == :activity ? t('common.view_pupil_activity') : t('common.view_adult_action')
   end
 
   def render?
-    items.any?
-  end
-
-  class ItemComponent < ViewComponent::Base
-    attr_accessor :name, :href
-
-    def initialize(name: nil, href: nil, image: nil)
-      @name = name
-      @href = href
-      @image = image
-    end
-
-    def image
-      @image || self.class.default_image
-    end
-
-    def self.default_image
-      'placeholder300x200.png'
-    end
+    @tasks.any?
   end
 end

--- a/app/components/recommendations_component/recommendations_component.html.erb
+++ b/app/components/recommendations_component/recommendations_component.html.erb
@@ -5,21 +5,45 @@
   <% if description %>
     <p><%= description %></p>
   <% end %>
-  <div class="card-deck justify-content-center">
-    <% items.first(limit).each_with_index do |item, i| %>
-      <div class="card<%= responsive_classes(i) %>">
-        <%= link_to item.href do %>
-          <%= image_tag(cdn_link_url(item.image), class: 'card-img-top img-fluid activity-card-img') %>
+
+  <%= render Layout::GridComponent.new(
+        id: 'recommendations',
+        cols: limit,
+        cell_classes: 'mb-4',
+        component_classes: 'h-100'
+      ) do |grid| %>
+    <%# TODO: Make task into a component, to be used widely throughout the site %>
+    <%# Rather than recommendations component, we might rename it a tasklist component %>
+    <%# Tasks::List or Tasks::Grid and maybe Tasks::Card %>
+    <%# Make description turn on / offable %>
+    <%# Consider not having the link at the bottom and making the whole card clickable %>
+    <%# to save on space %>
+    <%# NB the "Languages, Literacy and Communication" subject is problematically long and busts out of the card %>
+    <% @tasks.first(limit).each do |task| %>
+      <%= grid.with_card do |card| %>
+        <%= card.with_image(
+              src: cdn_link_url(task.t_attached_or_default(:image)),
+              rounded: :top,
+              classes: 'border-top border-start border-end'
+            ) %>
+        <%= card.with_feature_card(
+              theme: task.public_type == :activity ? :accent : :light, size: :xs,
+              classes: 'rounded-bottom-xl'
+            ) do |feature| %>
+          <%= feature.with_header(title: task.name) %>
+          <%= feature.with_tag(t('nav.points', count: task.score),
+                               colour: :success, tooltip: t("tasks.points.#{task.public_type}")) %>
+          <% if task.is_a?(ActivityType) %>
+            <% task.key_stages.order(:name).each do |key_stage| %>
+              <%= feature.with_tag(t(key_stage.i18n_key), colour: :info, tooltip: t('activity_types.key_stages')) %>
+            <% end %>
+            <% task.subjects.order(:name).each do |subject| %>
+              <%= feature.with_tag(t(subject.i18n_key), colour: :warning, tooltip: t('activity_types.subjects')) %>
+            <% end %>
+          <% end %>
+          <%= feature.with_link(href: helpers.url_for(task)) { link_text(task) } %>
         <% end %>
-        <div class="card-body">
-          <p class="card-text">
-          <%= link_to item.name, item.href, class: 'text-decoration-none stretched-link' %>
-          </p>
-        </div>
-        <% if footer %>
-          <div class="card-footer border-top-0 bg-transparent"><%= footer %></div>
-        <% end %>
-      </div>
+      <% end %>
     <% end %>
-  </div>
+  <% end %>
 <% end %>

--- a/app/components/recommendations_component/recommendations_component.scss
+++ b/app/components/recommendations_component/recommendations_component.scss
@@ -3,10 +3,3 @@
   max-height: 150px;
   object-fit: contain;
 }
-
-/* only have a max width for md and up */
-@media(min-width:768px) {
-  .recommendations-component .card {
-    max-width: 300px;
-  }
-}

--- a/app/services/recommendations/actions.rb
+++ b/app/services/recommendations/actions.rb
@@ -7,11 +7,7 @@ module Recommendations
     end
 
     def audit_tasks
-      if Flipper.enabled?(:todos)
-        school.audit_intervention_type_tasks
-      else
-        school.audit_intervention_types
-      end
+      school.audit_intervention_type_tasks
     end
 
     def task_tasks(task)

--- a/app/services/recommendations/activities.rb
+++ b/app/services/recommendations/activities.rb
@@ -11,11 +11,7 @@ module Recommendations
     end
 
     def audit_tasks
-      if Flipper.enabled?(:todos)
-        with_key_stage(school.audit_activity_type_tasks)
-      else
-        with_key_stage(school.audit_activity_types)
-      end
+      with_key_stage(school.audit_activity_type_tasks)
     end
 
     def task_tasks(task)

--- a/app/services/recommendations/base.rb
+++ b/app/services/recommendations/base.rb
@@ -1,6 +1,6 @@
 module Recommendations
   class Base
-    NUMBER_OF_SUGGESTIONS = 5
+    NUMBER_OF_SUGGESTIONS = 4
 
     attr_reader :school
 
@@ -67,19 +67,19 @@ module Recommendations
     def audit_suggestions(limit, suggestions: [])
       count = limit - suggestions.length
 
-      count > 0 ? audit_tasks.active.not_including(completed_this_year + suggestions).limit(count) : []
+      count.positive? ? audit_tasks.active.not_including(completed_this_year + suggestions).limit(count) : []
     end
 
     def task_suggestions(task, limit, suggestions: [])
       count_remaining = limit - suggestions.length
 
-      count_remaining > 0 ? task_tasks(task).active.not_including(completed_this_year + suggestions).limit(count_remaining) : []
+      count_remaining.positive? ? task_tasks(task).active.not_including(completed_this_year + suggestions).limit(count_remaining) : []
     end
 
     def random_suggestions(limit, suggestions: [])
       count_remaining = limit - suggestions.length
 
-      count_remaining > 0 ? all(excluding: completed_this_year + suggestions).active.sample(count_remaining) : []
+      count_remaining.positive? ? all(excluding: completed_this_year + suggestions).active.sample(count_remaining) : []
     end
 
     def all(excluding: [])

--- a/app/views/schools/advice/advice_base/insights.html.erb
+++ b/app/views/schools/advice/advice_base/insights.html.erb
@@ -14,11 +14,11 @@
     <p><%= @advice_page_insights_next_steps %></p>
   <% end %>
 
-  <%= render RecommendationsComponent.new(recommendations: @activity_types,
+  <%= render RecommendationsComponent.new(tasks: @activity_types,
                                           title: t('advice_pages.insights.recommendations.activities_title'),
                                           classes: 'pb-4') %>
 
-  <%= render RecommendationsComponent.new(recommendations: @intervention_types,
+  <%= render RecommendationsComponent.new(tasks: @intervention_types,
                                           title: t('advice_pages.insights.recommendations.actions_title'),
                                           classes: 'pb-4') %>
 

--- a/app/views/schools/recommendations/index.html.erb
+++ b/app/views/schools/recommendations/index.html.erb
@@ -8,7 +8,7 @@
 <%= render 'schools/prompt_join_programme', school: @school, style: :compact %>
 <%= render 'schools/prompt_audit', audit: Audits::AuditService.new(@school).last_audit, style: :compact %>
 
-<% display_options = { classes: 'pb-4', limit: 5, limit_lg: 3 } %>
+<% display_options = { classes: 'pb-4', limit: 4 } %>
 <% display_limit = display_options[:limit] %>
 
 <%= render PanelSwitcherComponent.new(
@@ -19,13 +19,13 @@
     ) do |switcher| %>
   <% switcher.with_panel(label: t('common.labels.pupil_activities'), name: 'pupil') do |panel| %>
     <%= render RecommendationsComponent.new(
-          recommendations: Recommendations::Activities.new(@school).based_on_energy_use(display_limit),
+          tasks: Recommendations::Activities.new(@school).based_on_energy_use(display_limit),
           **display_options
         ) %>
   <% end %>
   <% switcher.with_panel(label: t('common.labels.adult_actions'), name: 'adult') do |panel| %>
     <%= render RecommendationsComponent.new(
-          recommendations: Recommendations::Actions.new(@school).based_on_energy_use(display_limit),
+          tasks: Recommendations::Actions.new(@school).based_on_energy_use(display_limit),
           **display_options
         ) %>
   <% end %>
@@ -39,13 +39,13 @@
     ) do |switcher| %>
   <% switcher.with_panel(label: t('common.labels.pupil_activities'), name: 'pupil') do |panel| %>
     <%= render RecommendationsComponent.new(
-          recommendations: Recommendations::Activities.new(@school).based_on_recent_activity(display_limit),
+          tasks: Recommendations::Activities.new(@school).based_on_recent_activity(display_limit),
           **display_options
         ) %>
   <% end %>
   <% switcher.with_panel(label: t('common.labels.adult_actions'), name: 'adult') do |panel| %>
     <%= render RecommendationsComponent.new(
-          recommendations: Recommendations::Actions.new(@school).based_on_recent_activity(display_limit),
+          tasks: Recommendations::Actions.new(@school).based_on_recent_activity(display_limit),
           **display_options
         ) %>
   <% end %>
@@ -56,6 +56,7 @@
       description: t('schools.recommendations.more_ideas.description'),
       id: 'more-ideas', **display_options
     ) do |c| %>
+
   <% c.with_item(name: t('schools.recommendations.more_ideas.programme'), href: programme_types_path,
                  image: 'recommendations/get-energised.png') %>
   <% c.with_item(name: t('schools.recommendations.more_ideas.activities', count: ActivityType.count),

--- a/config/locales/common.yml
+++ b/config/locales/common.yml
@@ -132,9 +132,11 @@ en:
       minutes:
         one: "%{count} minute"
         other: "%{count} minutes"
+    view_adult_action: View adult action
     view_all_potential_savings: View all potential savings
     view_analysis: View analysis
     view_dashboard: View dashboard
+    view_pupil_activity: View pupil activity
     view_scoreboard: View scoreboard
     view_timeline: View timeline
   kwh: kWh

--- a/spec/services/recommendations/actions_spec.rb
+++ b/spec/services/recommendations/actions_spec.rb
@@ -20,16 +20,8 @@ describe Recommendations::Actions, type: :service do
   end
 
   describe '#based_on_energy_use' do
-    context without_feature: :todos do
-      subject(:energy_use) { service.based_on_energy_use(limit) }
+    subject(:energy_use) { service.based_on_energy_use(limit) }
 
-      it_behaves_like 'a service making recommendations based on energy use', with_todos: false
-    end
-
-    context with_feature: :todos do
-      subject(:energy_use) { service.based_on_energy_use(limit) }
-
-      it_behaves_like 'a service making recommendations based on energy use', with_todos: true
-    end
+    it_behaves_like 'a service making recommendations based on energy use', with_todos: true
   end
 end

--- a/spec/services/recommendations/activities_spec.rb
+++ b/spec/services/recommendations/activities_spec.rb
@@ -63,13 +63,7 @@ describe Recommendations::Activities, type: :service do
     context 'when school has no key stages' do
       let(:key_stages) { [] }
 
-      context without_feature: :todos do
-        it_behaves_like 'a service making recommendations based on energy use'
-      end
-
-      context with_feature: :todos do
-        it_behaves_like 'a service making recommendations based on energy use', with_todos: true
-      end
+      it_behaves_like 'a service making recommendations based on energy use'
     end
 
     context 'when school has key stages' do

--- a/spec/support/shared_examples/recommendations_service.rb
+++ b/spec/support/shared_examples/recommendations_service.rb
@@ -68,7 +68,7 @@ RSpec.shared_examples 'a service making recommendations based on recent activity
   end
 end
 
-RSpec.shared_examples 'a service making recommendations based on energy use' do |with_todos: false|
+RSpec.shared_examples 'a service making recommendations based on energy use' do
   let!(:alert_generation_run) { create(:alert_generation_run, school: school)}
   let!(:alert_type_elec) { create(:alert_type, fuel_type: :electricity)}
   let!(:alert_type_gas) { create(:alert_type, fuel_type: :gas)}
@@ -193,19 +193,11 @@ RSpec.shared_examples 'a service making recommendations based on energy use' do 
 
     context 'when school has suggested actions from an audit' do
       let!(:audit) do
-        if with_todos
-          create(:audit, school: school, "#{task_type}_todos": create_list("#{task_type}_todo", 6))
-        else
-          create(:audit, school: school, "#{task_types}": create_list(task_type, 6))
-        end
+        create(:audit, school: school, "#{task_type}_todos": create_list("#{task_type}_todo", 6))
       end
 
       let(:audit_task_types) do
-        if with_todos
-          audit.send("#{task_type}_tasks")
-        else
-          audit.send(task_types)
-        end
+        audit.send("#{task_type}_tasks")
       end
 
       it 'tops up from them' do


### PR DESCRIPTION
Leaving this here for September. This was the start of restyling the recommendations component to the new design.

It was decided that we should restyle all places where tasks are listed at the same time for consistency.
We discussed making the background light blue for adult actions and light yellow for pupil activities.

See inline notes but in summary:
* We need a task component and a tasklist component, rather than a recommendations component. Suggest Tasks::List and maybe Tasks::Card.
* We should make the summary / description turn off/onable.
* Consider not having the link at the bottom and making the whole card clickable
* NB the "Languages, Literacy and Communication" subject is problematically long and busts out of the card
* We should consider restyling the task/show pages to also have light yellow header background

Some previews of current code:
<img width="1403" height="665" alt="Screenshot 2026-07-15 at 10 07 16" src="https://github.com/user-attachments/assets/c804f3a2-8bb9-4338-8f33-5a36c7c2dbb3" />
<img width="1403" height="598" alt="Screenshot 2026-07-15 at 10 07 30" src="https://github.com/user-attachments/assets/629e9896-8bba-48ed-9134-91399e38aeab" />

