### PR TITLE
Add data visibility indicator to manage licences page

### DIFF
--- a/app/components/commercial/licensing_summary_component.rb
+++ b/app/components/commercial/licensing_summary_component.rb
@@ -8,8 +8,10 @@ module Commercial
       RowComponent.new(**kwargs)
     }
 
+    # rubocop:disable Metrics/ParameterLists
     def initialize(first_range: nil, second_range: nil,
                    labels: { first: 'Current Academic Year', second: nil },
+                   show_data_visibility: false,
                    table_id: 'summary-table', **)
       super(**)
       @table_id = table_id
@@ -18,19 +20,22 @@ module Commercial
         year.start_date..year.end_date
       end
       @second_range = second_range
+      @show_data_visibility = show_data_visibility
     end
+    # rubocop:enable Metrics/ParameterLists
 
     class RowComponent < ViewComponent::Base
       attr_reader :school, :date_range
 
       renders_many :buttons
 
-      def initialize(school:, first_range:, second_range: nil, id: "school-#{school.id}")
+      def initialize(school:, first_range:, second_range: nil, show_data_visibility: false, id: "school-#{school.id}")
         super()
         @id = id
         @school = school
         @first_range = first_range
         @second_range = second_range
+        @show_data_visibility = show_data_visibility
       end
 
       private

--- a/app/components/commercial/licensing_summary_component/licensing_summary_component.html.erb
+++ b/app/components/commercial/licensing_summary_component/licensing_summary_component.html.erb
@@ -2,7 +2,7 @@
   <table id="<%= @table_id %>" class="table table-sorted table-sm advice-table">
     <thead>
       <tr>
-        <th></th>
+        <th colspan="<%= @show_data_visibility ? '2' : '1' %>"></th>
         <th colspan="4"><%= @labels[:first] %></th>
         <% if @second_range.present? %>
           <th colspan="4"><%= @labels[:second] %></th>
@@ -11,17 +11,20 @@
       </tr>
       <tr>
         <th class="col-2">School</th>
+        <% if @show_data_visibility %>
+          <th class="col-1">Data visible</th>
+        <% end %>
         <th class="col-1">Licensed?</th>
-        <th class="col-2">Funder</th>
+        <th class="col-1">Funder</th>
         <th class="col-1">First licence start</th>
         <th class="col-1">First licence end</th>
         <% if @second_range.present? %>
           <th class="col-1">Licensed?</th>
-          <th class="col-2">Funder</th>
+          <th class="col-1">Funder</th>
           <th class="col-1">First licence start</th>
           <th class="col-1">First licence end</th>
         <% end %>
-        <th class="col-2"></th>
+        <th class="col-1"></th>
       </tr>
     </thead>
     <tbody>

--- a/app/components/commercial/licensing_summary_component/row_component.html.erb
+++ b/app/components/commercial/licensing_summary_component/row_component.html.erb
@@ -2,6 +2,15 @@
   <td>
     <%= link_to school.name, school_path(school) %>
   </td>
+  <% if @show_data_visibility %>
+    <td>
+      <% if school.data_enabled? %>
+        <span class="badge rounded-pill text-bg-success">Yes</span>
+      <% else %>
+        <span class="badge rounded-pill text-bg-danger">No</span>
+      <% end %>
+    </td>
+  <% end %>
   <td>
     <%= render(Elements::BadgeComponent.new(licensed_for(@first_range).to_s.humanize,
                                             pill: true,

--- a/app/components/forms/commercial/bulk_licence_editor_component/bulk_licence_editor_component.html.erb
+++ b/app/components/forms/commercial/bulk_licence_editor_component/bulk_licence_editor_component.html.erb
@@ -6,6 +6,7 @@
           <tr>
             <th>Id</th>
             <th>School</th>
+            <th>Data Visible</th>
             <% if show_field?(:start_date) %>
               <th>Start</th>
             <% end %>
@@ -59,10 +60,11 @@
       <%= render ::Commercial::LicensingSummaryComponent.new(
             table_id: "contract-#{@contract.id}-additional-schools-table",
             second_range: @contract.as_range,
+            show_data_visibility: true,
             labels: { first: 'Current Academic Year', second: 'Contract Period' }
           ) do |c| %>
         <% @additional_schools.each do |school| %>
-          <% c.with_row id: "additional-school-#{school.id}", school: school do |r| %>
+          <% c.with_row id: "additional-school-#{school.id}", show_data_visibility: true, school: school do |r| %>
             <% r.with_button do %>
               <%= button_to 'Add licence',
                             create_licence_admin_commercial_contract_licences_path(@contract),

--- a/app/components/forms/commercial/bulk_licence_editor_component/licence_row_component.html.erb
+++ b/app/components/forms/commercial/bulk_licence_editor_component/licence_row_component.html.erb
@@ -3,7 +3,13 @@
     <%= lf.hidden_field :id %>
     <td><%= link_to "##{licence.id}", admin_commercial_licence_path(licence) %></td>
     <td><%= link_to licence.school.name, school_path(licence.school) %></td>
-
+    <td>
+      <% if licence.school.data_enabled? %>
+        <span class="badge rounded-pill text-bg-success">Yes</span>
+      <% else %>
+        <span class="badge rounded-pill text-bg-danger">No</span>
+      <% end %>
+    </td>
     <% if show_field?(:start_date) %>
       <td class="col-2">
         <%= lf.input :start_date, as: :tempus_dominus_date, label: false, disabled: licence.invoiced? %>
@@ -45,7 +51,7 @@
   </tr>
   <% if show_field?(:comments) %>
     <tr id="<%= "licence-#{licence.id}-comments-row" %>" class="comments-row">
-      <td colspan="2"></td>
+      <td colspan="3"></td>
       <td colspan="5">
         <%= lf.input :comments,
                      as: :text,

--- a/spec/components/commercial/licensing_summary_component_spec.rb
+++ b/spec/components/commercial/licensing_summary_component_spec.rb
@@ -70,9 +70,10 @@ RSpec.describe Commercial::LicensingSummaryComponent, :include_application_helpe
       render_inline described_class.new(first_range: date_range.begin..date_range.end,
                                         second_range: (date_range.end + 1)..(date_range.end + 364),
                                         labels: { first: 'Current Year', second: 'Following Year' },
+                                        show_data_visibility: true,
                                         id: 'custom-id',
                                         classes: 'extra-classes') do |c|
-        c.with_row id: "custom-school-id-#{school.id}", school: school
+        c.with_row id: "custom-school-id-#{school.id}", school: school, show_data_visibility: true
       end
     end
 

--- a/spec/components/commercial/licensing_summary_component_spec.rb
+++ b/spec/components/commercial/licensing_summary_component_spec.rb
@@ -19,8 +19,9 @@ RSpec.describe Commercial::LicensingSummaryComponent, :include_application_helpe
       render_inline described_class.new(first_range:
         date_range.begin..date_range.end,
                                         id: 'custom-id',
-                                        classes: 'extra-classes') do |c|
-        c.with_row id: "custom-school-id-#{school.id}", school: school
+                                        classes: 'extra-classes',
+                                        show_data_visibility: true) do |c|
+        c.with_row id: "custom-school-id-#{school.id}", school: school, show_data_visibility: true
       end
     end
 
@@ -40,13 +41,14 @@ RSpec.describe Commercial::LicensingSummaryComponent, :include_application_helpe
         let(:expected_header) do
           [
             ['', 'Current Academic Year', ''],
-            ['School', 'Licensed?', 'Funder', 'First licence start', 'First licence end', '']
+            ['School', 'Data visible', 'Licensed?', 'Funder', 'First licence start', 'First licence end', '']
           ]
         end
         let(:expected_rows) do
           [
             [
               school.name,
+              'Yes',
               'Full',
               licence.contract.contract_holder.name,
               licence.start_date.to_fs(:es_short),
@@ -80,7 +82,7 @@ RSpec.describe Commercial::LicensingSummaryComponent, :include_application_helpe
         [
           ['', 'Current Year', 'Following Year', ''],
           [
-            'School',
+            'School', 'Data visible',
             'Licensed?', 'Funder', 'First licence start', 'First licence end',
             'Licensed?', 'Funder', 'First licence start', 'First licence end',
             ''
@@ -91,6 +93,7 @@ RSpec.describe Commercial::LicensingSummaryComponent, :include_application_helpe
         [
           [
             school.name,
+            'Yes',
             'Full',
             licence.contract.contract_holder.name,
             licence.start_date.to_fs(:es_short),

--- a/spec/components/forms/commercial/bulk_licence_editor_component_spec.rb
+++ b/spec/components/forms/commercial/bulk_licence_editor_component_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe Forms::Commercial::BulkLicenceEditorComponent, :include_applicati
         let(:table_id) { "#contract-#{contract.id}-licence-table" }
         let(:expected_header) do
           [
-            ['Id', 'School', 'Start', 'End', 'Status', 'Price', 'Invoice Ref', '']
+            ['Id', 'School', 'Data Visible', 'Start', 'End', 'Status', 'Price', 'Invoice Ref', '']
           ]
         end
       end
@@ -89,6 +89,10 @@ RSpec.describe Forms::Commercial::BulkLicenceEditorComponent, :include_applicati
 
         it 'links to school' do
           expect(main).to have_link(licence.school.name, href: school_path(licence.school))
+        end
+
+        it 'shows data visibility to school' do
+          expect(main).to have_text('Yes')
         end
 
         it 'renders the date fields' do
@@ -165,7 +169,7 @@ RSpec.describe Forms::Commercial::BulkLicenceEditorComponent, :include_applicati
           let(:table_id) { "#contract-#{contract.id}-licence-table" }
           let(:expected_header) do
             [
-              ['Id', 'School', 'Start', 'End', 'Status', 'Price', '']
+              ['Id', 'School', 'Data Visible', 'Start', 'End', 'Status', 'Price', '']
             ]
           end
         end
@@ -212,7 +216,7 @@ RSpec.describe Forms::Commercial::BulkLicenceEditorComponent, :include_applicati
             [
               ['', 'Current Academic Year', 'Contract Period', ''],
               [
-                'School',
+                'School', 'Data visible',
                 'Licensed?', 'Funder', 'First licence start', 'First licence end',
                 'Licensed?', 'Funder', 'First licence start', 'First licence end',
                 ''
@@ -221,7 +225,7 @@ RSpec.describe Forms::Commercial::BulkLicenceEditorComponent, :include_applicati
           end
           let(:expected_rows) do
             [
-              [additional_school.name, 'No', '', '', '', 'No', '', '', '', 'Add licence Licences Issues']
+              [additional_school.name, 'Yes', 'No', '', '', '', 'No', '', '', '', 'Add licence Licences Issues']
             ]
           end
         end


### PR DESCRIPTION
Show whether a school is data enabled or not on the manage licences page for a contract

- include indicator in the editing table
- include indicator in the licensing summary
