### PR TITLE
Enable impact page for all users

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -92,7 +92,6 @@ class HomeController < ApplicationController
 
   def our_impact
     @organisation_statement = ImpactReport::OrganisationStatement.current_statement
-    redirect_to home_page_path unless Flipper.enabled?(:org_impact_page, current_user)
     redirect_to home_page_path unless @organisation_statement
   end
 

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -115,6 +115,10 @@
             t('home.buttons.watch_a_demo'),
             watch_demo_campaigns_path, style: :secondary, classes: 'mb-2'
           ) %>
+      <%= render Elements::ButtonComponent.new(
+            t('about_menu.our_impact'),
+            our_impact_path, style: :secondary, classes: 'mb-2 me-2'
+          ) %>
     </div>
 
     <%= render Layout::GridComponent.new(

--- a/app/views/home/product.html.erb
+++ b/app/views/home/product.html.erb
@@ -73,6 +73,9 @@
       <%= section_header.with_button t('home.buttons.watch_a_demo'),
                                      watch_demo_campaigns_path(utm_params),
                                      style: :primary %>
+      <%= section_header.with_button t('about_menu.our_impact'),
+                                     our_impact_path(utm_params),
+                                     style: :secondary %>
       <%= section_header.with_button t('common.labels.request_more_info'),
                                      more_information_campaigns_path(utm_params),
                                      style: :secondary %>
@@ -188,6 +191,8 @@
         <%= feature.with_header(title: t('product.call_to_action.title')) %>
         <%= feature.with_description { t('product.call_to_action.description_html', count: schools_count) } %>
         <%= feature.with_button t('enrol.enrol_now'), enrol_our_school_path, style: :primary %>
+        <%= feature.with_button(t('about_menu.our_impact'),
+                                our_impact_path, style: :secondary) %>
         <%= feature.with_button(t('common.labels.request_more_info'),
                                 more_information_campaigns_path(utm_params), style: :secondary) %>
       <% end %>

--- a/app/views/shared/page/navigation/top_nav/_about_menu.html.erb
+++ b/app/views/shared/page/navigation/top_nav/_about_menu.html.erb
@@ -13,9 +13,7 @@
     <%= link_to t('about_menu.team'), team_path, class: 'dropdown-item' %>
     <%= link_to t('about_menu.blog'), 'http://blog.energysparks.uk',
                 target: '_blank', class: 'dropdown-item', rel: 'noopener' %>
-    <% if Flipper.enabled?(:org_impact_page, current_user) %>
-      <%= link_to t('about_menu.our_impact'), our_impact_path, class: 'dropdown-item' %>
-    <% end %>
+    <%= link_to t('about_menu.our_impact'), our_impact_path, class: 'dropdown-item' %>
     <%= link_to t('about_menu.funders'), funders_path, class: 'dropdown-item' %>
     <%= link_to t('support_us.title'), support_us_path, class: 'dropdown-item' %>
     <%= link_to t('about_menu.jobs'), jobs_path, class: 'dropdown-item' %>

--- a/lib/tasks/deployment/20260727100358_remove_impact_feature.rake
+++ b/lib/tasks/deployment/20260727100358_remove_impact_feature.rake
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+namespace :after_party do
+  desc 'Deployment task: remove_impact_feature'
+  task remove_impact_feature: :environment do
+    puts "Running deploy task 'remove_impact_feature'"
+
+    Flipper.remove(:org_impact_page)
+
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord
+      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+  end
+end

--- a/spec/system/navigation/top_nav_spec.rb
+++ b/spec/system/navigation/top_nav_spec.rb
@@ -7,7 +7,6 @@ RSpec.describe 'Navigation -> top nav', type: :system do
 
   before do
     Flipper.enable :support_pages
-    Flipper.enable :org_impact_page
     sign_in(user) if user
     visit root_path(locale: locale)
   end

--- a/spec/system/our_impact_spec.rb
+++ b/spec/system/our_impact_spec.rb
@@ -8,7 +8,6 @@ describe 'manage organisation impact statement' do
   let!(:statement) { create(:impact_report_organisation_statement, :current) }
 
   before do
-    Flipper.enable :org_impact_page
     visit our_impact_path
   end
 


### PR DESCRIPTION
Enables the org impact page for all users, by removing use of the feature flag.

Add extra links to the page from the home and product pages.