### PR TITLE
Fix context for school contracts page

### DIFF
--- a/app/controllers/admin/commercial/contract_holder_contracts_controller.rb
+++ b/app/controllers/admin/commercial/contract_holder_contracts_controller.rb
@@ -13,6 +13,9 @@ module Admin
           @school_group = @contract_holder
           breadcrumbs
           render :index, layout: 'group_settings'
+        elsif @contract_holder.is_a?(School)
+          @school = @contract_holder
+          render :index
         else
           render :index
         end


### PR DESCRIPTION
Make sure there is a `@school` in scope when showing contracts for schools. Ensures that the standard breadcrumbs and second navigation bar are displayed.