### PR TITLE
Update recommendations page header

### DIFF
--- a/app/views/schools/recommendations/index.html.erb
+++ b/app/views/schools/recommendations/index.html.erb
@@ -1,12 +1,15 @@
-<h1><%= t('schools.recommendations.title') %></h1>
+<% content_for(:header) do %>
+  <h1><%= t('schools.recommendations.title') %></h1>
+  <p><%= t('schools.recommendations.intro') %></p>
+<% end %>
 
-<p><%= t('schools.recommendations.intro') %></p>
-
-<%= render 'schools/prompts/complete_programme',
-           programmes: @school.programmes.active.started.order(started_on: :desc),
-           style: :compact %>
-<%= render 'schools/prompts/join_programme', school: @school, style: :compact %>
-<%= render 'schools/prompts/audit', audit: Audits::AuditService.new(@school).last_audit, style: :compact %>
+<div class='pt-1'>
+  <%= render 'schools/prompts/complete_programme',
+             programmes: @school.programmes.active.started.order(started_on: :desc),
+             style: :compact %>
+  <%= render 'schools/prompts/join_programme', school: @school, style: :compact %>
+  <%= render 'schools/prompts/audit', audit: Audits::AuditService.new(@school).last_audit, style: :compact %>
+</div>
 
 <% display_options = { classes: 'pb-4', limit: 5, limit_lg: 3 } %>
 <% display_limit = display_options[:limit] %>


### PR DESCRIPTION
Not sure what I think about the blue background in the header here. Just putting it up here to see what you think @ldodds 

<img width="1748" height="2259" alt="screencapture-localhost-3000-schools-south-ferriby-primary-school-recommendations-2026-07-15-19_02_49" src="https://github.com/user-attachments/assets/e4965cc7-d30c-49c3-b1be-9b779ee00978" />

With some text breaking up the blue header and the prompts (doesn't have to be this text):
<img width="1309" height="2503" alt="screencapture-localhost-3000-schools-south-ferriby-primary-school-recommendations-2026-07-16-08_28_51" src="https://github.com/user-attachments/assets/307373d0-3c8f-4905-836c-f1156c9c72e0" />

With the white background:
<img width="1309" height="2423" alt="screencapture-localhost-3000-schools-south-ferriby-primary-school-recommendations-2026-07-16-08_29_56" src="https://github.com/user-attachments/assets/28546cc0-cffa-483f-8030-732a8dee6e47" />

