### PR TITLE
Fix icon colour issue for dark themed cards

### DIFF
--- a/app/assets/stylesheets/_themes.scss
+++ b/app/assets/stylesheets/_themes.scss
@@ -2,7 +2,6 @@
   &.theme-dark {
     background-color: $blue-very-dark;
     color: $blue-light;
-    --elements-icon-colour: #{$blue-very-dark};
 
     h1, h2, h3, h4, h5, h6, .text-main {
       color: $white;
@@ -27,6 +26,10 @@
 
     .btn-secondary {
       @extend .btn-outline-white;
+    }
+
+    &.prompt-component .elements-icon-component {
+      color: $blue-very-dark;
     }
   }
 
@@ -73,8 +76,4 @@
   &.theme-pale {
     background-color: $blue-pale;
   }
-}
-
-.elements-icon-component {
-  color: var(--elements-icon-colour, currentColor);
 }

--- a/app/assets/stylesheets/_themes.scss
+++ b/app/assets/stylesheets/_themes.scss
@@ -2,6 +2,7 @@
   &.theme-dark {
     background-color: $blue-very-dark;
     color: $blue-light;
+    --elements-icon-colour: #{$blue-very-dark};
 
     h1, h2, h3, h4, h5, h6, .text-main {
       color: $white;
@@ -26,10 +27,6 @@
 
     .btn-secondary {
       @extend .btn-outline-white;
-    }
-
-    .elements-icon-component {
-      color: $blue-very-dark;
     }
   }
 
@@ -76,4 +73,8 @@
   &.theme-pale {
     background-color: $blue-pale;
   }
+}
+
+.elements-icon-component {
+  color: var(--elements-icon-colour, currentColor);
 }

--- a/app/views/shared/tasks/prompts/_login_to_record.html.erb
+++ b/app/views/shared/tasks/prompts/_login_to_record.html.erb
@@ -3,7 +3,7 @@
 <%# i18n-tasks-use t('tasks.activity.record_this') %>
 <%# i18n-tasks-use t('tasks.action.record_this') %>
 
-<%= render PromptComponent.new(icon: 'tasks', classes: 'mb-4 theme theme-dark') do |prompt| %>
+<%= render PromptComponent.new(icon: 'tasks', theme: :dark, classes: 'mb-4') do |prompt| %>
   <% prompt.with_title { t('tasks.login_to_record.are_you_an_energy_sparks_user') } %>
   <% prompt.with_content_action do |c| %>
       <% c.with_body do %>


### PR DESCRIPTION
This works but not sure it's as robust as I thought, as it's dependant on the order css is output by asset pipeline