### PR TITLE
Remove old readings

### DIFF
--- a/.ebextensions/cronjob.config
+++ b/.ebextensions/cronjob.config
@@ -90,6 +90,7 @@ files:
             # ============================================================
             0 12 1  * * root run-webapp-job school:load_and_match_gias_schools
             0 15 15 * * root run-webapp-job school_groups:generate_impact_reports
+            0 0 2 * * root run-webapp-job data_feeds:delete_old_readings
             # ============================================================
             # Less than monthly
             # ============================================================

--- a/app/controllers/admin/manual_data_load_runs_controller.rb
+++ b/app/controllers/admin/manual_data_load_runs_controller.rb
@@ -16,7 +16,7 @@ module Admin
 
     def destroy
       @manual_data_load_run = ManualDataLoadRun.find(params[:id])
-      @manual_data_load_run.destroy!
+      @manual_data_load_run.amr_uploaded_reading.destroy!
       respond_to do |format|
         format.html { redirect_to admin_reports_data_loads_path, notice: 'Manual data load was successfully deleted.' }
         format.json { head :no_content }

--- a/app/models/amr_data_feed_import_log.rb
+++ b/app/models/amr_data_feed_import_log.rb
@@ -20,7 +20,7 @@
 
 class AmrDataFeedImportLog < ApplicationRecord
   has_many :amr_data_feed_readings
-  has_many :amr_reading_warnings
+  has_many :amr_reading_warnings, dependent: :delete_all
   has_many :meters, -> { distinct }, through: :amr_data_feed_readings
 
   belongs_to :amr_data_feed_config
@@ -30,6 +30,10 @@ class AmrDataFeedImportLog < ApplicationRecord
   scope :with_warnings, -> { where(id: AmrReadingWarning.select(:amr_data_feed_import_log_id)) }
 
   scope :since, ->(date) { where('import_time >= ?', date) }
+
+  scope :unused, lambda {
+    where.missing(:amr_data_feed_readings)
+  }
 
   def errors?
     error_messages.present?

--- a/app/models/amr_data_feed_reading.rb
+++ b/app/models/amr_data_feed_reading.rb
@@ -52,6 +52,8 @@ class AmrDataFeedReading < ApplicationRecord
   belongs_to :amr_data_feed_import_log
   belongs_to :amr_data_feed_config
 
+  DELETE_THRESHOLD = 3.years
+
   CSV_HEADER_DATA_FEED_READING = 'School URN,Name,Mpan Mprn,Meter Type,Reading Date,Reading Date Format,Record Last Updated,00:30,01:00,01:30,02:00,02:30,03:00,03:30,04:00,04:30,05:00,05:30,06:00,06:30,07:00,07:30,08:00,08:30,09:00,09:30,10:00,10:30,11:00,11:30,12:00,12:30,13:00,13:30,14:00,14:30,15:00,15:30,16:00,16:30,17:00,17:30,18:00,18:30,19:00,19:30,20:00,20:30,21:00,21:30,22:00,22:30,23:00,23:30,00:00'.freeze
 
   PARSED_DATE = <<~SQL.squish.freeze
@@ -178,6 +180,13 @@ class AmrDataFeedReading < ApplicationRecord
         rows << { 'mpan_mprn' => mpan, 'meter_id' => '-', 'identifier' => '-', 'description' => '-',
                   'earliest_reading' => '-', 'latest_reading' => '-' }
       end
+    end
+  end
+
+  def self.delete_old_records!(before_date: DELETE_THRESHOLD.ago)
+    AmrDataFeedReading.transaction do
+      AmrDataFeedReading.where(meter_id: nil).where(created_at: ...before_date).delete_all
+      AmrDataFeedImportLog.unused.delete_all # remove those no longer referenced from table
     end
   end
 end

--- a/app/models/amr_data_feed_reading.rb
+++ b/app/models/amr_data_feed_reading.rb
@@ -183,7 +183,7 @@ class AmrDataFeedReading < ApplicationRecord
     end
   end
 
-  def self.delete_old_records!(before_date: DELETE_THRESHOLD.ago)
+  def self.delete_old_readings!(before_date: DELETE_THRESHOLD.ago)
     AmrDataFeedReading.transaction do
       AmrDataFeedReading.where(meter_id: nil).where(created_at: ...before_date).delete_all
       AmrDataFeedImportLog.unused.delete_all # remove those no longer referenced from table

--- a/app/models/amr_uploaded_reading.rb
+++ b/app/models/amr_uploaded_reading.rb
@@ -33,7 +33,7 @@ class AmrUploadedReading < ApplicationRecord
     reading_data.map(&:with_indifferent_access).reject { |reading| reading[:warnings]  }
   end
 
-  def self.delete_old_records!(before_date: AmrDataFeedReading::DELETE_THRESHOLD.ago)
+  def self.delete_old_readings!(before_date: AmrDataFeedReading::DELETE_THRESHOLD.ago)
     AmrUploadedReading.transaction do
       AmrUploadedReading.where(created_at: ...before_date).destroy_all
     end

--- a/app/models/amr_uploaded_reading.rb
+++ b/app/models/amr_uploaded_reading.rb
@@ -21,8 +21,9 @@
 
 class AmrUploadedReading < ApplicationRecord
   belongs_to :amr_data_feed_config
+  has_one :manual_data_load_run, dependent: :destroy
 
-  validates_presence_of :file_name
+  validates :file_name, presence: true
 
   def warnings
     reading_data.map(&:with_indifferent_access).select { |reading| reading[:warnings]  }
@@ -30,5 +31,11 @@ class AmrUploadedReading < ApplicationRecord
 
   def valid_readings
     reading_data.map(&:with_indifferent_access).reject { |reading| reading[:warnings]  }
+  end
+
+  def self.delete_old_records!(before_date: AmrDataFeedReading::DELETE_THRESHOLD.ago)
+    AmrUploadedReading.transaction do
+      AmrUploadedReading.where(created_at: ...before_date).destroy_all
+    end
   end
 end

--- a/app/models/manual_data_load_run.rb
+++ b/app/models/manual_data_load_run.rb
@@ -17,7 +17,7 @@
 #  fk_rails_...  (amr_uploaded_reading_id => amr_uploaded_readings.id)
 #
 class ManualDataLoadRun < ApplicationRecord
-  belongs_to :amr_uploaded_reading, dependent: :destroy
+  belongs_to :amr_uploaded_reading
   enum :status, { pending: 0, running: 1, done: 2, failed: 3 }
   has_many :manual_data_load_run_log_entries, dependent: :delete_all
 

--- a/app/models/manual_data_load_run.rb
+++ b/app/models/manual_data_load_run.rb
@@ -17,9 +17,9 @@
 #  fk_rails_...  (amr_uploaded_reading_id => amr_uploaded_readings.id)
 #
 class ManualDataLoadRun < ApplicationRecord
-  belongs_to :amr_uploaded_reading, dependent: :destroy
+  belongs_to :amr_uploaded_reading
   enum :status, { pending: 0, running: 1, done: 2, failed: 3 }
-  has_many :manual_data_load_run_log_entries, dependent: :destroy
+  has_many :manual_data_load_run_log_entries, dependent: :delete_all
 
   scope :by_date, -> { order(created_at: :desc) }
 

--- a/app/models/manual_data_load_run.rb
+++ b/app/models/manual_data_load_run.rb
@@ -17,7 +17,7 @@
 #  fk_rails_...  (amr_uploaded_reading_id => amr_uploaded_readings.id)
 #
 class ManualDataLoadRun < ApplicationRecord
-  belongs_to :amr_uploaded_reading
+  belongs_to :amr_uploaded_reading, dependent: :destroy
   enum :status, { pending: 0, running: 1, done: 2, failed: 3 }
   has_many :manual_data_load_run_log_entries, dependent: :delete_all
 

--- a/lib/tasks/data_feeds/delete_old_readings.rake
+++ b/lib/tasks/data_feeds/delete_old_readings.rake
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+namespace :data_feeds do
+  desc 'Remove old, unused data feed readings, import logs and caches of manually uploaded data'
+  task delete_old_readings: :environment do |_t, args|
+    puts "#{DateTime.now.utc} delete_old_readings start"
+    AmrDataFeedReading.delete_old_readings!
+    AmrUploadedReading.delete_old_readings!
+    puts "#{DateTime.now.utc} delete_old_readings end"
+  end
+end

--- a/lib/tasks/data_feeds/delete_old_readings.rake
+++ b/lib/tasks/data_feeds/delete_old_readings.rake
@@ -2,7 +2,7 @@
 
 namespace :data_feeds do
   desc 'Remove old, unused data feed readings, import logs and caches of manually uploaded data'
-  task delete_old_readings: :environment do |_t, args|
+  task delete_old_readings: :environment do
     puts "#{DateTime.now.utc} delete_old_readings start"
     AmrDataFeedReading.delete_old_readings!
     AmrUploadedReading.delete_old_readings!

--- a/spec/models/amr_data_feed_reading_spec.rb
+++ b/spec/models/amr_data_feed_reading_spec.rb
@@ -157,7 +157,7 @@ describe AmrDataFeedReading do
         end
       end
 
-      context 'with an newer unused record' do
+      context 'with a newer unused record' do
         before { create(:amr_data_feed_reading, meter: nil, created_at: 3.years.ago + 1.day) }
 
         it 'does nothing' do

--- a/spec/models/amr_data_feed_reading_spec.rb
+++ b/spec/models/amr_data_feed_reading_spec.rb
@@ -143,5 +143,51 @@ describe AmrDataFeedReading do
                                                ])
       end
     end
+
+    describe '.delete_old_records!' do
+      context 'with an old unused record' do
+        before { create(:amr_data_feed_reading, meter: nil, created_at: 3.years.ago) }
+
+        it 'deletes the record' do
+          expect { described_class.delete_old_records! }.to change(described_class, :count).by(-1)
+        end
+
+        it 'cleans up the import log' do
+          expect { described_class.delete_old_records! }.to change(AmrDataFeedImportLog, :count).by(-1)
+        end
+      end
+
+      context 'with an newer unused record' do
+        before { create(:amr_data_feed_reading, meter: nil, created_at: 3.years.ago + 1.day) }
+
+        it 'does nothing' do
+          expect { described_class.delete_old_records! }.not_to change(described_class, :count)
+        end
+
+        it 'does not clean up the import log' do
+          expect { described_class.delete_old_records! }.not_to change(AmrDataFeedImportLog, :count)
+        end
+      end
+
+      context 'with an old but in-use record' do
+        before { create(:amr_data_feed_reading, created_at: 3.years.ago) }
+
+        it 'does nothing' do
+          expect { described_class.delete_old_records! }.not_to change(described_class, :count)
+        end
+
+        it 'does not clean up the import log' do
+          expect { described_class.delete_old_records! }.not_to change(AmrDataFeedImportLog, :count)
+        end
+      end
+
+      context 'with an old, unused import log' do
+        before { create(:amr_data_feed_import_log) }
+
+        it 'cleans up the import log' do
+          expect { described_class.delete_old_records! }.to change(AmrDataFeedImportLog, :count).by(-1)
+        end
+      end
+    end
   end
 end

--- a/spec/models/amr_data_feed_reading_spec.rb
+++ b/spec/models/amr_data_feed_reading_spec.rb
@@ -144,16 +144,16 @@ describe AmrDataFeedReading do
       end
     end
 
-    describe '.delete_old_records!' do
+    describe '.delete_old_readings!' do
       context 'with an old unused record' do
         before { create(:amr_data_feed_reading, meter: nil, created_at: 3.years.ago) }
 
         it 'deletes the record' do
-          expect { described_class.delete_old_records! }.to change(described_class, :count).by(-1)
+          expect { described_class.delete_old_readings! }.to change(described_class, :count).by(-1)
         end
 
         it 'cleans up the import log' do
-          expect { described_class.delete_old_records! }.to change(AmrDataFeedImportLog, :count).by(-1)
+          expect { described_class.delete_old_readings! }.to change(AmrDataFeedImportLog, :count).by(-1)
         end
       end
 
@@ -161,11 +161,11 @@ describe AmrDataFeedReading do
         before { create(:amr_data_feed_reading, meter: nil, created_at: 3.years.ago + 1.day) }
 
         it 'does nothing' do
-          expect { described_class.delete_old_records! }.not_to change(described_class, :count)
+          expect { described_class.delete_old_readings! }.not_to change(described_class, :count)
         end
 
         it 'does not clean up the import log' do
-          expect { described_class.delete_old_records! }.not_to change(AmrDataFeedImportLog, :count)
+          expect { described_class.delete_old_readings! }.not_to change(AmrDataFeedImportLog, :count)
         end
       end
 
@@ -173,11 +173,11 @@ describe AmrDataFeedReading do
         before { create(:amr_data_feed_reading, created_at: 3.years.ago) }
 
         it 'does nothing' do
-          expect { described_class.delete_old_records! }.not_to change(described_class, :count)
+          expect { described_class.delete_old_readings! }.not_to change(described_class, :count)
         end
 
         it 'does not clean up the import log' do
-          expect { described_class.delete_old_records! }.not_to change(AmrDataFeedImportLog, :count)
+          expect { described_class.delete_old_readings! }.not_to change(AmrDataFeedImportLog, :count)
         end
       end
 
@@ -185,7 +185,7 @@ describe AmrDataFeedReading do
         before { create(:amr_data_feed_import_log) }
 
         it 'cleans up the import log' do
-          expect { described_class.delete_old_records! }.to change(AmrDataFeedImportLog, :count).by(-1)
+          expect { described_class.delete_old_readings! }.to change(AmrDataFeedImportLog, :count).by(-1)
         end
       end
     end

--- a/spec/models/amr_uploaded_reading_spec.rb
+++ b/spec/models/amr_uploaded_reading_spec.rb
@@ -14,4 +14,22 @@ describe AmrUploadedReading do
       expect(amr_uploaded_reading.valid?).to be false
     end
   end
+
+  describe '.delete_old_records!' do
+    context 'with an old record' do
+      before { create(:amr_uploaded_reading, created_at: 3.years.ago) }
+
+      it 'deletes the record' do
+        expect { described_class.delete_old_records! }.to change(described_class, :count).by(-1)
+      end
+    end
+
+    context 'with an newer unused record' do
+      before { create(:amr_uploaded_reading, created_at: 3.years.ago + 1.day) }
+
+      it 'does nothing' do
+        expect { described_class.delete_old_records! }.not_to change(described_class, :count)
+      end
+    end
+  end
 end

--- a/spec/models/amr_uploaded_reading_spec.rb
+++ b/spec/models/amr_uploaded_reading_spec.rb
@@ -24,7 +24,7 @@ describe AmrUploadedReading do
       end
     end
 
-    context 'with an newer unused record' do
+    context 'with a newer unused record' do
       before { create(:amr_uploaded_reading, created_at: 3.years.ago + 1.day) }
 
       it 'does nothing' do

--- a/spec/models/amr_uploaded_reading_spec.rb
+++ b/spec/models/amr_uploaded_reading_spec.rb
@@ -15,12 +15,12 @@ describe AmrUploadedReading do
     end
   end
 
-  describe '.delete_old_records!' do
+  describe '.delete_old_readings!' do
     context 'with an old record' do
       before { create(:amr_uploaded_reading, created_at: 3.years.ago) }
 
       it 'deletes the record' do
-        expect { described_class.delete_old_records! }.to change(described_class, :count).by(-1)
+        expect { described_class.delete_old_readings! }.to change(described_class, :count).by(-1)
       end
     end
 
@@ -28,7 +28,7 @@ describe AmrUploadedReading do
       before { create(:amr_uploaded_reading, created_at: 3.years.ago + 1.day) }
 
       it 'does nothing' do
-        expect { described_class.delete_old_records! }.not_to change(described_class, :count)
+        expect { described_class.delete_old_readings! }.not_to change(described_class, :count)
       end
     end
   end

--- a/spec/models/manual_data_load_run_spec.rb
+++ b/spec/models/manual_data_load_run_spec.rb
@@ -14,8 +14,7 @@ RSpec.describe ManualDataLoadRun, type: :model do
       expect do
         new_manual_data_load_run.destroy
       end.to change(ManualDataLoadRun, :count).by(-1) &
-             change(ManualDataLoadRunLogEntry, :count).by(-2) &
-             change(AmrUploadedReading, :count).by(-1)
+             change(ManualDataLoadRunLogEntry, :count).by(-2)
     end
   end
 end


### PR DESCRIPTION
Adds a monthly cronjob to tidy up old readings from the database. Set to run on second of the month to avoid clashing with deleting soft-deleted schools.

Will result in

- AmrDataFeedReadings created 3 years ago and not associated with a meter, being removed
- AmrUploadedReadings created 3 years ago, being removed, along with associations
- AmrDataFeedImportLogs no longer referenced from AmrDataFeedReadings being removed, along with associations

Import logs can become "orphaned" through natural updates if readings are reloaded, so there's a separate scope and deletion for those rather than relying on an association.

Will need to `VACUUM ANALYSE amr_data_feed_readings` the first time this is run, as there's a large amount of data being removed. So suggest running immediately after the code is released.  When run monthly it should be OK to rely on the database autovacuum.