### PR TITLE
Only attempt contact update if user is in Mailchimp audience

### DIFF
--- a/app/jobs/mailchimp/user_deletion_job.rb
+++ b/app/jobs/mailchimp/user_deletion_job.rb
@@ -8,6 +8,8 @@ module Mailchimp
       contact = Mailchimp::Contact.from_params({ email_address:, name:, school:, interests: {} })
       audience_manager = AudienceManager.new
       mailchimp_member = audience_manager.update_contact(contact)
+      return unless mailchimp_member
+
       audience_manager.remove_tags_from_contact(email_address, tags_to_remove(mailchimp_member))
     rescue => e
       EnergySparks::Log.exception(e, job: :user_deletion)

--- a/app/services/mailchimp/audience_manager.rb
+++ b/app/services/mailchimp/audience_manager.rb
@@ -1,5 +1,5 @@
 module Mailchimp
-  class AudienceManager
+  class AudienceManager # rubocop:disable Metrics/ClassLength
     def initialize(client = Rails.configuration.mailchimp_client)
       @client = client
     end
@@ -53,6 +53,9 @@ module Mailchimp
     end
 
     def update_contact(mailchimp_contact, original_email = nil)
+      contact = get_list_member(mailchimp_key(mailchimp_contact, original_email))
+      return unless contact
+
       resp = @client.lists.set_list_member(list.id,
                                            mailchimp_key(mailchimp_contact, original_email),
                                            mailchimp_contact.to_mailchimp_hash,

--- a/spec/jobs/mailchimp/user_deletion_job_spec.rb
+++ b/spec/jobs/mailchimp/user_deletion_job_spec.rb
@@ -60,5 +60,16 @@ describe Mailchimp::UserDeletionJob do
       expect(double).to receive(:remove_tags_from_contact).with(email_address, %w[FSM30 school-of-hard-knocks])
       job.perform(email_address:, name:, school:)
     end
+
+    context 'when user is not in mailchimp' do
+      before do
+        allow(double).to receive(:update_contact).and_return(nil)
+      end
+
+      it 'does not try to remove tags' do
+        expect(double).not_to receive(:remove_tags_from_contact)
+        job.perform(email_address:, name:, school:)
+      end
+    end
   end
 end

--- a/spec/services/mailchimp/audience_manager_spec.rb
+++ b/spec/services/mailchimp/audience_manager_spec.rb
@@ -101,28 +101,43 @@ describe Mailchimp::AudienceManager do
       Mailchimp::Contact.new('user@example.org', 'Jane Smith')
     end
 
-    before do
-      allow(lists_api).to receive(:get_all_lists).and_return(lists_data)
+    context 'when user is in mailchimp' do
+      before do
+        contact = YAML.safe_load_file('spec/fixtures/mailchimp/contact.yml')
+        allow(lists_api).to receive_messages(get_all_lists: lists_data, get_list_member: contact)
+      end
+
+      it 'updates contact' do
+        expect(lists_api).to receive(:set_list_member).with(
+          'aff6ac9f1b',
+          Digest::MD5.hexdigest(contact.email_address.downcase),
+          contact.to_mailchimp_hash,
+          { skip_merge_validation: true }
+        )
+        service.update_contact(contact)
+      end
+
+      it 'updates contact using old email' do
+        expect(lists_api).to receive(:set_list_member).with(
+          'aff6ac9f1b',
+          Digest::MD5.hexdigest('old@example.org'),
+          contact.to_mailchimp_hash,
+          { skip_merge_validation: true }
+        )
+        service.update_contact(contact, 'old@example.org')
+      end
     end
 
-    it 'updates contact' do
-      expect(lists_api).to receive(:set_list_member).with(
-        'aff6ac9f1b',
-        Digest::MD5.hexdigest(contact.email_address.downcase),
-        contact.to_mailchimp_hash,
-        { skip_merge_validation: true }
-      )
-      service.update_contact(contact)
-    end
+    context 'when contact is not in mailchimp' do
+      before do
+        allow(lists_api).to receive(:get_all_lists).and_return(lists_data)
+        allow(lists_api).to receive(:get_list_member).and_raise(StandardError)
+      end
 
-    it 'updates contact using old email' do
-      expect(lists_api).to receive(:set_list_member).with(
-        'aff6ac9f1b',
-        Digest::MD5.hexdigest('old@example.org'),
-        contact.to_mailchimp_hash,
-        { skip_merge_validation: true }
-      )
-      service.update_contact(contact, 'old@example.org')
+      it 'does not call the API' do
+        expect(lists_api).not_to receive(:set_list_member)
+        service.update_contact(contact)
+      end
     end
   end
 


### PR DESCRIPTION
We occasionally get an error from Mailchimp when updating a contact. It appears to be due to the email address not being in the audience. All users should be in the audience, with preferences set. But users may have opted out or been removed. Which might explain why the API returns an error.

Changes just ensures that when updating a contact we first check if they are present, then do the update.

When deleting a user we only remove tags if the user is in the audience.