### PR TITLE
Remove unused alert template variables

### DIFF
--- a/analytics/lib/dashboard/alerts/common/alert_additional_prioritisation_data.rb
+++ b/analytics/lib/dashboard/alerts/common/alert_additional_prioritisation_data.rb
@@ -6,8 +6,7 @@ require_relative './alert_analysis_base.rb'
 # prioritisation of other alerts
 class AlertAdditionalPrioritisationData < AlertAnalysisBase
   include Logging
-  attr_reader :days_to_next_holiday, :days_from_last_holiday
-  attr_reader :average_temperature_last_week, :average_forecast_temperature_next_week_deprecated, :annual_electricity_kwh, :annual_gas_kwh, :annual_storage_heater_kwh, :annual_electricity_£, :annual_gas_£, :annual_storage_heater_£, :degree_days_15_5C_domestic, :school_area, :electricity_economic_tariff_changed_this_year, :electricity_economic_tariff_changed_in_the_previous_year, :electricity_economic_tariff_changed_this_year_percent,
+  attr_reader :electricity_economic_tariff_changed_this_year, :electricity_economic_tariff_changed_in_the_previous_year, :electricity_economic_tariff_changed_this_year_percent,
               :electricity_economic_tariff_last_changed_date, :gas_economic_tariff_changed_this_year, :gas_economic_tariff_changed_in_the_previous_year, :gas_economic_tariff_changed_this_year_percent, :gas_economic_tariff_last_changed_date, :activation_date
 
   def initialize(school)

--- a/analytics/lib/dashboard/alerts/common/alert_additional_prioritisation_data.rb
+++ b/analytics/lib/dashboard/alerts/common/alert_additional_prioritisation_data.rb
@@ -38,85 +38,10 @@ class AlertAdditionalPrioritisationData < AlertAnalysisBase
       units: :m2,
       benchmark_code: 'flra'
     },
-    school_type: {
-      description: 'Primary or Secondary',
-      units: :school_type,
-      benchmark_code: 'sctp'
-    },
     school_type_name: {
       description: 'Primary or Secondary',
       units: String,
       benchmark_code: 'stpn'
-    },
-    school_name: {
-      description: 'Name of school',
-      units: String,
-      benchmark_code: 'name'
-    },
-    school_area: {
-      description: 'School area (school group name)',
-      units: String,
-      benchmark_code: 'area'
-    },
-    urn: {
-      description: 'School URN',
-      units: Integer,
-      benchmark_code: 'urn'
-    },
-    days_to_next_holiday: {
-      description: 'days to next holiday',
-      units: Integer,
-      priority_code: 'DYTH'
-    },
-    days_from_last_holiday: {
-      description: 'days from_last holiday',
-      units: Integer,
-      priority_code: 'DYFH'
-    },
-    average_temperature_last_week: {
-      description: 'average_temperature last week',
-      units: Float,
-      priority_code: 'AVGT'
-    },
-    average_forecast_temperature_next_week_deprecated: {
-      description: 'average forecast temperature next week',
-      units: Float,
-      priority_code: 'FAVT'
-    },
-    annual_electricity_kwh: {
-      description: 'annual electricity consumption (kWh)',
-      units: { kwh: :electricity },
-      priority_code: 'EKWH'
-    },
-    annual_gas_kwh: {
-      description: 'annual gas consumption (kWh)',
-      units: { kwh: :gas },
-      priority_code: 'GKWH'
-    },
-    annual_storage_heater_kwh: {
-      description: 'annual storage heater consumption (kWh)',
-      units: { kwh: :gas },
-      priority_code: 'SKWH'
-    },
-    annual_electricity_£: {
-      description: 'annual electricity consumption (£)',
-      units: { kwh: :electricity },
-      priority_code: 'ECST'
-    },
-    annual_gas_£: {
-      description: 'annual gas consumption (£)',
-      units: { kwh: :gas },
-      priority_code: 'GCST'
-    },
-    annual_storage_heater_£: {
-      description: 'annual storage heater consumption (£)',
-      units: { kwh: :gas },
-      priority_code: 'SCST'
-    },
-    degree_days_15_5C_domestic: {
-      description: 'Degree days (15.5C base, domestic(i.e. continuous occupation)',
-      units: Float,
-      benchmark_code: 'ddays'
     },
     electricity_economic_tariff_changed_this_year: {
       description: 'Has the electricity economic changed in the last year',
@@ -186,21 +111,7 @@ class AlertAdditionalPrioritisationData < AlertAnalysisBase
 
   def calculate_private(asof_date)
     @activation_date = @school.energysparks_start_date
-    @days_to_next_holiday = calculate_days_to_next_holiday(asof_date)
-    @days_from_last_holiday = calculate_days_to_previous_holiday(asof_date)
-    @annual_electricity_kwh     = annual_kwh(@school.aggregated_electricity_meters, :electricity,     asof_date, :kwh)
-    @annual_gas_kwh             = annual_kwh(@school.aggregated_heat_meters,        :gas,             asof_date, :kwh)
-    @annual_storage_heater_kwh  = annual_kwh(@school.storage_heater_meter,          :storage_heaters, asof_date, :kwh)
-
-    @annual_electricity_£     = annual_kwh(@school.aggregated_electricity_meters, :electricity,     asof_date, :£)
-    @annual_gas_£             = annual_kwh(@school.aggregated_heat_meters,        :gas,             asof_date, :£)
-    @annual_storage_heater_£  = annual_kwh(@school.storage_heater_meter,          :storage_heaters, asof_date, :£)
-
-    @degree_days_15_5C_domestic = @school.temperatures.degree_days_this_year(asof_date)
-
     calculate_economic_tariff_data
-
-    @school_area = @school.area_name
   end
 
   def school_type_name
@@ -228,32 +139,5 @@ class AlertAdditionalPrioritisationData < AlertAnalysisBase
   rescue StandardError => e
     puts e.message
     puts e.backtrace
-  end
-
-  def annual_kwh(meter, fuel_type, asof_date, data_type)
-    return 0.0 if meter.nil?
-
-    asof_date = [asof_date, meter.amr_data.end_date].min
-    chart_end_date = { asof_date: asof_date }
-    begin
-      CalculateAggregateValues.new(@school).aggregate_value({ year: 0 }, fuel_type, data_type, chart_end_date)
-    rescue StandardError => e
-      logger.info e.message
-      0.0
-    end
-  end
-
-  def calculate_days_to_next_holiday(asof_date)
-    holiday = @school.holidays.find_next_holiday(asof_date)
-    return 0 if asof_date.between?(holiday.start_date, holiday.end_date)
-
-    (holiday.start_date - asof_date).to_i
-  end
-
-  def calculate_days_to_previous_holiday(asof_date)
-    holiday = @school.holidays.find_previous_or_current_holiday(asof_date)
-    return 0 if asof_date.between?(holiday.start_date, holiday.end_date)
-
-    (asof_date - holiday.end_date).to_i
   end
 end

--- a/analytics/lib/dashboard/alerts/common/alert_analysis_base.rb
+++ b/analytics/lib/dashboard/alerts/common/alert_analysis_base.rb
@@ -89,31 +89,11 @@ class AlertAnalysisBase < ContentBase
   end
 
   TEMPLATE_VARIABLES = {
-    relevance: {
-      description: 'Relevance of a alert to a school at this point in time',
-      units: :relevance
-    },
-    analysis_date: {
-      description: 'Latest date on which the alert data is based',
-      units: :date
-    },
-    status: {
-      description: 'Status: good, bad, failed',
-      units: Symbol
-    },
     rating: {
       description: 'Rating out of 10',
       units: Float,
       priority_code: 'RATE',
       benchmark_code: 'ratg'
-    },
-    term: {
-      description: 'long term or short term',
-      units: Symbol
-    },
-    max_asofdate: {
-      description: 'The latest date on which an alert can be run given the available data',
-      units: :date
     },
     pupils: {
       description: 'Number of pupils for relevant part of school on this date',
@@ -122,26 +102,6 @@ class AlertAnalysisBase < ContentBase
     floor_area: {
       description: 'Floor area of relevant part of school',
       units: :m2
-    },
-    school_type: {
-      description: 'Primary or Secondary',
-      units: :school_type
-    },
-    school_name: {
-      description: 'Name of school',
-      units: String
-    },
-    school_activation_date: {
-      description: 'Date school activated on Energy Sparks',
-      units: Date
-    },
-    school_creation_date: {
-      description: 'Date school created on Energy Sparks',
-      units: Date
-    },
-    urn: {
-      description: 'School URN',
-      units: Integer
     },
     one_year_saving_kwh: {
       description: 'Estimated one year kwh reduction range',
@@ -191,10 +151,6 @@ class AlertAnalysisBase < ContentBase
       description: 'Average Capital cost',
       units: :£,
       priority_code: 'CAPC'
-    },
-    timescale: {
-      description: 'Timescale of analysis e.g. week, month, year',
-      units: String
     },
     time_of_year_relevance: {
       description: 'Rating: 10 = relevant to time of year, 0 = irrelevant, 5 = average/normal',

--- a/analytics/lib/dashboard/alerts/common/alert_analysis_base.rb
+++ b/analytics/lib/dashboard/alerts/common/alert_analysis_base.rb
@@ -152,6 +152,10 @@ class AlertAnalysisBase < ContentBase
       units: :£,
       priority_code: 'CAPC'
     },
+    timescale: {
+      description: 'Timescale of analysis e.g. week, month, year',
+      units: String
+    },
     time_of_year_relevance: {
       description: 'Rating: 10 = relevant to time of year, 0 = irrelevant, 5 = average/normal',
       units: Float,

--- a/spec/analytics/lib/dashboard/alerts/common/alert_additional_prioritisation_data_spec.rb
+++ b/spec/analytics/lib/dashboard/alerts/common/alert_additional_prioritisation_data_spec.rb
@@ -22,21 +22,20 @@ describe AlertAdditionalPrioritisationData do
     allow(meter_collection).to receive(:aggregated_heat_meters).and_return(meter)
   end
 
-  describe '#benchmark_template_data' do
+  describe '#analyse' do
     before do
       alert.analyse(asof_date)
     end
 
-    let(:template_data) { alert.benchmark_template_data }
+    context 'when producing variables for reporting' do
+      subject(:variables) { alert.variables_for_reporting }
 
-    it 'assigns the correct values' do
-      expect(template_data[:addp_name]).to eq meter_collection.school.name
-      expect(template_data[:addp_pupn]).to eq meter_collection.school.number_of_pupils
-      expect(template_data[:addp_flra]).to eq meter_collection.school.floor_area
-      expect(template_data[:addp_sctp]).to eq meter_collection.school.school_type
-      expect(template_data[:addp_urn]).to eq meter_collection.school.urn
-      expect(template_data[:addp_sact]).to eq meter_collection.school.activation_date
-      expect(template_data[:addp_sact]).to eq meter_collection.energysparks_start_date
+      it 'produces simple variables used in comparison reports' do
+        expect(variables[:activation_date]).to eq meter_collection.school.activation_date
+        expect(variables[:pupils]).to eq meter_collection.school.number_of_pupils
+        expect(variables[:floor_area]).to eq meter_collection.school.floor_area
+        expect(variables[:school_type_name]).to eq(I18n.t('analytics.school_types')[meter_collection.school.school_type])
+      end
     end
   end
 end


### PR DESCRIPTION
The alert base class defines a number of template variables are are unused, e.g. school name or rating. But they aren't necessary as they're not used in the template text for displaying alerts or the alert framework already captures them on the alert record. 

They're just taking up space in the database as they're repeated for individual alerts and across all alert types. They also increase size of JSON produced when deserializing the variables in queries, etc.

They're mostly calculated on demand so removing the template variable declarations stops them from being calculated and saved.

The `AlertAdditionalPrioritisationData` alert also had some unused variables. These were used in the old benchmarking pages but we've since reimplemented that. I've just kept those that are currently used in `Comparison::View`s and removed the others.

