### PR TITLE
Change academic years shown on licence summary

### DIFF
--- a/app/components/commercial/unlicensed_schools_component/unlicensed_schools_component.html.erb
+++ b/app/components/commercial/unlicensed_schools_component/unlicensed_schools_component.html.erb
@@ -1,16 +1,22 @@
 <%= tag.div id: id, class: classes do %>
   <table id="unlicensed-schools" class="table table-sorted table-sm advice-table">
       <thead>
-      <tr>
-          <th>School Group</th>
-          <th>School</th>
-          <th class="text-end">Visible?</th>
-          <th class="text-end">Data visible?</th>
-          <th class="text-end">Expired Licence?</th>
-          <th class="text-end">Licensed for Current Academic Year?</th>
-          <th class="text-end">Licensed for Next Academic Year?</th>
-          <th class="text-end"></th>
-      </tr>
+        <tr>
+            <th colspan="5"></th>
+            <th colspan="3" class="text-center">Licensed for</th>
+            <th></th>
+        </tr>
+        <tr>
+            <th>School Group</th>
+            <th>School</th>
+            <th class="text-end">Visible?</th>
+            <th class="text-end">Data visible?</th>
+            <th class="text-end">Expired Licence?</th>
+            <th class="text-end">Previous Academic Year?</th>
+            <th class="text-end">Current Academic Year?</th>
+            <th class="text-end">Next Academic Year?</th>
+            <th class="text-end"></th>
+        </tr>
       </thead>
       <tbody>
           <% @schools.each do |school| %>
@@ -29,6 +35,9 @@
                   </td>
                   <td class="text-end">
                       <%= checkmark(school.licences.expired.any?) %>
+                  </td>
+                  <td class="text-end">
+                      <%= render(badge(school, @academic_year.previous_year)) %>
                   </td>
                   <td class="text-end">
                       <%= render(badge(school)) %>

--- a/app/controllers/admin/school_groups/licence_summaries_controller.rb
+++ b/app/controllers/admin/school_groups/licence_summaries_controller.rb
@@ -8,13 +8,11 @@ module Admin
       load_and_authorize_resource :school_group
 
       before_action :breadcrumbs
+      before_action :set_academic_years, only: :show
 
       layout 'group_settings'
 
       def show
-        @current_year = Calendar.default_national.current_academic_year
-        @next_year = Calendar.default_national.current_academic_year.next_year
-
         respond_to do |format|
           format.html { render :show }
           format.text do
@@ -28,8 +26,27 @@ module Admin
         end
       end
 
+      private
+
       def breadcrumbs
         build_breadcrumbs([{ name: t('school_groups.titles.licence_summaries') }])
+      end
+
+      # Up until March show previous and current academic years.
+      # From March show current and next academic years
+      def set_academic_years
+        this_year = Calendar.default_national.current_academic_year
+        if in_september_to_february?
+          @current_year = this_year.previous_year
+          @next_year = this_year
+        else
+          @current_year = this_year
+          @next_year = this_year.next_year
+        end
+      end
+
+      def in_september_to_february?
+        (9..12).cover?(Time.zone.today.month) || (1..2).cover?(Time.zone.today.month)
       end
     end
   end

--- a/app/views/admin/school_groups/licence_summaries/show.html.erb
+++ b/app/views/admin/school_groups/licence_summaries/show.html.erb
@@ -7,19 +7,21 @@
       years.
     </p>
     <p>
+      Between September and end of February the table and emailable summary will show the previous and current academic year.
+      From March onwards they will show the current and next academic year.
+    </p>
+    <p>
       The table below lists all schools in this group along with an indication of whether:
     </p>
     <ul>
-      <li>For the current academic year
-          (<%= short_dates(@current_year.start_date) %> - <%= short_dates(@current_year.end_date) %>).
+      <li>For <%= short_dates(@current_year.start_date) %> - <%= short_dates(@current_year.end_date) %>.
           <ul>
             <li>Whether they are licensed for that period</li>
             <li>The contract holder(s) for those licences that cover that period</li>
             <li>The start and end dates for the first licence the school holds for that period (there may be several)</li>
           </ul>
       </li>
-      <li>For the next academic year
-          (<%= short_dates(@next_year.start_date) %> - <%= short_dates(@next_year.end_date) %>).
+      <li>For <%= short_dates(@next_year.start_date) %> - <%= short_dates(@next_year.end_date) %>.
           <ul>
             <li>Whether they are licensed for that period</li>
             <li>The contract holder(s) for those licences that cover that period</li>
@@ -41,7 +43,7 @@
     <%= render Commercial::RangeFundingSummaryComponent.new(
           school_group: @school_group,
           range: @next_year.start_date..@next_year.end_date,
-          range_label: 'the next academic year'
+          range_label: "#{short_dates(@next_year.start_date)} - #{short_dates(@next_year.end_date)}"
         ) %>
     <%= link_to 'Emailable summary',
                 admin_school_group_licence_summaries_path(@school_group, format: :text),

--- a/spec/components/commercial/unlicensed_schools_component_spec.rb
+++ b/spec/components/commercial/unlicensed_schools_component_spec.rb
@@ -16,6 +16,10 @@ RSpec.describe Commercial::UnlicensedSchoolsComponent, type: :component do
            calendar:,
            start_date: academic_year.end_date + 1.day,
            end_date: academic_year.end_date + 1.year)
+    create(:academic_year,
+           calendar:,
+           start_date: academic_year.start_date - 1.year,
+           end_date: academic_year.start_date - 1.day)
     render_inline described_class.new(schools: [school])
   end
 
@@ -23,13 +27,14 @@ RSpec.describe Commercial::UnlicensedSchoolsComponent, type: :component do
     let(:table_id) { '#unlicensed-schools' }
     let(:expected_header) do
       [
+        ['', 'Licensed for', ''],
         ['School Group', 'School', 'Visible?', 'Data visible?', 'Expired Licence?',
-         'Licensed for Current Academic Year?', 'Licensed for Next Academic Year?', '']
+         'Previous Academic Year?', 'Current Academic Year?', 'Next Academic Year?', '']
       ]
     end
     let(:expected_rows) do
       [
-        [school.organisation_group.name, school.name, '', '', '', 'No', 'No', 'Licences']
+        [school.organisation_group.name, school.name, '', '', '', 'No', 'No', 'No', 'Licences']
       ]
     end
   end

--- a/spec/system/admin/commercial/group_contracts_and_licences_spec.rb
+++ b/spec/system/admin/commercial/group_contracts_and_licences_spec.rb
@@ -2,17 +2,26 @@
 
 require 'rails_helper'
 
-describe 'group contracts and licences' do
+describe 'group contracts and licences', :include_application_helper do
   let(:school_group) { create(:school_group) }
   let!(:licence) { create(:commercial_licence, school: create(:school, :with_trust, group: school_group)) }
-
-  before do
-    calendar = create(:national_calendar, title: 'England and Wales')
-    academic_year = create(:academic_year, calendar:)
+  let!(:academic_year) { create(:academic_year, calendar: create(:national_calendar, title: 'England and Wales')) }
+  let!(:next_academic_year) do
     create(:academic_year,
-           calendar:,
+           calendar: academic_year.calendar,
            start_date: academic_year.end_date + 1.day,
            end_date: academic_year.end_date + 12.months)
+  end
+  let!(:previous_academic_year) do
+    create(:academic_year,
+           calendar: academic_year.calendar,
+           start_date: academic_year.start_date - 12.months,
+           end_date: academic_year.start_date - 1.day)
+  end
+  let(:today) { Date.new(2026, 4, 1) }
+
+  before do
+    travel_to today
     sign_in(create(:admin))
     visit settings_school_group_path(school_group)
   end
@@ -28,10 +37,44 @@ describe 'group contracts and licences' do
     it { expect(page).to have_text(licence.school.name) }
     it { expect(page).to have_link('Licences', href: admin_school_licences_path(licence.school)) }
 
+    it 'summarises current year' do
+      expect(page).to have_text(
+        "#{short_dates(academic_year.start_date)} - #{short_dates(academic_year.end_date)}"
+      )
+    end
+
+    it 'summarises next year' do
+      expect(page).to have_text(
+        "#{short_dates(next_academic_year.start_date)} - #{short_dates(next_academic_year.end_date)}"
+      )
+    end
+
     it {
       expect(page).to have_link('Emailable summary',
                                 href: admin_school_group_licence_summaries_path(school_group, format: :text))
     }
+  end
+
+  context 'when in September' do
+    let(:today) { Date.new(2026, 9, 1) }
+
+    before do
+      within('#admin') do
+        click_on 'Licence summaries'
+      end
+    end
+
+    it 'summarises current year' do
+      expect(page).to have_text(
+        "#{short_dates(academic_year.start_date)} - #{short_dates(academic_year.end_date)}"
+      )
+    end
+
+    it 'summarises previous year' do
+      expect(page).to have_text(
+        "#{short_dates(previous_academic_year.start_date)} - #{short_dates(previous_academic_year.end_date)}"
+      )
+    end
   end
 
   context 'when visiting contracts' do


### PR DESCRIPTION
For licence summary page:

- Between September-February show previous and current academic year. 
- From March to September show current and next academic year

For unlicensed schools report, include previous academic year not just current and next.