### PR TITLE
Revise pending invoicing report and alert

### DIFF
--- a/app/components/commercial/exception_report_prompt_component.rb
+++ b/app/components/commercial/exception_report_prompt_component.rb
@@ -23,7 +23,7 @@ module Commercial
           content: "There are currently #{overlapping_licences} overlapping licences for the same school." },
         { id: 'pending-invoices', check: pending_invoices?, status: :negative,
           icon: 'file-invoice', link: 'Pending invoices', path: pending_invoicing_admin_commercial_contracts_path,
-          content: "There are currently #{pending_invoices} contracts with pending invoices." }
+          content: "There are #{pending_invoices} current contracts with pending invoices." }
       ]
     end
 
@@ -58,7 +58,7 @@ module Commercial
     end
 
     def pending_invoices
-      @pending_invoices ||= ::Commercial::Contract.pending_invoicing.count
+      @pending_invoices ||= ::Commercial::Contract.pending_invoicing.current.count
     end
 
     def add_prompt(list:, status:, icon:, check: true, id: nil, link: nil, path: nil) # rubocop:disable Metrics/ParameterLists

--- a/app/components/commercial/pending_invoicing_component/pending_invoicing_component.html.erb
+++ b/app/components/commercial/pending_invoicing_component/pending_invoicing_component.html.erb
@@ -22,7 +22,7 @@
         <tr>
           <td class="col-2"><%= link_to contract.name, admin_commercial_contract_path(contract) %></td>
           <td class="col-2"><%= contract.contract_holder.name %></td>
-          <td class="col-2" data-order="<%= contract.start_date.iso8601 %>" class="text-end">
+          <td class="text-end col-2" data-order="<%= contract.start_date.iso8601 %>">
             <%= contract.start_date.to_fs(:es_short) %>
           </td>
           <td class="text-end col-1"><%= contract.licences.pending_invoice.count %></td>

--- a/app/components/commercial/pending_invoicing_component/pending_invoicing_component.html.erb
+++ b/app/components/commercial/pending_invoicing_component/pending_invoicing_component.html.erb
@@ -2,13 +2,14 @@
   <table id="pending-invoicing-table" class="table table-paged table-sm">
     <thead>
       <tr>
-        <th colspan="2"></th>
+        <th colspan="3"></th>
         <th class="text-center" colspan="3">Schools</th>
         <th colspan="2"></th>
       </tr>
       <tr>
         <th>Name</th>
         <th>Contract Holder</th>
+        <th>Start Date</th>
         <th class="text-end">To be invoiced</th>
         <th class="text-end">Invoiced</th>
         <th class="text-end">Licensed</th>
@@ -19,8 +20,11 @@
     <tbody>
       <% @contracts.each do |contract| %>
         <tr>
-          <td><%= link_to contract.name, admin_commercial_contract_path(contract) %></td>
-          <td><%= contract.contract_holder.name %></td>
+          <td class="col-2"><%= link_to contract.name, admin_commercial_contract_path(contract) %></td>
+          <td class="col-2"><%= contract.contract_holder.name %></td>
+          <td class="col-2" data-order="<%= contract.start_date.iso8601 %>" class="text-end">
+            <%= contract.start_date.to_fs(:es_short) %>
+          </td>
           <td class="text-end col-1"><%= contract.licences.pending_invoice.count %></td>
           <td class="text-end col-1"><%= contract.licences.invoiced.count %></td>
           <td class="text-end col-1"><%= contract.licences.count %></td>

--- a/app/controllers/admin/commercial/contracts_controller.rb
+++ b/app/controllers/admin/commercial/contracts_controller.rb
@@ -37,7 +37,7 @@ module Admin
       end
 
       def pending_invoicing
-        @contracts = ::Commercial::Contract.pending_invoicing
+        @contracts = ::Commercial::Contract.pending_invoicing.by_start_date
       end
 
       def contract_holder_options

--- a/spec/components/commercial/exception_report_prompt_component_spec.rb
+++ b/spec/components/commercial/exception_report_prompt_component_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe Commercial::ExceptionReportPromptComponent, :include_url_helpers,
     end
 
     it {
-      expect(page).to have_text('There are currently 1 contracts with pending invoices')
+      expect(page).to have_text('There are 1 current contracts with pending invoices')
     }
   end
 end

--- a/spec/components/commercial/pending_invoicing_component_spec.rb
+++ b/spec/components/commercial/pending_invoicing_component_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Commercial::PendingInvoicingComponent, type: :component do
     let(:expected_header) do
       [
         ['', 'Schools', ''],
-        ['Name', 'Contract Holder', 'To be invoiced', 'Invoiced', 'Licensed', 'Invoices', 'Actions']
+        ['Name', 'Contract Holder', 'Start Date', 'To be invoiced', 'Invoiced', 'Licensed', 'Invoices', 'Actions']
       ]
     end
     let(:expected_rows) do
@@ -24,6 +24,7 @@ RSpec.describe Commercial::PendingInvoicingComponent, type: :component do
         [
           contract.name,
           contract.contract_holder.name,
+          contract.start_date.to_fs(:es_short),
           '3',
           '1',
           '4',


### PR DESCRIPTION
Revising the pending invoice report to include contract start date and to sort by date. The prompt to highlight thats invoicing is due now only looks for current contracts.