### PR TITLE
Add exports for invoice reconciliation

### DIFF
--- a/app/controllers/admin/commercial/invoices_controller.rb
+++ b/app/controllers/admin/commercial/invoices_controller.rb
@@ -7,18 +7,37 @@ module Admin
 
       def index
         @invoices = ::Commercial::Invoice.by_date
+
+        respond_to do |format|
+          format.html do
+            render :index
+          end
+          format.csv do
+            csv = export_detail? ? @invoices.to_csv : ::Commercial::LineItem.with_context.invoice_order.to_csv
+            file_name = export_detail? ? 'invoices' : 'invoice-details'
+            send_data csv, filename: EnergySparks::Filenames.csv(file_name)
+          end
+        end
       end
 
       def export
         invoices = ::Commercial::Invoice.where(id: invoice_params)
         send_data ::Commercial::XeroInvoiceExporter.new(invoices:).perform,
-                  filename: EnergySparks::Filenames.csv('invoices')
+                  filename: EnergySparks::Filenames.csv('xero-invoices')
       end
 
       private
 
       def invoice_params
         params.require(:invoices)
+      end
+
+      def export_detail?
+        export_params[:detail] == 'summary'
+      end
+
+      def export_params
+        params.permit(:detail).with_defaults(detail: 'summary')
       end
     end
   end

--- a/app/controllers/admin/commercial/invoices_controller.rb
+++ b/app/controllers/admin/commercial/invoices_controller.rb
@@ -13,8 +13,8 @@ module Admin
             render :index
           end
           format.csv do
-            csv = export_detail? ? @invoices.to_csv : ::Commercial::LineItem.with_context.invoice_order.to_csv
-            file_name = export_detail? ? 'invoices' : 'invoice-details'
+            csv = export_summary? ? @invoices.to_csv : ::Commercial::LineItem.with_context.invoice_order.to_csv
+            file_name = export_summary? ? 'invoices' : 'invoice-details'
             send_data csv, filename: EnergySparks::Filenames.csv(file_name)
           end
         end
@@ -32,7 +32,7 @@ module Admin
         params.require(:invoices)
       end
 
-      def export_detail?
+      def export_summary?
         export_params[:detail] == 'summary'
       end
 

--- a/app/models/commercial/invoice.rb
+++ b/app/models/commercial/invoice.rb
@@ -23,6 +23,8 @@
 #
 module Commercial
   class Invoice < ApplicationRecord
+    include CsvExportable
+
     self.table_name = 'commercial_invoices'
 
     scope :by_date, -> { order(created_at: :asc) }
@@ -35,6 +37,18 @@ module Commercial
 
     delegate :contract_holder, to: :contract
     accepts_nested_attributes_for :line_items
+
+    def self.csv_headers
+      ['ID', 'Contract', 'Contract Holder',
+       'Created By', 'Date', 'Purchase Order Number',
+       'Base Price', 'Metering Fee', 'Private Account Fee', 'Total']
+    end
+
+    def self.csv_attributes
+      %w[invoice_number contract.name contract.contract_holder.name
+         created_by.display_name date purchase_order_number
+         value.base_price value.metering_fee value.private_account_fee value.total]
+    end
 
     def date
       created_at.to_date

--- a/app/models/commercial/line_item.rb
+++ b/app/models/commercial/line_item.rb
@@ -27,6 +27,8 @@
 #
 module Commercial
   class LineItem < ApplicationRecord
+    include CsvExportable
+
     self.table_name = 'commercial_line_items'
 
     belongs_to :invoice, class_name: 'Commercial::Invoice'
@@ -35,6 +37,25 @@ module Commercial
     validates :base_price, :metering_fee, :private_account_fee, presence: true
 
     delegate :school, to: :licence
+
+    scope :with_context, -> { includes(:invoice, :licence) }
+    scope :invoice_order, -> { order(invoice_id: :asc, id: :asc) }
+
+    def self.csv_headers
+      ['ID', 'Contract', 'Contract Holder',
+       'Created By', 'Date', 'Purchase Order Number',
+       'School', 'Licence Id', 'Licence Start Date', 'Licence End Date',
+       'Private Account', 'Number of Meters',
+       'Base Price', 'Metering Fee', 'Private Account Fee', 'Total']
+    end
+
+    def self.csv_attributes
+      %w[invoice.invoice_number invoice.contract.name invoice.contract_holder.name
+         invoice.created_by.display_name invoice.date invoice.purchase_order_number
+         school.name licence.id licence.start_date licence.end_date
+         private_account number_of_meters
+         base_price metering_fee private_account_fee value.total]
+    end
 
     def value
       Price.new(base_price:, metering_fee:, private_account_fee:)

--- a/app/services/commercial/xero_invoice_exporter.rb
+++ b/app/services/commercial/xero_invoice_exporter.rb
@@ -50,7 +50,7 @@ module Commercial
     # One extra line item per extra fee with note, e.g. X meters
     def invoice_to_line_items(invoice)
       invoice_line_items = []
-      invoice.line_items.each do |line_item|
+      invoice.line_items.invoice_order.each do |line_item|
         add_base_price(invoice_line_items, invoice, line_item)
         add_metering_fee(invoice_line_items, invoice, line_item)
         add_private_account_fee(invoice_line_items, invoice, line_item)

--- a/app/views/admin/commercial/invoices/index.html.erb
+++ b/app/views/admin/commercial/invoices/index.html.erb
@@ -3,4 +3,14 @@
   <% header_nav.with_button 'Contracts & Licensing', admin_commercial_path %>
 <% end %>
 
+<p>
+<%= link_to 'Export summary to CSV',
+            admin_commercial_invoices_path(format: :csv, params: { detail: :summary }),
+            class: 'btn btn-sm' %>
+<%= link_to 'Export detail to CSV',
+            admin_commercial_invoices_path(format: :csv, params: { detail: :full }),
+            class: 'btn btn-sm' %>
+
+</p>
+
 <%= render ::Commercial::InvoicesComponent.new(invoices: @invoices) %>

--- a/spec/models/commercial/invoice_spec.rb
+++ b/spec/models/commercial/invoice_spec.rb
@@ -8,4 +8,32 @@ describe Commercial::Invoice do
 
     it { expect(invoice.invoice_number).to eq("ES#{invoice.id.to_s.rjust(4, '0')}") }
   end
+
+  describe '.to_csv' do
+    subject(:csv) { CSV.parse(described_class.to_csv) }
+
+    let!(:invoice) { create(:commercial_invoice) }
+
+    it 'produces the expected headers' do
+      expect(csv[0]).to eq([
+                             'ID', 'Contract', 'Contract Holder', 'Created By', 'Date', 'Purchase Order Number',
+                             'Base Price', 'Metering Fee', 'Private Account Fee', 'Total'
+                           ])
+    end
+
+    it 'produces the expected rows' do
+      expect(csv[1]).to eq([
+                             invoice.invoice_number,
+                             invoice.contract.name,
+                             invoice.contract_holder.name,
+                             invoice.created_by&.display_name,
+                             invoice.date.iso8601,
+                             invoice.purchase_order_number,
+                             invoice.value.base_price.to_s,
+                             invoice.value.metering_fee.to_s,
+                             invoice.value.private_account_fee.to_s,
+                             invoice.value.total.to_s
+                           ])
+    end
+  end
 end

--- a/spec/models/commercial/line_item_spec.rb
+++ b/spec/models/commercial/line_item_spec.rb
@@ -6,4 +6,39 @@ describe Commercial::LineItem do
   it { is_expected.to validate_presence_of(:base_price) }
   it { is_expected.to validate_presence_of(:metering_fee) }
   it { is_expected.to validate_presence_of(:private_account_fee) }
+
+  describe '.to_csv' do
+    subject(:csv) { CSV.parse(described_class.to_csv) }
+
+    let!(:invoice) { create(:commercial_invoice, :with_line_items) }
+
+    it 'produces the expected headers' do
+      expect(csv[0]).to eq(['ID', 'Contract', 'Contract Holder',
+                            'Created By', 'Date', 'Purchase Order Number',
+                            'School', 'Licence Id', 'Licence Start Date', 'Licence End Date',
+                            'Private Account', 'Number of Meters',
+                            'Base Price', 'Metering Fee', 'Private Account Fee', 'Total'])
+    end
+
+    it 'produces the expected rows' do # rubocop:disable RSpec/ExampleLength
+      expect(csv[1]).to eq([
+                             invoice.invoice_number,
+                             invoice.contract.name,
+                             invoice.contract_holder.name,
+                             invoice.created_by&.display_name,
+                             invoice.date.iso8601,
+                             invoice.purchase_order_number,
+                             invoice.line_items.first.school.name,
+                             invoice.line_items.first.licence.id.to_s,
+                             invoice.line_items.first.licence.start_date.iso8601,
+                             invoice.line_items.first.licence.end_date.iso8601,
+                             'false',
+                             invoice.line_items.first.number_of_meters.to_s,
+                             invoice.line_items.first.value.base_price.to_s,
+                             invoice.line_items.first.value.metering_fee.to_s,
+                             invoice.line_items.first.value.private_account_fee.to_s,
+                             invoice.line_items.first.value.total.to_s
+                           ])
+    end
+  end
 end

--- a/spec/system/admin/commercial/manage_invoices_spec.rb
+++ b/spec/system/admin/commercial/manage_invoices_spec.rb
@@ -17,6 +17,16 @@ describe 'manage invoices', :include_application_helper do
 
     it { expect(page).to have_text('All Invoices') }
 
+    it {
+      expect(page).to have_link('Export summary to CSV',
+                                href: admin_commercial_invoices_path(format: :csv, detail: :summary))
+    }
+
+    it {
+      expect(page).to have_link('Export detail to CSV',
+                                href: admin_commercial_invoices_path(format: :csv, detail: :full))
+    }
+
     it_behaves_like 'it contains the expected data table', sortable: true, aligned: false do
       let(:table_id) { '#invoices-table' }
       let(:expected_header) do
@@ -47,7 +57,29 @@ describe 'manage invoices', :include_application_helper do
 
       it 'downloads a CSV' do
         expect(page.response_headers['Content-Type']).to eq 'text/csv'
+        expect(page.response_headers['Content-Disposition']).to match(/energy-sparks-xero-invoices/)
+      end
+    end
+
+    context 'when downloading summary CSV' do
+      before do
+        click_on 'Export summary to CSV'
+      end
+
+      it 'downloads a CSV' do
+        expect(page.response_headers['Content-Type']).to eq 'text/csv'
         expect(page.response_headers['Content-Disposition']).to match(/energy-sparks-invoices/)
+      end
+    end
+
+    context 'when downloading detail CSV' do
+      before do
+        click_on 'Export detail to CSV'
+      end
+
+      it 'downloads a CSV' do
+        expect(page.response_headers['Content-Type']).to eq 'text/csv'
+        expect(page.response_headers['Content-Disposition']).to match(/energy-sparks-invoice-details/)
       end
     end
   end


### PR DESCRIPTION
Adds two CSV exports to the invoices page:

- a summary which exports just the metadata and total pricing for each invoice
- a detailed view which exports all line items for all invoices