### PR TITLE
Change system to use parsed_date

### DIFF
--- a/app/models/amr_data_feed_reading.rb
+++ b/app/models/amr_data_feed_reading.rb
@@ -49,35 +49,6 @@ class AmrDataFeedReading < ApplicationRecord
   CSV_HEADER_DATA_FEED_READING = 'School URN,Name,Mpan Mprn,Meter Type,Reading Date,Reading Date Format,Record Last Updated,Estimated,00:30,01:00,01:30,02:00,02:30,03:00,03:30,04:00,04:30,05:00,05:30,06:00,06:30,07:00,07:30,08:00,08:30,09:00,09:30,10:00,10:30,11:00,11:30,12:00,12:30,13:00,13:30,14:00,14:30,15:00,15:30,16:00,16:30,17:00,17:30,18:00,18:30,19:00,19:30,20:00,20:30,21:00,21:30,22:00,22:30,23:00,23:30,00:00'.freeze
   DELETE_THRESHOLD = 3.years
 
-  PARSED_DATE = <<~SQL.squish.freeze
-    CASE
-    WHEN reading_date ~ '\\d{4}/\\d{1,2}/\\d{1,2}' THEN to_date(reading_date, 'YYYY/MM/DD')
-    WHEN reading_date ~ '\\d{1,2}-(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)-\\d{2}' THEN to_date(reading_date, 'DD-MON-YY')
-    WHEN date_format='%d %b %Y %H:%M:%S' AND reading_date~'\\d{4}-\\d{2}-\\d{2}' THEN to_date(reading_date, 'YYYY-MM-DD')
-    WHEN date_format='%d-%b-%y' AND reading_date~'\\d{4}-\\d{2}-\\d{2}' THEN to_date(reading_date, 'YYYY-MM-DD')
-    WHEN date_format='%d-%m-%Y' AND reading_date~'\\d{4}-\\d{2}-\\d{2}' THEN to_date(reading_date, 'YYYY-MM-DD')
-    WHEN date_format='%Y%m%d' AND reading_date~'\\d{4}-\\d{2}-\\d{2}' THEN to_date(reading_date, 'YYYY-MM-DD')
-    WHEN date_format='%d/%m/%Y %H:%M:%S' AND reading_date~'\\d{4}-\\d{2}-\\d{2}' THEN to_date(reading_date, 'YYYY/MM/DD')
-    WHEN date_format='%d-%m-%Y' THEN to_date(reading_date, 'DD-MM-YYYY')
-    WHEN date_format='%d/%m/%Y' AND reading_date~'\\d{4}-\\d{2}-\\d{2}' THEN to_date(reading_date, 'YYYY-MM-DD')
-    WHEN date_format='%d/%m/%Y' THEN to_date(reading_date, 'DD/MM/YYYY')
-    WHEN date_format='%d/%m/%y' AND reading_date~'\\d{4}-\\d{2}-\\d{2}' THEN to_date(reading_date, 'YYYY-MM-DD')
-    WHEN date_format='%d/%m/%y' THEN to_date(reading_date, 'DD/MM/YY')
-    WHEN date_format='%Y-%m-%d ' AND reading_date~'\\d{4}-\\d{2}-\\d{2}\s*$' THEN to_date(reading_date, 'YYYY-MM-DD')
-    WHEN date_format='%Y-%m-%d' AND reading_date~'\\d{2}/\\d{2}/\\d{4}' THEN to_date(reading_date, 'DD/MM/YYYY')
-    WHEN date_format='%Y-%m-%d' THEN to_date(reading_date, 'YYYY-MM-DD')
-    WHEN date_format='%y-%m-%d' AND reading_date~'\\d{2}/\\d{2}/\\d{4}' THEN to_date(reading_date, 'DD/MM/YYYY')
-    WHEN date_format='%y-%m-%d' THEN to_date(reading_date, 'YY-MM-DD ')
-    WHEN date_format='"%d-%m-%Y"' THEN to_date(reading_date, '"DD-MM-YYYY"')
-    WHEN date_format='%d/%m/%Y %H:%M:%S' THEN to_date(reading_date, 'DD/MM/YYYY HH24:MI::SS')
-    WHEN date_format='%H:%M:%S %a %d/%m/%Y' THEN to_date(reading_date, 'HH24:MI::SS Dy DD/MM/YYYY')
-    WHEN date_format='%e %b %Y %H:%M:%S' AND reading_date~'\\d{4}-\\d{2}-\\d{2}' THEN to_date(reading_date, 'YYYY-MM-DD')
-    WHEN date_format='%e %b %Y %H:%M:%S' THEN to_date(reading_date, 'DD Mon YYYY HH24:MI::SS')
-    WHEN date_format='%b %e %Y %I:%M%p' THEN to_date(reading_date, 'Mon DD YYYY HH12:MIam')
-    ELSE NULL
-    END db_parsed_date
-  SQL
-
   def self.download_query_for_school(school_id)
     <<~QUERY
       SELECT s.urn,
@@ -111,9 +82,9 @@ class AmrDataFeedReading < ApplicationRecord
       :amr_data_feed_config_id,
       'amr_data_feed_configs.identifier',
       'amr_data_feed_configs.source_type', 'amr_uploaded_readings.imported',
-      PARSED_DATE
+      :parsed_date
     ).order(
-      db_parsed_date: :desc,
+      parsed_date: :desc,
       created_at: :desc
     )
   end
@@ -126,9 +97,8 @@ class AmrDataFeedReading < ApplicationRecord
     list_of_amr_data_feed_config_ids = amr_data_feed_config_ids.map { |m| "'#{m}'" }.join(',')
 
     <<~QUERY
-      SELECT mpan_mprn, meter_id, identifier, description, MIN(db_parsed_date) as earliest_reading, MAX(db_parsed_date) as latest_reading FROM (
-        SELECT mpan_mprn, meter_id, identifier, amr_data_feed_configs.description, reading_date,
-        #{PARSED_DATE}
+      SELECT mpan_mprn, meter_id, identifier, description, MIN(parsed_date) as earliest_reading, MAX(parsed_date) as latest_reading FROM (
+        SELECT mpan_mprn, meter_id, identifier, amr_data_feed_configs.description, reading_date, parsed_date
         FROM amr_data_feed_readings
         JOIN amr_data_feed_configs ON amr_data_feed_configs.id = amr_data_feed_readings.amr_data_feed_config_id
         WHERE mpan_mprn IN (#{list_of_mpans}) AND amr_data_feed_readings.amr_data_feed_config_id IN (#{list_of_amr_data_feed_config_ids})

--- a/app/models/amr_data_feed_reading.rb
+++ b/app/models/amr_data_feed_reading.rb
@@ -46,7 +46,7 @@ class AmrDataFeedReading < ApplicationRecord
   belongs_to :amr_data_feed_import_log
   belongs_to :amr_data_feed_config
 
-  CSV_HEADER_DATA_FEED_READING = 'School URN,Name,Mpan Mprn,Meter Type,Reading Date,Reading Date Format,Record Last Updated,Estimated,00:30,01:00,01:30,02:00,02:30,03:00,03:30,04:00,04:30,05:00,05:30,06:00,06:30,07:00,07:30,08:00,08:30,09:00,09:30,10:00,10:30,11:00,11:30,12:00,12:30,13:00,13:30,14:00,14:30,15:00,15:30,16:00,16:30,17:00,17:30,18:00,18:30,19:00,19:30,20:00,20:30,21:00,21:30,22:00,22:30,23:00,23:30,00:00'.freeze
+  CSV_HEADER_DATA_FEED_READING = 'School URN,Name,Mpan Mprn,Meter Type,Reading Date,Data Feed Config,Record Last Updated,Estimated,00:30,01:00,01:30,02:00,02:30,03:00,03:30,04:00,04:30,05:00,05:30,06:00,06:30,07:00,07:30,08:00,08:30,09:00,09:30,10:00,10:30,11:00,11:30,12:00,12:30,13:00,13:30,14:00,14:30,15:00,15:30,16:00,16:30,17:00,17:30,18:00,18:30,19:00,19:30,20:00,20:30,21:00,21:30,22:00,22:30,23:00,23:30,00:00'.freeze
   DELETE_THRESHOLD = 3.years
 
   def self.download_query_for_school(school_id)
@@ -55,8 +55,8 @@ class AmrDataFeedReading < ApplicationRecord
              s.name,
              m.mpan_mprn,
              CASE m.meter_type WHEN 0 THEN 'Electricity' WHEN 1 THEN 'Gas' WHEN 2 THEN 'Solar PV' WHEN 3 THEN 'Exported Solar PV' END,
-             amr.reading_date,
-             c.date_format,
+             amr.parsed_date,
+             c.identifier,
              amr.updated_at,
              CASE amr.estimated WHEN 'f' then 'No' WHEN 't' THEN 'Yes' END,
              amr.readings

--- a/app/services/amr/analytics_unvalidated_amr_data_factory.rb
+++ b/app/services/amr/analytics_unvalidated_amr_data_factory.rb
@@ -41,7 +41,7 @@ module Amr
              .pluck(
                :meter_id,
                :amr_data_feed_config_id,
-               :reading_date,
+               :parsed_date,
                :created_at,
                :readings,
                :estimated
@@ -66,7 +66,7 @@ module Amr
     def reading_if_valid(_meter_id, reading)
       return if reading_invalid?(reading)
 
-      reading_date = date_from_string_using_date_format(reading)
+      reading_date = reading[1]
       return if reading_date.nil?
 
       OneDayAMRReading.new(
@@ -90,10 +90,6 @@ module Amr
       else
         false
       end
-    end
-
-    def date_from_string_using_date_format(reading)
-      AmrDataFeedConfig.date_from_string_using_date_format(reading[1], @feed_configs[reading[0]].date_format)
     end
   end
 end

--- a/app/views/admin/reports/meter_loading_reports/index.html.erb
+++ b/app/views/admin/reports/meter_loading_reports/index.html.erb
@@ -41,7 +41,7 @@
       <% @results.each do |result| %>
         <tr>
           <td><%= result.created_at.iso8601 %></td>
-          <td><%= result.db_parsed_date %></td>
+          <td><%= result.parsed_date %></td>
           <td>
             <% if result.imported || result.source_type == 2 %>
               <%= result.file_name %>

--- a/spec/factories/amr_data_feed_readings_factory.rb
+++ b/spec/factories/amr_data_feed_readings_factory.rb
@@ -1,6 +1,7 @@
 FactoryBot.define do
   factory :amr_data_feed_reading do
     reading_date  { Date.yesterday.strftime('%b %e %Y %I:%M%p') }
+    parsed_date { Date.yesterday }
     readings      { Array.new(48, rand) }
     association :meter, factory: :gas_meter
     mpan_mprn { Random.new.rand(240000000000000)}

--- a/spec/factories/amr_data_feed_readings_factory.rb
+++ b/spec/factories/amr_data_feed_readings_factory.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :amr_data_feed_reading do
-    reading_date  { parsed_date.strftime('%b %e %Y %I:%M%p') }
+    reading_date  { Date.yesterday.strftime('%b %e %Y %I:%M%p') }
     parsed_date { Date.yesterday }
     readings      { Array.new(48, rand) }
     association :meter, factory: :gas_meter

--- a/spec/factories/amr_data_feed_readings_factory.rb
+++ b/spec/factories/amr_data_feed_readings_factory.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :amr_data_feed_reading do
-    reading_date  { Date.yesterday.strftime('%b %e %Y %I:%M%p') }
+    reading_date  { parsed_date.strftime('%b %e %Y %I:%M%p') }
     parsed_date { Date.yesterday }
     readings      { Array.new(48, rand) }
     association :meter, factory: :gas_meter

--- a/spec/factories/meters_factory.rb
+++ b/spec/factories/meters_factory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :gas_meter, class: 'Meter' do
     school
@@ -18,7 +20,8 @@ FactoryBot.define do
 
       after(:create) do |meter, evaluator|
         (evaluator.start_date.to_date..evaluator.end_date.to_date).each do |this_date|
-          create(:amr_data_feed_reading, meter: meter, reading_date: this_date.strftime('%b %e %Y %I:%M%p'), amr_data_feed_config: evaluator.config, amr_data_feed_import_log: evaluator.log)
+          create(:amr_data_feed_reading,
+                 meter:, reading_date: this_date.strftime('%b %e %Y %I:%M%p'), parsed_date: this_date, amr_data_feed_config: evaluator.config, amr_data_feed_import_log: evaluator.log)
         end
       end
     end
@@ -52,13 +55,13 @@ FactoryBot.define do
       after(:create) do |meter, evaluator|
         (evaluator.start_date.to_date..evaluator.end_date.to_date).each do |this_date|
           create(:amr_validated_reading,
-            meter: meter,
-            reading_date: this_date,
-            upload_datetime: evaluator.upload_datetime,
-            status: evaluator.status,
-            kwh_data_x48: evaluator.kwh_data_x48,
-            one_day_kwh: evaluator.one_day_kwh,
-            substitute_date: evaluator.substitute_date)
+                 meter: meter,
+                 reading_date: this_date,
+                 upload_datetime: evaluator.upload_datetime,
+                 status: evaluator.status,
+                 kwh_data_x48: evaluator.kwh_data_x48,
+                 one_day_kwh: evaluator.one_day_kwh,
+                 substitute_date: evaluator.substitute_date)
         end
       end
     end
@@ -66,7 +69,7 @@ FactoryBot.define do
 
   factory :electricity_meter, class: 'Meter' do
     school
-    sequence(:mpan_mprn) { |n| "10#{sprintf('%011d', n)}" }
+    sequence(:mpan_mprn) { |n| "10#{format('%011d', n)}" }
     sequence(:name, 'Meter AAAAA1')
     meter_type            { :electricity }
     active                { true }
@@ -84,7 +87,8 @@ FactoryBot.define do
         end_date = Date.parse('01/06/2019')
         start_date = end_date - (evaluator.reading_count - 1).days
         (start_date..end_date).each do |this_date|
-          create(:amr_data_feed_reading, meter: meter, reading_date: this_date.strftime(evaluator.reading_date_format),
+          create(:amr_data_feed_reading, meter:, parsed_date: this_date,
+                                         reading_date: this_date.strftime(evaluator.reading_date_format),
                                          readings: evaluator.readings, amr_data_feed_config: evaluator.config)
         end
       end
@@ -118,7 +122,7 @@ FactoryBot.define do
 
   factory :exported_solar_pv_meter, class: 'Meter' do
     school
-    sequence(:mpan_mprn)  { |n| "91#{sprintf('%012d', n)}" }
+    sequence(:mpan_mprn)  { |n| "91#{format('%012d', n)}" }
     meter_type            { :exported_solar_pv }
     active                { true }
     meter_system          { :nhh_amr }
@@ -134,7 +138,9 @@ FactoryBot.define do
 
       after(:create) do |meter, evaluator|
         (evaluator.start_date.to_date..evaluator.end_date.to_date).each do |this_date|
-          create(:amr_data_feed_reading, meter: meter, reading_date: this_date.strftime('%b %e %Y %I:%M%p'), amr_data_feed_config: evaluator.config, amr_data_feed_import_log: evaluator.import_log)
+          create(:amr_data_feed_reading, meter:, parsed_date: this_date,
+                                         reading_date: this_date.strftime('%b %e %Y %I:%M%p'),
+                                         amr_data_feed_config: evaluator.config, amr_data_feed_import_log: evaluator.import_log)
         end
       end
     end
@@ -142,7 +148,7 @@ FactoryBot.define do
 
   factory :solar_pv_meter, class: 'Meter' do
     school
-    sequence(:mpan_mprn) { |n| "71#{sprintf('%012d', n)}" }
+    sequence(:mpan_mprn) { |n| "71#{format('%012d', n)}" }
     sequence(:name, 'Meter AAAAA1')
     meter_type            { :solar_pv }
     active                { true }
@@ -159,7 +165,9 @@ FactoryBot.define do
 
       after(:create) do |meter, evaluator|
         (evaluator.start_date.to_date..evaluator.end_date.to_date).each do |this_date|
-          create(:amr_data_feed_reading, meter: meter, reading_date: this_date.strftime('%b %e %Y %I:%M%p'), amr_data_feed_config: evaluator.config, amr_data_feed_import_log: evaluator.log)
+          create(:amr_data_feed_reading, meter:, parsed_date: this_date,
+                                         reading_date: this_date.strftime('%b %e %Y %I:%M%p'),
+                                         amr_data_feed_config: evaluator.config, amr_data_feed_import_log: evaluator.log)
         end
       end
     end

--- a/spec/models/amr_data_feed_reading_spec.rb
+++ b/spec/models/amr_data_feed_reading_spec.rb
@@ -6,8 +6,11 @@ describe AmrDataFeedReading do
   describe '.unvalidated_data_report_for_mpans' do
     let(:date_format)   { '%d-%m-%Y' }
     let(:reading_date)  { '28-06-2023' }
-    let!(:config)      { create(:amr_data_feed_config, date_format: date_format) }
-    let!(:reading)     { create(:amr_data_feed_reading, reading_date: reading_date, amr_data_feed_config: config) }
+    let!(:config) { create(:amr_data_feed_config, date_format: date_format) }
+    let!(:reading) do
+      create(:amr_data_feed_reading, reading_date: reading_date,
+                                     parsed_date: Date.parse(reading_date), amr_data_feed_config: config)
+    end
 
     let(:results) { described_class.unvalidated_data_report_for_mpans([reading.mpan_mprn]) }
 
@@ -19,57 +22,6 @@ describe AmrDataFeedReading do
       expect(results[0]['earliest_reading']).to eq Date.new(2023, 6, 28)
       expect(results[0]['latest_reading']).to eq Date.new(2023, 6, 28)
     end
-
-    context 'with other date formats' do
-      FORMATS = {
-        '%d/%m/%Y' => '28/06/2023',
-        '%Y-%m-%d' => '2023-06-28',
-        '%Y-%m-%d ' => '2023-06-28 ',
-        '%y-%m-%d' => '23-06-28',
-        '%H:%M:%S %a %d/%m/%Y' => '14:00:00 Wed 28/06/2023',
-        '%e %b %Y %H:%M:%S' => '28 Jun 2023 14:00:00',
-        '%b %e %Y %I:%M%p' => 'Jun 28 2023 02:00pm'
-      }.freeze
-
-      FORMATS.each do |format, read_date|
-        context "it parses #{format}" do
-          let(:date_format)   { format }
-          let(:reading_date)  { read_date }
-
-          it { expect(results[0]['latest_reading']).to eq Date.new(2023, 6, 28) }
-        end
-      end
-    end
-
-    context 'with incorrectly loaded data' do
-      FORMATS = [
-        ['%d-%b-%y', '2023-06-28'],
-        ['%Y-%m-%d', '28-Jun-23'],
-        ['%Y-%m-%d', '28/06/2023'],
-        ['%d-%m-%Y', '2023-06-28'],
-        ['%e %b %Y %H:%M:%S', '2023-06-28'],
-        ['%d/%m/%Y %H:%M:%S', '2023-06-28'],
-        ['%y-%m-%d', '28/06/2023']
-      ].freeze
-
-      FORMATS.each do |format|
-        context "it parses #{format[1]} despite format being #{format[0]}" do
-          let(:date_format)   { format[0] }
-          let(:reading_date)  { format[1] }
-
-          it { expect(results[0]['latest_reading']).to eq Date.new(2023, 6, 28) }
-        end
-      end
-
-      context 'with single digit date' do
-        let(:date_format)   { '%d/%m/%Y' }
-        let(:reading_date)  { '2-Jun-23' }
-
-        context 'it parses correctly' do
-          it { expect(results[0]['latest_reading']).to eq Date.new(2023, 6, 2) }
-        end
-      end
-    end
   end
 
   describe '.meter_loading_report' do
@@ -80,7 +32,8 @@ describe AmrDataFeedReading do
     let(:mpan_mprn) { '2200012304567' }
 
     let!(:reading) do
-      create(:amr_data_feed_reading, mpan_mprn: mpan_mprn, reading_date: '2024-12-25')
+      create(:amr_data_feed_reading, mpan_mprn: mpan_mprn,
+                                     reading_date: '2024-12-25', parsed_date: Date.parse('2024-12-25'))
     end
 
     before do
@@ -91,7 +44,7 @@ describe AmrDataFeedReading do
       it 'returns the selected columns' do
         expect(results.size).to eq(1)
         expect(results.first.file_name).to eq(reading.amr_data_feed_import_log.file_name)
-        expect(results.first.db_parsed_date).to eq(Date.parse('2024-12-25'))
+        expect(results.first.parsed_date).to eq(Date.parse('2024-12-25'))
         expect(results.first.identifier).to eq(reading.amr_data_feed_config.identifier)
         expect(results.first.imported).to be_nil
       end
@@ -120,21 +73,22 @@ describe AmrDataFeedReading do
     context 'with several readings' do
       let!(:duplicate) do
         create(:amr_data_feed_reading, mpan_mprn: mpan_mprn, reading_date: '25/12/2024',
-                                       created_at: reading.created_at - 1.day)
+                                       parsed_date: Date.parse('2024-12-25'), created_at: reading.created_at - 1.day)
       end
 
       let!(:earlier) do
-        create(:amr_data_feed_reading, mpan_mprn: mpan_mprn, reading_date: '2024-12-24')
+        create(:amr_data_feed_reading, mpan_mprn: mpan_mprn, reading_date: '2024-12-24',
+                                       parsed_date: Date.parse('2024-12-24'))
       end
 
       it 'sorts by the dates' do
         expect(results.size).to eq(3)
 
-        expect(results.map(&:db_parsed_date)).to eq([
-                                                      Date.parse(reading.reading_date),
-                                                      Date.parse(duplicate.reading_date),
-                                                      Date.parse(earlier.reading_date)
-                                                    ])
+        expect(results.map(&:parsed_date)).to eq([
+                                                   Date.parse(reading.reading_date),
+                                                   Date.parse(duplicate.reading_date),
+                                                   Date.parse(earlier.reading_date)
+                                                 ])
 
         expect(results.map(&:file_name)).to eq([
                                                  reading.amr_data_feed_import_log.file_name,

--- a/spec/services/amr/analytics_unvalidated_amr_data_factory_spec.rb
+++ b/spec/services/amr/analytics_unvalidated_amr_data_factory_spec.rb
@@ -45,7 +45,7 @@ module Amr
           create(:amr_data_feed_reading,
                  meter: e_meter,
                  readings: Array.new(48, rand),
-                 reading_date: Date.tomorrow.strftime('%d/%m/%Y'),
+                 parsed_date: Date.tomorrow,
                  mpan_mprn: e_meter.mpan_mprn)
         end
 
@@ -61,7 +61,7 @@ module Amr
           create(:amr_data_feed_reading,
                  meter: e_meter,
                  readings: Array.new(48, rand),
-                 reading_date: 'baddate',
+                 parsed_date: nil,
                  mpan_mprn: e_meter.mpan_mprn)
         end
 
@@ -76,7 +76,7 @@ module Amr
           create(:amr_data_feed_reading,
                  meter: e_meter,
                  readings: Array.new(48, nil),
-                 reading_date: Date.tomorrow.strftime('%b %e %Y'),
+                 parsed_date: Date.tomorrow,
                  mpan_mprn: e_meter.mpan_mprn)
         end
 
@@ -96,7 +96,7 @@ module Amr
                  meter: e_meter,
                  amr_data_feed_config: amr_data_feed_config,
                  readings: [1.23] + Array.new(47, nil),
-                 reading_date: Date.tomorrow.strftime('%b %e %Y'),
+                 parsed_date: Date.tomorrow,
                  mpan_mprn: e_meter.mpan_mprn)
         end
 

--- a/spec/support/data_helpers.rb
+++ b/spec/support/data_helpers.rb
@@ -34,7 +34,7 @@ module EnergySparksDataHelpers
     # The gsub trims the trailing zero where appropriate
     formatted_date_time_stamp = amr.updated_at.strftime('%Y-%m-%d %H:%M:%S.%6N').gsub(/0+$/, '')
     estimated = amr.estimated ? 'Yes' : 'No'
-    "#{meter.school.urn},#{meter.school.name},#{meter.mpan_mprn},#{meter.meter_type.titleize},#{amr.reading_date},#{amr.amr_data_feed_import_log.amr_data_feed_config.date_format},#{formatted_date_time_stamp},#{estimated},#{amr.readings.join(',')}"
+    "#{meter.school.urn},#{meter.school.name},#{meter.mpan_mprn},#{meter.meter_type.titleize},#{amr.parsed_date},#{amr.amr_data_feed_config.identifier},#{formatted_date_time_stamp},#{estimated},#{amr.readings.join(',')}"
   end
 end
 

--- a/spec/system/admin/reports/meter_loading_report_spec.rb
+++ b/spec/system/admin/reports/meter_loading_report_spec.rb
@@ -1,12 +1,13 @@
 require 'rails_helper'
 
 describe 'meter loading report' do
-  let!(:admin)       { create(:admin) }
-  let!(:reading)     { create(:amr_data_feed_reading, reading_date: '2024-12-25') }
+  let!(:reading) do
+    create(:amr_data_feed_reading, reading_date: '2024-12-25', parsed_date: Date.parse('2024-12-25'))
+  end
 
   before do
     allow_any_instance_of(S3Helper).to receive(:s3_csv_download_url).and_return('https://example.org')
-    sign_in(admin)
+    sign_in(create(:admin))
     visit root_path
     click_on('Reports')
     click_on('Meter loading report')

--- a/spec/system/admin/reports/unvalidated_readings_spec.rb
+++ b/spec/system/admin/reports/unvalidated_readings_spec.rb
@@ -1,9 +1,14 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
-describe 'unvalidated readings', type: :system do
+describe 'unvalidated readings' do
   let!(:admin)       { create(:admin) }
   let!(:config)      { create(:amr_data_feed_config, description: 'Description', date_format: '%d-%m-%Y') }
-  let!(:reading)     { create(:amr_data_feed_reading, reading_date: '23-06-2023', amr_data_feed_config: config) }
+  let!(:reading) do
+    create(:amr_data_feed_reading, reading_date: '23-06-2023',
+                                   parsed_date: Date.parse('2023-06-23'), amr_data_feed_config: config)
+  end
 
   before do
     sign_in(admin)


### PR DESCRIPTION
Once we've back-filled the `AmrDataFeedReading` table on production using the script in https://github.com/Energy-Sparks/energy-sparks/pull/5592 we can merge these changes.

- [x] Start using `parsed_date` when loading unvalidated readings.
- [x] Change unvalidated reading report to use parsed_date
- [x] Change meter loading report to use parsed_date
- [x] Review and update any other reports where we can use parsed_date

At a later date we could also change parsed_date column to be not null, to match reading_date. Haven't done this here as want to confirm all rows populated successfully after backfill and ongoing loading.