### PR TITLE
Resolve issues destroying schools

### DIFF
--- a/app/models/meter.rb
+++ b/app/models/meter.rb
@@ -76,7 +76,7 @@ class Meter < ApplicationRecord
   has_many :issues, through: :issue_meters
   has_many :meter_attributes, dependent: :destroy
   has_many :meter_monthly_summaries, dependent: :destroy
-  has_one :rtone_variant_installation, required: false, dependent: :nullify
+  has_one :rtone_variant_installation, required: false, dependent: :destroy
   has_one :school_group, through: :school
 
   before_destroy :ensure_not_consented

--- a/app/models/meter.rb
+++ b/app/models/meter.rb
@@ -76,7 +76,7 @@ class Meter < ApplicationRecord
   has_many :issues, through: :issue_meters
   has_many :meter_attributes, dependent: :destroy
   has_many :meter_monthly_summaries, dependent: :destroy
-  has_one :rtone_variant_installation, required: false
+  has_one :rtone_variant_installation, required: false, dependent: :nullify
   has_one :school_group, through: :school
 
   before_destroy :ensure_not_consented

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -193,11 +193,13 @@ class User < ApplicationRecord
   end
 
   def disable!
-    update!(active: false)
+    self.active = false
+    save(validate: false)
   end
 
   def enable!
-    update!(active: true)
+    self.active = true
+    save(validate: false)
   end
 
   def default_scoreboard

--- a/app/services/schools/destroyer.rb
+++ b/app/services/schools/destroyer.rb
@@ -22,6 +22,7 @@ module Schools
           school.transaction do
             remover.remove_users! # deactivate users, remove association with school if user has multiple schools
             remover.remove_meters! # deactivate meters, removing consent via API call if needed
+            IssueMeter.where(meter: school.meters).delete_all
             school.destroy!
           end
         rescue StandardError => e

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -12,6 +12,19 @@ describe User do
     it { is_expected.to allow_value(create(:school_group)).for(:school_group) }
   end
 
+  describe '#disable!' do
+    it 'still disables invalid users' do
+      user = create(:user)
+      user.disable!
+      expect(user.reload.active).to be(false)
+      user = create(:user)
+      user.update_column(:email, 'invalid') # rubocop:disable Rails/SkipsModelValidations
+      expect(user.reload.valid?).to be(false)
+      user.disable!
+      expect(user.reload.active).to be(false)
+    end
+  end
+
   describe 'associations' do
     subject(:user) { build(:user) }
 


### PR DESCRIPTION
Fixes some issues when destroying archived schools:

- disabling users fails when model is invalid, so disable validations on `disable!` and `enable!`
- ensure rtone variant installations are removed from meter, these will be destroyed when school destroyed
- remove meter issues before destroying school. Currently failing for some schools. Seems to be due to an Issue referencing both schools and meters, so destroying with the school fails as not yet destroyed the meter. Added explicit call to remove the meter association, the issue will then be destroyed when school destroyed

