### PR TITLE
Add index to amr_validated_reading

### DIFF
--- a/app/models/amr_validated_reading.rb
+++ b/app/models/amr_validated_reading.rb
@@ -21,9 +21,9 @@
 #
 # Indexes
 #
+#  idx_amr_validated_reading_meter_status                    (meter_id,status)
 #  index_amr_validated_readings_on_meter_id_and_one_day_kwh  (meter_id,one_day_kwh)
 #  index_amr_validated_readings_on_reading_date              (reading_date)
-#  unique_amr_meter_validated_readings                       (meter_id,reading_date) UNIQUE
 #
 # Foreign Keys
 #

--- a/app/models/amr_validated_reading.rb
+++ b/app/models/amr_validated_reading.rb
@@ -24,6 +24,7 @@
 #  idx_amr_validated_reading_meter_status                    (meter_id,status)
 #  index_amr_validated_readings_on_meter_id_and_one_day_kwh  (meter_id,one_day_kwh)
 #  index_amr_validated_readings_on_reading_date              (reading_date)
+#  unique_amr_meter_validated_readings                       (meter_id,reading_date) UNIQUE
 #
 # Foreign Keys
 #

--- a/db/migrate/20260820134134_add_status_index_to_validated_reads.rb
+++ b/db/migrate/20260820134134_add_status_index_to_validated_reads.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class AddStatusIndexToValidatedReads < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+  def up
+    add_index :amr_validated_readings,
+              %i[meter_id status],
+              name: 'idx_amr_validated_reading_meter_status',
+              algorithm: :concurrently
+  end
+
+  def down
+    remove_index :amr_validated_readings,
+                 name: 'idx_amr_validated_reading_meter_status',
+                 algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_18_131456) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_20_134134) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pg_catalog.plpgsql"
@@ -517,6 +517,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_18_131456) do
     t.date "substitute_date"
     t.datetime "upload_datetime", precision: nil
     t.index ["meter_id", "one_day_kwh"], name: "index_amr_validated_readings_on_meter_id_and_one_day_kwh"
+    t.index ["meter_id", "status"], name: "idx_amr_validated_reading_meter_status"
     t.index ["reading_date"], name: "index_amr_validated_readings_on_reading_date"
     t.unique_constraint ["meter_id", "reading_date"], name: "unique_amr_meter_validated_readings"
   end


### PR DESCRIPTION
Added a combined index on meter_id, status. Speeds up the queries that look for specific statuses, e.g. EST, PROB.