### PR TITLE
Create new group level solar advice page

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -701,6 +701,13 @@ source_lang  = en
 type         = YML
 minimum_perc = 100
 
+[o:energy-sparks:p:energy-sparks:r:views-home-our_impact-yml]
+file_filter  = config/locales/<lang>/views/home/our_impact.yml
+source_file  = config/locales/views/home/our_impact.yml
+source_lang  = en
+type         = YML
+minimum_perc = 100
+
 [o:energy-sparks:p:energy-sparks:r:views-home-privacy_and_cookie_policy-yml]
 file_filter  = config/locales/<lang>/views/home/privacy_and_cookie_policy.yml
 source_file  = config/locales/views/home/privacy_and_cookie_policy.yml
@@ -851,6 +858,13 @@ minimum_perc = 100
 [o:energy-sparks:p:energy-sparks:r:views-school_groups-advice-long_term-yml]
 file_filter  = config/locales/<lang>/views/school_groups/advice/long_term.yml
 source_file  = config/locales/views/school_groups/advice/long_term.yml
+source_lang  = en
+type         = YML
+minimum_perc = 100
+
+[o:energy-sparks:p:energy-sparks:r:views-school_groups-advice-solar_pv-yml]
+file_filter  = config/locales/<lang>/views/school_groups/advice/solar_pv.yml
+source_file  = config/locales/views/school_groups/advice/solar_pv.yml
 source_lang  = en
 type         = YML
 minimum_perc = 100

--- a/analytics/config/locales/benchmarking/content_base.yml
+++ b/analytics/config/locales/benchmarking/content_base.yml
@@ -119,7 +119,7 @@ en:
           previous_year_temperature_adjusted: Previous year (temperature adjusted)
           projected_usage_by_end_of_holiday: Projected usage by end of holiday
           pupils: Pupils
-          reduction_in_mains_consumption_pct: Reduction in mains consumption (%)
+          reduction_in_mains_consumption_pct: Reduction in mains consumption
           regression_model_optimum_start_r2: Regression model optimum start r2
           regression_model_optimum_start_sensitivity_to_outside_temperature: Regression model optimum start sensitivity to outside temperature
           regression_model_optimum_start_time: Regression model optimum start time
@@ -129,7 +129,7 @@ en:
           saving_if_matched_exemplar_school: Potential savings
           saving_if_same_all_year_around: Saving if same all year around (at latest tariff)
           saving_improving_timing: Saving improving timing
-          saving_optimal_panels: Annual saving at latest tariff if optimal panel size installed
+          saving_optimal_panels: Annual saving
           saving_through_improved_thermostatic_control: Saving through improved thermostatic control
           saving_through_turning_heating_off_in_warm_weather_kwh: Saving through turning heating off in warm weather (kWh)
           saving_with_pou_electric_hot_water: Saving with POU electric hot water
@@ -137,7 +137,7 @@ en:
           school: School
           school_day_closed: School Day Closed
           school_day_open: School Day Open
-          size_kwp: 'Capacity (kWp)'
+          size_kwp: Capacity (kWp)
           solar_export: Export (kWh)
           solar_generation: Generation (kWh)
           solar_mains_consume: Mains consumption (kWh)

--- a/analytics/config/locales/benchmarking/content_base.yml
+++ b/analytics/config/locales/benchmarking/content_base.yml
@@ -105,7 +105,7 @@ en:
           number_of_days_heating_on_in_warm_weather: Number of days heating on in warm weather
           optimum_start_rating: Optimum start rating
           overnight_charging: Overnight charging
-          payback_years: Payback (years)
+          payback_years: Payback years
           percent_above_or_below_target_since_target_set: Percent above or below target since target set
           percent_increase_on_winter_baseload_over_summer: Percent increase on winter baseload over summer
           percentage_of_annual_heating_consumed_in_warm_weather: Percentage of annual heating consumed in warm weather
@@ -137,7 +137,7 @@ en:
           school: School
           school_day_closed: School Day Closed
           school_day_open: School Day Open
-          size_kwp: 'Size: kWp'
+          size_kwp: 'Capacity (kWp)'
           solar_export: Export (kWh)
           solar_generation: Generation (kWh)
           solar_mains_consume: Mains consumption (kWh)

--- a/app/components/dashboards/group_advice_page_list_component.rb
+++ b/app/components/dashboards/group_advice_page_list_component.rb
@@ -1,7 +1,6 @@
 module Dashboards
   class GroupAdvicePageListComponent < ApplicationComponent
     attr_reader :school_group, :fuel_types
-    GROUP_ADVICE_PAGES = %w[baseload electricity_long_term electricity_out_of_hours gas_long_term gas_out_of_hours heating_control].freeze
 
     include ApplicationHelper
     include AdvicePageHelper

--- a/app/components/dashboards/group_alerts_component.rb
+++ b/app/components/dashboards/group_alerts_component.rb
@@ -2,7 +2,7 @@ module Dashboards
   # FIXME should use PromptList directly, and pass through additional prompts if possible.
   class GroupAlertsComponent < ApplicationComponent
     ALERT_GROUPS = %w[priority change benchmarking advice].freeze # specific order
-    GROUP_ADVICE_PAGES = %w[baseload electricity_long_term electricity_out_of_hours gas_long_term gas_out_of_hours heating_control].freeze
+    GROUP_ADVICE_PAGES = %w[baseload electricity_long_term electricity_out_of_hours gas_long_term gas_out_of_hours heating_control solar_pv].freeze
 
     attr_reader :school_group, :limit
 

--- a/app/controllers/comparisons/solar_generation_summary_controller.rb
+++ b/app/controllers/comparisons/solar_generation_summary_controller.rb
@@ -23,7 +23,8 @@ module Comparisons
     def create_charts(results)
       create_multi_chart(results, {
                            annual_mains_consumed_kwh: :solar_mains_consume,
-                           annual_solar_pv_consumed_onsite_kwh: :solar_self_consume
+                           annual_solar_pv_consumed_onsite_kwh: :solar_self_consume,
+                           annual_exported_solar_pv_kwh: :solar_export
                          }, 1.0, :kwh)
     end
   end

--- a/app/controllers/comparisons/solar_generation_summary_controller.rb
+++ b/app/controllers/comparisons/solar_generation_summary_controller.rb
@@ -1,16 +1,11 @@
+# frozen_string_literal: true
+
 module Comparisons
   class SolarGenerationSummaryController < BaseController
     private
 
     def headers
-      [
-        t('analytics.benchmarking.configuration.column_headings.school'),
-        t('analytics.benchmarking.configuration.column_headings.solar_generation'),
-        t('analytics.benchmarking.configuration.column_headings.solar_self_consume'),
-        t('analytics.benchmarking.configuration.column_headings.solar_export'),
-        t('analytics.benchmarking.configuration.column_headings.solar_mains_consume'),
-        t('analytics.benchmarking.configuration.column_headings.solar_mains_onsite')
-      ]
+      Comparison::SolarGenerationSummary.report_headers
     end
 
     def key
@@ -28,8 +23,7 @@ module Comparisons
     def create_charts(results)
       create_multi_chart(results, {
                            annual_mains_consumed_kwh: :solar_mains_consume,
-                           annual_solar_pv_consumed_onsite_kwh: :solar_self_consume,
-                           annual_exported_solar_pv_kwh: :solar_export
+                           annual_solar_pv_consumed_onsite_kwh: :solar_self_consume
                          }, 1.0, :kwh)
     end
   end

--- a/app/controllers/comparisons/solar_generation_summary_controller.rb
+++ b/app/controllers/comparisons/solar_generation_summary_controller.rb
@@ -24,5 +24,13 @@ module Comparisons
     def load_data
       Comparison::SolarGenerationSummary.for_schools(@schools).with_data.sort_default
     end
+
+    def create_charts(results)
+      create_multi_chart(results, {
+                           annual_mains_consumed_kwh: :solar_mains_consume,
+                           annual_solar_pv_consumed_onsite_kwh: :solar_self_consume,
+                           annual_exported_solar_pv_kwh: :solar_export
+                         }, 1.0, :kwh)
+    end
   end
 end

--- a/app/controllers/comparisons/solar_pv_benefit_estimate_controller.rb
+++ b/app/controllers/comparisons/solar_pv_benefit_estimate_controller.rb
@@ -3,13 +3,7 @@ module Comparisons
     private
 
     def headers
-      [
-        t('analytics.benchmarking.configuration.column_headings.school'),
-        t('analytics.benchmarking.configuration.column_headings.size_kwp'),
-        t('analytics.benchmarking.configuration.column_headings.payback_years'),
-        t('analytics.benchmarking.configuration.column_headings.reduction_in_mains_consumption_pct'),
-        t('analytics.benchmarking.configuration.column_headings.saving_optimal_panels')
-      ]
+      Comparison::SolarPvBenefitEstimate.report_headers
     end
 
     def key

--- a/app/controllers/school_groups/advice/solar_pv_controller.rb
+++ b/app/controllers/school_groups/advice/solar_pv_controller.rb
@@ -3,21 +3,38 @@
 module SchoolGroups
   module Advice
     class SolarPvController < BaseAdviceWithComparisonController
+      before_action :set_benefit_report, only: %i[insights analysis]
+
       def insights
         @insight_table_headers = insight_table_headers
+        @benefit_table_headers = insight_benefit_table_headers
       end
 
       def analysis
         @solar_generation_summary_headers = Comparison::SolarGenerationSummary.report_headers
+        @benefit_table_headers = Comparison::SolarPvBenefitEstimate.report_headers
       end
 
       private
+
+      def set_benefit_report
+        @benefit_report = Comparison::Report.find_by!(key: :solar_pv_benefit_estimate)
+        @benefit_report_results = Comparison::SolarPvBenefitEstimate.for_schools(@schools).with_data.sort_default
+      end
 
       def insight_table_headers
         [
           t('analytics.benchmarking.configuration.column_headings.school'),
           t('analytics.benchmarking.configuration.column_headings.solar_mains_consume'),
           t('analytics.benchmarking.configuration.column_headings.solar_self_consume')
+        ]
+      end
+
+      def insight_benefit_table_headers
+        [
+          t('analytics.benchmarking.configuration.column_headings.school'),
+          t('analytics.benchmarking.configuration.column_headings.reduction_in_mains_consumption_pct'),
+          t('analytics.benchmarking.configuration.column_headings.saving_optimal_panels')
         ]
       end
 

--- a/app/controllers/school_groups/advice/solar_pv_controller.rb
+++ b/app/controllers/school_groups/advice/solar_pv_controller.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module SchoolGroups
+  module Advice
+    class SolarPvController < BaseAdviceWithComparisonController
+      def insights
+        @insight_table_headers = insight_table_headers
+      end
+
+      def analysis
+        @solar_generation_summary_headers = Comparison::SolarGenerationSummary.report_headers
+      end
+
+      private
+
+      def insight_table_headers
+        [
+          t('analytics.benchmarking.configuration.column_headings.school'),
+          t('analytics.benchmarking.configuration.column_headings.solar_mains_consume'),
+          t('analytics.benchmarking.configuration.column_headings.solar_self_consume')
+        ]
+      end
+
+      def advice_page_key
+        :solar_pv
+      end
+
+      def report_key
+        :solar_generation_summary
+      end
+
+      def load_data
+        Comparison::SolarGenerationSummary.for_schools(@schools).with_data.sort_default
+      end
+
+      def breadcrumbs
+        build_breadcrumbs([
+                            { name: I18n.t('advice_pages.breadcrumbs.root'),
+                              href: school_group_advice_path(@school_group) },
+                            { name: I18n.t('advice_pages.solar_pv.has_solar_pv.page_title') }
+                          ])
+      end
+    end
+  end
+end

--- a/app/models/chart_data_values.rb
+++ b/app/models/chart_data_values.rb
@@ -128,6 +128,9 @@ class ChartDataValues
       I18n.t("analytics.series_data_manager.series_name.#{SolarPVPanels::SOLAR_PV_ONSITE_ELECTRIC_CONSUMPTION_METER_NAME_I18N_KEY}") => Colours.chart_electricity_consumed_from_solar_pv,
       I18n.t("analytics.series_data_manager.series_name.#{SolarPVPanels::ELECTRIC_CONSUMED_FROM_MAINS_METER_NAME_I18N_KEY}") => Colours.chart_electric_dark,
       I18n.t("analytics.series_data_manager.series_name.#{SolarPVPanels::SOLAR_PV_EXPORTED_ELECTRIC_METER_NAME_I18N_KEY}") => Colours.chart_gas_light_line,
+      I18n.t('analytics.benchmarking.configuration.column_headings.solar_self_consume') => Colours.chart_electricity_consumed_from_solar_pv,
+      I18n.t('analytics.benchmarking.configuration.column_headings.solar_mains_consume') => Colours.chart_electric_dark,
+      I18n.t('analytics.benchmarking.configuration.column_headings.solar_export') => Colours.chart_gas_light_line,
       I18n.t('analytics.series_data_manager.y2_solar_label') => Colours.chart_y2_solar_label,
       I18n.t('analytics.series_data_manager.y2_rating') => Colours.chart_y2_rating
     }

--- a/app/models/comparison/solar_generation_summary.rb
+++ b/app/models/comparison/solar_generation_summary.rb
@@ -18,4 +18,15 @@
 class Comparison::SolarGenerationSummary < Comparison::View
   scope :with_data, -> { where.not(annual_solar_pv_kwh: nil) }
   scope :sort_default, -> { joins(:school).order('schools.name') }
+
+  def self.report_headers
+    [
+      I18n.t('analytics.benchmarking.configuration.column_headings.school'),
+      I18n.t('analytics.benchmarking.configuration.column_headings.solar_mains_consume'),
+      I18n.t('analytics.benchmarking.configuration.column_headings.solar_generation'),
+      I18n.t('analytics.benchmarking.configuration.column_headings.solar_self_consume'),
+      I18n.t('analytics.benchmarking.configuration.column_headings.solar_export'),
+      I18n.t('analytics.benchmarking.configuration.column_headings.solar_mains_onsite')
+    ]
+  end
 end

--- a/app/models/comparison/solar_pv_benefit_estimate.rb
+++ b/app/models/comparison/solar_pv_benefit_estimate.rb
@@ -17,5 +17,15 @@
 #
 class Comparison::SolarPvBenefitEstimate < Comparison::View
   scope :with_data, -> { where.not(optimum_kwp: nil) }
-  scope :sort_default, -> { order(optimum_kwp: :desc) }
+  scope :sort_default, -> { order(optimum_mains_reduction_percent: :desc) }
+
+  def self.report_headers
+    [
+      I18n.t('analytics.benchmarking.configuration.column_headings.school'),
+      I18n.t('analytics.benchmarking.configuration.column_headings.size_kwp'),
+      I18n.t('analytics.benchmarking.configuration.column_headings.payback_years'),
+      I18n.t('analytics.benchmarking.configuration.column_headings.reduction_in_mains_consumption_pct'),
+      I18n.t('analytics.benchmarking.configuration.column_headings.saving_optimal_panels')
+    ]
+  end
 end

--- a/app/views/comparisons/solar_generation_summary/_table.csv.ruby
+++ b/app/views/comparisons/solar_generation_summary/_table.csv.ruby
@@ -3,10 +3,10 @@ CSV.generate do |csv|
   @results.each do |result|
     csv << [
       result.school.name,
+      format_unit(result.annual_mains_consumed_kwh, Float, true, :benchmark),
       format_unit(result.annual_solar_pv_kwh, Float, true, :benchmark),
       format_unit(result.annual_solar_pv_consumed_onsite_kwh, Float, true, :benchmark),
       format_unit(result.annual_exported_solar_pv_kwh, Float, true, :benchmark),
-      format_unit(result.annual_mains_consumed_kwh, Float, true, :benchmark),
       format_unit(result.annual_electricity_kwh, Float, true, :benchmark)
     ]
   end

--- a/app/views/comparisons/solar_generation_summary/_table.html.erb
+++ b/app/views/comparisons/solar_generation_summary/_table.html.erb
@@ -2,7 +2,7 @@
       report: report, advice_page: advice_page, table_name: table_name, index_params: index_params,
       headers: headers, colgroups: colgroups, advice_page_tab: advice_page_tab
     ) do |c| %>
-  <% @results.each do |result| %>
+  <% results.each do |result| %>
     <% c.with_row do |r| %>
       <% r.with_school school: result.school %>
       <%= r.with_var val: result.annual_mains_consumed_kwh, unit: :kwh %>

--- a/app/views/comparisons/solar_generation_summary/_table.html.erb
+++ b/app/views/comparisons/solar_generation_summary/_table.html.erb
@@ -5,10 +5,10 @@
   <% @results.each do |result| %>
     <% c.with_row do |r| %>
       <% r.with_school school: result.school %>
+      <%= r.with_var val: result.annual_mains_consumed_kwh, unit: :kwh %>
       <%= r.with_var val: result.annual_solar_pv_kwh, unit: :kwh %>
       <%= r.with_var val: result.annual_solar_pv_consumed_onsite_kwh, unit: :kwh %>
       <%= r.with_var val: result.annual_exported_solar_pv_kwh, unit: :kwh %>
-      <%= r.with_var val: result.annual_mains_consumed_kwh, unit: :kwh %>
       <%= r.with_var val: result.annual_electricity_kwh, unit: :kwh %>
     <% end %>
   <% end %>

--- a/app/views/comparisons/solar_pv_benefit_estimate/_table.html.erb
+++ b/app/views/comparisons/solar_pv_benefit_estimate/_table.html.erb
@@ -2,7 +2,7 @@
       report: report, advice_page: advice_page, table_name: table_name, index_params: index_params,
       headers: headers, colgroups: colgroups, advice_page_tab: advice_page_tab
     ) do |c| %>
-  <% @results.each do |result| %>
+  <% results.each do |result| %>
     <% c.with_row do |r| %>
       <% r.with_school school: result.school %>
       <% r.with_reference key: 'tariff_changed_last_year',
@@ -12,8 +12,5 @@
       <%= r.with_var val: result.optimum_mains_reduction_percent, unit: :percent %>
       <%= r.with_var val: result.one_year_saving_gbpcurrent, unit: :£current %>
     <% end %>
-  <% end %>
-  <% c.with_note do %>
-    <%= t('analytics.benchmarking.configuration.column_heading_explanation.last_year_definition_html') %>
   <% end %>
 <% end %>

--- a/app/views/school_groups/advice/shared/_nav.html.erb
+++ b/app/views/school_groups/advice/shared/_nav.html.erb
@@ -53,6 +53,11 @@
     <% s.with_item(name: I18n.t('advice_pages.nav.pages.electricity_long_term'),
                    href: school_group_advice_electricity_long_term_path(school_group),
                    classes: 'small electric-item') %>
+    <% if Flipper.enabled?(:group_solar_advice_page, current_user) %>
+      <% s.with_item(name: I18n.t('advice_pages.nav.pages.solar_pv'),
+                     href: school_group_advice_solar_pv_path(school_group),
+                     classes: 'small electric-item') %>
+    <% end %>
   <% end %>
   <% c.with_section(name: t('advice_pages.nav.sections.gas'),
                     icon: fuel_type_icon(:gas), classes: 'gas-section',

--- a/app/views/school_groups/advice/solar_pv/_analysis.html.erb
+++ b/app/views/school_groups/advice/solar_pv/_analysis.html.erb
@@ -1,0 +1,44 @@
+<p><%= t('school_groups.advice_pages.solar_pv.analysis.summary') %></p>
+
+<ul>
+  <li>
+    <%= link_to(t('school_groups.advice_pages.solar_pv.analysis.potential_savings.title'),
+                '#potential-savings') %>
+  </li>
+  <li>
+    <%= link_to(t('school_groups.advice_pages.solar_pv.analysis.comparisons.title'), '#comparison') %>
+  </li>
+</ul>
+
+<%= render 'schools/advice/section_title',
+           section_id: 'comparison',
+           section_title: t('school_groups.advice_pages.solar_pv.analysis.potential_savings.title') %>
+
+<%= render 'schools/advice/section_title',
+           section_id: 'comparison',
+           section_title: t('school_groups.advice_pages.solar_pv.analysis.comparisons.title') %>
+
+<%= render Charts::GroupComparisonChartComponent.new(school_group: @school_group,
+                                                     report: @report,
+                                                     classes: 'mb-4') do |c| %>
+  <% c.with_title { I18n.t('school_groups.advice_pages.solar_pv.analysis.comparisons.chart.title') } %>
+  <% c.with_subtitle { I18n.t('school_groups.advice_pages.solar_pv.analysis.comparisons.chart.subtitle') } %>
+  <% c.with_header { I18n.t('school_groups.advice_pages.solar_pv.analysis.comparisons.chart.header') } %>
+  <% c.with_footer do %>
+    <%= render 'school_groups/advice/shared/analysis_footnotes_link' %>
+  <% end %>
+<% end %>
+
+<%= t('school_groups.advice_pages.solar_pv.analysis.comparisons.table.header_html') %>
+
+<%= render 'comparisons/solar_generation_summary/table',
+           results: @results,
+           report: @report,
+           advice_page: @advice_page,
+           table_name: :table,
+           index_params: index_params,
+           headers: @solar_generation_summary_headers,
+           colgroups: [],
+           advice_page_tab: @advice_page_tab,
+           table_classes: comparison_table_class(@results),
+           table_number: 0 %>

--- a/app/views/school_groups/advice/solar_pv/_analysis.html.erb
+++ b/app/views/school_groups/advice/solar_pv/_analysis.html.erb
@@ -2,8 +2,8 @@
 
 <ul>
   <li>
-    <%= link_to(t('school_groups.advice_pages.solar_pv.analysis.potential_savings.title'),
-                '#potential-savings') %>
+    <%= link_to(t('school_groups.advice_pages.solar_pv.analysis.potential_benefits.title'),
+                '#potential-benefits') %>
   </li>
   <li>
     <%= link_to(t('school_groups.advice_pages.solar_pv.analysis.comparisons.title'), '#comparison') %>
@@ -12,9 +12,9 @@
 
 <%= render 'schools/advice/section_title',
            section_id: 'comparison',
-           section_title: t('school_groups.advice_pages.solar_pv.analysis.potential_savings.title') %>
+           section_title: t('school_groups.advice_pages.solar_pv.analysis.potential_benefits.title') %>
 
-<%= t('school_groups.advice_pages.solar_pv.analysis.potential_savings.summary_html') %>
+<%= t('school_groups.advice_pages.solar_pv.analysis.potential_benefits.summary_html') %>
 
 <%= render 'comparisons/solar_pv_benefit_estimate/table',
            results: @benefit_report_results,

--- a/app/views/school_groups/advice/solar_pv/_analysis.html.erb
+++ b/app/views/school_groups/advice/solar_pv/_analysis.html.erb
@@ -14,6 +14,20 @@
            section_id: 'comparison',
            section_title: t('school_groups.advice_pages.solar_pv.analysis.potential_savings.title') %>
 
+<%= t('school_groups.advice_pages.solar_pv.analysis.potential_savings.summary_html') %>
+
+<%= render 'comparisons/solar_pv_benefit_estimate/table',
+           results: @benefit_report_results,
+           report: @benefit_report,
+           advice_page: @advice_page,
+           table_name: :table,
+           index_params: index_params,
+           headers: @benefit_table_headers,
+           colgroups: [],
+           advice_page_tab: :analysis,
+           table_classes: comparison_table_class(@benefit_report_results),
+           table_number: 0 %>
+
 <%= render 'schools/advice/section_title',
            section_id: 'comparison',
            section_title: t('school_groups.advice_pages.solar_pv.analysis.comparisons.title') %>
@@ -39,6 +53,6 @@
            index_params: index_params,
            headers: @solar_generation_summary_headers,
            colgroups: [],
-           advice_page_tab: @advice_page_tab,
+           advice_page_tab: :analysis,
            table_classes: comparison_table_class(@results),
            table_number: 0 %>

--- a/app/views/school_groups/advice/solar_pv/_analysis.html.erb
+++ b/app/views/school_groups/advice/solar_pv/_analysis.html.erb
@@ -11,7 +11,7 @@
 </ul>
 
 <%= render 'schools/advice/section_title',
-           section_id: 'comparison',
+           section_id: 'potential-benefits',
            section_title: t('school_groups.advice_pages.solar_pv.analysis.potential_benefits.title') %>
 
 <%= t('school_groups.advice_pages.solar_pv.analysis.potential_benefits.summary_html') %>

--- a/app/views/school_groups/advice/solar_pv/_insights.html.erb
+++ b/app/views/school_groups/advice/solar_pv/_insights.html.erb
@@ -4,13 +4,34 @@
 
 <%= render 'schools/advice/section_title',
            section_id: 'current-benefits',
+           section_title: t('school_groups.advice_pages.solar_pv.insights.potential_benefits.title') %>
+
+<%= t('school_groups.advice_pages.solar_pv.insights.potential_benefits.summary_html',
+      link: analysis_school_group_advice_solar_pv_path(@school_group, anchor: 'potential-savings')) %>
+
+<%= render ComparisonTableComponent.new(
+      advice_page: @advice_page, advice_page_tab: :analysis,
+      colgroups: [], headers: @benefit_table_headers, index_params: index_params,
+      report: @benefit_report, table_name: :table, table_classes: comparison_table_class(@benefit_report_results)
+    ) do |c| %>
+  <% @benefit_report_results.each do |result| %>
+    <% c.with_row do |r| %>
+      <% r.with_school school: result.school %>
+      <%= r.with_var val: result.optimum_mains_reduction_percent, unit: :percent %>
+      <%= r.with_var val: result.one_year_saving_gbpcurrent, unit: :£current %>
+    <% end %>
+  <% end %>
+<% end %>
+
+<%= render 'schools/advice/section_title',
+           section_id: 'current-benefits',
            section_title: t('school_groups.advice_pages.solar_pv.insights.current_benefits.title') %>
 
 <%= t('school_groups.advice_pages.solar_pv.insights.current_benefits.summary_html',
       link: analysis_school_group_advice_solar_pv_path(@school_group, anchor: 'comparison')) %>
 
 <%= render ComparisonTableComponent.new(
-      advice_page: @advice_page, advice_page_tab: @advice_page_tab,
+      advice_page: @advice_page, advice_page_tab: :analysis,
       colgroups: [], headers: @insight_table_headers, index_params: index_params,
       report: @report, table_name: :table, table_classes: comparison_table_class(@results)
     ) do |c| %>

--- a/app/views/school_groups/advice/solar_pv/_insights.html.erb
+++ b/app/views/school_groups/advice/solar_pv/_insights.html.erb
@@ -7,7 +7,7 @@
            section_title: t('school_groups.advice_pages.solar_pv.insights.potential_benefits.title') %>
 
 <%= t('school_groups.advice_pages.solar_pv.insights.potential_benefits.summary_html',
-      link: analysis_school_group_advice_solar_pv_path(@school_group, anchor: 'potential-savings')) %>
+      link: analysis_school_group_advice_solar_pv_path(@school_group, anchor: 'potential-benefits')) %>
 
 <%= render ComparisonTableComponent.new(
       advice_page: @advice_page, advice_page_tab: :analysis,

--- a/app/views/school_groups/advice/solar_pv/_insights.html.erb
+++ b/app/views/school_groups/advice/solar_pv/_insights.html.erb
@@ -1,0 +1,24 @@
+<%= render PromptComponent.new(status: :none, icon: :lightbulb) do |c| %>
+  <%= t('school_groups.advice_pages.solar_pv.insights.summary_html') %>
+<% end %>
+
+<%= render 'schools/advice/section_title',
+           section_id: 'current-benefits',
+           section_title: t('school_groups.advice_pages.solar_pv.insights.current_benefits.title') %>
+
+<%= t('school_groups.advice_pages.solar_pv.insights.current_benefits.summary_html',
+      link: analysis_school_group_advice_solar_pv_path(@school_group, anchor: 'comparison')) %>
+
+<%= render ComparisonTableComponent.new(
+      advice_page: @advice_page, advice_page_tab: @advice_page_tab,
+      colgroups: [], headers: @insight_table_headers, index_params: index_params,
+      report: @report, table_name: :table, table_classes: comparison_table_class(@results)
+    ) do |c| %>
+  <% @results.each do |result| %>
+    <% c.with_row do |r| %>
+      <% r.with_school school: result.school %>
+      <%= r.with_var val: result.annual_mains_consumed_kwh, unit: :kwh %>
+      <%= r.with_var val: result.annual_solar_pv_consumed_onsite_kwh, unit: :kwh %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/config/locales/analytics/benchmarking/content_base.yml
+++ b/config/locales/analytics/benchmarking/content_base.yml
@@ -105,7 +105,7 @@ en:
           number_of_days_heating_on_in_warm_weather: Number of days heating on in warm weather
           optimum_start_rating: Optimum start rating
           overnight_charging: Overnight charging
-          payback_years: Payback (years)
+          payback_years: Payback years
           percent_above_or_below_target_since_target_set: Percent above or below target since target set
           percent_increase_on_winter_baseload_over_summer: Percent increase on winter baseload over summer
           percentage_of_annual_heating_consumed_in_warm_weather: Percentage of annual heating consumed in warm weather
@@ -119,7 +119,7 @@ en:
           previous_year_temperature_adjusted: Previous year (temperature adjusted)
           projected_usage_by_end_of_holiday: Projected usage by end of holiday
           pupils: Pupils
-          reduction_in_mains_consumption_pct: Reduction in mains consumption (%)
+          reduction_in_mains_consumption_pct: Reduction in mains consumption
           regression_model_optimum_start_r2: Regression model optimum start r2
           regression_model_optimum_start_sensitivity_to_outside_temperature: Regression model optimum start sensitivity to outside temperature
           regression_model_optimum_start_time: Regression model optimum start time
@@ -129,7 +129,7 @@ en:
           saving_if_matched_exemplar_school: Potential savings
           saving_if_same_all_year_around: Saving if same all year around (at latest tariff)
           saving_improving_timing: Saving improving timing
-          saving_optimal_panels: Annual saving at latest tariff if optimal panel size installed
+          saving_optimal_panels: Annual saving
           saving_through_improved_thermostatic_control: Saving through improved thermostatic control
           saving_through_turning_heating_off_in_warm_weather_kwh: Saving through turning heating off in warm weather (kWh)
           saving_with_pou_electric_hot_water: Saving with POU electric hot water
@@ -137,7 +137,7 @@ en:
           school: School
           school_day_closed: School Day Closed
           school_day_open: School Day Open
-          size_kwp: 'Size: kWp'
+          size_kwp: Capacity (kWp)
           solar_export: Export (kWh)
           solar_generation: Generation (kWh)
           solar_mains_consume: Mains consumption (kWh)

--- a/config/locales/views/school_groups/advice/advice.yml
+++ b/config/locales/views/school_groups/advice/advice.yml
@@ -28,5 +28,6 @@ en:
           gas_long_term: See long term trends in your gas use
           gas_out_of_hours: How much of gas are schools using is outside of school hours?
           heating_control: Review how well schools are managing their heating
+          solar_pv: Understand benefits of solar generation at these schools
         pages: Your group's energy use explained
         pages_intro: These pages provide more insights and analysis into energy use across the schools in this group. Areas that need improvement or where you are doing well have been highlighted.

--- a/config/locales/views/school_groups/advice/solar_pv.yml
+++ b/config/locales/views/school_groups/advice/solar_pv.yml
@@ -19,7 +19,7 @@ en:
                 exported to the national grid, with a comparison of how this compares to overall grid consumption.
                 </p>
             title: School comparison
-          potential_savings:
+          potential_benefits:
             summary_html: |-
               <p>
                 The table below summarises the potential benefits of installing solar at schools which don't already
@@ -37,7 +37,7 @@ en:
                 each school, and our internal estimates of solar installation costs per kWp. The savings assume installation
                 of estimated panel sizes. View the analysis for individual schools for more details and scenarios.
               </p>
-            title: Potential savings
+            title: Potential benefits
           summary: This page provides an overview of how schools are benefitting from installed solar panels and estimates of potential benefits of installing solar at additional schools.
         insights:
           current_benefits:

--- a/config/locales/views/school_groups/advice/solar_pv.yml
+++ b/config/locales/views/school_groups/advice/solar_pv.yml
@@ -20,6 +20,22 @@ en:
                 </p>
             title: School comparison
           potential_savings:
+            summary_html: |-
+              <p>
+                The table below summarises the potential benefits of installing solar at schools which don't already
+                have solar installed.
+              </p>
+              <p>
+                Our analysis combines the latest 12 months of half-hourly electricity data for each school with
+                data on local half-hourly solar generation data to estimate the potential benefits of installing solar panels.
+              </p>
+              <p>
+                Panel capacity is based on floor area data for each school. Actual available roof space may vary.
+              </p>
+              <p>
+                Cost savings and payback periods are calculated using the latest electricity tariff data available for
+                each school, and our internal estimates of solar installation costs per kWp.
+              </p>
             title: Potential savings
           summary: This page provides an overview of how schools are benefitting from installed solar panels and estimates of potential benefits of installing solar at additional schools.
         insights:
@@ -34,6 +50,16 @@ en:
               the solar generation with the mains consumption at each school.
               </p>
             title: Current benefits
+          potential_benefits:
+            summary_html: |-
+              <p>
+              The table below summarises the potential benefits of installing solar at schools which don't already
+              have solar installed.
+              </p>
+              <p>
+              A <a href="%{link}">more detailed table</a> with more notes on our analysis is also available.
+              </p>
+            title: Potential benefits
           summary_html: |-
             <p>Solar panels work well for schools as they produce most energy around midday which is when a school typically uses most energy.</p>
             <p>The panels reduce both the school's electricity consumption from the national grid and its carbon emissions. Electricity produced from solar panels produces very little carbon.</p>

--- a/config/locales/views/school_groups/advice/solar_pv.yml
+++ b/config/locales/views/school_groups/advice/solar_pv.yml
@@ -1,0 +1,40 @@
+---
+en:
+  school_groups:
+    advice_pages:
+      solar_pv:
+        analysis:
+          comparisons:
+            chart:
+              header: The following chart shows the amount of mains electricity each school is using, along with the amount of electricity consumed from panels and exported to the grid
+              subtitle: Solar generation summary based on the most recent 12 months of data for each school
+              title: Solar generation summary
+            table:
+              header_html: |-
+                <p>
+                The following table provides a more detailed breakdown of on-site solar generation data for each school. The analysis is based on the latest 12 months of data for each school.
+                </p>
+                <p>
+                The table indicates how much electricity is being generated on-site across all arrays, how much of this electricity is being consumed on-site or
+                exported to the national grid, with a comparison of how this compares to overall grid consumption.
+                </p>
+            title: School comparison
+          potential_savings:
+            title: Potential savings
+          summary: This page provides an overview of how schools are benefitting from installed solar panels and estimates of potential benefits of installing solar at additional schools.
+        insights:
+          current_benefits:
+            summary_html: |-
+              <p>
+              The following table summarises the solar generation data for schools in this group where we have access
+              to data from the solar monitoring system, or can estimate on-site generation and consumption.
+              <p>
+              <p>
+              A <a href="%{link}">more detailed table and a chart</a> is also available. This includes a comparison of
+              the solar generation with the mains consumption at each school.
+              </p>
+            title: Current benefits
+          summary_html: |-
+            <p>Solar panels work well for schools as they produce most energy around midday which is when a school typically uses most energy.</p>
+            <p>The panels reduce both the school's electricity consumption from the national grid and its carbon emissions. Electricity produced from solar panels produces very little carbon.</p>
+        page_title: Solar generation overview

--- a/config/locales/views/school_groups/advice/solar_pv.yml
+++ b/config/locales/views/school_groups/advice/solar_pv.yml
@@ -34,7 +34,8 @@ en:
               </p>
               <p>
                 Cost savings and payback periods are calculated using the latest electricity tariff data available for
-                each school, and our internal estimates of solar installation costs per kWp.
+                each school, and our internal estimates of solar installation costs per kWp. The savings assume installation
+                of estimated panel sizes. View the analysis for individual schools for more details and scenarios.
               </p>
             title: Potential savings
           summary: This page provides an overview of how schools are benefitting from installed solar panels and estimates of potential benefits of installing solar at additional schools.

--- a/config/locales/views/school_groups/advice/solar_pv.yml
+++ b/config/locales/views/school_groups/advice/solar_pv.yml
@@ -45,7 +45,7 @@ en:
               <p>
               The following table summarises the solar generation data for schools in this group where we have access
               to data from the solar monitoring system, or can estimate on-site generation and consumption.
-              <p>
+              </p>
               <p>
               A <a href="%{link}">more detailed table and a chart</a> is also available. This includes a comparison of
               the solar generation with the mains consumption at each school.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -312,7 +312,8 @@ Rails.application.routes.draw do
            gas_out_of_hours
            electricity_long_term
            gas_long_term
-           heating_control].each do |page|
+           heating_control
+           solar_pv].each do |page|
           # Override Rails default behaviour of mapping HEAD request to a GET and send to a
           # generic action method that returns OK with no content.
           %i[insights analysis].each do |action|

--- a/lib/tasks/deployment/20260722125905_group_solar_advice_page_feature.rake
+++ b/lib/tasks/deployment/20260722125905_group_solar_advice_page_feature.rake
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+namespace :after_party do
+  desc 'Deployment task: group_solar_advice_page_feature'
+  task group_solar_advice_page_feature: :environment do
+    puts "Running deploy task 'group_solar_advice_page_feature'"
+
+    Flipper.add(:group_solar_advice_page)
+    Flipper.enable_group(:group_solar_advice_page, :admins)
+
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord
+      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+  end
+end

--- a/spec/components/dashboards/group_advice_page_list_component_spec.rb
+++ b/spec/components/dashboards/group_advice_page_list_component_spec.rb
@@ -5,20 +5,22 @@ require 'rails_helper'
 RSpec.describe Dashboards::GroupAdvicePageListComponent, :include_application_helper, :include_url_helpers,
                type: :component do
   let!(:school_group) { create(:school_group) }
-  let(:fuel_types) { %i[electricity gas storage_heaters] }
+  let(:fuel_types) { %i[electricity gas storage_heaters solar_pv] }
   let!(:school) { create(:school, school_group:) }
 
   context 'when advice pages exist' do
     before do
       create(:advice_page, key: :baseload, fuel_type: :electricity)
       create(:advice_page, key: :gas_long_term, fuel_type: :gas)
+      create(:advice_page, key: :solar_pv, fuel_type: :solar_pv)
+
       render_inline(described_class.new(school_group:, schools: school_group.schools, fuel_types:))
     end
 
     it { expect(page).to have_css('div.dashboards-group-advice-page-list-component') }
 
     it 'includes section titles for the group fuel types with group advice pages' do
-      %i[electricity gas].each do |fuel_type|
+      %i[electricity gas solar_pv].each do |fuel_type|
         expect(page).to have_text(I18n.t(fuel_type, scope: 'advice_pages.nav.sections'))
       end
     end

--- a/spec/models/chart_data_values_spec.rb
+++ b/spec/models/chart_data_values_spec.rb
@@ -220,6 +220,9 @@ describe ChartDataValues do
           'Electricity consumed from solar pv' => Colours.chart_electricity_consumed_from_solar_pv,
           'Electricity consumed from mains' => Colours.chart_electricity_consumed_from_mains,
           'Exported solar electricity (not consumed onsite)' => Colours.chart_exported_solar_electricity,
+          'Self consumption (kWh)' => Colours.chart_electricity_consumed_from_solar_pv,
+          'Mains consumption (kWh)' => Colours.chart_electricity_consumed_from_mains,
+          'Export (kWh)' => Colours.chart_exported_solar_electricity,
           'Solar irradiance (brightness of sunshine)' => Colours.chart_y2_solar_label,
           'Rating' => Colours.chart_y2_rating }
       )

--- a/spec/system/comparisons/solar_generation_summary_spec.rb
+++ b/spec/system/comparisons/solar_generation_summary_spec.rb
@@ -38,7 +38,7 @@ describe 'solar_generation_summary' do
       let(:expected_report) { report }
       let(:expected_school) { school }
       let(:headers) do
-        ['School', 'Generation (kWh)', 'Self consumption (kWh)', 'Export (kWh)', 'Mains consumption (kWh)',
+        ['School', 'Mains consumption (kWh)', 'Generation (kWh)', 'Self consumption (kWh)', 'Export (kWh)',
          'Total onsite consumption (kWh)']
       end
       let(:advice_page_path) { polymorphic_path([:insights, expected_school, :advice, advice_page_key]) }
@@ -46,10 +46,10 @@ describe 'solar_generation_summary' do
         [
           headers,
           [school.name,
+           '1,000',
            '2,500',
            '2,000',
            '500',
-           '1,000',
            '4,000']
         ]
       end
@@ -57,10 +57,10 @@ describe 'solar_generation_summary' do
         [
           headers,
           [school.name,
+           '1,000',
            '2,500',
            '2,000',
            '500',
-           '1,000',
            '4,000']
         ]
       end

--- a/spec/system/comparisons/solar_generation_summary_spec.rb
+++ b/spec/system/comparisons/solar_generation_summary_spec.rb
@@ -65,5 +65,9 @@ describe 'solar_generation_summary' do
         ]
       end
     end
+
+    it_behaves_like 'a school comparison report with a chart' do
+      let(:expected_report) { report }
+    end
   end
 end

--- a/spec/system/comparisons/solar_pv_benefit_estimate_spec.rb
+++ b/spec/system/comparisons/solar_pv_benefit_estimate_spec.rb
@@ -68,8 +68,7 @@ describe 'solar_pv_benefit_estimate' do
            '£1,000'],
           ["Notes\n" \
            '[5] The tariff has changed during the last year for this school. Savings are calculated using the latest ' \
-           'tariff but other £ values are calculated using the relevant tariff at the time' \
-           "\nIn school comparisons 'last year' is defined as this year to date."]
+           'tariff but other £ values are calculated using the relevant tariff at the time']
         ]
       end
       let(:expected_csv) do

--- a/spec/system/school_groups/advice/solar_pv_spec.rb
+++ b/spec/system/school_groups/advice/solar_pv_spec.rb
@@ -115,7 +115,9 @@ describe 'School group solar pv page' do
       end
 
       context 'with potential benefits section' do
-        it { expect(page).to have_text(I18n.t('school_groups.advice_pages.solar_pv.analysis.potential_savings.title')) }
+        it {
+          expect(page).to have_text(I18n.t('school_groups.advice_pages.solar_pv.analysis.potential_benefits.title'))
+        }
 
         it_behaves_like 'a school comparison report with a table', visit: false do
           let(:expected_report) { potential_benefit_report }

--- a/spec/system/school_groups/advice/solar_pv_spec.rb
+++ b/spec/system/school_groups/advice/solar_pv_spec.rb
@@ -5,7 +5,10 @@ require 'rails_helper'
 describe 'School group solar pv page' do
   let!(:school_group) { create(:school_group, :with_active_schools, public: true) }
   let!(:school) { create(:school, :with_fuel_configuration, school_group: school_group) }
-  let!(:report) { create(:report, key: :solar_generation_summary) }
+  let!(:no_solar_school) { create(:school, :with_fuel_configuration, school_group: school_group) }
+
+  let!(:current_benefit_report) { create(:report, key: :solar_generation_summary) }
+  let!(:potential_benefit_report) { create(:report, key: :solar_pv_benefit_estimate) }
 
   let(:solar_generation_variables) do
     {
@@ -17,6 +20,25 @@ describe 'School group solar pv page' do
     }
   end
 
+  let(:solar_benefit_variables) do
+    {
+      optimum_kwp: 44.2,
+      optimum_payback_years: 2.5,
+      optimum_mains_reduction_percent: 0.15,
+      one_year_saving_gbpcurrent: 1000
+    }
+  end
+
+  let(:additional_data_variables) do
+    {
+      electricity_economic_tariff_changed_this_year: true
+    }
+  end
+
+  include_context 'with comparison report footnotes' do
+    let(:footnotes) { [tariff_changed_last_year] }
+  end
+
   before do
     Flipper.enable(:group_solar_advice_page)
     create(:advice_page, key: :solar_pv)
@@ -24,10 +46,19 @@ describe 'School group solar pv page' do
     alert_run = create(:alert_generation_run, school: school)
 
     solar_generation_alert = create(:alert_type, class_name: 'AlertSolarGeneration')
-    create(:alert, school: school, alert_generation_run: alert_run, alert_type: solar_generation_alert,
-                   variables: solar_generation_variables)
+    create(:alert, school: school, alert_generation_run: alert_run,
+                   alert_type: solar_generation_alert, variables: solar_generation_variables)
+
+    solar_benefit_alert = create(:alert_type, class_name: 'AlertSolarPVBenefitEstimator')
+    create(:alert, school: no_solar_school, alert_generation_run: alert_run,
+                   alert_type: solar_benefit_alert, variables: solar_benefit_variables)
+
+    additional_data_alert = create(:alert_type, class_name: 'AlertAdditionalPrioritisationData')
+    create(:alert, school: no_solar_school, alert_generation_run: alert_run, alert_type: additional_data_alert,
+                   variables: additional_data_variables)
 
     Comparison::SolarGenerationSummary.refresh
+    Comparison::SolarPvBenefitEstimate.refresh
   end
 
   context 'when on the insights page' do
@@ -48,12 +79,21 @@ describe 'School group solar pv page' do
         let(:title) { I18n.t('school_groups.advice_pages.solar_pv.page_title') }
       end
 
-      it 'has the key insights section' do
+      it 'has the current benefits section' do
         expect(page).to have_text(I18n.t('school_groups.advice_pages.solar_pv.insights.current_benefits.title'))
         expect(page).to have_css('#solar_generation_summary-table')
         within('#solar_generation_summary-table') do
           expect(page).to have_text(school.name)
           expect(page).to have_text('1,000')
+        end
+      end
+
+      it 'has the potential benefits section' do
+        expect(page).to have_text(I18n.t('school_groups.advice_pages.solar_pv.insights.potential_benefits.title'))
+        expect(page).to have_css('#solar_pv_benefit_estimate-table')
+        within('#solar_pv_benefit_estimate-table') do
+          expect(page).to have_text(no_solar_school.name)
+          expect(page).to have_text('15&percnt;')
         end
       end
     end
@@ -74,13 +114,55 @@ describe 'School group solar pv page' do
         let(:title) { I18n.t('school_groups.advice_pages.solar_pv.page_title') }
       end
 
+      context 'with potential benefits section' do
+        it { expect(page).to have_text(I18n.t('school_groups.advice_pages.solar_pv.analysis.potential_savings.title')) }
+
+        it_behaves_like 'a school comparison report with a table', visit: false do
+          let(:expected_report) { potential_benefit_report }
+          let(:expected_school) { no_solar_school }
+          let(:advice_page_path) { analysis_school_advice_solar_pv_path(expected_school) }
+          let(:headers) do
+            [
+              I18n.t('analytics.benchmarking.configuration.column_headings.school'),
+              I18n.t('analytics.benchmarking.configuration.column_headings.size_kwp'),
+              I18n.t('analytics.benchmarking.configuration.column_headings.payback_years'),
+              I18n.t('analytics.benchmarking.configuration.column_headings.reduction_in_mains_consumption_pct'),
+              I18n.t('analytics.benchmarking.configuration.column_headings.saving_optimal_panels')
+            ]
+          end
+          let(:expected_table) do
+            [
+              headers,
+              ["#{no_solar_school.name} [5]",
+               '44.2',
+               '2 years 6 months',
+               '15&percnt;',
+               '£1,000'],
+              ["Notes\n" \
+               '[5] The tariff has changed during the last year for this school. Savings are calculated using the ' \
+               'latest tariff but other £ values are calculated using the relevant tariff at the time']
+            ]
+          end
+          let(:expected_csv) do
+            [
+              headers,
+              [no_solar_school.name,
+               '44.2',
+               '2.5',
+               '15',
+               '1,000']
+            ]
+          end
+        end
+      end
+
       context 'with comparison section' do
         it { expect(page).to have_text(I18n.t('school_groups.advice_pages.solar_pv.analysis.comparisons.title')) }
 
         it_behaves_like 'a school comparison report with a table', visit: false do
-          let(:expected_report) { report }
+          let(:expected_report) { current_benefit_report }
           let(:expected_school) { school }
-          let(:advice_page_path) { insights_school_advice_solar_pv_path(expected_school) }
+          let(:advice_page_path) { analysis_school_advice_solar_pv_path(expected_school) }
           let(:headers) do
             ['School', 'Mains consumption (kWh)', 'Generation (kWh)', 'Self consumption (kWh)', 'Export (kWh)',
              'Total onsite consumption (kWh)']

--- a/spec/system/school_groups/advice/solar_pv_spec.rb
+++ b/spec/system/school_groups/advice/solar_pv_spec.rb
@@ -1,0 +1,116 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'School group solar pv page' do
+  let!(:school_group) { create(:school_group, :with_active_schools, public: true) }
+  let!(:school) { create(:school, :with_fuel_configuration, school_group: school_group) }
+  let!(:report) { create(:report, key: :solar_generation_summary) }
+
+  let(:solar_generation_variables) do
+    {
+      annual_solar_pv_kwh: 2500,
+      annual_solar_pv_consumed_onsite_kwh: 2000,
+      annual_exported_solar_pv_kwh: 500,
+      annual_mains_consumed_kwh: 1000,
+      annual_electricity_kwh: 4000
+    }
+  end
+
+  before do
+    Flipper.enable(:group_solar_advice_page)
+    create(:advice_page, key: :solar_pv)
+
+    alert_run = create(:alert_generation_run, school: school)
+
+    solar_generation_alert = create(:alert_type, class_name: 'AlertSolarGeneration')
+    create(:alert, school: school, alert_generation_run: alert_run, alert_type: solar_generation_alert,
+                   variables: solar_generation_variables)
+
+    Comparison::SolarGenerationSummary.refresh
+  end
+
+  context 'when on the insights page' do
+    it_behaves_like 'an access controlled group page' do
+      let(:path) { insights_school_group_advice_solar_pv_path(school_group) }
+    end
+
+    context 'when not signed in' do
+      before do
+        visit school_group_advice_path(school_group)
+        within('.advice-page-nav') do
+          click_on(I18n.t('advice_pages.nav.pages.solar_pv'))
+        end
+      end
+
+      it_behaves_like 'a school group advice page', index: false do
+        let(:breadcrumb) { I18n.t('advice_pages.solar_pv.has_solar_pv.page_title') }
+        let(:title) { I18n.t('school_groups.advice_pages.solar_pv.page_title') }
+      end
+
+      it 'has the key insights section' do
+        expect(page).to have_text(I18n.t('school_groups.advice_pages.solar_pv.insights.current_benefits.title'))
+        expect(page).to have_css('#solar_generation_summary-table')
+        within('#solar_generation_summary-table') do
+          expect(page).to have_text(school.name)
+          expect(page).to have_text('1,000')
+        end
+      end
+    end
+  end
+
+  context 'when on the analysis page' do
+    it_behaves_like 'an access controlled group page' do
+      let(:path) { analysis_school_group_advice_solar_pv_path(school_group) }
+    end
+
+    context 'when not signed in' do
+      before do
+        visit analysis_school_group_advice_solar_pv_path(school_group)
+      end
+
+      it_behaves_like 'a school group advice page', index: false do
+        let(:breadcrumb) { I18n.t('advice_pages.solar_pv.has_solar_pv.page_title') }
+        let(:title) { I18n.t('school_groups.advice_pages.solar_pv.page_title') }
+      end
+
+      context 'with comparison section' do
+        it { expect(page).to have_text(I18n.t('school_groups.advice_pages.solar_pv.analysis.comparisons.title')) }
+
+        it_behaves_like 'a school comparison report with a table', visit: false do
+          let(:expected_report) { report }
+          let(:expected_school) { school }
+          let(:advice_page_path) { insights_school_advice_solar_pv_path(expected_school) }
+          let(:headers) do
+            ['School', 'Mains consumption (kWh)', 'Generation (kWh)', 'Self consumption (kWh)', 'Export (kWh)',
+             'Total onsite consumption (kWh)']
+          end
+          let(:expected_table) do
+            [
+              headers,
+              [school.name,
+               '1,000',
+               '2,500',
+               '2,000',
+               '500',
+               '4,000']
+            ]
+          end
+          let(:expected_csv) do
+            [
+              headers,
+              [school.name,
+               '1,000',
+               '2,500',
+               '2,000',
+               '500',
+               '4,000']
+            ]
+          end
+        end
+
+        it { expect(page).to have_css('#solar_generation_summary-chart') }
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds a new solar advice page for school groups.

Similar to the other group pages, the new page combines together some existing comparison reports to provide a better overview of the benefits of installing new solar and existing solar arrays at each school.

I've tidied the existing comparison reports as the column headings and labelling weren't great. I've also added a chart to the solar generation summary to provide a better overview of the mains, self consumption and export at each school.

The page is behind a feature flag as will need some internal review on wording before releasing more widely.