### PR TITLE
Add photo guidance to activity and action recording forms

### DIFF
--- a/app/views/shared/tasks/_activity_intervention_form.html.erb
+++ b/app/views/shared/tasks/_activity_intervention_form.html.erb
@@ -82,9 +82,14 @@
         </p>
         <p class='small'>
             <%= t('tasks.form.photo_guidance') %>.
-        </p>
-        <p class='small'>
-            <%= t('tasks.form.photo_reproduction_guidance') %>.
+            <% guidance_link = if activity
+                                 category_page_path('engaging-the-school-community', 'educational-activities',
+                                                    anchor: 'sharing-photographs-of-your-activities')
+                               elsif observation
+                                 category_page_path('engaging-the-school-community', 'energy-saving-actions',
+                                                    anchor: 'sharing-photographs-of-your-actions')
+                               end %>
+            <%= link_to t('tasks.form.photo_guidance_link'), guidance_link %>.
         </p>
         <p class='small text-muted'>
             <% if activity %>

--- a/app/views/shared/tasks/_activity_intervention_form.html.erb
+++ b/app/views/shared/tasks/_activity_intervention_form.html.erb
@@ -64,39 +64,39 @@
         <%= render 'shared/tasks/bonus_points', type: %>
       </h4>
       <div>
-        <small>
-          <% if activity %>
-            <%= t('activities.form.tell_us_more_message') %>
-          <% elsif observation %>
-            <%= t('interventions.form.adding_some_background_detail_label') %>.
-          <% end %>
-        </small>
-        <% if SiteSettings.current&.photo_bonus_points&.nonzero? %>
-          <small>
-            <%= t("#{type}.form.bonus_points_message") %>
-            <strong>
-              <%= SiteSettings.current.photo_bonus_points %>
-              <%# i18n-tasks-use t("activities.form.bonus_points") %>
-              <%# i18n-tasks-use t("interventions.form.bonus_points") %>
-              <%= t("#{type}.form.bonus_points", count: SiteSettings.current.photo_bonus_points) %>.
+        <p class='small'>
+            <% if activity %>
+              <%= t('activities.form.tell_us_more_message') %>
+            <% elsif observation %>
+              <%= t('interventions.form.adding_some_background_detail_label') %>.
+            <% end %>
+          <% if SiteSettings.current&.photo_bonus_points&.nonzero? %>
+              <%= t("#{type}.form.bonus_points_message") %>
+              <strong>
+                <%= SiteSettings.current.photo_bonus_points %>
+                <%# i18n-tasks-use t("activities.form.bonus_points") %>
+                <%# i18n-tasks-use t("interventions.form.bonus_points") %>
+                <%= t("#{type}.form.bonus_points", count: SiteSettings.current.photo_bonus_points) %>.
               </strong>
-            </small>
-        <% end %>
-      </div>
-      <p>
-        <small class="text-muted">
-          <% if activity %>
-              <%= t('activities.form.tell_us_more_formatting_message') %>.
-          <% elsif observation %>
-            <%= t('interventions.form.you_can_add_formatting_label') %>.
           <% end %>
-        </small>
-      </p>
-
-      <div class="mt-4">
+        </p>
+        <p class='small'>
+            <%= t('tasks.form.photo_guidance') %>.
+        </p>
+        <p class='small'>
+            <%= t('tasks.form.photo_reproduction_guidance') %>.
+        </p>
+        <p class='small text-muted'>
+            <% if activity %>
+                <%= t('activities.form.tell_us_more_formatting_message') %>.
+            <% elsif observation %>
+              <%= t('interventions.form.you_can_add_formatting_label') %>.
+            <% end %>
+        </p>
+      </div>
+      <div>
         <%= render(Forms::TrixComponent.new(form: f, field: :description, button_size: :default, controls: :simple)) %>
       </div>
-
       <hr class="my-4">
       <div class="d-flex justify-content-end gap-2">
         <% if activity

--- a/config/locales/views/tasks/tasks.yml
+++ b/config/locales/views/tasks/tasks.yml
@@ -50,8 +50,8 @@ en:
     completed_on: Completed on %{date}
     download_resources: Download resources
     form:
-      photo_guidance: Where possible, please choose photographs that illustrate the activity without clearly identifying individual pupils. Images showing pupils from behind, in groups, or focusing on the activity itself are often just as effective. Only upload photographs where you have appropriate consent for public publication
-      photo_reproduction_guidance: Please note that photographs uploaded to the Energy Sparks website may also be reproduced in our newsletters, blog posts, and social media, and shared with Energy Sparks' funders and the DfE if relevant
+      photo_guidance: Please only upload photographs where you have consent for public publication. Where possible, choose images that do not clearly identify individual pupils. Photos uploaded to Energy Sparks may also be used in our newsletters, blog, social media and reports to funders
+      photo_guidance_link: See our Help pages for full guidance on using photographs
     login_to_record:
       are_you_an_energy_sparks_user: Are you an Energy Sparks user?
     points:

--- a/config/locales/views/tasks/tasks.yml
+++ b/config/locales/views/tasks/tasks.yml
@@ -49,6 +49,9 @@ en:
       what_next: What do you want to do next?
     completed_on: Completed on %{date}
     download_resources: Download resources
+    form:
+      photo_guidance: Where possible, please choose photographs that illustrate the activity without clearly identifying individual pupils. Images showing pupils from behind, in groups, or focusing on the activity itself are often just as effective. Only upload photographs where you have appropriate consent for public publication
+      photo_reproduction_guidance: Please note that photographs uploaded to the Energy Sparks website may also be reproduced in our newsletters, blog posts, and social media, and shared with Energy Sparks' funders and the DfE if relevant
     login_to_record:
       are_you_an_energy_sparks_user: Are you an Energy Sparks user?
     points:

--- a/spec/system/activities_spec.rb
+++ b/spec/system/activities_spec.rb
@@ -212,7 +212,7 @@ describe 'viewing and recording activities' do
         visit activity_type_path(activity_type)
       end
 
-      context with_feature: :todos do
+      context 'when school has an audit' do # needed for task_completed page to show audit prompt
         let(:audit) { create(:audit, :with_todos, school:) }
 
         before do
@@ -221,6 +221,12 @@ describe 'viewing and recording activities' do
 
         it 'shows score and threshold' do
           expect(page).to have_text('Completing this activity up to 10 times this academic year will earn you 25 points')
+        end
+
+        it 'links to help page' do
+          expect(page).to have_link('See our Help pages for full guidance on using photographs',
+                                    href: category_page_path('engaging-the-school-community', 'educational-activities',
+                                                             anchor: 'sharing-photographs-of-your-activities'))
         end
 
         context 'with non-custom activity' do
@@ -371,7 +377,7 @@ describe 'viewing and recording activities' do
       end
     end
 
-    context 'when recording an activity', toggle_feature: :todos do
+    context 'when recording an activity' do
       before do
         select other_school.name, from: :school_id
         click_on 'Record this activity'
@@ -420,7 +426,7 @@ describe 'viewing and recording activities' do
     let!(:school_1)   { create(:school) }
     let!(:school_2)   { create(:school) }
 
-    context 'viewing an activity type', toggle_feature: :todos do
+    context 'viewing an activity type' do
       before do
         sign_in(admin)
         visit activity_type_path(activity_type)
@@ -448,7 +454,7 @@ describe 'viewing and recording activities' do
   context 'as a pupil' do
     let(:pupil) { create(:pupil, school:) }
 
-    context 'viewing an activity type', toggle_feature: :todos do
+    context 'viewing an activity type' do
       before do
         sign_in(pupil)
         visit activity_type_path(activity_type)

--- a/spec/system/interventions_spec.rb
+++ b/spec/system/interventions_spec.rb
@@ -256,6 +256,12 @@ describe 'viewing and recording action' do
         expect(page).to have_text('Completing this action up to 10 times this academic year will earn you 30 points')
       end
 
+      it 'links to help page' do
+        expect(page).to have_link('See our Help pages for full guidance on using photographs',
+                                  href: category_page_path('engaging-the-school-community', 'energy-saving-actions',
+                                                           anchor: 'sharing-photographs-of-your-actions'))
+      end
+
       context "when time isn't provided" do
         before do
           fill_in 'observation_at', with: ''
@@ -265,7 +271,7 @@ describe 'viewing and recording action' do
         it { expect(page).to have_text("can't be blank") }
       end
 
-      context with_feature: :todos do
+      context 'when school has an audit' do # needed for task_completed page to show audit prompt
         let!(:audit) { create(:audit, :with_todos, school:) }
 
         context 'when time is in previous academic year' do


### PR DESCRIPTION
Adds photo guidance as follows:

<img width="1107" height="560" alt="Screenshot 2026-09-02 at 12 11 49" src="https://github.com/user-attachments/assets/fe7d8c20-5557-4eb1-82e8-b761af871e51" />

Is rather a large block of text, all of which is important, otherwise we might want to consider moving some of it below in a footnote perhaps.