### PR TITLE
Make overlapping invoices warning more prominent

### DIFF
--- a/app/controllers/admin/commercial/contracts/invoices_controller.rb
+++ b/app/controllers/admin/commercial/contracts/invoices_controller.rb
@@ -8,6 +8,7 @@ module Admin
         def raise_invoice
           @licences = @contract.licences.includes(school: :school_group).pending_invoice.by_start_date
           @prices = ::Commercial::ContractPriceCalculator.new(@contract).per_school
+          @overlapping_licences = ::Commercial::Licence.overlapping.where(contract_id: @contract.id)
         end
 
         def new

--- a/app/views/admin/commercial/contracts/_licences_warning.html.erb
+++ b/app/views/admin/commercial/contracts/_licences_warning.html.erb
@@ -1,0 +1,6 @@
+<% if @overlapping_licences.any? %>
+  <%= render PromptComponent.new(id: 'overlapping-licences', status: :negative, icon: 'calendar-xmark') do |p| %>
+    <% p.with_link { link_to 'Overlapping licences', overlapping_admin_commercial_licences_path } %>
+    <%= "#{@overlapping_licences.count} of the licences in this contract overlap with licences from other contracts" %>
+  <% end %>
+<% end %>

--- a/app/views/admin/commercial/contracts/_licences_warning.html.erb
+++ b/app/views/admin/commercial/contracts/_licences_warning.html.erb
@@ -1,6 +1,6 @@
-<% if @overlapping_licences.any? %>
+<% if overlapping_licences.any? %>
   <%= render PromptComponent.new(id: 'overlapping-licences', status: :negative, icon: 'calendar-xmark') do |p| %>
     <% p.with_link { link_to 'Overlapping licences', overlapping_admin_commercial_licences_path } %>
-    <%= "#{@overlapping_licences.count} of the licences in this contract overlap with licences from other contracts" %>
+    <%= "#{overlapping_licences.count} of the licences in this contract overlap with licences from other contracts" %>
   <% end %>
 <% end %>

--- a/app/views/admin/commercial/contracts/invoices/raise_invoice.html.erb
+++ b/app/views/admin/commercial/contracts/invoices/raise_invoice.html.erb
@@ -8,6 +8,8 @@
   <%= link_to @contract.name, admin_commercial_contract_path(@contract) %> contract.
 </p>
 
+<%= render 'admin/commercial/contracts/licences_warning' %>
+
 <h3>Review account code</h3>
 
 <p>This contract is set to raise invoices using <strong><%= @contract.xero_account_code&.display_label %></strong></p>

--- a/app/views/admin/commercial/contracts/invoices/raise_invoice.html.erb
+++ b/app/views/admin/commercial/contracts/invoices/raise_invoice.html.erb
@@ -8,7 +8,7 @@
   <%= link_to @contract.name, admin_commercial_contract_path(@contract) %> contract.
 </p>
 
-<%= render 'admin/commercial/contracts/licences_warning' %>
+<%= render 'admin/commercial/contracts/licences_warning', overlapping_licences: @overlapping_licences %>
 
 <h3>Review account code</h3>
 

--- a/app/views/admin/commercial/contracts/show.html.erb
+++ b/app/views/admin/commercial/contracts/show.html.erb
@@ -46,7 +46,7 @@
   </div>
 </div>
 
-<%= render 'licences_warning' %>
+<%= render 'licences_warning', overlapping_licences: @overlapping_licences %>
 
 <div class="row">
   <div class="col-12">

--- a/app/views/admin/commercial/contracts/show.html.erb
+++ b/app/views/admin/commercial/contracts/show.html.erb
@@ -46,6 +46,8 @@
   </div>
 </div>
 
+<%= render 'licences_warning' %>
+
 <div class="row">
   <div class="col-12">
     <%= render Layout::GridComponent.new(classes: 'mb-4',
@@ -222,12 +224,6 @@
     <p>
       The following table includes all licences for this contract sorted by start date.
     </p>
-    <% if @overlapping_licences.any? %>
-      <%= render PromptComponent.new(id: 'overlapping-licences', status: :negative, icon: 'calendar-xmark') do |p| %>
-        <% p.with_link { link_to 'Overlapping licences', overlapping_admin_commercial_licences_path } %>
-        <%= "#{@overlapping_licences.count} of these licences overlap with licences from other contracts" %>
-      <% end %>
-    <% end %>
     <%= render Commercial::LicencesComponent.new(id: 'licences',
                                                  licences: @contract.licences.by_start_date,
                                                  show_contract: false,

--- a/spec/system/admin/commercial/manage_contracts_spec.rb
+++ b/spec/system/admin/commercial/manage_contracts_spec.rb
@@ -931,7 +931,10 @@ describe 'manage contracts', :include_application_helper do
         end
 
         it { expect(page).to have_link('Overlapping licences', href: overlapping_admin_commercial_licences_path) }
-        it { expect(page).to have_text('1 of these licences overlap with licences from other contracts') }
+
+        it do
+          expect(page).to have_text('1 of the licences in this contract overlap with licences from other contracts')
+        end
       end
     end
 

--- a/spec/system/admin/commercial/manage_invoices_spec.rb
+++ b/spec/system/admin/commercial/manage_invoices_spec.rb
@@ -212,6 +212,19 @@ describe 'manage invoices', :include_application_helper do
         end
       end
 
+      context 'with an overlapping licence' do
+        before do
+          create(:commercial_licence, school: licence.school, start_date: licence.start_date)
+          refresh
+        end
+
+        it { expect(page).to have_link('Overlapping licences', href: overlapping_admin_commercial_licences_path) }
+
+        it do
+          expect(page).to have_text('1 of the licences in this contract overlap with licences from other contracts')
+        end
+      end
+
       context 'when then proceeding', :js do
         before do
           check "licence_#{licence.id}"


### PR DESCRIPTION
- Move higher on the contract page
- Add to the raise invoice page