### PR TITLE
Update annotations and schema following upgrades

### DIFF
--- a/.annotaterb.yml
+++ b/.annotaterb.yml
@@ -5,3 +5,4 @@
 :exclude_tests: true
 :sort: true
 :hide_limit_column_types: 'integer,boolean'
+:show_enums: true

--- a/app/models/advice_page_school_benchmark.rb
+++ b/app/models/advice_page_school_benchmark.rb
@@ -3,7 +3,7 @@
 # Table name: advice_page_school_benchmarks
 #
 #  id             :bigint(8)        not null, primary key
-#  benchmarked_as :integer          default("other_school"), not null
+#  benchmarked_as :integer          default(0), not null
 #  created_at     :datetime         not null
 #  updated_at     :datetime         not null
 #  advice_page_id :bigint(8)        not null

--- a/app/models/alert.rb
+++ b/app/models/alert.rb
@@ -9,7 +9,7 @@
 #  enough_data             :integer
 #  priority_data           :json
 #  rating                  :decimal(, )
-#  relevance               :integer          default("relevant")
+#  relevance               :integer          default(0)
 #  reporting_period        :integer
 #  run_on                  :date
 #  template_data           :json

--- a/app/models/alert_subscription_event.rb
+++ b/app/models/alert_subscription_event.rb
@@ -3,10 +3,10 @@
 # Table name: alert_subscription_events
 #
 #  id                                   :bigint(8)        not null, primary key
-#  communication_type                   :integer          default("email"), not null
+#  communication_type                   :integer          default(0), not null
 #  message                              :text
 #  priority                             :decimal(, )      default(0.0), not null
-#  status                               :integer          default("pending"), not null
+#  status                               :integer          default(0), not null
 #  unsubscription_uuid                  :string
 #  created_at                           :datetime         not null
 #  updated_at                           :datetime         not null

--- a/app/models/alert_type.rb
+++ b/app/models/alert_type.rb
@@ -9,11 +9,11 @@
 #  enabled         :boolean          default(TRUE), not null
 #  frequency       :integer
 #  fuel_type       :integer
-#  group           :integer          default("advice"), not null
+#  group           :integer          default(0), not null
 #  has_ratings     :boolean          default(TRUE)
-#  link_to         :integer          default("insights_page"), not null
+#  link_to         :integer          default(0), not null
 #  link_to_section :string
-#  source          :integer          default("analytics"), not null
+#  source          :integer          default(0), not null
 #  sub_category    :integer
 #  title           :text
 #  user_restricted :boolean          default(FALSE), not null

--- a/app/models/alert_type_rating_content_version.rb
+++ b/app/models/alert_type_rating_content_version.rb
@@ -3,7 +3,7 @@
 # Table name: alert_type_rating_content_versions
 #
 #  id                                    :bigint(8)        not null, primary key
-#  colour                                :integer          default("negative"), not null
+#  colour                                :integer          default(0), not null
 #  email_end_date                        :date
 #  email_start_date                      :date
 #  email_title                           :string

--- a/app/models/amr_data_feed_config.rb
+++ b/app/models/amr_data_feed_config.rb
@@ -8,14 +8,14 @@
 #  allow_merging           :boolean          default(FALSE), not null
 #  column_row_filters      :jsonb
 #  column_separator        :text             default(","), not null
-#  convert_to_kwh          :enum             default("no")
+#  convert_to_kwh          :enum             default("no"), enum_type: amr_data_feed_config_convert_to_kwh
 #  date_format             :text             not null
 #  delayed_reading         :boolean          default(FALSE), not null
 #  description             :text             not null
 #  enabled                 :boolean          default(TRUE), not null
 #  estimate_flags          :string           default([]), not null, is an Array
 #  expected_units          :string
-#  half_hourly_labelling   :enum
+#  half_hourly_labelling   :enum             enum_type: half_hourly_labelling
 #  handle_off_by_one       :boolean          default(FALSE)
 #  header_example          :text
 #  identifier              :text             not null
@@ -49,6 +49,11 @@
 # Foreign Keys
 #
 #  fk_rails_...  (owned_by_id => users.id)
+#
+# Enums
+#
+#  amr_data_feed_config_convert_to_kwh  no, m3, meter
+#  half_hourly_labelling                start, end
 #
 
 class AmrDataFeedConfig < ApplicationRecord # rubocop:disable Metrics/ClassLength

--- a/app/models/amr_validated_reading.rb
+++ b/app/models/amr_validated_reading.rb
@@ -24,7 +24,6 @@
 #  idx_amr_validated_reading_meter_status                    (meter_id,status)
 #  index_amr_validated_readings_on_meter_id_and_one_day_kwh  (meter_id,one_day_kwh)
 #  index_amr_validated_readings_on_reading_date              (reading_date)
-#  unique_amr_meter_validated_readings                       (meter_id,reading_date) UNIQUE
 #
 # Foreign Keys
 #

--- a/app/models/calendar_event_type.rb
+++ b/app/models/calendar_event_type.rb
@@ -4,7 +4,7 @@
 #
 #  id                   :bigint(8)        not null, primary key
 #  alias                :text
-#  analytics_event_type :integer          default("term_time"), not null
+#  analytics_event_type :integer          default(0), not null
 #  bank_holiday         :boolean          default(FALSE)
 #  colour               :text
 #  description          :text

--- a/app/models/cms/page.rb
+++ b/app/models/cms/page.rb
@@ -3,7 +3,7 @@
 # Table name: cms_pages
 #
 #  id            :bigint(8)        not null, primary key
-#  audience      :enum             default("anyone"), not null
+#  audience      :enum             default("anyone"), not null, enum_type: audience
 #  published     :boolean          default(FALSE), not null
 #  slug          :string           not null
 #  created_at    :datetime         not null
@@ -23,6 +23,10 @@
 #  fk_rails_...  (category_id => cms_categories.id)
 #  fk_rails_...  (created_by_id => users.id) ON DELETE => nullify
 #  fk_rails_...  (updated_by_id => users.id) ON DELETE => nullify
+#
+# Enums
+#
+#  audience  anyone, school_users, school_admins, group_admins
 #
 module Cms
   class Page < Cms::Base

--- a/app/models/commercial/contract.rb
+++ b/app/models/commercial/contract.rb
@@ -9,14 +9,14 @@
 #  comments              :text
 #  contract_holder_type  :string           not null
 #  end_date              :date             not null
-#  invoice_terms         :enum             default("pro_rata"), not null
-#  licence_period        :enum             default("contract"), not null
+#  invoice_terms         :enum             default("pro_rata"), not null, enum_type: contract_invoice_terms
+#  licence_period        :enum             default("contract"), not null, enum_type: contract_licence_period
 #  licence_years         :decimal(4, 2)
 #  name                  :string           not null
 #  number_of_schools     :integer          not null
 #  purchase_order_number :string
 #  start_date            :date             not null
-#  status                :enum             default("provisional"), not null
+#  status                :enum             default("provisional"), not null, enum_type: contract_status
 #  created_at            :datetime         not null
 #  updated_at            :datetime         not null
 #  contract_holder_id    :bigint(8)        not null
@@ -40,6 +40,12 @@
 #  fk_rails_...  (product_id => commercial_products.id)
 #  fk_rails_...  (updated_by_id => users.id)
 #  fk_rails_...  (xero_account_code_id => commercial_xero_account_codes.id)
+#
+# Enums
+#
+#  contract_invoice_terms   pro_rata, full
+#  contract_licence_period  contract, custom
+#  contract_status          provisional, confirmed
 #
 module Commercial
   class Contract < ApplicationRecord # rubocop:disable Metrics/ClassLength

--- a/app/models/commercial/contract_contact.rb
+++ b/app/models/commercial/contract_contact.rb
@@ -4,7 +4,7 @@
 #
 #  id                   :bigint(8)        not null, primary key
 #  comments             :text
-#  contact_type         :enum             not null
+#  contact_type         :enum             not null, enum_type: contract_contact_type
 #  contract_holder_type :string           not null
 #  email                :string           not null
 #  name                 :string           not null
@@ -26,6 +26,10 @@
 #
 #  fk_rails_...  (created_by_id => users.id)
 #  fk_rails_...  (updated_by_id => users.id)
+#
+# Enums
+#
+#  contract_contact_type  procurement, invoicing, loa, renewals
 #
 module Commercial
   class ContractContact < ApplicationRecord

--- a/app/models/commercial/licence.rb
+++ b/app/models/commercial/licence.rb
@@ -8,7 +8,7 @@
 #  invoice_reference     :string
 #  school_specific_price :decimal(10, 2)
 #  start_date            :date             not null
-#  status                :enum             default("provisional"), not null
+#  status                :enum             default("provisional"), not null, enum_type: licence_status
 #  created_at            :datetime         not null
 #  updated_at            :datetime         not null
 #  contract_id           :bigint(8)        not null
@@ -28,6 +28,10 @@
 #  fk_rails_...  (contract_id => commercial_contracts.id)
 #  fk_rails_...  (created_by_id => users.id)
 #  fk_rails_...  (updated_by_id => users.id)
+#
+# Enums
+#
+#  licence_status  provisional, confirmed, pending_invoice, invoiced
 #
 module Commercial
   class Licence < ApplicationRecord

--- a/app/models/energy_tariff.rb
+++ b/app/models/energy_tariff.rb
@@ -3,16 +3,16 @@
 # Table name: energy_tariffs
 #
 #  id                 :bigint(8)        not null, primary key
-#  applies_to         :integer          default("both")
+#  applies_to         :integer          default(0)
 #  ccl                :boolean          default(FALSE)
 #  enabled            :boolean          default(TRUE)
 #  end_date           :date
-#  meter_type         :integer          default("electricity"), not null
+#  meter_type         :integer          default(0), not null
 #  name               :text             not null
-#  source             :integer          default("manually_entered"), not null
+#  source             :integer          default(0), not null
 #  start_date         :date
 #  tariff_holder_type :string
-#  tariff_type        :integer          default("flat_rate"), not null
+#  tariff_type        :integer          default(0), not null
 #  tnuos              :boolean          default(FALSE)
 #  vat_rate           :integer
 #  created_at         :datetime         not null

--- a/app/models/equivalence_type.rb
+++ b/app/models/equivalence_type.rb
@@ -3,7 +3,7 @@
 # Table name: equivalence_types
 #
 #  id          :bigint(8)        not null, primary key
-#  image_name  :integer          default("no_image"), not null
+#  image_name  :integer          default(0), not null
 #  meter_type  :integer          not null
 #  time_period :integer          not null
 #  created_at  :datetime         not null

--- a/app/models/impact_report/metric.rb
+++ b/app/models/impact_report/metric.rb
@@ -8,10 +8,10 @@
 #  id                   :bigint(8)        not null, primary key
 #  enough_data          :boolean          default(FALSE), not null
 #  fuel_type            :integer
-#  metric_category      :enum             not null
-#  metric_type          :enum             not null
+#  metric_category      :enum             not null, enum_type: impact_report_metric_categories
+#  metric_type          :enum             not null, enum_type: impact_report_metric_types
 #  number_of_schools    :integer
-#  unit                 :enum
+#  unit                 :enum             enum_type: impact_report_metric_units
 #  value                :integer
 #  created_at           :datetime         not null
 #  updated_at           :datetime         not null
@@ -25,6 +25,12 @@
 # Foreign Keys
 #
 #  fk_rails_...  (impact_report_run_id => impact_report_runs.id)
+#
+# Enums
+#
+#  impact_report_metric_categories  overview, energy_efficiency, engagement, potential_savings
+#  impact_report_metric_types       actions, active_users, activities, annual_saving, baseload, data_visible_schools, enrolled_schools, enrolling_schools, heating_control, heating_down, heating_early, heating_off, holiday_previous, holiday_previous_year, insulate_pipes, long_term, out_of_hours, peak, points, pupils, solar_panels, targets, thermostatic_control, use, users, visible_schools
+#  impact_report_metric_units       kwh, co2, gbp
 #
 # rubocop:enable Layout/LineLength
 

--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -4,11 +4,11 @@
 #
 #  id             :bigint(8)        not null, primary key
 #  fuel_type      :integer
-#  issue_type     :integer          default("issue"), not null
+#  issue_type     :integer          default(0), not null
 #  issueable_type :string
 #  pinned         :boolean          default(FALSE)
 #  review_date    :date
-#  status         :integer          default("open"), not null
+#  status         :integer          default(0), not null
 #  title          :string           not null
 #  created_at     :datetime         not null
 #  updated_at     :datetime         not null

--- a/app/models/manual_data_load_run.rb
+++ b/app/models/manual_data_load_run.rb
@@ -3,7 +3,7 @@
 # Table name: manual_data_load_runs
 #
 #  id                      :bigint(8)        not null, primary key
-#  status                  :integer          default("pending"), not null
+#  status                  :integer          default(0), not null
 #  created_at              :datetime         not null
 #  updated_at              :datetime         not null
 #  amr_uploaded_reading_id :bigint(8)        not null

--- a/app/models/meter.rb
+++ b/app/models/meter.rb
@@ -10,7 +10,7 @@
 #  gas_unit                       :enum
 #  manual_reads                   :boolean          default(FALSE), not null
 #  meter_serial_number            :text
-#  meter_system                   :integer          default("nhh_amr")
+#  meter_system                   :integer          default(0)
 #  meter_type                     :integer
 #  mpan_mprn                      :bigint(8)
 #  name                           :string

--- a/app/models/meter.rb
+++ b/app/models/meter.rb
@@ -6,15 +6,15 @@
 #  active                         :boolean          default(TRUE)
 #  consent_granted                :boolean          default(FALSE)
 #  dcc_checked_at                 :datetime
-#  dcc_meter                      :enum             default("no"), not null
-#  gas_unit                       :enum
+#  dcc_meter                      :enum             default("no"), not null, enum_type: dcc_meter
+#  gas_unit                       :enum             enum_type: gas_unit
 #  manual_reads                   :boolean          default(FALSE), not null
 #  meter_serial_number            :text
 #  meter_system                   :integer          default(0)
 #  meter_type                     :integer
 #  mpan_mprn                      :bigint(8)
 #  name                           :string
-#  perse_api                      :enum
+#  perse_api                      :enum             enum_type: meter_perse_api
 #  pseudo                         :boolean          default(FALSE)
 #  created_at                     :datetime         not null
 #  updated_at                     :datetime         not null
@@ -51,6 +51,12 @@
 #  fk_rails_...  (school_id => schools.id) ON DELETE => cascade
 #  fk_rails_...  (solar_edge_installation_id => solar_edge_installations.id) ON DELETE => cascade
 #  fk_rails_...  (solis_cloud_installation_id => solis_cloud_installations.id) ON DELETE => cascade
+#
+# Enums
+#
+#  dcc_meter        no, smets2, other
+#  gas_unit         kwh, m3, ft3, hcf
+#  meter_perse_api  half_hourly
 #
 
 class Meter < ApplicationRecord

--- a/app/models/meter_monthly_summary.rb
+++ b/app/models/meter_monthly_summary.rb
@@ -6,9 +6,9 @@
 #
 #  id          :bigint(8)        not null, primary key
 #  consumption :float            not null, is an Array
-#  quality     :enum             not null, is an Array
+#  quality     :enum             not null, is an Array, enum_type: meter_monthly_summary_quality
 #  total       :float            not null
-#  type        :enum             not null
+#  type        :enum             not null, enum_type: meter_monthly_summary_type
 #  year        :integer          not null
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
@@ -18,6 +18,11 @@
 #
 #  index_meter_monthly_summaries_on_meter_id                    (meter_id)
 #  index_meter_monthly_summaries_on_meter_id_and_year_and_type  (meter_id,year,type) UNIQUE
+#
+# Enums
+#
+#  meter_monthly_summary_quality  incomplete, actual, estimated, corrected
+#  meter_monthly_summary_type     consumption, generation, self_consume, export
 #
 class MeterMonthlySummary < ApplicationRecord
   belongs_to :meter

--- a/app/models/programme.rb
+++ b/app/models/programme.rb
@@ -5,7 +5,7 @@
 #  id                :bigint(8)        not null, primary key
 #  ended_on          :date
 #  started_on        :date             not null
-#  status            :integer          default("started"), not null
+#  status            :integer          default(0), not null
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
 #  programme_type_id :bigint(8)        not null

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -9,17 +9,17 @@
 #  archived_date                           :date
 #  bill_requested                          :boolean          default(FALSE)
 #  bill_requested_at                       :datetime
-#  chart_preference                        :integer          default("default"), not null
+#  chart_preference                        :integer          default(0), not null
 #  cooks_dinners_for_other_schools         :boolean          default(FALSE), not null
 #  cooks_dinners_for_other_schools_count   :integer
 #  cooks_dinners_onsite                    :boolean          default(FALSE), not null
-#  country                                 :integer          default("england"), not null
+#  country                                 :integer          default(0), not null
 #  data_enabled                            :boolean          default(FALSE)
 #  data_sharing                            :enum             default("public"), not null
 #  enable_targets_feature                  :boolean          default(TRUE)
 #  floor_area                              :decimal(, )
 #  full_school                             :boolean          default(TRUE)
-#  funding_status                          :integer          default("state_school"), not null
+#  funding_status                          :integer          default(0), not null
 #  has_battery                             :boolean          default(FALSE), not null
 #  has_swimming_pool                       :boolean          default(FALSE), not null
 #  heating_air_source_heat_pump            :boolean          default(FALSE), not null

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -15,7 +15,7 @@
 #  cooks_dinners_onsite                    :boolean          default(FALSE), not null
 #  country                                 :integer          default(0), not null
 #  data_enabled                            :boolean          default(FALSE)
-#  data_sharing                            :enum             default("public"), not null
+#  data_sharing                            :enum             default("public"), not null, enum_type: data_sharing
 #  enable_targets_feature                  :boolean          default(TRUE)
 #  floor_area                              :decimal(, )
 #  full_school                             :boolean          default(TRUE)
@@ -69,7 +69,7 @@
 #  public                                  :boolean          default(TRUE)
 #  region                                  :integer
 #  removal_date                            :date
-#  renewal_behaviour                       :enum             default("renew"), not null
+#  renewal_behaviour                       :enum             default("renew"), not null, enum_type: renewal_behaviour
 #  school_type                             :integer          not null
 #  serves_dinners                          :boolean          default(FALSE), not null
 #  slug                                    :string
@@ -111,6 +111,11 @@
 #  fk_rails_...  (school_group_cluster_id => school_group_clusters.id) ON DELETE => nullify
 #  fk_rails_...  (school_group_id => school_groups.id) ON DELETE => restrict
 #  fk_rails_...  (scoreboard_id => scoreboards.id) ON DELETE => nullify
+#
+# Enums
+#
+#  data_sharing       public, within_group, private
+#  renewal_behaviour  renew, archive, waitlist
 #
 
 require 'securerandom'

--- a/app/models/school_batch_run.rb
+++ b/app/models/school_batch_run.rb
@@ -3,7 +3,7 @@
 # Table name: school_batch_runs
 #
 #  id         :bigint(8)        not null, primary key
-#  status     :integer          default("pending"), not null
+#  status     :integer          default(0), not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
 #  school_id  :bigint(8)

--- a/app/models/school_group.rb
+++ b/app/models/school_group.rb
@@ -3,11 +3,11 @@
 # Table name: school_groups
 #
 #  id                                       :bigint(8)        not null, primary key
-#  default_chart_preference                 :integer          default("default"), not null
-#  default_country                          :integer          default("england"), not null
+#  default_chart_preference                 :integer          default(0), not null
+#  default_country                          :integer          default(0), not null
 #  description                              :string
 #  dfe_code                                 :string
-#  group_type                               :integer          default("general")
+#  group_type                               :integer          default(0)
 #  mailchimp_fields_changed_at              :datetime
 #  name                                     :string           not null
 #  public                                   :boolean          default(TRUE)

--- a/app/models/school_grouping.rb
+++ b/app/models/school_grouping.rb
@@ -3,7 +3,7 @@
 # Table name: school_groupings
 #
 #  id              :bigint(8)        not null, primary key
-#  role            :enum             not null
+#  role            :enum             not null, enum_type: school_grouping_role
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
 #  school_group_id :bigint(8)        not null
@@ -19,6 +19,10 @@
 #
 #  fk_rails_...  (school_group_id => school_groups.id)
 #  fk_rails_...  (school_id => schools.id)
+#
+# Enums
+#
+#  school_grouping_role  organisation, area, project, diocese
 #
 class SchoolGrouping < ApplicationRecord
   belongs_to :school

--- a/app/models/school_onboarding.rb
+++ b/app/models/school_onboarding.rb
@@ -4,9 +4,9 @@
 #
 #  id                       :bigint(8)        not null, primary key
 #  contact_email            :string           not null
-#  country                  :integer          default("england"), not null
+#  country                  :integer          default(0), not null
 #  data_sharing             :enum             default("public"), not null
-#  default_chart_preference :integer          default("default"), not null
+#  default_chart_preference :integer          default(0), not null
 #  full_school              :boolean          default(TRUE)
 #  notes                    :text
 #  school_name              :string           not null

--- a/app/models/school_onboarding.rb
+++ b/app/models/school_onboarding.rb
@@ -5,7 +5,7 @@
 #  id                       :bigint(8)        not null, primary key
 #  contact_email            :string           not null
 #  country                  :integer          default(0), not null
-#  data_sharing             :enum             default("public"), not null
+#  data_sharing             :enum             default("public"), not null, enum_type: data_sharing
 #  default_chart_preference :integer          default(0), not null
 #  full_school              :boolean          default(TRUE)
 #  notes                    :text
@@ -54,6 +54,10 @@
 #  fk_rails_...  (school_id => schools.id) ON DELETE => cascade
 #  fk_rails_...  (scoreboard_id => scoreboards.id) ON DELETE => nullify
 #  fk_rails_...  (template_calendar_id => calendars.id) ON DELETE => nullify
+#
+# Enums
+#
+#  data_sharing  public, within_group, private
 #
 
 class SchoolOnboarding < ApplicationRecord

--- a/app/models/school_time.rb
+++ b/app/models/school_time.rb
@@ -3,11 +3,11 @@
 # Table name: school_times
 #
 #  id              :bigint(8)        not null, primary key
-#  calendar_period :integer          default("term_times"), not null
+#  calendar_period :integer          default(0), not null
 #  closing_time    :integer          default(1520)
 #  day             :integer
 #  opening_time    :integer          default(850)
-#  usage_type      :integer          default("school_day"), not null
+#  usage_type      :integer          default(0), not null
 #  school_id       :bigint(8)        not null
 #
 # Indexes

--- a/app/models/team_member.rb
+++ b/app/models/team_member.rb
@@ -5,7 +5,7 @@
 #  id          :bigint(8)        not null, primary key
 #  description :text
 #  position    :integer          default(0), not null
-#  role        :integer          default("staff"), not null
+#  role        :integer          default(0), not null
 #  title       :string           not null
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null

--- a/app/models/testimonial.rb
+++ b/app/models/testimonial.rb
@@ -6,7 +6,7 @@
 #
 #  id            :bigint(8)        not null, primary key
 #  active        :boolean          default(FALSE), not null
-#  category      :integer          default("default"), not null
+#  category      :integer          default(0), not null
 #  name          :string
 #  organisation  :string
 #  created_at    :datetime         not null

--- a/app/models/transifex_load.rb
+++ b/app/models/transifex_load.rb
@@ -5,7 +5,7 @@
 #  id         :bigint(8)        not null, primary key
 #  pulled     :integer          default(0), not null
 #  pushed     :integer          default(0), not null
-#  status     :integer          default("running"), not null
+#  status     :integer          default(0), not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
 #

--- a/app/models/transport_survey/response.rb
+++ b/app/models/transport_survey/response.rb
@@ -7,7 +7,7 @@
 #  passengers          :integer          default(1), not null
 #  run_identifier      :string           not null
 #  surveyed_at         :datetime         not null
-#  weather             :integer          default("sun"), not null
+#  weather             :integer          default(0), not null
 #  created_at          :datetime         not null
 #  updated_at          :datetime         not null
 #  transport_survey_id :bigint(8)        not null

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -26,7 +26,7 @@
 #  remember_created_at         :datetime
 #  reset_password_sent_at      :datetime
 #  reset_password_token        :string
-#  role                        :integer          default("guest"), not null
+#  role                        :integer          default(0), not null
 #  sign_in_count               :integer          default(0), not null
 #  terms_accepted              :boolean          default(FALSE)
 #  unlock_token                :string

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -17,7 +17,7 @@
 #  last_sign_in_ip             :inet
 #  locked_at                   :datetime
 #  mailchimp_fields_changed_at :datetime
-#  mailchimp_status            :enum
+#  mailchimp_status            :enum             enum_type: mailchimp_status
 #  mailchimp_updated_at        :datetime
 #  name                        :string
 #  operations                  :boolean          default(FALSE), not null
@@ -53,6 +53,10 @@
 #  fk_rails_...  (school_group_id => school_groups.id) ON DELETE => restrict
 #  fk_rails_...  (school_id => schools.id) ON DELETE => cascade
 #  fk_rails_...  (staff_role_id => staff_roles.id) ON DELETE => restrict
+#
+# Enums
+#
+#  mailchimp_status  subscribed, unsubscribed, cleaned, nonsubscribed, archived
 #
 
 class User < ApplicationRecord

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -2759,27 +2759,27 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_20_134134) do
       additional.economic_tariff_changed_this_year
      FROM ( SELECT alerts.alert_generation_run_id,
               alerts.school_id,
-              json.out_of_hours_kwh,
-              json.out_of_hours_co2,
-              json.out_of_hours_gbpcurrent
+              "json".out_of_hours_kwh,
+              "json".out_of_hours_co2,
+              "json".out_of_hours_gbpcurrent
              FROM alerts,
               alert_types,
-              LATERAL jsonb_to_record(alerts.variables) json(out_of_hours_kwh double precision, out_of_hours_co2 double precision, out_of_hours_gbpcurrent double precision)
+              LATERAL jsonb_to_record(alerts.variables) "json"(out_of_hours_kwh double precision, out_of_hours_co2 double precision, out_of_hours_gbpcurrent double precision)
             WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertOutOfHoursElectricityUsage'::text))) usage,
       ( SELECT alerts.alert_generation_run_id,
               alerts.school_id,
-              json.out_of_hours_kwh AS previous_out_of_hours_kwh,
-              json.out_of_hours_co2 AS previous_out_of_hours_co2,
-              json.out_of_hours_gbpcurrent AS previous_out_of_hours_gbpcurrent
+              "json".out_of_hours_kwh AS previous_out_of_hours_kwh,
+              "json".out_of_hours_co2 AS previous_out_of_hours_co2,
+              "json".out_of_hours_gbpcurrent AS previous_out_of_hours_gbpcurrent
              FROM alerts,
               alert_types,
-              LATERAL jsonb_to_record(alerts.variables) json(out_of_hours_kwh double precision, out_of_hours_co2 double precision, out_of_hours_gbpcurrent double precision)
+              LATERAL jsonb_to_record(alerts.variables) "json"(out_of_hours_kwh double precision, out_of_hours_co2 double precision, out_of_hours_gbpcurrent double precision)
             WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertOutOfHoursElectricityUsagePreviousYear'::text))) usage_previous_year,
       ( SELECT alerts.alert_generation_run_id,
-              json.electricity_economic_tariff_changed_this_year AS economic_tariff_changed_this_year
+              "json".electricity_economic_tariff_changed_this_year AS economic_tariff_changed_this_year
              FROM alerts,
               alert_types,
-              LATERAL jsonb_to_record(alerts.variables) json(electricity_economic_tariff_changed_this_year boolean)
+              LATERAL jsonb_to_record(alerts.variables) "json"(electricity_economic_tariff_changed_this_year boolean)
             WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertAdditionalPrioritisationData'::text))) additional,
       ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
              FROM alert_generation_runs
@@ -2801,27 +2801,27 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_20_134134) do
       additional.economic_tariff_changed_this_year
      FROM ( SELECT alerts.alert_generation_run_id,
               alerts.school_id,
-              json.out_of_hours_kwh,
-              json.out_of_hours_co2,
-              json.out_of_hours_gbpcurrent
+              "json".out_of_hours_kwh,
+              "json".out_of_hours_co2,
+              "json".out_of_hours_gbpcurrent
              FROM alerts,
               alert_types,
-              LATERAL jsonb_to_record(alerts.variables) json(out_of_hours_kwh double precision, out_of_hours_co2 double precision, out_of_hours_gbpcurrent double precision)
+              LATERAL jsonb_to_record(alerts.variables) "json"(out_of_hours_kwh double precision, out_of_hours_co2 double precision, out_of_hours_gbpcurrent double precision)
             WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertOutOfHoursGasUsage'::text))) usage,
       ( SELECT alerts.alert_generation_run_id,
               alerts.school_id,
-              json.out_of_hours_kwh AS previous_out_of_hours_kwh,
-              json.out_of_hours_co2 AS previous_out_of_hours_co2,
-              json.out_of_hours_gbpcurrent AS previous_out_of_hours_gbpcurrent
+              "json".out_of_hours_kwh AS previous_out_of_hours_kwh,
+              "json".out_of_hours_co2 AS previous_out_of_hours_co2,
+              "json".out_of_hours_gbpcurrent AS previous_out_of_hours_gbpcurrent
              FROM alerts,
               alert_types,
-              LATERAL jsonb_to_record(alerts.variables) json(out_of_hours_kwh double precision, out_of_hours_co2 double precision, out_of_hours_gbpcurrent double precision)
+              LATERAL jsonb_to_record(alerts.variables) "json"(out_of_hours_kwh double precision, out_of_hours_co2 double precision, out_of_hours_gbpcurrent double precision)
             WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertOutOfHoursGasUsagePreviousYear'::text))) usage_previous_year,
       ( SELECT alerts.alert_generation_run_id,
-              json.gas_economic_tariff_changed_this_year AS economic_tariff_changed_this_year
+              "json".gas_economic_tariff_changed_this_year AS economic_tariff_changed_this_year
              FROM alerts,
               alert_types,
-              LATERAL jsonb_to_record(alerts.variables) json(gas_economic_tariff_changed_this_year boolean)
+              LATERAL jsonb_to_record(alerts.variables) "json"(gas_economic_tariff_changed_this_year boolean)
             WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertAdditionalPrioritisationData'::text))) additional,
       ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
              FROM alert_generation_runs
@@ -2843,27 +2843,27 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_20_134134) do
       additional.economic_tariff_changed_this_year
      FROM ( SELECT alerts.alert_generation_run_id,
               alerts.school_id,
-              json.out_of_hours_kwh,
-              json.out_of_hours_co2,
-              json.out_of_hours_gbpcurrent
+              "json".out_of_hours_kwh,
+              "json".out_of_hours_co2,
+              "json".out_of_hours_gbpcurrent
              FROM alerts,
               alert_types,
-              LATERAL jsonb_to_record(alerts.variables) json(out_of_hours_kwh double precision, out_of_hours_co2 double precision, out_of_hours_gbpcurrent double precision)
+              LATERAL jsonb_to_record(alerts.variables) "json"(out_of_hours_kwh double precision, out_of_hours_co2 double precision, out_of_hours_gbpcurrent double precision)
             WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertStorageHeaterOutOfHours'::text))) usage,
       ( SELECT alerts.alert_generation_run_id,
               alerts.school_id,
-              json.out_of_hours_kwh AS previous_out_of_hours_kwh,
-              json.out_of_hours_co2 AS previous_out_of_hours_co2,
-              json.out_of_hours_gbpcurrent AS previous_out_of_hours_gbpcurrent
+              "json".out_of_hours_kwh AS previous_out_of_hours_kwh,
+              "json".out_of_hours_co2 AS previous_out_of_hours_co2,
+              "json".out_of_hours_gbpcurrent AS previous_out_of_hours_gbpcurrent
              FROM alerts,
               alert_types,
-              LATERAL jsonb_to_record(alerts.variables) json(out_of_hours_kwh double precision, out_of_hours_co2 double precision, out_of_hours_gbpcurrent double precision)
+              LATERAL jsonb_to_record(alerts.variables) "json"(out_of_hours_kwh double precision, out_of_hours_co2 double precision, out_of_hours_gbpcurrent double precision)
             WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertOutOfHoursStorageHeaterUsagePreviousYear'::text))) usage_previous_year,
       ( SELECT alerts.alert_generation_run_id,
-              json.electricity_economic_tariff_changed_this_year AS economic_tariff_changed_this_year
+              "json".electricity_economic_tariff_changed_this_year AS economic_tariff_changed_this_year
              FROM alerts,
               alert_types,
-              LATERAL jsonb_to_record(alerts.variables) json(electricity_economic_tariff_changed_this_year boolean)
+              LATERAL jsonb_to_record(alerts.variables) "json"(electricity_economic_tariff_changed_this_year boolean)
             WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertAdditionalPrioritisationData'::text))) additional,
       ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
              FROM alert_generation_runs
@@ -3690,23 +3690,23 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_20_134134) do
       gas.temperature_adjusted_percent
      FROM ( SELECT alerts.alert_generation_run_id,
               alerts.school_id,
-              json.previous_year_gas_kwh AS previous_year_kwh,
-              json.current_year_gas_kwh AS current_year_kwh,
-              json.previous_year_gas_co2 AS previous_year_co2,
-              json.current_year_gas_co2 AS current_year_co2,
-              json.previous_year_gas_gbpcurrent AS previous_year_gbp,
-              json.current_year_gas_gbpcurrent AS current_year_gbp
+              "json".previous_year_gas_kwh AS previous_year_kwh,
+              "json".current_year_gas_kwh AS current_year_kwh,
+              "json".previous_year_gas_co2 AS previous_year_co2,
+              "json".current_year_gas_co2 AS current_year_co2,
+              "json".previous_year_gas_gbpcurrent AS previous_year_gbp,
+              "json".current_year_gas_gbpcurrent AS current_year_gbp
              FROM alerts,
               alert_types,
-              LATERAL jsonb_to_record(alerts.variables) json(previous_year_gas_kwh double precision, current_year_gas_kwh double precision, previous_year_gas_co2 double precision, current_year_gas_co2 double precision, previous_year_gas_gbpcurrent double precision, current_year_gas_gbpcurrent double precision)
+              LATERAL jsonb_to_record(alerts.variables) "json"(previous_year_gas_kwh double precision, current_year_gas_kwh double precision, previous_year_gas_co2 double precision, current_year_gas_co2 double precision, previous_year_gas_gbpcurrent double precision, current_year_gas_gbpcurrent double precision)
             WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertEnergyAnnualVersusBenchmark'::text))) energy,
       ( SELECT alerts.alert_generation_run_id,
               alerts.school_id,
-              json.temperature_adjusted_previous_year_kwh,
-              json.temperature_adjusted_percent
+              "json".temperature_adjusted_previous_year_kwh,
+              "json".temperature_adjusted_percent
              FROM alerts,
               alert_types,
-              LATERAL jsonb_to_record(alerts.variables) json(temperature_adjusted_previous_year_kwh double precision, temperature_adjusted_percent double precision)
+              LATERAL jsonb_to_record(alerts.variables) "json"(temperature_adjusted_previous_year_kwh double precision, temperature_adjusted_percent double precision)
             WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertGasAnnualVersusBenchmark'::text))) gas,
       ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
              FROM alert_generation_runs
@@ -3755,23 +3755,23 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_20_134134) do
       storage.temperature_adjusted_percent
      FROM ( SELECT alerts.alert_generation_run_id,
               alerts.school_id,
-              json.previous_year_storage_heaters_kwh AS previous_year_kwh,
-              json.current_year_storage_heaters_kwh AS current_year_kwh,
-              json.previous_year_storage_heaters_co2 AS previous_year_co2,
-              json.current_year_storage_heaters_co2 AS current_year_co2,
-              json.previous_year_storage_heaters_gbpcurrent AS previous_year_gbp,
-              json.current_year_storage_heaters_gbpcurrent AS current_year_gbp
+              "json".previous_year_storage_heaters_kwh AS previous_year_kwh,
+              "json".current_year_storage_heaters_kwh AS current_year_kwh,
+              "json".previous_year_storage_heaters_co2 AS previous_year_co2,
+              "json".current_year_storage_heaters_co2 AS current_year_co2,
+              "json".previous_year_storage_heaters_gbpcurrent AS previous_year_gbp,
+              "json".current_year_storage_heaters_gbpcurrent AS current_year_gbp
              FROM alerts,
               alert_types,
-              LATERAL jsonb_to_record(alerts.variables) json(previous_year_storage_heaters_kwh double precision, current_year_storage_heaters_kwh double precision, previous_year_storage_heaters_co2 double precision, current_year_storage_heaters_co2 double precision, previous_year_storage_heaters_gbpcurrent double precision, current_year_storage_heaters_gbpcurrent double precision)
+              LATERAL jsonb_to_record(alerts.variables) "json"(previous_year_storage_heaters_kwh double precision, current_year_storage_heaters_kwh double precision, previous_year_storage_heaters_co2 double precision, current_year_storage_heaters_co2 double precision, previous_year_storage_heaters_gbpcurrent double precision, current_year_storage_heaters_gbpcurrent double precision)
             WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertEnergyAnnualVersusBenchmark'::text))) energy,
       ( SELECT alerts.alert_generation_run_id,
               alerts.school_id,
-              json.temperature_adjusted_previous_year_kwh,
-              json.temperature_adjusted_percent
+              "json".temperature_adjusted_previous_year_kwh,
+              "json".temperature_adjusted_percent
              FROM alerts,
               alert_types,
-              LATERAL jsonb_to_record(alerts.variables) json(temperature_adjusted_previous_year_kwh double precision, temperature_adjusted_percent double precision)
+              LATERAL jsonb_to_record(alerts.variables) "json"(temperature_adjusted_previous_year_kwh double precision, temperature_adjusted_percent double precision)
             WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertStorageHeaterAnnualVersusBenchmark'::text))) storage,
       ( SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
              FROM alert_generation_runs
@@ -3784,52 +3784,52 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_20_134134) do
       WITH electricity AS (
            SELECT alerts.alert_generation_run_id,
               alerts.comparison_report_id,
-              json.current_period_kwh,
-              json.previous_period_kwh,
-              json.current_period_co2,
-              json.previous_period_co2,
-              json.current_period_gbp,
-              json.previous_period_gbp,
-              json.tariff_has_changed,
-              json.pupils_changed,
-              json.floor_area_changed
+              "json".current_period_kwh,
+              "json".previous_period_kwh,
+              "json".current_period_co2,
+              "json".previous_period_co2,
+              "json".current_period_gbp,
+              "json".previous_period_gbp,
+              "json".tariff_has_changed,
+              "json".pupils_changed,
+              "json".floor_area_changed
              FROM (alerts
                JOIN alert_types ON ((alerts.alert_type_id = alert_types.id))),
-              LATERAL jsonb_to_record(alerts.variables) json(current_period_kwh double precision, previous_period_kwh double precision, current_period_co2 double precision, previous_period_co2 double precision, current_period_gbp double precision, previous_period_gbp double precision, tariff_has_changed boolean, pupils_changed boolean, floor_area_changed boolean)
+              LATERAL jsonb_to_record(alerts.variables) "json"(current_period_kwh double precision, previous_period_kwh double precision, current_period_co2 double precision, previous_period_co2 double precision, current_period_gbp double precision, previous_period_gbp double precision, tariff_has_changed boolean, pupils_changed boolean, floor_area_changed boolean)
             WHERE (alert_types.class_name = 'AlertConfigurablePeriodElectricityComparison'::text)
           ), gas AS (
            SELECT alerts.alert_generation_run_id,
               alerts.comparison_report_id,
-              json.current_period_kwh,
-              json.previous_period_kwh,
-              json.current_period_co2,
-              json.previous_period_co2,
-              json.current_period_gbp,
-              json.previous_period_gbp,
-              json.previous_period_kwh_unadjusted,
-              json.tariff_has_changed,
-              json.pupils_changed,
-              json.floor_area_changed
+              "json".current_period_kwh,
+              "json".previous_period_kwh,
+              "json".current_period_co2,
+              "json".previous_period_co2,
+              "json".current_period_gbp,
+              "json".previous_period_gbp,
+              "json".previous_period_kwh_unadjusted,
+              "json".tariff_has_changed,
+              "json".pupils_changed,
+              "json".floor_area_changed
              FROM (alerts
                JOIN alert_types ON ((alerts.alert_type_id = alert_types.id))),
-              LATERAL jsonb_to_record(alerts.variables) json(current_period_kwh double precision, previous_period_kwh double precision, current_period_co2 double precision, previous_period_co2 double precision, current_period_gbp double precision, previous_period_gbp double precision, previous_period_kwh_unadjusted double precision, tariff_has_changed boolean, pupils_changed boolean, floor_area_changed boolean)
+              LATERAL jsonb_to_record(alerts.variables) "json"(current_period_kwh double precision, previous_period_kwh double precision, current_period_co2 double precision, previous_period_co2 double precision, current_period_gbp double precision, previous_period_gbp double precision, previous_period_kwh_unadjusted double precision, tariff_has_changed boolean, pupils_changed boolean, floor_area_changed boolean)
             WHERE (alert_types.class_name = 'AlertConfigurablePeriodGasComparison'::text)
           ), storage_heater AS (
            SELECT alerts.alert_generation_run_id,
               alerts.comparison_report_id,
-              json.current_period_kwh,
-              json.previous_period_kwh,
-              json.current_period_co2,
-              json.previous_period_co2,
-              json.current_period_gbp,
-              json.previous_period_gbp,
-              json.previous_period_kwh_unadjusted,
-              json.tariff_has_changed,
-              json.pupils_changed,
-              json.floor_area_changed
+              "json".current_period_kwh,
+              "json".previous_period_kwh,
+              "json".current_period_co2,
+              "json".previous_period_co2,
+              "json".current_period_gbp,
+              "json".previous_period_gbp,
+              "json".previous_period_kwh_unadjusted,
+              "json".tariff_has_changed,
+              "json".pupils_changed,
+              "json".floor_area_changed
              FROM (alerts
                JOIN alert_types ON ((alerts.alert_type_id = alert_types.id))),
-              LATERAL jsonb_to_record(alerts.variables) json(current_period_kwh double precision, previous_period_kwh double precision, current_period_co2 double precision, previous_period_co2 double precision, current_period_gbp double precision, previous_period_gbp double precision, previous_period_kwh_unadjusted double precision, tariff_has_changed boolean, pupils_changed boolean, floor_area_changed boolean)
+              LATERAL jsonb_to_record(alerts.variables) "json"(current_period_kwh double precision, previous_period_kwh double precision, current_period_co2 double precision, previous_period_co2 double precision, current_period_gbp double precision, previous_period_gbp double precision, previous_period_kwh_unadjusted double precision, tariff_has_changed boolean, pupils_changed boolean, floor_area_changed boolean)
             WHERE (alert_types.class_name = 'AlertConfigurablePeriodStorageHeaterComparison'::text)
           ), benchmark AS (
            SELECT alerts.alert_generation_run_id,
@@ -4039,31 +4039,31 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_20_134134) do
   create_view "comparison_heating_coming_on_too_early", materialized: true, sql_definition: <<-SQL
       WITH early AS (
            SELECT alerts.alert_generation_run_id,
-              json.avg_week_start_time,
-              json.one_year_optimum_start_saving_gbpcurrent
+              "json".avg_week_start_time,
+              "json".one_year_optimum_start_saving_gbpcurrent
              FROM alerts,
               alert_types,
-              LATERAL jsonb_to_record(alerts.variables) json(avg_week_start_time time without time zone, one_year_optimum_start_saving_gbpcurrent double precision)
+              LATERAL jsonb_to_record(alerts.variables) "json"(avg_week_start_time time without time zone, one_year_optimum_start_saving_gbpcurrent double precision)
             WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertHeatingComingOnTooEarly'::text))
           ), optimum AS (
            SELECT alerts.alert_generation_run_id,
-              json.average_start_time_hh_mm,
-              json.start_time_standard_devation,
-              json.rating,
-              json.regression_start_time,
-              json.optimum_start_sensitivity,
-              json.regression_r2
+              "json".average_start_time_hh_mm,
+              "json".start_time_standard_devation,
+              "json".rating,
+              "json".regression_start_time,
+              "json".optimum_start_sensitivity,
+              "json".regression_r2
              FROM alerts,
               alert_types,
-              LATERAL jsonb_to_record(alerts.variables) json(average_start_time_hh_mm time without time zone, start_time_standard_devation double precision, rating double precision, regression_start_time double precision, optimum_start_sensitivity double precision, regression_r2 double precision)
+              LATERAL jsonb_to_record(alerts.variables) "json"(average_start_time_hh_mm time without time zone, start_time_standard_devation double precision, rating double precision, regression_start_time double precision, optimum_start_sensitivity double precision, regression_r2 double precision)
             WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertOptimumStartAnalysis'::text))
           ), additional AS (
            SELECT alerts.alert_generation_run_id,
               alerts.school_id,
-              json.gas_economic_tariff_changed_this_year
+              "json".gas_economic_tariff_changed_this_year
              FROM alerts,
               alert_types,
-              LATERAL jsonb_to_record(alerts.variables) json(gas_economic_tariff_changed_this_year boolean)
+              LATERAL jsonb_to_record(alerts.variables) "json"(gas_economic_tariff_changed_this_year boolean)
             WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertAdditionalPrioritisationData'::text))
           ), latest_runs AS (
            SELECT DISTINCT ON (alert_generation_runs.school_id) alert_generation_runs.id
@@ -4160,62 +4160,62 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_20_134134) do
   create_view "comparison_holiday_and_terms", materialized: true, sql_definition: <<-SQL
       WITH electricity AS (
            SELECT alerts.alert_generation_run_id,
-              json.current_period_kwh,
-              json.previous_period_kwh,
-              json.current_period_co2,
-              json.previous_period_co2,
-              json.current_period_gbp,
-              json.previous_period_gbp,
-              json.tariff_has_changed,
-              json.pupils_changed,
-              json.floor_area_changed,
-              json.current_period_type,
-              json.current_period_start_date,
-              json.current_period_end_date,
-              json.truncated_current_period
+              "json".current_period_kwh,
+              "json".previous_period_kwh,
+              "json".current_period_co2,
+              "json".previous_period_co2,
+              "json".current_period_gbp,
+              "json".previous_period_gbp,
+              "json".tariff_has_changed,
+              "json".pupils_changed,
+              "json".floor_area_changed,
+              "json".current_period_type,
+              "json".current_period_start_date,
+              "json".current_period_end_date,
+              "json".truncated_current_period
              FROM alerts,
               alert_types,
-              LATERAL jsonb_to_record(alerts.variables) json(current_period_kwh double precision, previous_period_kwh double precision, current_period_co2 double precision, previous_period_co2 double precision, current_period_gbp double precision, previous_period_gbp double precision, tariff_has_changed boolean, pupils_changed boolean, floor_area_changed boolean, current_period_type text, current_period_start_date date, current_period_end_date date, truncated_current_period boolean)
+              LATERAL jsonb_to_record(alerts.variables) "json"(current_period_kwh double precision, previous_period_kwh double precision, current_period_co2 double precision, previous_period_co2 double precision, current_period_gbp double precision, previous_period_gbp double precision, tariff_has_changed boolean, pupils_changed boolean, floor_area_changed boolean, current_period_type text, current_period_start_date date, current_period_end_date date, truncated_current_period boolean)
             WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertHolidayAndTermElectricityComparison'::text))
           ), gas AS (
            SELECT alerts.alert_generation_run_id,
-              json.current_period_kwh,
-              json.previous_period_kwh,
-              json.current_period_co2,
-              json.previous_period_co2,
-              json.current_period_gbp,
-              json.previous_period_gbp,
-              json.previous_period_kwh_unadjusted,
-              json.tariff_has_changed,
-              json.pupils_changed,
-              json.floor_area_changed,
-              json.current_period_type,
-              json.current_period_start_date,
-              json.current_period_end_date,
-              json.truncated_current_period
+              "json".current_period_kwh,
+              "json".previous_period_kwh,
+              "json".current_period_co2,
+              "json".previous_period_co2,
+              "json".current_period_gbp,
+              "json".previous_period_gbp,
+              "json".previous_period_kwh_unadjusted,
+              "json".tariff_has_changed,
+              "json".pupils_changed,
+              "json".floor_area_changed,
+              "json".current_period_type,
+              "json".current_period_start_date,
+              "json".current_period_end_date,
+              "json".truncated_current_period
              FROM alerts,
               alert_types,
-              LATERAL jsonb_to_record(alerts.variables) json(current_period_kwh double precision, previous_period_kwh double precision, current_period_co2 double precision, previous_period_co2 double precision, current_period_gbp double precision, previous_period_gbp double precision, previous_period_kwh_unadjusted double precision, tariff_has_changed boolean, pupils_changed boolean, floor_area_changed boolean, current_period_type text, current_period_start_date date, current_period_end_date date, truncated_current_period boolean)
+              LATERAL jsonb_to_record(alerts.variables) "json"(current_period_kwh double precision, previous_period_kwh double precision, current_period_co2 double precision, previous_period_co2 double precision, current_period_gbp double precision, previous_period_gbp double precision, previous_period_kwh_unadjusted double precision, tariff_has_changed boolean, pupils_changed boolean, floor_area_changed boolean, current_period_type text, current_period_start_date date, current_period_end_date date, truncated_current_period boolean)
             WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertHolidayAndTermGasComparison'::text))
           ), storage_heater AS (
            SELECT alerts.alert_generation_run_id,
-              json.current_period_kwh,
-              json.previous_period_kwh,
-              json.current_period_co2,
-              json.previous_period_co2,
-              json.current_period_gbp,
-              json.previous_period_gbp,
-              json.previous_period_kwh_unadjusted,
-              json.tariff_has_changed,
-              json.pupils_changed,
-              json.floor_area_changed,
-              json.current_period_type,
-              json.current_period_start_date,
-              json.current_period_end_date,
-              json.truncated_current_period
+              "json".current_period_kwh,
+              "json".previous_period_kwh,
+              "json".current_period_co2,
+              "json".previous_period_co2,
+              "json".current_period_gbp,
+              "json".previous_period_gbp,
+              "json".previous_period_kwh_unadjusted,
+              "json".tariff_has_changed,
+              "json".pupils_changed,
+              "json".floor_area_changed,
+              "json".current_period_type,
+              "json".current_period_start_date,
+              "json".current_period_end_date,
+              "json".truncated_current_period
              FROM alerts,
               alert_types,
-              LATERAL jsonb_to_record(alerts.variables) json(current_period_kwh double precision, previous_period_kwh double precision, current_period_co2 double precision, previous_period_co2 double precision, current_period_gbp double precision, previous_period_gbp double precision, previous_period_kwh_unadjusted double precision, tariff_has_changed boolean, pupils_changed boolean, floor_area_changed boolean, current_period_type text, current_period_start_date date, current_period_end_date date, truncated_current_period boolean)
+              LATERAL jsonb_to_record(alerts.variables) "json"(current_period_kwh double precision, previous_period_kwh double precision, current_period_co2 double precision, previous_period_co2 double precision, current_period_gbp double precision, previous_period_gbp double precision, previous_period_kwh_unadjusted double precision, tariff_has_changed boolean, pupils_changed boolean, floor_area_changed boolean, current_period_type text, current_period_start_date date, current_period_end_date date, truncated_current_period boolean)
             WHERE ((alerts.alert_type_id = alert_types.id) AND (alert_types.class_name = 'AlertHolidayAndTermStorageHeaterComparison'::text))
           ), enba AS (
            SELECT alerts.alert_generation_run_id,
@@ -4640,13 +4640,13 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_20_134134) do
                LEFT JOIN daily_baseload t2 ON (((t1.meter_id = t2.meter_id) AND (t1.reading_date = (t2.reading_date + 'P1D'::interval)))))
             WHERE (t1.reading_date >= (CURRENT_DATE - 'P30D'::interval))
           )
-   SELECT last_two_days_baseload.id,
-      last_two_days_baseload.meter_id,
-      last_two_days_baseload.reading_date,
-      last_two_days_baseload.today_baseload,
-      last_two_days_baseload.previous_day_baseload
+   SELECT id,
+      meter_id,
+      reading_date,
+      today_baseload,
+      previous_day_baseload
      FROM last_two_days_baseload
-    WHERE ((last_two_days_baseload.previous_day_baseload IS NOT NULL) AND (last_two_days_baseload.previous_day_baseload > 0.5) AND (((last_two_days_baseload.today_baseload >= (0)::numeric) AND (last_two_days_baseload.today_baseload < 0.01)) OR (last_two_days_baseload.previous_day_baseload >= (last_two_days_baseload.today_baseload * (5)::numeric))));
+    WHERE ((previous_day_baseload IS NOT NULL) AND (previous_day_baseload > 0.5) AND (((today_baseload >= (0)::numeric) AND (today_baseload < 0.01)) OR (previous_day_baseload >= (today_baseload * (5)::numeric))));
   SQL
   add_index "report_baseload_anomalies", ["id"], name: "index_report_baseload_anomalies_on_id", unique: true
 


### PR DESCRIPTION
This PR updates annotated model and db schema due to recent upgrades.

Upgrade to `annotaterb` has changed default format for columns with Rails backed enums. [See report](https://github.com/drwl/annotaterb/issues/373). This is likely to be fixed in future release, but changes now reduces noise.

I've also added `show_enums` option to annotaterb config to include postgres backed enums in the annotations. The enum used for the column is now named and all enums used by the table are listed in the annotations along with their values. The enum information is always present/obvious in the model files so I think useful to have included by default.

There is also an change to `db/schema.rb`. The upgrade to Postgres 18 apparently includes changes to how SQL is extracted and serialised which means the SQL includes in `db/schema.rb` is slightly different. The key changes are:

- In materialised views used for comparison reports we were typically using `data` as the record_type provided to `jsonb_to_record` to extract variables. Postgres now seems to prefer using `json` as the variable name and now quotes that everywhere
- In the baseload anomaly query the SQL export has removed some unnecessary column qualification

Neither of these are functional changes.