### PR TITLE
Optimise duplicate reading checks during loading

### DIFF
--- a/app/models/amr_reading_data.rb
+++ b/app/models/amr_reading_data.rb
@@ -78,6 +78,8 @@ class AmrReadingData
   end
 
   def invalid_row_check
+    create_duplicate_checking_index
+
     @reading_data.each_with_index do |reading, index|
       reading_date = reading[:reading_date]
       readings = reading[:readings]
@@ -88,7 +90,7 @@ class AmrReadingData
       warnings << :missing_mpan_mprn if reading[:mpan_mprn].blank?
       warnings << :invalid_non_numeric_mpan_mprn if invalid_non_numeric_mpan_mprn?(reading[:mpan_mprn])
       warnings << :missing_reading_date if reading_date.blank?
-      warnings << :duplicate_reading if duplicate_reading?(reading, @reading_data[index + 1..-1])
+      warnings << :duplicate_reading if duplicate_reading?(reading, index)
 
       if reading_date.present? && valid_reading_date?(reading_date)
         warnings << :future_reading_date if future_reading_date?(reading_date)
@@ -147,10 +149,19 @@ class AmrReadingData
     end
   end
 
-  def duplicate_reading?(reading, remainder)
-    remainder.any? do |other_reading|
-      other_reading[:mpan_mprn] == reading[:mpan_mprn] &&
-        other_reading[:reading_date] == reading[:reading_date]
+  # Where there are duplicates we do not add a warning to the last occurence. Only that one will be inserted.
+  def duplicate_reading?(reading, index)
+    key = [reading[:mpan_mprn], reading[:reading_date]]
+
+    @occurrences[key].length > 1 && index != @occurrences[key].last
+  end
+
+  def create_duplicate_checking_index
+    @occurrences = Hash.new { |h, k| h[k] = [] }
+
+    @reading_data.each_with_index do |r, idx|
+      key = [r[:mpan_mprn], r[:reading_date]]
+      @occurrences[key] << idx
     end
   end
 end


### PR DESCRIPTION
Currently we check whether an incoming data file has duplicate readings for the same combination of mpxn and reading_date. We then end up rejecting all but the last duplicate, so we only load the last entry in the file

Checking the database shows that that the validation is being triggered so is worth keeping. Although might need to investigate root cause of the duplicates.

However the way we're doing the duplicate checks involves repeatedly slicing and scanning the parsed readings to look for any that have the same mpxn/reading_date. This is going to be very inefficient for larger files as we're checking every row against all subsequent rows.

This PR fixes that by building an index that captures which readings are duplicated. They uses that to add a warning to all but the last one.

Hopefully this will have a big improvements for the larger TGP files (30mb+) files in particular.