### PR TITLE
Change Xero Account Codes to be Strings

### DIFF
--- a/app/models/commercial/xero_account_code.rb
+++ b/app/models/commercial/xero_account_code.rb
@@ -20,7 +20,8 @@ module Commercial
 
     self.table_name = 'commercial_xero_account_codes'
 
-    validates :code, presence: true, uniqueness: true
+    validates :code, presence: true
+    validates :code, uniqueness: { case_sensitive: false }
     validates :label, presence: true
 
     scope :by_code, -> { order(:code) }

--- a/app/models/commercial/xero_account_code.rb
+++ b/app/models/commercial/xero_account_code.rb
@@ -5,7 +5,7 @@
 # Table name: commercial_xero_account_codes
 #
 #  id         :bigint(8)        not null, primary key
-#  code       :integer          not null
+#  code       :string
 #  label      :string           not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null

--- a/db/migrate/20260730142636_change_xero_account_code_to_string.rb
+++ b/db/migrate/20260730142636_change_xero_account_code_to_string.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+class ChangeXeroAccountCodeToString < ActiveRecord::Migration[8.1]
+  def up
+    add_column :commercial_xero_account_codes, :code_str, :string
+
+    execute <<~SQL.squish
+      UPDATE commercial_xero_account_codes
+      SET code_str = code::text;
+    SQL
+
+    remove_column :commercial_xero_account_codes, :code
+    rename_column :commercial_xero_account_codes, :code_str, :code
+    add_index :commercial_xero_account_codes, :code, unique: true
+  end
+
+  def down
+    add_column :commercial_xero_account_codes, :code_int, :integer
+
+    execute <<~SQL.squish
+      UPDATE commercial_xero_account_codes
+      SET code_int = code::integer;
+    SQL
+
+    remove_column :commercial_xero_account_codes, :code
+    rename_column :commercial_xero_account_codes, :code_int, :code
+    add_index :commercial_xero_account_codes, :code, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -396,7 +396,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_30_142636) do
     t.integer "reporting_period"
     t.date "run_on"
     t.bigint "school_id", null: false
-    t.json "table_data"
+    t.json "table_data", default: {}
     t.json "template_data", default: {}
     t.json "template_data_cy", default: {}
     t.datetime "updated_at", precision: nil, null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_20_100515) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_30_142636) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pg_catalog.plpgsql"
@@ -396,7 +396,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_20_100515) do
     t.integer "reporting_period"
     t.date "run_on"
     t.bigint "school_id", null: false
-    t.json "table_data", default: {}
+    t.json "table_data"
     t.json "template_data", default: {}
     t.json "template_data_cy", default: {}
     t.datetime "updated_at", precision: nil, null: false
@@ -803,7 +803,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_20_100515) do
   end
 
   create_table "commercial_xero_account_codes", force: :cascade do |t|
-    t.integer "code", null: false
+    t.string "code"
     t.datetime "created_at", null: false
     t.string "label", null: false
     t.datetime "updated_at", null: false

--- a/spec/models/commercial/xero_account_code_spec.rb
+++ b/spec/models/commercial/xero_account_code_spec.rb
@@ -9,6 +9,6 @@ describe Commercial::XeroAccountCode do
   context 'when validating code' do
     subject { create(:commercial_xero_account_code) }
 
-    it { is_expected.to validate_uniqueness_of(:code) }
+    it { is_expected.to validate_uniqueness_of(:code).case_insensitive }
   end
 end

--- a/spec/system/admin/commercial/manage_xero_account_codes_spec.rb
+++ b/spec/system/admin/commercial/manage_xero_account_codes_spec.rb
@@ -14,14 +14,14 @@ describe 'manage xero account codes' do
     before do
       click_on 'Xero Account Codes'
       click_on 'New account code'
-      fill_in 'Code', with: 42
+      fill_in 'Code', with: '042'
       fill_in 'Label', with: 'The label'
     end
 
     it 'creates the code' do
       expect { click_on 'Save' }.to change(Commercial::XeroAccountCode, :count).by(1)
       expect(page).to have_text('Code was successfully created')
-      expect(Commercial::XeroAccountCode.last).to have_attributes(code: 42, label: 'The label')
+      expect(Commercial::XeroAccountCode.last).to have_attributes(code: '042', label: 'The label')
     end
   end
 


### PR DESCRIPTION
Need to allow for optional leading zeros, so switch code to a string.